### PR TITLE
Enhanced projection

### DIFF
--- a/ADRs/008_cypher_execution_over_projections.md
+++ b/ADRs/008_cypher_execution_over_projections.md
@@ -1,0 +1,141 @@
+# Cypher Execution over Subgraphs and Projections ADR
+
+**Author**
+Gareth Lloyd (https://github.com/Ignition)
+
+**Status**
+ACCEPTED (target model; implementation staged, see Consequences)
+
+**Date**
+July 15, 2026
+
+**Problem**
+
+Memgraph can hand a derived view of the graph to an algorithm procedure, but
+users want more: to run declarative Cypher over a view, and to write computed
+values back onto its nodes. Two kinds of derived view exist. A **subgraph**
+(`project(path)`) is a membership-filtered set of real vertices and edges; its
+elements carry real accessors, so a write persists. A **projection**
+(`derive(path, config)`, or `virtualGraph(nodes, edges)` assembled from lists) is
+built from nodes and edges that are not real vertices.
+
+Three forces shape the design. First, the original projection copied every
+property of every node into compute, which is untenable for embedding-heavy
+nodes. Second, a projection's nodes must still map back to a real node where one
+exists, so a written value lands on the right vertex. Third, adding derived-view
+nodes as a second element kind forces every consumer (built-in functions, the
+`SET` operator, Bolt serialization, every scan and expand operator) to branch on
+kind, and each new capability multiplies the branching.
+
+**Criteria**
+
+- **Real-graph path is not regressed** (highest weight). The overwhelming
+  majority of queries touch no derived view; they must pay nothing.
+- **One code path, not per-kind forks.** Adding a derived view must not fork
+  every operator and function.
+- **No eager data copy.** A projection over real nodes must not materialise
+  properties it never reads.
+- **Declarative expressiveness.** The whole query engine, not a fixed set of
+  procedures, should run over a view.
+
+**Decision**
+
+Seven decisions, each addressing part of the problem above.
+
+## 1. One projected-node type
+
+Every node in a derived view is one in-memory type (`query::VirtualNode`) holding
+an **optional origin** real vertex and its own **overlay** property store. An
+*overlay node* has an origin: reads fall through to it lazily (an origin property
+is never copied unless read), and declared overlay keys shadow it. A *synthetic
+node* has no origin: reads and writes hit its overlay only. These are two
+configurations of one type, not two types, which collapses the per-kind branching
+to a single path. This directly serves "no eager data copy" and "one code path".
+
+## 2. Per-property binding with a static schema
+
+Each property is bound to one store: `origin` (read-through and write-through,
+persisted), `overlay` (read and write hit the overlay, compute-only), or `hidden`
+(not visible). Read source and write target are coupled to the same store, so a
+read after a write cannot return a stale shadowed value. The set of overlay and
+hidden keys is fixed at construction, so the schema is static and can be shipped
+before the result stream. A single shared schema object is referenced by every
+node in a projection rather than copied per node.
+
+## 3. Synthetic-edge endpoints carry unresolved import handles
+
+A synthetic edge's endpoint is settled per endpoint: either a resolved node, or
+an unresolved integer **handle** (an import key the user passed to
+`virtualEdge`). The handle is stored on the node, is not the node's identity, and
+is bound to a node at list assembly by matching handles. This lets a user wire an
+edge to a node that does not exist yet, and lets a standalone edge serialize with
+its handles as endpoints. A real vertex is rejected as an endpoint; it is wired by
+passing its id as a handle.
+
+## 4. List assembly is a scalar constructor
+
+`virtualGraph(nodes, edges, config)` assembles a projection from lists in one
+query, so an external graph (nodes and edges tables from another system) imports
+in a single statement. It is a scalar function, not an aggregation, which avoids a
+plan-time accumulator type and the two-expression argument limit. A dangling edge
+(an endpoint resolving to no node in the list) aborts assembly by default, or is
+dropped per config; a duplicate import handle is always an error.
+
+## 5. A projection is a bindable graph scope, not a value
+
+Querying a view happens by binding it as the ambient graph for a `CALL { ... }`
+block with `USE`, not by threading a value through functions:
+
+```cypher
+WITH derive(path, {...}) AS g
+CALL { USE g MATCH (n:Person)-[:KNOWS]->(m) WHERE m.churned RETURN n }
+SET n.at_risk = true
+```
+
+Inside the scope, `MATCH`, built-in functions, and reads resolve against the
+bound view; write-back happens outside the scope through the binding. The first
+version of the scope is read-only, single-nesting, and full-scan.
+
+## 6. GraphView: one seam for real, subgraph, and projected graphs
+
+The execution engine runs against one abstraction, `query::GraphView`, that
+answers only what an operator needs of "the graph": scan vertices, expand a
+vertex's edges, and map names to ids. **The real accessor is the identity view.**
+A subgraph is that view filtered by membership; a projection composes its own
+topology and delegates origin reads to a base view. `USE` rebinds which view is
+ambient for a scope, so nesting a view over a view is composition, not a special
+case.
+
+The virtual boundary is **coarse**: one call yields a vertex range or a vertex's
+edge range, and iteration then runs over concrete elements with direct reads. The
+boundary is crossed once per scan, not once per row, so the real-graph path is not
+regressed. Scan and expand are graph operations on the view; property read and
+write stay on the element, which already encapsulates binding and read-through.
+
+## 7. Identity on the wire
+
+Virtual elements are given synthetic gids counted down from the maximum, so they
+never collide with real gids (which count up from zero). At the query boundary
+these are mapped to small, query-local external ids (`-1, -2, ...`) that `id()`
+reports and that Bolt serialization matches. An overlay node serializes at its
+origin's real id so a client maps it back to the real node. Provenance travels as
+a non-breaking channel: each projected node carries a small reserved tag
+referencing a schema table sent once in the result header, so a streaming client
+resolves provenance as nodes arrive, and property values are never wrapped.
+
+**Consequences**
+
+- The GraphView seam is the foundation; the element-kind unification, the USE
+  scope, and function support over a view are its payoff. Implementation is
+  staged: single-hop scan and expand run through the seam, and the
+  variable-length and shortest-path family runs over a per-view traversal policy.
+  Completing the seam for every remaining per-operator branch (edge expansion, the
+  ambient-view dispatch) is follow-up work, tracked outside this ADR.
+- Version-one boundaries surface as clear query errors, not silent wrong results:
+  no writes inside a USE scope, no nested USE, no index-backed scans inside the
+  scope (full scan only), no filter or accumulated-path lambda over a projection,
+  and no named path over a projection (a path value holds real elements only).
+  Each has a documented error; over a subgraph, whose elements are real, these
+  restrictions do not apply.
+- Supporting cross-tenant virtual elements and rendering an arbitrary virtual
+  graph in external clients are enabled by this model but are not built here.

--- a/src/communication/bolt/v1/mg_types.hpp
+++ b/src/communication/bolt/v1/mg_types.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -29,6 +29,11 @@ struct mg_type_info {
 constexpr std::string_view kMgTypeEnum = "mg_enum";
 constexpr std::string_view kMgTypeType = "__type";
 constexpr std::string_view kMgTypeValue = "__value";
+
+// Reserved property carried by an overlay node from a projection: a plain Int referencing the
+// projection-schema entry for the derive() that produced it. Generic clients ignore the key; a
+// projection-aware client uses it to look the node's schema up in the RUN-header schema table.
+constexpr std::string_view kMgOverlayRef = "__mg_overlay_ref";
 
 auto BoltMapToMgTypeInfo(map_t const &value) -> std::optional<mg_type_info>;
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -192,6 +192,16 @@ State HandlePullDiscardV4(TSession &session, const State state, const Marker mar
 }
 }  // namespace details
 
+// Outcome of preparing a query for streaming, assembled into the RUN response header. `fields` names
+// the result columns; `qid` is the optional query id; `projection_schema` is a per-derive() schema
+// table keyed by the projection reference, empty when the query yields no projection. A
+// projection-aware client uses the table to resolve the reference carried on each overlay node.
+struct PreparedRunMetadata {
+  std::vector<std::string> fields;
+  std::optional<int> qid;
+  map_t projection_schema;
+};
+
 template <typename TSession>
 inline State HandleFailure(TSession &session, const std::exception &e) {
   spdlog::trace("Error message: {}", e.what());
@@ -213,17 +223,22 @@ template <typename TSession>
 State HandlePrepare(TSession &session) {
   try {
     // Interpret can throw.
-    const auto [header, qid] = session.InterpretPrepare();
+    auto [fields, qid, projection_schema] = session.InterpretPrepare();
     // Convert std::string to Value
     std::vector<Value> vec;
     map_t data;
-    vec.reserve(header.size());
-    for (auto &i : header) vec.emplace_back(std::move(i));
+    vec.reserve(fields.size());
+    for (auto &i : fields) vec.emplace_back(std::move(i));
     data.emplace("fields", std::move(vec));
     if (session.version_.major > 1) {
       if (qid) {
         data.emplace("qid", Value{*qid});
       }
+    }
+    // A projection-aware client reads this table to style projected nodes; generic clients ignore
+    // the unknown key. Omitted entirely when the query produced no projection.
+    if (!projection_schema.empty()) {
+      data.emplace("projection_schema", Value{std::move(projection_schema)});
     }
 
     // Send the header.

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -440,7 +440,26 @@ void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, cons
   }
 }
 
-std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrepare() {
+namespace {
+// Converts the query layer's projection schemas into the Bolt RUN-header table: a map keyed by each
+// projection's reference (rendered as a string, since Bolt map keys are strings) to a small,
+// extensible map describing that projection. Empty when the query produced no projection.
+bolt_map_t ToBoltProjectionSchema(const std::vector<memgraph::query::ProjectionSchema> &schemas) {
+  bolt_map_t table;
+  for (const auto &schema : schemas) {
+    std::vector<bolt_value_t> overlay;
+    overlay.reserve(schema.overlay.size());
+    for (const auto &key : schema.overlay) overlay.emplace_back(key);
+    bolt_map_t entry;
+    entry.emplace("overlay", std::move(overlay));
+    entry.emplace("edgeType", schema.edge_type);
+    table.emplace(std::to_string(schema.ref), std::move(entry));
+  }
+  return table;
+}
+}  // namespace
+
+memgraph::communication::bolt::PreparedRunMetadata SessionHL::InterpretPrepare() {
   if (!parsed_res_) {
     throw memgraph::communication::bolt::ClientError("Trying to prepare a query that was not parsed.");
   }
@@ -451,8 +470,7 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrep
     auto result =
         interpreter_.Prepare(std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
     interpreter_.CheckAuthorized(result.privileges, result.db);
-
-    return {std::move(result.headers), result.qid};
+    return {std::move(result.headers), result.qid, ToBoltProjectionSchema(result.projection_schemas)};
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -444,7 +444,7 @@ namespace {
 // Converts the query layer's projection schemas into the Bolt RUN-header table: a map keyed by each
 // projection's reference (rendered as a string, since Bolt map keys are strings) to a small,
 // extensible map describing that projection. Empty when the query produced no projection.
-bolt_map_t ToBoltProjectionSchema(const std::vector<memgraph::query::ProjectionSchema> &schemas) {
+bolt_map_t ToBoltProjectionSchemaEntry(const std::vector<memgraph::query::ProjectionSchemaEntry> &schemas) {
   bolt_map_t table;
   for (const auto &schema : schemas) {
     std::vector<bolt_value_t> overlay;
@@ -472,7 +472,7 @@ memgraph::communication::bolt::PreparedRunMetadata SessionHL::InterpretPrepare()
     interpreter_.CheckAuthorized(result.privileges, result.db);
     return {.fields = std::move(result.headers),
             .qid = result.qid,
-            .projection_schema = ToBoltProjectionSchema(result.projection_schemas)};
+            .projection_schema = ToBoltProjectionSchemaEntry(result.projection_schemas)};
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -470,7 +470,9 @@ memgraph::communication::bolt::PreparedRunMetadata SessionHL::InterpretPrepare()
     auto result =
         interpreter_.Prepare(std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
     interpreter_.CheckAuthorized(result.privileges, result.db);
-    return {std::move(result.headers), result.qid, ToBoltProjectionSchema(result.projection_schemas)};
+    return {.fields = std::move(result.headers),
+            .qid = result.qid,
+            .projection_schema = ToBoltProjectionSchema(result.projection_schemas)};
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -88,14 +88,16 @@ template <typename TEncoder>
 class TypedValueResultStream {
  public:
   TypedValueResultStream(TEncoder *encoder, memgraph::storage::Storage *storage,
-                         memgraph::query::FineGrainedAuthChecker const *auth_checker)
-      : storage_{storage}, auth_checker_{auth_checker}, encoder_(encoder) {}
+                         memgraph::query::FineGrainedAuthChecker const *auth_checker,
+                         memgraph::query::SyntheticIdMapper *id_mapper)
+      : storage_{storage}, auth_checker_{auth_checker}, id_mapper_{id_mapper}, encoder_(encoder) {}
 
   void Result(const std::vector<memgraph::query::TypedValue> &values) {
     // Splitting the MessageRecord allows us to skip vector insertion and just directly encode the value
     encoder_->MessageRecordHeader(values.size());
     for (const auto &v : values) {
-      auto maybe_value = memgraph::glue::ToBoltValue(v, storage_, memgraph::storage::View::NEW, auth_checker_);
+      auto maybe_value =
+          memgraph::glue::ToBoltValue(v, storage_, memgraph::storage::View::NEW, auth_checker_, id_mapper_);
       if (!maybe_value) {
         switch (maybe_value.error()) {
           case memgraph::storage::Error::DELETED_OBJECT:
@@ -119,6 +121,7 @@ class TypedValueResultStream {
   // NOTE: Needed only for ToBoltValue conversions
   memgraph::storage::Storage *storage_;
   memgraph::query::FineGrainedAuthChecker const *auth_checker_;
+  memgraph::query::SyntheticIdMapper *id_mapper_;
   TEncoder *encoder_;
 };
 
@@ -388,7 +391,8 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
         communication::bolt::Encoder<communication::bolt::ChunkedEncoderBuffer<communication::v2::OutputStream>>;
     auto &db = interpreter_.current_db_.db_acc_;
     auto *storage = db ? db->get()->storage() : nullptr;
-    TypedValueResultStream<TEncoder> stream(&encoder_, storage, interpreter_.GetCachedFga());
+    TypedValueResultStream<TEncoder> stream(
+        &encoder_, storage, interpreter_.GetCachedFga(), interpreter_.GetSyntheticIdMapper());
     return DecodeSummary(interpreter_.Pull(&stream, n, qid));
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -77,10 +77,10 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   void InterpretParse(const std::string &query, bolt_map_t params, const bolt_map_t &extra);
 
-  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare();
+  memgraph::communication::bolt::PreparedRunMetadata InterpretPrepare();
 
-  std::pair<std::vector<std::string>, std::optional<int>> Interpret(const std::string &query, const bolt_map_t &params,
-                                                                    const bolt_map_t &extra) {
+  memgraph::communication::bolt::PreparedRunMetadata Interpret(const std::string &query, const bolt_map_t &params,
+                                                               const bolt_map_t &extra) {
     // Interpret has been split in two (Parse and Prepare)
     // This allows us to Parse, deduce the priority and then schedule accordingly
     // Leaving this one-shot version for back-compatiblity

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -19,6 +19,7 @@
 #include "communication/bolt/v1/value.hpp"
 #include "query/auth_checker.hpp"
 #include "query/graph.hpp"
+#include "query/overlay_authorization.hpp"
 #include "query/synthetic_gid.hpp"
 #include "query/typed_value.hpp"
 #include "query/virtual_graph.hpp"
@@ -127,8 +128,7 @@ communication::bolt::Edge ToBoltEdge(const query::VirtualEdge &ve, const storage
   // A synthetic gid maps to the query-local external id id() reports; null falls back to the raw
   // gid. The edge's own id and any resolved endpoint travel this axis.
   const auto external = [&](storage::Gid gid) {
-    return id_mapper ? communication::bolt::Id::FromInt(id_mapper->ExternalId(gid))
-                     : communication::bolt::Id::FromUint(gid.AsUint());
+    return communication::bolt::Id::FromInt(query::ExternalId(gid, id_mapper));
   };
   // An unresolved (handle) endpoint references an import key, not a node identity, so it stays on
   // the raw handle axis (never mapped); a resolved endpoint shares id()'s external axis.
@@ -312,8 +312,7 @@ storage::Result<communication::bolt::Vertex> ToBoltVertex(const query::VirtualNo
   // node (real gid axis, unchanged). A synthetic node maps its synthetic gid to the query-local
   // external id id() reports; null falls back to the raw synthetic gid.
   auto id = node.HasOrigin() ? communication::bolt::Id::FromUint(node.Origin()->Gid().AsUint())
-            : id_mapper      ? communication::bolt::Id::FromInt(id_mapper->ExternalId(node.Gid()))
-                             : communication::bolt::Id::FromUint(node.Gid().AsUint());
+                             : communication::bolt::Id::FromInt(query::ExternalId(node.Gid(), id_mapper));
   std::vector<std::string> labels;
   labels.reserve(node.Labels().size());
   for (const auto &label : node.Labels()) labels.emplace_back(label);
@@ -321,21 +320,14 @@ storage::Result<communication::bolt::Vertex> ToBoltVertex(const query::VirtualNo
   // Origin-read-through properties are gated by the origin's per-property READ permission (over the
   // origin's real labels), matching a real vertex. Overlay-bound overrides are the author's own
   // computed values, and a synthetic node (no origin) mints no real-graph data - both are always
-  // included.
-  std::optional<std::vector<storage::LabelId>> origin_labels;
-  if (auth_checker && node.HasOrigin()) {
-    auto maybe_labels = node.Origin()->Labels(view);
-    if (!maybe_labels) return std::unexpected{maybe_labels.error()};
-    origin_labels.emplace(maybe_labels->begin(), maybe_labels->end());
-  }
+  // included. The visibility decision is single-sourced in OverlayReadAuthorization.
+  auto auth = query::OverlayReadAuthorization::For(node, view, auth_checker);
+  if (!auth) return std::unexpected{auth.error()};
   auto maybe_props = node.Properties(view);
   if (!maybe_props) return std::unexpected{maybe_props.error()};
   bolt_map_t properties;
   for (const auto &[prop_id, prop_value] : *maybe_props) {
-    if (origin_labels && !node.IsOverlayBound(prop_id) &&
-        !auth_checker->HasPropertyPermission(*origin_labels, prop_id, query::AuthQuery::PropertyPermissionType::READ)) {
-      continue;
-    }
+    if (!auth->IsReadable(node, prop_id)) continue;
     properties[db.PropertyToName(prop_id)] = ToBoltValue(prop_value, db);
   }
   // An overlay node from a projection with a known schema carries a reserved Int property pointing at

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -29,6 +29,7 @@
 #include "storage/v2/vertex_accessor.hpp"
 #include "utils/temporal.hpp"
 
+using memgraph::communication::bolt::kMgOverlayRef;
 using memgraph::communication::bolt::kMgTypeEnum;
 using memgraph::communication::bolt::kMgTypeType;
 using memgraph::communication::bolt::kMgTypeValue;
@@ -142,13 +143,22 @@ communication::bolt::Edge ToBoltEdge(const query::VirtualEdge &ve, const storage
 }
 
 communication::bolt::Vertex ToBoltVertex(const query::VirtualNode &node, const storage::Storage &db) {
-  auto id = communication::bolt::Id::FromUint(node.Gid().AsUint());
+  // An overlay node serializes at its origin's identity, so a click, expand, or edit in a client
+  // maps back to the real node. A synthetic node (no origin) keeps its synthetic id.
+  const auto gid = node.HasOrigin() ? node.Origin()->Gid() : node.Gid();
+  auto id = communication::bolt::Id::FromUint(gid.AsUint());
   std::vector<std::string> labels;
   labels.reserve(node.Labels().size());
   for (const auto &label : node.Labels()) labels.emplace_back(label);
   bolt_map_t properties;
   for (const auto &[prop_id, prop_value] : node.Properties()) {
     properties[db.PropertyToName(prop_id)] = ToBoltValue(prop_value, db);
+  }
+  // An overlay node from a projection with a known schema carries a reserved Int property pointing
+  // at its projection-schema entry. The value is sent unwrapped so generic clients read it as an
+  // ordinary property and ignore it.
+  if (node.HasProjectionRef()) {
+    properties[std::string{kMgOverlayRef}] = Value{node.ProjectionRef()};
   }
   auto element_id = std::to_string(id.AsInt());
   return communication::bolt::Vertex{

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -142,28 +142,6 @@ communication::bolt::Edge ToBoltEdge(const query::VirtualEdge &ve, const storage
                                    .to_element_id = std::move(to_element_id)};
 }
 
-communication::bolt::Vertex ToBoltVertex(const query::VirtualNode &node, const storage::Storage &db) {
-  // An overlay node serializes at its origin's identity, so a click, expand, or edit in a client
-  // maps back to the real node. A synthetic node (no origin) keeps its synthetic id.
-  const auto gid = node.HasOrigin() ? node.Origin()->Gid() : node.Gid();
-  auto id = communication::bolt::Id::FromUint(gid.AsUint());
-  std::vector<std::string> labels;
-  labels.reserve(node.Labels().size());
-  for (const auto &label : node.Labels()) labels.emplace_back(label);
-  bolt_map_t properties;
-  for (const auto &[prop_id, prop_value] : node.Properties()) {
-    properties[db.PropertyToName(prop_id)] = ToBoltValue(prop_value, db);
-  }
-  // An overlay node from a projection with a known schema carries a reserved Int property pointing
-  // at its projection-schema entry. The value is sent unwrapped so generic clients read it as an
-  // ordinary property and ignore it.
-  if (node.HasProjectionRef()) {
-    properties[std::string{kMgOverlayRef}] = Value{node.ProjectionRef()};
-  }
-  auto element_id = std::to_string(id.AsInt());
-  return communication::bolt::Vertex{
-      .id = id, .labels = std::move(labels), .properties = std::move(properties), .element_id = std::move(element_id)};
-}
 }  // namespace
 
 storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage::Storage *db, storage::View view,
@@ -244,8 +222,9 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
     }
     case query::TypedValue::Type::VirtualGraph: {
       check_db();
-      auto maybe_vg = ToBoltVirtualGraph(value.ValueVirtualGraph(), *db);
-      return storage::Result<Value>{std::in_place, std::move(maybe_vg)};
+      auto maybe_vg = ToBoltVirtualGraph(value.ValueVirtualGraph(), *db, view, auth_checker);
+      if (!maybe_vg) return std::unexpected{maybe_vg.error()};
+      return storage::Result<Value>{std::in_place, std::move(*maybe_vg)};
     }
     case query::TypedValue::Type::Enum: {
       check_db();
@@ -272,7 +251,9 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
 
     case query::TypedValue::Type::VirtualNode: {
       check_db();
-      return storage::Result<Value>{std::in_place, ToBoltVertex(value.ValueVirtualNode(), *db)};
+      auto maybe_vertex = ToBoltVertex(value.ValueVirtualNode(), *db, view, auth_checker);
+      if (!maybe_vertex) return std::unexpected{maybe_vertex.error()};
+      return storage::Result<Value>{std::in_place, std::move(*maybe_vertex)};
     }
 
     // Unsupported conversions
@@ -304,6 +285,47 @@ storage::Result<communication::bolt::Vertex> ToBoltVertex(const storage::VertexA
     properties[db.PropertyToName(prop.first)] = ToBoltValue(prop.second, db);
   }
   // Introduced in Bolt v5 (for now just send the ID)
+  auto element_id = std::to_string(id.AsInt());
+  return communication::bolt::Vertex{
+      .id = id, .labels = std::move(labels), .properties = std::move(properties), .element_id = std::move(element_id)};
+}
+
+storage::Result<communication::bolt::Vertex> ToBoltVertex(const query::VirtualNode &node, const storage::Storage &db,
+                                                          storage::View view,
+                                                          query::FineGrainedAuthChecker const *auth_checker) {
+  // An overlay node serializes at its origin's identity so a client maps it back to the real node; a
+  // synthetic node keeps its synthetic id.
+  const auto gid = node.HasOrigin() ? node.Origin()->Gid() : node.Gid();
+  auto id = communication::bolt::Id::FromUint(gid.AsUint());
+  std::vector<std::string> labels;
+  labels.reserve(node.Labels().size());
+  for (const auto &label : node.Labels()) labels.emplace_back(label);
+
+  // Origin-read-through properties are gated by the origin's per-property READ permission (over the
+  // origin's real labels), matching a real vertex. Overlay-bound overrides are the author's own
+  // computed values, and a synthetic node (no origin) mints no real-graph data - both are always
+  // included.
+  std::optional<std::vector<storage::LabelId>> origin_labels;
+  if (auth_checker && node.HasOrigin()) {
+    auto maybe_labels = node.Origin()->Labels(view);
+    if (!maybe_labels) return std::unexpected{maybe_labels.error()};
+    origin_labels.emplace(maybe_labels->begin(), maybe_labels->end());
+  }
+  auto maybe_props = node.Properties(view);
+  if (!maybe_props) return std::unexpected{maybe_props.error()};
+  bolt_map_t properties;
+  for (const auto &[prop_id, prop_value] : *maybe_props) {
+    if (origin_labels && !node.IsOverlayBound(prop_id) &&
+        !auth_checker->HasPropertyPermission(*origin_labels, prop_id, query::AuthQuery::PropertyPermissionType::READ)) {
+      continue;
+    }
+    properties[db.PropertyToName(prop_id)] = ToBoltValue(prop_value, db);
+  }
+  // An overlay node from a projection with a known schema carries a reserved Int property pointing at
+  // its projection-schema entry, sent unwrapped so generic clients read it as an ordinary property.
+  if (node.HasProjectionRef()) {
+    properties[std::string{kMgOverlayRef}] = Value{node.ProjectionRef()};
+  }
   auto element_id = std::to_string(id.AsInt());
   return communication::bolt::Vertex{
       .id = id, .labels = std::move(labels), .properties = std::move(properties), .element_id = std::move(element_id)};
@@ -378,12 +400,15 @@ storage::Result<bolt_map_t> ToBoltGraph(const query::Graph &graph, const storage
   return std::move(map);
 }
 
-bolt_map_t ToBoltVirtualGraph(const query::VirtualGraph &vg, const storage::Storage &db) {
+storage::Result<bolt_map_t> ToBoltVirtualGraph(const query::VirtualGraph &vg, const storage::Storage &db,
+                                               storage::View view, query::FineGrainedAuthChecker const *auth_checker) {
   bolt_map_t map;
   std::vector<Value> nodes;
   nodes.reserve(vg.nodes().size());
   for (const auto &[gid, vn] : vg.nodes()) {
-    nodes.emplace_back(ToBoltVertex(*vn, db));
+    auto maybe_vertex = ToBoltVertex(*vn, db, view, auth_checker);
+    if (!maybe_vertex) return std::unexpected{maybe_vertex.error()};
+    nodes.emplace_back(std::move(*maybe_vertex));
   }
   map.emplace("nodes", Value(std::move(nodes)));
 
@@ -394,7 +419,7 @@ bolt_map_t ToBoltVirtualGraph(const query::VirtualGraph &vg, const storage::Stor
   }
   map.emplace("edges", Value(std::move(edges)));
 
-  return map;
+  return storage::Result<bolt_map_t>{std::in_place, std::move(map)};
 }
 
 storage::ExternalPropertyValue ToExternalPropertyValue(communication::bolt::Value const &value,

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -19,6 +19,7 @@
 #include "communication/bolt/v1/value.hpp"
 #include "query/auth_checker.hpp"
 #include "query/graph.hpp"
+#include "query/synthetic_gid.hpp"
 #include "query/typed_value.hpp"
 #include "query/virtual_graph.hpp"
 #include "storage/v2/edge_accessor.hpp"
@@ -121,10 +122,22 @@ storage::Result<communication::bolt::Edge> ToBoltEdge(const query::EdgeAccessor 
 }
 
 namespace {
-communication::bolt::Edge ToBoltEdge(const query::VirtualEdge &ve, const storage::Storage &db) {
-  auto id = communication::bolt::Id::FromUint(ve.Gid().AsUint());
-  auto from = communication::bolt::Id::FromUint(ve.FromGid().AsUint());
-  auto to = communication::bolt::Id::FromUint(ve.ToGid().AsUint());
+communication::bolt::Edge ToBoltEdge(const query::VirtualEdge &ve, const storage::Storage &db,
+                                     query::SyntheticIdMapper *id_mapper) {
+  // A synthetic gid maps to the query-local external id id() reports; null falls back to the raw
+  // gid. The edge's own id and any resolved endpoint travel this axis.
+  const auto external = [&](storage::Gid gid) {
+    return id_mapper ? communication::bolt::Id::FromInt(id_mapper->ExternalId(gid))
+                     : communication::bolt::Id::FromUint(gid.AsUint());
+  };
+  // An unresolved (handle) endpoint references an import key, not a node identity, so it stays on
+  // the raw handle axis (never mapped); a resolved endpoint shares id()'s external axis.
+  const auto endpoint = [&](std::optional<int64_t> handle, storage::Gid gid) {
+    return handle ? communication::bolt::Id::FromInt(*handle) : external(gid);
+  };
+  auto id = external(ve.Gid());
+  auto from = endpoint(ve.FromHandle(), ve.FromGid());
+  auto to = endpoint(ve.ToHandle(), ve.ToGid());
   bolt_map_t properties;
   for (const auto &[prop_id, prop_value] : ve.Properties()) {
     properties[db.PropertyToName(prop_id)] = ToBoltValue(prop_value, db);
@@ -145,7 +158,8 @@ communication::bolt::Edge ToBoltEdge(const query::VirtualEdge &ve, const storage
 }  // namespace
 
 storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage::Storage *db, storage::View view,
-                                   query::FineGrainedAuthChecker const *auth_checker) {
+                                   query::FineGrainedAuthChecker const *auth_checker,
+                                   query::SyntheticIdMapper *id_mapper) {
   auto check_db = [db]() {
     if (db == nullptr) [[unlikely]]
       throw communication::bolt::ValueException("Database needed for TypedValue conversion.");
@@ -222,7 +236,7 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
     }
     case query::TypedValue::Type::VirtualGraph: {
       check_db();
-      auto maybe_vg = ToBoltVirtualGraph(value.ValueVirtualGraph(), *db, view, auth_checker);
+      auto maybe_vg = ToBoltVirtualGraph(value.ValueVirtualGraph(), *db, view, auth_checker, id_mapper);
       if (!maybe_vg) return std::unexpected{maybe_vg.error()};
       return storage::Result<Value>{std::in_place, std::move(*maybe_vg)};
     }
@@ -246,12 +260,12 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
 
     case query::TypedValue::Type::VirtualEdge: {
       check_db();
-      return storage::Result<Value>{std::in_place, ToBoltEdge(value.ValueVirtualEdge(), *db)};
+      return storage::Result<Value>{std::in_place, ToBoltEdge(value.ValueVirtualEdge(), *db, id_mapper)};
     }
 
     case query::TypedValue::Type::VirtualNode: {
       check_db();
-      auto maybe_vertex = ToBoltVertex(value.ValueVirtualNode(), *db, view, auth_checker);
+      auto maybe_vertex = ToBoltVertex(value.ValueVirtualNode(), *db, view, auth_checker, id_mapper);
       if (!maybe_vertex) return std::unexpected{maybe_vertex.error()};
       return storage::Result<Value>{std::in_place, std::move(*maybe_vertex)};
     }
@@ -292,11 +306,14 @@ storage::Result<communication::bolt::Vertex> ToBoltVertex(const storage::VertexA
 
 storage::Result<communication::bolt::Vertex> ToBoltVertex(const query::VirtualNode &node, const storage::Storage &db,
                                                           storage::View view,
-                                                          query::FineGrainedAuthChecker const *auth_checker) {
-  // An overlay node serializes at its origin's identity so a client maps it back to the real node; a
-  // synthetic node keeps its synthetic id.
-  const auto gid = node.HasOrigin() ? node.Origin()->Gid() : node.Gid();
-  auto id = communication::bolt::Id::FromUint(gid.AsUint());
+                                                          query::FineGrainedAuthChecker const *auth_checker,
+                                                          query::SyntheticIdMapper *id_mapper) {
+  // An overlay node serializes at its origin's real identity so a client maps it back to the real
+  // node (real gid axis, unchanged). A synthetic node maps its synthetic gid to the query-local
+  // external id id() reports; null falls back to the raw synthetic gid.
+  auto id = node.HasOrigin() ? communication::bolt::Id::FromUint(node.Origin()->Gid().AsUint())
+            : id_mapper      ? communication::bolt::Id::FromInt(id_mapper->ExternalId(node.Gid()))
+                             : communication::bolt::Id::FromUint(node.Gid().AsUint());
   std::vector<std::string> labels;
   labels.reserve(node.Labels().size());
   for (const auto &label : node.Labels()) labels.emplace_back(label);
@@ -401,12 +418,13 @@ storage::Result<bolt_map_t> ToBoltGraph(const query::Graph &graph, const storage
 }
 
 storage::Result<bolt_map_t> ToBoltVirtualGraph(const query::VirtualGraph &vg, const storage::Storage &db,
-                                               storage::View view, query::FineGrainedAuthChecker const *auth_checker) {
+                                               storage::View view, query::FineGrainedAuthChecker const *auth_checker,
+                                               query::SyntheticIdMapper *id_mapper) {
   bolt_map_t map;
   std::vector<Value> nodes;
   nodes.reserve(vg.nodes().size());
   for (const auto &[gid, vn] : vg.nodes()) {
-    auto maybe_vertex = ToBoltVertex(*vn, db, view, auth_checker);
+    auto maybe_vertex = ToBoltVertex(*vn, db, view, auth_checker, id_mapper);
     if (!maybe_vertex) return std::unexpected{maybe_vertex.error()};
     nodes.emplace_back(std::move(*maybe_vertex));
   }
@@ -415,7 +433,7 @@ storage::Result<bolt_map_t> ToBoltVirtualGraph(const query::VirtualGraph &vg, co
   std::vector<Value> edges;
   edges.reserve(vg.edges().size());
   for (const auto &ve : vg.edges()) {
-    edges.emplace_back(ToBoltEdge(ve, db));
+    edges.emplace_back(ToBoltEdge(ve, db, id_mapper));
   }
   map.emplace("edges", Value(std::move(edges)));
 

--- a/src/glue/communication.hpp
+++ b/src/glue/communication.hpp
@@ -19,6 +19,7 @@
 
 namespace memgraph::query {
 class FineGrainedAuthChecker;
+class VirtualNode;
 }  // namespace memgraph::query
 
 namespace memgraph::storage {
@@ -37,6 +38,16 @@ namespace memgraph::glue {
 /// @throw std::bad_alloc
 storage::Result<communication::bolt::Vertex> ToBoltVertex(const storage::VertexAccessor &vertex,
                                                           const storage::Storage &db, storage::View view,
+                                                          query::FineGrainedAuthChecker const *auth_checker);
+
+/// Overlay/synthetic node -> bolt::Vertex. An overlay node serializes at its origin's identity;
+/// origin-read-through properties are subject to the origin's per-property READ permission (over the
+/// origin's labels), while overlay-bound overrides and synthetic nodes (no origin) are always
+/// included - matching how a real vertex serializes.
+///
+/// @throw std::bad_alloc
+storage::Result<communication::bolt::Vertex> ToBoltVertex(const query::VirtualNode &node, const storage::Storage &db,
+                                                          storage::View view,
                                                           query::FineGrainedAuthChecker const *auth_checker);
 
 /// @param storage::EdgeAccessor for converting to communication::bolt::Edge.
@@ -66,7 +77,9 @@ storage::Result<communication::bolt::map_t> ToBoltGraph(const query::Graph &grap
                                                         storage::View view,
                                                         query::FineGrainedAuthChecker const *auth_checker);
 
-communication::bolt::map_t ToBoltVirtualGraph(const query::VirtualGraph &vg, const storage::Storage &db);
+storage::Result<communication::bolt::map_t> ToBoltVirtualGraph(const query::VirtualGraph &vg,
+                                                               const storage::Storage &db, storage::View view,
+                                                               query::FineGrainedAuthChecker const *auth_checker);
 
 /// @param query::TypedValue for converting to communication::bolt::Value.
 /// @param storage::Storage for ToBoltVertex and ToBoltEdge.

--- a/src/glue/communication.hpp
+++ b/src/glue/communication.hpp
@@ -20,6 +20,7 @@
 namespace memgraph::query {
 class FineGrainedAuthChecker;
 class VirtualNode;
+class SyntheticIdMapper;
 }  // namespace memgraph::query
 
 namespace memgraph::storage {
@@ -46,9 +47,12 @@ storage::Result<communication::bolt::Vertex> ToBoltVertex(const storage::VertexA
 /// included - matching how a real vertex serializes.
 ///
 /// @throw std::bad_alloc
+/// @param id_mapper the query's synthetic-id mapper, so a synthetic node serializes at the same
+///        query-local external id as `id()`; null falls back to the raw synthetic gid.
 storage::Result<communication::bolt::Vertex> ToBoltVertex(const query::VirtualNode &node, const storage::Storage &db,
                                                           storage::View view,
-                                                          query::FineGrainedAuthChecker const *auth_checker);
+                                                          query::FineGrainedAuthChecker const *auth_checker,
+                                                          query::SyntheticIdMapper *id_mapper = nullptr);
 
 /// @param storage::EdgeAccessor for converting to communication::bolt::Edge.
 /// @param storage::Storage for getting edge type and property names.
@@ -79,7 +83,8 @@ storage::Result<communication::bolt::map_t> ToBoltGraph(const query::Graph &grap
 
 storage::Result<communication::bolt::map_t> ToBoltVirtualGraph(const query::VirtualGraph &vg,
                                                                const storage::Storage &db, storage::View view,
-                                                               query::FineGrainedAuthChecker const *auth_checker);
+                                                               query::FineGrainedAuthChecker const *auth_checker,
+                                                               query::SyntheticIdMapper *id_mapper = nullptr);
 
 /// @param query::TypedValue for converting to communication::bolt::Value.
 /// @param storage::Storage for ToBoltVertex and ToBoltEdge.
@@ -88,7 +93,8 @@ storage::Result<communication::bolt::map_t> ToBoltVirtualGraph(const query::Virt
 /// @throw std::bad_alloc
 storage::Result<communication::bolt::Value> ToBoltValue(const query::TypedValue &value, const storage::Storage *db,
                                                         storage::View view,
-                                                        query::FineGrainedAuthChecker const *auth_checker);
+                                                        query::FineGrainedAuthChecker const *auth_checker,
+                                                        query::SyntheticIdMapper *id_mapper = nullptr);
 
 query::TypedValue ToTypedValue(const communication::bolt::Value &value, storage::Storage const *storage);
 

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -19,6 +19,7 @@
 #include "query/metadata.hpp"
 #include "query/parameters.hpp"
 #include "query/plan/profile.hpp"
+#include "query/synthetic_gid.hpp"
 #include "storage/v2/commit_args.hpp"
 #include "utils/async_timer.hpp"
 #include "utils/counter.hpp"
@@ -77,6 +78,10 @@ struct EvaluationContext {
   // over. Bound to the identity view (the real graph) by default; a
   // `CALL { USE ... }` scope rebinds a projection or subgraph view for the block.
   GraphView *graph_view{nullptr};
+  // Query-local projection of synthetic Gids onto dense external ids. Shared (not deep-copied) so
+  // parallel workers agree on a virtual entity's external id; a fresh one per query gives the
+  // per-query reset that id()/virtual_id() expose.
+  std::shared_ptr<SyntheticIdMapper> synthetic_id_mapper{std::make_shared<SyntheticIdMapper>()};
 };
 
 std::vector<storage::PropertyId> NamesToProperties(const std::vector<std::string> &property_names, DbAccessor *dba);

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -75,8 +75,11 @@ struct EvaluationContext {
   mutable std::unordered_map<std::string, int64_t> counters{};
   Scope scope{};
   // The ambient graph the read operators scan and the topology functions resolve
-  // over. Bound to the identity view (the real graph) by default; a
-  // `CALL { USE ... }` scope rebinds a projection or subgraph view for the block.
+  // over. Every executor binds one before the plan runs - the real graph as the
+  // identity view (PullPlan, the trigger executor, the test MakeContext helper) -
+  // and a `CALL { USE ... }` scope rebinds a projection or subgraph view for the
+  // block. The read path assumes it is non-null during execution; the null default
+  // is only the pre-bind value.
   GraphView *graph_view{nullptr};
   // Query-local projection of synthetic Gids onto dense external ids. Shared (not deep-copied) so
   // parallel workers agree on a virtual entity's external id; a fresh one per query gives the

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -39,6 +39,7 @@ namespace memgraph::query {
 
 class FineGrainedAuthChecker;
 class TriggerContextCollector;
+class GraphView;
 
 enum class TransactionStatus {
   IDLE,
@@ -72,6 +73,10 @@ struct EvaluationContext {
   /// modifies the values
   mutable std::unordered_map<std::string, int64_t> counters{};
   Scope scope{};
+  // The ambient graph the read operators scan and the topology functions resolve
+  // over. Bound to the identity view (the real graph) by default; a
+  // `CALL { USE ... }` scope rebinds a projection or subgraph view for the block.
+  GraphView *graph_view{nullptr};
 };
 
 std::vector<storage::PropertyId> NamesToProperties(const std::vector<std::string> &property_names, DbAccessor *dba);

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -4044,6 +4044,11 @@ class CallSubquery : public memgraph::query::Clause {
   // True if `CALL (*) { ... }` was used — import every variable currently in
   // the outer scope. When set, scoped_variables_ is left empty
   bool all_variables_scoped_{false};
+  // The graph bound for this subquery's scope by `CALL { USE <expr> ... }`.
+  // Null for an ordinary subquery; non-null binds <expr> (a projection or
+  // subgraph value, produced outside the block) as the scope's ambient graph.
+  // Resolved in the outer scope, so it is not visited by Accept.
+  Expression *use_graph_{nullptr};
 
   CallSubquery *Clone(AstStorage *storage) const override {
     CallSubquery *object = storage->Create<CallSubquery>();
@@ -4054,6 +4059,7 @@ class CallSubquery : public memgraph::query::Clause {
     }
     object->has_variable_scope_ = has_variable_scope_;
     object->all_variables_scoped_ = all_variables_scoped_;
+    object->use_graph_ = use_graph_ ? use_graph_->Clone(storage) : nullptr;
     return object;
   }
 

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -4383,6 +4383,12 @@ antlrcpp::Any CypherMainVisitor::visitCallSubquery(MemgraphCypher::CallSubqueryC
     }
   }
 
+  // `CALL { USE <expr> ... }` binds <expr> as the scope's ambient graph. The
+  // expression is resolved in the outer scope during semantic analysis.
+  if (auto *use_clause = ctx->useClause()) {
+    call_subquery->use_graph_ = std::any_cast<Expression *>(use_clause->expression()->accept(this));
+  }
+
   call_subquery->cypher_query_ = std::any_cast<CypherQuery *>(ctx->cypherQuery()->accept(this));
 
   PreQueryDirectives pre_query_directives;

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -418,7 +418,9 @@ periodicSubquery : IN TRANSACTIONS OF_TOKEN periodicCommitNumber=literal ROWS ;
 
 scopeClause : ASTERISK | variable ( ',' variable )* ;
 
-callSubquery : CALL ( '(' scopeClause? ')' )? '{' cypherQuery '}' ( periodicSubquery )? ;
+useClause : USE expression ;
+
+callSubquery : CALL ( '(' scopeClause? ')' )? '{' ( useClause )? cypherQuery '}' ( periodicSubquery )? ;
 
 streamQuery : checkStream
             | createStream

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -240,6 +240,7 @@ bool SymbolGenerator::PostVisit(CypherUnion &cypher_union) {
 // Clauses
 
 bool SymbolGenerator::PreVisit(Create &) {
+  RejectWriteInUseScope("CREATE");
   scopes_.back().in_create = true;
   return true;
 }
@@ -269,8 +270,28 @@ bool SymbolGenerator::PostVisit(CallProcedure &call_proc) {
   return true;
 }
 
+void SymbolGenerator::RejectWriteInUseScope(std::string_view clause) const {
+  if (scopes_.back().in_use_scope) {
+    throw SemanticException("{} is not allowed inside a USE scope: a USE scope is read-only.", clause);
+  }
+}
+
 bool SymbolGenerator::PreVisit(CallSubquery &call_sub) {
+  const bool outer_in_use_scope = scopes_.back().in_use_scope;
+
   Scope new_scope{.in_call_subquery = true};
+  // Inherited so a write nested anywhere in the block is still rejected.
+  new_scope.in_use_scope = outer_in_use_scope;
+
+  if (call_sub.use_graph_ != nullptr) {
+    if (outer_in_use_scope) {
+      throw SemanticException("A USE scope may not contain another USE: nesting is single-level.");
+    }
+    // The bound graph value is produced outside the block, so resolve the
+    // expression against the outer scope before entering the subquery scope.
+    call_sub.use_graph_->Accept(*this);
+    new_scope.in_use_scope = true;
+  }
 
   if (call_sub.has_variable_scope_) {
     // `CALL (...) { ... }`: resolve imports against the current outer scope
@@ -404,6 +425,7 @@ bool SymbolGenerator::PostVisit(Where &) {
 }
 
 bool SymbolGenerator::PreVisit(Merge &) {
+  RejectWriteInUseScope("MERGE");
   scopes_.back().in_merge = true;
   return true;
 }
@@ -443,6 +465,7 @@ bool SymbolGenerator::PostVisit(Match &) {
 }
 
 bool SymbolGenerator::PreVisit(Foreach &for_each) {
+  RejectWriteInUseScope("FOREACH");
   const auto &name = for_each.named_expression_->name_;
   scopes_.emplace_back(Scope());
   scopes_.back().in_foreach = true;
@@ -729,9 +752,15 @@ bool SymbolGenerator::PreVisit(NamedExpression &named_expression) {
 }
 
 bool SymbolGenerator::PreVisit(SetProperty & /*set_property*/) {
+  RejectWriteInUseScope("SET");
   auto &scope = scopes_.back();
   scope.in_set_property = true;
 
+  return true;
+}
+
+bool SymbolGenerator::PreVisit(SetProperties & /*set_properties*/) {
+  RejectWriteInUseScope("SET");
   return true;
 }
 
@@ -767,6 +796,11 @@ bool SymbolGenerator::PostVisit(SetProperty &set_property) {
   return true;
 }
 
+bool SymbolGenerator::PreVisit(RemoveProperty & /*remove_property*/) {
+  RejectWriteInUseScope("REMOVE");
+  return true;
+}
+
 bool SymbolGenerator::PostVisit(RemoveProperty &remove_property) {
   auto &scope = scopes_.back();
 
@@ -796,6 +830,7 @@ bool SymbolGenerator::PostVisit(RemoveProperty &remove_property) {
 }
 
 bool SymbolGenerator::PreVisit(SetLabels &set_labels) {
+  RejectWriteInUseScope("SET");
   auto &scope = scopes_.back();
   scope.in_set_labels = true;
   for (auto &label : set_labels.labels_) {
@@ -815,6 +850,7 @@ bool SymbolGenerator::PostVisit(SetLabels & /*set_labels*/) {
 }
 
 bool SymbolGenerator::PreVisit(RemoveLabels &remove_labels) {
+  RejectWriteInUseScope("REMOVE");
   auto &scope = scopes_.back();
   scope.in_remove_labels = true;
   for (auto &label : remove_labels.labels_) {
@@ -834,6 +870,7 @@ bool SymbolGenerator::PostVisit(RemoveLabels & /*remove_labels*/) {
 }
 
 bool SymbolGenerator::PreVisit(Delete & /*delete*/) {
+  RejectWriteInUseScope("DELETE");
   global_scope_.has_delete = true;
   return true;
 }

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <optional>
+#include <string_view>
 #include <vector>
 
 #include "query/exceptions.hpp"
@@ -76,6 +77,8 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   bool PostVisit(Foreach &) override;
   bool PreVisit(SetProperty & /*set_property*/) override;
   bool PostVisit(SetProperty & /*set_property*/) override;
+  bool PreVisit(SetProperties & /*set_properties*/) override;
+  bool PreVisit(RemoveProperty & /*remove_property*/) override;
   bool PostVisit(RemoveProperty & /*remove_property*/) override;
   bool PreVisit(SetLabels &) override;
   bool PostVisit(SetLabels & /*set_labels*/) override;
@@ -153,6 +156,10 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
     bool in_reduce{false};
     bool in_set_property{false};
     bool in_call_subquery{false};
+    // True anywhere inside a `CALL { USE ... }` scope. Inherited by nested
+    // scopes so a write nested in the block is still rejected. v1 USE scopes are
+    // read-only and single-level.
+    bool in_use_scope{false};
     bool has_return{false};
     bool in_set_labels{false};
     bool in_remove_labels{false};
@@ -185,6 +192,9 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   static std::optional<Symbol> FindSymbolInScope(const std::string &name, const Scope &scope, Symbol::Type type);
 
   bool HasSymbol(const std::string &name) const;
+
+  // Rejects a write clause inside a read-only `CALL { USE ... }` scope.
+  void RejectWriteInUseScope(std::string_view clause) const;
 
   // @return true if it added a predefined identifier with that name
   bool ConsumePredefinedIdentifier(const std::string &name);

--- a/src/query/graph_view.hpp
+++ b/src/query/graph_view.hpp
@@ -1,0 +1,161 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+#include "query/db_accessor.hpp"
+#include "query/virtual_graph.hpp"
+#include "query/virtual_node.hpp"
+#include "storage/v2/id_types.hpp"
+#include "storage/v2/view.hpp"
+
+namespace memgraph::query {
+
+// A range over a VirtualGraph's nodes, yielding each node by reference. The
+// VirtualGraph owns the nodes; the range only borrows its node map.
+class VirtualNodeRange final {
+  const VirtualGraph::node_map *nodes_;
+
+ public:
+  explicit VirtualNodeRange(const VirtualGraph::node_map &nodes) : nodes_(&nodes) {}
+
+  class Iterator final {
+    VirtualGraph::node_map::const_iterator it_;
+
+   public:
+    explicit Iterator(VirtualGraph::node_map::const_iterator it) : it_(it) {}
+
+    const VirtualNode &operator*() const { return *it_->second; }
+
+    Iterator &operator++() {
+      ++it_;
+      return *this;
+    }
+
+    bool operator==(const Iterator &other) const { return it_ == other.it_; }
+
+    bool operator!=(const Iterator &other) const { return it_ != other.it_; }
+  };
+
+  Iterator begin() const { return Iterator(nodes_->begin()); }
+
+  Iterator end() const { return Iterator(nodes_->end()); }
+};
+
+// One scanned vertex: a real VertexAccessor (identity view) or a projection's
+// VirtualNode. Both are concrete - a scan iterates over these directly, the
+// virtual boundary having been crossed once to obtain the range. The frame
+// already carries both kinds as a TypedValue, so an operator writes either.
+using ScanVertex = std::variant<VertexAccessor, VirtualNode>;
+
+// A range over the vertices yielded by one scan of a GraphView. The boundary is
+// crossed once to obtain the range; iteration is then over concrete elements, so
+// the real-graph read path is not regressed per row. The identity view backs it
+// with the real accessor's VerticesIterable; a projection backs it with its
+// VirtualGraph's nodes.
+class VertexRange final {
+  std::variant<VerticesIterable, VirtualNodeRange> impl_;
+
+ public:
+  explicit VertexRange(VerticesIterable iterable) : impl_(std::move(iterable)) {}
+
+  explicit VertexRange(VirtualNodeRange iterable) : impl_(std::move(iterable)) {}
+
+  class Iterator final {
+    std::variant<VerticesIterable::Iterator, VirtualNodeRange::Iterator> it_;
+
+   public:
+    explicit Iterator(VerticesIterable::Iterator it) : it_(std::move(it)) {}
+
+    explicit Iterator(VirtualNodeRange::Iterator it) : it_(std::move(it)) {}
+
+    ScanVertex operator*() const {
+      return std::visit([](const auto &it) -> ScanVertex { return *it; }, it_);
+    }
+
+    Iterator &operator++() {
+      std::visit([](auto &it) { ++it; }, it_);
+      return *this;
+    }
+
+    bool operator==(const Iterator &other) const { return it_ == other.it_; }
+
+    bool operator!=(const Iterator &other) const { return it_ != other.it_; }
+  };
+
+  Iterator begin() {
+    return std::visit([](auto &iterable) { return Iterator(iterable.begin()); }, impl_);
+  }
+
+  Iterator end() {
+    return std::visit([](auto &iterable) { return Iterator(iterable.end()); }, impl_);
+  }
+};
+
+// The single graph abstraction the read operators run against: scan the vertices
+// and map names to/from ids. Property reads and edge expansion stay on the
+// element (VertexAccessor / VirtualNode), not here.
+//
+// The real DbAccessor is the identity view (DbAccessorGraphView); a subgraph or
+// projection is a view layered over it. ExecutionContext binds the ambient view,
+// and a `CALL { USE ... }` scope rebinds it for the block.
+class GraphView {
+ public:
+  GraphView() = default;
+  GraphView(const GraphView &) = default;
+  GraphView(GraphView &&) = default;
+  GraphView &operator=(const GraphView &) = default;
+  GraphView &operator=(GraphView &&) = default;
+  virtual ~GraphView() = default;
+
+  // Full scan of the view's vertices. No index/label overload: inside a
+  // projection scope a label-filtered match is a full scan plus a filter, since
+  // a projection exposes no index.
+  virtual VertexRange Vertices(storage::View view) = 0;
+
+  virtual storage::LabelId NameToLabel(std::string_view name) = 0;
+  virtual const std::string &LabelToName(storage::LabelId label) const = 0;
+  virtual storage::PropertyId NameToProperty(std::string_view name) = 0;
+  virtual const std::string &PropertyToName(storage::PropertyId prop) const = 0;
+  virtual storage::EdgeTypeId NameToEdgeType(std::string_view name) = 0;
+  virtual const std::string &EdgeTypeToName(storage::EdgeTypeId type) const = 0;
+};
+
+// The identity view: the real graph seen as a GraphView. Every call forwards to
+// the underlying DbAccessor, so a real-graph scan through this view produces the
+// same vertices as scanning the accessor directly.
+class DbAccessorGraphView final : public GraphView {
+  DbAccessor *dba_;
+
+ public:
+  explicit DbAccessorGraphView(DbAccessor *dba) : dba_(dba) {}
+
+  VertexRange Vertices(storage::View view) override { return VertexRange{dba_->Vertices(view)}; }
+
+  storage::LabelId NameToLabel(std::string_view name) override { return dba_->NameToLabel(name); }
+
+  const std::string &LabelToName(storage::LabelId label) const override { return dba_->LabelToName(label); }
+
+  storage::PropertyId NameToProperty(std::string_view name) override { return dba_->NameToProperty(name); }
+
+  const std::string &PropertyToName(storage::PropertyId prop) const override { return dba_->PropertyToName(prop); }
+
+  storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return dba_->NameToEdgeType(name); }
+
+  const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return dba_->EdgeTypeToName(type); }
+};
+
+}  // namespace memgraph::query

--- a/src/query/graph_view.hpp
+++ b/src/query/graph_view.hpp
@@ -11,15 +11,23 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "query/db_accessor.hpp"
+#include "query/edge_accessor.hpp"
+#include "query/exceptions.hpp"
+#include "query/hops_limit.hpp"
+#include "query/virtual_edge.hpp"
 #include "query/virtual_graph.hpp"
 #include "query/virtual_node.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/result.hpp"
 #include "storage/v2/view.hpp"
 
 namespace memgraph::query {
@@ -105,9 +113,99 @@ class VertexRange final {
   }
 };
 
-// The single graph abstraction the read operators run against: scan the vertices
-// and map names to/from ids. Property reads and edge expansion stay on the
-// element (VertexAccessor / VirtualNode), not here.
+// One expanded edge: a real EdgeAccessor (identity or subgraph view) or a
+// projection's VirtualEdge. Mirrors ScanVertex - an expansion yields these
+// directly, the virtual boundary having been crossed once to obtain the range.
+using ScanEdge = std::variant<EdgeAccessor, VirtualEdge>;
+
+// A range over the edges yielded by one expansion of a GraphView node. As with
+// VertexRange the boundary is crossed once to obtain the range; iteration is then
+// over concrete elements. The identity and subgraph views back it with a real
+// EdgeAccessor vector (already filtered and counted by storage); a projection
+// backs it with the borrowed VirtualEdge pointers matching the requested
+// direction and filters. expanded_count is the number of edges examined during
+// the expansion (for hops accounting), counted before any type/destination filter
+// drops one - so a projection and the real graph account the same traversal.
+class EdgeRange final {
+  std::variant<std::vector<EdgeAccessor>, std::vector<const VirtualEdge *>> impl_;
+  int64_t expanded_count_{0};
+
+ public:
+  EdgeRange(std::vector<EdgeAccessor> edges, int64_t expanded_count)
+      : impl_(std::move(edges)), expanded_count_(expanded_count) {}
+
+  EdgeRange(std::vector<const VirtualEdge *> edges, int64_t expanded_count)
+      : impl_(std::move(edges)), expanded_count_(expanded_count) {}
+
+  [[nodiscard]] int64_t expanded_count() const { return expanded_count_; }
+
+  class Iterator final {
+    std::variant<std::vector<EdgeAccessor>::const_iterator, std::vector<const VirtualEdge *>::const_iterator> it_;
+
+   public:
+    explicit Iterator(std::vector<EdgeAccessor>::const_iterator it) : it_(it) {}
+
+    explicit Iterator(std::vector<const VirtualEdge *>::const_iterator it) : it_(it) {}
+
+    ScanEdge operator*() const {
+      return std::visit(
+          [](const auto &it) -> ScanEdge {
+            // The real arm dereferences to an EdgeAccessor; the projection arm
+            // dereferences to a VirtualEdge pointer, so it is deref'd once more to
+            // copy the edge into the variant.
+            using Elem = std::decay_t<decltype(*it)>;
+            if constexpr (std::is_same_v<Elem, EdgeAccessor>) {
+              return *it;
+            } else {
+              return **it;
+            }
+          },
+          it_);
+    }
+
+    Iterator &operator++() {
+      std::visit([](auto &it) { ++it; }, it_);
+      return *this;
+    }
+
+    bool operator==(const Iterator &other) const { return it_ == other.it_; }
+
+    bool operator!=(const Iterator &other) const { return it_ != other.it_; }
+  };
+
+  Iterator begin() const {
+    return std::visit([](const auto &edges) { return Iterator(edges.begin()); }, impl_);
+  }
+
+  Iterator end() const {
+    return std::visit([](const auto &edges) { return Iterator(edges.end()); }, impl_);
+  }
+};
+
+// Maps a storage edges result onto the query-layer edge/count shape, turning a
+// storage error into the query error the read path reports. Mirrors the read
+// path's edges-result unwrap; the operator's copy retires once expansion routes
+// through this seam.
+inline EdgeVertexAccessorResult UnwrapEdges(storage::Result<EdgeVertexAccessorResult> &&result) {
+  if (!result) {
+    switch (result.error()) {
+      case storage::Error::DELETED_OBJECT:
+        throw QueryRuntimeException("Trying to get relationships of a deleted node.");
+      case storage::Error::NONEXISTENT_OBJECT:
+        throw QueryRuntimeException("Trying to get relationships from a node that doesn't exist.");
+      case storage::Error::VERTEX_HAS_EDGES:
+      case storage::Error::SERIALIZATION_ERROR:
+      case storage::Error::PROPERTIES_DISABLED:
+        throw QueryRuntimeException("Unexpected error when accessing relationships.");
+    }
+  }
+  return std::move(*result);
+}
+
+// The single graph abstraction the read operators run against: scan the vertices,
+// expand a node's edges, and map names to/from ids. Property reads stay on the
+// element (VertexAccessor / VirtualNode); topology - scan and expand - is here, so
+// the operators run over real, subgraph, and projection graphs through one seam.
 //
 // The real DbAccessor is the identity view (DbAccessorGraphView); a subgraph or
 // projection is a view layered over it. ExecutionContext binds the ambient view,
@@ -125,6 +223,27 @@ class GraphView {
   // projection scope a label-filtered match is a full scan plus a filter, since
   // a projection exposes no index.
   virtual VertexRange Vertices(storage::View view) = 0;
+
+  // Expand a scanned node's out-/in-edges through the view. edge_types filters by
+  // type (empty = any); existing_dest, when set, keeps only the edge reaching that
+  // already-bound endpoint. `from` must match the view's element kind - a real
+  // vertex for the identity/subgraph views, a VirtualNode for a projection - which
+  // holds because a node is expanded through the same view that scanned it; a
+  // mismatch is a programming error.
+  //
+  // Topology filtering (type, destination) happens behind the seam; the range
+  // yields edges only. Fine-grained READ authorization is NOT applied here - it
+  // stays on the operator, which drops forbidden edges and neighbours per element -
+  // so the seam stays topology-only. hops threads the traversal's budget to storage
+  // for the identity and subgraph views; enforcing it over a projection lands with
+  // the variable-length routing (issue 43).
+  virtual EdgeRange OutEdges(const ScanVertex &from, storage::View view,
+                             const std::vector<storage::EdgeTypeId> &edge_types,
+                             const std::optional<ScanVertex> &existing_dest, HopsLimit *hops) = 0;
+
+  virtual EdgeRange InEdges(const ScanVertex &from, storage::View view,
+                            const std::vector<storage::EdgeTypeId> &edge_types,
+                            const std::optional<ScanVertex> &existing_dest, HopsLimit *hops) = 0;
 
   virtual storage::LabelId NameToLabel(std::string_view name) = 0;
   virtual const std::string &LabelToName(storage::LabelId label) const = 0;
@@ -144,6 +263,24 @@ class DbAccessorGraphView final : public GraphView {
   explicit DbAccessorGraphView(DbAccessor *dba) : dba_(dba) {}
 
   VertexRange Vertices(storage::View view) override { return VertexRange{dba_->Vertices(view)}; }
+
+  EdgeRange OutEdges(const ScanVertex &from, storage::View view, const std::vector<storage::EdgeTypeId> &edge_types,
+                     const std::optional<ScanVertex> &existing_dest, HopsLimit *hops) override {
+    const auto &vertex = std::get<VertexAccessor>(from);
+    auto result = existing_dest ? vertex.OutEdges(view, edge_types, std::get<VertexAccessor>(*existing_dest), hops)
+                                : vertex.OutEdges(view, edge_types, hops);
+    auto edges = UnwrapEdges(std::move(result));
+    return EdgeRange{std::move(edges.edges), edges.expanded_count};
+  }
+
+  EdgeRange InEdges(const ScanVertex &from, storage::View view, const std::vector<storage::EdgeTypeId> &edge_types,
+                    const std::optional<ScanVertex> &existing_dest, HopsLimit *hops) override {
+    const auto &vertex = std::get<VertexAccessor>(from);
+    auto result = existing_dest ? vertex.InEdges(view, edge_types, std::get<VertexAccessor>(*existing_dest), hops)
+                                : vertex.InEdges(view, edge_types, hops);
+    auto edges = UnwrapEdges(std::move(result));
+    return EdgeRange{std::move(edges.edges), edges.expanded_count};
+  }
 
   storage::LabelId NameToLabel(std::string_view name) override { return dba_->NameToLabel(name); }
 

--- a/src/query/graph_view.hpp
+++ b/src/query/graph_view.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -202,6 +203,24 @@ inline EdgeVertexAccessorResult UnwrapEdges(storage::Result<EdgeVertexAccessorRe
   return std::move(*result);
 }
 
+// Maps a storage degree result onto the query-layer count, turning a storage error into the query
+// error the read path reports. Mirrors the read path's degree unwrap.
+inline size_t UnwrapDegree(storage::Result<size_t> &&result) {
+  if (!result) {
+    switch (result.error()) {
+      case storage::Error::DELETED_OBJECT:
+        throw QueryRuntimeException("Trying to get degree of a deleted node.");
+      case storage::Error::NONEXISTENT_OBJECT:
+        throw QueryRuntimeException("Trying to get degree of a node that doesn't exist.");
+      case storage::Error::VERTEX_HAS_EDGES:
+      case storage::Error::SERIALIZATION_ERROR:
+      case storage::Error::PROPERTIES_DISABLED:
+        throw QueryRuntimeException("Unexpected error when getting node degree.");
+    }
+  }
+  return *result;
+}
+
 // The single graph abstraction the read operators run against: scan the vertices,
 // expand a node's edges, and map names to/from ids. Property reads stay on the
 // element (VertexAccessor / VirtualNode); topology - scan and expand - is here, so
@@ -212,7 +231,6 @@ inline EdgeVertexAccessorResult UnwrapEdges(storage::Result<EdgeVertexAccessorRe
 // and a `CALL { USE ... }` scope rebinds it for the block.
 class GraphView {
  public:
-  GraphView() = default;
   GraphView(const GraphView &) = default;
   GraphView(GraphView &&) = default;
   GraphView &operator=(const GraphView &) = default;
@@ -245,12 +263,32 @@ class GraphView {
                             const std::vector<storage::EdgeTypeId> &edge_types,
                             const std::optional<ScanVertex> &existing_dest, HopsLimit *hops) = 0;
 
-  virtual storage::LabelId NameToLabel(std::string_view name) = 0;
-  virtual const std::string &LabelToName(storage::LabelId label) const = 0;
-  virtual storage::PropertyId NameToProperty(std::string_view name) = 0;
-  virtual const std::string &PropertyToName(storage::PropertyId prop) const = 0;
-  virtual storage::EdgeTypeId NameToEdgeType(std::string_view name) = 0;
-  virtual const std::string &EdgeTypeToName(storage::EdgeTypeId type) const = 0;
+  // The (in, out) degree of a scanned node over this view: the real graph's fast per-vertex degree for
+  // the identity view, the member-filtered count for a subgraph, and the projection's edge counts for a
+  // projection. A node of the wrong kind for the view (a real vertex in a projection, or a synthetic
+  // node with no projection bound) has no topology here and reports {0, 0}.
+  virtual std::pair<int64_t, int64_t> Degree(const ScanVertex &from, storage::View view) = 0;
+
+  // Name<->id mapping is database-global, not view-specific: every view resolves names through the same
+  // DbAccessor, so these are shared non-virtual forwards, not per-adapter overrides.
+  storage::LabelId NameToLabel(std::string_view name) { return names_->NameToLabel(name); }
+
+  const std::string &LabelToName(storage::LabelId label) const { return names_->LabelToName(label); }
+
+  storage::PropertyId NameToProperty(std::string_view name) { return names_->NameToProperty(name); }
+
+  const std::string &PropertyToName(storage::PropertyId prop) const { return names_->PropertyToName(prop); }
+
+  storage::EdgeTypeId NameToEdgeType(std::string_view name) { return names_->NameToEdgeType(name); }
+
+  const std::string &EdgeTypeToName(storage::EdgeTypeId type) const { return names_->EdgeTypeToName(type); }
+
+ protected:
+  // The database-global name resolver every view shares. The identity view passes its own DbAccessor;
+  // a subgraph or projection passes the accessor it was built against.
+  explicit GraphView(DbAccessor *names) : names_(names) {}
+
+  DbAccessor *names_;
 };
 
 // The identity view: the real graph seen as a GraphView. Every call forwards to
@@ -260,7 +298,7 @@ class DbAccessorGraphView final : public GraphView {
   DbAccessor *dba_;
 
  public:
-  explicit DbAccessorGraphView(DbAccessor *dba) : dba_(dba) {}
+  explicit DbAccessorGraphView(DbAccessor *dba) : GraphView(dba), dba_(dba) {}
 
   VertexRange Vertices(storage::View view) override { return VertexRange{dba_->Vertices(view)}; }
 
@@ -282,17 +320,14 @@ class DbAccessorGraphView final : public GraphView {
     return EdgeRange{std::move(edges.edges), edges.expanded_count};
   }
 
-  storage::LabelId NameToLabel(std::string_view name) override { return dba_->NameToLabel(name); }
-
-  const std::string &LabelToName(storage::LabelId label) const override { return dba_->LabelToName(label); }
-
-  storage::PropertyId NameToProperty(std::string_view name) override { return dba_->NameToProperty(name); }
-
-  const std::string &PropertyToName(storage::PropertyId prop) const override { return dba_->PropertyToName(prop); }
-
-  storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return dba_->NameToEdgeType(name); }
-
-  const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return dba_->EdgeTypeToName(type); }
+  // The real graph's per-vertex degree (O(1) storage metadata). A synthetic node reaching the identity
+  // view has no real-graph topology and reports {0, 0}.
+  std::pair<int64_t, int64_t> Degree(const ScanVertex &from, storage::View view) override {
+    const auto *vertex = std::get_if<VertexAccessor>(&from);
+    if (vertex == nullptr) return {0, 0};
+    return {static_cast<int64_t>(UnwrapDegree(vertex->InDegree(view))),
+            static_cast<int64_t>(UnwrapDegree(vertex->OutDegree(view)))};
+  }
 };
 
 }  // namespace memgraph::query

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -41,6 +41,7 @@
 #include "query/virtual_graph_view.hpp"
 #include "query/virtual_node.hpp"
 #include "storage/v2/point_functions.hpp"
+#include "storage/v2/property_store.hpp"
 #include "utils/case_insensitve_set.hpp"
 #include "utils/pmr/string.hpp"
 #include "utils/string.hpp"
@@ -454,14 +455,67 @@ TypedValue Last(const TypedValue *args, int64_t nargs, const FunctionContext &ct
 
 constexpr auto allow_all_properties = [](storage::PropertyId) { return true; };
 
-// Returned by value: a virtual node's Properties() merges its origin's properties with its overlay
-// and is not a stored map.
-auto VirtualProperties(const TypedValue &value) -> VirtualNode::property_map {
-  if (value.IsVirtualNode()) return value.ValueVirtualNode().Properties();
-  const auto &edge_properties = value.ValueVirtualEdge().Properties();
-  VirtualNode::property_map result{edge_properties.get_allocator()};
-  for (const auto &[id, property_value] : edge_properties) result.insert_or_assign(id, property_value);
-  return result;
+// One binding-aware, view-honoring, auth-filtered pass over a graph element's properties, shared by
+// properties()/keys()/values(). Invokes `f(PropertyId, const PropertyValue &, bool allowed)` for each
+// property, where `allowed` is the fine-grained READ permission for that property (always true when
+// no auth checker is bound, and for virtual nodes/edges, which mint no real-graph privileges of their
+// own). `count_hint(size_t)` is invoked once with the property count so a list-building caller can
+// reserve (a map-building caller passes a no-op). A real accessor is iterated in its stored PropertyId
+// order at `view`; a virtual node merges its origin (lazy read-through at `view`) with its overlay,
+// hidden keys omitted; a virtual edge yields its overlay (no origin, so `view` is irrelevant). `fn`
+// names the caller for error wording. Beyond the accessor's own result the helper makes no further
+// copy of the property set, so the stored order is preserved and keys() never copies a value it
+// discards. (propertySize() reads a single key lazily instead so an unread embedding is never
+// materialized; see VirtualPropertySize.)
+template <typename CountFn, typename F>
+void ForEachElementProperty(const TypedValue &value, storage::View view, std::string_view fn,
+                            FineGrainedAuthChecker const *checker, CountFn &&count_hint, F &&f) {
+  auto emit = [&](const auto &props, auto &&is_allowed) {
+    count_hint(props.size());
+    for (const auto &[id, property_value] : props) f(id, property_value, is_allowed(id));
+  };
+  auto absorb = [&](auto &&maybe_props, auto &&is_allowed) {
+    if (!maybe_props) {
+      switch (maybe_props.error()) {
+        case storage::Error::DELETED_OBJECT:
+          throw QueryRuntimeException("Trying to get {} from a deleted object.", fn);
+        case storage::Error::NONEXISTENT_OBJECT:
+          throw QueryRuntimeException("Trying to get {} from an object that doesn't exist.", fn);
+        case storage::Error::SERIALIZATION_ERROR:
+        case storage::Error::VERTEX_HAS_EDGES:
+        case storage::Error::PROPERTIES_DISABLED:
+          throw QueryRuntimeException("Unexpected error when getting {}.", fn);
+      }
+    }
+    emit(*maybe_props, is_allowed);
+  };
+  if (value.IsVertex()) {
+    auto const &vertex = value.ValueVertex();
+    if (!checker) {
+      absorb(vertex.Properties(view), allow_all_properties);
+      return;
+    }
+    auto maybe_labels = vertex.Labels(view);
+    if (!maybe_labels) ThrowVertexLabelsReadFailure(maybe_labels.error());
+    absorb(vertex.Properties(view), [&](storage::PropertyId prop) {
+      return checker->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
+    });
+  } else if (value.IsEdge()) {
+    auto const &edge = value.ValueEdge();
+    if (!checker) {
+      absorb(edge.Properties(view), allow_all_properties);
+      return;
+    }
+    absorb(edge.Properties(view), [&](storage::PropertyId prop) {
+      return checker->HasPropertyPermission(edge.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
+    });
+  } else if (value.IsVirtualNode()) {
+    auto maybe_props = value.ValueVirtualNode().Properties(view);
+    if (!maybe_props) throw QueryRuntimeException("Reading {} of a projected node's origin failed.", fn);
+    emit(*maybe_props, allow_all_properties);
+  } else {
+    emit(value.ValueVirtualEdge().Properties(), allow_all_properties);
+  }
 }
 
 // NOTE: Denied properties appear as keys with null values. This differs from
@@ -470,71 +524,22 @@ auto VirtualProperties(const TypedValue &value) -> VirtualNode::property_map {
 TypedValue Properties(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex, Edge>>("properties", args, nargs);
   auto *dba = ctx.db_accessor;
-  auto get_properties = [&](const auto &record_accessor, auto const &is_allowed) {
-    TypedValue::TMap properties(ctx.memory);
-    auto maybe_props = record_accessor.Properties(ctx.view);
-    if (!maybe_props) {
-      switch (maybe_props.error()) {
-        case storage::Error::DELETED_OBJECT:
-          throw QueryRuntimeException("Trying to get properties from a deleted object.");
-        case storage::Error::NONEXISTENT_OBJECT:
-          throw query::QueryRuntimeException("Trying to get properties from an object that doesn't exist.");
-        case storage::Error::SERIALIZATION_ERROR:
-        case storage::Error::VERTEX_HAS_EDGES:
-        case storage::Error::PROPERTIES_DISABLED:
-          throw QueryRuntimeException("Unexpected error when getting properties.");
-      }
-    }
-    for (const auto &property : *maybe_props) {
-      auto key = TypedValue::TString(dba->PropertyToName(property.first), ctx.memory);
-      if (is_allowed(property.first)) {
-        auto typed_value =
-            TypedValue(property.second, ctx.db_accessor->GetStorageAccessor()->GetNameIdMapper(), ctx.memory);
-        properties.emplace(std::move(key), std::move(typed_value));
-      } else {
-        properties.emplace(std::move(key), TypedValue(ctx.memory));
-      }
-    }
-    return TypedValue(std::move(properties));
-  };
-  auto const *checker = ctx.auth_checker;
-
   const auto &value = args[0];
-  if (value.IsNull()) {
-    return TypedValue(ctx.memory);
-  } else if (value.IsVirtualNode()) {
-    auto const &vn = value.ValueVirtualNode();
-    TypedValue::TMap properties(ctx.memory);
-    for (auto const &[prop_id, prop_value] : vn.Properties()) {
-      properties.emplace(TypedValue::TString(dba->PropertyToName(prop_id), ctx.memory),
-                         TypedValue(prop_value, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
-    }
-    return TypedValue(std::move(properties));
-  } else if (value.IsVirtualEdge()) {
-    auto const &ve = value.ValueVirtualEdge();
-    TypedValue::TMap properties(ctx.memory);
-    for (auto const &[prop_id, prop_value] : ve.Properties()) {
-      properties.emplace(TypedValue::TString(dba->PropertyToName(prop_id), ctx.memory),
-                         TypedValue(prop_value, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
-    }
-    return TypedValue(std::move(properties));
-  }
-  if (value.IsVertex()) {
-    auto const &vertex = value.ValueVertex();
-    if (!checker) return get_properties(vertex, allow_all_properties);
-    auto maybe_labels = vertex.Labels(ctx.view);
-    if (!maybe_labels) {
-      ThrowVertexLabelsReadFailure(maybe_labels.error());
-    }
-    return get_properties(vertex, [&](storage::PropertyId prop) {
-      return checker->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
-    });
-  }
-  auto const &edge = value.ValueEdge();
-  if (!checker) return get_properties(edge, allow_all_properties);
-  return get_properties(edge, [&](storage::PropertyId prop) {
-    return checker->HasPropertyPermission(edge.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
-  });
+  if (value.IsNull()) return TypedValue(ctx.memory);
+  TypedValue::TMap properties(ctx.memory);
+  // Denied properties appear as keys with null values (see the NOTE above); keys()/values() omit them.
+  ForEachElementProperty(
+      value, ctx.view, "properties", ctx.auth_checker, [](size_t) {},
+      [&](storage::PropertyId id, const storage::PropertyValue &pv, bool allowed) {
+        auto key = TypedValue::TString(dba->PropertyToName(id), ctx.memory);
+        if (allowed) {
+          properties.emplace(std::move(key),
+                             TypedValue(pv, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
+        } else {
+          properties.emplace(std::move(key), TypedValue(ctx.memory));
+        }
+      });
+  return TypedValue(std::move(properties));
 }
 
 TypedValue RandomUuid(const TypedValue * /*args*/, int64_t /*nargs*/, const FunctionContext &ctx) {
@@ -559,6 +564,26 @@ TypedValue Size(const TypedValue *args, int64_t nargs, const FunctionContext &ct
   }
 }
 
+namespace {
+
+// The encoded byte size of a virtual element's property value, matching the metric
+// storage::*::GetPropertySize reports for a real accessor: the value's footprint once encoded
+// into a PropertyStore. The binding-aware read is the seam - an overlay node reads through to
+// its origin for an origin-bound key, a hidden or absent key returns null and so contributes 0.
+template <typename VirtualElement>
+uint64_t VirtualPropertySize(const VirtualElement &element, storage::PropertyId key, storage::View view) {
+  auto maybe_value = element.GetProperty(view, key);
+  if (!maybe_value) {
+    throw QueryRuntimeException("Reading a property of a projected element's origin failed.");
+  }
+  if (maybe_value->IsNull()) return 0;
+  storage::PropertyStore store;
+  store.SetProperty(key, *maybe_value);
+  return store.PropertySize(key);
+}
+
+}  // namespace
+
 TypedValue PropertySize(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex, Edge>, Or<String>>("propertySize", args, nargs);
 
@@ -577,6 +602,10 @@ TypedValue PropertySize(const TypedValue *args, int64_t nargs, const FunctionCon
     property_size = graph_entity.ValueVertex().GetPropertySize(*maybe_property_id, ctx.view).value();
   } else if (graph_entity.IsEdge()) {
     property_size = graph_entity.ValueEdge().GetPropertySize(*maybe_property_id, ctx.view).value();
+  } else if (graph_entity.IsVirtualNode()) {
+    property_size = VirtualPropertySize(graph_entity.ValueVirtualNode(), *maybe_property_id, ctx.view);
+  } else if (graph_entity.IsVirtualEdge()) {
+    property_size = VirtualPropertySize(graph_entity.ValueVirtualEdge(), *maybe_property_id, ctx.view);
   }
 
   return TypedValue(static_cast<int64_t>(property_size), ctx.memory);
@@ -889,151 +918,43 @@ TypedValue ValueType(const TypedValue *args, int64_t nargs, const FunctionContex
   }
 }
 
-// TODO: How is Keys different from Properties function?
 TypedValue Keys(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex, Edge, Map>>("keys", args, nargs);
   auto *dba = ctx.db_accessor;
-  auto get_keys = [&](const auto &record_accessor, auto const &is_allowed) {
-    TypedValue::TVector keys(ctx.memory);
-    auto maybe_props = record_accessor.Properties(ctx.view);
-    if (!maybe_props) {
-      switch (maybe_props.error()) {
-        case storage::Error::DELETED_OBJECT:
-          throw QueryRuntimeException("Trying to get keys from a deleted object.");
-        case storage::Error::NONEXISTENT_OBJECT:
-          throw query::QueryRuntimeException("Trying to get keys from an object that doesn't exist.");
-        case storage::Error::SERIALIZATION_ERROR:
-        case storage::Error::VERTEX_HAS_EDGES:
-        case storage::Error::PROPERTIES_DISABLED:
-          throw QueryRuntimeException("Unexpected error when getting keys.");
-      }
-    }
-    for (const auto &property : *maybe_props) {
-      if (is_allowed(property.first)) keys.emplace_back(dba->PropertyToName(property.first));
-    }
-    return TypedValue(std::move(keys));
-  };
-  auto const *checker = ctx.auth_checker;
-
   const auto &value = args[0];
   if (value.IsNull()) {
     return TypedValue(ctx.memory);
   }
-  if (value.IsVertex()) {
-    auto const &vertex = value.ValueVertex();
-    if (!checker) return get_keys(vertex, allow_all_properties);
-    auto maybe_labels = vertex.Labels(ctx.view);
-    if (!maybe_labels) {
-      ThrowVertexLabelsReadFailure(maybe_labels.error());
-    }
-    return get_keys(vertex, [&](storage::PropertyId prop) {
-      return checker->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
-    });
-  }
-  if (value.IsEdge()) {
-    auto const &edge = value.ValueEdge();
-    if (!checker) return get_keys(edge, allow_all_properties);
-    return get_keys(edge, [&](storage::PropertyId prop) {
-      return checker->HasPropertyPermission(edge.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
-    });
-  }
-  if (value.IsVirtualNode()) {
-    TypedValue::TVector keys(ctx.memory);
-    for (auto const &[prop_id, prop_value] : value.ValueVirtualNode().Properties()) {
-      keys.emplace_back(dba->PropertyToName(prop_id));
-    }
-    return TypedValue(std::move(keys));
-  }
-  if (value.IsVirtualEdge()) {
-    TypedValue::TVector keys(ctx.memory);
-    for (auto const &[prop_id, prop_value] : value.ValueVirtualEdge().Properties()) {
-      keys.emplace_back(dba->PropertyToName(prop_id));
-    }
-    return TypedValue(std::move(keys));
-  }
-
-  // map
   TypedValue::TVector keys(ctx.memory);
-  for (const auto &[string_key, value] : value.ValueMap()) {
-    keys.emplace_back(string_key);
+  if (value.IsMap()) {
+    for (const auto &[string_key, map_value] : value.ValueMap()) keys.emplace_back(string_key);
+    return TypedValue(std::move(keys));
   }
+  ForEachElementProperty(
+      value, ctx.view, "keys", ctx.auth_checker, [&](size_t n) { keys.reserve(n); },
+      [&](storage::PropertyId id, const storage::PropertyValue &, bool allowed) {
+        if (allowed) keys.emplace_back(TypedValue(dba->PropertyToName(id), ctx.memory));
+      });
   return TypedValue(std::move(keys));
 }
 
 TypedValue Values(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex, Edge, Map>>("values", args, nargs);
-
-  auto get_values = [&](const auto &record_accessor, auto const &is_allowed) {
-    TypedValue::TVector values(ctx.memory);
-    auto maybe_props = record_accessor.Properties(ctx.view);
-    if (!maybe_props) {
-      switch (maybe_props.error()) {
-        case storage::Error::DELETED_OBJECT:
-          throw QueryRuntimeException("Trying to get keys from a deleted object.");
-        case storage::Error::NONEXISTENT_OBJECT:
-          throw query::QueryRuntimeException("Trying to get keys from an object that doesn't exist.");
-        case storage::Error::SERIALIZATION_ERROR:
-        case storage::Error::VERTEX_HAS_EDGES:
-        case storage::Error::PROPERTIES_DISABLED:
-          throw QueryRuntimeException("Unexpected error when getting keys.");
-      }
-    }
-    for (const auto &[key, value] : *maybe_props) {
-      if (is_allowed(key)) {
-        values.emplace_back(TypedValue(value, ctx.db_accessor->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
-      }
-    }
-    return TypedValue(std::move(values));
-  };
-
-  auto const *checker = ctx.auth_checker;
-
+  auto *dba = ctx.db_accessor;
   const auto &value = args[0];
   if (value.IsNull()) {
     return TypedValue(ctx.memory);
   }
-  if (value.IsVertex()) {
-    auto const &vertex = value.ValueVertex();
-    if (!checker) return get_values(vertex, allow_all_properties);
-    auto maybe_labels = vertex.Labels(ctx.view);
-    if (!maybe_labels) {
-      ThrowVertexLabelsReadFailure(maybe_labels.error());
-    }
-    return get_values(vertex, [&](storage::PropertyId prop) {
-      return checker->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
-    });
-  }
-  if (value.IsEdge()) {
-    auto const &edge = value.ValueEdge();
-    if (!checker) return get_values(edge, allow_all_properties);
-    return get_values(edge, [&](storage::PropertyId prop) {
-      return checker->HasPropertyPermission(edge.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
-    });
-  }
-  auto *dba = ctx.db_accessor;
-  if (value.IsVirtualNode()) {
-    TypedValue::TVector values(ctx.memory);
-    for (auto const &[prop_id, prop_value] : value.ValueVirtualNode().Properties()) {
-      // NOLINTNEXTLINE(modernize-use-emplace)
-      values.emplace_back(TypedValue(prop_value, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
-    }
-    return TypedValue(std::move(values));
-  }
-  if (value.IsVirtualEdge()) {
-    TypedValue::TVector values(ctx.memory);
-    for (auto const &[prop_id, prop_value] : value.ValueVirtualEdge().Properties()) {
-      // NOLINTNEXTLINE(modernize-use-emplace)
-      values.emplace_back(TypedValue(prop_value, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
-    }
-    return TypedValue(std::move(values));
-  }
-
-  // map
   TypedValue::TVector values(ctx.memory);
-  for (const auto &[string_key, value] : value.ValueMap()) {
-    values.emplace_back(value);
+  if (value.IsMap()) {
+    for (const auto &[string_key, map_value] : value.ValueMap()) values.emplace_back(map_value);
+    return TypedValue(std::move(values));
   }
-
+  ForEachElementProperty(
+      value, ctx.view, "values", ctx.auth_checker, [&](size_t n) { values.reserve(n); },
+      [&](storage::PropertyId, const storage::PropertyValue &pv, bool allowed) {
+        if (allowed) values.emplace_back(TypedValue(pv, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
+      });
   return TypedValue(std::move(values));
 }
 
@@ -1307,15 +1228,27 @@ TypedValue Counter(const TypedValue *args, int64_t nargs, const FunctionContext 
   return TypedValue(value, context.memory);
 }
 
+// The query-local external id for a synthetic Gid, or the raw synthetic id when there is no mapper
+// (a path with no query context).
+int64_t ExternalSyntheticId(storage::Gid gid, const FunctionContext &ctx) {
+  if (ctx.synthetic_id_mapper) return ctx.synthetic_id_mapper->ExternalId(gid);
+  return gid.AsInt();
+}
+
 TypedValue IdOf(const TypedValue &arg, const FunctionContext &ctx) {
   if (arg.IsNull()) {
     return TypedValue(ctx.memory);
   } else if (arg.IsVirtualNode()) {
-    return TypedValue(arg.ValueVirtualNode().CypherId(), ctx.memory);
+    const auto &vnode = arg.ValueVirtualNode();
+    // An overlay node (one derived over a real vertex) reports its origin's real id, so id() is the
+    // entity's identity in the real graph. A synthetic node has no origin and reports its query-local
+    // external id.
+    if (vnode.HasOrigin()) return TypedValue(vnode.Origin()->CypherId(), ctx.memory);
+    return TypedValue(ExternalSyntheticId(vnode.Gid(), ctx), ctx.memory);
   } else if (arg.IsVertex()) {
     return TypedValue(arg.ValueVertex().CypherId(), ctx.memory);
   } else if (arg.IsVirtualEdge()) {
-    return TypedValue(arg.ValueVirtualEdge().Gid().AsInt(), ctx.memory);
+    return TypedValue(ExternalSyntheticId(arg.ValueVirtualEdge().Gid(), ctx), ctx.memory);
   } else {
     return TypedValue(arg.ValueEdge().CypherId(), ctx.memory);
   }
@@ -1324,6 +1257,22 @@ TypedValue IdOf(const TypedValue &arg, const FunctionContext &ctx) {
 TypedValue Id(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex, Edge>>("id", args, nargs);
   return IdOf(args[0], ctx);
+}
+
+// The overlay-local id: the query-local external id for a virtual node or edge (whether synthetic or
+// an overlay over a real entity), and null for a real entity that has no overlay identity.
+TypedValue VirtualIdOf(const TypedValue &arg, const FunctionContext &ctx) {
+  if (arg.IsVirtualNode()) {
+    return TypedValue(ExternalSyntheticId(arg.ValueVirtualNode().Gid(), ctx), ctx.memory);
+  } else if (arg.IsVirtualEdge()) {
+    return TypedValue(ExternalSyntheticId(arg.ValueVirtualEdge().Gid(), ctx), ctx.memory);
+  }
+  return TypedValue(ctx.memory);
+}
+
+TypedValue VirtualId(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<Or<Null, Vertex, Edge>>("virtual_id", args, nargs);
+  return VirtualIdOf(args[0], ctx);
 }
 
 // Returns the id as a string for compatibility with external integrations.
@@ -2219,6 +2168,7 @@ auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{
     {"ENDNODE", func_info{.func_ = EndNode, .is_pure_ = true}},
     {"HEAD", func_info{.func_ = Head, .is_pure_ = true}},
     {kId, func_info{.func_ = Id, .is_pure_ = true}},
+    {kVirtualId, func_info{.func_ = VirtualId, .is_pure_ = true}},
     {kElementId, func_info{.func_ = ElementId, .is_pure_ = true}},
     {"LAST", func_info{.func_ = Last, .is_pure_ = true}},
     {"PROPERTIES", func_info{.func_ = Properties, .is_pure_ = true}},

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -35,8 +35,10 @@
 #include "query/procedure/module.hpp"
 #include "query/query_user.hpp"
 #include "query/string_helpers.hpp"
+#include "query/subgraph_graph_view.hpp"
 #include "query/typed_value.hpp"
 #include "query/virtual_graph.hpp"
+#include "query/virtual_graph_view.hpp"
 #include "query/virtual_node.hpp"
 #include "storage/v2/point_functions.hpp"
 #include "utils/case_insensitve_set.hpp"
@@ -624,29 +626,61 @@ TypedValue IsEmpty(const TypedValue *args, int64_t nargs, const FunctionContext 
   }
 }
 
+// Resolves a node's (in, out) degree over the ambient graph view: a projection
+// node counts the projection's edges, a subgraph member counts only its member
+// edges, and a real vertex on the identity view (or with no view bound) counts
+// the real graph's edges.
+std::pair<int64_t, int64_t> AmbientInOutDegree(const TypedValue &arg, const FunctionContext &ctx) {
+  if (arg.IsVirtualNode()) {
+    const auto gid = arg.ValueVirtualNode().Gid();
+    if (auto *projection = dynamic_cast<VirtualGraphView *>(ctx.graph_view)) {
+      return {static_cast<int64_t>(projection->InEdges(gid).size()),
+              static_cast<int64_t>(projection->OutEdges(gid).size())};
+    }
+    // A virtual node outside a projection scope (a literal virtualNode(), no
+    // VirtualGraphView bound) has no ambient topology.
+    return {0, 0};
+  }
+  const auto &vertex = arg.ValueVertex();
+  if (auto *subgraph = dynamic_cast<SubgraphGraphView *>(ctx.graph_view)) {
+    const auto count_members = [&](auto maybe_edges) -> int64_t {
+      if (!maybe_edges) throw QueryRuntimeException("Trying to get degree of a node that doesn't exist.");
+      int64_t count = 0;
+      for (const auto &edge : maybe_edges->edges) {
+        if (subgraph->ContainsEdge(edge)) ++count;
+      }
+      return count;
+    };
+    return {count_members(vertex.InEdges(ctx.view)), count_members(vertex.OutEdges(ctx.view))};
+  }
+  if (dynamic_cast<VirtualGraphView *>(ctx.graph_view) != nullptr) {
+    // A real vertex is not a node of a projection, so it has no edges in the
+    // ambient projection graph. Reached when a real vertex is imported into a
+    // CALL { USE <projection> ... } scope; the scope must not report the
+    // vertex's real-graph degree.
+    return {0, 0};
+  }
+  return {static_cast<int64_t>(UnwrapDegreeResult(vertex.InDegree(ctx.view))),
+          static_cast<int64_t>(UnwrapDegreeResult(vertex.OutDegree(ctx.view)))};
+}
+
 TypedValue Degree(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex>>("degree", args, nargs);
   if (args[0].IsNull()) return TypedValue(ctx.memory);
-  const auto &vertex = args[0].ValueVertex();
-  size_t out_degree = UnwrapDegreeResult(vertex.OutDegree(ctx.view));
-  size_t in_degree = UnwrapDegreeResult(vertex.InDegree(ctx.view));
-  return TypedValue(static_cast<int64_t>(out_degree + in_degree), ctx.memory);
+  const auto [in_degree, out_degree] = AmbientInOutDegree(args[0], ctx);
+  return TypedValue(in_degree + out_degree, ctx.memory);
 }
 
 TypedValue InDegree(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex>>("inDegree", args, nargs);
   if (args[0].IsNull()) return TypedValue(ctx.memory);
-  const auto &vertex = args[0].ValueVertex();
-  size_t in_degree = UnwrapDegreeResult(vertex.InDegree(ctx.view));
-  return TypedValue(static_cast<int64_t>(in_degree), ctx.memory);
+  return TypedValue(AmbientInOutDegree(args[0], ctx).first, ctx.memory);
 }
 
 TypedValue OutDegree(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex>>("outDegree", args, nargs);
   if (args[0].IsNull()) return TypedValue(ctx.memory);
-  const auto &vertex = args[0].ValueVertex();
-  size_t out_degree = UnwrapDegreeResult(vertex.OutDegree(ctx.view));
-  return TypedValue(static_cast<int64_t>(out_degree), ctx.memory);
+  return TypedValue(AmbientInOutDegree(args[0], ctx).second, ctx.memory);
 }
 
 // Type-set shared by each strict to* and its *OrNull variant: strict throws on a rejected type, *OrNull

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -510,9 +510,24 @@ void ForEachElementProperty(const TypedValue &value, storage::View view, std::st
       return checker->HasPropertyPermission(edge.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
     });
   } else if (value.IsVirtualNode()) {
-    auto maybe_props = value.ValueVirtualNode().Properties(view);
+    auto const &vnode = value.ValueVirtualNode();
+    auto maybe_props = vnode.Properties(view);
     if (!maybe_props) throw QueryRuntimeException("Reading {} of a projected node's origin failed.", fn);
-    emit(*maybe_props, allow_all_properties);
+    auto const &origin = vnode.Origin();
+    if (!checker || !origin) {
+      // A synthetic node (no origin) mints no real-graph data; without a checker nothing is filtered.
+      emit(*maybe_props, allow_all_properties);
+    } else {
+      // An overlay node reads through to its origin, so origin-backed properties get the origin's
+      // per-property READ permission (over the origin's labels), matching a real vertex. An
+      // overlay-bound override is the author's own value and is exempt.
+      auto maybe_labels = origin->Labels(view);
+      if (!maybe_labels) ThrowVertexLabelsReadFailure(maybe_labels.error());
+      emit(*maybe_props, [&](storage::PropertyId prop) {
+        return vnode.IsOverlayBound(prop) ||
+               checker->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
+      });
+    }
   } else {
     emit(value.ValueVirtualEdge().Properties(), allow_all_properties);
   }
@@ -529,12 +544,15 @@ TypedValue Properties(const TypedValue *args, int64_t nargs, const FunctionConte
   TypedValue::TMap properties(ctx.memory);
   // Denied properties appear as keys with null values (see the NOTE above); keys()/values() omit them.
   ForEachElementProperty(
-      value, ctx.view, "properties", ctx.auth_checker, [](size_t) {},
+      value,
+      ctx.view,
+      "properties",
+      ctx.auth_checker,
+      [](size_t) {},
       [&](storage::PropertyId id, const storage::PropertyValue &pv, bool allowed) {
         auto key = TypedValue::TString(dba->PropertyToName(id), ctx.memory);
         if (allowed) {
-          properties.emplace(std::move(key),
-                             TypedValue(pv, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
+          properties.emplace(std::move(key), TypedValue(pv, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
         } else {
           properties.emplace(std::move(key), TypedValue(ctx.memory));
         }
@@ -931,7 +949,11 @@ TypedValue Keys(const TypedValue *args, int64_t nargs, const FunctionContext &ct
     return TypedValue(std::move(keys));
   }
   ForEachElementProperty(
-      value, ctx.view, "keys", ctx.auth_checker, [&](size_t n) { keys.reserve(n); },
+      value,
+      ctx.view,
+      "keys",
+      ctx.auth_checker,
+      [&](size_t n) { keys.reserve(n); },
       [&](storage::PropertyId id, const storage::PropertyValue &, bool allowed) {
         if (allowed) keys.emplace_back(TypedValue(dba->PropertyToName(id), ctx.memory));
       });
@@ -951,7 +973,11 @@ TypedValue Values(const TypedValue *args, int64_t nargs, const FunctionContext &
     return TypedValue(std::move(values));
   }
   ForEachElementProperty(
-      value, ctx.view, "values", ctx.auth_checker, [&](size_t n) { values.reserve(n); },
+      value,
+      ctx.view,
+      "values",
+      ctx.auth_checker,
+      [&](size_t n) { values.reserve(n); },
       [&](storage::PropertyId, const storage::PropertyValue &pv, bool allowed) {
         if (allowed) values.emplace_back(TypedValue(pv, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
       });

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -674,7 +674,9 @@ std::pair<int64_t, int64_t> AmbientInOutDegree(const TypedValue &arg, const Func
   // there is no view-kind branch here.
   const ScanVertex node = arg.IsVirtualNode() ? ScanVertex{arg.ValueVirtualNode()} : ScanVertex{arg.ValueVertex()};
   if (ctx.graph_view != nullptr) return ctx.graph_view->Degree(node, ctx.view);
-  // No ambient view bound (a real vertex evaluated outside a graph scope): fall back to real degree.
+  // No ambient view bound (evaluated outside a graph scope). A synthetic node has no ambient topology;
+  // a real vertex falls back to the real graph's per-vertex degree.
+  if (arg.IsVirtualNode()) return {0, 0};
   const auto &vertex = arg.ValueVertex();
   return {static_cast<int64_t>(UnwrapDegreeResult(vertex.InDegree(ctx.view))),
           static_cast<int64_t>(UnwrapDegreeResult(vertex.OutDegree(ctx.view)))};

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -31,11 +31,13 @@
 #include "query/auth_checker.hpp"
 #include "query/common.hpp"
 #include "query/exceptions.hpp"
+#include "query/overlay_authorization.hpp"
 #include "query/procedure/mg_procedure_impl.hpp"
 #include "query/procedure/module.hpp"
 #include "query/query_user.hpp"
 #include "query/string_helpers.hpp"
 #include "query/subgraph_graph_view.hpp"
+#include "query/synthetic_gid.hpp"
 #include "query/typed_value.hpp"
 #include "query/virtual_graph.hpp"
 #include "query/virtual_graph_view.hpp"
@@ -513,21 +515,9 @@ void ForEachElementProperty(const TypedValue &value, storage::View view, std::st
     auto const &vnode = value.ValueVirtualNode();
     auto maybe_props = vnode.Properties(view);
     if (!maybe_props) throw QueryRuntimeException("Reading {} of a projected node's origin failed.", fn);
-    auto const &origin = vnode.Origin();
-    if (!checker || !origin) {
-      // A synthetic node (no origin) mints no real-graph data; without a checker nothing is filtered.
-      emit(*maybe_props, allow_all_properties);
-    } else {
-      // An overlay node reads through to its origin, so origin-backed properties get the origin's
-      // per-property READ permission (over the origin's labels), matching a real vertex. An
-      // overlay-bound override is the author's own value and is exempt.
-      auto maybe_labels = origin->Labels(view);
-      if (!maybe_labels) ThrowVertexLabelsReadFailure(maybe_labels.error());
-      emit(*maybe_props, [&](storage::PropertyId prop) {
-        return vnode.IsOverlayBound(prop) ||
-               checker->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
-      });
-    }
+    auto auth = OverlayReadAuthorization::For(vnode, view, checker);
+    if (!auth) ThrowVertexLabelsReadFailure(auth.error());
+    emit(*maybe_props, [&](storage::PropertyId prop) { return auth->IsReadable(vnode, prop); });
   } else {
     emit(value.ValueVirtualEdge().Properties(), allow_all_properties);
   }
@@ -1261,8 +1251,7 @@ TypedValue Counter(const TypedValue *args, int64_t nargs, const FunctionContext 
 // The query-local external id for a synthetic Gid, or the raw synthetic id when there is no mapper
 // (a path with no query context).
 int64_t ExternalSyntheticId(storage::Gid gid, const FunctionContext &ctx) {
-  if (ctx.synthetic_id_mapper) return ctx.synthetic_id_mapper->ExternalId(gid);
-  return gid.AsInt();
+  return ExternalId(gid, ctx.synthetic_id_mapper);
 }
 
 TypedValue IdOf(const TypedValue &arg, const FunctionContext &ctx) {

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "query/auth_checker.hpp"
 #include "query/common.hpp"
@@ -35,6 +36,8 @@
 #include "query/query_user.hpp"
 #include "query/string_helpers.hpp"
 #include "query/typed_value.hpp"
+#include "query/virtual_graph.hpp"
+#include "query/virtual_node.hpp"
 #include "storage/v2/point_functions.hpp"
 #include "utils/case_insensitve_set.hpp"
 #include "utils/pmr/string.hpp"
@@ -448,6 +451,16 @@ TypedValue Last(const TypedValue *args, int64_t nargs, const FunctionContext &ct
 }
 
 constexpr auto allow_all_properties = [](storage::PropertyId) { return true; };
+
+// Returned by value: a virtual node's Properties() merges its origin's properties with its overlay
+// and is not a stored map.
+auto VirtualProperties(const TypedValue &value) -> VirtualNode::property_map {
+  if (value.IsVirtualNode()) return value.ValueVirtualNode().Properties();
+  const auto &edge_properties = value.ValueVirtualEdge().Properties();
+  VirtualNode::property_map result{edge_properties.get_allocator()};
+  for (const auto &[id, property_value] : edge_properties) result.insert_or_assign(id, property_value);
+  return result;
+}
 
 // NOTE: Denied properties appear as keys with null values. This differs from
 // keys() and values(), which omit denied properties entirely. This divergence
@@ -2055,6 +2068,112 @@ TypedValue Roles(const TypedValue *args, int64_t nargs, const FunctionContext &c
   return TypedValue(std::move(roles_list));
 }
 
+// virtualNode(handle, labels, properties) constructs a synthetic node: a node with no origin,
+// holding an overlay property store only. Its identity is a fresh synthetic gid; the first
+// argument is the import handle, stored on the node to wire virtual edges to it by reference when a
+// projection is assembled, not the node's identity. Labels may be a single string or a list.
+TypedValue VirtualNodeCtor(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<Integer, Or<String, List>, Map>("virtualNode", args, nargs);
+
+  const auto alloc = VirtualNode::allocator_type{ctx.memory};
+
+  VirtualNode::label_list labels{alloc};
+  if (args[1].type() == TypedValue::Type::String) {
+    labels.emplace_back(args[1].ValueString());
+  } else {
+    for (const auto &label : args[1].ValueList()) {
+      if (label.type() != TypedValue::Type::String) {
+        throw QueryRuntimeException("virtualNode() labels must be strings.");
+      }
+      labels.emplace_back(label.ValueString());
+    }
+  }
+
+  VirtualNode::property_map properties{alloc};
+  auto *name_id_mapper = ctx.db_accessor->GetStorageAccessor()->GetNameIdMapper();
+  for (const auto &[name, value] : args[2].ValueMap()) {
+    properties.insert_or_assign(ctx.db_accessor->NameToProperty(name), value.ToPropertyValue(name_id_mapper));
+  }
+
+  VirtualNode node{std::move(labels), std::move(properties), alloc};
+  node.SetHandle(args[0].ValueInt());
+  return TypedValue(std::move(node), ctx.memory);
+}
+
+// virtualEdge(type, from, to) constructs a synthetic edge with a fresh synthetic gid. Each endpoint
+// is given as a virtual node (a resolved endpoint) or as a gid handle (an unresolved endpoint bound
+// to a node only when a projection is assembled from lists); the two forms may be mixed. A real
+// vertex is not an endpoint - wire a real node by passing its id() as the handle.
+TypedValue VirtualEdgeCtor(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<String, Or<Integer, Vertex>, Or<Integer, Vertex>>("virtualEdge", args, nargs);
+
+  auto resolve = [&](const TypedValue &endpoint) -> VirtualEdge::Endpoint {
+    if (endpoint.IsInt()) return endpoint.ValueInt();
+    if (endpoint.IsVirtualNode()) {
+      return std::allocate_shared<VirtualNode>(std::pmr::polymorphic_allocator<VirtualNode>(ctx.memory),
+                                               endpoint.ValueVirtualNode());
+    }
+    throw QueryRuntimeException(
+        "virtualEdge() endpoints must be a virtual node or a gid handle; to wire a real node, pass "
+        "its id() as the handle, e.g. virtualEdge('T', id(n1), id(n2)).");
+  };
+
+  utils::pmr::string edge_type{args[0].ValueString(), ctx.memory};
+  VirtualEdge edge{resolve(args[1]), resolve(args[2]), std::move(edge_type), VirtualEdge::allocator_type{ctx.memory}};
+  return TypedValue(std::move(edge), ctx.memory);
+}
+
+// virtualGraph(nodes, edges, config?) assembles a projection from a list of synthetic nodes and a
+// list of synthetic edges, binding each edge's endpoints to a node by import handle (or by identity
+// for a resolved endpoint). Nulls in either list are skipped; a real vertex or edge is rejected. The
+// optional config map's onDanglingEdge key chooses 'error' (default) or 'drop' for an edge whose
+// endpoint matches no listed node.
+TypedValue VirtualGraphCtor(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<List, List, Optional<Map>>("virtualGraph", args, nargs);
+
+  std::vector<VirtualNode> nodes;
+  for (const auto &element : args[0].ValueList()) {
+    if (element.IsNull()) continue;
+    if (!element.IsVirtualNode()) {
+      throw QueryRuntimeException(
+          "virtualGraph() node list must contain virtual nodes or nulls; use project()/derive() for real nodes.");
+    }
+    nodes.push_back(element.ValueVirtualNode());
+  }
+
+  std::vector<VirtualEdge> edges;
+  for (const auto &element : args[1].ValueList()) {
+    if (element.IsNull()) continue;
+    if (!element.IsVirtualEdge()) {
+      throw QueryRuntimeException(
+          "virtualGraph() edge list must contain virtual edges or nulls; use project()/derive() for real edges.");
+    }
+    edges.push_back(element.ValueVirtualEdge());
+  }
+
+  auto policy = DanglingEdgePolicy::kError;
+  if (nargs == 3) {
+    const auto &config = args[2].ValueMap();
+    if (const auto it = config.find("onDanglingEdge"); it != config.end()) {
+      if (it->second.type() != TypedValue::Type::String) {
+        throw QueryRuntimeException("virtualGraph() option 'onDanglingEdge' must be 'error' or 'drop'.");
+      }
+      const auto &mode = it->second.ValueString();
+      if (mode == "drop") {
+        policy = DanglingEdgePolicy::kDrop;
+      } else if (mode == "error") {
+        policy = DanglingEdgePolicy::kError;
+      } else {
+        throw QueryRuntimeException("virtualGraph() option 'onDanglingEdge' must be 'error' or 'drop', got '{}'.",
+                                    std::string_view{mode});
+      }
+    }
+  }
+
+  auto graph = AssembleVirtualGraph(nodes, edges, policy, VirtualGraph::allocator_type{ctx.memory});
+  return TypedValue(std::move(graph), ctx.memory);
+}
+
 auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{
     // Predicate functions
     {"ISEMPTY", func_info{.func_ = IsEmpty, .is_pure_ = true}},
@@ -2097,6 +2216,11 @@ auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{
     {"TOSET", func_info{.func_ = ToSet, .is_pure_ = true}},
     {"UNIFORMSAMPLE", func_info{.func_ = UniformSample, .is_pure_ = false}},
     {"VALUES", func_info{.func_ = Values, .is_pure_ = true}},
+
+    // Virtual graph constructors. Not pure: each call mints a fresh synthetic gid.
+    {"VIRTUALNODE", func_info{.func_ = VirtualNodeCtor, .is_pure_ = false}},
+    {"VIRTUALEDGE", func_info{.func_ = VirtualEdgeCtor, .is_pure_ = false}},
+    {"VIRTUALGRAPH", func_info{.func_ = VirtualGraphCtor, .is_pure_ = false}},
 
     // Mathematical functions - numeric
     {"ABS", func_info{.func_ = Abs, .is_pure_ = true}},

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -668,35 +668,14 @@ TypedValue IsEmpty(const TypedValue *args, int64_t nargs, const FunctionContext 
 // edges, and a real vertex on the identity view (or with no view bound) counts
 // the real graph's edges.
 std::pair<int64_t, int64_t> AmbientInOutDegree(const TypedValue &arg, const FunctionContext &ctx) {
-  if (arg.IsVirtualNode()) {
-    const auto gid = arg.ValueVirtualNode().Gid();
-    if (auto *projection = dynamic_cast<VirtualGraphView *>(ctx.graph_view)) {
-      return {static_cast<int64_t>(projection->InEdges(gid).size()),
-              static_cast<int64_t>(projection->OutEdges(gid).size())};
-    }
-    // A virtual node outside a projection scope (a literal virtualNode(), no
-    // VirtualGraphView bound) has no ambient topology.
-    return {0, 0};
-  }
+  // Degree is a topology question answered by the ambient view: the identity view uses the real graph's
+  // O(1) per-vertex degree, a subgraph counts only member edges, a projection counts its own edges, and
+  // a node of the wrong kind for the view reports {0, 0}. The per-view logic lives behind GraphView, so
+  // there is no view-kind branch here.
+  const ScanVertex node = arg.IsVirtualNode() ? ScanVertex{arg.ValueVirtualNode()} : ScanVertex{arg.ValueVertex()};
+  if (ctx.graph_view != nullptr) return ctx.graph_view->Degree(node, ctx.view);
+  // No ambient view bound (a real vertex evaluated outside a graph scope): fall back to real degree.
   const auto &vertex = arg.ValueVertex();
-  if (auto *subgraph = dynamic_cast<SubgraphGraphView *>(ctx.graph_view)) {
-    const auto count_members = [&](auto maybe_edges) -> int64_t {
-      if (!maybe_edges) throw QueryRuntimeException("Trying to get degree of a node that doesn't exist.");
-      int64_t count = 0;
-      for (const auto &edge : maybe_edges->edges) {
-        if (subgraph->ContainsEdge(edge)) ++count;
-      }
-      return count;
-    };
-    return {count_members(vertex.InEdges(ctx.view)), count_members(vertex.OutEdges(ctx.view))};
-  }
-  if (dynamic_cast<VirtualGraphView *>(ctx.graph_view) != nullptr) {
-    // A real vertex is not a node of a projection, so it has no edges in the
-    // ambient projection graph. Reached when a real vertex is imported into a
-    // CALL { USE <projection> ... } scope; the scope must not report the
-    // vertex's real-graph degree.
-    return {0, 0};
-  }
   return {static_cast<int64_t>(UnwrapDegreeResult(vertex.InDegree(ctx.view))),
           static_cast<int64_t>(UnwrapDegreeResult(vertex.OutDegree(ctx.view)))};
 }

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -955,6 +955,8 @@ TypedValue Keys(const TypedValue *args, int64_t nargs, const FunctionContext &ct
       ctx.auth_checker,
       [&](size_t n) { keys.reserve(n); },
       [&](storage::PropertyId id, const storage::PropertyValue &, bool allowed) {
+        // TypedValue is allocator-aware, so emplace_back(args) can't supply ctx.memory; keep the temporary.
+        // NOLINTNEXTLINE(modernize-use-emplace)
         if (allowed) keys.emplace_back(TypedValue(dba->PropertyToName(id), ctx.memory));
       });
   return TypedValue(std::move(keys));
@@ -979,6 +981,8 @@ TypedValue Values(const TypedValue *args, int64_t nargs, const FunctionContext &
       ctx.auth_checker,
       [&](size_t n) { values.reserve(n); },
       [&](storage::PropertyId, const storage::PropertyValue &pv, bool allowed) {
+        // TypedValue is allocator-aware, so emplace_back(args) can't supply ctx.memory; keep the temporary.
+        // NOLINTNEXTLINE(modernize-use-emplace)
         if (allowed) values.emplace_back(TypedValue(pv, dba->GetStorageAccessor()->GetNameIdMapper(), ctx.memory));
       });
   return TypedValue(std::move(values));
@@ -2180,7 +2184,7 @@ TypedValue VirtualGraphCtor(const TypedValue *args, int64_t nargs, const Functio
   }
 
   auto graph = AssembleVirtualGraph(nodes, edges, policy, VirtualGraph::allocator_type{ctx.memory});
-  return TypedValue(std::move(graph), ctx.memory);
+  return {std::move(graph), ctx.memory};
 }
 
 auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{

--- a/src/query/interpret/awesome_memgraph_functions.hpp
+++ b/src/query/interpret/awesome_memgraph_functions.hpp
@@ -16,6 +16,7 @@
 #include <unordered_map>
 
 #include "query/procedure/module_fwd.hpp"
+#include "query/synthetic_gid.hpp"
 #include "storage/v2/view.hpp"
 #include "utils/memory.hpp"
 
@@ -32,6 +33,7 @@ const char kStartsWith[] = "STARTSWITH";
 const char kEndsWith[] = "ENDSWITH";
 const char kContains[] = "CONTAINS";
 const char kId[] = "ID";
+const char kVirtualId[] = "VIRTUAL_ID";
 const char kElementId[] = "ELEMENTID";
 }  // namespace
 
@@ -48,6 +50,9 @@ struct FunctionContext {
   // The ambient graph view, bound inside a `CALL { USE ... }` scope. The topology
   // functions resolve over it; null outside the operator path.
   GraphView *graph_view{nullptr};
+  // Projects a virtual entity's synthetic Gid onto its query-local external id for id()/virtual_id().
+  // Null on paths with no query context, where the raw synthetic id is used instead.
+  SyntheticIdMapper *synthetic_id_mapper{nullptr};
 };
 
 using func_impl =

--- a/src/query/interpret/awesome_memgraph_functions.hpp
+++ b/src/query/interpret/awesome_memgraph_functions.hpp
@@ -24,6 +24,7 @@ namespace memgraph::query {
 class DbAccessor;
 class FineGrainedAuthChecker;
 class TypedValue;
+class GraphView;
 struct QueryUserOrRole;
 
 namespace {
@@ -44,6 +45,9 @@ struct FunctionContext {
   const QueryUserOrRole *user_or_role{nullptr};
   const QueryUserOrRole *triggering_user{nullptr};
   FineGrainedAuthChecker const *auth_checker{nullptr};
+  // The ambient graph view, bound inside a `CALL { USE ... }` scope. The topology
+  // functions resolve over it; null outside the operator path.
+  GraphView *graph_view{nullptr};
 };
 
 using func_impl =

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -588,6 +588,20 @@ bool ExpressionEvaluator::CheckPropertyPermission(EdgeAccessor const &accessor, 
   return auth_checker_->HasPropertyPermission(accessor.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
 }
 
+bool ExpressionEvaluator::IsPropertyAllowed(VirtualNode const &node, storage::PropertyId prop) const {
+  // An overlay-bound override is the author's own computed value, not the origin's protected data, so
+  // it is always readable (any origin data it was computed from was itself FGA-checked at construction).
+  if (node.IsOverlayBound(prop)) return true;
+  // An origin-read-through property gets the origin's per-property READ permission - the same decision
+  // a real vertex receives over its labels. A synthetic node has no origin and is always allowed.
+  auto const &origin = node.Origin();
+  if (!origin) return true;
+  if (!auth_checker_) return true;
+  auto maybe_labels = origin->Labels(view_);
+  if (!maybe_labels) return false;
+  return auth_checker_->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
+}
+
 #endif
 
 }  // namespace memgraph::query

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -13,6 +13,7 @@
 
 #include "query/auth_checker.hpp"
 #include "query/graph.hpp"
+#include "query/overlay_authorization.hpp"
 #include "query/virtual_graph.hpp"
 
 #include <ranges>
@@ -589,17 +590,10 @@ bool ExpressionEvaluator::CheckPropertyPermission(EdgeAccessor const &accessor, 
 }
 
 bool ExpressionEvaluator::IsPropertyAllowed(VirtualNode const &node, storage::PropertyId prop) const {
-  // An overlay-bound override is the author's own computed value, not the origin's protected data, so
-  // it is always readable (any origin data it was computed from was itself FGA-checked at construction).
-  if (node.IsOverlayBound(prop)) return true;
-  // An origin-read-through property gets the origin's per-property READ permission - the same decision
-  // a real vertex receives over its labels. A synthetic node has no origin and is always allowed.
-  auto const &origin = node.Origin();
-  if (!origin) return true;
-  if (!auth_checker_) return true;
-  auto maybe_labels = origin->Labels(view_);
-  if (!maybe_labels) return false;
-  return auth_checker_->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
+  auto auth = OverlayReadAuthorization::For(node, view_, auth_checker_);
+  // The read path fails closed: if the origin's labels cannot be read, the property is not exposed.
+  if (!auth) return false;
+  return auth->IsReadable(node, prop);
 }
 
 #endif

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -467,18 +467,17 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
                 GetNameIdMapper(),
                 ctx_->memory};
       }
-    case TypedValue::Type::VirtualEdge: {
-      auto prop_id = dba_->NameToProperty(property_lookup.property_.name);
-      auto prop_value = expression_result_ptr->ValueVirtualEdge().GetProperty(prop_id);
-      if (prop_value.IsNull()) return TypedValue(ctx_->memory);
-      return {std::move(prop_value), GetNameIdMapper(), ctx_->memory};
-    }
-    case TypedValue::Type::VirtualNode: {
-      auto prop_id = dba_->NameToProperty(property_lookup.property_.name);
-      auto prop_value = expression_result_ptr->ValueVirtualNode().GetProperty(prop_id);
-      if (prop_value.IsNull()) return TypedValue(ctx_->memory);
-      return {std::move(prop_value), GetNameIdMapper(), ctx_->memory};
-    }
+    case TypedValue::Type::VirtualEdge:
+      // A projected edge reads through the same EdgeAccessor-shaped GetProperty as a real edge.
+      return {GetProperty(expression_result_ptr->ValueVirtualEdge(), property_lookup.property_),
+              GetNameIdMapper(),
+              ctx_->memory};
+    case TypedValue::Type::VirtualNode:
+      // A projected node reads through the same VertexAccessor-shaped GetProperty as a real vertex,
+      // so the read goes through the shared helper with no node-kind branch.
+      return {GetProperty(expression_result_ptr->ValueVirtualNode(), property_lookup.property_),
+              GetNameIdMapper(),
+              ctx_->memory};
     case TypedValue::Type::Map: {
       auto &map = expression_result_ptr->ValueMap();
       auto found = map.find(property_lookup.property_.name.c_str());

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -20,6 +20,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "query/common.hpp"
@@ -29,6 +30,8 @@
 #include "query/frontend/semantic/symbol_table.hpp"
 #include "query/interpret/frame.hpp"
 #include "query/typed_value.hpp"
+#include "query/virtual_edge.hpp"
+#include "query/virtual_node.hpp"
 #include "spdlog/spdlog.h"
 #include "storage/v2/name_id_mapper.hpp"
 #include "storage/v2/point.hpp"
@@ -477,7 +480,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       lhs_ptr = &lhs;
     }
     auto index = list_indexing.expression2_->Accept(*this);
-    if (!lhs_ptr->IsList() && !lhs_ptr->IsMap() && !lhs_ptr->IsVertex() && !lhs_ptr->IsEdge() && !lhs_ptr->IsNull())
+    if (!lhs_ptr->IsList() && !lhs_ptr->IsMap() && !lhs_ptr->IsVertex() && !lhs_ptr->IsEdge() &&
+        !lhs_ptr->IsVirtualNode() && !lhs_ptr->IsVirtualEdge() && !lhs_ptr->IsNull())
       throw QueryRuntimeException(
           "Expected a list, a map, a node or an edge to index with '[]', got "
           "{}.",
@@ -514,6 +518,18 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
       return {GetProperty(lhs_ptr->ValueEdge(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
     };
+
+    if (lhs_ptr->IsVirtualNode()) {
+      if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
+      // A projected node reads through the same GetProperty as a real vertex.
+      return {GetProperty(lhs_ptr->ValueVirtualNode(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
+    }
+
+    if (lhs_ptr->IsVirtualEdge()) {
+      if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
+      // A projected edge reads through the same GetProperty as a real edge.
+      return {GetProperty(lhs_ptr->ValueVirtualEdge(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
+    }
 
     // lhs is Null
     return TypedValue(ctx_->memory);
@@ -644,6 +660,22 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
         }
         return TypedValue(true, ctx_->memory);
       }
+      case TypedValue::Type::VirtualNode: {
+        // A projection node carries its labels as names, not ids, and exposes no
+        // index, so the test is a membership check over its label list.
+        const auto &node = expression_result.ValueVirtualNode();
+        const auto has_label = [&](const LabelIx &label) {
+          return std::ranges::any_of(
+              node.Labels(), [&](const auto &held) { return std::string_view{held} == std::string_view{label.name}; });
+        };
+        for (const auto &label : labels_test.labels_) {
+          if (!has_label(label)) return TypedValue(false, ctx_->memory);
+        }
+        for (const auto &or_labels_pattern : labels_test.or_labels_) {
+          if (!std::ranges::any_of(or_labels_pattern, has_label)) return TypedValue(false, ctx_->memory);
+        }
+        return TypedValue(true, ctx_->memory);
+      }
       default:
         throw QueryRuntimeException("Only nodes have labels.");
     }
@@ -754,11 +786,11 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
                                  user_or_role_,
                                  triggering_user_,
 #ifdef MG_ENTERPRISE
-                                 auth_checker_
+                                 auth_checker_,
 #else
-                                 nullptr
+                                 nullptr,
 #endif
-    };
+                                 ctx_->graph_view};
     bool is_transactional = storage::IsTransactional(dba_->GetStorageMode());
     TypedValue res(ctx_->memory);
     // Stack allocate evaluated arguments when there's a small number of them.

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1113,12 +1113,13 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   bool IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const;
   bool IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const;
 
-  // A projected element mints no real-graph privileges of its own: a synthetic node/edge has no
-  // origin, and an overlay node's real-graph visibility is already enforced at the scan (label-level,
-  // issue 30). A read through a projected element is therefore allowed. Per-property READ permission
-  // over an overlay's origin is a tracked follow-up (see rebase auth-glue notes).
-  bool IsPropertyAllowed(VirtualNode const &, storage::PropertyId) const { return true; }
+  // An overlay node reads through to a real origin vertex, so reading an origin-backed property is
+  // subject to that origin's per-property READ permission (the same check a real vertex gets, over
+  // the origin's labels). A synthetic node has no origin and mints no real-graph data, so it is
+  // allowed.
+  bool IsPropertyAllowed(VirtualNode const &node, storage::PropertyId prop) const;
 
+  // A virtual edge is always synthetic (no real origin edge), so it carries no real-graph privileges.
   bool IsPropertyAllowed(VirtualEdge const &, storage::PropertyId) const { return true; }
 #else
   template <typename T>

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -591,92 +591,27 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 
   TypedValue Visit(LabelsTest &labels_test) override {
     auto expression_result = labels_test.expression_->Accept(*this);
+    // The AND/OR structure is one test over any labelled element; HasLabel(element,
+    // label) is the per-kind primitive (id-based over a real vertex, name-based
+    // over a projection node), so both kinds run the same test.
+    auto test = [&](const auto &element) -> TypedValue {
+      for (const auto &label : labels_test.labels_) {
+        if (!HasLabel(element, label)) return TypedValue(false, ctx_->memory);
+      }
+      for (const auto &or_labels_pattern : labels_test.or_labels_) {
+        if (!std::ranges::any_of(or_labels_pattern, [&](const LabelIx &label) { return HasLabel(element, label); })) {
+          return TypedValue(false, ctx_->memory);
+        }
+      }
+      return TypedValue(true, ctx_->memory);
+    };
     switch (expression_result.type()) {
       case TypedValue::Type::Null:
         return TypedValue(ctx_->memory);
-      case TypedValue::Type::Vertex: {
-        const auto &vertex = expression_result.ValueVertex();
-        for (const auto &label : labels_test.labels_) {
-          auto has_label = vertex.HasLabel(view_, GetLabel(label));
-          if (has_label == std::unexpected{storage::Error::NONEXISTENT_OBJECT}) {
-            // This is a very nasty and temporary hack in order to make MERGE
-            // work. The old storage had the following logic when returning an
-            // `OLD` view: `return old ? old : new`. That means that if the
-            // `OLD` view didn't exist, it returned the NEW view. With this hack
-            // we simulate that behavior.
-            // TODO: Remove once MERGE is
-            // reimplemented.
-            has_label = vertex.HasLabel(storage::View::NEW, GetLabel(label));
-          }
-          if (!has_label) {
-            switch (has_label.error()) {
-              case storage::Error::DELETED_OBJECT:
-                throw QueryRuntimeException("Trying to access labels on a deleted node.");
-              case storage::Error::NONEXISTENT_OBJECT:
-                throw query::QueryRuntimeException("Trying to access labels from a node that doesn't exist.");
-              case storage::Error::SERIALIZATION_ERROR:
-              case storage::Error::VERTEX_HAS_EDGES:
-              case storage::Error::PROPERTIES_DISABLED:
-                throw QueryRuntimeException("Unexpected error when accessing labels.");
-            }
-          }
-          if (!*has_label) {
-            return TypedValue(false, ctx_->memory);
-          }
-        }
-        for (const auto &or_labels_pattern : labels_test.or_labels_) {
-          bool has_at_least_one_label = false;
-          for (const auto &label : or_labels_pattern) {
-            auto has_label = vertex.HasLabel(view_, GetLabel(label));
-            if (has_label == std::unexpected{storage::Error::NONEXISTENT_OBJECT}) {
-              // This is a very nasty and temporary hack in order to make MERGE
-              // work. The old storage had the following logic when returning an
-              // `OLD` view: `return old ? old : new`. That means that if the
-              // `OLD` view didn't exist, it returned the NEW view. With this hack
-              // we simulate that behavior.
-              // TODO: Remove once MERGE is
-              // reimplemented.
-              has_label = vertex.HasLabel(storage::View::NEW, GetLabel(label));
-            }
-            if (!has_label) {
-              switch (has_label.error()) {
-                case storage::Error::DELETED_OBJECT:
-                  throw QueryRuntimeException("Trying to access labels on a deleted node.");
-                case storage::Error::NONEXISTENT_OBJECT:
-                  throw query::QueryRuntimeException("Trying to access labels from a node that doesn't exist.");
-                case storage::Error::SERIALIZATION_ERROR:
-                case storage::Error::VERTEX_HAS_EDGES:
-                case storage::Error::PROPERTIES_DISABLED:
-                  throw QueryRuntimeException("Unexpected error when accessing labels.");
-              }
-            }
-            if (*has_label) {
-              has_at_least_one_label = true;
-              break;
-            }
-          }
-          if (!has_at_least_one_label) {
-            return TypedValue(false, ctx_->memory);
-          }
-        }
-        return TypedValue(true, ctx_->memory);
-      }
-      case TypedValue::Type::VirtualNode: {
-        // A projection node carries its labels as names, not ids, and exposes no
-        // index, so the test is a membership check over its label list.
-        const auto &node = expression_result.ValueVirtualNode();
-        const auto has_label = [&](const LabelIx &label) {
-          return std::ranges::any_of(
-              node.Labels(), [&](const auto &held) { return std::string_view{held} == std::string_view{label.name}; });
-        };
-        for (const auto &label : labels_test.labels_) {
-          if (!has_label(label)) return TypedValue(false, ctx_->memory);
-        }
-        for (const auto &or_labels_pattern : labels_test.or_labels_) {
-          if (!std::ranges::any_of(or_labels_pattern, has_label)) return TypedValue(false, ctx_->memory);
-        }
-        return TypedValue(true, ctx_->memory);
-      }
+      case TypedValue::Type::Vertex:
+        return test(expression_result.ValueVertex());
+      case TypedValue::Type::VirtualNode:
+        return test(expression_result.ValueVirtualNode());
       default:
         throw QueryRuntimeException("Only nodes have labels.");
     }
@@ -1224,6 +1159,41 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   }
 
   storage::LabelId GetLabel(const LabelIx &label) const { return ctx_->labels[label.ix]; }
+
+  // Per-kind label-membership test behind one call site, so LabelsTest does not
+  // branch on the element kind (mirrors GetProperty). A real vertex tests by id
+  // under the current view, with the MERGE OLD->NEW fallback and the storage-error
+  // mapping; a projection node carries its labels as names and exposes no index,
+  // so it is a name membership check.
+  bool HasLabel(const VertexAccessor &vertex, const LabelIx &label) {
+    auto has_label = vertex.HasLabel(view_, GetLabel(label));
+    if (has_label == std::unexpected{storage::Error::NONEXISTENT_OBJECT}) {
+      // This is a very nasty and temporary hack in order to make MERGE work. The
+      // old storage had the following logic when returning an `OLD` view:
+      // `return old ? old : new`. That means that if the `OLD` view didn't exist,
+      // it returned the NEW view. With this hack we simulate that behavior.
+      // TODO: Remove once MERGE is reimplemented.
+      has_label = vertex.HasLabel(storage::View::NEW, GetLabel(label));
+    }
+    if (!has_label) {
+      switch (has_label.error()) {
+        case storage::Error::DELETED_OBJECT:
+          throw QueryRuntimeException("Trying to access labels on a deleted node.");
+        case storage::Error::NONEXISTENT_OBJECT:
+          throw query::QueryRuntimeException("Trying to access labels from a node that doesn't exist.");
+        case storage::Error::SERIALIZATION_ERROR:
+        case storage::Error::VERTEX_HAS_EDGES:
+        case storage::Error::PROPERTIES_DISABLED:
+          throw QueryRuntimeException("Unexpected error when accessing labels.");
+      }
+    }
+    return *has_label;
+  }
+
+  bool HasLabel(const VirtualNode &node, const LabelIx &label) const {
+    return std::ranges::any_of(
+        node.Labels(), [&](const auto &held) { return std::string_view{held} == std::string_view{label.name}; });
+  }
 
   storage::EdgeTypeId GetEdgeType(const EdgeTypeIx &edgetype) const { return ctx_->edgetypes[edgetype.ix]; }
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -162,7 +162,8 @@ class PrimitiveLiteralExpressionEvaluator : public ExpressionVisitor<TypedValue>
                                  .memory = ctx_->memory,
                                  .timestamp = ctx_->timestamp,
                                  .counters = &ctx_->counters,
-                                 .view = storage::View::OLD};
+                                 .view = storage::View::OLD,
+                                 .synthetic_id_mapper = ctx_->synthetic_id_mapper.get()};
     TypedValue res(ctx_->memory);
     if (function.arguments_.size() <= 8) {
       utils::uninitialised_storage<std::array<TypedValue, 8>> arguments;
@@ -790,7 +791,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 #else
                                  nullptr,
 #endif
-                                 ctx_->graph_view};
+                                 ctx_->graph_view,
+                                 ctx_->synthetic_id_mapper.get()};
     bool is_transactional = storage::IsTransactional(dba_->GetStorageMode());
     TypedValue res(ctx_->memory);
     // Stack allocate evaluated arguments when there's a small number of them.
@@ -1110,9 +1112,18 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 #ifdef MG_ENTERPRISE
   bool IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const;
   bool IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const;
+
+  // A projected element mints no real-graph privileges of its own: a synthetic node/edge has no
+  // origin, and an overlay node's real-graph visibility is already enforced at the scan (label-level,
+  // issue 30). A read through a projected element is therefore allowed. Per-property READ permission
+  // over an overlay's origin is a tracked follow-up (see rebase auth-glue notes).
+  bool IsPropertyAllowed(VirtualNode const &, storage::PropertyId) const { return true; }
+
+  bool IsPropertyAllowed(VirtualEdge const &, storage::PropertyId) const { return true; }
 #else
   template <typename T>
-    requires std::same_as<T, VertexAccessor> || std::same_as<T, EdgeAccessor>
+    requires std::same_as<T, VertexAccessor> || std::same_as<T, EdgeAccessor> || std::same_as<T, VirtualNode> ||
+             std::same_as<T, VirtualEdge>
   bool IsPropertyAllowed(T const &, storage::PropertyId) const {
     return true;
   }

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -510,26 +510,11 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       return referenced ? TypedValue(found->second, ctx_->memory) : TypedValue(std::move(found->second), ctx_->memory);
     }
 
-    if (lhs_ptr->IsVertex()) {
+    if (lhs_ptr->IsVertex() || lhs_ptr->IsEdge() || lhs_ptr->IsVirtualNode() || lhs_ptr->IsVirtualEdge()) {
       if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
-      return {GetProperty(lhs_ptr->ValueVertex(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
-    }
-
-    if (lhs_ptr->IsEdge()) {
-      if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
-      return {GetProperty(lhs_ptr->ValueEdge(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
-    };
-
-    if (lhs_ptr->IsVirtualNode()) {
-      if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
-      // A projected node reads through the same GetProperty as a real vertex.
-      return {GetProperty(lhs_ptr->ValueVirtualNode(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
-    }
-
-    if (lhs_ptr->IsVirtualEdge()) {
-      if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
-      // A projected edge reads through the same GetProperty as a real edge.
-      return {GetProperty(lhs_ptr->ValueVirtualEdge(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
+      // A real and a projected element read through the same GetProperty; GetElementProperty hides the
+      // element-kind extraction so this call site does not branch on real-vs-virtual.
+      return {GetElementProperty(*lhs_ptr, index.ValueString()), GetNameIdMapper(), ctx_->memory};
     }
 
     // lhs is Null
@@ -1120,6 +1105,25 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       }
     }
     return *maybe_prop;
+  }
+
+  // Reads a named property from a node- or edge-like TypedValue, hiding the real-vs-virtual element
+  // extraction behind one call. The read logic is the shared GetProperty template above; only which
+  // concrete accessor it is handed differs, so the element-kind switch lives here once rather than
+  // being repeated at each property call site. Callers guard that `element` is one of these kinds.
+  storage::PropertyValue GetElementProperty(const TypedValue &element, std::string_view name) {
+    switch (element.type()) {
+      case TypedValue::Type::Vertex:
+        return GetProperty(element.ValueVertex(), name);
+      case TypedValue::Type::VirtualNode:
+        return GetProperty(element.ValueVirtualNode(), name);
+      case TypedValue::Type::Edge:
+        return GetProperty(element.ValueEdge(), name);
+      case TypedValue::Type::VirtualEdge:
+        return GetProperty(element.ValueVirtualEdge(), name);
+      default:
+        throw QueryRuntimeException("Expected a node or an edge to read a property from, got {}.", element.type());
+    }
   }
 
  private:

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3573,6 +3573,21 @@ Expression *FindMapLiteralEntry(const MapLiteral &map, std::string_view key) {
   return nullptr;
 }
 
+// Evaluates a derive() config value at prepare time, but only if it is statically resolvable - a
+// literal or a parameter-substituted literal. A value that needs runtime context (a bound variable, or
+// a function requiring a database accessor such as `type(r)`) is not statically known: the prepare-time
+// evaluator raises a QueryRuntimeException, which is caught here and reported as nullopt rather than
+// failing the query. The field it feeds is then omitted from the header schema; the executor still
+// resolves the value per row. A genuine error in a constant expression resurfaces at execution, where
+// the config is evaluated for real.
+std::optional<TypedValue> EvaluateIfStatic(Expression &expr, ExpressionVisitor<TypedValue> &evaluator) {
+  try {
+    return expr.Accept(evaluator);
+  } catch (const QueryRuntimeException &) {
+    return std::nullopt;
+  }
+}
+
 // Reads a derive()'s overlay key set and edge type out of its options. The options map keys are
 // structural (kept in the literal), but scalar values are stripped to parameters for plan caching,
 // so the edge type and the policy bindings are recovered by evaluating those constant expressions
@@ -3585,12 +3600,14 @@ ProjectionSchemaEntry BuildProjectionSchemaEntry(int64_t ref, const MapLiteral &
   schema.ref = ref;
 
   if (auto *edge_type = FindMapLiteralEntry(options, "virtualEdgeType")) {
-    if (auto value = edge_type->Accept(evaluator); value.IsString()) schema.edge_type = value.ValueString();
+    if (auto value = EvaluateIfStatic(*edge_type, evaluator); value && value->IsString())
+      schema.edge_type = value->ValueString();
   }
 
   if (auto *policy = utils::Downcast<MapLiteral>(FindMapLiteralEntry(options, "propertyPolicy"))) {
     for (const auto &[property, binding] : policy->elements_) {
-      if (auto value = binding->Accept(evaluator); value.IsString() && value.ValueString() == "overlay") {
+      if (auto value = EvaluateIfStatic(*binding, evaluator);
+          value && value->IsString() && value->ValueString() == "overlay") {
         schema.overlay.push_back(property.name);
       }
     }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3154,7 +3154,8 @@ struct PullPlan {
                     std::optional<size_t> parallel_execution = std::nullopt,
                     std::shared_ptr<utils::UserResources> user_resource = {}
 #endif
-  );
+                    ,
+                    std::shared_ptr<SyntheticIdMapper> synthetic_id_mapper = {});
 
   std::optional<plan::ProfilingStatsWithTotalTime> Pull(AnyStream *stream, std::optional<int> n,
                                                         const std::vector<Symbol> &output_symbols,
@@ -3198,7 +3199,8 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
                    ,
                    std::optional<size_t> parallel_execution, std::shared_ptr<utils::UserResources> user_resource
 #endif
-                   )
+                   ,
+                   std::shared_ptr<SyntheticIdMapper> synthetic_id_mapper)
     : plan_(plan),
       cursor_(plan->plan().MakeCursor(execution_memory, metric_handles)),
       frame_(plan->symbol_table().max_position(), execution_memory),
@@ -3212,6 +3214,9 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
       identity_graph_view_(dba) {
   ctx_.profile_execution_time = std::chrono::duration<double>(0.0);
   ctx_.metric_handles = &metric_handles;
+  // Share the interpreter's per-query mapper so id()/virtual_id() (evaluated here) and Bolt
+  // serialization externalize virtual ids through the same instance; else keep the default.
+  if (synthetic_id_mapper) ctx_.evaluation_context.synthetic_id_mapper = std::move(synthetic_id_mapper);
   if (hops_limit) {
 #ifdef MG_ENTERPRISE
     if (parallel_execution) {
@@ -3399,6 +3404,13 @@ Interpreter::~Interpreter() { Abort(); }
 void Interpreter::ResetCachedFga() { cached_fga_->Reset(); }
 
 FineGrainedAuthChecker const *Interpreter::GetCachedFga() const { return cached_fga_->get(); }
+
+SyntheticIdMapper *Interpreter::GetSyntheticIdMapper() const { return synthetic_id_mapper_.get(); }
+
+std::shared_ptr<SyntheticIdMapper> Interpreter::RenewSyntheticIdMapper() {
+  synthetic_id_mapper_ = std::make_shared<SyntheticIdMapper>();
+  return synthetic_id_mapper_;
+}
 
 auto DetermineTxTimeout(std::optional<int64_t> tx_timeout_ms, InterpreterConfig const &config) -> TxTimeout {
   using double_seconds = std::chrono::duration<double>;
@@ -3774,7 +3786,8 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                               parallel_execution,
                                               user_resource
 #endif
-  );
+                                              ,
+                                              interpreter.RenewSyntheticIdMapper());
   return PreparedQuery{
       .header = std::move(header),
       .privileges = std::move(parsed_query.required_privileges),

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3593,8 +3593,8 @@ ProjectionSchema BuildProjectionSchema(int64_t ref, const MapLiteral &options,
   }
 
   // A key can be named by both the policy and an override; the client wants each once.
-  std::sort(schema.overlay.begin(), schema.overlay.end());
-  schema.overlay.erase(std::unique(schema.overlay.begin(), schema.overlay.end()), schema.overlay.end());
+  std::ranges::sort(schema.overlay);
+  schema.overlay.erase(std::ranges::unique(schema.overlay).begin(), schema.overlay.end());
 
   return schema;
 }
@@ -9921,7 +9921,11 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     auto &query_execution = query_executions_.emplace_back(QueryExecution::Create(db_query_tracker));
     query_execution->prepared_query = PrepareTransactionQuery(tx_query_enum, extras);
     auto qid = in_explicit_transaction_ ? static_cast<int>(query_executions_.size() - 1) : std::optional<int>{};
-    return {query_execution->prepared_query->header, query_execution->prepared_query->privileges, qid, {}, {}};
+    return {.headers = query_execution->prepared_query->header,
+            .privileges = query_execution->prepared_query->privileges,
+            .qid = qid,
+            .db = {},
+            .projection_schemas = {}};
   }
 
   MG_ASSERT(std::holds_alternative<ParseInfo>(parse_res), "Unkown ParseRes type");

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3567,9 +3567,9 @@ Expression *FindMapLiteralEntry(const MapLiteral &map, std::string_view key) {
 // against the query parameters. A key is overlay-bound either by an explicit 'overlay' propertyPolicy
 // binding or by appearing as a source/target property override - the same rules the executor applies
 // when it builds the overlay nodes, so the schema describes the nodes the client will receive.
-ProjectionSchema BuildProjectionSchema(int64_t ref, const MapLiteral &options,
-                                       ExpressionVisitor<TypedValue> &evaluator) {
-  ProjectionSchema schema;
+ProjectionSchemaEntry BuildProjectionSchemaEntry(int64_t ref, const MapLiteral &options,
+                                                 ExpressionVisitor<TypedValue> &evaluator) {
+  ProjectionSchemaEntry schema;
   schema.ref = ref;
 
   if (auto *edge_type = FindMapLiteralEntry(options, "virtualEdgeType")) {
@@ -3599,7 +3599,7 @@ ProjectionSchema BuildProjectionSchema(int64_t ref, const MapLiteral &options,
   return schema;
 }
 
-// Collects one ProjectionSchema per derive() projection in the plan whose options are a static map
+// Collects one ProjectionSchemaEntry per derive() projection in the plan whose options are a static map
 // literal. A derive() is an Aggregation::Op::DERIVE element; its output symbol's plan position is
 // the schema reference the executor stamps onto the matching overlay nodes. A projection whose
 // options are not a literal is skipped here, matching the executor leaving its nodes untagged.
@@ -3618,19 +3618,19 @@ class ProjectionSchemaExtractor final : public plan::HierarchicalLogicalOperator
       if (element.op != Aggregation::Op::DERIVE) continue;
       auto *options = utils::Downcast<MapLiteral>(element.arg2);
       if (options == nullptr) continue;
-      schemas.push_back(BuildProjectionSchema(element.output_sym.position(), *options, *evaluator_));
+      schemas.push_back(BuildProjectionSchemaEntry(element.output_sym.position(), *options, *evaluator_));
     }
     return true;
   }
 
-  std::vector<ProjectionSchema> schemas;
+  std::vector<ProjectionSchemaEntry> schemas;
 
  private:
   ExpressionVisitor<TypedValue> *evaluator_;
 };
 
-std::vector<ProjectionSchema> ExtractProjectionSchemas(const plan::LogicalOperator &plan,
-                                                       ExpressionVisitor<TypedValue> &evaluator) {
+std::vector<ProjectionSchemaEntry> ExtractProjectionSchemas(const plan::LogicalOperator &plan,
+                                                            ExpressionVisitor<TypedValue> &evaluator) {
   ProjectionSchemaExtractor extractor{evaluator};
   // The cached plan is shared and logically const at prepare time; the extractor only reads it, so
   // the const_cast for the non-const Accept interface is safe (mirrors ProvidePlanHints).

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3547,6 +3547,92 @@ void CheckParallelExecution(std::optional<size_t> &parallel_execution, plan::Log
 }
 #endif
 
+// Walks a MapLiteral's entries looking for the one whose key name matches `key`; returns its value
+// expression, or nullptr if absent. Map keys are PropertyIx, so this is a linear scan by name.
+Expression *FindMapLiteralEntry(const MapLiteral &map, std::string_view key) {
+  for (const auto &[property, value] : map.elements_) {
+    if (property.name == key) return value;
+  }
+  return nullptr;
+}
+
+// Reads a derive()'s overlay key set and edge type out of its options. The options map keys are
+// structural (kept in the literal), but scalar values are stripped to parameters for plan caching,
+// so the edge type and the policy bindings are recovered by evaluating those constant expressions
+// against the query parameters. A key is overlay-bound either by an explicit 'overlay' propertyPolicy
+// binding or by appearing as a source/target property override - the same rules the executor applies
+// when it builds the overlay nodes, so the schema describes the nodes the client will receive.
+ProjectionSchema BuildProjectionSchema(int64_t ref, const MapLiteral &options,
+                                       ExpressionVisitor<TypedValue> &evaluator) {
+  ProjectionSchema schema;
+  schema.ref = ref;
+
+  if (auto *edge_type = FindMapLiteralEntry(options, "virtualEdgeType")) {
+    if (auto value = edge_type->Accept(evaluator); value.IsString()) schema.edge_type = value.ValueString();
+  }
+
+  if (auto *policy = utils::Downcast<MapLiteral>(FindMapLiteralEntry(options, "propertyPolicy"))) {
+    for (const auto &[property, binding] : policy->elements_) {
+      if (auto value = binding->Accept(evaluator); value.IsString() && value.ValueString() == "overlay") {
+        schema.overlay.push_back(property.name);
+      }
+    }
+  }
+
+  for (const auto *override_key : {"sourceNodeProperties", "targetNodeProperties"}) {
+    if (auto *overrides = utils::Downcast<MapLiteral>(FindMapLiteralEntry(options, override_key))) {
+      for (const auto &[property, value] : overrides->elements_) {
+        schema.overlay.push_back(property.name);
+      }
+    }
+  }
+
+  // A key can be named by both the policy and an override; the client wants each once.
+  std::sort(schema.overlay.begin(), schema.overlay.end());
+  schema.overlay.erase(std::unique(schema.overlay.begin(), schema.overlay.end()), schema.overlay.end());
+
+  return schema;
+}
+
+// Collects one ProjectionSchema per derive() projection in the plan whose options are a static map
+// literal. A derive() is an Aggregation::Op::DERIVE element; its output symbol's plan position is
+// the schema reference the executor stamps onto the matching overlay nodes. A projection whose
+// options are not a literal is skipped here, matching the executor leaving its nodes untagged.
+class ProjectionSchemaExtractor final : public plan::HierarchicalLogicalOperatorVisitor {
+ public:
+  explicit ProjectionSchemaExtractor(ExpressionVisitor<TypedValue> &evaluator) : evaluator_(&evaluator) {}
+
+  using HierarchicalLogicalOperatorVisitor::PostVisit;
+  using HierarchicalLogicalOperatorVisitor::PreVisit;
+  using HierarchicalLogicalOperatorVisitor::Visit;
+
+  bool Visit(plan::Once & /*unused*/) override { return true; }
+
+  bool PreVisit(plan::Aggregate &aggregate) override {
+    for (const auto &element : aggregate.aggregations_) {
+      if (element.op != Aggregation::Op::DERIVE) continue;
+      auto *options = utils::Downcast<MapLiteral>(element.arg2);
+      if (options == nullptr) continue;
+      schemas.push_back(BuildProjectionSchema(element.output_sym.position(), *options, *evaluator_));
+    }
+    return true;
+  }
+
+  std::vector<ProjectionSchema> schemas;
+
+ private:
+  ExpressionVisitor<TypedValue> *evaluator_;
+};
+
+std::vector<ProjectionSchema> ExtractProjectionSchemas(const plan::LogicalOperator &plan,
+                                                       ExpressionVisitor<TypedValue> &evaluator) {
+  ProjectionSchemaExtractor extractor{evaluator};
+  // The cached plan is shared and logically const at prepare time; the extractor only reads it, so
+  // the const_cast for the non-const Accept interface is safe (mirrors ProvidePlanHints).
+  const_cast<plan::LogicalOperator &>(plan).Accept(extractor);
+  return std::move(extractor.schemas);
+}
+
 PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string, TypedValue> *summary,
                                  InterpreterContext *interpreter_context, CurrentDB &current_db,
                                  utils::MemoryResource *execution_memory, std::vector<Notification> *notifications,
@@ -3656,6 +3742,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
     header.push_back(
         utils::FindOr(parsed_query.stripped_query.named_expressions(), symbol.token_position(), symbol.name()).first);
   }
+  auto projection_schemas = ExtractProjectionSchemas(plan->plan(), evaluator);
   // TODO: pass current DB into plan, in future current can change during pull
   auto *trigger_context_collector =
       current_db.trigger_context_collector_ ? &*current_db.trigger_context_collector_ : nullptr;
@@ -3696,7 +3783,8 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
       .rw_type = rw_type,
       .db = current_db.db_acc_->get()->name(),
       .priority = utils::Priority::LOW,  // Default to LOW priority for all Cypher queries
-      .slow_query_plan_renderer = std::move(slow_query_plan_renderer)};
+      .slow_query_plan_renderer = std::move(slow_query_plan_renderer),
+      .projection_schemas = std::move(projection_schemas)};
 }
 
 PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::vector<Notification> *notifications,
@@ -9828,7 +9916,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     auto &query_execution = query_executions_.emplace_back(QueryExecution::Create(db_query_tracker));
     query_execution->prepared_query = PrepareTransactionQuery(tx_query_enum, extras);
     auto qid = in_explicit_transaction_ ? static_cast<int>(query_executions_.size() - 1) : std::optional<int>{};
-    return {query_execution->prepared_query->header, query_execution->prepared_query->privileges, qid, {}};
+    return {query_execution->prepared_query->header, query_execution->prepared_query->privileges, qid, {}, {}};
   }
 
   MG_ASSERT(std::holds_alternative<ParseInfo>(parse_res), "Unkown ParseRes type");
@@ -10377,7 +10465,8 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     return {.headers = query_execution->prepared_query->header,
             .privileges = query_execution->prepared_query->privileges,
             .qid = qid,
-            .db = query_execution->prepared_query->db};
+            .db = query_execution->prepared_query->db,
+            .projection_schemas = query_execution->prepared_query->projection_schemas};
   } catch (const utils::BasicException &e) {
     memgraph::logging::EmitSessionTraceEvent("Failed query: {}", e.what());
     // query_execution holds the query string copy that survives Prepare* moving it out.

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -78,6 +78,7 @@
 #include "query/frontend/ast/ast.hpp"
 #include "query/frontend/ast/ast_visitor.hpp"
 #include "query/frontend/opencypher/parser.hpp"
+#include "query/graph_view.hpp"
 #include "query/hops_limit.hpp"
 #include "query/interpret/eval.hpp"
 #include "query/interpret/frame.hpp"
@@ -3181,6 +3182,8 @@ struct PullPlan {
   // manually by using this flag.
   bool has_unsent_results_ = false;
   metrics::DatabaseMetricHandles *metric_handles_;
+  // The ambient graph view bound into ctx_: the real graph seen as a GraphView.
+  DbAccessorGraphView identity_graph_view_;
 };
 
 PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &parameters, const bool is_profile_query,
@@ -3205,7 +3208,8 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
       user_resource_{std::move(user_resource)}
 #endif
       ,
-      metric_handles_(&metric_handles) {
+      metric_handles_(&metric_handles),
+      identity_graph_view_(dba) {
   ctx_.profile_execution_time = std::chrono::duration<double>(0.0);
   ctx_.metric_handles = &metric_handles;
   if (hops_limit) {
@@ -3223,6 +3227,7 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
   ctx_.parallel_execution = parallel_execution;
 #endif
   ctx_.db_accessor = dba;
+  ctx_.evaluation_context.graph_view = &identity_graph_view_;
   ctx_.db_arena_pool = db_arena_pool;
   ctx_.symbol_table = plan->symbol_table();
   ctx_.evaluation_context.timestamp = QueryTimestamp();

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -291,6 +291,12 @@ class Interpreter final {
   void ResetCachedFga();
   FineGrainedAuthChecker const *GetCachedFga() const;
 
+  // The current query's synthetic-id mapper - the same instance id()/virtual_id() use, so Bolt
+  // serialization externalizes virtual ids onto the identical query-local axis. Renewed per query
+  // (a new query restarts the external ids at -1).
+  SyntheticIdMapper *GetSyntheticIdMapper() const;
+  std::shared_ptr<SyntheticIdMapper> RenewSyntheticIdMapper();
+
   struct PrepareResult {
     std::vector<std::string> headers;
     std::vector<query::AuthQuery::Privilege> privileges;
@@ -319,6 +325,7 @@ class Interpreter final {
   std::shared_ptr<utils::UserResources> user_resource_;
 #endif
   std::unique_ptr<CachedFineGrainedAuth> cached_fga_;
+  std::shared_ptr<SyntheticIdMapper> synthetic_id_mapper_{std::make_shared<SyntheticIdMapper>()};
   SessionInfo session_info_;
   bool in_explicit_transaction_{false};
   CurrentDB current_db_;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -221,7 +221,7 @@ struct PreparedQuery {
   std::function<std::string()> slow_query_plan_renderer{};
   // One entry per derive() projection whose schema is statically known; empty for queries with no
   // projection. Extracted from the plan at prepare time so it can ship in the result header.
-  std::vector<ProjectionSchema> projection_schemas{};
+  std::vector<ProjectionSchemaEntry> projection_schemas{};
 };
 
 /**
@@ -296,7 +296,7 @@ class Interpreter final {
     std::vector<query::AuthQuery::Privilege> privileges;
     std::optional<int> qid;
     std::optional<std::string> db;
-    std::vector<ProjectionSchema> projection_schemas;
+    std::vector<ProjectionSchemaEntry> projection_schemas;
   };
 
 #ifdef MG_ENTERPRISE

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -23,6 +23,7 @@
 #include "query/context.hpp"
 #include "query/db_accessor.hpp"
 #include "query/plan_v2/frontend/query_planner_context.hpp"
+#include "query/projection_schema.hpp"
 #include "query/stream.hpp"
 #include "query/trigger_context.hpp"
 #include "system/transaction.hpp"
@@ -218,6 +219,9 @@ struct PreparedQuery {
   // Lazily renders the EXPLAIN plan for the slow-query log; empty unless slow logging may
   // apply. Pull invokes it past the duration gate, while the plan's DbAccessor is alive.
   std::function<std::string()> slow_query_plan_renderer{};
+  // One entry per derive() projection whose schema is statically known; empty for queries with no
+  // projection. Extracted from the plan at prepare time so it can ship in the result header.
+  std::vector<ProjectionSchema> projection_schemas{};
 };
 
 /**
@@ -292,6 +296,7 @@ class Interpreter final {
     std::vector<query::AuthQuery::Privilege> privileges;
     std::optional<int> qid;
     std::optional<std::string> db;
+    std::vector<ProjectionSchema> projection_schemas;
   };
 
 #ifdef MG_ENTERPRISE

--- a/src/query/overlay_authorization.hpp
+++ b/src/query/overlay_authorization.hpp
@@ -1,0 +1,67 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "query/auth_checker.hpp"
+#include "query/frontend/ast/ast.hpp"
+#include "query/virtual_node.hpp"
+#include "storage/v2/id_types.hpp"
+#include "storage/v2/result.hpp"
+#include "storage/v2/view.hpp"
+
+namespace memgraph::query {
+
+// The single source of truth for whether a property of an overlay or synthetic node is READ-visible
+// under fine-grained access control. Resolve once with For() (which may read the origin's labels),
+// then decide per property with IsReadable().
+//
+// Resolving once is deliberate: the bulk callers (properties()/keys() and Bolt serialization) iterate
+// every property, so a per-property predicate that re-read the origin's labels would turn one label
+// read into N. A label-read failure is carried in the Result For() returns, so each caller surfaces it
+// in the way its context requires - the read-path evaluator fails closed, the property functions throw,
+// Bolt propagates the storage error - while the visibility decision itself lives in exactly one place.
+class OverlayReadAuthorization {
+ public:
+  // Resolves the authorization context. A null checker or a synthetic node (no origin) mints no
+  // real-graph data, so every property is readable. Otherwise the origin's labels are read (the only
+  // fallible step); a failure is returned so the caller can surface it.
+  static storage::Result<OverlayReadAuthorization> For(const VirtualNode &node, storage::View view,
+                                                       const FineGrainedAuthChecker *checker) {
+    if (checker == nullptr || !node.HasOrigin()) return OverlayReadAuthorization{nullptr, std::nullopt};
+    auto maybe_labels = node.Origin()->Labels(view);
+    if (!maybe_labels) return std::unexpected{maybe_labels.error()};
+    return OverlayReadAuthorization{checker, std::vector<storage::LabelId>{maybe_labels->begin(), maybe_labels->end()}};
+  }
+
+  // An overlay-bound override is the author's own computed value (any origin data it derived from was
+  // itself FGA-checked at construction), so it is always readable. Otherwise an origin-read-through
+  // property gets the origin's per-property READ permission over the origin's labels.
+  [[nodiscard]] bool IsReadable(const VirtualNode &node, storage::PropertyId prop) const {
+    if (checker_ == nullptr || !origin_labels_) return true;
+    if (node.IsOverlayBound(prop)) return true;
+    return checker_->HasPropertyPermission(*origin_labels_, prop, AuthQuery::PropertyPermissionType::READ);
+  }
+
+ private:
+  OverlayReadAuthorization(const FineGrainedAuthChecker *checker,
+                           std::optional<std::vector<storage::LabelId>> origin_labels)
+      : checker_(checker), origin_labels_(std::move(origin_labels)) {}
+
+  const FineGrainedAuthChecker *checker_;
+  std::optional<std::vector<storage::LabelId>> origin_labels_;
+};
+
+}  // namespace memgraph::query

--- a/src/query/overlay_authorization.hpp
+++ b/src/query/overlay_authorization.hpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "query/auth_checker.hpp"
-#include "query/frontend/ast/ast.hpp"
 #include "query/virtual_node.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/result.hpp"

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -313,6 +313,10 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
 
   bool PostVisit(Apply & /*op*/) override { return true; }
 
+  bool PreVisit(BindGraphView & /*unused*/) override { return true; }
+
+  bool PostVisit(BindGraphView & /*unused*/) override { return true; }
+
   bool PreVisit(LoadCsv & /*unused*/) override { return true; }
 
   bool PostVisit(LoadCsv & /*unused*/) override { return true; }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2297,10 +2297,65 @@ struct VirtualTraversal {
   }
 };
 
-// True when the ambient graph view is a projection; then a VirtualTraversal is used, otherwise the
-// real graph (identity or subgraph view) is traversed unchanged.
-inline VirtualGraphView *ProjectionView(ExecutionContext &context) {
-  return dynamic_cast<VirtualGraphView *>(context.evaluation_context.graph_view);
+// Subgraph traversal: real vertices and edges, but a vertex's edges are filtered to the subgraph's
+// membership so an expansion cannot leave the subgraph (issue 49). Mirrors RealTraversal for input,
+// visibility, and cyphermorphism; only Expand differs, materialising the member-filtered level. A
+// subgraph is non-hot (like a projection), so the real identity path keeps its lazy, unregressed shape.
+template <bool AccountHops>
+struct SubgraphTraversal {
+  using Vertex = VertexAccessor;
+  using Edge = EdgeAccessor;
+
+  const ExpandVariable *self;
+  SubgraphGraphView *sview;
+
+  utils::pmr::vector<std::pair<Edge, EdgeAtom::Direction>> Expand(const Vertex &vertex, EdgeAtom::Direction direction,
+                                                                  ExecutionContext &context) const {
+    utils::pmr::vector<std::pair<Edge, EdgeAtom::Direction>> level(context.evaluation_context.memory);
+    // All traversed real edges count toward hops (via ExpandFromVertex), even non-member ones dropped
+    // here - matching single-hop expansion over a subgraph.
+    for (auto pair : ExpandFromVertex<AccountHops>(
+             vertex, direction, self->common_.edge_types, context.evaluation_context.memory, &context)) {
+      if (sview->ContainsEdge(pair.first)) level.push_back(pair);
+    }
+    return level;
+  }
+
+  static Vertex GetInput(const TypedValue &value, const Symbol &symbol) {
+    return RealTraversal<AccountHops>::GetInput(value, symbol);
+  }
+
+  static bool Visible(const Edge &edge, const Vertex &far, ExecutionContext &context) {
+    return RealTraversal<AccountHops>::Visible(edge, far, context);
+  }
+
+  static bool AlreadyOnFrame(const Edge &edge, const utils::pmr::vector<TypedValue> &edges_on_frame) {
+    return RealTraversal<AccountHops>::AlreadyOnFrame(edge, edges_on_frame);
+  }
+
+  static bool SameBoundNode(const Vertex &vertex, const Symbol &symbol, Frame &frame) {
+    return RealTraversal<AccountHops>::SameBoundNode(vertex, symbol, frame);
+  }
+};
+
+// Selects the traversal policy for the ambient graph view and invokes make(policy) to build the arm's
+// cursor: a projection materialises its level from the bound overlay; a subgraph materialises a
+// membership-filtered level; anything else (the real identity view) keeps RealTraversal's lazy,
+// unregressed hot path. The view dispatch (one dynamic_cast per cursor build, never per row) and the
+// projection edge-type name resolution live here once, shared by all six traversal-family arms.
+template <bool AccountHops, class Make>
+void DispatchAmbientTraversal(ExecutionContext &context, const ExpandVariable &self, Make &&make) {
+  auto *ambient = context.evaluation_context.graph_view;
+  if (auto *vview = dynamic_cast<VirtualGraphView *>(ambient)) {
+    std::vector<std::string_view> allowed;
+    allowed.reserve(self.common_.edge_types.size());
+    for (const auto type : self.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
+    make(VirtualTraversal{&self, vview, std::move(allowed)});
+  } else if (auto *sview = dynamic_cast<SubgraphGraphView *>(ambient)) {
+    make(SubgraphTraversal<AccountHops>{&self, sview});
+  } else {
+    make(RealTraversal<AccountHops>{&self});
+  }
 }
 
 // The variable-length (DFS) expansion, written once over a traversal policy.
@@ -2513,13 +2568,16 @@ class ExpandVariableCursor : public Cursor {
       Init(context);
     if (auto *impl = std::get_if<VariableExpansionImpl<RealTraversal<true>>>(&impl_)) [[likely]]
       return impl->Pull(frame, context);
-    return std::get<VariableExpansionImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+    if (auto *impl = std::get_if<VariableExpansionImpl<VirtualTraversal>>(&impl_)) return impl->Pull(frame, context);
+    return std::get<VariableExpansionImpl<SubgraphTraversal<true>>>(impl_).Pull(frame, context);
   }
 
   void Shutdown() override {
     if (auto *impl = std::get_if<VariableExpansionImpl<RealTraversal<true>>>(&impl_))
       impl->Shutdown();
     else if (auto *impl = std::get_if<VariableExpansionImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<VariableExpansionImpl<SubgraphTraversal<true>>>(&impl_))
       impl->Shutdown();
     else
       input_cursor_->Shutdown();
@@ -2530,6 +2588,8 @@ class ExpandVariableCursor : public Cursor {
       impl->Reset();
     else if (auto *impl = std::get_if<VariableExpansionImpl<VirtualTraversal>>(&impl_))
       impl->Reset();
+    else if (auto *impl = std::get_if<VariableExpansionImpl<SubgraphTraversal<true>>>(&impl_))
+      impl->Reset();
     else
       input_cursor_->Reset();
   }
@@ -2538,22 +2598,17 @@ class ExpandVariableCursor : public Cursor {
   const ExpandVariable &self_;
   utils::MemoryResource *mem_;
   UniqueCursorPtr input_cursor_;
-  // Chosen on the first Pull from the ambient graph view and reused; a projection traverses the
-  // overlay, anything else the real graph. One implementation, two instantiations.
-  std::variant<std::monostate, VariableExpansionImpl<RealTraversal<true>>, VariableExpansionImpl<VirtualTraversal>>
+  // Chosen on the first Pull from the ambient graph view and reused: a projection traverses the
+  // overlay, a subgraph the member-filtered real edges, anything else the real graph. One
+  // implementation, three instantiations.
+  std::variant<std::monostate, VariableExpansionImpl<RealTraversal<true>>, VariableExpansionImpl<VirtualTraversal>,
+               VariableExpansionImpl<SubgraphTraversal<true>>>
       impl_;
 
   void Init(ExecutionContext &context) {
-    if (auto *vview = ProjectionView(context)) {
-      std::vector<std::string_view> allowed;
-      allowed.reserve(self_.common_.edge_types.size());
-      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
-      impl_.emplace<VariableExpansionImpl<VirtualTraversal>>(
-          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor_), mem_);
-    } else {
-      impl_.emplace<VariableExpansionImpl<RealTraversal<true>>>(
-          self_, RealTraversal<true>{&self_}, std::move(input_cursor_), mem_);
-    }
+    DispatchAmbientTraversal<true>(context, self_, [&](auto trav) {
+      impl_.emplace<VariableExpansionImpl<decltype(trav)>>(self_, std::move(trav), std::move(input_cursor_), mem_);
+    });
   }
 };
 
@@ -2754,13 +2809,16 @@ class STShortestPathCursor : public query::plan::Cursor {
       Init(context);
     if (auto *impl = std::get_if<STShortestPathImpl<RealTraversal<true>>>(&impl_)) [[likely]]
       return impl->Pull(frame, context);
-    return std::get<STShortestPathImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+    if (auto *impl = std::get_if<STShortestPathImpl<VirtualTraversal>>(&impl_)) return impl->Pull(frame, context);
+    return std::get<STShortestPathImpl<SubgraphTraversal<true>>>(impl_).Pull(frame, context);
   }
 
   void Shutdown() override {
     if (auto *impl = std::get_if<STShortestPathImpl<RealTraversal<true>>>(&impl_))
       impl->Shutdown();
     else if (auto *impl = std::get_if<STShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<STShortestPathImpl<SubgraphTraversal<true>>>(&impl_))
       impl->Shutdown();
   }
 
@@ -2769,25 +2827,23 @@ class STShortestPathCursor : public query::plan::Cursor {
       impl->Reset();
     else if (auto *impl = std::get_if<STShortestPathImpl<VirtualTraversal>>(&impl_))
       impl->Reset();
+    else if (auto *impl = std::get_if<STShortestPathImpl<SubgraphTraversal<true>>>(&impl_))
+      impl->Reset();
   }
 
  private:
   const ExpandVariable &self_;
   utils::MemoryResource *mem_;
   metrics::DatabaseMetricHandles &metric_handles_;
-  std::variant<std::monostate, STShortestPathImpl<RealTraversal<true>>, STShortestPathImpl<VirtualTraversal>> impl_;
+  std::variant<std::monostate, STShortestPathImpl<RealTraversal<true>>, STShortestPathImpl<VirtualTraversal>,
+               STShortestPathImpl<SubgraphTraversal<true>>>
+      impl_;
 
   void Init(ExecutionContext &context) {
     auto input_cursor = self_.input()->MakeCursor(mem_, metric_handles_);
-    if (auto *vview = ProjectionView(context)) {
-      std::vector<std::string_view> allowed;
-      allowed.reserve(self_.common_.edge_types.size());
-      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
-      impl_.emplace<STShortestPathImpl<VirtualTraversal>>(
-          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor));
-      return;
-    }
-    impl_.emplace<STShortestPathImpl<RealTraversal<true>>>(self_, RealTraversal<true>{&self_}, std::move(input_cursor));
+    DispatchAmbientTraversal<true>(context, self_, [&](auto trav) {
+      impl_.emplace<STShortestPathImpl<decltype(trav)>>(self_, std::move(trav), std::move(input_cursor));
+    });
   }
 };
 
@@ -2998,13 +3054,17 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
       Init(context);
     if (auto *impl = std::get_if<SingleSourceShortestPathImpl<RealTraversal<true>>>(&impl_)) [[likely]]
       return impl->Pull(frame, context);
-    return std::get<SingleSourceShortestPathImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+    if (auto *impl = std::get_if<SingleSourceShortestPathImpl<VirtualTraversal>>(&impl_))
+      return impl->Pull(frame, context);
+    return std::get<SingleSourceShortestPathImpl<SubgraphTraversal<true>>>(impl_).Pull(frame, context);
   }
 
   void Shutdown() override {
     if (auto *impl = std::get_if<SingleSourceShortestPathImpl<RealTraversal<true>>>(&impl_))
       impl->Shutdown();
     else if (auto *impl = std::get_if<SingleSourceShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<SingleSourceShortestPathImpl<SubgraphTraversal<true>>>(&impl_))
       impl->Shutdown();
   }
 
@@ -3013,6 +3073,8 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
       impl->Reset();
     else if (auto *impl = std::get_if<SingleSourceShortestPathImpl<VirtualTraversal>>(&impl_))
       impl->Reset();
+    else if (auto *impl = std::get_if<SingleSourceShortestPathImpl<SubgraphTraversal<true>>>(&impl_))
+      impl->Reset();
   }
 
  private:
@@ -3020,21 +3082,15 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
   utils::MemoryResource *mem_;
   metrics::DatabaseMetricHandles &metric_handles_;
   std::variant<std::monostate, SingleSourceShortestPathImpl<RealTraversal<true>>,
-               SingleSourceShortestPathImpl<VirtualTraversal>>
+               SingleSourceShortestPathImpl<VirtualTraversal>, SingleSourceShortestPathImpl<SubgraphTraversal<true>>>
       impl_;
 
   void Init(ExecutionContext &context) {
     auto input_cursor = self_.input()->MakeCursor(mem_, metric_handles_);
-    if (auto *vview = ProjectionView(context)) {
-      std::vector<std::string_view> allowed;
-      allowed.reserve(self_.common_.edge_types.size());
-      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
-      impl_.emplace<SingleSourceShortestPathImpl<VirtualTraversal>>(
-          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
-      return;
-    }
-    impl_.emplace<SingleSourceShortestPathImpl<RealTraversal<true>>>(
-        self_, RealTraversal<true>{&self_}, std::move(input_cursor), mem_);
+    DispatchAmbientTraversal<true>(context, self_, [&](auto trav) {
+      impl_.emplace<SingleSourceShortestPathImpl<decltype(trav)>>(
+          self_, std::move(trav), std::move(input_cursor), mem_);
+    });
   }
 };
 
@@ -3342,13 +3398,16 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
       Init(context);
     if (auto *impl = std::get_if<WeightedShortestPathImpl<RealTraversal<false>>>(&impl_)) [[likely]]
       return impl->Pull(frame, context);
-    return std::get<WeightedShortestPathImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+    if (auto *impl = std::get_if<WeightedShortestPathImpl<VirtualTraversal>>(&impl_)) return impl->Pull(frame, context);
+    return std::get<WeightedShortestPathImpl<SubgraphTraversal<false>>>(impl_).Pull(frame, context);
   }
 
   void Shutdown() override {
     if (auto *impl = std::get_if<WeightedShortestPathImpl<RealTraversal<false>>>(&impl_))
       impl->Shutdown();
     else if (auto *impl = std::get_if<WeightedShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<WeightedShortestPathImpl<SubgraphTraversal<false>>>(&impl_))
       impl->Shutdown();
   }
 
@@ -3357,6 +3416,8 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
       impl->Reset();
     else if (auto *impl = std::get_if<WeightedShortestPathImpl<VirtualTraversal>>(&impl_))
       impl->Reset();
+    else if (auto *impl = std::get_if<WeightedShortestPathImpl<SubgraphTraversal<false>>>(&impl_))
+      impl->Reset();
   }
 
  private:
@@ -3364,22 +3425,15 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
   utils::MemoryResource *mem_;
   metrics::DatabaseMetricHandles &metric_handles_;
   std::variant<std::monostate, WeightedShortestPathImpl<RealTraversal<false>>,
-               WeightedShortestPathImpl<VirtualTraversal>>
+               WeightedShortestPathImpl<VirtualTraversal>, WeightedShortestPathImpl<SubgraphTraversal<false>>>
       impl_;
 
   void Init(ExecutionContext &context) {
     auto input_cursor = self_.input_->MakeCursor(mem_, metric_handles_);
-    if (auto *vview = ProjectionView(context)) {
-      std::vector<std::string_view> allowed;
-      allowed.reserve(self_.common_.edge_types.size());
-      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
-      impl_.emplace<WeightedShortestPathImpl<VirtualTraversal>>(
-          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
-      return;
-    }
-    // Weighted shortest path historically does not account hops (RealTraversal<false>).
-    impl_.emplace<WeightedShortestPathImpl<RealTraversal<false>>>(
-        self_, RealTraversal<false>{&self_}, std::move(input_cursor), mem_);
+    // Weighted shortest path historically does not account hops (AccountHops = false).
+    DispatchAmbientTraversal<false>(context, self_, [&](auto trav) {
+      impl_.emplace<WeightedShortestPathImpl<decltype(trav)>>(self_, std::move(trav), std::move(input_cursor), mem_);
+    });
   }
 };
 
@@ -3748,13 +3802,16 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       Init(context);
     if (auto *impl = std::get_if<AllShortestPathsImpl<RealTraversal<false>>>(&impl_)) [[likely]]
       return impl->Pull(frame, context);
-    return std::get<AllShortestPathsImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+    if (auto *impl = std::get_if<AllShortestPathsImpl<VirtualTraversal>>(&impl_)) return impl->Pull(frame, context);
+    return std::get<AllShortestPathsImpl<SubgraphTraversal<false>>>(impl_).Pull(frame, context);
   }
 
   void Shutdown() override {
     if (auto *impl = std::get_if<AllShortestPathsImpl<RealTraversal<false>>>(&impl_))
       impl->Shutdown();
     else if (auto *impl = std::get_if<AllShortestPathsImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<AllShortestPathsImpl<SubgraphTraversal<false>>>(&impl_))
       impl->Shutdown();
   }
 
@@ -3763,28 +3820,24 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       impl->Reset();
     else if (auto *impl = std::get_if<AllShortestPathsImpl<VirtualTraversal>>(&impl_))
       impl->Reset();
+    else if (auto *impl = std::get_if<AllShortestPathsImpl<SubgraphTraversal<false>>>(&impl_))
+      impl->Reset();
   }
 
  private:
   const ExpandVariable &self_;
   utils::MemoryResource *mem_;
   metrics::DatabaseMetricHandles &metric_handles_;
-  std::variant<std::monostate, AllShortestPathsImpl<RealTraversal<false>>, AllShortestPathsImpl<VirtualTraversal>>
+  std::variant<std::monostate, AllShortestPathsImpl<RealTraversal<false>>, AllShortestPathsImpl<VirtualTraversal>,
+               AllShortestPathsImpl<SubgraphTraversal<false>>>
       impl_;
 
   void Init(ExecutionContext &context) {
     auto input_cursor = self_.input_->MakeCursor(mem_, metric_handles_);
-    if (auto *vview = ProjectionView(context)) {
-      std::vector<std::string_view> allowed;
-      allowed.reserve(self_.common_.edge_types.size());
-      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
-      impl_.emplace<AllShortestPathsImpl<VirtualTraversal>>(
-          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
-      return;
-    }
-    // All-shortest historically does not account hops (RealTraversal<false>).
-    impl_.emplace<AllShortestPathsImpl<RealTraversal<false>>>(
-        self_, RealTraversal<false>{&self_}, std::move(input_cursor), mem_);
+    // All-shortest historically does not account hops (AccountHops = false).
+    DispatchAmbientTraversal<false>(context, self_, [&](auto trav) {
+      impl_.emplace<AllShortestPathsImpl<decltype(trav)>>(self_, std::move(trav), std::move(input_cursor), mem_);
+    });
   }
 };
 
@@ -4182,13 +4235,16 @@ class KShortestPathsCursor : public Cursor {
       Init(context);
     if (auto *impl = std::get_if<KShortestPathsImpl<RealTraversal<true>>>(&impl_)) [[likely]]
       return impl->Pull(frame, context);
-    return std::get<KShortestPathsImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+    if (auto *impl = std::get_if<KShortestPathsImpl<VirtualTraversal>>(&impl_)) return impl->Pull(frame, context);
+    return std::get<KShortestPathsImpl<SubgraphTraversal<true>>>(impl_).Pull(frame, context);
   }
 
   void Shutdown() override {
     if (auto *impl = std::get_if<KShortestPathsImpl<RealTraversal<true>>>(&impl_))
       impl->Shutdown();
     else if (auto *impl = std::get_if<KShortestPathsImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<KShortestPathsImpl<SubgraphTraversal<true>>>(&impl_))
       impl->Shutdown();
   }
 
@@ -4197,26 +4253,23 @@ class KShortestPathsCursor : public Cursor {
       impl->Reset();
     else if (auto *impl = std::get_if<KShortestPathsImpl<VirtualTraversal>>(&impl_))
       impl->Reset();
+    else if (auto *impl = std::get_if<KShortestPathsImpl<SubgraphTraversal<true>>>(&impl_))
+      impl->Reset();
   }
 
  private:
   const ExpandVariable &self_;
   utils::MemoryResource *mem_;
   metrics::DatabaseMetricHandles &metric_handles_;
-  std::variant<std::monostate, KShortestPathsImpl<RealTraversal<true>>, KShortestPathsImpl<VirtualTraversal>> impl_;
+  std::variant<std::monostate, KShortestPathsImpl<RealTraversal<true>>, KShortestPathsImpl<VirtualTraversal>,
+               KShortestPathsImpl<SubgraphTraversal<true>>>
+      impl_;
 
   void Init(ExecutionContext &context) {
     auto input_cursor = self_.input_->MakeCursor(mem_, metric_handles_);
-    if (auto *vview = ProjectionView(context)) {
-      std::vector<std::string_view> allowed;
-      allowed.reserve(self_.common_.edge_types.size());
-      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
-      impl_.emplace<KShortestPathsImpl<VirtualTraversal>>(
-          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
-      return;
-    }
-    impl_.emplace<KShortestPathsImpl<RealTraversal<true>>>(
-        self_, RealTraversal<true>{&self_}, std::move(input_cursor), mem_);
+    DispatchAmbientTraversal<true>(context, self_, [&](auto trav) {
+      impl_.emplace<KShortestPathsImpl<decltype(trav)>>(self_, std::move(trav), std::move(input_cursor), mem_);
+    });
   }
 };
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2159,6 +2159,10 @@ namespace {
  * @param memory - Used to allocate the result.
  * @return See above.
  */
+// AccountHops gates hops-limit checking and number_of_hops accounting at compile time: the DFS/BFS/s-t
+// arms account hops, the weighted / all-shortest arms historically do not. A template (not a runtime
+// argument) so the branch compiles away entirely.
+template <bool AccountHops>
 auto ExpandFromVertex(const VertexAccessor &vertex, EdgeAtom::Direction direction,
                       const std::vector<storage::EdgeTypeId> &edge_types, utils::MemoryResource *memory,
                       ExecutionContext *context) {
@@ -2169,20 +2173,22 @@ auto ExpandFromVertex(const VertexAccessor &vertex, EdgeAtom::Direction directio
   };
 
   storage::View view = storage::View::OLD;
+  decltype(&context->hops_limit) hops = nullptr;
+  if constexpr (AccountHops) hops = &context->hops_limit;
   utils::pmr::vector<decltype(wrapper(direction, vertex.InEdges(view, edge_types).value().edges))> chain_elements(
       memory);
 
   if (direction != EdgeAtom::Direction::OUT) {
-    auto edges_result = UnwrapEdgesResult(vertex.InEdges(view, edge_types, &context->hops_limit));
-    context->number_of_hops += edges_result.expanded_count;
+    auto edges_result = UnwrapEdgesResult(vertex.InEdges(view, edge_types, hops));
+    if constexpr (AccountHops) context->number_of_hops += edges_result.expanded_count;
     if (!edges_result.edges.empty()) {
       chain_elements.emplace_back(wrapper(EdgeAtom::Direction::IN, std::move(edges_result.edges)));
     }
   }
 
   if (direction != EdgeAtom::Direction::IN) {
-    auto edges_result = UnwrapEdgesResult(vertex.OutEdges(view, edge_types, &context->hops_limit));
-    context->number_of_hops += edges_result.expanded_count;
+    auto edges_result = UnwrapEdgesResult(vertex.OutEdges(view, edge_types, hops));
+    if constexpr (AccountHops) context->number_of_hops += edges_result.expanded_count;
     if (!edges_result.edges.empty()) {
       chain_elements.emplace_back(wrapper(EdgeAtom::Direction::OUT, std::move(edges_result.edges)));
     }
@@ -2192,42 +2198,148 @@ auto ExpandFromVertex(const VertexAccessor &vertex, EdgeAtom::Direction directio
   return iter::chain.from_iterable(std::move(chain_elements));
 }
 
-}  // namespace
+// ---------------------------------------------------------------------------------------------------
+// Traversal policies: the whole variable-length family (DFS here, shortest paths below) is written
+// once and instantiated for the real graph and for a projection. A policy supplies only what differs:
+// how a node's incident edges are enumerated, per-hop visibility, and the identity used for
+// cyphermorphism and existing-node binding. Everything else (the stacks, maps, priority queues, path
+// reconstruction, and weight-lambda evaluation over TypedValue) is shared. The real instantiation
+// keeps its exact shape - Expand returns the same lazy (edge, direction) chain - so there is no
+// hot-path regression (ADR 0005 / issue 43 binding constraint). A projection is small and non-hot
+// (ADR 0004), so its Expand materialises the level from the bound view's edge index.
 
-class ExpandVariableCursor : public Cursor {
+// Real-graph traversal.
+template <bool AccountHops>
+struct RealTraversal {
+  using Vertex = VertexAccessor;
+  using Edge = EdgeAccessor;
+
+  const ExpandVariable *self;
+
+  [[gnu::always_inline]] auto Expand(const Vertex &vertex, EdgeAtom::Direction direction,
+                                     ExecutionContext &context) const {
+    return ExpandFromVertex<AccountHops>(
+        vertex, direction, self->common_.edge_types, context.evaluation_context.memory, &context);
+  }
+
+  static Vertex GetInput(const TypedValue &value, const Symbol &symbol) {
+    ExpectType(symbol, value, TypedValue::Type::Vertex);
+    return value.ValueVertex();
+  }
+
+  static bool Visible(const Edge &edge, const Vertex &far, ExecutionContext &context) {
+#ifdef MG_ENTERPRISE
+    if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
+        !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
+          context.auth_checker->Has(far, storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
+      return false;
+    }
+#endif
+    return true;
+  }
+
+  static bool AlreadyOnFrame(const Edge &edge, const utils::pmr::vector<TypedValue> &edges_on_frame) {
+    return std::ranges::any_of(edges_on_frame, [&](const TypedValue &e) { return edge == e.ValueEdge(); });
+  }
+
+  static bool SameBoundNode(const Vertex &vertex, const Symbol &symbol, Frame &frame) {
+    return CheckExistingNode(vertex, symbol, frame);
+  }
+};
+
+// Projection traversal: VirtualEdge is held by value so edge.From()/To() read uniformly with the real
+// Edge; edge-type names are resolved once (empty = any).
+struct VirtualTraversal {
+  using Vertex = VirtualNode;
+  using Edge = VirtualEdge;
+
+  const ExpandVariable *self;
+  VirtualGraphView *vview;
+  std::vector<std::string_view> allowed;
+
+  utils::pmr::vector<std::pair<Edge, EdgeAtom::Direction>> Expand(const Vertex &vertex, EdgeAtom::Direction direction,
+                                                                  ExecutionContext &context) const {
+    utils::pmr::vector<std::pair<Edge, EdgeAtom::Direction>> level(context.evaluation_context.memory);
+    const auto type_ok = [&](const VirtualEdge *edge) {
+      return allowed.empty() || std::ranges::find(allowed, std::string_view{edge->EdgeTypeName()}) != allowed.end();
+    };
+    if (direction != EdgeAtom::Direction::OUT) {
+      for (const auto *edge : vview->InEdges(vertex.Gid()))
+        if (type_ok(edge)) level.emplace_back(*edge, EdgeAtom::Direction::IN);
+    }
+    if (direction != EdgeAtom::Direction::IN) {
+      for (const auto *edge : vview->OutEdges(vertex.Gid()))
+        if (type_ok(edge)) level.emplace_back(*edge, EdgeAtom::Direction::OUT);
+    }
+    return level;
+  }
+
+  static Vertex GetInput(const TypedValue &value, const Symbol & /*symbol*/) { return value.ValueVirtualNode(); }
+
+  static bool Visible(const Edge & /*edge*/, const Vertex &far, ExecutionContext &context) {
+#ifdef MG_ENTERPRISE
+    if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker) {
+      return OverlayNodeVisible(*context.auth_checker, far, storage::View::OLD);
+    }
+#endif
+    return true;
+  }
+
+  static bool AlreadyOnFrame(const Edge &edge, const utils::pmr::vector<TypedValue> &edges_on_frame) {
+    return std::ranges::any_of(edges_on_frame,
+                               [&](const TypedValue &e) { return e.ValueVirtualEdge().Gid() == edge.Gid(); });
+  }
+
+  static bool SameBoundNode(const Vertex &vertex, const Symbol &symbol, Frame &frame) {
+    const TypedValue &bound = frame[symbol];
+    return !bound.IsNull() && bound.type() == TypedValue::Type::VirtualNode &&
+           bound.ValueVirtualNode().Gid() == vertex.Gid();
+  }
+};
+
+// True when the ambient graph view is a projection; then a VirtualTraversal is used, otherwise the
+// real graph (identity or subgraph view) is traversed unchanged.
+inline VirtualGraphView *ProjectionView(ExecutionContext &context) {
+  return dynamic_cast<VirtualGraphView *>(context.evaluation_context.graph_view);
+}
+
+// The variable-length (DFS) expansion, written once over a traversal policy.
+struct VariableExpansion {
+  virtual ~VariableExpansion() = default;
+  virtual bool Pull(Frame &frame, ExecutionContext &context) = 0;
+  virtual void Reset() = 0;
+  virtual void Shutdown() = 0;
+};
+
+template <class Trav>
+class VariableExpansionImpl final : public VariableExpansion {
+  using Vertex = typename Trav::Vertex;
+  using Edge = typename Trav::Edge;
+  using Range = decltype(std::declval<const Trav &>().Expand(std::declval<const Vertex &>(), EdgeAtom::Direction::OUT,
+                                                             std::declval<ExecutionContext &>()));
+
  public:
-  ExpandVariableCursor(const ExpandVariable &self, utils::MemoryResource *mem,
-                       metrics::DatabaseMetricHandles &metric_handles)
-      : self_(self), input_cursor_(self.input_->MakeCursor(mem, metric_handles)), edges_(mem), edges_it_(mem) {}
+  VariableExpansionImpl(const ExpandVariable &self, Trav trav, UniqueCursorPtr input_cursor, utils::MemoryResource *mem)
+      : self_(self), trav_(std::move(trav)), input_cursor_(std::move(input_cursor)), edges_(mem), edges_it_(mem) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
-    SCOPED_PROFILE_OP_BY_REF(self_);
-
-    AbortCheck(context);
-
     while (true) {
       if (Expand(frame, context)) return true;
 
       if (PullInput(frame, context)) {
         // if lower bound is zero we also yield empty paths
         if (lower_bound_ == 0) {
-          auto &start_vertex = frame[self_.input_symbol_].ValueVertex();
+          Vertex start = Trav::GetInput(frame[self_.input_symbol_], self_.input_symbol_);
           if (!self_.common_.existing_node) {
             auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
-            frame_writer.Write(self_.common_.node_symbol, start_vertex);
+            frame_writer.Write(self_.common_.node_symbol, start);
             return true;
           }
-          if (CheckExistingNode(start_vertex, self_.common_.node_symbol, frame)) {
-            return true;
-          }
+          if (Trav::SameBoundNode(start, self_.common_.node_symbol, frame)) return true;
         }
-        // if lower bound is not zero, we just continue, the next
-        // loop iteration will attempt to expand and we're good
-      } else
+      } else {
         return false;
-      // else continue with the loop, try to expand again
-      // because we succesfully pulled from the input
+      }
     }
   }
 
@@ -2241,93 +2353,70 @@ class ExpandVariableCursor : public Cursor {
 
  private:
   const ExpandVariable &self_;
-  const UniqueCursorPtr input_cursor_;
-  // bounds. in the cursor they are not optional but set to
-  // default values if missing in the ExpandVariable operator
+  Trav trav_;
+  UniqueCursorPtr input_cursor_;
+  // bounds. in the cursor they are not optional but set to default values if missing in the operator.
   int64_t upper_bound_{-1};
   int64_t lower_bound_{-1};
-
-  // a stack of edge iterables corresponding to the level/depth of
-  // the expansion currently being Pulled
-  using ExpandEdges =
-      decltype(ExpandFromVertex(std::declval<VertexAccessor>(), EdgeAtom::Direction::IN, self_.common_.edge_types,
-                                utils::NewDeleteResource(), std::declval<ExecutionContext *>()));
-
-  utils::pmr::vector<ExpandEdges> edges_;
-  // an iterator indicating the position in the corresponding edges_ element
+  // a stack of edge iterables per level, and an iterator into each - the real chain or the projection
+  // level materialised by the policy.
+  utils::pmr::vector<Range> edges_;
   utils::pmr::vector<decltype(edges_.begin()->begin())> edges_it_;
 
-  /**
-   * Helper function that Pulls from the input vertex and
-   * makes iteration over it's edges possible.
-   *
-   * @return If the Pull succeeded. If not, this VariableExpandCursor
-   * is exhausted.
-   */
-  bool PullInput(Frame &frame, ExecutionContext &context) {
-    // Input Vertex could be null if it is created by a failed optional match.
-    // In those cases we skip that input pull and continue with the next.
+  [[gnu::noinline]] bool PullInput(Frame &frame, ExecutionContext &context) {
     while (true) {
       AbortCheck(context);
       if (!input_cursor_->Pull(frame, context)) return false;
-
       if (context.hops_limit.IsLimitReached()) return false;
 
       TypedValue const &vertex_value = frame[self_.input_symbol_];
-
-      // Null check due to possible failed optional match.
       if (vertex_value.IsNull()) continue;
 
-      ExpectType(self_.input_symbol_, vertex_value, TypedValue::Type::Vertex);
-      auto &vertex = vertex_value.ValueVertex();
-
-      // Evaluate the upper and lower bounds.
-      ExpressionEvaluator evaluator =
-          ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
-
+      ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
       auto calc_bound = [&evaluator](auto &bound) {
         auto value = EvaluateInt(evaluator, bound, "Variable expansion bound");
         if (value < 0) throw QueryRuntimeException("Variable expansion bound must be a non-negative integer.");
         return value;
       };
-
       lower_bound_ = self_.lower_bound_ ? calc_bound(self_.lower_bound_) : 1;
       upper_bound_ = self_.upper_bound_ ? calc_bound(self_.upper_bound_) : std::numeric_limits<int64_t>::max();
 
+      if constexpr (std::same_as<Edge, VirtualEdge>) {
+        // v1 does not support a filter lambda or an accumulated path over a projection.
+        if (self_.filter_lambda_.expression || self_.filter_lambda_.accumulated_path_symbol) {
+          throw QueryRuntimeException(
+              "A variable-length filter or accumulated path is not supported over a projection in a USE scope.");
+        }
+      }
+
+      Vertex vertex = Trav::GetInput(vertex_value, self_.input_symbol_);
+      auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
+
       if (upper_bound_ > 0) {
-        auto *memory = edges_.get_allocator().resource();
-        edges_.emplace_back(
-            ExpandFromVertex(vertex, self_.common_.direction, self_.common_.edge_types, memory, &context));
+        edges_.emplace_back(trav_.Expand(vertex, self_.common_.direction, context));
         edges_it_.emplace_back(edges_.back().begin());
       }
 
-      auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
-      if (self_.filter_lambda_.accumulated_path_symbol) {
-        // Add initial vertex of path to the accumulated path
-        frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), Path(vertex));
+      if constexpr (std::same_as<Edge, EdgeAccessor>) {
+        if (self_.filter_lambda_.accumulated_path_symbol) {
+          frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), Path(vertex));
+        }
       }
 
       // reset the frame value to an empty edge list
       if (frame[self_.common_.edge_symbol].IsList()) {
-        // Preserve the list capacity if possible
         frame_writer.Modify(self_.common_.edge_symbol, [](TypedValue &value) { value.ValueList().clear(); });
       } else {
-        auto *pull_memory = context.evaluation_context.memory;
-        frame_writer.Write(self_.common_.edge_symbol, TypedValue::TVector(pull_memory));
+        frame_writer.Write(self_.common_.edge_symbol, TypedValue::TVector(context.evaluation_context.memory));
       }
 
       return true;
     }
   }
 
-  // Helper function for appending an edge to the list on the frame.
-  void AppendEdge(const EdgeAccessor &new_edge, utils::pmr::vector<TypedValue> *edges_on_frame) {
-    // We are placing an edge on the frame. It is possible that there already
-    // exists an edge on the frame for this level. If so first remove it.
-    DMG_ASSERT(edges_.size() > 0, "Edges are empty");
+  void AppendEdge(const Edge &new_edge, utils::pmr::vector<TypedValue> *edges_on_frame) {
+    DMG_ASSERT(!edges_.empty(), "Edges are empty");
     if (self_.is_reverse_) {
-      // TODO: This is innefficient, we should look into replacing
-      // vector with something else for TypedValue::List.
       size_t diff = edges_on_frame->size() - std::min(edges_on_frame->size(), edges_.size() - 1U);
       if (diff > 0U) edges_on_frame->erase(edges_on_frame->begin(), edges_on_frame->begin() + diff);
       edges_on_frame->emplace(edges_on_frame->begin(), new_edge);
@@ -2337,166 +2426,186 @@ class ExpandVariableCursor : public Cursor {
     }
   }
 
-  /**
-   * Performs a single expansion for the current state of this
-   * VariableExpansionCursor.
-   *
-   * @return True if the expansion was a success and this Cursor's
-   * consumer can consume it. False if the expansion failed. In that
-   * case no more expansions are available from the current input
-   * vertex and another Pull from the input cursor should be performed.
-   */
-  bool Expand(Frame &frame, ExecutionContext &context) {
-    ExpressionEvaluator evaluator =
-        ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
-
-    // Some expansions might not be valid due to edge uniqueness and
-    // existing_node criterions, so expand in a loop until either the input
-    // vertex is exhausted or a valid variable-length expansion is available.
-
+  [[gnu::noinline]] bool Expand(Frame &frame, ExecutionContext &context) {
+    [[maybe_unused]] ExpressionEvaluator evaluator{
+        &frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
     auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
     auto try_expand = [&](TypedValue &value) {
-      // we use this a lot
       auto &edges_on_frame = value.ValueList();
-
-      // it is possible that edges_on_frame does not contain as many
-      // elements as edges_ due to edge-uniqueness (when a whole layer
-      // gets exhausted but no edges are valid). for that reason only
-      // pop from edges_on_frame if they contain enough elements
+      // edges_on_frame may hold fewer elements than edges_ (a whole layer exhausted with no valid
+      // edge), so only trim when it has enough.
       if (self_.is_reverse_) {
         auto diff = edges_on_frame.size() - std::min(edges_on_frame.size(), edges_.size());
-        if (diff > 0) {
-          edges_on_frame.erase(edges_on_frame.begin(), edges_on_frame.begin() + diff);
-        }
+        if (diff > 0) edges_on_frame.erase(edges_on_frame.begin(), edges_on_frame.begin() + diff);
       } else {
         edges_on_frame.resize(std::min(edges_on_frame.size(), edges_.size()));
       }
 
-      // if we are here, we have a valid stack,
-      // get the edge, increase the relevant iterator
+      // Copy the (edge, direction) out before any push can invalidate the level.
       auto current_edge = *edges_it_.back()++;
-      // Check edge-uniqueness.
-      bool const found_existing = std::ranges::any_of(
-          edges_on_frame, [&current_edge](const TypedValue &edge) { return current_edge.first == edge.ValueEdge(); });
-      if (found_existing) return false;
+      if (Trav::AlreadyOnFrame(current_edge.first, edges_on_frame)) return false;
 
-      VertexAccessor current_vertex =
+      Vertex current_vertex =
           current_edge.second == EdgeAtom::Direction::IN ? current_edge.first.From() : current_edge.first.To();
-#ifdef MG_ENTERPRISE
-      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-          !(context.auth_checker->Has(current_edge.first, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-            context.auth_checker->Has(
-                current_vertex, storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-        return false;
-      }
-#endif
+      if (!Trav::Visible(current_edge.first, current_vertex, context)) return false;
+
       AppendEdge(current_edge.first, &edges_on_frame);
+      if (!self_.common_.existing_node) frame_writer.Write(self_.common_.node_symbol, current_vertex);
 
-      if (!self_.common_.existing_node) {
-        frame_writer.Write(self_.common_.node_symbol, current_vertex);
-      }
-
-      // Skip expanding out of filtered expansion.
-      if (self_.filter_lambda_.expression) {
-        frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, current_edge.first);
-        frame_writer.Write(self_.filter_lambda_.inner_node_symbol, current_vertex);
-        if (self_.filter_lambda_.accumulated_path_symbol) {
-          auto update_path = [&](TypedValue &value) {
-            MG_ASSERT(value.IsPath(), "Accumulated path must be path");
-            Path &accumulated_path = value.ValuePath();
-            // Shrink the accumulated path including current level if necessary
-            while (accumulated_path.size() >= edges_on_frame.size()) {
-              accumulated_path.Shrink();
-            }
-            accumulated_path.Expand(current_edge.first);
-            accumulated_path.Expand(current_vertex);
-          };
-          frame_writer.Modify(*self_.filter_lambda_.accumulated_path_symbol, update_path);
+      if constexpr (std::same_as<Edge, EdgeAccessor>) {
+        // Skip expanding out of a filtered expansion (real graph only; rejected over a projection).
+        if (self_.filter_lambda_.expression) {
+          frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, current_edge.first);
+          frame_writer.Write(self_.filter_lambda_.inner_node_symbol, current_vertex);
+          if (self_.filter_lambda_.accumulated_path_symbol) {
+            auto update_path = [&](TypedValue &value) {
+              MG_ASSERT(value.IsPath(), "Accumulated path must be path");
+              Path &accumulated_path = value.ValuePath();
+              while (accumulated_path.size() >= edges_on_frame.size()) accumulated_path.Shrink();
+              accumulated_path.Expand(current_edge.first);
+              accumulated_path.Expand(current_vertex);
+            };
+            frame_writer.Modify(*self_.filter_lambda_.accumulated_path_symbol, update_path);
+          }
+          if (!EvaluateFilter(evaluator, self_.filter_lambda_.expression)) return false;
         }
-        if (!EvaluateFilter(evaluator, self_.filter_lambda_.expression)) return false;
       }
 
-      // we are doing depth-first search, so place the current
-      // edge's expansions onto the stack, if we should continue to expand
+      // Depth-first: push the current edge's expansions if we should continue.
       if (upper_bound_ > static_cast<int64_t>(edges_.size()) && !context.hops_limit.IsLimitReached()) {
-        auto *memory = edges_.get_allocator().resource();
-        edges_.emplace_back(
-            ExpandFromVertex(current_vertex, self_.common_.direction, self_.common_.edge_types, memory, &context));
+        edges_.emplace_back(trav_.Expand(current_vertex, self_.common_.direction, context));
         edges_it_.emplace_back(edges_.back().begin());
       }
 
-      if (self_.common_.existing_node && !CheckExistingNode(current_vertex, self_.common_.node_symbol, frame))
+      if (self_.common_.existing_node && !Trav::SameBoundNode(current_vertex, self_.common_.node_symbol, frame))
         return false;
       return true;
     };
 
     while (true) {
       AbortCheck(context);
-      // pop from the stack while there is stuff to pop and the current
-      // level is exhausted
       while (!edges_.empty() && edges_it_.back() == edges_.back().end()) {
         edges_.pop_back();
         edges_it_.pop_back();
       }
-
-      // check if we exhausted everything, if so return false
       if (edges_.empty()) return false;
 
       bool const expand_is_valid = frame_writer.Modify(self_.common_.edge_symbol, try_expand);
-
-      // We only yield true if we satisfy the lower bound.
       auto const &edges_on_frame = frame[self_.common_.edge_symbol].ValueList();
-      if (expand_is_valid && static_cast<int64_t>(edges_on_frame.size()) >= lower_bound_) {
-        return true;
-      }
+      if (expand_is_valid && static_cast<int64_t>(edges_on_frame.size()) >= lower_bound_) return true;
     }
   }
 };
 
-class STShortestPathCursor : public query::plan::Cursor {
+}  // namespace
+
+class ExpandVariableCursor : public Cursor {
  public:
-  STShortestPathCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+  ExpandVariableCursor(const ExpandVariable &self, utils::MemoryResource *mem,
                        metrics::DatabaseMetricHandles &metric_handles)
-      : self_(self), input_cursor_(self_.input()->MakeCursor(mem, metric_handles)) {
-    MG_ASSERT(self_.common_.existing_node,
-              "s-t shortest path algorithm should only "
-              "be used when `existing_node` flag is "
-              "set!");
-  }
+      : self_(self), mem_(mem), input_cursor_(self.input_->MakeCursor(mem, metric_handles)) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
-    SCOPED_PROFILE_OP("STShortestPath");
-
+    SCOPED_PROFILE_OP_BY_REF(self_);
     AbortCheck(context);
+    if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
+      Init(context);
+    if (auto *impl = std::get_if<VariableExpansionImpl<RealTraversal<true>>>(&impl_)) [[likely]]
+      return impl->Pull(frame, context);
+    return std::get<VariableExpansionImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+  }
 
-    ExpressionEvaluator evaluator =
-        ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
+  void Shutdown() override {
+    if (auto *impl = std::get_if<VariableExpansionImpl<RealTraversal<true>>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<VariableExpansionImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+    else
+      input_cursor_->Shutdown();
+  }
+
+  void Reset() override {
+    if (auto *impl = std::get_if<VariableExpansionImpl<RealTraversal<true>>>(&impl_))
+      impl->Reset();
+    else if (auto *impl = std::get_if<VariableExpansionImpl<VirtualTraversal>>(&impl_))
+      impl->Reset();
+    else
+      input_cursor_->Reset();
+  }
+
+ private:
+  const ExpandVariable &self_;
+  utils::MemoryResource *mem_;
+  UniqueCursorPtr input_cursor_;
+  // Chosen on the first Pull from the ambient graph view and reused; a projection traverses the
+  // overlay, anything else the real graph. One implementation, two instantiations.
+  std::variant<std::monostate, VariableExpansionImpl<RealTraversal<true>>, VariableExpansionImpl<VirtualTraversal>>
+      impl_;
+
+  void Init(ExecutionContext &context) {
+    if (auto *vview = ProjectionView(context)) {
+      std::vector<std::string_view> allowed;
+      allowed.reserve(self_.common_.edge_types.size());
+      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
+      impl_.emplace<VariableExpansionImpl<VirtualTraversal>>(
+          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor_), mem_);
+    } else {
+      impl_.emplace<VariableExpansionImpl<RealTraversal<true>>>(
+          self_, RealTraversal<true>{&self_}, std::move(input_cursor_), mem_);
+    }
+  }
+};
+
+namespace {
+
+// s-t shortest path (bidirectional BFS), written once over a traversal policy.
+struct STShortestPath {
+  virtual ~STShortestPath() = default;
+  virtual bool Pull(Frame &frame, ExecutionContext &context) = 0;
+  virtual void Reset() = 0;
+  virtual void Shutdown() = 0;
+};
+
+template <class Trav>
+class STShortestPathImpl final : public STShortestPath {
+  using Vertex = typename Trav::Vertex;
+  using Edge = typename Trav::Edge;
+  // A null edge marks a search root, as std::nullopt does; the map is keyed by the policy's node type.
+  using VertexEdgeMap = utils::pmr::unordered_map<Vertex, std::optional<Edge>>;
+
+ public:
+  STShortestPathImpl(const ExpandVariable &self, Trav trav, UniqueCursorPtr input_cursor)
+      : self_(self), trav_(std::move(trav)), input_cursor_(std::move(input_cursor)) {}
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    AbortCheck(context);
+    ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
 
     while (input_cursor_->Pull(frame, context)) {
       if (context.hops_limit.IsLimitReached()) return false;
 
       const auto &source_tv = frame[self_.input_symbol_];
       const auto &sink_tv = frame[self_.common_.node_symbol];
-
-      // It is possible that source or sink vertex is Null due to optional
-      // matching.
+      // source or sink can be Null due to optional matching.
       if (source_tv.IsNull() || sink_tv.IsNull()) continue;
-
-      const auto &source = source_tv.ValueVertex();
-      const auto &sink = sink_tv.ValueVertex();
 
       int64_t lower_bound =
           self_.lower_bound_ ? EvaluateInt(evaluator, self_.lower_bound_, "Min depth in breadth-first expansion") : 1;
       int64_t upper_bound = self_.upper_bound_
                                 ? EvaluateInt(evaluator, self_.upper_bound_, "Max depth in breadth-first expansion")
                                 : std::numeric_limits<int64_t>::max();
-
       if (upper_bound < 1 || lower_bound > upper_bound) continue;
 
-      if (FindPath(source, sink, lower_bound, upper_bound, &frame, &evaluator, context)) {
-        return true;
+      if constexpr (std::same_as<Edge, VirtualEdge>) {
+        if (self_.filter_lambda_.expression) {
+          throw QueryRuntimeException("A shortest-path filter is not supported over a projection in a USE scope.");
+        }
       }
+
+      Vertex source = Trav::GetInput(source_tv, self_.input_symbol_);
+      Vertex sink = Trav::GetInput(sink_tv, self_.common_.node_symbol);
+      if (FindPath(source, sink, lower_bound, upper_bound, &frame, &evaluator, context)) return true;
     }
     return false;
   }
@@ -2507,14 +2616,13 @@ class STShortestPathCursor : public query::plan::Cursor {
 
  private:
   const ExpandVariable &self_;
+  Trav trav_;
   UniqueCursorPtr input_cursor_;
 
-  using VertexEdgeMapT = utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>>;
-
-  void ReconstructPath(const VertexAccessor &midpoint, const VertexEdgeMapT &in_edge, const VertexEdgeMapT &out_edge,
+  void ReconstructPath(const Vertex &midpoint, const VertexEdgeMap &in_edge, const VertexEdgeMap &out_edge,
                        Frame *frame, ExecutionContext &ctx) {
     utils::pmr::vector<TypedValue> result(ctx.evaluation_context.memory);
-    auto last_vertex = midpoint;
+    Vertex last_vertex = midpoint;
     while (true) {
       const auto &last_edge = in_edge.at(last_vertex);
       if (!last_edge) break;
@@ -2533,49 +2641,41 @@ class STShortestPathCursor : public query::plan::Cursor {
     frame_writer.WriteAt(self_.common_.edge_symbol, std::move(result));
   }
 
-  bool ShouldExpand(const VertexAccessor &vertex, const EdgeAccessor &edge, Frame *frame,
-                    ExpressionEvaluator *evaluator, ExecutionContext &context) {
-    if (!self_.filter_lambda_.expression) return true;
-
-    auto frame_writer = frame->GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
-
-    frame_writer.WriteAt(self_.filter_lambda_.inner_node_symbol, vertex);
-    frame_writer.WriteAt(self_.filter_lambda_.inner_edge_symbol, edge);
-
-    TypedValue result = self_.filter_lambda_.expression->Accept(*evaluator);
-    if (result.IsNull()) return false;
-    if (result.IsBool()) return result.ValueBool();
-
-    throw QueryRuntimeException("Expansion condition must evaluate to boolean or null");
+  bool ShouldExpand(const Vertex &vertex, const Edge &edge, Frame *frame, ExpressionEvaluator *evaluator,
+                    ExecutionContext &context) {
+    if constexpr (std::same_as<Edge, EdgeAccessor>) {
+      if (!self_.filter_lambda_.expression) return true;
+      auto frame_writer = frame->GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
+      frame_writer.WriteAt(self_.filter_lambda_.inner_node_symbol, vertex);
+      frame_writer.WriteAt(self_.filter_lambda_.inner_edge_symbol, edge);
+      TypedValue result = self_.filter_lambda_.expression->Accept(*evaluator);
+      if (result.IsNull()) return false;
+      if (result.IsBool()) return result.ValueBool();
+      throw QueryRuntimeException("Expansion condition must evaluate to boolean or null");
+    } else {
+      return true;  // no filter lambda over a projection (rejected upstream)
+    }
   }
 
-  bool FindPath(const VertexAccessor &source, const VertexAccessor &sink, int64_t lower_bound, int64_t upper_bound,
-                Frame *frame, ExpressionEvaluator *evaluator, ExecutionContext &context) {
+  [[gnu::noinline]] bool FindPath(const Vertex &source, const Vertex &sink, int64_t lower_bound, int64_t upper_bound,
+                                  Frame *frame, ExpressionEvaluator *evaluator, ExecutionContext &context) {
     if (source == sink) return false;
 
-    // We expand from both directions, both from the source and the sink.
-    // Expansions meet at the middle of the path if it exists. This should
-    // perform better for real-world like graphs where the expansion front
-    // grows exponentially, effectively reducing the exponent by half.
+    // Expand from both ends; the fronts meet in the middle. The sink side expands with the mirrored
+    // direction, and its filter binds the current frontier node (the source side binds the far node).
+    auto *pull_memory = context.evaluation_context.memory;
+    utils::pmr::vector<Vertex> source_frontier(pull_memory);
+    utils::pmr::vector<Vertex> sink_frontier(pull_memory);
+    utils::pmr::vector<Vertex> source_next(pull_memory);
+    utils::pmr::vector<Vertex> sink_next(pull_memory);
+    VertexEdgeMap in_edge(pull_memory);
+    VertexEdgeMap out_edge(pull_memory);
 
-    auto *pull_memory = evaluator->GetMemoryResource();
-    // Holds vertices at the current level of expansion from the source
-    // (sink).
-    utils::pmr::vector<VertexAccessor> source_frontier(pull_memory);
-    utils::pmr::vector<VertexAccessor> sink_frontier(pull_memory);
-
-    // Holds vertices we can expand to from `source_frontier`
-    // (`sink_frontier`).
-    utils::pmr::vector<VertexAccessor> source_next(pull_memory);
-    utils::pmr::vector<VertexAccessor> sink_next(pull_memory);
-
-    // Maps each vertex we visited expanding from the source (sink) to the
-    // edge used. Necessary for path reconstruction.
-    VertexEdgeMapT in_edge(pull_memory);
-    VertexEdgeMapT out_edge(pull_memory);
+    const auto reversed = self_.common_.direction == EdgeAtom::Direction::IN    ? EdgeAtom::Direction::OUT
+                          : self_.common_.direction == EdgeAtom::Direction::OUT ? EdgeAtom::Direction::IN
+                                                                                : EdgeAtom::Direction::BOTH;
 
     size_t current_length = 0;
-
     source_frontier.emplace_back(source);
     in_edge[source] = std::nullopt;
     sink_frontier.emplace_back(sink);
@@ -2585,135 +2685,50 @@ class STShortestPathCursor : public query::plan::Cursor {
       AbortCheck(context);
       // Top-down step (expansion from the source).
       ++current_length;
-      if (current_length > upper_bound) return false;
-
+      if (static_cast<int64_t>(current_length) > upper_bound) return false;
       for (const auto &vertex : source_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
-        if (self_.common_.direction != EdgeAtom::Direction::IN) {
-          auto out_edges_result =
-              UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-          context.number_of_hops += out_edges_result.expanded_count;
-          for (const auto &edge : out_edges_result.edges) {
-#ifdef MG_ENTERPRISE
-            if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-                !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                  context.auth_checker->Has(
-                      edge.To(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-              continue;
-            }
-#endif
-            if (ShouldExpand(edge.To(), edge, frame, evaluator, context) && !in_edge.contains(edge.To())) {
-              in_edge.emplace(edge.To(), edge);
-              if (out_edge.contains(edge.To())) {
-                if (current_length >= lower_bound) {
-                  ReconstructPath(edge.To(), in_edge, out_edge, frame, context);
-                  return true;
-                } else {
-                  return false;
-                }
+        for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
+          Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+          if (!Trav::Visible(edge, far, context)) continue;
+          if (ShouldExpand(far, edge, frame, evaluator, context) && !in_edge.contains(far)) {
+            in_edge.emplace(far, edge);
+            if (out_edge.contains(far)) {
+              if (current_length >= static_cast<size_t>(lower_bound)) {
+                ReconstructPath(far, in_edge, out_edge, frame, context);
+                return true;
               }
-              source_next.push_back(edge.To());
+              return false;
             }
-          }
-        }
-        if (self_.common_.direction != EdgeAtom::Direction::OUT) {
-          auto in_edges_result =
-              UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-          context.number_of_hops += in_edges_result.expanded_count;
-          for (const auto &edge : in_edges_result.edges) {
-#ifdef MG_ENTERPRISE
-            if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-                !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                  context.auth_checker->Has(
-                      edge.From(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-              continue;
-            }
-#endif
-            if (ShouldExpand(edge.From(), edge, frame, evaluator, context) && !in_edge.contains(edge.From())) {
-              in_edge.emplace(edge.From(), edge);
-              if (out_edge.contains(edge.From())) {
-                if (current_length >= lower_bound) {
-                  ReconstructPath(edge.From(), in_edge, out_edge, frame, context);
-                  return true;
-                } else {
-                  return false;
-                }
-              }
-              source_next.push_back(edge.From());
-            }
+            source_next.push_back(far);
           }
         }
       }
-
       if (source_next.empty()) return false;
       source_frontier.clear();
       std::swap(source_frontier, source_next);
 
-      // Bottom-up step (expansion from the sink).
+      // Bottom-up step (expansion from the sink); direction mirrored.
       ++current_length;
-      if (current_length > upper_bound) return false;
-
-      // When expanding from the sink we have to be careful which edge
-      // endpoint we pass to `should_expand`, because everything is
-      // reversed.
+      if (static_cast<int64_t>(current_length) > upper_bound) return false;
       for (const auto &vertex : sink_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
-        if (self_.common_.direction != EdgeAtom::Direction::OUT) {
-          auto out_edges_result =
-              UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-          context.number_of_hops += out_edges_result.expanded_count;
-          for (const auto &edge : out_edges_result.edges) {
-#ifdef MG_ENTERPRISE
-            if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-                !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                  context.auth_checker->Has(
-                      edge.To(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-              continue;
-            }
-#endif
-            if (ShouldExpand(vertex, edge, frame, evaluator, context) && !out_edge.contains(edge.To())) {
-              out_edge.emplace(edge.To(), edge);
-              if (in_edge.contains(edge.To())) {
-                if (current_length >= lower_bound) {
-                  ReconstructPath(edge.To(), in_edge, out_edge, frame, context);
-                  return true;
-                } else {
-                  return false;
-                }
+        for (auto [edge, dir] : trav_.Expand(vertex, reversed, context)) {
+          Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+          if (!Trav::Visible(edge, far, context)) continue;
+          if (ShouldExpand(vertex, edge, frame, evaluator, context) && !out_edge.contains(far)) {
+            out_edge.emplace(far, edge);
+            if (in_edge.contains(far)) {
+              if (current_length >= static_cast<size_t>(lower_bound)) {
+                ReconstructPath(far, in_edge, out_edge, frame, context);
+                return true;
               }
-              sink_next.push_back(edge.To());
+              return false;
             }
-          }
-        }
-        if (self_.common_.direction != EdgeAtom::Direction::IN) {
-          auto in_edges_result =
-              UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-          context.number_of_hops += in_edges_result.expanded_count;
-          for (const auto &edge : in_edges_result.edges) {
-#ifdef MG_ENTERPRISE
-            if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-                !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                  context.auth_checker->Has(
-                      edge.From(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-              continue;
-            }
-#endif
-            if (ShouldExpand(vertex, edge, frame, evaluator, context) && !out_edge.contains(edge.From())) {
-              out_edge.emplace(edge.From(), edge);
-              if (in_edge.contains(edge.From())) {
-                if (current_length >= lower_bound) {
-                  ReconstructPath(edge.From(), in_edge, out_edge, frame, context);
-                  return true;
-                } else {
-                  return false;
-                }
-              }
-              sink_next.push_back(edge.From());
-            }
+            sink_next.push_back(far);
           }
         }
       }
-
       if (sink_next.empty()) return false;
       sink_frontier.clear();
       std::swap(sink_frontier, sink_next);
@@ -2721,73 +2736,125 @@ class STShortestPathCursor : public query::plan::Cursor {
   }
 };
 
-class SingleSourceShortestPathCursor : public query::plan::Cursor {
+}  // namespace
+
+class STShortestPathCursor : public query::plan::Cursor {
  public:
-  SingleSourceShortestPathCursor(const ExpandVariable &self, utils::MemoryResource *mem,
-                                 metrics::DatabaseMetricHandles &metric_handles)
-      : self_(self),
-        input_cursor_(self_.input()->MakeCursor(mem, metric_handles)),
-        processed_(mem),
-        to_visit_next_(mem),
-        to_visit_current_(mem) {
-    DMG_ASSERT(!self_.common_.existing_node,
-               "Single source shortest path algorithm "
-               "should not be used when `existing_node` "
-               "flag is set, s-t shortest path algorithm "
-               "should be used instead!");
+  STShortestPathCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+                       metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self), mem_(mem), metric_handles_(metric_handles) {
+    MG_ASSERT(self_.common_.existing_node,
+              "s-t shortest path algorithm should only be used when `existing_node` flag is set!");
   }
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
-    SCOPED_PROFILE_OP("SingleSourceShortestPath");
+    SCOPED_PROFILE_OP("STShortestPath");
+    if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
+      Init(context);
+    if (auto *impl = std::get_if<STShortestPathImpl<RealTraversal<true>>>(&impl_)) [[likely]]
+      return impl->Pull(frame, context);
+    return std::get<STShortestPathImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+  }
 
-    ExpressionEvaluator evaluator =
-        ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
+  void Shutdown() override {
+    if (auto *impl = std::get_if<STShortestPathImpl<RealTraversal<true>>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<STShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+  }
 
+  void Reset() override {
+    if (auto *impl = std::get_if<STShortestPathImpl<RealTraversal<true>>>(&impl_))
+      impl->Reset();
+    else if (auto *impl = std::get_if<STShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Reset();
+  }
+
+ private:
+  const ExpandVariable &self_;
+  utils::MemoryResource *mem_;
+  metrics::DatabaseMetricHandles &metric_handles_;
+  std::variant<std::monostate, STShortestPathImpl<RealTraversal<true>>, STShortestPathImpl<VirtualTraversal>> impl_;
+
+  void Init(ExecutionContext &context) {
+    auto input_cursor = self_.input()->MakeCursor(mem_, metric_handles_);
+    if (auto *vview = ProjectionView(context)) {
+      std::vector<std::string_view> allowed;
+      allowed.reserve(self_.common_.edge_types.size());
+      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
+      impl_.emplace<STShortestPathImpl<VirtualTraversal>>(
+          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor));
+      return;
+    }
+    impl_.emplace<STShortestPathImpl<RealTraversal<true>>>(self_, RealTraversal<true>{&self_}, std::move(input_cursor));
+  }
+};
+
+namespace {
+
+// Single-source shortest path (unweighted BFS), written once over a traversal policy. Keeps its
+// cross-Pull frontier state (processed_ / to_visit_*) and yields one path per Pull, for both the real
+// graph and a projection.
+struct SingleSourceShortestPath {
+  virtual ~SingleSourceShortestPath() = default;
+  virtual bool Pull(Frame &frame, ExecutionContext &context) = 0;
+  virtual void Reset() = 0;
+  virtual void Shutdown() = 0;
+};
+
+template <class Trav>
+class SingleSourceShortestPathImpl final : public SingleSourceShortestPath {
+  using Vertex = typename Trav::Vertex;
+  using Edge = typename Trav::Edge;
+
+ public:
+  SingleSourceShortestPathImpl(const ExpandVariable &self, Trav trav, UniqueCursorPtr input_cursor,
+                               utils::MemoryResource *mem)
+      : self_(self),
+        trav_(std::move(trav)),
+        input_cursor_(std::move(input_cursor)),
+        processed_(mem),
+        to_visit_next_(mem),
+        to_visit_current_(mem) {}
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
     auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
 
-    // for the given (edge, vertex) pair checks if they satisfy the
-    // "where" condition. if so, places them in the to_visit_ structure.
-    auto expand_pair = [this, &evaluator, &frame, &context, &frame_writer](EdgeAccessor edge,
-                                                                           VertexAccessor vertex) -> bool {
-      (void)context;  // unused in community version
-      // if we already processed the given vertex it doesn't get expanded
+    // Check (edge, vertex): visibility, and (real graph only) the filter lambda / accumulated path. If
+    // acceptable, place it on to_visit_next_. Returns whether the accumulated path was touched (so the
+    // caller can shrink it) - always the outcome the real algorithm returned.
+    auto expand_pair = [&](Edge edge, Vertex vertex) -> bool {
       if (processed_.contains(vertex)) return false;
-#ifdef MG_ENTERPRISE
-      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-          !(context.auth_checker->Has(
-                vertex, storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-            context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-        return false;
-      }
-#endif
-      frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
-      frame_writer.Write(self_.filter_lambda_.inner_node_symbol, vertex);
+      if (!Trav::Visible(edge, vertex, context)) return false;
+
       std::optional<Path> curr_acc_path = std::nullopt;
-      if (self_.filter_lambda_.accumulated_path_symbol) {
-        MG_ASSERT(frame[self_.filter_lambda_.accumulated_path_symbol.value()].IsPath(),
-                  "Accumulated path must have Path type");
-
-        auto expand_path = [&](TypedValue &value) {
-          Path &accumulated_path = value.ValuePath();
-          accumulated_path.Expand(edge);
-          accumulated_path.Expand(vertex);
-        };
-        frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), expand_path);
-
-        curr_acc_path = frame[self_.filter_lambda_.accumulated_path_symbol.value()].ValuePath();  // const ref
-      }
-
-      if (self_.filter_lambda_.expression) {
-        TypedValue result = self_.filter_lambda_.expression->Accept(evaluator);
-        switch (result.type()) {
-          case TypedValue::Type::Null:
-            return true;
-          case TypedValue::Type::Bool:
-            if (!result.ValueBool()) return true;
-            break;
-          default:
-            throw QueryRuntimeException("Expansion condition must evaluate to boolean or null.");
+      if constexpr (std::same_as<Edge, EdgeAccessor>) {
+        frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
+        frame_writer.Write(self_.filter_lambda_.inner_node_symbol, vertex);
+        if (self_.filter_lambda_.accumulated_path_symbol) {
+          MG_ASSERT(frame[self_.filter_lambda_.accumulated_path_symbol.value()].IsPath(),
+                    "Accumulated path must have Path type");
+          auto expand_path = [&](TypedValue &value) {
+            Path &accumulated_path = value.ValuePath();
+            accumulated_path.Expand(edge);
+            accumulated_path.Expand(vertex);
+          };
+          frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), expand_path);
+          curr_acc_path = frame[self_.filter_lambda_.accumulated_path_symbol.value()].ValuePath();
+        }
+        if (self_.filter_lambda_.expression) {
+          TypedValue result = self_.filter_lambda_.expression->Accept(evaluator);
+          switch (result.type()) {
+            case TypedValue::Type::Null:
+              return true;
+            case TypedValue::Type::Bool:
+              if (!result.ValueBool()) return true;
+              break;
+            default:
+              throw QueryRuntimeException("Expansion condition must evaluate to boolean or null.");
+          }
         }
       }
       to_visit_next_.emplace_back(edge, vertex, std::move(curr_acc_path));
@@ -2795,48 +2862,29 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
       return true;
     };
 
-    auto restore_frame_state_after_expansion = [this, &frame_writer](bool was_expanded) {
-      if (was_expanded && self_.filter_lambda_.accumulated_path_symbol) {
-        auto shrink = [&](TypedValue &value) { value.ValuePath().Shrink(); };
-        frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), shrink);
-      }
-    };
-
-    // populates the to_visit_next_ structure with expansions
-    // from the given vertex. skips expansions that don't satisfy
-    // the "where" condition.
-    auto expand_from_vertex = [this, &expand_pair, &restore_frame_state_after_expansion, &context](const auto &vertex) {
-      if (self_.common_.direction != EdgeAtom::Direction::IN) {
-        auto out_edges_result =
-            UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-        context.number_of_hops += out_edges_result.expanded_count;
-        for (const auto &edge : out_edges_result.edges) {
-          bool was_expanded = expand_pair(edge, edge.To());
-          restore_frame_state_after_expansion(was_expanded);
-        }
-      }
-      if (self_.common_.direction != EdgeAtom::Direction::OUT) {
-        auto in_edges_result =
-            UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-        context.number_of_hops += in_edges_result.expanded_count;
-        for (const auto &edge : in_edges_result.edges) {
-          bool was_expanded = expand_pair(edge, edge.From());
-          restore_frame_state_after_expansion(was_expanded);
+    auto restore_frame_state_after_expansion = [&](bool was_expanded) {
+      if constexpr (std::same_as<Edge, EdgeAccessor>) {
+        if (was_expanded && self_.filter_lambda_.accumulated_path_symbol) {
+          auto shrink = [&](TypedValue &value) { value.ValuePath().Shrink(); };
+          frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), shrink);
         }
       }
     };
 
-    // do it all in a loop because we skip some elements
+    auto expand_from_vertex = [&](const Vertex &vertex) {
+      for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
+        Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+        bool was_expanded = expand_pair(edge, far);
+        restore_frame_state_after_expansion(was_expanded);
+      }
+    };
+
     while (true) {
       AbortCheck(context);
-      // if we have nothing to visit on the current depth, switch to next
       if (to_visit_current_.empty()) to_visit_current_.swap(to_visit_next_);
 
-      // if current is still empty, it means both are empty, so pull from
-      // input
       if (to_visit_current_.empty()) {
         if (!input_cursor_->Pull(frame, context)) return false;
-
         if (context.hops_limit.IsLimitReached()) return false;
 
         to_visit_current_.clear();
@@ -2844,72 +2892,67 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
         processed_.clear();
 
         const auto &vertex_value = frame[self_.input_symbol_];
-        // it is possible that the vertex is Null due to optional matching
         if (vertex_value.IsNull()) continue;
         lower_bound_ =
             self_.lower_bound_ ? EvaluateInt(evaluator, self_.lower_bound_, "Min depth in breadth-first expansion") : 1;
         upper_bound_ = self_.upper_bound_
                            ? EvaluateInt(evaluator, self_.upper_bound_, "Max depth in breadth-first expansion")
                            : std::numeric_limits<int64_t>::max();
-
         if (upper_bound_ < 1 || lower_bound_ > upper_bound_) continue;
 
-        const auto &vertex = vertex_value.ValueVertex();
+        if constexpr (std::same_as<Edge, VirtualEdge>) {
+          if (self_.filter_lambda_.expression || self_.filter_lambda_.accumulated_path_symbol) {
+            throw QueryRuntimeException(
+                "A breadth-first filter or accumulated path is not supported over a projection in a USE scope.");
+          }
+        }
+
+        Vertex vertex = Trav::GetInput(vertex_value, self_.input_symbol_);
         processed_.emplace(vertex, std::nullopt);
 
-        if (self_.filter_lambda_.accumulated_path_symbol) {
-          // Add initial vertex of path to the accumulated path
-          frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), Path(vertex));
+        if constexpr (std::same_as<Edge, EdgeAccessor>) {
+          if (self_.filter_lambda_.accumulated_path_symbol) {
+            frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), Path(vertex));
+          }
         }
 
         expand_from_vertex(vertex);
-
-        // go back to loop start and see if we expanded anything
         continue;
       }
 
-      // take the next expansion from the queue
       auto [curr_edge, curr_vertex, curr_acc_path] = to_visit_current_.back();
       to_visit_current_.pop_back();
 
-      // create the frame value for the edges
+      // Reconstruct the edge list back to the source using the typed edge (uniform across policies).
       auto *pull_memory = context.evaluation_context.memory;
       utils::pmr::vector<TypedValue> edge_list(pull_memory);
       edge_list.emplace_back(curr_edge);
-      auto last_vertex = curr_vertex;
+      Vertex last_vertex = curr_vertex;
+      Edge last_edge = curr_edge;
       while (true) {
-        const EdgeAccessor &last_edge = edge_list.back().ValueEdge();
         last_vertex = last_edge.From() == last_vertex ? last_edge.To() : last_edge.From();
-        // origin_vertex must be in processed
         const auto &previous_edge = processed_.find(last_vertex)->second;
         if (!previous_edge) break;
-
-        edge_list.emplace_back(previous_edge.value());
+        last_edge = *previous_edge;
+        edge_list.emplace_back(last_edge);
       }
 
-      // expand only if what we've just expanded is less then max depth
       if (static_cast<int64_t>(edge_list.size()) < upper_bound_) {
-        if (self_.filter_lambda_.accumulated_path_symbol) {
-          MG_ASSERT(curr_acc_path.has_value(), "Expected non-null accumulated path");
-          frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), std::move(curr_acc_path.value()));
+        if constexpr (std::same_as<Edge, EdgeAccessor>) {
+          if (self_.filter_lambda_.accumulated_path_symbol) {
+            MG_ASSERT(curr_acc_path.has_value(), "Expected non-null accumulated path");
+            frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), std::move(curr_acc_path.value()));
+          }
         }
-        if (!context.hops_limit.IsLimitReached()) {
-          expand_from_vertex(curr_vertex);
-        }
+        if (!context.hops_limit.IsLimitReached()) expand_from_vertex(curr_vertex);
       }
 
       if (static_cast<int64_t>(edge_list.size()) < lower_bound_) continue;
 
       frame_writer.Write(self_.common_.node_symbol, curr_vertex);
-
-      // place edges on the frame in the correct order
-      // If is_reverse_ is false, reverse to get source-to-destination order (input_symbol -> node_symbol)
-      // If is_reverse_ is true, keep as-is to get destination-to-source order (node_symbol -> input_symbol)
-      if (!self_.is_reverse_) {
-        std::ranges::reverse(edge_list);
-      }
+      // is_reverse_ false: reverse to source-to-destination order; true: keep destination-to-source.
+      if (!self_.is_reverse_) std::ranges::reverse(edge_list);
       frame_writer.Write(self_.common_.edge_symbol, std::move(edge_list));
-
       return true;
     }
   }
@@ -2925,20 +2968,74 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
 
  private:
   const ExpandVariable &self_;
-  const UniqueCursorPtr input_cursor_;
-
-  // Depth bounds. Calculated on each pull from the input, the initial value
-  // is irrelevant.
+  Trav trav_;
+  UniqueCursorPtr input_cursor_;
   int64_t lower_bound_{-1};
   int64_t upper_bound_{-1};
+  // Maps each visited (and scheduled) node to the edge it was reached by; a null edge marks the source.
+  utils::pmr::unordered_map<Vertex, std::optional<Edge>> processed_;
+  // (edge, node, accumulated path) yet to visit, for the current and next depth.
+  utils::pmr::vector<std::tuple<Edge, Vertex, std::optional<Path>>> to_visit_next_;
+  utils::pmr::vector<std::tuple<Edge, Vertex, std::optional<Path>>> to_visit_current_;
+};
 
-  // maps vertices to the edge they got expanded from. it is an optional
-  // edge because the root does not get expanded from anything.
-  // contains visited vertices as well as those scheduled to be visited.
-  utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>> processed_;
-  // edge, vertex we have yet to visit, for current and next depth and their accumulated paths
-  utils::pmr::vector<std::tuple<EdgeAccessor, VertexAccessor, std::optional<Path>>> to_visit_next_;
-  utils::pmr::vector<std::tuple<EdgeAccessor, VertexAccessor, std::optional<Path>>> to_visit_current_;
+}  // namespace
+
+class SingleSourceShortestPathCursor : public query::plan::Cursor {
+ public:
+  SingleSourceShortestPathCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+                                 metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self), mem_(mem), metric_handles_(metric_handles) {
+    DMG_ASSERT(!self_.common_.existing_node,
+               "Single source shortest path algorithm should not be used when `existing_node` flag is set, s-t "
+               "shortest path algorithm should be used instead!");
+  }
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    OOMExceptionEnabler oom_exception;
+    SCOPED_PROFILE_OP("SingleSourceShortestPath");
+    if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
+      Init(context);
+    if (auto *impl = std::get_if<SingleSourceShortestPathImpl<RealTraversal<true>>>(&impl_)) [[likely]]
+      return impl->Pull(frame, context);
+    return std::get<SingleSourceShortestPathImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+  }
+
+  void Shutdown() override {
+    if (auto *impl = std::get_if<SingleSourceShortestPathImpl<RealTraversal<true>>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<SingleSourceShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+  }
+
+  void Reset() override {
+    if (auto *impl = std::get_if<SingleSourceShortestPathImpl<RealTraversal<true>>>(&impl_))
+      impl->Reset();
+    else if (auto *impl = std::get_if<SingleSourceShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Reset();
+  }
+
+ private:
+  const ExpandVariable &self_;
+  utils::MemoryResource *mem_;
+  metrics::DatabaseMetricHandles &metric_handles_;
+  std::variant<std::monostate, SingleSourceShortestPathImpl<RealTraversal<true>>,
+               SingleSourceShortestPathImpl<VirtualTraversal>>
+      impl_;
+
+  void Init(ExecutionContext &context) {
+    auto input_cursor = self_.input()->MakeCursor(mem_, metric_handles_);
+    if (auto *vview = ProjectionView(context)) {
+      std::vector<std::string_view> allowed;
+      allowed.reserve(self_.common_.edge_types.size());
+      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
+      impl_.emplace<SingleSourceShortestPathImpl<VirtualTraversal>>(
+          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
+      return;
+    }
+    impl_.emplace<SingleSourceShortestPathImpl<RealTraversal<true>>>(
+        self_, RealTraversal<true>{&self_}, std::move(input_cursor), mem_);
+  }
 };
 
 namespace {
@@ -2995,115 +3092,112 @@ TypedValue CalculateNextWeight(const std::optional<memgraph::query::plan::Expans
 
 }  // namespace
 
-class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
+// Weighted shortest path (Dijkstra), written once over a traversal policy. The weight lambda reads a
+// property from the (edge, node) written to the frame; over a projection those are VirtualEdge /
+// VirtualNode and the read flows through the unified GetProperty, so the same evaluator and
+// CalculateNextWeight serve both. Keeps its cross-Pull priority-queue state.
+struct WeightedShortestPath {
+  virtual ~WeightedShortestPath() = default;
+  virtual bool Pull(Frame &frame, ExecutionContext &context) = 0;
+  virtual void Reset() = 0;
+  virtual void Shutdown() = 0;
+};
+
+template <class Trav>
+class WeightedShortestPathImpl final : public WeightedShortestPath {
+  using Vertex = typename Trav::Vertex;
+  using Edge = typename Trav::Edge;
+
+  struct StateHash {
+    size_t operator()(const std::pair<Vertex, int64_t> &key) const {
+      return utils::HashCombine<Vertex, int64_t>{}(key.first, key.second);
+    }
+  };
+
+  using PqEntry = std::tuple<TypedValue, int64_t, Vertex, std::optional<Edge>, std::optional<Path>>;
+
+  struct PqCompare {
+    bool operator()(const PqEntry &lhs, const PqEntry &rhs) const {
+      const auto &lw = std::get<0>(lhs);
+      const auto &rw = std::get<0>(rhs);
+      if (lw.IsNull()) return false;
+      if (rw.IsNull()) return true;
+      ValidateWeightTypes(lw, rw);
+      return (lw > rw).ValueBool();
+    }
+  };
+
  public:
-  ExpandWeightedShortestPathCursor(const ExpandVariable &self, utils::MemoryResource *mem,
-                                   metrics::DatabaseMetricHandles &metric_handles)
+  WeightedShortestPathImpl(const ExpandVariable &self, Trav trav, UniqueCursorPtr input_cursor,
+                           utils::MemoryResource *mem)
       : self_(self),
-        input_cursor_(self_.input_->MakeCursor(mem, metric_handles)),
+        trav_(std::move(trav)),
+        input_cursor_(std::move(input_cursor)),
         total_cost_(mem),
         previous_(mem),
         yielded_vertices_(mem),
         pq_(mem) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
-    SCOPED_PROFILE_OP("ExpandWeightedShortestPath");
-
-    ExpressionEvaluator evaluator =
-        ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
-
+    ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
     auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
 
-    auto create_state = [this](const VertexAccessor &vertex, int64_t depth) {
-      return std::make_pair(vertex, upper_bound_set_ ? depth : 0);
+    auto create_state = [this](const Vertex &vertex, int64_t depth) {
+      return std::make_pair(vertex, upper_bound_set_ ? depth : int64_t{0});
     };
 
-    // For the given (edge, vertex, weight, depth) tuple checks if they
-    // satisfy the "where" condition. if so, places them in the priority
-    // queue.
-    auto expand_pair = [this, &evaluator, &frame, &create_state, &frame_writer](const EdgeAccessor &edge,
-                                                                                const VertexAccessor &vertex,
-                                                                                const TypedValue &total_weight,
-                                                                                int64_t depth) {
+    auto expand_pair = [&](const Edge &edge, const Vertex &vertex, const TypedValue &total_weight, int64_t depth) {
       frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, edge);
       frame_writer.Write(self_.weight_lambda_->inner_node_symbol, vertex);
       TypedValue next_weight = CalculateNextWeight(self_.weight_lambda_, total_weight, evaluator);
 
       std::optional<Path> curr_acc_path = std::nullopt;
-      if (self_.filter_lambda_.expression) {
-        frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
-        frame_writer.Write(self_.filter_lambda_.inner_node_symbol, vertex);
-        if (self_.filter_lambda_.accumulated_path_symbol) {
-          MG_ASSERT(frame[self_.filter_lambda_.accumulated_path_symbol.value()].IsPath(),
-                    "Accumulated path must be path");
-
-          auto expand_path = [&](TypedValue &value) {
-            Path &accumulated_path = value.ValuePath();
-            accumulated_path.Expand(edge);
-            accumulated_path.Expand(vertex);
-          };
-          frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), expand_path);
-          curr_acc_path = frame[self_.filter_lambda_.accumulated_path_symbol.value()].ValuePath();  // const ref
-
-          if (self_.filter_lambda_.accumulated_weight_symbol) {
-            frame_writer.Write(self_.filter_lambda_.accumulated_weight_symbol.value(), next_weight);
+      if constexpr (std::same_as<Edge, EdgeAccessor>) {
+        if (self_.filter_lambda_.expression) {
+          frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
+          frame_writer.Write(self_.filter_lambda_.inner_node_symbol, vertex);
+          if (self_.filter_lambda_.accumulated_path_symbol) {
+            MG_ASSERT(frame[self_.filter_lambda_.accumulated_path_symbol.value()].IsPath(),
+                      "Accumulated path must be path");
+            auto expand_path = [&](TypedValue &value) {
+              Path &accumulated_path = value.ValuePath();
+              accumulated_path.Expand(edge);
+              accumulated_path.Expand(vertex);
+            };
+            frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), expand_path);
+            curr_acc_path = frame[self_.filter_lambda_.accumulated_path_symbol.value()].ValuePath();
+            if (self_.filter_lambda_.accumulated_weight_symbol) {
+              frame_writer.Write(self_.filter_lambda_.accumulated_weight_symbol.value(), next_weight);
+            }
           }
+          if (!EvaluateFilter(evaluator, self_.filter_lambda_.expression)) return;
         }
-
-        if (!EvaluateFilter(evaluator, self_.filter_lambda_.expression)) return;
       }
 
       auto next_state = create_state(vertex, depth);
-
       auto found_it = total_cost_.find(next_state);
-      if (found_it != total_cost_.end() && (found_it->second.IsNull() || (found_it->second <= next_weight).ValueBool()))
+      if (found_it != total_cost_.end() &&
+          (found_it->second.IsNull() || (found_it->second <= next_weight).ValueBool())) {
         return;
-
-      pq_.emplace(next_weight, depth + 1, vertex, edge, curr_acc_path);
+      }
+      pq_.emplace(std::move(next_weight), depth + 1, vertex, edge, std::move(curr_acc_path));
     };
 
-    auto restore_frame_state_after_expansion = [this, &frame_writer]() {
-      if (self_.filter_lambda_.accumulated_path_symbol) {
-        auto shrink = [&](TypedValue &value) { value.ValuePath().Shrink(); };
-        frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), shrink);
+    auto restore_frame_state_after_expansion = [&]() {
+      if constexpr (std::same_as<Edge, EdgeAccessor>) {
+        if (self_.filter_lambda_.accumulated_path_symbol) {
+          auto shrink = [&](TypedValue &value) { value.ValuePath().Shrink(); };
+          frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), shrink);
+        }
       }
     };
 
-    // Populates the priority queue structure with expansions
-    // from the given vertex. skips expansions that don't satisfy
-    // the "where" condition.
-    auto expand_from_vertex = [this, &context, &expand_pair, &restore_frame_state_after_expansion](
-                                  const VertexAccessor &vertex, const TypedValue &weight, int64_t depth) {
-      if (self_.common_.direction != EdgeAtom::Direction::IN) {
-        auto out_edges = UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types)).edges;
-        for (const auto &edge : out_edges) {
-#ifdef MG_ENTERPRISE
-          if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-              !(context.auth_checker->Has(
-                    edge.To(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-            continue;
-          }
-#endif
-          expand_pair(edge, edge.To(), weight, depth);
-          restore_frame_state_after_expansion();
-        }
-      }
-      if (self_.common_.direction != EdgeAtom::Direction::OUT) {
-        auto in_edges = UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types)).edges;
-        for (const auto &edge : in_edges) {
-#ifdef MG_ENTERPRISE
-          if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-              !(context.auth_checker->Has(
-                    edge.From(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-            continue;
-          }
-#endif
-          expand_pair(edge, edge.From(), weight, depth);
-          restore_frame_state_after_expansion();
-        }
+    auto expand_from_vertex = [&](const Vertex &vertex, const TypedValue &weight, int64_t depth) {
+      for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
+        Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+        if (!Trav::Visible(edge, far, context)) continue;
+        expand_pair(edge, far, weight, depth);
+        restore_frame_state_after_expansion();
       }
     };
 
@@ -3113,19 +3207,26 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
         if (!input_cursor_->Pull(frame, context)) return false;
         const auto &vertex_value = frame[self_.input_symbol_];
         if (vertex_value.IsNull()) continue;
-        auto vertex = vertex_value.ValueVertex();
+
+        if constexpr (std::same_as<Edge, VirtualEdge>) {
+          if (self_.filter_lambda_.expression) {
+            throw QueryRuntimeException(
+                "A weighted-shortest-path filter is not supported over a projection in a USE scope.");
+          }
+        }
+
+        Vertex vertex = Trav::GetInput(vertex_value, self_.input_symbol_);
         if (self_.common_.existing_node) {
           const auto &node = frame[self_.common_.node_symbol];
-          // Due to optional matching the existing node could be null.
-          // Skip expansion for such nodes.
-          if (node.IsNull()) continue;
+          if (node.IsNull()) continue;  // unbound optional end
         }
 
         std::optional<Path> curr_acc_path;
-        if (self_.filter_lambda_.accumulated_path_symbol) {
-          // Add initial vertex of path to the accumulated path
-          curr_acc_path = Path(vertex);
-          frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), curr_acc_path.value());
+        if constexpr (std::same_as<Edge, EdgeAccessor>) {
+          if (self_.filter_lambda_.accumulated_path_symbol) {
+            curr_acc_path = Path(vertex);
+            frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), curr_acc_path.value());
+          }
         }
         if (self_.upper_bound_) {
           upper_bound_ = EvaluateInt(evaluator, self_.upper_bound_, "Max depth in weighted shortest path expansion");
@@ -3134,25 +3235,20 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
           upper_bound_ = std::numeric_limits<int64_t>::max();
           upper_bound_set_ = false;
         }
-        if (upper_bound_ < 1)
-          throw QueryRuntimeException(
-              "Maximum depth in weighted shortest path expansion must be at "
-              "least 1.");
+        if (upper_bound_ < 1) {
+          throw QueryRuntimeException("Maximum depth in weighted shortest path expansion must be at least 1.");
+        }
 
         frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, TypedValue());
         frame_writer.Write(self_.weight_lambda_->inner_node_symbol, vertex);
-        TypedValue current_weight =
-            CalculateNextWeight(self_.weight_lambda_, /* total_weight */ TypedValue(), evaluator);
+        TypedValue current_weight = CalculateNextWeight(self_.weight_lambda_, TypedValue(), evaluator);
 
-        // Clear existing data structures.
         previous_.clear();
         total_cost_.clear();
         yielded_vertices_.clear();
 
-        pq_.emplace(current_weight, 0, vertex, std::nullopt, curr_acc_path);
-        // We are adding the starting vertex to the set of yielded vertices
-        // because we don't want to yield paths that end with the starting
-        // vertex.
+        pq_.emplace(std::move(current_weight), 0, vertex, std::nullopt, std::move(curr_acc_path));
+        // The start vertex is pre-yielded so a zero-length path to it is never returned.
         yielded_vertices_.insert(vertex);
       }
 
@@ -3162,57 +3258,42 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
         pq_.pop();
 
         auto current_state = create_state(current_vertex, current_depth);
-
-        // Check if the vertex has already been processed.
-        if (total_cost_.contains(current_state)) {
-          continue;
-        }
+        if (total_cost_.contains(current_state)) continue;
         previous_.emplace(current_state, current_edge);
         total_cost_.emplace(current_state, current_weight);
 
-        // Expand only if what we've just expanded is less than max depth.
         if (current_depth < upper_bound_) {
-          if (self_.filter_lambda_.accumulated_path_symbol) {
-            frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), std::move(curr_acc_path.value()));
+          if constexpr (std::same_as<Edge, EdgeAccessor>) {
+            if (self_.filter_lambda_.accumulated_path_symbol) {
+              frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(),
+                                 std::move(curr_acc_path.value()));
+            }
           }
           expand_from_vertex(current_vertex, current_weight, current_depth);
         }
 
-        // If we yielded a path for a vertex already, make the expansion but
-        // don't return the path again.
         if (yielded_vertices_.contains(current_vertex)) continue;
 
-        // Reconstruct the path.
-        auto last_vertex = current_vertex;
-        auto last_depth = current_depth;
-        auto *pull_memory = context.evaluation_context.memory;
-        utils::pmr::vector<TypedValue> edge_list(pull_memory);
+        // Reconstruct via the typed edge (uniform across policies).
+        Vertex last_vertex = current_vertex;
+        int64_t last_depth = current_depth;
+        utils::pmr::vector<TypedValue> edge_list(context.evaluation_context.memory);
         while (true) {
-          // Origin_vertex must be in previous.
           const auto &previous_edge = previous_.find(create_state(last_vertex, last_depth))->second;
           if (!previous_edge) break;
           last_vertex = previous_edge->From() == last_vertex ? previous_edge->To() : previous_edge->From();
-          last_depth--;
-          edge_list.emplace_back(previous_edge.value());
+          --last_depth;
+          edge_list.emplace_back(*previous_edge);
         }
 
-        // Place destination node on the frame, handle existence flag.
         if (self_.common_.existing_node) {
-          const auto &node = frame[self_.common_.node_symbol];
-          if ((node != TypedValue(current_vertex, pull_memory)).ValueBool()) {
-            continue;
-          }
-          // Prevent expanding other paths, because we found the
-          // shortest to existing node.
-          ClearQueue();
+          if (!Trav::SameBoundNode(current_vertex, self_.common_.node_symbol, frame)) continue;
+          ClearQueue();  // shortest path to the bound sink found; stop
         } else {
           frame_writer.Write(self_.common_.node_symbol, current_vertex);
         }
 
-        if (!self_.is_reverse_) {
-          // Place edges on the frame in the correct order.
-          std::ranges::reverse(edge_list);
-        }
+        if (!self_.is_reverse_) std::ranges::reverse(edge_list);
         frame_writer.Write(self_.common_.edge_symbol, std::move(edge_list));
         frame_writer.Write(self_.total_weight_.value(), current_weight);
         yielded_vertices_.insert(current_vertex);
@@ -3233,57 +3314,72 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
 
  private:
   const ExpandVariable &self_;
-  const UniqueCursorPtr input_cursor_;
-
-  // Upper bound on the path length.
+  Trav trav_;
+  UniqueCursorPtr input_cursor_;
   int64_t upper_bound_{-1};
   bool upper_bound_set_{false};
 
-  struct WspStateHash {
-    size_t operator()(const std::pair<VertexAccessor, int64_t> &key) const {
-      return utils::HashCombine<VertexAccessor, int64_t>{}(key.first, key.second);
-    }
-  };
-
-  // Maps vertices to weights they got in expansion.
-  utils::pmr::unordered_map<std::pair<VertexAccessor, int64_t>, TypedValue, WspStateHash> total_cost_;
-
-  // Maps vertices to edges used to reach them.
-  utils::pmr::unordered_map<std::pair<VertexAccessor, int64_t>, std::optional<EdgeAccessor>, WspStateHash> previous_;
-
-  // Keeps track of vertices for which we yielded a path already.
-  utils::pmr::unordered_set<VertexAccessor> yielded_vertices_;
-
-  // Priority queue comparator. Keep lowest weight on top of the queue.
-  class PriorityQueueComparator {
-   public:
-    bool operator()(
-        const std::tuple<TypedValue, int64_t, VertexAccessor, std::optional<EdgeAccessor>, std::optional<Path>> &lhs,
-        const std::tuple<TypedValue, int64_t, VertexAccessor, std::optional<EdgeAccessor>, std::optional<Path>> &rhs) {
-      const auto &lhs_weight = std::get<0>(lhs);
-      const auto &rhs_weight = std::get<0>(rhs);
-      // Null defines minimum value for all types
-      if (lhs_weight.IsNull()) {
-        return false;
-      }
-
-      if (rhs_weight.IsNull()) {
-        return true;
-      }
-
-      ValidateWeightTypes(lhs_weight, rhs_weight);
-      return (lhs_weight > rhs_weight).ValueBool();
-    }
-  };
-
-  std::priority_queue<std::tuple<TypedValue, int64_t, VertexAccessor, std::optional<EdgeAccessor>, std::optional<Path>>,
-                      utils::pmr::vector<std::tuple<TypedValue, int64_t, VertexAccessor, std::optional<EdgeAccessor>,
-                                                    std::optional<Path>>>,
-                      PriorityQueueComparator>
-      pq_;
+  utils::pmr::unordered_map<std::pair<Vertex, int64_t>, TypedValue, StateHash> total_cost_;
+  utils::pmr::unordered_map<std::pair<Vertex, int64_t>, std::optional<Edge>, StateHash> previous_;
+  utils::pmr::unordered_set<Vertex> yielded_vertices_;
+  std::priority_queue<PqEntry, utils::pmr::vector<PqEntry>, PqCompare> pq_;
 
   void ClearQueue() {
     while (!pq_.empty()) pq_.pop();
+  }
+};
+
+class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
+ public:
+  ExpandWeightedShortestPathCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+                                   metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self), mem_(mem), metric_handles_(metric_handles) {}
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    OOMExceptionEnabler oom_exception;
+    SCOPED_PROFILE_OP("ExpandWeightedShortestPath");
+    if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
+      Init(context);
+    if (auto *impl = std::get_if<WeightedShortestPathImpl<RealTraversal<false>>>(&impl_)) [[likely]]
+      return impl->Pull(frame, context);
+    return std::get<WeightedShortestPathImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+  }
+
+  void Shutdown() override {
+    if (auto *impl = std::get_if<WeightedShortestPathImpl<RealTraversal<false>>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<WeightedShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+  }
+
+  void Reset() override {
+    if (auto *impl = std::get_if<WeightedShortestPathImpl<RealTraversal<false>>>(&impl_))
+      impl->Reset();
+    else if (auto *impl = std::get_if<WeightedShortestPathImpl<VirtualTraversal>>(&impl_))
+      impl->Reset();
+  }
+
+ private:
+  const ExpandVariable &self_;
+  utils::MemoryResource *mem_;
+  metrics::DatabaseMetricHandles &metric_handles_;
+  std::variant<std::monostate, WeightedShortestPathImpl<RealTraversal<false>>,
+               WeightedShortestPathImpl<VirtualTraversal>>
+      impl_;
+
+  void Init(ExecutionContext &context) {
+    auto input_cursor = self_.input_->MakeCursor(mem_, metric_handles_);
+    if (auto *vview = ProjectionView(context)) {
+      std::vector<std::string_view> allowed;
+      allowed.reserve(self_.common_.edge_types.size());
+      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
+      impl_.emplace<WeightedShortestPathImpl<VirtualTraversal>>(
+          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
+      return;
+    }
+    // Weighted shortest path historically does not account hops (RealTraversal<false>).
+    impl_.emplace<WeightedShortestPathImpl<RealTraversal<false>>>(
+        self_, RealTraversal<false>{&self_}, std::move(input_cursor), mem_);
   }
 };
 
@@ -3304,12 +3400,49 @@ inline bool are_equal(const TypedValue &lhs, const TypedValue &rhs) {
 }
 }  // namespace
 
-class ExpandAllShortestPathsCursor : public query::plan::Cursor {
+namespace {
+
+// All-shortest paths (equal-cost enumeration via a DFS traversal tree), written once over a traversal
+// policy. Templating gives the projection arm for free: the algorithm is identical, only edge
+// enumeration, visibility, node identity, and the weight lambda's element type differ.
+struct AllShortestPaths {
+  virtual ~AllShortestPaths() = default;
+  virtual bool Pull(Frame &frame, ExecutionContext &context) = 0;
+  virtual void Reset() = 0;
+  virtual void Shutdown() = 0;
+};
+
+template <class Trav>
+class AllShortestPathsImpl final : public AllShortestPaths {
+  using Vertex = typename Trav::Vertex;
+  using Edge = typename Trav::Edge;
+  using DirectedEdge = std::tuple<Edge, EdgeAtom::Direction, TypedValue>;
+  using NextEdgesState = std::pair<Vertex, int64_t>;
+
+  struct StateHash {
+    size_t operator()(const std::pair<Vertex, int64_t> &key) const {
+      return utils::HashCombine<Vertex, int64_t>{}(key.first, key.second);
+    }
+  };
+
+  using PqEntry = std::tuple<TypedValue, int64_t, Vertex, DirectedEdge, std::optional<Path>>;
+
+  struct PqCompare {
+    bool operator()(const PqEntry &lhs, const PqEntry &rhs) const {
+      const auto &lw = std::get<0>(lhs);
+      const auto &rw = std::get<0>(rhs);
+      if (lw.IsNull()) return false;
+      if (rw.IsNull()) return true;
+      ValidateWeightTypes(lw, rw);
+      return (lw > rw).ValueBool();
+    }
+  };
+
  public:
-  ExpandAllShortestPathsCursor(const ExpandVariable &self, utils::MemoryResource *mem,
-                               metrics::DatabaseMetricHandles &metric_handles)
+  AllShortestPathsImpl(const ExpandVariable &self, Trav trav, UniqueCursorPtr input_cursor, utils::MemoryResource *mem)
       : self_(self),
-        input_cursor_(self_.input_->MakeCursor(mem, metric_handles)),
+        trav_(std::move(trav)),
+        input_cursor_(std::move(input_cursor)),
         cheapest_cost_(mem),
         visited_cost_(mem),
         total_cost_(mem),
@@ -3318,145 +3451,100 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
         pq_(mem) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
-    SCOPED_PROFILE_OP("ExpandAllShortestPathsCursor");
-
-    ExpressionEvaluator evaluator =
-        ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
-
     auto *memory = context.evaluation_context.memory;
+    ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
     auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, memory);
 
-    auto create_state = [this](const VertexAccessor &vertex, int64_t depth) {
-      return std::make_pair(vertex, upper_bound_set_ ? depth : 0);
+    auto create_state = [this](const Vertex &vertex, int64_t depth) {
+      return std::make_pair(vertex, upper_bound_set_ ? depth : int64_t{0});
     };
 
-    // For the given (edge, direction, weight, depth) tuple checks if they
-    // satisfy the "where" condition. if so, places them in the priority
-    // queue.
-    auto expand_vertex = [this, &evaluator, &frame, &frame_writer](const EdgeAccessor &edge,
-                                                                   const EdgeAtom::Direction direction,
-                                                                   const TypedValue &total_weight,
-                                                                   int64_t depth) {
-      auto const &next_vertex = direction == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+    auto expand_vertex =
+        [&](const Edge &edge, const EdgeAtom::Direction direction, const TypedValue &total_weight, int64_t depth) {
+          auto const &next_vertex = direction == EdgeAtom::Direction::IN ? edge.From() : edge.To();
 
-      // Evaluate current weight
-      frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, edge);
-      frame_writer.Write(self_.weight_lambda_->inner_node_symbol, next_vertex);
-      TypedValue next_weight = CalculateNextWeight(self_.weight_lambda_, total_weight, evaluator);
+          frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, edge);
+          frame_writer.Write(self_.weight_lambda_->inner_node_symbol, next_vertex);
+          TypedValue next_weight = CalculateNextWeight(self_.weight_lambda_, total_weight, evaluator);
 
-      // If filter expression exists, evaluate filter
-      std::optional<Path> curr_acc_path = std::nullopt;
-      if (self_.filter_lambda_.expression) {
-        frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
-        frame_writer.Write(self_.filter_lambda_.inner_node_symbol, next_vertex);
+          std::optional<Path> curr_acc_path = std::nullopt;
+          if constexpr (std::same_as<Edge, EdgeAccessor>) {
+            if (self_.filter_lambda_.expression) {
+              frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
+              frame_writer.Write(self_.filter_lambda_.inner_node_symbol, next_vertex);
+              if (self_.filter_lambda_.accumulated_path_symbol) {
+                MG_ASSERT(frame[self_.filter_lambda_.accumulated_path_symbol.value()].IsPath(),
+                          "Accumulated path must be path");
+                auto expand_path = [&](TypedValue &value) {
+                  Path &accumulated_path = value.ValuePath();
+                  accumulated_path.Expand(edge);
+                  accumulated_path.Expand(next_vertex);
+                };
+                frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), expand_path);
+                curr_acc_path = frame[self_.filter_lambda_.accumulated_path_symbol.value()].ValuePath();
+                if (self_.filter_lambda_.accumulated_weight_symbol) {
+                  frame_writer.Write(self_.filter_lambda_.accumulated_weight_symbol.value(), next_weight);
+                }
+              }
+              if (!EvaluateFilter(evaluator, self_.filter_lambda_.expression)) return;
+            }
+          }
+
+          auto found_it = visited_cost_.find(next_vertex);
+          if (found_it != visited_cost_.end()) {
+            auto &weights = found_it->second;
+            bool insert = std::ranges::none_of(weights, [&depth, &next_weight](const auto &entry) {
+              auto const &[old_weight, old_depth] = entry;
+              return old_depth <= depth && (old_weight < next_weight).ValueBool() &&
+                     !are_equal(old_weight, next_weight);
+            });
+            if (!insert) return;
+            std::erase_if(weights, [&next_weight, depth](const std::pair<TypedValue, int64_t> &p) {
+              return p.second >= depth && (p.first > next_weight).ValueBool();
+            });
+            weights.emplace_back(next_weight, depth);
+          } else {
+            visited_cost_[next_vertex] = {std::make_pair(next_weight, depth)};
+          }
+
+          auto best_cost = cheapest_cost_.find(next_vertex);
+          if (best_cost == cheapest_cost_.end() || best_cost->second.IsNull() ||
+              (next_weight < best_cost->second).ValueBool()) {
+            cheapest_cost_[next_vertex] = next_weight;
+          }
+
+          pq_.emplace(std::move(next_weight),
+                      depth + 1,
+                      next_vertex,
+                      DirectedEdge{edge, direction, next_weight},
+                      std::move(curr_acc_path));
+        };
+
+    auto restore_frame_state_after_expansion = [&]() {
+      if constexpr (std::same_as<Edge, EdgeAccessor>) {
         if (self_.filter_lambda_.accumulated_path_symbol) {
-          MG_ASSERT(frame[self_.filter_lambda_.accumulated_path_symbol.value()].IsPath(),
-                    "Accumulated path must be path");
-          auto expand_path = [&](TypedValue &value) {
-            Path &accumulated_path = value.ValuePath();
-            accumulated_path.Expand(edge);
-            accumulated_path.Expand(next_vertex);
-          };
-          frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), expand_path);
-          curr_acc_path = frame[self_.filter_lambda_.accumulated_path_symbol.value()].ValuePath();  // const ref
-
-          if (self_.filter_lambda_.accumulated_weight_symbol) {
-            frame_writer.Write(self_.filter_lambda_.accumulated_weight_symbol.value(), next_weight);
-          }
-        }
-
-        if (!EvaluateFilter(evaluator, self_.filter_lambda_.expression)) return;
-      }
-
-      auto found_it = visited_cost_.find(next_vertex);
-      // Check if the vertex has already been processed.
-      if (found_it != visited_cost_.end()) {
-        auto &weights = found_it->second;
-        bool insert = std::ranges::none_of(weights, [&depth, &next_weight](const auto &entry) {
-          auto const &[old_weight, old_depth] = entry;
-          return old_depth <= depth && (old_weight < next_weight).ValueBool() && !are_equal(old_weight, next_weight);
-        });
-
-        if (!insert) return;
-        // They cannot be equal since we checked for that above
-        // Its possible that some weights are worse because we update weights at the same time as expanding instead of
-        // later when popping from the queue
-        std::erase_if(weights, [&next_weight, depth](const std::pair<TypedValue, int64_t> &p) {
-          return p.second >= depth && (p.first > next_weight).ValueBool();
-        });
-        weights.emplace_back(next_weight, depth);
-
-      } else {
-        visited_cost_[next_vertex] = {
-            std::make_pair(next_weight, depth)};  // TODO (ivan): will this use correct allocator?
-      }
-
-      // update cheapest cost to get to the vertex
-      auto best_cost = cheapest_cost_.find(next_vertex);
-      if (best_cost == cheapest_cost_.end() || best_cost->second.IsNull() ||
-          (next_weight < best_cost->second).ValueBool()) {
-        cheapest_cost_[next_vertex] = next_weight;
-      }
-
-      pq_.emplace(std::move(next_weight),
-                  depth + 1,
-                  next_vertex,
-                  DirectedEdge{edge, direction, next_weight},
-                  std::move(curr_acc_path));
-    };
-
-    auto restore_frame_state_after_expansion = [this, &frame_writer]() {
-      if (self_.filter_lambda_.accumulated_path_symbol) {
-        auto shrink = [&](TypedValue &value) { value.ValuePath().Shrink(); };
-        frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), shrink);
-      }
-    };
-
-    // Populates the priority queue structure with expansions
-    // from the given vertex. skips expansions that don't satisfy
-    // the "where" condition.
-    auto expand_from_vertex = [this, &expand_vertex, &context, &restore_frame_state_after_expansion](
-                                  const VertexAccessor &vertex, const TypedValue &weight, int64_t depth) {
-      if (self_.common_.direction != EdgeAtom::Direction::IN) {
-        auto out_edges = UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types)).edges;
-        for (const auto &edge : out_edges) {
-#ifdef MG_ENTERPRISE
-          if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-              !(context.auth_checker->Has(
-                    edge.To(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-            continue;
-          }
-#endif
-          expand_vertex(edge, EdgeAtom::Direction::OUT, weight, depth);
-          restore_frame_state_after_expansion();
-        }
-      }
-      if (self_.common_.direction != EdgeAtom::Direction::OUT) {
-        auto in_edges = UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types)).edges;
-        for (const auto &edge : in_edges) {
-#ifdef MG_ENTERPRISE
-          if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-              !(context.auth_checker->Has(
-                    edge.From(), storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-                context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-            continue;
-          }
-#endif
-          expand_vertex(edge, EdgeAtom::Direction::IN, weight, depth);
-          restore_frame_state_after_expansion();
+          auto shrink = [&](TypedValue &value) { value.ValuePath().Shrink(); };
+          frame_writer.Modify(self_.filter_lambda_.accumulated_path_symbol.value(), shrink);
         }
       }
     };
 
-    std::optional<VertexAccessor> start_vertex;
+    auto expand_from_vertex = [&](const Vertex &vertex, const TypedValue &weight, int64_t depth) {
+      for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
+        Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+        if (!Trav::Visible(edge, far, context)) continue;
+        expand_vertex(edge, dir, weight, depth);
+        restore_frame_state_after_expansion();
+      }
+    };
 
-    auto create_path = [this, &frame, &memory, &frame_writer]() {
+    std::optional<Vertex> start_vertex;
+
+    auto create_path = [&]() {
       auto &current_level = traversal_stack_.back();
 
       auto pop_edge = [&](TypedValue &value) {
-        auto &edges_on_frame = value.ValueList();  // Clean out the current stack
+        auto &edges_on_frame = value.ValueList();
         if (current_level.empty()) {
           if (!edges_on_frame.empty()) {
             if (!self_.is_reverse_) {
@@ -3479,7 +3567,6 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
 
       auto push_current_edge = [&](TypedValue &value) {
         auto &edges_on_frame = value.ValueList();
-        // Edges order depends on direction of expansion
         if (!self_.is_reverse_)
           edges_on_frame.emplace_back(current_edge);
         else
@@ -3494,32 +3581,25 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       if (next_edges_.contains({next_vertex, traversal_stack_.size()})) {
         auto [it, inserted] =
             next_edges_.try_emplace({next_vertex, traversal_stack_.size()}, utils::pmr::list<DirectedEdge>(memory));
-
-        // Need to propagate the allocator
         traversal_stack_.emplace_back(utils::pmr::list<DirectedEdge>(it->second, memory));
       } else {
-        // Signal the end of iteration
         traversal_stack_.emplace_back(utils::pmr::list<DirectedEdge>(memory));
       }
 
       auto cheapest_cost = cheapest_cost_.find(next_vertex)->second;
       if ((current_weight > cheapest_cost).ValueBool() && !are_equal(current_weight, cheapest_cost)) return false;
 
-      // Place destination node on the frame, handle existence flag
       if (self_.common_.existing_node) {
-        const auto &node = frame[self_.common_.node_symbol];
-        ExpectType(self_.common_.node_symbol, node, TypedValue::Type::Vertex);
-        if (node.ValueVertex() != next_vertex) return false;
+        if (!Trav::SameBoundNode(next_vertex, self_.common_.node_symbol, frame)) return false;
       } else {
         frame_writer.Write(self_.common_.node_symbol, next_vertex);
       }
       return true;
     };
 
-    auto create_DFS_traversal_tree = [this, &context, &memory, &frame_writer, &create_state, &expand_from_vertex]() {
+    auto create_DFS_traversal_tree = [&]() {
       while (!pq_.empty()) {
         AbortCheck(context);
-
         auto [current_weight, current_depth, current_vertex, directed_edge, acc_path] = pq_.top();
         pq_.pop();
 
@@ -3532,18 +3612,17 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
         } else {
           total_cost_.emplace(current_state, current_weight);
           if (current_depth < upper_bound_) {
-            if (self_.filter_lambda_.accumulated_path_symbol) {
-              DMG_ASSERT(acc_path.has_value(), "Path must be already filled in AllShortestPath DFS traversals");
-              frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), std::move(acc_path.value()));
+            if constexpr (std::same_as<Edge, EdgeAccessor>) {
+              if (self_.filter_lambda_.accumulated_path_symbol) {
+                DMG_ASSERT(acc_path.has_value(), "Path must be already filled in AllShortestPath DFS traversals");
+                frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), std::move(acc_path.value()));
+              }
             }
             expand_from_vertex(current_vertex, current_weight, current_depth);
           }
         }
 
-        // Searching for a previous vertex in the expansion
         auto prev_vertex = direction == EdgeAtom::Direction::IN ? current_edge.To() : current_edge.From();
-
-        // Update the parent
         if (!next_edges_.contains({prev_vertex, current_depth - 1})) {
           next_edges_[{prev_vertex, current_depth - 1}] = utils::pmr::list<DirectedEdge>(memory);
         }
@@ -3551,8 +3630,6 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       }
     };
 
-    // upper_bound_set is used when storing visited edges, because with an upper bound we also consider suboptimal
-    // paths if they are shorter in depth
     if (self_.upper_bound_) {
       upper_bound_ = EvaluateInt(evaluator, self_.upper_bound_, "Max depth in all shortest path expansion");
       upper_bound_set_ = true;
@@ -3560,59 +3637,51 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       upper_bound_ = std::numeric_limits<int64_t>::max();
       upper_bound_set_ = false;
     }
-
-    // Check if upper bound is valid
     if (upper_bound_ < 1) {
       throw QueryRuntimeException("Maximum depth in all shortest paths expansion must be at least 1.");
     }
 
-    // On first Pull run, traversal stack and priority queue are empty, so we start a pulling stream
-    // and create a DFS traversal tree (main part of algorithm). Then we return the first path
-    // created from the DFS traversal tree (basically a DFS algorithm).
-    // On each subsequent Pull run, paths are created from the traversal stack and returned.
     while (true) {
-      // Check if there is an external error.
       AbortCheck(context);
-
-      // The algorithm is run all at once by create_DFS_traversal_tree, after which we
-      // traverse the tree iteratively by preserving the traversal state on stack.
       while (!traversal_stack_.empty()) {
         if (create_path()) return true;
       }
 
-      // If priority queue is empty start new pulling stream.
       if (pq_.empty()) {
-        // Finish if there is nothing to pull
         if (!input_cursor_->Pull(frame, context)) return false;
 
         const auto &vertex_value = frame[self_.input_symbol_];
         if (vertex_value.IsNull()) continue;
 
-        start_vertex = vertex_value.ValueVertex();
+        if constexpr (std::same_as<Edge, VirtualEdge>) {
+          if (self_.filter_lambda_.expression) {
+            throw QueryRuntimeException(
+                "An all-shortest-paths filter is not supported over a projection in a USE scope.");
+          }
+        }
+
+        start_vertex = Trav::GetInput(vertex_value, self_.input_symbol_);
 
         if (self_.common_.existing_node) {
           const auto &node = frame[self_.common_.node_symbol];
-          // Due to optional matching the existing node could be null.
-          // Skip expansion for such nodes.
-          if (node.IsNull()) continue;
+          if (node.IsNull()) continue;  // unbound optional end
         }
 
-        // Clear existing data structures.
         visited_cost_.clear();
         cheapest_cost_.clear();
         next_edges_.clear();
         traversal_stack_.clear();
         total_cost_.clear();
 
-        if (self_.filter_lambda_.accumulated_path_symbol) {
-          // Add initial vertex of path to the accumulated path
-          frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), Path(*start_vertex));
+        if constexpr (std::same_as<Edge, EdgeAccessor>) {
+          if (self_.filter_lambda_.accumulated_path_symbol) {
+            frame_writer.Write(self_.filter_lambda_.accumulated_path_symbol.value(), Path(*start_vertex));
+          }
         }
 
         frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, TypedValue());
         frame_writer.Write(self_.weight_lambda_->inner_node_symbol, *start_vertex);
-        TypedValue current_weight =
-            CalculateNextWeight(self_.weight_lambda_, /* total_weight */ TypedValue(), evaluator);
+        TypedValue current_weight = CalculateNextWeight(self_.weight_lambda_, TypedValue(), evaluator);
 
         expand_from_vertex(*start_vertex, current_weight, 0);
         cheapest_cost_[*start_vertex] = 0;
@@ -3620,16 +3689,12 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
                               std::vector<std::pair<TypedValue, int64_t>>{std::make_pair(TypedValue(0, memory), 0)});
 
         auto new_vector = TypedValue::TVector(memory);
-        if (upper_bound_set_ && upper_bound_ > 0) {
-          new_vector.reserve(upper_bound_);
-        }
+        if (upper_bound_set_ && upper_bound_ > 0) new_vector.reserve(upper_bound_);
         frame_writer.Write(self_.common_.edge_symbol, std::move(new_vector));
       }
 
-      // Create a DFS traversal tree from the start node
       create_DFS_traversal_tree();
 
-      // DFS traversal tree is create,
       if (start_vertex && next_edges_.contains({*start_vertex, 0})) {
         auto [it, inserted] = next_edges_.try_emplace({*start_vertex, 0}, utils::pmr::list<DirectedEdge>(memory));
         traversal_stack_.emplace_back(utils::pmr::list<DirectedEdge>(it->second, memory));
@@ -3651,164 +3716,205 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
 
  private:
   const ExpandVariable &self_;
-  const UniqueCursorPtr input_cursor_;
-
-  // Upper bound on the path length.
+  Trav trav_;
+  UniqueCursorPtr input_cursor_;
   int64_t upper_bound_{-1};
   bool upper_bound_set_{false};
 
-  struct AspStateHash {
-    size_t operator()(const std::pair<VertexAccessor, int64_t> &key) const {
-      return utils::HashCombine<VertexAccessor, int64_t>{}(key.first, key.second);
-    }
-  };
-
-  using DirectedEdge = std::tuple<EdgeAccessor, EdgeAtom::Direction, TypedValue>;
-  using NextEdgesState = std::pair<VertexAccessor, int64_t>;
-  using VertexState = std::pair<VertexAccessor, int64_t>;
-  // Maps vertices to minimum weights they got in expansion.
-  utils::pmr::unordered_map<VertexAccessor, TypedValue> cheapest_cost_;
-  utils::pmr::unordered_map<VertexAccessor, std::vector<std::pair<TypedValue, int64_t>>> visited_cost_;
-  // Maps vertices to weights they got in expansion.
-  utils::pmr::unordered_map<NextEdgesState, TypedValue, AspStateHash> total_cost_;
-  // Maps the vertex with the potential expansion edge.
-  utils::pmr::unordered_map<NextEdgesState, utils::pmr::list<DirectedEdge>, AspStateHash> next_edges_;
-  // Stack indicating the traversal level.
+  utils::pmr::unordered_map<Vertex, TypedValue> cheapest_cost_;
+  utils::pmr::unordered_map<Vertex, std::vector<std::pair<TypedValue, int64_t>>> visited_cost_;
+  utils::pmr::unordered_map<NextEdgesState, TypedValue, StateHash> total_cost_;
+  utils::pmr::unordered_map<NextEdgesState, utils::pmr::list<DirectedEdge>, StateHash> next_edges_;
   utils::pmr::list<utils::pmr::list<DirectedEdge>> traversal_stack_;
-
-  // Priority queue comparator. Keep lowest weight on top of the queue.
-  class PriorityQueueComparator {
-   public:
-    bool operator()(const std::tuple<TypedValue, int64_t, VertexAccessor, DirectedEdge, std::optional<Path>> &lhs,
-                    const std::tuple<TypedValue, int64_t, VertexAccessor, DirectedEdge, std::optional<Path>> &rhs) {
-      const auto &lhs_weight = std::get<0>(lhs);
-      const auto &rhs_weight = std::get<0>(rhs);
-      // Null defines minimum value for all types
-      if (lhs_weight.IsNull()) {
-        return false;
-      }
-
-      if (rhs_weight.IsNull()) {
-        return true;
-      }
-
-      ValidateWeightTypes(lhs_weight, rhs_weight);
-      return (lhs_weight > rhs_weight).ValueBool();
-    }
-  };
-
-  // Priority queue - core element of the algorithm.
-  // Stores: {weight, depth, next vertex, edge and direction}
-  std::priority_queue<
-      std::tuple<TypedValue, int64_t, VertexAccessor, DirectedEdge, std::optional<Path>>,
-      utils::pmr::vector<std::tuple<TypedValue, int64_t, VertexAccessor, DirectedEdge, std::optional<Path>>>,
-      PriorityQueueComparator>
-      pq_;
+  std::priority_queue<PqEntry, utils::pmr::vector<PqEntry>, PqCompare> pq_;
 
   void ClearQueue() {
     while (!pq_.empty()) pq_.pop();
   }
 };
 
-// K-Shortest Paths Cursor using lazy-evaluated Yen's algorithm
-class KShortestPathsCursor : public Cursor {
+}  // namespace
+
+class ExpandAllShortestPathsCursor : public query::plan::Cursor {
  public:
-  KShortestPathsCursor(const ExpandVariable &self, utils::MemoryResource *mem,
-                       metrics::DatabaseMetricHandles &metric_handles)
-      : self_(self),
-        input_cursor_(self.input_->MakeCursor(mem, metric_handles)),
-        shortest_paths_(mem),
-        candidate_paths_(mem),
-        found_paths_set_(mem),
-        current_source_(std::nullopt),
-        current_target_(std::nullopt),
-        blocked_edges_(mem),
-        blocked_vertices_(mem),
-        distances_(mem),
-        predecessors_(mem) {}
+  ExpandAllShortestPathsCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+                               metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self), mem_(mem), metric_handles_(metric_handles) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
-    SCOPED_PROFILE_OP("KShortestPaths");
+    SCOPED_PROFILE_OP("ExpandAllShortestPathsCursor");
+    if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
+      Init(context);
+    if (auto *impl = std::get_if<AllShortestPathsImpl<RealTraversal<false>>>(&impl_)) [[likely]]
+      return impl->Pull(frame, context);
+    return std::get<AllShortestPathsImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+  }
 
-    ExpressionEvaluator evaluator =
-        ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
+  void Shutdown() override {
+    if (auto *impl = std::get_if<AllShortestPathsImpl<RealTraversal<false>>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<AllShortestPathsImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+  }
+
+  void Reset() override {
+    if (auto *impl = std::get_if<AllShortestPathsImpl<RealTraversal<false>>>(&impl_))
+      impl->Reset();
+    else if (auto *impl = std::get_if<AllShortestPathsImpl<VirtualTraversal>>(&impl_))
+      impl->Reset();
+  }
+
+ private:
+  const ExpandVariable &self_;
+  utils::MemoryResource *mem_;
+  metrics::DatabaseMetricHandles &metric_handles_;
+  std::variant<std::monostate, AllShortestPathsImpl<RealTraversal<false>>, AllShortestPathsImpl<VirtualTraversal>>
+      impl_;
+
+  void Init(ExecutionContext &context) {
+    auto input_cursor = self_.input_->MakeCursor(mem_, metric_handles_);
+    if (auto *vview = ProjectionView(context)) {
+      std::vector<std::string_view> allowed;
+      allowed.reserve(self_.common_.edge_types.size());
+      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
+      impl_.emplace<AllShortestPathsImpl<VirtualTraversal>>(
+          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
+      return;
+    }
+    // All-shortest historically does not account hops (RealTraversal<false>).
+    impl_.emplace<AllShortestPathsImpl<RealTraversal<false>>>(
+        self_, RealTraversal<false>{&self_}, std::move(input_cursor), mem_);
+  }
+};
+
+// K-Shortest Paths Cursor using lazy-evaluated Yen's algorithm
+namespace {
+
+// K-shortest paths (lazy Yen's algorithm), written once over a traversal policy. There was no
+// projection arm before; templating the existing real algorithm gives one for free. The per-vertex
+// directional edge caches are preserved (Yen re-runs the inner search many times), so the real path
+// keeps its memoisation.
+struct KShortestPaths {
+  virtual ~KShortestPaths() = default;
+  virtual bool Pull(Frame &frame, ExecutionContext &context) = 0;
+  virtual void Reset() = 0;
+  virtual void Shutdown() = 0;
+};
+
+template <class Trav>
+class KShortestPathsImpl final : public KShortestPaths {
+  using Vertex = typename Trav::Vertex;
+  using Edge = typename Trav::Edge;
+
+  struct PathInfo {
+    utils::pmr::vector<Edge> edges;
+    size_t deviation_vertex_index;
+
+    explicit PathInfo(utils::MemoryResource *mem) : edges(mem), deviation_vertex_index(0) {}
+
+    PathInfo(const utils::pmr::vector<Edge> &path_edges, size_t deviation_idx, utils::MemoryResource *mem)
+        : edges(path_edges.begin(), path_edges.end(), mem), deviation_vertex_index(deviation_idx) {}
+  };
+
+  struct PathComparator {
+    bool operator()(const PathInfo &a, const PathInfo &b) const { return a.edges.size() > b.edges.size(); }
+  };
+
+  struct VertexHash {
+    size_t operator()(const Vertex &vertex) const { return std::hash<storage::Gid>{}(vertex.Gid()); }
+  };
+
+  struct PathGidsHash {
+    size_t operator()(const utils::pmr::vector<storage::Gid> &path_gids) const {
+      size_t hash = 0;
+      for (const auto &gid : path_gids) hash = utils::HashCombine<size_t, storage::Gid>{}(hash, gid);
+      return hash;
+    }
+  };
+
+  using VertexEdgeMap = utils::pmr::unordered_map<Vertex, std::optional<Edge>, VertexHash>;
+  using EdgeList = utils::pmr::vector<std::pair<Edge, EdgeAtom::Direction>>;
+
+ public:
+  KShortestPathsImpl(const ExpandVariable &self, Trav trav, UniqueCursorPtr input_cursor, utils::MemoryResource *mem)
+      : self_(self),
+        trav_(std::move(trav)),
+        input_cursor_(std::move(input_cursor)),
+        shortest_paths_(mem),
+        candidate_paths_(PathComparator{}, utils::pmr::vector<PathInfo>(mem)),
+        found_paths_set_(mem),
+        blocked_edges_(mem),
+        blocked_vertices_(mem),
+        out_cache_(mem),
+        in_cache_(mem) {}
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
 
     limit_ = self_.limit_ ? EvaluateInt(evaluator, self_.limit_, "Limit in KSHORTEST path expansion")
                           : std::numeric_limits<int64_t>::max();
 
-    auto push_next_path = [&](Frame &frame, ExpressionEvaluator &evaluator) {
-      PushPathToFrame(shortest_paths_[current_path_index_++], &frame, evaluator.GetMemoryResource(), context);
+    auto push_next_path = [&](Frame &frame) {
+      PushPathToFrame(shortest_paths_[current_path_index_++], &frame, context.evaluation_context.memory, context);
       n_returned_paths_++;
     };
 
-    // Check if we reached the maximum number of paths to return
-    if (n_returned_paths_ >= limit_) {
-      return false;
-    }
+    if (n_returned_paths_ >= limit_) return false;
 
     auto unsent_paths_count = [&]() { return shortest_paths_.size() - current_path_index_; };
 
-    // If we have cached shortest paths, return the next one
     if (unsent_paths_count() > 0) {
-      push_next_path(frame, evaluator);
+      push_next_path(frame);
       return true;
     }
 
-    // Try to compute the next shortest path for current input
     if (current_input_initialized_ && current_source_.has_value() && current_target_.has_value() &&
-        ComputeNextShortestPath(current_source_.value(), current_target_.value(), evaluator, context)) {
-      push_next_path(frame, evaluator);
+        ComputeNextShortestPath(current_source_.value(), current_target_.value(), context)) {
+      push_next_path(frame);
       return true;
     }
 
-    // Need to pull new input
     while (input_cursor_->Pull(frame, context)) {
       AbortCheck(context);
       if (context.hops_limit.IsLimitReached()) return false;
 
       auto &source_tv = frame[self_.input_symbol_];
       auto &target_tv = frame[self_.common_.node_symbol];
-
-      // It is possible that source or sink vertex is Null due to optional matching.
       if (source_tv.IsNull() || target_tv.IsNull()) continue;
 
-      auto &source_vertex = source_tv.ValueVertex();
-      auto &target_vertex = target_tv.ValueVertex();
+      if constexpr (std::same_as<Edge, VirtualEdge>) {
+        if (self_.filter_lambda_.expression) {
+          throw QueryRuntimeException("A k-shortest-paths filter is not supported over a projection in a USE scope.");
+        }
+      }
 
-      // Skip if source and target are the same vertex
+      Vertex source_vertex = Trav::GetInput(source_tv, self_.input_symbol_);
+      Vertex target_vertex = Trav::GetInput(target_tv, self_.common_.node_symbol);
       if (source_vertex == target_vertex) continue;
 
       lower_bound_ = self_.lower_bound_ ? EvaluateInt(evaluator, self_.lower_bound_, "Min depth in expansion") : 1;
       upper_bound_ = self_.upper_bound_ ? EvaluateInt(evaluator, self_.upper_bound_, "Max depth in expansion")
                                         : std::numeric_limits<int64_t>::max();
 
-      // Initialize for this new source-target pair
       current_source_ = source_vertex;
       current_target_ = target_vertex;
       current_input_initialized_ = true;
 
-      if (!InitializeKShortestPaths(source_vertex, target_vertex, evaluator, context)) {
-        // If no path found, continue to next input
-        continue;
-      }
+      if (!InitializeKShortestPaths(source_vertex, target_vertex, context)) continue;
 
-      // Handle lower bound
       auto *last_path = &shortest_paths_.back();
-      while (last_path->edges.size() < lower_bound_) {
+      while (last_path->edges.size() < static_cast<size_t>(lower_bound_)) {
         current_path_index_ = shortest_paths_.size();
-        if (!ComputeNextShortestPath(current_source_.value(), current_target_.value(), evaluator, context)) {
-          break;
-        }
+        if (!ComputeNextShortestPath(current_source_.value(), current_target_.value(), context)) break;
         last_path = &shortest_paths_.back();
       }
 
       if (unsent_paths_count() > 0) {
-        push_next_path(frame, evaluator);
+        push_next_path(frame);
         return true;
       }
     }
-
     return false;
   }
 
@@ -3821,75 +3927,44 @@ class KShortestPathsCursor : public Cursor {
   }
 
  private:
-  struct PathInfo {
-    utils::pmr::vector<EdgeAccessor> edges;
-    size_t deviation_vertex_index;  // Index where this path deviates from parent
-
-    explicit PathInfo(utils::MemoryResource *mem) : edges(mem), deviation_vertex_index(0) {}
-
-    PathInfo(const utils::pmr::vector<EdgeAccessor> &path_edges, size_t deviation_idx, utils::MemoryResource *mem)
-        : edges(path_edges.begin(), path_edges.end(), mem), deviation_vertex_index(deviation_idx) {}
-  };
-
-  struct PathComparator {
-    bool operator()(const PathInfo &a, const PathInfo &b) const {
-      return a.edges.size() > b.edges.size();  // Min-heap: smaller costs have higher priority
-    }
-  };
-
-  struct EdgeAccessorHash {
-    size_t operator()(const EdgeAccessor &edge) const { return std::hash<storage::Gid>{}(edge.Gid()); }
-  };
-
-  struct VertexAccessorHash {
-    size_t operator()(const VertexAccessor &vertex) const { return std::hash<storage::Gid>{}(vertex.Gid()); }
-  };
-
-  struct PathGidsHash {
-    size_t operator()(const utils::pmr::vector<storage::Gid> &path_gids) const {
-      size_t hash = 0;
-      for (const auto &gid : path_gids) {
-        hash = utils::HashCombine<size_t, storage::Gid>{}(hash, gid);
-      }
-      return hash;
-    }
-  };
-
   const ExpandVariable &self_;
+  Trav trav_;
   UniqueCursorPtr input_cursor_;
   int64_t lower_bound_{1};
   int64_t upper_bound_{std::numeric_limits<int64_t>::max()};
   int64_t limit_{0};
   int64_t n_returned_paths_{0};
 
-  // State for K-shortest paths algorithm
   utils::pmr::vector<PathInfo> shortest_paths_;
   std::priority_queue<PathInfo, utils::pmr::vector<PathInfo>, PathComparator> candidate_paths_;
   utils::pmr::unordered_set<utils::pmr::vector<storage::Gid>, PathGidsHash> found_paths_set_;
   size_t current_path_index_ = 0;
 
-  // Re-entrant state
   bool current_input_initialized_ = false;
-  std::optional<VertexAccessor> current_source_;
-  std::optional<VertexAccessor> current_target_;
+  std::optional<Vertex> current_source_;
+  std::optional<Vertex> current_target_;
 
-  // Dijkstra's algorithm state (reused for efficiency)
-  utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> blocked_edges_;
-  utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
-  utils::pmr::unordered_map<VertexAccessor, double, VertexAccessorHash> distances_;
-  utils::pmr::unordered_map<VertexAccessor, EdgeVertexAccessorResult, VertexAccessorHash> in_edges_;
-  utils::pmr::unordered_map<VertexAccessor, EdgeVertexAccessorResult, VertexAccessorHash> out_edges_;
-  utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>, VertexAccessorHash> predecessors_;
+  // Yen state, reused across the repeated inner searches.
+  utils::pmr::unordered_set<storage::Gid> blocked_edges_;
+  utils::pmr::unordered_set<Vertex, VertexHash> blocked_vertices_;
+  // Per-vertex directional edge caches (physical OUT / IN), populated once per source-target pair.
+  utils::pmr::unordered_map<Vertex, EdgeList, VertexHash> out_cache_;
+  utils::pmr::unordered_map<Vertex, EdgeList, VertexHash> in_cache_;
 
-  // Bidirectional search state
-  using VertexEdgeMapT = utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>>;
+  const EdgeList &CachedEdges(const Vertex &vertex, bool out, ExecutionContext &context) {
+    auto &cache = out ? out_cache_ : in_cache_;
+    auto it = cache.find(vertex);
+    if (it != cache.end()) return it->second;
+    EdgeList level(cache.get_allocator().resource());
+    for (auto pair : trav_.Expand(vertex, out ? EdgeAtom::Direction::OUT : EdgeAtom::Direction::IN, context)) {
+      level.emplace_back(pair.first, pair.second);
+    }
+    return cache.emplace(vertex, std::move(level)).first->second;
+  }
 
-  bool InitializeKShortestPaths(const VertexAccessor &source, const VertexAccessor &target,
-                                ExpressionEvaluator &evaluator, ExecutionContext &context) {
+  bool InitializeKShortestPaths(const Vertex &source, const Vertex &target, ExecutionContext &context) {
     ResetState();
-
-    // Find the shortest path using Dijkstra's algorithm
-    auto shortest_path = ComputeShortestPath(source, target, evaluator, context);
+    auto shortest_path = ComputeShortestPath(source, target, context);
     if (!shortest_path.edges.empty()) {
       shortest_paths_.emplace_back(std::move(shortest_path));
       AddPathToFoundSet(shortest_paths_.back());
@@ -3898,26 +3973,16 @@ class KShortestPathsCursor : public Cursor {
     return false;
   }
 
-  bool ComputeNextShortestPath(const VertexAccessor &source, const VertexAccessor &target,
-                               ExpressionEvaluator &evaluator, ExecutionContext &context) {
+  bool ComputeNextShortestPath(const Vertex &source, const Vertex &target, ExecutionContext &context) {
     if (shortest_paths_.empty()) return false;
-
     const auto &last_path = shortest_paths_.back();
-
-    // Generate candidate paths by deviating at each vertex of the last shortest path
     for (size_t i = 0UZ; i < last_path.edges.size(); ++i) {
-      GenerateCandidatesFromDeviation(source, target, last_path, i, evaluator, context);
+      GenerateCandidatesFromDeviation(source, target, last_path, i, context);
     }
-
-    // Find the best candidate path
     while (!candidate_paths_.empty()) {
       PathInfo candidate = candidate_paths_.top();
       candidate_paths_.pop();
-      // Handle upper bound
-      if (candidate.edges.size() > upper_bound_) {
-        // Next path is too long, stop generating candidates
-        return false;
-      }
+      if (candidate.edges.size() > static_cast<size_t>(upper_bound_)) return false;
       if (!IsPathInFoundSet(candidate)) {
         shortest_paths_.emplace_back(std::move(candidate));
         AddPathToFoundSet(shortest_paths_.back());
@@ -3927,47 +3992,25 @@ class KShortestPathsCursor : public Cursor {
     return false;
   }
 
-  void GenerateCandidatesFromDeviation(const VertexAccessor &source, const VertexAccessor &target,
-                                       const PathInfo &base_path, size_t deviation_index,
-                                       ExpressionEvaluator &evaluator, ExecutionContext &context) {
-    // Set up blocked edges and vertices for this deviation
+  void GenerateCandidatesFromDeviation(const Vertex &source, const Vertex &target, const PathInfo &base_path,
+                                       size_t deviation_index, ExecutionContext &context) {
     SetupBlockedElementsForDeviation(source, base_path, deviation_index);
-
-    // Get the deviation vertex
-    VertexAccessor deviation_vertex = GetVertexAtIndex(source, base_path, deviation_index);
-
-    // Compute shortest path from deviation vertex to target with blocked elements
-    auto spur_path = ComputeShortestPath(deviation_vertex, target, evaluator, context);
-
+    Vertex deviation_vertex = GetVertexAtIndex(source, base_path, deviation_index);
+    auto spur_path = ComputeShortestPath(deviation_vertex, target, context);
     if (!spur_path.edges.empty()) {
-      // Combine the root path (up to deviation) with the spur path
-      PathInfo candidate_path(evaluator.GetMemoryResource());
-
-      // Add edges from source to deviation vertex
-      for (size_t i = 0UZ; i < deviation_index; ++i) {
-        candidate_path.edges.push_back(base_path.edges[i]);
-      }
-
-      // Add spur path edges
-      for (const auto &edge : spur_path.edges) {
-        candidate_path.edges.push_back(edge);
-      }
-
+      PathInfo candidate_path(context.evaluation_context.memory);
+      for (size_t i = 0UZ; i < deviation_index; ++i) candidate_path.edges.push_back(base_path.edges[i]);
+      for (const auto &edge : spur_path.edges) candidate_path.edges.push_back(edge);
       candidate_path.deviation_vertex_index = deviation_index;
-
       candidate_paths_.push(std::move(candidate_path));
     }
   }
 
-  void SetupBlockedElementsForDeviation(const VertexAccessor &source, const PathInfo &base_path,
-                                        size_t deviation_index) {
+  void SetupBlockedElementsForDeviation(const Vertex &source, const PathInfo &base_path, size_t deviation_index) {
     blocked_edges_.clear();
     blocked_vertices_.clear();
-
-    // Block the edge at deviation index from all previously found paths that share the same prefix
     for (const auto &path : shortest_paths_) {
       if (deviation_index < path.edges.size()) {
-        // Check if the path prefix matches up to deviation index
         bool prefix_matches = true;
         for (size_t i = 0UZ; i < deviation_index; ++i) {
           if (i >= base_path.edges.size() || path.edges[i].Gid() != base_path.edges[i].Gid()) {
@@ -3975,15 +4018,10 @@ class KShortestPathsCursor : public Cursor {
             break;
           }
         }
-
-        if (prefix_matches) {
-          blocked_edges_.insert(path.edges[deviation_index]);
-        }
+        if (prefix_matches) blocked_edges_.insert(path.edges[deviation_index].Gid());
       }
     }
-
-    // Block vertices in the root path (except the deviation vertex)
-    VertexAccessor current_vertex = source;
+    Vertex current_vertex = source;
     for (size_t i = 0UZ; i < deviation_index; ++i) {
       blocked_vertices_.insert(current_vertex);
       const auto &edge = base_path.edges[i];
@@ -3991,10 +4029,9 @@ class KShortestPathsCursor : public Cursor {
     }
   }
 
-  static VertexAccessor GetVertexAtIndex(const VertexAccessor &source, const PathInfo &path, size_t index) {
+  static Vertex GetVertexAtIndex(const Vertex &source, const PathInfo &path, size_t index) {
     if (index == 0) return source;
-
-    VertexAccessor current = source;
+    Vertex current = source;
     for (size_t i = 0UZ; i < index && i < path.edges.size(); ++i) {
       const auto &edge = path.edges[i];
       current = (edge.From() == current) ? edge.To() : edge.From();
@@ -4002,199 +4039,98 @@ class KShortestPathsCursor : public Cursor {
     return current;
   }
 
-  static PathInfo ReconstructPath(const VertexAccessor &midpoint, const VertexEdgeMapT &in_edge,
-                                  const VertexEdgeMapT &out_edge, utils::MemoryResource *memory) {
-    utils::pmr::vector<EdgeAccessor> result(memory);
-    VertexAccessor current = midpoint;
-
-    // Reconstruct the path from midpoint to source
+  static PathInfo ReconstructPath(const Vertex &midpoint, const VertexEdgeMap &in_edge, const VertexEdgeMap &out_edge,
+                                  utils::MemoryResource *memory) {
+    utils::pmr::vector<Edge> result(memory);
+    Vertex current = midpoint;
     while (in_edge.contains(current)) {
       const auto &edge_opt = in_edge.at(current);
-      if (edge_opt) {
-        const auto &edge = edge_opt.value();
-        result.push_back(edge);
-        current = (edge.From() == current) ? edge.To() : edge.From();
-      } else {
-        break;
-      }
+      if (!edge_opt) break;
+      const auto &edge = edge_opt.value();
+      result.push_back(edge);
+      current = (edge.From() == current) ? edge.To() : edge.From();
     }
-
-    // Reverse the path from source to midpoint
     std::ranges::reverse(result);
-
-    // Reconstruct the path from midpoint to target
     current = midpoint;
     while (out_edge.contains(current)) {
       const auto &edge_opt = out_edge.at(current);
-      if (edge_opt) {
-        const auto &edge = edge_opt.value();
-        result.push_back(edge);
-        current = (edge.From() == current) ? edge.To() : edge.From();
-      } else {
-        break;
-      }
+      if (!edge_opt) break;
+      const auto &edge = edge_opt.value();
+      result.push_back(edge);
+      current = (edge.From() == current) ? edge.To() : edge.From();
     }
-
     return PathInfo(result, 0, memory);
   }
 
-  static constexpr bool kTo = true;
-  static constexpr bool kFrom = !kTo;
-
-  template <bool To>
-  static bool FineGrainedAccessCheck(const EdgeAccessor &edge, ExecutionContext &context) {
-#ifdef MG_ENTERPRISE
-    return (!license::global_license_checker.IsEnterpriseValidFast() || !context.auth_checker ||
-            (context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-             context.auth_checker->Has(To == kTo ? edge.To() : edge.From(),
-                                       storage::View::OLD,
-                                       memgraph::query::AuthQuery::FineGrainedPrivilege::READ)));
-#else
-    (void)edge;
-    (void)context;
-    return true;
-#endif
+  bool ShouldExpand(const Edge &edge, const Vertex &far, ExecutionContext &context, const VertexEdgeMap &edges) {
+    return Trav::Visible(edge, far, context) && !blocked_edges_.contains(edge.Gid()) &&
+           !blocked_vertices_.contains(far) && !edges.contains(far);
   }
 
-  template <bool To>
-  static bool ShouldExpand(const EdgeAccessor &edge, ExecutionContext &context, const VertexEdgeMapT &edges,
-                           const utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> &blocked_edges,
-                           const utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> &blocked_vertices) {
-    return FineGrainedAccessCheck<To>(edge, context) && !blocked_edges.contains(edge) &&
-           !blocked_vertices.contains(To == kTo ? edge.To() : edge.From()) &&
-           !edges.contains(To == kTo ? edge.To() : edge.From());
-  }
+  [[gnu::noinline]] PathInfo ComputeShortestPath(const Vertex &source, const Vertex &target,
+                                                 ExecutionContext &context) {
+    auto *pull_memory = context.evaluation_context.memory;
+    if (source == target) return PathInfo(pull_memory);
 
-  PathInfo ComputeShortestPath(const VertexAccessor &source, const VertexAccessor &target,
-                               ExpressionEvaluator &evaluator, ExecutionContext &context) {
-    if (source == target) return PathInfo(evaluator.GetMemoryResource());
-
-    // We expand from both directions, both from the source and the target.
-    // Expansions meet at the middle of the path if it exists. This should
-    // perform better for real-world like graphs where the expansion front
-    // grows exponentially, effectively reducing the exponent by half.
-
-    auto *pull_memory = evaluator.GetMemoryResource();
-    // Holds vertices at the current level of expansion from the source
-    // (target).
-    utils::pmr::vector<VertexAccessor> source_frontier(pull_memory);
-    utils::pmr::vector<VertexAccessor> target_frontier(pull_memory);
-
-    // Holds vertices we can expand to from `source_frontier`
-    // (`target_frontier`).
-    utils::pmr::vector<VertexAccessor> source_next(pull_memory);
-    utils::pmr::vector<VertexAccessor> target_next(pull_memory);
-
-    // Maps each vertex we visited expanding from the source (target) to the
-    // edge used. Necessary for path reconstruction.
-    VertexEdgeMapT in_edge(pull_memory);
-    VertexEdgeMapT out_edge(pull_memory);
+    utils::pmr::vector<Vertex> source_frontier(pull_memory);
+    utils::pmr::vector<Vertex> target_frontier(pull_memory);
+    utils::pmr::vector<Vertex> source_next(pull_memory);
+    utils::pmr::vector<Vertex> target_next(pull_memory);
+    VertexEdgeMap in_edge(pull_memory);
+    VertexEdgeMap out_edge(pull_memory);
 
     size_t current_length = 0;
-
     source_frontier.emplace_back(source);
     in_edge[source] = std::nullopt;
     target_frontier.emplace_back(target);
     out_edge[target] = std::nullopt;
 
+    // Iterate one physical-direction edge list of `vertex`, recording each accepted far end into
+    // `record` and returning a reconstructed path if the two fronts meet, else nullopt.
+    auto step = [&](const Vertex &vertex,
+                    bool out,
+                    VertexEdgeMap &record,
+                    const VertexEdgeMap &other,
+                    utils::pmr::vector<Vertex> &next) -> std::optional<PathInfo> {
+      for (const auto &[edge, dir] : CachedEdges(vertex, out, context)) {
+        Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+        if (!ShouldExpand(edge, far, context, record)) continue;
+        record.emplace(far, edge);
+        if (other.contains(far)) return ReconstructPath(far, in_edge, out_edge, pull_memory);
+        next.push_back(far);
+      }
+      return std::nullopt;
+    };
+
     while (true) {
       AbortCheck(context);
-      // Top-down step (expansion from the source).
       ++current_length;
-      if (current_length > upper_bound_) return PathInfo(evaluator.GetMemoryResource());
-
+      if (current_length > static_cast<size_t>(upper_bound_)) return PathInfo(pull_memory);
       for (const auto &vertex : source_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
         if (self_.common_.direction != EdgeAtom::Direction::IN) {
-          if (!out_edges_.contains(vertex)) {
-            auto out_edges_result =
-                UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-            context.number_of_hops += out_edges_result.expanded_count;
-            out_edges_.emplace(vertex, out_edges_result);
-          }
-          for (const auto &edge : out_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kTo>(edge, context, in_edge, blocked_edges_, blocked_vertices_)) {
-              continue;
-            }
-            in_edge.emplace(edge.To(), edge);
-            if (out_edge.contains(edge.To())) {
-              return ReconstructPath(edge.To(), in_edge, out_edge, evaluator.GetMemoryResource());
-            }
-            source_next.push_back(edge.To());
-          }
+          if (auto p = step(vertex, /*out=*/true, in_edge, out_edge, source_next)) return std::move(*p);
         }
         if (self_.common_.direction != EdgeAtom::Direction::OUT) {
-          if (!in_edges_.contains(vertex)) {
-            auto in_edges_result =
-                UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-            context.number_of_hops += in_edges_result.expanded_count;
-            in_edges_.emplace(vertex, in_edges_result);
-          }
-          for (const auto &edge : in_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kFrom>(edge, context, in_edge, blocked_edges_, blocked_vertices_)) {
-              continue;
-            }
-            in_edge.emplace(edge.From(), edge);
-            if (out_edge.contains(edge.From())) {
-              return ReconstructPath(edge.From(), in_edge, out_edge, evaluator.GetMemoryResource());
-            }
-            source_next.push_back(edge.From());
-          }
+          if (auto p = step(vertex, /*out=*/false, in_edge, out_edge, source_next)) return std::move(*p);
         }
       }
-
-      if (source_next.empty()) return PathInfo(evaluator.GetMemoryResource());
+      if (source_next.empty()) return PathInfo(pull_memory);
       source_frontier.clear();
       std::swap(source_frontier, source_next);
 
-      // Bottom-up step (expansion from the target).
       ++current_length;
-      if (current_length > upper_bound_) return PathInfo(evaluator.GetMemoryResource());
-
-      // When expanding from the target we have to be careful which edge
-      // endpoint we pass to `should_expand`, because everything is
-      // reversed.
+      if (current_length > static_cast<size_t>(upper_bound_)) return PathInfo(pull_memory);
       for (const auto &vertex : target_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
         if (self_.common_.direction != EdgeAtom::Direction::OUT) {
-          if (!out_edges_.contains(vertex)) {
-            auto out_edges_result =
-                UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-            context.number_of_hops += out_edges_result.expanded_count;
-            out_edges_.emplace(vertex, out_edges_result);
-          }
-          for (const auto &edge : out_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kTo>(edge, context, out_edge, blocked_edges_, blocked_vertices_)) {
-              continue;
-            }
-            out_edge.emplace(edge.To(), edge);
-            if (in_edge.contains(edge.To())) {
-              return ReconstructPath(edge.To(), in_edge, out_edge, evaluator.GetMemoryResource());
-            }
-            target_next.push_back(edge.To());
-          }
+          if (auto p = step(vertex, /*out=*/true, out_edge, in_edge, target_next)) return std::move(*p);
         }
         if (self_.common_.direction != EdgeAtom::Direction::IN) {
-          if (!in_edges_.contains(vertex)) {
-            auto in_edges_result =
-                UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
-            context.number_of_hops += in_edges_result.expanded_count;
-            in_edges_.emplace(vertex, in_edges_result);
-          }
-          for (const auto &edge : in_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kFrom>(edge, context, out_edge, blocked_edges_, blocked_vertices_)) {
-              continue;
-            }
-            out_edge.emplace(edge.From(), edge);
-            if (in_edge.contains(edge.From())) {
-              return ReconstructPath(edge.From(), in_edge, out_edge, evaluator.GetMemoryResource());
-            }
-            target_next.push_back(edge.From());
-          }
+          if (auto p = step(vertex, /*out=*/false, out_edge, in_edge, target_next)) return std::move(*p);
         }
       }
-
-      if (target_next.empty()) return PathInfo(evaluator.GetMemoryResource());
+      if (target_next.empty()) return PathInfo(pull_memory);
       target_frontier.clear();
       std::swap(target_frontier, target_next);
     }
@@ -4202,26 +4138,20 @@ class KShortestPathsCursor : public Cursor {
 
   void PushPathToFrame(const PathInfo &path, Frame *frame, utils::MemoryResource *memory, ExecutionContext &context) {
     auto edge_list = TypedValue::TVector(memory);
-    for (const auto &edge : path.edges) {
-      edge_list.emplace_back(edge);
-    }
+    for (const auto &edge : path.edges) edge_list.emplace_back(edge);
     auto frame_writer = frame->GetFrameWriter(context.frame_change_collector, memory);
     frame_writer.Write(self_.common_.edge_symbol, std::move(edge_list));
   }
 
   bool IsPathInFoundSet(const PathInfo &path) {
     utils::pmr::vector<storage::Gid> path_gids(found_paths_set_.get_allocator());
-    for (const auto &edge : path.edges) {
-      path_gids.push_back(edge.Gid());
-    }
+    for (const auto &edge : path.edges) path_gids.push_back(edge.Gid());
     return found_paths_set_.contains(path_gids);
   }
 
   void AddPathToFoundSet(const PathInfo &path) {
     utils::pmr::vector<storage::Gid> path_gids(found_paths_set_.get_allocator());
-    for (const auto &edge : path.edges) {
-      path_gids.push_back(edge.Gid());
-    }
+    for (const auto &edge : path.edges) path_gids.push_back(edge.Gid());
     found_paths_set_.insert(std::move(path_gids));
   }
 
@@ -4232,8 +4162,61 @@ class KShortestPathsCursor : public Cursor {
     current_path_index_ = 0;
     blocked_edges_.clear();
     blocked_vertices_.clear();
-    distances_.clear();
-    predecessors_.clear();
+    out_cache_.clear();
+    in_cache_.clear();
+  }
+};
+
+}  // namespace
+
+class KShortestPathsCursor : public Cursor {
+ public:
+  KShortestPathsCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+                       metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self), mem_(mem), metric_handles_(metric_handles) {}
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    OOMExceptionEnabler oom_exception;
+    SCOPED_PROFILE_OP("KShortestPaths");
+    if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
+      Init(context);
+    if (auto *impl = std::get_if<KShortestPathsImpl<RealTraversal<true>>>(&impl_)) [[likely]]
+      return impl->Pull(frame, context);
+    return std::get<KShortestPathsImpl<VirtualTraversal>>(impl_).Pull(frame, context);
+  }
+
+  void Shutdown() override {
+    if (auto *impl = std::get_if<KShortestPathsImpl<RealTraversal<true>>>(&impl_))
+      impl->Shutdown();
+    else if (auto *impl = std::get_if<KShortestPathsImpl<VirtualTraversal>>(&impl_))
+      impl->Shutdown();
+  }
+
+  void Reset() override {
+    if (auto *impl = std::get_if<KShortestPathsImpl<RealTraversal<true>>>(&impl_))
+      impl->Reset();
+    else if (auto *impl = std::get_if<KShortestPathsImpl<VirtualTraversal>>(&impl_))
+      impl->Reset();
+  }
+
+ private:
+  const ExpandVariable &self_;
+  utils::MemoryResource *mem_;
+  metrics::DatabaseMetricHandles &metric_handles_;
+  std::variant<std::monostate, KShortestPathsImpl<RealTraversal<true>>, KShortestPathsImpl<VirtualTraversal>> impl_;
+
+  void Init(ExecutionContext &context) {
+    auto input_cursor = self_.input_->MakeCursor(mem_, metric_handles_);
+    if (auto *vview = ProjectionView(context)) {
+      std::vector<std::string_view> allowed;
+      allowed.reserve(self_.common_.edge_types.size());
+      for (const auto type : self_.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
+      impl_.emplace<KShortestPathsImpl<VirtualTraversal>>(
+          self_, VirtualTraversal{&self_, vview, std::move(allowed)}, std::move(input_cursor), mem_);
+      return;
+    }
+    impl_.emplace<KShortestPathsImpl<RealTraversal<true>>>(
+        self_, RealTraversal<true>{&self_}, std::move(input_cursor), mem_);
   }
 };
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7002,7 +7002,7 @@ class AggregateCursor : public Cursor {
         if (value == "hidden") {
           hidden.push_back(id);
         } else if (value == "origin") {
-          if (overlay.find(id) != overlay.end()) {
+          if (overlay.contains(id)) {
             throw QueryRuntimeException("derive() property '{}' is both overlaid and bound to origin.", name);
           }
         } else if (value == "overlay") {
@@ -9156,7 +9156,7 @@ class BindGraphViewCursor : public Cursor {
       : self_(self), input_cursor_(self.input_->MakeCursor(mem, metric_handles)) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
+    OOMExceptionEnabler const oom_exception;
     SCOPED_PROFILE_OP("BindGraphView");
 
     AbortCheck(context);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2338,24 +2338,35 @@ struct SubgraphTraversal {
   }
 };
 
+// Classifies the ambient graph view into its concrete kind and invokes the matching handler: a
+// projection (VirtualGraphView), a subgraph (SubgraphGraphView), or the real identity view (any other
+// view, including none bound). The dynamic_cast ladder over the GraphView kinds lives here once - one
+// cast per call, never per row - so the callers that need it (traversal-family dispatch and
+// procedure-call routing) share a single place to extend when a new graph kind is added.
+template <class OnVirtual, class OnSubgraph, class OnReal>
+decltype(auto) WithAmbientView(GraphView *ambient, OnVirtual &&on_virtual, OnSubgraph &&on_subgraph, OnReal &&on_real) {
+  if (auto *vview = dynamic_cast<VirtualGraphView *>(ambient)) return on_virtual(*vview);
+  if (auto *sview = dynamic_cast<SubgraphGraphView *>(ambient)) return on_subgraph(*sview);
+  return on_real();
+}
+
 // Selects the traversal policy for the ambient graph view and invokes make(policy) to build the arm's
 // cursor: a projection materialises its level from the bound overlay; a subgraph materialises a
 // membership-filtered level; anything else (the real identity view) keeps RealTraversal's lazy,
-// unregressed hot path. The view dispatch (one dynamic_cast per cursor build, never per row) and the
-// projection edge-type name resolution live here once, shared by all six traversal-family arms.
+// unregressed hot path. The projection edge-type name resolution lives here once, shared by all six
+// traversal-family arms; the view classification is WithAmbientView's single dynamic_cast per build.
 template <bool AccountHops, class Make>
 void DispatchAmbientTraversal(ExecutionContext &context, const ExpandVariable &self, Make &&make) {
-  auto *ambient = context.evaluation_context.graph_view;
-  if (auto *vview = dynamic_cast<VirtualGraphView *>(ambient)) {
-    std::vector<std::string_view> allowed;
-    allowed.reserve(self.common_.edge_types.size());
-    for (const auto type : self.common_.edge_types) allowed.emplace_back(vview->EdgeTypeToName(type));
-    make(VirtualTraversal{&self, vview, std::move(allowed)});
-  } else if (auto *sview = dynamic_cast<SubgraphGraphView *>(ambient)) {
-    make(SubgraphTraversal<AccountHops>{&self, sview});
-  } else {
-    make(RealTraversal<AccountHops>{&self});
-  }
+  WithAmbientView(
+      context.evaluation_context.graph_view,
+      [&](VirtualGraphView &vview) {
+        std::vector<std::string_view> allowed;
+        allowed.reserve(self.common_.edge_types.size());
+        for (const auto type : self.common_.edge_types) allowed.emplace_back(vview.EdgeTypeToName(type));
+        make(VirtualTraversal{&self, &vview, std::move(allowed)});
+      },
+      [&](SubgraphGraphView &sview) { make(SubgraphTraversal<AccountHops>{&self, &sview}); },
+      [&] { make(RealTraversal<AccountHops>{&self}); });
 }
 
 // The variable-length (DFS) expansion, written once over a traversal policy.
@@ -8026,13 +8037,18 @@ void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, 
     // No explicit graph argument, but a `CALL { USE g ... }` scope bound an
     // ambient view: route the procedure over it, borrowing the scope-owned
     // graph (no copy). An explicit argument above takes precedence over this.
-    if (auto *subgraph_view = dynamic_cast<query::SubgraphGraphView *>(ambient_view)) {
-      db_acc = query::SubgraphDbAccessor(*std::get<query::DbAccessor *>(graph.impl), subgraph_view->graph());
-      graph.impl = &*db_acc;
-    } else if (auto *virtual_view = dynamic_cast<query::VirtualGraphView *>(ambient_view)) {
-      vg_acc = query::VirtualGraphDbAccessor(*std::get<query::DbAccessor *>(graph.impl), virtual_view->graph());
-      graph.impl = &*vg_acc;
-    }
+    // The real identity view needs no wrapper - the procedure runs over the real graph directly.
+    WithAmbientView(
+        ambient_view,
+        [&](query::VirtualGraphView &virtual_view) {
+          vg_acc = query::VirtualGraphDbAccessor(*std::get<query::DbAccessor *>(graph.impl), virtual_view.graph());
+          graph.impl = &*vg_acc;
+        },
+        [&](query::SubgraphGraphView &subgraph_view) {
+          db_acc = query::SubgraphDbAccessor(*std::get<query::DbAccessor *>(graph.impl), subgraph_view.graph());
+          graph.impl = &*db_acc;
+        },
+        [] {});
   }
 
   procedure::ValidateArguments(args_list, proc, fully_qualified_procedure_name);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -57,6 +57,7 @@
 #include "query/subgraph_graph_view.hpp"
 #include "query/trigger_context.hpp"
 #include "query/typed_value.hpp"
+#include "query/virtual_graph.hpp"
 #include "query/virtual_graph_view.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/point_iterator.hpp"
@@ -6434,7 +6435,7 @@ class AggregateCursor : public Cursor {
     using TSet = utils::pmr::unordered_set<TypedValue, TypedValue::Hash, TypedValue::BoolEqual>;
     // Per-slot real-vertex-gid → canonical-synthetic-gid map for DERIVE aggregation.
     // Empty for non-DERIVE slots.
-    using DeriveDedup = utils::pmr::unordered_map<storage::Gid, storage::Gid>;
+    using DeriveDedup = DerivedNodeDedup;
 
     // Pointers to the start of our arrays within the single memory block
     int64_t *counts_ = nullptr;
@@ -6735,11 +6736,12 @@ class AggregateCursor : public Cursor {
             break;
           }
           case Aggregation::Op::DERIVE: {
-            ProjectPathWithOptions(input_value,
-                                   agg_elem.arg2->Accept(*evaluator),
-                                   agg_value->values_[pos].ValueVirtualGraph(),
-                                   agg_value->derive_dedup_[pos],
-                                   ProjectionRefForDerive(agg_elem));
+            AddPathToProjection(input_value,
+                                agg_elem.arg2->Accept(*evaluator),
+                                agg_value->values_[pos].ValueVirtualGraph(),
+                                agg_value->derive_dedup_[pos],
+                                ProjectionRefForDerive(agg_elem),
+                                db_accessor_);
             break;
           }
           case Aggregation::Op::COLLECT_MAP:
@@ -6803,11 +6805,12 @@ class AggregateCursor : public Cursor {
           break;
         }
         case Aggregation::Op::DERIVE: {
-          ProjectPathWithOptions(input_value,
-                                 agg_elem.arg2->Accept(*evaluator),
-                                 agg_value->values_[pos].ValueVirtualGraph(),
-                                 agg_value->derive_dedup_[pos],
-                                 ProjectionRefForDerive(agg_elem));
+          AddPathToProjection(input_value,
+                              agg_elem.arg2->Accept(*evaluator),
+                              agg_value->values_[pos].ValueVirtualGraph(),
+                              agg_value->derive_dedup_[pos],
+                              ProjectionRefForDerive(agg_elem),
+                              db_accessor_);
           break;
         }
         case Aggregation::Op::COLLECT_MAP:
@@ -6837,20 +6840,6 @@ class AggregateCursor : public Cursor {
     projectedGraph.Expand(arg1.ValueList(), arg2.ValueList());
   }
 
-  // Walks options[key] as a map of (name -> value) and invokes setter(prop_id, pv) for each entry.
-  template <typename Setter>
-  void ApplyPropertyMap(const TypedValue::TMap &options, std::string_view key, Setter &&setter) const {
-    const auto it = options.find(key);
-    if (it == options.end() || !db_accessor_) return;
-    if (it->second.type() != TypedValue::Type::Map) {
-      throw QueryRuntimeException("derive() option '{}' must be a map of property names to values.", key);
-    }
-    auto *name_id_mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
-    for (const auto &[name, val] : it->second.ValueMap()) {
-      setter(db_accessor_->NameToProperty(name), val.ToPropertyValue(name_id_mapper));
-    }
-  }
-
   // The projection-schema reference a derive() stamps onto its overlay nodes: the output symbol's
   // plan position, unique per derive() site. It is set only when the options are a static map
   // literal; with non-literal options (e.g. the whole map is a parameter) the schema cannot be
@@ -6859,173 +6848,6 @@ class AggregateCursor : public Cursor {
   static int64_t ProjectionRefForDerive(const Aggregate::Element &element) {
     if (utils::Downcast<MapLiteral>(element.arg2) == nullptr) return VirtualNode::kNoProjectionRef;
     return element.output_sym.position();
-  }
-
-  VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key,
-                               std::string_view props_key, const TypedValue::TMap &options, int64_t projection_ref,
-                               VirtualNode::allocator_type alloc) const {
-    static constexpr auto kPropertyPolicy = "propertyPolicy";
-
-    VirtualNode::label_list labels{alloc};
-    if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
-      if (labels_it->second.type() != TypedValue::Type::List) {
-        throw QueryRuntimeException("derive() option '{}' must be a list of label strings.", labels_key);
-      }
-      for (const auto &label : labels_it->second.ValueList()) {
-        if (label.type() != TypedValue::Type::String) {
-          throw QueryRuntimeException("derive() option '{}' must contain only strings.", labels_key);
-        }
-        labels.emplace_back(label.ValueString());
-      }
-    } else {
-      // no labels option -> inherit every label from the original vertex
-      auto maybe_labels = real_vertex.Labels(storage::View::NEW);
-      if (!maybe_labels) throw QueryRuntimeException("derive() could not read labels of a path vertex.");
-      for (const auto label_id : *maybe_labels) {
-        const auto &name = db_accessor_->LabelToName(label_id);
-        labels.emplace_back(name.data(), name.size());
-      }
-    }
-
-    // The overlay holds only the explicitly-overridden properties; every other property is read
-    // through the origin lazily, so a projection never copies the origin's properties (e.g. vector
-    // embeddings) unless they are actually read.
-    // overlay_bound names every key whose read and write target this node's overlay: the
-    // construction-time override keys below and the 'overlay' propertyPolicy bindings. Every other
-    // key on the resulting overlay node is origin-bound, so a write to it persists to the origin.
-    VirtualNode::property_map overlay{alloc};
-    VirtualNode::key_set overlay_bound{alloc};
-    if (options.find(props_key) != options.end()) {
-      ApplyPropertyMap(options, props_key, [&](storage::PropertyId id, storage::PropertyValue pv) {
-        overlay.insert_or_assign(id, std::move(pv));
-        overlay_bound.push_back(id);
-      });
-    }
-
-    // The static property policy: per property, 'hidden' makes it invisible, 'origin' binds it to
-    // the origin (read-through), 'overlay' allows an overlay value to shadow. Read source and write
-    // target are coupled, so a key bound to 'origin' may not also be overlaid - that is a conflict
-    // rejected at construction rather than resolved silently.
-    VirtualNode::hidden_keys hidden{alloc};
-    if (const auto policy_it = options.find(kPropertyPolicy); policy_it != options.end()) {
-      if (policy_it->second.type() != TypedValue::Type::Map) {
-        throw QueryRuntimeException("derive() option '{}' must be a map of property names to bindings.",
-                                    kPropertyPolicy);
-      }
-      for (const auto &[name, binding] : policy_it->second.ValueMap()) {
-        if (binding.type() != TypedValue::Type::String) {
-          throw QueryRuntimeException(
-              "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
-        }
-        const auto id = db_accessor_->NameToProperty(name);
-        const auto &value = binding.ValueString();
-        if (value == "hidden") {
-          hidden.push_back(id);
-        } else if (value == "origin") {
-          if (overlay.contains(id)) {
-            throw QueryRuntimeException("derive() property '{}' is both overlaid and bound to origin.", name);
-          }
-        } else if (value == "overlay") {
-          overlay_bound.push_back(id);
-        } else {
-          throw QueryRuntimeException(
-              "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
-        }
-      }
-    }
-
-    return {std::move(labels),
-            std::move(overlay),
-            alloc,
-            std::optional<VertexAccessor>{real_vertex},
-            std::move(hidden),
-            std::move(overlay_bound),
-            projection_ref};
-  }
-
-  // Collapses the path to a single synthetic edge between its endpoints. Intermediate vertices
-  // on the path are ignored by design — derive() is for producing compressed overlay edges
-  // (e.g. shortest-path distillation), not for replicating the path structurally.
-  //
-  // `dedup` is the real-vertex-gid → canonical-synthetic-gid map owned by the aggregation slot.
-  // If a path endpoint's real gid is already present, we reuse the canonical VirtualNode; only
-  // the first occurrence inserts a new one into `projected_graph`.
-  void ProjectPathWithOptions(TypedValue const &path_value, TypedValue const &options_value,
-                              VirtualGraph &projected_graph, CompactAggregationValue::DeriveDedup &dedup,
-                              int64_t projection_ref) {
-    static constexpr auto kVirtualEdgeType = "virtualEdgeType";
-    static constexpr auto kSourceLabels = "sourceNodeLabels";
-    static constexpr auto kSourceProperties = "sourceNodeProperties";
-    static constexpr auto kTargetLabels = "targetNodeLabels";
-    static constexpr auto kTargetProperties = "targetNodeProperties";
-    static constexpr auto kRelationshipProperties = "relationshipProperties";
-    static constexpr auto kUndirectedEdgeTypes = "undirectedEdgeTypes";
-
-    if (path_value.type() != TypedValue::Type::Path) {
-      throw QueryRuntimeException("derive() requires a path as argument 1.");
-    }
-    if (options_value.type() != TypedValue::Type::Map) {
-      throw QueryRuntimeException("derive() argument 2 must be a map of options (e.g. {virtualEdgeType: 'TYPE'}).");
-    }
-    const auto &options = options_value.ValueMap();
-
-    const auto &path_vertices = path_value.ValuePath().vertices();
-    if (path_vertices.empty()) return;
-
-    const auto alloc = projected_graph.get_allocator();
-    auto canonical = [&](const VertexAccessor &real_vertex,
-                         std::string_view labels_key,
-                         std::string_view props_key) -> std::shared_ptr<const VirtualNode> {
-      const auto real_gid = real_vertex.Gid();
-      if (const auto it = dedup.find(real_gid); it != dedup.end()) {
-        return projected_graph.FindNode(it->second);
-      }
-      auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, projection_ref, alloc);
-      const auto synth_gid = new_node.Gid();
-      dedup[real_gid] = synth_gid;
-      projected_graph.InsertNode(std::move(new_node));
-      return projected_graph.FindNode(synth_gid);
-    };
-
-    auto stored_from = canonical(path_vertices.front(), kSourceLabels, kSourceProperties);
-
-    if (path_vertices.size() < 2) return;
-
-    // The path has edges, so a virtual edge type is now required. It is not needed to project a
-    // single-vertex path's overlay node, so a bare derive(p, {}) over one node is allowed.
-    const auto type_it = options.find(kVirtualEdgeType);
-    if (type_it == options.end() || type_it->second.type() != TypedValue::Type::String) {
-      throw QueryRuntimeException("derive() requires a 'virtualEdgeType' string option when the path has edges.");
-    }
-    const auto &type_name = type_it->second.ValueString();
-    const bool type_is_undirected = [&] {
-      const auto it = options.find(kUndirectedEdgeTypes);
-      if (it == options.end()) return false;
-      if (it->second.type() != TypedValue::Type::List) {
-        throw QueryRuntimeException("derive() option '{}' must be a list of edge-type strings.", kUndirectedEdgeTypes);
-      }
-      const auto &list = it->second.ValueList();
-      if (std::ranges::any_of(list, [](const auto &e) { return e.type() != TypedValue::Type::String; })) {
-        throw QueryRuntimeException("derive() option '{}' entries must be strings.", kUndirectedEdgeTypes);
-      }
-      return std::ranges::any_of(list,
-                                 [&](const auto &e) { return e.ValueString() == "*" || e.ValueString() == type_name; });
-    }();
-
-    auto stored_to = canonical(path_vertices.back(), kTargetLabels, kTargetProperties);
-
-    auto build_edge = [&](std::shared_ptr<const VirtualNode> from, std::shared_ptr<const VirtualNode> to) {
-      VirtualEdge e(std::move(from), std::move(to), utils::pmr::string{type_name, alloc}, alloc);
-      ApplyPropertyMap(options, kRelationshipProperties, [&](storage::PropertyId id, storage::PropertyValue pv) {
-        e.SetProperty(id, std::move(pv));
-      });
-      return e;
-    };
-
-    projected_graph.InsertEdgeIfNew(build_edge(stored_from, stored_to));
-    if (type_is_undirected && stored_from.get() != stored_to.get()) {
-      projected_graph.InsertEdgeIfNew(build_edge(std::move(stored_to), std::move(stored_from)));
-    }
   }
 
   /** Checks if the given TypedValue is legal in MIN and MAX. If not

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2229,10 +2229,9 @@ struct RealTraversal {
 
   static bool Visible(const Edge &edge, const Vertex &far, ExecutionContext &context) {
 #ifdef MG_ENTERPRISE
-    if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-        !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-          context.auth_checker->Has(far, storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-      return false;
+    if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker) {
+      return context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
+             context.auth_checker->Has(far, storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ);
     }
 #endif
     return true;
@@ -2363,7 +2362,7 @@ void DispatchAmbientTraversal(ExecutionContext &context, const ExpandVariable &s
         std::vector<std::string_view> allowed;
         allowed.reserve(self.common_.edge_types.size());
         for (const auto type : self.common_.edge_types) allowed.emplace_back(vview.EdgeTypeToName(type));
-        make(VirtualTraversal{&self, &vview, std::move(allowed)});
+        make(VirtualTraversal{.self = &self, .vview = &vview, .allowed = std::move(allowed)});
       },
       [&](SubgraphGraphView &sview) { make(SubgraphTraversal<AccountHops>{&self, &sview}); },
       [&] { make(RealTraversal<AccountHops>{&self}); });
@@ -2395,7 +2394,7 @@ class VariableExpansionImpl final : public VariableExpansion {
       if (PullInput(frame, context)) {
         // if lower bound is zero we also yield empty paths
         if (lower_bound_ == 0) {
-          Vertex start = Trav::GetInput(frame[self_.input_symbol_], self_.input_symbol_);
+          Vertex const start = Trav::GetInput(frame[self_.input_symbol_], self_.input_symbol_);
           if (!self_.common_.existing_node) {
             auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
             frame_writer.Write(self_.common_.node_symbol, start);
@@ -2455,7 +2454,7 @@ class VariableExpansionImpl final : public VariableExpansion {
         }
       }
 
-      Vertex vertex = Trav::GetInput(vertex_value, self_.input_symbol_);
+      Vertex const vertex = Trav::GetInput(vertex_value, self_.input_symbol_);
       auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
 
       if (upper_bound_ > 0) {
@@ -2493,6 +2492,9 @@ class VariableExpansionImpl final : public VariableExpansion {
   }
 
   [[gnu::noinline]] bool Expand(Frame &frame, ExecutionContext &context) {
+    // The real-graph instantiation passes this to EvaluateFilter by non-const reference; it is
+    // const-detectable only in the projection instantiation, where the filtered branch below is gone.
+    // NOLINTNEXTLINE(misc-const-correctness)
     [[maybe_unused]] ExpressionEvaluator evaluator{
         &frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
     auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
@@ -2511,7 +2513,7 @@ class VariableExpansionImpl final : public VariableExpansion {
       auto current_edge = *edges_it_.back()++;
       if (Trav::AlreadyOnFrame(current_edge.first, edges_on_frame)) return false;
 
-      Vertex current_vertex =
+      Vertex const current_vertex =
           current_edge.second == EdgeAtom::Direction::IN ? current_edge.first.From() : current_edge.first.To();
       if (!Trav::Visible(current_edge.first, current_vertex, context)) return false;
 
@@ -2558,7 +2560,7 @@ class VariableExpansionImpl final : public VariableExpansion {
 
       bool const expand_is_valid = frame_writer.Modify(self_.common_.edge_symbol, try_expand);
       auto const &edges_on_frame = frame[self_.common_.edge_symbol].ValueList();
-      if (expand_is_valid && static_cast<int64_t>(edges_on_frame.size()) >= lower_bound_) return true;
+      if (expand_is_valid && std::cmp_greater_equal(edges_on_frame.size(), lower_bound_)) return true;
     }
   }
 };
@@ -2669,8 +2671,8 @@ class STShortestPathImpl final : public STShortestPath {
         }
       }
 
-      Vertex source = Trav::GetInput(source_tv, self_.input_symbol_);
-      Vertex sink = Trav::GetInput(sink_tv, self_.common_.node_symbol);
+      Vertex const source = Trav::GetInput(source_tv, self_.input_symbol_);
+      Vertex const sink = Trav::GetInput(sink_tv, self_.common_.node_symbol);
       if (FindPath(source, sink, lower_bound, upper_bound, &frame, &evaluator, context)) return true;
     }
     return false;
@@ -2737,9 +2739,11 @@ class STShortestPathImpl final : public STShortestPath {
     VertexEdgeMap in_edge(pull_memory);
     VertexEdgeMap out_edge(pull_memory);
 
-    const auto reversed = self_.common_.direction == EdgeAtom::Direction::IN    ? EdgeAtom::Direction::OUT
-                          : self_.common_.direction == EdgeAtom::Direction::OUT ? EdgeAtom::Direction::IN
-                                                                                : EdgeAtom::Direction::BOTH;
+    const auto reversed = [&]() -> EdgeAtom::Direction {
+      if (self_.common_.direction == EdgeAtom::Direction::IN) return EdgeAtom::Direction::OUT;
+      if (self_.common_.direction == EdgeAtom::Direction::OUT) return EdgeAtom::Direction::IN;
+      return EdgeAtom::Direction::BOTH;
+    }();
 
     size_t current_length = 0;
     source_frontier.emplace_back(source);
@@ -2751,7 +2755,7 @@ class STShortestPathImpl final : public STShortestPath {
       AbortCheck(context);
       // Top-down step (expansion from the source).
       ++current_length;
-      if (static_cast<int64_t>(current_length) > upper_bound) return false;
+      if (std::cmp_greater(current_length, upper_bound)) return false;
       for (const auto &vertex : source_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
         for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
@@ -2760,7 +2764,7 @@ class STShortestPathImpl final : public STShortestPath {
           if (ShouldExpand(far, edge, frame, evaluator, context) && !in_edge.contains(far)) {
             in_edge.emplace(far, edge);
             if (out_edge.contains(far)) {
-              if (current_length >= static_cast<size_t>(lower_bound)) {
+              if (std::cmp_greater_equal(current_length, lower_bound)) {
                 ReconstructPath(far, in_edge, out_edge, frame, context);
                 return true;
               }
@@ -2776,7 +2780,7 @@ class STShortestPathImpl final : public STShortestPath {
 
       // Bottom-up step (expansion from the sink); direction mirrored.
       ++current_length;
-      if (static_cast<int64_t>(current_length) > upper_bound) return false;
+      if (std::cmp_greater(current_length, upper_bound)) return false;
       for (const auto &vertex : sink_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
         for (auto [edge, dir] : trav_.Expand(vertex, reversed, context)) {
@@ -2785,7 +2789,7 @@ class STShortestPathImpl final : public STShortestPath {
           if (ShouldExpand(vertex, edge, frame, evaluator, context) && !out_edge.contains(far)) {
             out_edge.emplace(far, edge);
             if (in_edge.contains(far)) {
-              if (current_length >= static_cast<size_t>(lower_bound)) {
+              if (std::cmp_greater_equal(current_length, lower_bound)) {
                 ReconstructPath(far, in_edge, out_edge, frame, context);
                 return true;
               }
@@ -2814,7 +2818,7 @@ class STShortestPathCursor : public query::plan::Cursor {
   }
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
+    OOMExceptionEnabler const oom_exception;
     SCOPED_PROFILE_OP("STShortestPath");
     if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
       Init(context);
@@ -2896,6 +2900,7 @@ class SingleSourceShortestPathImpl final : public SingleSourceShortestPath {
       if (processed_.contains(vertex)) return false;
       if (!Trav::Visible(edge, vertex, context)) return false;
 
+      // NOLINTNEXTLINE(misc-const-correctness): assigned below in the real-graph instantiation only.
       std::optional<Path> curr_acc_path = std::nullopt;
       if constexpr (std::same_as<Edge, EdgeAccessor>) {
         frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
@@ -2939,9 +2944,9 @@ class SingleSourceShortestPathImpl final : public SingleSourceShortestPath {
     };
 
     auto expand_from_vertex = [&](const Vertex &vertex) {
-      for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
-        Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
-        bool was_expanded = expand_pair(edge, far);
+      for (const auto &[edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
+        Vertex const far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+        bool const was_expanded = expand_pair(edge, far);
         restore_frame_state_after_expansion(was_expanded);
       }
     };
@@ -3004,7 +3009,7 @@ class SingleSourceShortestPathImpl final : public SingleSourceShortestPath {
         edge_list.emplace_back(last_edge);
       }
 
-      if (static_cast<int64_t>(edge_list.size()) < upper_bound_) {
+      if (std::cmp_less(edge_list.size(), upper_bound_)) {
         if constexpr (std::same_as<Edge, EdgeAccessor>) {
           if (self_.filter_lambda_.accumulated_path_symbol) {
             MG_ASSERT(curr_acc_path.has_value(), "Expected non-null accumulated path");
@@ -3014,7 +3019,7 @@ class SingleSourceShortestPathImpl final : public SingleSourceShortestPath {
         if (!context.hops_limit.IsLimitReached()) expand_from_vertex(curr_vertex);
       }
 
-      if (static_cast<int64_t>(edge_list.size()) < lower_bound_) continue;
+      if (std::cmp_less(edge_list.size(), lower_bound_)) continue;
 
       frame_writer.Write(self_.common_.node_symbol, curr_vertex);
       // is_reverse_ false: reverse to source-to-destination order; true: keep destination-to-source.
@@ -3059,7 +3064,7 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
   }
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
+    OOMExceptionEnabler const oom_exception;
     SCOPED_PROFILE_OP("SingleSourceShortestPath");
     if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
       Init(context);
@@ -3216,8 +3221,9 @@ class WeightedShortestPathImpl final : public WeightedShortestPath {
     auto expand_pair = [&](const Edge &edge, const Vertex &vertex, const TypedValue &total_weight, int64_t depth) {
       frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, edge);
       frame_writer.Write(self_.weight_lambda_->inner_node_symbol, vertex);
-      TypedValue next_weight = CalculateNextWeight(self_.weight_lambda_, total_weight, evaluator);
+      TypedValue const next_weight = CalculateNextWeight(self_.weight_lambda_, total_weight, evaluator);
 
+      // NOLINTNEXTLINE(misc-const-correctness): assigned below in the real-graph instantiation only.
       std::optional<Path> curr_acc_path = std::nullopt;
       if constexpr (std::same_as<Edge, EdgeAccessor>) {
         if (self_.filter_lambda_.expression) {
@@ -3260,8 +3266,8 @@ class WeightedShortestPathImpl final : public WeightedShortestPath {
     };
 
     auto expand_from_vertex = [&](const Vertex &vertex, const TypedValue &weight, int64_t depth) {
-      for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
-        Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+      for (const auto &[edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
+        Vertex const far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
         if (!Trav::Visible(edge, far, context)) continue;
         expand_pair(edge, far, weight, depth);
         restore_frame_state_after_expansion();
@@ -3288,6 +3294,7 @@ class WeightedShortestPathImpl final : public WeightedShortestPath {
           if (node.IsNull()) continue;  // unbound optional end
         }
 
+        // NOLINTNEXTLINE(misc-const-correctness): assigned below in the real-graph instantiation only.
         std::optional<Path> curr_acc_path;
         if constexpr (std::same_as<Edge, EdgeAccessor>) {
           if (self_.filter_lambda_.accumulated_path_symbol) {
@@ -3308,7 +3315,7 @@ class WeightedShortestPathImpl final : public WeightedShortestPath {
 
         frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, TypedValue());
         frame_writer.Write(self_.weight_lambda_->inner_node_symbol, vertex);
-        TypedValue current_weight = CalculateNextWeight(self_.weight_lambda_, TypedValue(), evaluator);
+        TypedValue const current_weight = CalculateNextWeight(self_.weight_lambda_, TypedValue(), evaluator);
 
         previous_.clear();
         total_cost_.clear();
@@ -3403,7 +3410,7 @@ class ExpandWeightedShortestPathCursor : public query::plan::Cursor {
       : self_(self), mem_(mem), metric_handles_(metric_handles) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
+    OOMExceptionEnabler const oom_exception;
     SCOPED_PROFILE_OP("ExpandWeightedShortestPath");
     if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
       Init(context);
@@ -3532,6 +3539,7 @@ class AllShortestPathsImpl final : public AllShortestPaths {
           frame_writer.Write(self_.weight_lambda_->inner_node_symbol, next_vertex);
           TypedValue next_weight = CalculateNextWeight(self_.weight_lambda_, total_weight, evaluator);
 
+          // NOLINTNEXTLINE(misc-const-correctness): assigned below in the real-graph instantiation only.
           std::optional<Path> curr_acc_path = std::nullopt;
           if constexpr (std::same_as<Edge, EdgeAccessor>) {
             if (self_.filter_lambda_.expression) {
@@ -3558,7 +3566,7 @@ class AllShortestPathsImpl final : public AllShortestPaths {
           auto found_it = visited_cost_.find(next_vertex);
           if (found_it != visited_cost_.end()) {
             auto &weights = found_it->second;
-            bool insert = std::ranges::none_of(weights, [&depth, &next_weight](const auto &entry) {
+            bool const insert = std::ranges::none_of(weights, [&depth, &next_weight](const auto &entry) {
               auto const &[old_weight, old_depth] = entry;
               return old_depth <= depth && (old_weight < next_weight).ValueBool() &&
                      !are_equal(old_weight, next_weight);
@@ -3595,8 +3603,8 @@ class AllShortestPathsImpl final : public AllShortestPaths {
     };
 
     auto expand_from_vertex = [&](const Vertex &vertex, const TypedValue &weight, int64_t depth) {
-      for (auto [edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
-        Vertex far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
+      for (const auto &[edge, dir] : trav_.Expand(vertex, self_.common_.direction, context)) {
+        Vertex const far = dir == EdgeAtom::Direction::IN ? edge.From() : edge.To();
         if (!Trav::Visible(edge, far, context)) continue;
         expand_vertex(edge, dir, weight, depth);
         restore_frame_state_after_expansion();
@@ -3746,7 +3754,7 @@ class AllShortestPathsImpl final : public AllShortestPaths {
 
         frame_writer.Write(self_.weight_lambda_->inner_edge_symbol, TypedValue());
         frame_writer.Write(self_.weight_lambda_->inner_node_symbol, *start_vertex);
-        TypedValue current_weight = CalculateNextWeight(self_.weight_lambda_, TypedValue(), evaluator);
+        TypedValue const current_weight = CalculateNextWeight(self_.weight_lambda_, TypedValue(), evaluator);
 
         expand_from_vertex(*start_vertex, current_weight, 0);
         cheapest_cost_[*start_vertex] = 0;
@@ -3807,7 +3815,7 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       : self_(self), mem_(mem), metric_handles_(metric_handles) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
+    OOMExceptionEnabler const oom_exception;
     SCOPED_PROFILE_OP("ExpandAllShortestPathsCursor");
     if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
       Init(context);
@@ -3943,8 +3951,8 @@ class KShortestPathsImpl final : public KShortestPaths {
       AbortCheck(context);
       if (context.hops_limit.IsLimitReached()) return false;
 
-      auto &source_tv = frame[self_.input_symbol_];
-      auto &target_tv = frame[self_.common_.node_symbol];
+      const auto &source_tv = frame[self_.input_symbol_];
+      const auto &target_tv = frame[self_.common_.node_symbol];
       if (source_tv.IsNull() || target_tv.IsNull()) continue;
 
       if constexpr (std::same_as<Edge, VirtualEdge>) {
@@ -3953,8 +3961,8 @@ class KShortestPathsImpl final : public KShortestPaths {
         }
       }
 
-      Vertex source_vertex = Trav::GetInput(source_tv, self_.input_symbol_);
-      Vertex target_vertex = Trav::GetInput(target_tv, self_.common_.node_symbol);
+      Vertex const source_vertex = Trav::GetInput(source_tv, self_.input_symbol_);
+      Vertex const target_vertex = Trav::GetInput(target_tv, self_.common_.node_symbol);
       if (source_vertex == target_vertex) continue;
 
       lower_bound_ = self_.lower_bound_ ? EvaluateInt(evaluator, self_.lower_bound_, "Min depth in expansion") : 1;
@@ -4059,7 +4067,7 @@ class KShortestPathsImpl final : public KShortestPaths {
   void GenerateCandidatesFromDeviation(const Vertex &source, const Vertex &target, const PathInfo &base_path,
                                        size_t deviation_index, ExecutionContext &context) {
     SetupBlockedElementsForDeviation(source, base_path, deviation_index);
-    Vertex deviation_vertex = GetVertexAtIndex(source, base_path, deviation_index);
+    Vertex const deviation_vertex = GetVertexAtIndex(source, base_path, deviation_index);
     auto spur_path = ComputeShortestPath(deviation_vertex, target, context);
     if (!spur_path.edges.empty()) {
       PathInfo candidate_path(context.evaluation_context.memory);
@@ -4169,7 +4177,7 @@ class KShortestPathsImpl final : public KShortestPaths {
     while (true) {
       AbortCheck(context);
       ++current_length;
-      if (current_length > static_cast<size_t>(upper_bound_)) return PathInfo(pull_memory);
+      if (std::cmp_greater(current_length, upper_bound_)) return PathInfo(pull_memory);
       for (const auto &vertex : source_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
         if (self_.common_.direction != EdgeAtom::Direction::IN) {
@@ -4184,7 +4192,7 @@ class KShortestPathsImpl final : public KShortestPaths {
       std::swap(source_frontier, source_next);
 
       ++current_length;
-      if (current_length > static_cast<size_t>(upper_bound_)) return PathInfo(pull_memory);
+      if (std::cmp_greater(current_length, upper_bound_)) return PathInfo(pull_memory);
       for (const auto &vertex : target_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
         if (self_.common_.direction != EdgeAtom::Direction::OUT) {
@@ -4240,7 +4248,7 @@ class KShortestPathsCursor : public Cursor {
       : self_(self), mem_(mem), metric_handles_(metric_handles) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
-    OOMExceptionEnabler oom_exception;
+    OOMExceptionEnabler const oom_exception;
     SCOPED_PROFILE_OP("KShortestPaths");
     if (std::holds_alternative<std::monostate>(impl_)) [[unlikely]]
       Init(context);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4867,6 +4867,45 @@ std::unique_ptr<LogicalOperator> SetProperty::Clone(AstStorage *storage) const {
   return object;
 }
 
+namespace {
+
+// Writes a single property to a synthetic node's overlay. A null value removes the key, matching
+// SET n.x = null on a real node.
+void SetPropertyOnVirtualNode(VirtualNode &node, storage::PropertyId key, const TypedValue &value,
+                              storage::NameIdMapper *name_id_mapper) {
+  if (value.IsNull()) {
+    node.RemoveProperty(key);
+  } else {
+    node.SetProperty(key, value.ToPropertyValue(name_id_mapper));
+  }
+}
+
+// Writes a property map to a synthetic node's overlay. REPLACE clears the overlay first; UPDATE
+// merges. A null map value removes the key. Unlike a real node, a synthetic node has only its
+// overlay, so the right-hand side must be a map (there is no record to copy properties from).
+void SetPropertiesOnVirtualNode(VirtualNode &node, const TypedValue &rhs, SetProperties::Op op,
+                                ExecutionContext *context,
+                                std::unordered_map<std::string, storage::PropertyId> &cached_name_id) {
+  if (rhs.type() != TypedValue::Type::Map) {
+    throw QueryRuntimeException("Right-hand side in SET on a virtual node must be a map.");
+  }
+  auto *name_id_mapper = context->db_accessor->GetStorageAccessor()->GetNameIdMapper();
+  if (op == SetProperties::Op::REPLACE) node.ClearProperties();
+  for (const auto &[string_key, value] : rhs.ValueMap()) {
+    storage::PropertyId property_id;
+    if (auto it = cached_name_id.find(std::string(string_key)); it != cached_name_id.end()) [[likely]] {
+      property_id = it->second;
+    } else {
+      property_id = context->db_accessor->NameToProperty(string_key);
+      cached_name_id.emplace(string_key, property_id);
+    }
+    SetPropertyOnVirtualNode(node, property_id, value, name_id_mapper);
+    context->execution_stats[ExecutionStats::Key::UPDATED_PROPERTIES] += 1;
+  }
+}
+
+}  // namespace
+
 SetProperty::SetPropertyCursor::SetPropertyCursor(const SetProperty &self, utils::MemoryResource *mem,
                                                   metrics::DatabaseMetricHandles &metric_handles)
     : self_(self), input_cursor_(self.input_->MakeCursor(mem, metric_handles)) {}
@@ -4951,6 +4990,21 @@ bool SetProperty::SetPropertyCursor::Pull(Frame &frame, ExecutionContext &contex
             TypedValue{std::move(old_value), context.db_accessor->GetStorageAccessor()->GetNameIdMapper()},
             TypedValue{rhs});
       }
+      break;
+    }
+    case TypedValue::Type::VirtualNode: {
+      // A synthetic node has value semantics in a TypedValue, so the write must target the
+      // frame-resident node, not the evaluated copy above. This requires the node to be named.
+      auto *object = utils::Downcast<Identifier>(self_.lhs_->expression_);
+      if (object == nullptr) {
+        throw QueryRuntimeException("Setting a property on a virtual node requires a named node.");
+      }
+      auto *name_id_mapper = context.db_accessor->GetStorageAccessor()->GetNameIdMapper();
+      auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
+      frame_writer.Modify(context.symbol_table.at(*object), [&](TypedValue &node) {
+        SetPropertyOnVirtualNode(node.ValueVirtualNode(), self_.property_, rhs, name_id_mapper);
+      });
+      context.execution_stats[ExecutionStats::Key::UPDATED_PROPERTIES] += 1;
       break;
     }
     case TypedValue::Type::Null:
@@ -5485,6 +5539,12 @@ bool SetProperties::SetPropertiesCursor::Pull(Frame &frame, ExecutionContext &co
         SetPropertiesOnRecord(&edge.ValueEdge(), rhs, self_.op_, &context, cached_name_id_);
       };
       frame_writer.Modify(self_.input_symbol_, set_properties_on_record);
+      break;
+    }
+    case TypedValue::Type::VirtualNode: {
+      frame_writer.Modify(self_.input_symbol_, [&](TypedValue &node) {
+        SetPropertiesOnVirtualNode(node.ValueVirtualNode(), rhs, self_.op_, &context, cached_name_id_);
+      });
       break;
     }
     case TypedValue::Type::Null: {
@@ -6601,7 +6661,8 @@ class AggregateCursor : public Cursor {
             ProjectPathWithOptions(input_value,
                                    agg_elem.arg2->Accept(*evaluator),
                                    agg_value->values_[pos].ValueVirtualGraph(),
-                                   agg_value->derive_dedup_[pos]);
+                                   agg_value->derive_dedup_[pos],
+                                   ProjectionRefForDerive(agg_elem));
             break;
           }
           case Aggregation::Op::COLLECT_MAP:
@@ -6668,7 +6729,8 @@ class AggregateCursor : public Cursor {
           ProjectPathWithOptions(input_value,
                                  agg_elem.arg2->Accept(*evaluator),
                                  agg_value->values_[pos].ValueVirtualGraph(),
-                                 agg_value->derive_dedup_[pos]);
+                                 agg_value->derive_dedup_[pos],
+                                 ProjectionRefForDerive(agg_elem));
           break;
         }
         case Aggregation::Op::COLLECT_MAP:
@@ -6712,9 +6774,21 @@ class AggregateCursor : public Cursor {
     }
   }
 
+  // The projection-schema reference a derive() stamps onto its overlay nodes: the output symbol's
+  // plan position, unique per derive() site. It is set only when the options are a static map
+  // literal; with non-literal options (e.g. the whole map is a parameter) the schema cannot be
+  // extracted before execution, so the nodes carry no reference and the result describes no schema
+  // for them. The execution-time and prepare-time sides agree on this same predicate.
+  static int64_t ProjectionRefForDerive(const Aggregate::Element &element) {
+    if (utils::Downcast<MapLiteral>(element.arg2) == nullptr) return VirtualNode::kNoProjectionRef;
+    return element.output_sym.position();
+  }
+
   VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key,
-                               std::string_view props_key, const TypedValue::TMap &options,
+                               std::string_view props_key, const TypedValue::TMap &options, int64_t projection_ref,
                                VirtualNode::allocator_type alloc) const {
+    static constexpr auto kPropertyPolicy = "propertyPolicy";
+
     VirtualNode::label_list labels{alloc};
     if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
       if (labels_it->second.type() != TypedValue::Type::List) {
@@ -6736,29 +6810,60 @@ class AggregateCursor : public Cursor {
       }
     }
 
-    VirtualNode::property_map properties{alloc};
+    // The overlay holds only the explicitly-overridden properties; every other property is read
+    // through the origin lazily, so a projection never copies the origin's properties (e.g. vector
+    // embeddings) unless they are actually read.
+    // overlay_bound names every key whose read and write target this node's overlay: the
+    // construction-time override keys below and the 'overlay' propertyPolicy bindings. Every other
+    // key on the resulting overlay node is origin-bound, so a write to it persists to the origin.
+    VirtualNode::property_map overlay{alloc};
+    VirtualNode::key_set overlay_bound{alloc};
     if (options.find(props_key) != options.end()) {
       ApplyPropertyMap(options, props_key, [&](storage::PropertyId id, storage::PropertyValue pv) {
-        properties.insert_or_assign(id, std::move(pv));
+        overlay.insert_or_assign(id, std::move(pv));
+        overlay_bound.push_back(id);
       });
-    } else {
-      auto maybe_props = real_vertex.Properties(storage::View::NEW);
-      if (!maybe_props) throw QueryRuntimeException("derive() could not read properties of a path vertex.");
-      if (auth_checker_) {
-        auto label_ids = labels | rv::transform([this](auto const &name) { return db_accessor_->NameToLabel(name); }) |
-                         r::to<std::vector>();
-        for (auto &[id, pv] : *maybe_props) {
-          if (auth_checker_->HasPropertyPermission(label_ids, id, AuthQuery::PropertyPermissionType::READ)) {
-            properties.insert_or_assign(id, std::move(pv));
-          }
+    }
+
+    // The static property policy: per property, 'hidden' makes it invisible, 'origin' binds it to
+    // the origin (read-through), 'overlay' allows an overlay value to shadow. Read source and write
+    // target are coupled, so a key bound to 'origin' may not also be overlaid - that is a conflict
+    // rejected at construction rather than resolved silently.
+    VirtualNode::hidden_keys hidden{alloc};
+    if (const auto policy_it = options.find(kPropertyPolicy); policy_it != options.end()) {
+      if (policy_it->second.type() != TypedValue::Type::Map) {
+        throw QueryRuntimeException("derive() option '{}' must be a map of property names to bindings.",
+                                    kPropertyPolicy);
+      }
+      for (const auto &[name, binding] : policy_it->second.ValueMap()) {
+        if (binding.type() != TypedValue::Type::String) {
+          throw QueryRuntimeException(
+              "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
         }
-      } else {
-        for (auto &[id, pv] : *maybe_props) {
-          properties.insert_or_assign(id, std::move(pv));
+        const auto id = db_accessor_->NameToProperty(name);
+        const auto &value = binding.ValueString();
+        if (value == "hidden") {
+          hidden.push_back(id);
+        } else if (value == "origin") {
+          if (overlay.find(id) != overlay.end()) {
+            throw QueryRuntimeException("derive() property '{}' is both overlaid and bound to origin.", name);
+          }
+        } else if (value == "overlay") {
+          overlay_bound.push_back(id);
+        } else {
+          throw QueryRuntimeException(
+              "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
         }
       }
     }
-    return {std::move(labels), std::move(properties), alloc};
+
+    return {std::move(labels),
+            std::move(overlay),
+            alloc,
+            std::optional<VertexAccessor>{real_vertex},
+            std::move(hidden),
+            std::move(overlay_bound),
+            projection_ref};
   }
 
   // Collapses the path to a single synthetic edge between its endpoints. Intermediate vertices
@@ -6769,7 +6874,8 @@ class AggregateCursor : public Cursor {
   // If a path endpoint's real gid is already present, we reuse the canonical VirtualNode; only
   // the first occurrence inserts a new one into `projected_graph`.
   void ProjectPathWithOptions(TypedValue const &path_value, TypedValue const &options_value,
-                              VirtualGraph &projected_graph, CompactAggregationValue::DeriveDedup &dedup) {
+                              VirtualGraph &projected_graph, CompactAggregationValue::DeriveDedup &dedup,
+                              int64_t projection_ref) {
     static constexpr auto kVirtualEdgeType = "virtualEdgeType";
     static constexpr auto kSourceLabels = "sourceNodeLabels";
     static constexpr auto kSourceProperties = "sourceNodeProperties";
@@ -6785,11 +6891,35 @@ class AggregateCursor : public Cursor {
       throw QueryRuntimeException("derive() argument 2 must be a map of options (e.g. {virtualEdgeType: 'TYPE'}).");
     }
     const auto &options = options_value.ValueMap();
+
+    const auto &path_vertices = path_value.ValuePath().vertices();
+    if (path_vertices.empty()) return;
+
+    const auto alloc = projected_graph.get_allocator();
+    auto canonical = [&](const VertexAccessor &real_vertex,
+                         std::string_view labels_key,
+                         std::string_view props_key) -> std::shared_ptr<const VirtualNode> {
+      const auto real_gid = real_vertex.Gid();
+      if (const auto it = dedup.find(real_gid); it != dedup.end()) {
+        return projected_graph.FindNode(it->second);
+      }
+      auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, projection_ref, alloc);
+      const auto synth_gid = new_node.Gid();
+      dedup[real_gid] = synth_gid;
+      projected_graph.InsertNode(std::move(new_node));
+      return projected_graph.FindNode(synth_gid);
+    };
+
+    auto stored_from = canonical(path_vertices.front(), kSourceLabels, kSourceProperties);
+
+    if (path_vertices.size() < 2) return;
+
+    // The path has edges, so a virtual edge type is now required. It is not needed to project a
+    // single-vertex path's overlay node, so a bare derive(p, {}) over one node is allowed.
     const auto type_it = options.find(kVirtualEdgeType);
     if (type_it == options.end() || type_it->second.type() != TypedValue::Type::String) {
-      throw QueryRuntimeException("derive() options map must contain a 'virtualEdgeType' string key.");
+      throw QueryRuntimeException("derive() requires a 'virtualEdgeType' string option when the path has edges.");
     }
-
     const auto &type_name = type_it->second.ValueString();
     const bool type_is_undirected = [&] {
       const auto it = options.find(kUndirectedEdgeTypes);
@@ -6804,28 +6934,6 @@ class AggregateCursor : public Cursor {
       return std::ranges::any_of(list,
                                  [&](const auto &e) { return e.ValueString() == "*" || e.ValueString() == type_name; });
     }();
-
-    const auto &path_vertices = path_value.ValuePath().vertices();
-    if (path_vertices.empty()) return;
-
-    const auto alloc = projected_graph.get_allocator();
-    auto canonical = [&](const VertexAccessor &real_vertex,
-                         std::string_view labels_key,
-                         std::string_view props_key) -> std::shared_ptr<const VirtualNode> {
-      const auto real_gid = real_vertex.Gid();
-      if (const auto it = dedup.find(real_gid); it != dedup.end()) {
-        return projected_graph.FindNode(it->second);
-      }
-      auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, alloc);
-      const auto synth_gid = new_node.Gid();
-      dedup[real_gid] = synth_gid;
-      projected_graph.InsertNode(std::move(new_node));
-      return projected_graph.FindNode(synth_gid);
-    };
-
-    auto stored_from = canonical(path_vertices.front(), kSourceLabels, kSourceProperties);
-
-    if (path_vertices.size() < 2) return;
 
     auto stored_to = canonical(path_vertices.back(), kTargetLabels, kTargetProperties);
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2227,7 +2227,8 @@ struct RealTraversal {
     return value.ValueVertex();
   }
 
-  static bool Visible(const Edge &edge, const Vertex &far, ExecutionContext &context) {
+  static bool Visible([[maybe_unused]] const Edge &edge, [[maybe_unused]] const Vertex &far,
+                      [[maybe_unused]] ExecutionContext &context) {
 #ifdef MG_ENTERPRISE
     if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker) {
       return context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
@@ -2275,7 +2276,8 @@ struct VirtualTraversal {
 
   static Vertex GetInput(const TypedValue &value, const Symbol & /*symbol*/) { return value.ValueVirtualNode(); }
 
-  static bool Visible(const Edge & /*edge*/, const Vertex &far, ExecutionContext &context) {
+  static bool Visible(const Edge & /*edge*/, [[maybe_unused]] const Vertex &far,
+                      [[maybe_unused]] ExecutionContext &context) {
 #ifdef MG_ENTERPRISE
     if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker) {
       return OverlayNodeVisible(*context.auth_checker, far, storage::View::OLD);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -1062,12 +1062,11 @@ UniqueCursorPtr ScanAll::MakeCursor(utils::MemoryResource *mem, metrics::Databas
   metric_handles.scan_all_operator.Increment();
 
   auto vertices = [this](Frame &, ExecutionContext &context) -> std::optional<VertexRange> {
-    // Scan through the ambient graph view. Without one bound, read the real
-    // graph directly - the identity view's behaviour, expressed inline.
-    if (context.evaluation_context.graph_view != nullptr) {
-      return context.evaluation_context.graph_view->Vertices(view_);
-    }
-    return VertexRange{context.db_accessor->Vertices(view_)};
+    // Scan through the ambient graph view. Every executor binds one - the real
+    // graph as the identity view by default, a projection or subgraph inside a
+    // USE scope - so the read path is uniform and does not special-case the graph
+    // kind here.
+    return context.evaluation_context.graph_view->Vertices(view_);
   };
   return MakeUniqueCursorPtr<ScanAllCursor<decltype(vertices)>>(
       mem, *this, output_symbol_, input_->MakeCursor(mem, metric_handles), view_, std::move(vertices), "ScanAll");
@@ -1872,106 +1871,72 @@ bool Expand::ExpandCursor::Pull(Frame &frame, ExecutionContext &context) {
   OOMExceptionEnabler oom_exception;
   SCOPED_PROFILE_OP_BY_REF(self_);
 
-  // A helper function for expanding a node from an edge.
   auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
-  auto pull_node = [this, &frame_writer]<EdgeAtom::Direction direction>(const EdgeAccessor &new_edge,
-                                                                        utils::tag_value<direction>) {
-    if (self_.common_.existing_node) return;
-    if constexpr (direction == EdgeAtom::Direction::IN) {
-      frame_writer.Write(self_.common_.node_symbol, new_edge.From());
-    } else if constexpr (direction == EdgeAtom::Direction::OUT) {
-      frame_writer.Write(self_.common_.node_symbol, new_edge.To());
-    } else {
-      LOG_FATAL("Must indicate exact expansion direction here");
+
+  // A self-loop is both an in-edge and an out-edge; when expanding BOTH ways the
+  // in-edge arm emits it, so the out-edge arm skips it to keep it single.
+  auto is_self_loop = [](const ScanEdge &edge) {
+    if (const auto *real = std::get_if<EdgeAccessor>(&edge)) return real->IsCycle();
+    const auto &ve = std::get<VirtualEdge>(edge);
+    return ve.FromGid() == ve.ToGid();
+  };
+
+  // Writes an expanded edge and its far endpoint to the frame, after the
+  // fine-grained visibility check for the edge's kind (real edge + endpoint READ,
+  // or overlay-node visibility for a projection edge). Returns false when the edge
+  // is filtered out, true when emitted. Authorization stays here on the operator,
+  // not behind the GraphView seam, which is topology-only.
+  auto emit = [this, &frame_writer, &context]<EdgeAtom::Direction direction>(const ScanEdge &edge,
+                                                                             utils::tag_value<direction>) -> bool {
+    static_assert(direction == EdgeAtom::Direction::IN || direction == EdgeAtom::Direction::OUT);
+    if (const auto *real = std::get_if<EdgeAccessor>(&edge)) {
+      const auto other = direction == EdgeAtom::Direction::IN ? real->From() : real->To();
+#ifdef MG_ENTERPRISE
+      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
+          !(context.auth_checker->Has(*real, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
+            context.auth_checker->Has(other, self_.view_, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
+        return false;
+      }
+#endif
+      frame_writer.Write(self_.common_.edge_symbol, *real);
+      if (!self_.common_.existing_node) frame_writer.Write(self_.common_.node_symbol, other);
+      return true;
     }
+    const auto &ve = std::get<VirtualEdge>(edge);
+    const VirtualNode &other = direction == EdgeAtom::Direction::IN ? ve.From() : ve.To();
+#ifdef MG_ENTERPRISE
+    if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
+        !OverlayNodeVisible(*context.auth_checker, other, self_.view_)) {
+      return false;
+    }
+#endif
+    frame_writer.Write(self_.common_.edge_symbol, ve);
+    if (!self_.common_.existing_node) frame_writer.Write(self_.common_.node_symbol, other);
+    return true;
   };
 
   while (true) {
     AbortCheck(context);
 
-    // A projection's edges, when the input node is a VirtualNode. The endpoint
-    // is the edge's other end, and both edge and node go to the frame as their
-    // virtual TypedValue variants.
-    if (in_vedges_ && *in_vedges_it_ != in_vedges_->end()) {
-      const VirtualEdge *edge = *(*in_vedges_it_)++;
-      const VirtualNode &other = edge->From();
-      if (!VirtualEdgeMatches(*edge, other)) continue;
-#ifdef MG_ENTERPRISE
-      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-          !OverlayNodeVisible(*context.auth_checker, other, self_.view_)) {
-        continue;
-      }
-#endif
-      frame_writer.Write(self_.common_.edge_symbol, *edge);
-      if (!self_.common_.existing_node) frame_writer.Write(self_.common_.node_symbol, other);
-      return true;
-    }
-    if (out_vedges_ && *out_vedges_it_ != out_vedges_->end()) {
-      const VirtualEdge *edge = *(*out_vedges_it_)++;
-      // A self-loop is both an in-edge and an out-edge; expanding BOTH ways it
-      // was already emitted from the in-edge arm, so emit it once.
-      if (self_.common_.direction == EdgeAtom::Direction::BOTH && edge->FromGid() == edge->ToGid()) continue;
-      const VirtualNode &other = edge->To();
-      if (!VirtualEdgeMatches(*edge, other)) continue;
-#ifdef MG_ENTERPRISE
-      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-          !OverlayNodeVisible(*context.auth_checker, other, self_.view_)) {
-        continue;
-      }
-#endif
-      frame_writer.Write(self_.common_.edge_symbol, *edge);
-      if (!self_.common_.existing_node) frame_writer.Write(self_.common_.node_symbol, other);
-      return true;
-    }
-
-    // attempt to get a value from the incoming edges
+    // The in-edges then the out-edges of the ambient view (real, subgraph, or
+    // projection - the seam yields a ScanEdge for whichever). emit applies the
+    // per-kind visibility check and writes the edge and its far endpoint.
     if (in_edges_ && *in_edges_it_ != in_edges_->end()) {
-      auto edge = *(*in_edges_it_)++;
-      // Inside a subgraph scope, expansion stays within the subgraph: drop an
-      // edge that is not a member.
-      if (subgraph_view_ && !subgraph_view_->ContainsEdge(edge)) continue;
-#ifdef MG_ENTERPRISE
-      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-          !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-            context.auth_checker->Has(
-                edge.From(), self_.view_, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-        continue;
-      }
-#endif
-
-      frame_writer.Write(self_.common_.edge_symbol, edge);
-      pull_node(edge, utils::tag_v<EdgeAtom::Direction::IN>);
-      return true;
+      const ScanEdge edge = **in_edges_it_;
+      ++*in_edges_it_;
+      if (emit(edge, utils::tag_v<EdgeAtom::Direction::IN>)) return true;
+      continue;
     }
-
-    // attempt to get a value from the outgoing edges
     if (out_edges_ && *out_edges_it_ != out_edges_->end()) {
-      auto edge = *(*out_edges_it_)++;
-      // Inside a subgraph scope, expansion stays within the subgraph: drop an
-      // edge that is not a member.
-      if (subgraph_view_ && !subgraph_view_->ContainsEdge(edge)) continue;
-      // when expanding in EdgeAtom::Direction::BOTH directions
-      // we should do only one expansion for cycles, and it was
-      // already done in the block above
-      if (self_.common_.direction == EdgeAtom::Direction::BOTH && edge.IsCycle()) continue;
-#ifdef MG_ENTERPRISE
-      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
-          !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
-            context.auth_checker->Has(
-                edge.To(), self_.view_, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
-        continue;
-      }
-#endif
-      frame_writer.Write(self_.common_.edge_symbol, edge);
-      pull_node(edge, utils::tag_v<EdgeAtom::Direction::OUT>);
-      return true;
+      const ScanEdge edge = **out_edges_it_;
+      ++*out_edges_it_;
+      if (self_.common_.direction == EdgeAtom::Direction::BOTH && is_self_loop(edge)) continue;
+      if (emit(edge, utils::tag_v<EdgeAtom::Direction::OUT>)) return true;
+      continue;
     }
 
-    // If we are here, either the edges have not been initialized,
-    // or they have been exhausted. Attempt to initialize the edges.
+    // Edges not yet initialized or exhausted; (re)initialize from the next input.
     if (!InitEdges(frame, context)) return false;
-
-    // we have re-initialized the edges, continue with the loop
   }
 }
 
@@ -1983,10 +1948,6 @@ void Expand::ExpandCursor::Reset() {
   in_edges_it_ = std::nullopt;
   out_edges_ = std::nullopt;
   out_edges_it_ = std::nullopt;
-  in_vedges_ = std::nullopt;
-  in_vedges_it_ = std::nullopt;
-  out_vedges_ = std::nullopt;
-  out_vedges_it_ = std::nullopt;
 }
 
 ExpansionInfo Expand::ExpandCursor::GetExpansionInfo(Frame &frame) {
@@ -2040,6 +2001,36 @@ ExpansionInfo Expand::ExpandCursor::GetExpansionInfo(Frame &frame) {
 }
 
 bool Expand::ExpandCursor::InitEdges(Frame &frame, ExecutionContext &context) {
+  // Fetch a node's in- and/or out-edges through the ambient view (identity,
+  // subgraph, or projection - the seam picks the topology) and position the
+  // iterators, resetting the arms first. Returns the edges examined per direction.
+  // The hops budget is threaded to the view (the real graph enforces it); the
+  // caller accumulates number_of_hops only for a real expansion, as before.
+  auto fetch = [&](const ScanVertex &from,
+                   EdgeAtom::Direction direction,
+                   const std::optional<ScanVertex> &existing_dest) -> std::pair<int64_t, int64_t> {
+    auto *const view = context.evaluation_context.graph_view;
+    in_edges_ = std::nullopt;
+    in_edges_it_ = std::nullopt;
+    out_edges_ = std::nullopt;
+    out_edges_it_ = std::nullopt;
+    int64_t in_count = 0;
+    int64_t out_count = 0;
+    if (direction != EdgeAtom::Direction::OUT) {
+      auto range = view->InEdges(from, self_.view_, self_.common_.edge_types, existing_dest, &context.hops_limit);
+      in_count = range.expanded_count();
+      in_edges_.emplace(std::move(range));
+      in_edges_it_.emplace(in_edges_->begin());
+    }
+    if (direction != EdgeAtom::Direction::IN) {
+      auto range = view->OutEdges(from, self_.view_, self_.common_.edge_types, existing_dest, &context.hops_limit);
+      out_count = range.expanded_count();
+      out_edges_.emplace(std::move(range));
+      out_edges_it_.emplace(out_edges_->begin());
+    }
+    return {in_count, out_count};
+  };
+
   // Input Vertex could be null if it is created by a failed optional match. In
   // those cases we skip that input pull and continue with the next.
   while (true) {
@@ -2047,142 +2038,71 @@ bool Expand::ExpandCursor::InitEdges(Frame &frame, ExecutionContext &context) {
 
     if (context.hops_limit.IsLimitReached()) return false;
 
-    // A projection node expands through the bound view's edge index, not the
-    // real-graph accessor.
     const TypedValue &input_value = frame[self_.input_symbol_];
+    if (input_value.IsNull()) continue;
+
+    // A projection node expands through the bound view's edge index. There is no
+    // degree heuristic - a projection exposes no statistics - so it always expands
+    // from the input node. (A real vertex reaching a projection view has no edges
+    // there; the projection view returns an empty range.)
     if (input_value.IsVirtualNode()) {
-      if (InitVirtualEdges(frame, context, input_value.ValueVirtualNode())) return true;
-      continue;
-    }
-
-    // A real vertex is not a node of a projection, so inside a projection scope
-    // it has no edges in the ambient graph: its real-graph edges are not part of
-    // the projection and are not expanded. This keeps expansion consistent with
-    // degree(), which reports zero for the same pairing.
-    if (dynamic_cast<VirtualGraphView *>(context.evaluation_context.graph_view) != nullptr) {
-      continue;
-    }
-
-    // A real member of a bound subgraph expands its real edges filtered to the
-    // subgraph's membership; outside a subgraph scope this stays null.
-    subgraph_view_ = dynamic_cast<SubgraphGraphView *>(context.evaluation_context.graph_view);
-
-    expansion_info_ = GetExpansionInfo(frame);
-
-    if (!expansion_info_.input_node) {
-      continue;
-    }
-
-    auto vertex = *expansion_info_.input_node;
-    auto direction = expansion_info_.direction;
-
-    int64_t num_expanded_first = -1;
-    if (direction == EdgeAtom::Direction::IN || direction == EdgeAtom::Direction::BOTH) {
+      const ScanVertex from{input_value.ValueVirtualNode()};
+      std::optional<ScanVertex> existing_dest;
       if (self_.common_.existing_node) {
-        if (expansion_info_.existing_node) {
-          auto existing_node = *expansion_info_.existing_node;
-
-          auto edges_result = UnwrapEdgesResult(
-              vertex.InEdges(self_.view_, self_.common_.edge_types, existing_node, &context.hops_limit));
-          context.number_of_hops += edges_result.expanded_count;
-          in_edges_.emplace(std::move(edges_result.edges));
-          num_expanded_first = edges_result.expanded_count;
+        const TypedValue &existing = frame[self_.common_.node_symbol];
+        if (existing.IsNull()) {  // an unbound optional end matches nothing
+          in_edges_ = std::nullopt;
+          out_edges_ = std::nullopt;
+          return true;
         }
-      } else {
-        auto edges_result =
-            UnwrapEdgesResult(vertex.InEdges(self_.view_, self_.common_.edge_types, &context.hops_limit));
-        context.number_of_hops += edges_result.expanded_count;
-        in_edges_.emplace(std::move(edges_result.edges));
-        num_expanded_first = edges_result.expanded_count;
+        existing_dest = ScanVertex{existing.ValueVirtualNode()};
       }
-      if (in_edges_) {
-        in_edges_it_.emplace(in_edges_->begin());
-      }
-    }
-
-    int64_t num_expanded_second = -1;
-    if (direction == EdgeAtom::Direction::OUT || direction == EdgeAtom::Direction::BOTH) {
-      if (self_.common_.existing_node) {
-        if (expansion_info_.existing_node) {
-          auto existing_node = *expansion_info_.existing_node;
-          auto edges_result = UnwrapEdgesResult(
-              vertex.OutEdges(self_.view_, self_.common_.edge_types, existing_node, &context.hops_limit));
-          context.number_of_hops += edges_result.expanded_count;
-          out_edges_.emplace(std::move(edges_result.edges));
-          num_expanded_second = edges_result.expanded_count;
-        }
-      } else {
-        auto edges_result =
-            UnwrapEdgesResult(vertex.OutEdges(self_.view_, self_.common_.edge_types, &context.hops_limit));
-        context.number_of_hops += edges_result.expanded_count;
-        out_edges_.emplace(std::move(edges_result.edges));
-        num_expanded_second = edges_result.expanded_count;
-      }
-      if (out_edges_) {
-        out_edges_it_.emplace(out_edges_->begin());
-      }
-    }
-
-    if (!expansion_info_.existing_node) {
+      fetch(from, self_.common_.direction, existing_dest);
       return true;
     }
 
-    num_expanded_first = num_expanded_first == -1 ? 0 : num_expanded_first;
-    num_expanded_second = num_expanded_second == -1 ? 0 : num_expanded_second;
-    int64_t total_expanded_edges = num_expanded_first + num_expanded_second;
-
-    if (!expansion_info_.reversed) {
-      prev_input_degree_ = total_expanded_edges;
-    } else {
-      prev_existing_degree_ = total_expanded_edges;
+    // A real input vertex cannot reach an already-bound projection node through
+    // the ambient graph, so it has no such edges. Skip before GetExpansionInfo,
+    // whose ExpectType would otherwise raise on the virtual existing end. (This
+    // and the projection view's empty range for a real `from` together replace the
+    // old real-vertex-under-a-projection-view guard.)
+    if (self_.common_.existing_node && frame[self_.common_.node_symbol].IsVirtualNode()) {
+      in_edges_ = std::nullopt;
+      out_edges_ = std::nullopt;
+      return true;
     }
 
+    // A real vertex: the degree heuristic picks which end to expand from and the
+    // direction (possibly reversed).
+    expansion_info_ = GetExpansionInfo(frame);
+    if (!expansion_info_.input_node) continue;
+
+    // existing_node set but the bound end is null (an unbound optional) matches
+    // nothing.
+    if (self_.common_.existing_node && !expansion_info_.existing_node) {
+      in_edges_ = std::nullopt;
+      out_edges_ = std::nullopt;
+      return true;
+    }
+
+    const ScanVertex from{*expansion_info_.input_node};
+    std::optional<ScanVertex> existing_dest;
+    if (expansion_info_.existing_node) existing_dest = ScanVertex{*expansion_info_.existing_node};
+
+    const auto [in_count, out_count] = fetch(from, expansion_info_.direction, existing_dest);
+    context.number_of_hops += in_count + out_count;
+
+    // The degree heuristic records this end's degree only when both ends are bound.
+    if (self_.common_.existing_node) {
+      const int64_t total_expanded_edges = in_count + out_count;
+      if (!expansion_info_.reversed) {
+        prev_input_degree_ = total_expanded_edges;
+      } else {
+        prev_existing_degree_ = total_expanded_edges;
+      }
+    }
     return true;
   }
-}
-
-bool Expand::ExpandCursor::VirtualEdgeMatches(const VirtualEdge &edge, const VirtualNode &other) const {
-  if (!allowed_edge_type_names_.empty() &&
-      std::ranges::find(allowed_edge_type_names_, std::string_view{edge.EdgeTypeName()}) ==
-          allowed_edge_type_names_.end()) {
-    return false;
-  }
-  // When the pattern's other end is already bound (existing_node), only the edge
-  // reaching that node matches.
-  if (existing_vnode_gid_ && other.Gid() != *existing_vnode_gid_) return false;
-  return true;
-}
-
-bool Expand::ExpandCursor::InitVirtualEdges(Frame &frame, ExecutionContext &context, const VirtualNode &vnode) {
-  // A VirtualNode on the frame means a projection is the ambient view, so its
-  // edge index is the bound view's. Edge expansion is the projection's, reached
-  // through the view rather than the real-graph accessor.
-  auto *view = dynamic_cast<VirtualGraphView *>(context.evaluation_context.graph_view);
-  DMG_ASSERT(view, "A VirtualNode is scanned only with a projection bound as the ambient view");
-
-  allowed_edge_type_names_.clear();
-  for (const auto edge_type : self_.common_.edge_types) {
-    allowed_edge_type_names_.emplace_back(view->EdgeTypeToName(edge_type));
-  }
-
-  existing_vnode_gid_.reset();
-  if (self_.common_.existing_node) {
-    const TypedValue &existing = frame[self_.common_.node_symbol];
-    if (existing.IsNull()) return true;  // an unbound optional end matches nothing
-    existing_vnode_gid_ = existing.ValueVirtualNode().Gid();
-  }
-
-  const auto gid = vnode.Gid();
-  const auto direction = self_.common_.direction;
-  if (direction == EdgeAtom::Direction::IN || direction == EdgeAtom::Direction::BOTH) {
-    in_vedges_ = view->InEdges(gid);
-    in_vedges_it_ = in_vedges_->begin();
-  }
-  if (direction == EdgeAtom::Direction::OUT || direction == EdgeAtom::Direction::BOTH) {
-    out_vedges_ = view->OutEdges(gid);
-    out_vedges_it_ = out_vedges_->begin();
-  }
-  return true;
 }
 
 ExpandVariable::ExpandVariable(const std::shared_ptr<LogicalOperator> &input, Symbol input_symbol, Symbol node_symbol,

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4386,7 +4386,13 @@ class ConstructNamedPathCursor : public Cursor {
       return true;
     }
 
-    DMG_ASSERT(start_vertex.IsVertex(), "First named path element must be a vertex");
+    // A named path holds real accessors (query::Path), so a projection's virtual nodes/edges cannot
+    // be assembled into one. Raise a clear v1 boundary error rather than fall through to the cryptic
+    // TypedValue type error (release) or the DMG_ASSERT abort (debug). Named paths over a subgraph
+    // work, since a subgraph's elements are real.
+    if (!start_vertex.IsVertex()) [[unlikely]] {
+      throw QueryRuntimeException("A named path is not supported over a projection in a USE scope.");
+    }
     query::Path path(start_vertex.ValueVertex(), pull_memory);
 
     // If the last path element symbol was for an edge list, then

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -47,14 +47,17 @@
 #include "query/frontend/ast/ast.hpp"
 #include "query/frontend/semantic/symbol_table.hpp"
 #include "query/graph.hpp"
+#include "query/graph_view.hpp"
 #include "query/interpret/eval.hpp"
 #include "query/parallel_state.hpp"
 #include "query/path.hpp"
 #include "query/plan/scoped_profile.hpp"
 #include "query/procedure/mg_procedure_impl.hpp"
 #include "query/procedure/module.hpp"
+#include "query/subgraph_graph_view.hpp"
 #include "query/trigger_context.hpp"
 #include "query/typed_value.hpp"
+#include "query/virtual_graph_view.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/point_iterator.hpp"
 #include "storage/v2/property_value.hpp"
@@ -849,6 +852,47 @@ VertexAccessor const &CreateExpand::CreateExpandCursor::OtherVertex(Frame &frame
   }
 }
 
+namespace {
+// A scan yields either a real VertexAccessor (label/index scans, and the
+// identity view) or a ScanVertex (the ambient GraphView, which may be a
+// projection). These helpers let the shared ScanAllCursor handle both.
+
+template <typename TWriter>
+void WriteScannedVertex(TWriter &writer, const Symbol &symbol, const VertexAccessor &vertex) {
+  writer.Write(symbol, vertex);
+}
+
+template <typename TWriter>
+void WriteScannedVertex(TWriter &writer, const Symbol &symbol, const ScanVertex &vertex) {
+  std::visit([&](const auto &v) { writer.Write(symbol, v); }, vertex);
+}
+
+#ifdef MG_ENTERPRISE
+bool ScannedVertexVisible(FineGrainedAuthChecker const &checker, const VertexAccessor &vertex, storage::View view) {
+  return checker.Has(vertex, view, memgraph::query::AuthQuery::FineGrainedPrivilege::READ);
+}
+
+// An overlay node reads through to a real origin vertex, so it gets the same
+// label-based visibility decision a direct read of the origin would: it is
+// visible only if the origin is. A synthetic node has no origin and no
+// real-graph privileges, so it is always visible. A projection node surfaces
+// through both the scan and the expand paths, so both gate on this.
+bool OverlayNodeVisible(FineGrainedAuthChecker const &checker, const VirtualNode &vnode, storage::View view) {
+  if (const auto &origin = vnode.Origin()) {
+    return checker.Has(*origin, view, memgraph::query::AuthQuery::FineGrainedPrivilege::READ);
+  }
+  return true;
+}
+
+bool ScannedVertexVisible(FineGrainedAuthChecker const &checker, const ScanVertex &vertex, storage::View view) {
+  if (const auto *real = std::get_if<VertexAccessor>(&vertex)) {
+    return checker.Has(*real, view, memgraph::query::AuthQuery::FineGrainedPrivilege::READ);
+  }
+  return OverlayNodeVisible(checker, std::get<VirtualNode>(vertex), view);
+}
+#endif
+}  // namespace
+
 template <class TVerticesFun>
 class ScanAllCursor : public Cursor {
  public:
@@ -886,7 +930,7 @@ class ScanAllCursor : public Cursor {
 #endif
 
     auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
-    frame_writer.Write(output_symbol_, *vertices_it_.value());
+    WriteScannedVertex(frame_writer, output_symbol_, *vertices_it_.value());
     ++vertices_it_.value();
     return true;
   }
@@ -894,8 +938,7 @@ class ScanAllCursor : public Cursor {
 #ifdef MG_ENTERPRISE
   bool FindNextVertex(const ExecutionContext &context) {
     while (vertices_it_.value() != vertices_end_it_.value()) {
-      if (context.auth_checker->Has(
-              *vertices_it_.value(), view_, memgraph::query::AuthQuery::FineGrainedPrivilege::READ)) {
+      if (ScannedVertexVisible(*context.auth_checker, *vertices_it_.value(), view_)) {
         return true;
       }
       ++vertices_it_.value();
@@ -1018,9 +1061,13 @@ ACCEPT_WITH_INPUT(ScanAll)
 UniqueCursorPtr ScanAll::MakeCursor(utils::MemoryResource *mem, metrics::DatabaseMetricHandles &metric_handles) const {
   metric_handles.scan_all_operator.Increment();
 
-  auto vertices = [this](Frame &, ExecutionContext &context) {
-    auto *db = context.db_accessor;
-    return std::make_optional(db->Vertices(view_));
+  auto vertices = [this](Frame &, ExecutionContext &context) -> std::optional<VertexRange> {
+    // Scan through the ambient graph view. Without one bound, read the real
+    // graph directly - the identity view's behaviour, expressed inline.
+    if (context.evaluation_context.graph_view != nullptr) {
+      return context.evaluation_context.graph_view->Vertices(view_);
+    }
+    return VertexRange{context.db_accessor->Vertices(view_)};
   };
   return MakeUniqueCursorPtr<ScanAllCursor<decltype(vertices)>>(
       mem, *this, output_symbol_, input_->MakeCursor(mem, metric_handles), view_, std::move(vertices), "ScanAll");
@@ -1841,9 +1888,48 @@ bool Expand::ExpandCursor::Pull(Frame &frame, ExecutionContext &context) {
 
   while (true) {
     AbortCheck(context);
+
+    // A projection's edges, when the input node is a VirtualNode. The endpoint
+    // is the edge's other end, and both edge and node go to the frame as their
+    // virtual TypedValue variants.
+    if (in_vedges_ && *in_vedges_it_ != in_vedges_->end()) {
+      const VirtualEdge *edge = *(*in_vedges_it_)++;
+      const VirtualNode &other = edge->From();
+      if (!VirtualEdgeMatches(*edge, other)) continue;
+#ifdef MG_ENTERPRISE
+      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
+          !OverlayNodeVisible(*context.auth_checker, other, self_.view_)) {
+        continue;
+      }
+#endif
+      frame_writer.Write(self_.common_.edge_symbol, *edge);
+      if (!self_.common_.existing_node) frame_writer.Write(self_.common_.node_symbol, other);
+      return true;
+    }
+    if (out_vedges_ && *out_vedges_it_ != out_vedges_->end()) {
+      const VirtualEdge *edge = *(*out_vedges_it_)++;
+      // A self-loop is both an in-edge and an out-edge; expanding BOTH ways it
+      // was already emitted from the in-edge arm, so emit it once.
+      if (self_.common_.direction == EdgeAtom::Direction::BOTH && edge->FromGid() == edge->ToGid()) continue;
+      const VirtualNode &other = edge->To();
+      if (!VirtualEdgeMatches(*edge, other)) continue;
+#ifdef MG_ENTERPRISE
+      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
+          !OverlayNodeVisible(*context.auth_checker, other, self_.view_)) {
+        continue;
+      }
+#endif
+      frame_writer.Write(self_.common_.edge_symbol, *edge);
+      if (!self_.common_.existing_node) frame_writer.Write(self_.common_.node_symbol, other);
+      return true;
+    }
+
     // attempt to get a value from the incoming edges
     if (in_edges_ && *in_edges_it_ != in_edges_->end()) {
       auto edge = *(*in_edges_it_)++;
+      // Inside a subgraph scope, expansion stays within the subgraph: drop an
+      // edge that is not a member.
+      if (subgraph_view_ && !subgraph_view_->ContainsEdge(edge)) continue;
 #ifdef MG_ENTERPRISE
       if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
           !(context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
@@ -1861,6 +1947,9 @@ bool Expand::ExpandCursor::Pull(Frame &frame, ExecutionContext &context) {
     // attempt to get a value from the outgoing edges
     if (out_edges_ && *out_edges_it_ != out_edges_->end()) {
       auto edge = *(*out_edges_it_)++;
+      // Inside a subgraph scope, expansion stays within the subgraph: drop an
+      // edge that is not a member.
+      if (subgraph_view_ && !subgraph_view_->ContainsEdge(edge)) continue;
       // when expanding in EdgeAtom::Direction::BOTH directions
       // we should do only one expansion for cycles, and it was
       // already done in the block above
@@ -1894,6 +1983,10 @@ void Expand::ExpandCursor::Reset() {
   in_edges_it_ = std::nullopt;
   out_edges_ = std::nullopt;
   out_edges_it_ = std::nullopt;
+  in_vedges_ = std::nullopt;
+  in_vedges_it_ = std::nullopt;
+  out_vedges_ = std::nullopt;
+  out_vedges_it_ = std::nullopt;
 }
 
 ExpansionInfo Expand::ExpandCursor::GetExpansionInfo(Frame &frame) {
@@ -1953,6 +2046,26 @@ bool Expand::ExpandCursor::InitEdges(Frame &frame, ExecutionContext &context) {
     if (!input_cursor_->Pull(frame, context)) return false;
 
     if (context.hops_limit.IsLimitReached()) return false;
+
+    // A projection node expands through the bound view's edge index, not the
+    // real-graph accessor.
+    const TypedValue &input_value = frame[self_.input_symbol_];
+    if (input_value.IsVirtualNode()) {
+      if (InitVirtualEdges(frame, context, input_value.ValueVirtualNode())) return true;
+      continue;
+    }
+
+    // A real vertex is not a node of a projection, so inside a projection scope
+    // it has no edges in the ambient graph: its real-graph edges are not part of
+    // the projection and are not expanded. This keeps expansion consistent with
+    // degree(), which reports zero for the same pairing.
+    if (dynamic_cast<VirtualGraphView *>(context.evaluation_context.graph_view) != nullptr) {
+      continue;
+    }
+
+    // A real member of a bound subgraph expands its real edges filtered to the
+    // subgraph's membership; outside a subgraph scope this stays null.
+    subgraph_view_ = dynamic_cast<SubgraphGraphView *>(context.evaluation_context.graph_view);
 
     expansion_info_ = GetExpansionInfo(frame);
 
@@ -2026,6 +2139,50 @@ bool Expand::ExpandCursor::InitEdges(Frame &frame, ExecutionContext &context) {
 
     return true;
   }
+}
+
+bool Expand::ExpandCursor::VirtualEdgeMatches(const VirtualEdge &edge, const VirtualNode &other) const {
+  if (!allowed_edge_type_names_.empty() &&
+      std::ranges::find(allowed_edge_type_names_, std::string_view{edge.EdgeTypeName()}) ==
+          allowed_edge_type_names_.end()) {
+    return false;
+  }
+  // When the pattern's other end is already bound (existing_node), only the edge
+  // reaching that node matches.
+  if (existing_vnode_gid_ && other.Gid() != *existing_vnode_gid_) return false;
+  return true;
+}
+
+bool Expand::ExpandCursor::InitVirtualEdges(Frame &frame, ExecutionContext &context, const VirtualNode &vnode) {
+  // A VirtualNode on the frame means a projection is the ambient view, so its
+  // edge index is the bound view's. Edge expansion is the projection's, reached
+  // through the view rather than the real-graph accessor.
+  auto *view = dynamic_cast<VirtualGraphView *>(context.evaluation_context.graph_view);
+  DMG_ASSERT(view, "A VirtualNode is scanned only with a projection bound as the ambient view");
+
+  allowed_edge_type_names_.clear();
+  for (const auto edge_type : self_.common_.edge_types) {
+    allowed_edge_type_names_.emplace_back(view->EdgeTypeToName(edge_type));
+  }
+
+  existing_vnode_gid_.reset();
+  if (self_.common_.existing_node) {
+    const TypedValue &existing = frame[self_.common_.node_symbol];
+    if (existing.IsNull()) return true;  // an unbound optional end matches nothing
+    existing_vnode_gid_ = existing.ValueVirtualNode().Gid();
+  }
+
+  const auto gid = vnode.Gid();
+  const auto direction = self_.common_.direction;
+  if (direction == EdgeAtom::Direction::IN || direction == EdgeAtom::Direction::BOTH) {
+    in_vedges_ = view->InEdges(gid);
+    in_vedges_it_ = in_vedges_->begin();
+  }
+  if (direction == EdgeAtom::Direction::OUT || direction == EdgeAtom::Direction::BOTH) {
+    out_vedges_ = view->OutEdges(gid);
+    out_vedges_it_ = out_vedges_->begin();
+  }
+  return true;
 }
 
 ExpandVariable::ExpandVariable(const std::shared_ptr<LogicalOperator> &input, Symbol input_symbol, Symbol node_symbol,
@@ -8050,7 +8207,8 @@ namespace {
 void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, const mgp_proc &proc,
                          const std::vector<Expression *> &args, mgp_graph &graph, ExpressionEvaluator *evaluator,
                          utils::MemoryResource *memory, std::optional<size_t> memory_limit, mgp_result *result,
-                         int64_t procedure_id, const bool call_initializer = false) {
+                         int64_t procedure_id, const bool call_initializer = false,
+                         query::GraphView *ambient_view = nullptr) {
   static_assert(std::uses_allocator_v<mgp_value, utils::Allocator<mgp_value>>,
                 "Expected mgp_value to use custom allocator and makes STL "
                 "containers aware of that");
@@ -8080,6 +8238,17 @@ void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, 
 
     vg_acc = query::VirtualGraphDbAccessor(*std::get<query::DbAccessor *>(graph.impl), &*virtual_graph);
     graph.impl = &*vg_acc;
+  } else if (ambient_view != nullptr) {
+    // No explicit graph argument, but a `CALL { USE g ... }` scope bound an
+    // ambient view: route the procedure over it, borrowing the scope-owned
+    // graph (no copy). An explicit argument above takes precedence over this.
+    if (auto *subgraph_view = dynamic_cast<query::SubgraphGraphView *>(ambient_view)) {
+      db_acc = query::SubgraphDbAccessor(*std::get<query::DbAccessor *>(graph.impl), subgraph_view->graph());
+      graph.impl = &*db_acc;
+    } else if (auto *virtual_view = dynamic_cast<query::VirtualGraphView *>(ambient_view)) {
+      vg_acc = query::VirtualGraphDbAccessor(*std::get<query::DbAccessor *>(graph.impl), virtual_view->graph());
+      graph.impl = &*vg_acc;
+    }
   }
 
   procedure::ValidateArguments(args_list, proc, fully_qualified_procedure_name);
@@ -8270,7 +8439,8 @@ class CallProcedureCursor : public Cursor {
                           memory_limit,
                           &result_,
                           self_->procedure_id_,
-                          call_initializer);
+                          call_initializer,
+                          context.evaluation_context.graph_view);
 
       if (call_initializer) call_initializer = false;
 
@@ -8976,6 +9146,102 @@ void Apply::ApplyCursor::Reset() {
   input_->Reset();
   subquery_->Reset();
   pull_input_ = true;
+}
+
+namespace {
+class BindGraphViewCursor : public Cursor {
+ public:
+  BindGraphViewCursor(const BindGraphView &self, utils::MemoryResource *mem,
+                      metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self), input_cursor_(self.input_->MakeCursor(mem, metric_handles)) {}
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    OOMExceptionEnabler oom_exception;
+    SCOPED_PROFILE_OP("BindGraphView");
+
+    AbortCheck(context);
+
+    // The bound graph value comes from the outer frame; evaluate it once per
+    // outer row (Reset clears it) and reuse the view for every pull of the body.
+    if (!view_) BindView(frame, context);
+
+    auto *const outer_view = context.evaluation_context.graph_view;
+    context.evaluation_context.graph_view = view_;
+    try {
+      const bool pulled = input_cursor_->Pull(frame, context);
+      context.evaluation_context.graph_view = outer_view;
+      return pulled;
+    } catch (...) {
+      context.evaluation_context.graph_view = outer_view;
+      throw;
+    }
+  }
+
+  void Shutdown() override { input_cursor_->Shutdown(); }
+
+  void Reset() override {
+    input_cursor_->Reset();
+    view_ = nullptr;
+    view_storage_.emplace<std::monostate>();
+    graph_value_.reset();
+  }
+
+ private:
+  void BindView(Frame &frame, ExecutionContext &context) {
+    ExpressionEvaluator evaluator(&frame,
+                                  context.symbol_table,
+                                  context.evaluation_context,
+                                  context.db_accessor,
+                                  storage::View::NEW,
+                                  context.frame_change_collector,
+                                  &context.number_of_hops,
+                                  context.user_or_role,
+                                  context.triggering_user);
+    graph_value_.emplace(self_.use_graph_->Accept(evaluator));
+    switch (graph_value_->type()) {
+      case TypedValue::Type::VirtualGraph:
+        view_ = &view_storage_.emplace<VirtualGraphView>(&graph_value_->ValueVirtualGraph(), context.db_accessor);
+        break;
+      case TypedValue::Type::Graph:
+        view_ = &view_storage_.emplace<SubgraphGraphView>(&graph_value_->ValueGraph(), context.db_accessor);
+        break;
+      default:
+        throw QueryRuntimeException(
+            "USE expects a projection produced by virtualGraph()/derive() or a subgraph produced by project().");
+    }
+  }
+
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+  const BindGraphView &self_;
+  UniqueCursorPtr input_cursor_;
+  // graph_value_ owns the projection or subgraph; the view in view_storage_
+  // borrows it and view_ points at it through the GraphView seam, so the three
+  // are bound and released together.
+  std::optional<TypedValue> graph_value_;
+  std::variant<std::monostate, VirtualGraphView, SubgraphGraphView> view_storage_;
+  GraphView *view_{nullptr};
+};
+}  // namespace
+
+BindGraphView::BindGraphView(std::shared_ptr<LogicalOperator> input, Expression *use_graph)
+    : input_(input ? std::move(input) : std::make_shared<Once>()), use_graph_(use_graph) {}
+
+ACCEPT_WITH_INPUT(BindGraphView)
+
+UniqueCursorPtr BindGraphView::MakeCursor(utils::MemoryResource *mem,
+                                          metrics::DatabaseMetricHandles &metric_handles) const {
+  return MakeUniqueCursorPtr<BindGraphViewCursor>(mem, *this, mem, metric_handles);
+}
+
+std::vector<Symbol> BindGraphView::ModifiedSymbols(const SymbolTable &table) const {
+  return input_->ModifiedSymbols(table);
+}
+
+std::unique_ptr<LogicalOperator> BindGraphView::Clone(AstStorage *storage) const {
+  auto object = std::make_unique<BindGraphView>();
+  object->input_ = input_ ? input_->Clone(storage) : nullptr;
+  object->use_graph_ = use_graph_ ? use_graph_->Clone(storage) : nullptr;
+  return object;
 }
 
 IndexedJoin::IndexedJoin(const std::shared_ptr<LogicalOperator> main_branch,

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -9188,15 +9188,8 @@ class BindGraphViewCursor : public Cursor {
 
  private:
   void BindView(Frame &frame, ExecutionContext &context) {
-    ExpressionEvaluator evaluator(&frame,
-                                  context.symbol_table,
-                                  context.evaluation_context,
-                                  context.db_accessor,
-                                  storage::View::NEW,
-                                  context.frame_change_collector,
-                                  &context.number_of_hops,
-                                  context.user_or_role,
-                                  context.triggering_user);
+    ExpressionEvaluator evaluator(
+        &frame, context, storage::View::NEW, context.frame_change_collector, &context.number_of_hops);
     graph_value_.emplace(self_.use_graph_->Accept(evaluator));
     switch (graph_value_->type()) {
       case TypedValue::Type::VirtualGraph:

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -23,6 +23,7 @@
 
 #include "query/common.hpp"
 #include "query/frontend/semantic/symbol.hpp"
+#include "query/graph_view.hpp"
 #include "query/parameters.hpp"
 #include "query/plan/point_distance_condition.hpp"
 #include "query/plan/preprocess.hpp"
@@ -1075,46 +1076,23 @@ class Expand : public memgraph::query::plan::LogicalOperator {
     ExpansionInfo GetExpansionInfo(Frame &);
 
    private:
-    using InEdgeT = std::vector<EdgeAccessor>;
-    using InEdgeIteratorT = decltype(std::declval<InEdgeT>().begin());
-    using OutEdgeT = std::vector<EdgeAccessor>;
-    using OutEdgeIteratorT = decltype(std::declval<OutEdgeT>().begin());
-
-    // A projection's incident edges, borrowed from the bound view's edge index.
-    using VEdgeRange = std::span<const VirtualEdge *const>;
-    using VEdgeIteratorT = VEdgeRange::iterator;
-
     const Expand &self_;
     const UniqueCursorPtr input_cursor_;
 
-    // The iterable over edges and the current edge iterator are referenced via
-    // optional because they can not be initialized in the constructor of
-    // this class. They are initialized once for each pull from the input.
-    std::optional<InEdgeT> in_edges_;
-    std::optional<InEdgeIteratorT> in_edges_it_;
-    std::optional<OutEdgeT> out_edges_;
-    std::optional<OutEdgeIteratorT> out_edges_it_;
+    // The edges to expand and the current position, per direction. Optional
+    // because they are (re)initialized once per pull from the input, not in the
+    // constructor. Each is obtained from the ambient GraphView, so it carries the
+    // real graph's edges (identity or subgraph view) or the projection's edges
+    // uniformly, and iteration yields a ScanEdge for either kind.
+    std::optional<EdgeRange> in_edges_;
+    std::optional<EdgeRange::Iterator> in_edges_it_;
+    std::optional<EdgeRange> out_edges_;
+    std::optional<EdgeRange::Iterator> out_edges_it_;
     ExpansionInfo expansion_info_;
     int64_t prev_input_degree_{-1};
     int64_t prev_existing_degree_{-1};
 
-    // The projection-expansion arm, live when the input node is a VirtualNode.
-    // The ranges borrow the bound view's edge index, stable for the read-only
-    // scope; the allowed type names and existing-node gid are the in/out filter.
-    std::optional<VEdgeRange> in_vedges_;
-    std::optional<VEdgeIteratorT> in_vedges_it_;
-    std::optional<VEdgeRange> out_vedges_;
-    std::optional<VEdgeIteratorT> out_vedges_it_;
-    std::vector<std::string_view> allowed_edge_type_names_;
-    std::optional<storage::Gid> existing_vnode_gid_;
-
-    // Non-null while expanding a real member of a bound subgraph; expansion drops
-    // edges that are not members.
-    SubgraphGraphView *subgraph_view_{nullptr};
-
     bool InitEdges(Frame &, ExecutionContext &);
-    bool InitVirtualEdges(Frame &, ExecutionContext &, const VirtualNode &);
-    bool VirtualEdgeMatches(const VirtualEdge &, const VirtualNode &other) const;
   };
 
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -14,6 +14,8 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <span>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -45,6 +47,9 @@ class DbAccessor;
 class ExpressionEvaluator;
 class Frame;
 class SymbolTable;
+class VirtualNode;
+class VirtualEdge;
+class SubgraphGraphView;
 
 namespace plan {
 
@@ -189,6 +194,7 @@ class ScanParallelByEdgePropertyValue;
 class ScanParallelByEdgePropertyRange;
 class ScanChunk;
 class ScanChunkByEdge;
+class BindGraphView;
 
 using LogicalOperatorCompositeVisitor = utils::CompositeVisitor<
     Once, CreateNode, CreateExpand, ScanAll, ScanAllByLabel, ScanAllByLabelProperties, ScanAllById, ScanAllByEdge,
@@ -202,7 +208,7 @@ using LogicalOperatorCompositeVisitor = utils::CompositeVisitor<
     OrderByParallel, ScanParallel, ScanParallelByLabel, ScanParallelByLabelProperties, ScanParallelByEdgeType,
     ScanParallelByEdgeTypeProperty, ScanParallelByEdge, ScanParallelByEdgeTypePropertyValue,
     ScanParallelByEdgeTypePropertyRange, ScanParallelByEdgeProperty, ScanParallelByEdgePropertyValue,
-    ScanParallelByEdgePropertyRange, ScanChunk, ScanChunkByEdge, ParallelMerge>;
+    ScanParallelByEdgePropertyRange, ScanChunk, ScanChunkByEdge, ParallelMerge, BindGraphView>;
 
 using LogicalOperatorLeafVisitor = utils::LeafVisitor<Once>;
 
@@ -1074,6 +1080,10 @@ class Expand : public memgraph::query::plan::LogicalOperator {
     using OutEdgeT = std::vector<EdgeAccessor>;
     using OutEdgeIteratorT = decltype(std::declval<OutEdgeT>().begin());
 
+    // A projection's incident edges, borrowed from the bound view's edge index.
+    using VEdgeRange = std::span<const VirtualEdge *const>;
+    using VEdgeIteratorT = VEdgeRange::iterator;
+
     const Expand &self_;
     const UniqueCursorPtr input_cursor_;
 
@@ -1088,7 +1098,23 @@ class Expand : public memgraph::query::plan::LogicalOperator {
     int64_t prev_input_degree_{-1};
     int64_t prev_existing_degree_{-1};
 
+    // The projection-expansion arm, live when the input node is a VirtualNode.
+    // The ranges borrow the bound view's edge index, stable for the read-only
+    // scope; the allowed type names and existing-node gid are the in/out filter.
+    std::optional<VEdgeRange> in_vedges_;
+    std::optional<VEdgeIteratorT> in_vedges_it_;
+    std::optional<VEdgeRange> out_vedges_;
+    std::optional<VEdgeIteratorT> out_vedges_it_;
+    std::vector<std::string_view> allowed_edge_type_names_;
+    std::optional<storage::Gid> existing_vnode_gid_;
+
+    // Non-null while expanding a real member of a bound subgraph; expansion drops
+    // edges that are not members.
+    SubgraphGraphView *subgraph_view_{nullptr};
+
     bool InitEdges(Frame &, ExecutionContext &);
+    bool InitVirtualEdges(Frame &, ExecutionContext &, const VirtualNode &);
+    bool VirtualEdgeMatches(const VirtualEdge &, const VirtualNode &other) const;
   };
 
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
@@ -3047,6 +3073,39 @@ class Apply : public memgraph::query::plan::LogicalOperator {
     bool pull_input_{true};
     bool subquery_has_return_{true};
   };
+};
+
+/// Binds the ambient graph view for a `CALL { USE <expr> ... }` scope.
+///
+/// Wraps the subquery's plan. While pulling it, the bound graph expression is
+/// evaluated to a projection value and set as the execution context's ambient
+/// GraphView, so the read operators inside the scope run over the projection.
+/// The previous view is restored around each pull, so outside the scope the
+/// real graph is read.
+class BindGraphView : public memgraph::query::plan::LogicalOperator {
+ public:
+  static const utils::TypeInfo kType;
+
+  const utils::TypeInfo &GetTypeInfo() const override { return kType; }
+
+  BindGraphView() = default;
+
+  BindGraphView(std::shared_ptr<LogicalOperator> input, Expression *use_graph);
+
+  bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
+  UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
+  std::vector<Symbol> ModifiedSymbols(const SymbolTable &) const override;
+
+  bool HasSingleInput() const override { return true; }
+
+  std::shared_ptr<LogicalOperator> input() const override { return input_; }
+
+  void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
+
+  std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
+  Expression *use_graph_{nullptr};
+
+  std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
 
 /// Applies symbols from both join branches

--- a/src/query/plan/operator_type_info.cpp
+++ b/src/query/plan/operator_type_info.cpp
@@ -168,6 +168,9 @@ constexpr utils::TypeInfo query::plan::Foreach::kType{
 constexpr utils::TypeInfo query::plan::Apply::kType{
     .id = utils::TypeId::APPLY, .name = "Apply", .superclass = &query::plan::LogicalOperator::kType};
 
+constexpr utils::TypeInfo query::plan::BindGraphView::kType{
+    .id = utils::TypeId::BIND_GRAPH_VIEW, .name = "BindGraphView", .superclass = &query::plan::LogicalOperator::kType};
+
 constexpr utils::TypeInfo query::plan::IndexedJoin::kType{
     .id = utils::TypeId::INDEXED_JOIN, .name = "IndexedJoin", .superclass = &query::plan::LogicalOperator::kType};
 

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -280,6 +280,7 @@ struct PlanToJsonVisitor final : virtual HierarchicalLogicalOperatorVisitor {
   bool PreVisit(Apply & /*unused*/) override;
   bool PreVisit(HashJoin & /*unused*/) override;
   bool PreVisit(IndexedJoin & /*unused*/) override;
+  bool PreVisit(BindGraphView & /*unused*/) override;
 
   bool PreVisit(ScanAll & /*unused*/) override;
   bool PreVisit(ScanAllByLabel & /*unused*/) override;
@@ -582,6 +583,16 @@ bool PlanPrinter::PreVisit(query::plan::IndexedJoin &op) {
   WithPrintLn([this](auto &out) { out << StartSymbol() << " IndexedJoin"; });
   Branch(*op.sub_branch_);
   op.main_branch_->Accept(*this);
+  return false;
+}
+
+bool PlanPrinter::PreVisit(query::plan::BindGraphView &op) {
+  WithPrintLn([this, &op](auto &out) {
+    out << StartSymbol() << " BindGraphView (USE ";
+    PrintExpression(op.use_graph_, &out, *dba_);
+    out << ")";
+  });
+  op.input_->Accept(*this);
   return false;
 }
 
@@ -1585,6 +1596,18 @@ bool PlanToJsonVisitor::PreVisit(Apply &op) {
 
   op.subquery_->Accept(*this);
   self["subquery"] = PopOutput();
+
+  output_ = std::move(self);
+  return false;
+}
+
+bool PlanToJsonVisitor::PreVisit(BindGraphView &op) {
+  json self;
+  self["name"] = "BindGraphView";
+  self["use_graph"] = ToJson(op.use_graph_, *dba_);
+
+  op.input_->Accept(*this);
+  self["input"] = PopOutput();
 
   output_ = std::move(self);
   return false;

--- a/src/query/plan/pretty_print.hpp
+++ b/src/query/plan/pretty_print.hpp
@@ -123,6 +123,7 @@ struct PlanPrinter final : virtual HierarchicalLogicalOperatorVisitor {
   bool PreVisit(Foreach & /*unused*/) override;
   bool PreVisit(Apply & /*unused*/) override;
   bool PreVisit(IndexedJoin & /*unused*/) override;
+  bool PreVisit(BindGraphView & /*unused*/) override;
 
   bool Visit(Once & /*unused*/) override;
 

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -28,6 +28,7 @@
 #include "query/plan/operator.hpp"
 #include "query/plan/preprocess.hpp"
 #include "query/plan/rewrite/general.hpp"
+#include "query/plan/rewrite/index_substitution_rewriter.hpp"
 #include "query/plan/rewrite/order_by_elimination.hpp"
 #include "storage/v2/id_types.hpp"
 
@@ -36,7 +37,7 @@ namespace memgraph::query::plan {
 namespace impl {
 
 template <class TDbAccessor>
-class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
+class EdgeIndexRewriter final : public IndexSubstitutionRewriter {
  public:
   EdgeIndexRewriter(SymbolTable *symbol_table, AstStorage *ast_storage, TDbAccessor *db,
                     bool parallel_execution = false)
@@ -45,9 +46,9 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         db_(db),
         order_by_eliminator_(db, prev_ops_, parallel_execution) {}
 
-  using HierarchicalLogicalOperatorVisitor::PostVisit;
-  using HierarchicalLogicalOperatorVisitor::PreVisit;
-  using HierarchicalLogicalOperatorVisitor::Visit;
+  using IndexSubstitutionRewriter::PostVisit;
+  using IndexSubstitutionRewriter::PreVisit;
+  using IndexSubstitutionRewriter::Visit;
 
   bool Visit(Once &) override { return true; }
 
@@ -630,19 +631,6 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     return false;
   }
 
-  bool PreVisit(BindGraphView &op) override {
-    prev_ops_.push_back(&op);
-    // The body scans a projection, which exposes no edge-type index. An edge-type
-    // index scan reads the real graph, not the bound projection, so the body is
-    // left a full scan and not rewritten.
-    return false;
-  }
-
-  bool PostVisit(BindGraphView & /*op*/) override {
-    prev_ops_.pop_back();
-    return true;
-  }
-
   bool PostVisit(Apply & /*op*/) override {
     prev_ops_.pop_back();
     return true;
@@ -743,7 +731,6 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
   Filters filters_;
   // Expressions which no longer need a plain Filter operator.
   std::unordered_set<Expression *> filter_exprs_for_removal_;
-  std::vector<LogicalOperator *> prev_ops_;
   OrderByEliminator<TDbAccessor> order_by_eliminator_;
   std::unordered_set<Symbol> additional_bound_symbols_;
 
@@ -1291,10 +1278,10 @@ template <class TDbAccessor>
 std::unique_ptr<LogicalOperator> RewriteWithEdgeIndexRewriter(std::unique_ptr<LogicalOperator> root_op,
                                                               SymbolTable *symbol_table, AstStorage *ast_storage,
                                                               TDbAccessor *db, bool parallel_execution = false) {
-  impl::EdgeIndexRewriter<TDbAccessor> rewriter(symbol_table, ast_storage, db, parallel_execution);
-  root_op->Accept(rewriter);
-  if (rewriter.new_root_) {
-    return rewriter.new_root_->Clone(ast_storage);
+  auto new_root = impl::RunIndexSubstitution<impl::EdgeIndexRewriter<TDbAccessor>>(
+      *root_op, symbol_table, ast_storage, db, parallel_execution);
+  if (new_root) {
+    return new_root->Clone(ast_storage);
   }
   return root_op;
 }

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -630,6 +630,19 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     return false;
   }
 
+  bool PreVisit(BindGraphView &op) override {
+    prev_ops_.push_back(&op);
+    // The body scans a projection, which exposes no edge-type index. An edge-type
+    // index scan reads the real graph, not the bound projection, so the body is
+    // left a full scan and not rewritten.
+    return false;
+  }
+
+  bool PostVisit(BindGraphView & /*op*/) override {
+    prev_ops_.pop_back();
+    return true;
+  }
+
   bool PostVisit(Apply & /*op*/) override {
     prev_ops_.pop_back();
     return true;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -38,6 +38,7 @@
 #include "query/plan/preprocess.hpp"
 #include "query/plan/rewrite/balanced_union.hpp"
 #include "query/plan/rewrite/general.hpp"
+#include "query/plan/rewrite/index_substitution_rewriter.hpp"
 #include "query/plan/rewrite/order_by_elimination.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/label_properties_indices_info.hpp"
@@ -156,7 +157,7 @@ struct HashPair {
 };
 
 template <class TDbAccessor>
-class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
+class IndexLookupRewriter final : public IndexSubstitutionRewriter {
  public:
   IndexLookupRewriter(SymbolTable *symbol_table, AstStorage *ast_storage, TDbAccessor *db, IndexHints index_hints,
                       const Parameters &parameters, bool parallel_execution = false)
@@ -167,9 +168,9 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         parameters_(parameters),
         order_by_eliminator_(db, prev_ops_, parallel_execution) {}
 
-  using HierarchicalLogicalOperatorVisitor::PostVisit;
-  using HierarchicalLogicalOperatorVisitor::PreVisit;
-  using HierarchicalLogicalOperatorVisitor::Visit;
+  using IndexSubstitutionRewriter::PostVisit;
+  using IndexSubstitutionRewriter::PreVisit;
+  using IndexSubstitutionRewriter::Visit;
 
   bool Visit(Once &) override { return true; }
 
@@ -805,20 +806,6 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     return true;
   }
 
-  bool PreVisit(BindGraphView &op) override {
-    prev_ops_.push_back(&op);
-    // The body scans a projection, which exposes no index or statistics. Leave it
-    // a full ScanAll + Filter: an index scan reads the real graph through the
-    // accessor, not the bound projection, so substituting one here would read the
-    // wrong graph. The body is not rewritten.
-    return false;
-  }
-
-  bool PostVisit(BindGraphView & /*op*/) override {
-    prev_ops_.pop_back();
-    return true;
-  }
-
   bool PreVisit(LoadCsv &op) override {
     prev_ops_.push_back(&op);
     return true;
@@ -914,7 +901,6 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   Filters filters_;
   // Expressions which no longer need a plain Filter operator.
   std::unordered_set<Expression *> filter_exprs_for_removal_;
-  std::vector<LogicalOperator *> prev_ops_;
   IndexHints index_hints_;
   const Parameters &parameters_;
   OrderByEliminator<TDbAccessor> order_by_eliminator_;
@@ -1891,14 +1877,13 @@ std::unique_ptr<LogicalOperator> RewriteWithIndexLookup(std::unique_ptr<LogicalO
                                                         SymbolTable *symbol_table, AstStorage *ast_storage,
                                                         TDbAccessor *db, IndexHints index_hints,
                                                         const Parameters &parameters, bool parallel_execution = false) {
-  impl::IndexLookupRewriter<TDbAccessor> rewriter(
-      symbol_table, ast_storage, db, index_hints, parameters, parallel_execution);
-  root_op->Accept(rewriter);
-  if (rewriter.new_root_) {
+  auto new_root = impl::RunIndexSubstitution<impl::IndexLookupRewriter<TDbAccessor>>(
+      *root_op, symbol_table, ast_storage, db, index_hints, parameters, parallel_execution);
+  if (new_root) {
     // The root operator was removed (e.g., OrderBy elimination or Filter removal).
     // Since the internal tree uses shared_ptr but this function returns unique_ptr,
     // we clone the new root subtree to get a properly-owned unique_ptr hierarchy.
-    return rewriter.new_root_->Clone(ast_storage);
+    return new_root->Clone(ast_storage);
   }
   return root_op;
 }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -805,6 +805,20 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     return true;
   }
 
+  bool PreVisit(BindGraphView &op) override {
+    prev_ops_.push_back(&op);
+    // The body scans a projection, which exposes no index or statistics. Leave it
+    // a full ScanAll + Filter: an index scan reads the real graph through the
+    // accessor, not the bound projection, so substituting one here would read the
+    // wrong graph. The body is not rewritten.
+    return false;
+  }
+
+  bool PostVisit(BindGraphView & /*op*/) override {
+    prev_ops_.pop_back();
+    return true;
+  }
+
   bool PreVisit(LoadCsv &op) override {
     prev_ops_.push_back(&op);
     return true;

--- a/src/query/plan/rewrite/index_substitution_rewriter.hpp
+++ b/src/query/plan/rewrite/index_substitution_rewriter.hpp
@@ -20,17 +20,17 @@
 
 namespace memgraph::query::plan::impl {
 
-/// Base for the plan rewriters that substitute real-graph scans - the index,
-/// edge-index, and join rewriters. Their substitutions consult the real graph's
-/// indexes and statistics, so they must never descend into a `CALL { USE ... }`
-/// scope body (a `BindGraphView`), whose scan runs over a bound projection:
-/// substituting an index scan there would silently read the real graph, which
-/// ADR 0004 calls a correctness bug, not an optimization.
+/// Base for any plan rewriter that must not descend into a `CALL { USE ... }`
+/// scope body (a `BindGraphView`), whose scan runs over a bound projection rather
+/// than the real graph. The index, edge-index, and join rewriters substitute
+/// real-graph index scans; the parallel rewriter parallelizes real-graph scans -
+/// entering the scope would silently operate on the wrong graph, which ADR 0004
+/// calls a correctness bug, not an optimization.
 ///
-/// The guard is declared here, once, and `final`, so it cannot be copy-pasted
-/// out of sync per rewriter and no derived rewriter can re-enable descent - not
-/// even by accident. `prev_ops_` lives here too, since the guard maintains it.
-class IndexSubstitutionRewriter : public HierarchicalLogicalOperatorVisitor {
+/// The guard is declared here, once, and `final`, so it cannot be copy-pasted out
+/// of sync per rewriter and no derived rewriter can re-enable descent - not even
+/// by accident. `prev_ops_` lives here too, since the guard maintains it.
+class BoundViewScopeRewriter : public HierarchicalLogicalOperatorVisitor {
  public:
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;
@@ -52,6 +52,12 @@ class IndexSubstitutionRewriter : public HierarchicalLogicalOperatorVisitor {
  protected:
   std::vector<LogicalOperator *> prev_ops_;
 };
+
+/// The scope-guard base for the real-graph index-substitution rewriters (index,
+/// edge-index, join). It adds nothing beyond `BoundViewScopeRewriter`; it exists
+/// so `RunIndexSubstitution` can require it and reject any rewriter that was not
+/// built to stop at a USE-scope body.
+class IndexSubstitutionRewriter : public BoundViewScopeRewriter {};
 
 /// The single sanctioned way to run an index-substitution rewrite: construct the
 /// rewriter, walk the plan, and hand back its replacement root (null when the

--- a/src/query/plan/rewrite/index_substitution_rewriter.hpp
+++ b/src/query/plan/rewrite/index_substitution_rewriter.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <concepts>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "query/plan/operator.hpp"
+
+namespace memgraph::query::plan::impl {
+
+/// Base for the plan rewriters that substitute real-graph scans - the index,
+/// edge-index, and join rewriters. Their substitutions consult the real graph's
+/// indexes and statistics, so they must never descend into a `CALL { USE ... }`
+/// scope body (a `BindGraphView`), whose scan runs over a bound projection:
+/// substituting an index scan there would silently read the real graph, which
+/// ADR 0004 calls a correctness bug, not an optimization.
+///
+/// The guard is declared here, once, and `final`, so it cannot be copy-pasted
+/// out of sync per rewriter and no derived rewriter can re-enable descent - not
+/// even by accident. `prev_ops_` lives here too, since the guard maintains it.
+class IndexSubstitutionRewriter : public HierarchicalLogicalOperatorVisitor {
+ public:
+  using HierarchicalLogicalOperatorVisitor::PostVisit;
+  using HierarchicalLogicalOperatorVisitor::PreVisit;
+  using HierarchicalLogicalOperatorVisitor::Visit;
+
+  // Do not descend into a USE-scope body. The push/pop keeps prev_ops_ balanced
+  // with the surrounding PreVisit/PostVisit pairs; PostVisit always runs, even
+  // though PreVisit returns false to skip the body.
+  bool PreVisit(BindGraphView &op) final {
+    prev_ops_.push_back(&op);
+    return false;
+  }
+
+  bool PostVisit(BindGraphView & /*op*/) final {
+    prev_ops_.pop_back();
+    return true;
+  }
+
+ protected:
+  std::vector<LogicalOperator *> prev_ops_;
+};
+
+/// The single sanctioned way to run an index-substitution rewrite: construct the
+/// rewriter, walk the plan, and hand back its replacement root (null when the
+/// root was not replaced). The concept constraint means a rewriter that does not
+/// derive from `IndexSubstitutionRewriter` - and so lacks the USE-body guard -
+/// cannot be run through here: it is a compile error at the call site, not a
+/// silent wrong-graph read. Callers apply their own replacement-root policy.
+template <typename TRewriter, typename... Args>
+  requires std::derived_from<TRewriter, IndexSubstitutionRewriter>
+std::shared_ptr<LogicalOperator> RunIndexSubstitution(LogicalOperator &root, Args &&...args) {
+  TRewriter rewriter(std::forward<Args>(args)...);
+  root.Accept(rewriter);
+  return rewriter.new_root_;
+}
+
+}  // namespace memgraph::query::plan::impl

--- a/src/query/plan/rewrite/join.hpp
+++ b/src/query/plan/rewrite/join.hpp
@@ -554,6 +554,19 @@ class JoinRewriter final : public HierarchicalLogicalOperatorVisitor {
     return false;
   }
 
+  bool PreVisit(BindGraphView &op) override {
+    prev_ops_.push_back(&op);
+    // The body scans a projection, which exposes no index to drive an indexed
+    // join. A join rewrite would consult the real graph's indexes, so the body is
+    // left as planned and not rewritten.
+    return false;
+  }
+
+  bool PostVisit(BindGraphView & /*op*/) override {
+    prev_ops_.pop_back();
+    return true;
+  }
+
   bool PostVisit(Apply & /*op*/) override {
     prev_ops_.pop_back();
     return true;

--- a/src/query/plan/rewrite/join.hpp
+++ b/src/query/plan/rewrite/join.hpp
@@ -27,20 +27,21 @@
 #include "query/plan/operator.hpp"
 #include "query/plan/preprocess.hpp"
 #include "query/plan/rewrite/general.hpp"
+#include "query/plan/rewrite/index_substitution_rewriter.hpp"
 
 namespace memgraph::query::plan {
 
 namespace impl {
 
 template <class TDbAccessor>
-class JoinRewriter final : public HierarchicalLogicalOperatorVisitor {
+class JoinRewriter final : public IndexSubstitutionRewriter {
  public:
   JoinRewriter(SymbolTable *symbol_table, AstStorage *ast_storage, TDbAccessor *db)
       : symbol_table_(symbol_table), ast_storage_(ast_storage), db_(db) {}
 
-  using HierarchicalLogicalOperatorVisitor::PostVisit;
-  using HierarchicalLogicalOperatorVisitor::PreVisit;
-  using HierarchicalLogicalOperatorVisitor::Visit;
+  using IndexSubstitutionRewriter::PostVisit;
+  using IndexSubstitutionRewriter::PreVisit;
+  using IndexSubstitutionRewriter::Visit;
 
   bool Visit(Once &) override { return true; }
 
@@ -554,19 +555,6 @@ class JoinRewriter final : public HierarchicalLogicalOperatorVisitor {
     return false;
   }
 
-  bool PreVisit(BindGraphView &op) override {
-    prev_ops_.push_back(&op);
-    // The body scans a projection, which exposes no index to drive an indexed
-    // join. A join rewrite would consult the real graph's indexes, so the body is
-    // left as planned and not rewritten.
-    return false;
-  }
-
-  bool PostVisit(BindGraphView & /*op*/) override {
-    prev_ops_.pop_back();
-    return true;
-  }
-
   bool PostVisit(Apply & /*op*/) override {
     prev_ops_.pop_back();
     return true;
@@ -667,7 +655,6 @@ class JoinRewriter final : public HierarchicalLogicalOperatorVisitor {
   Filters filters_;
   // Expressions which no longer need a plain Filter operator.
   std::unordered_set<Expression *> filter_exprs_for_removal_;
-  std::vector<LogicalOperator *> prev_ops_;
   std::unordered_set<Symbol> cartesian_symbols_;
 
   bool DefaultPreVisit() override { throw utils::NotYetImplemented("Operator not yet covered by JoinRewriter"); }
@@ -771,9 +758,8 @@ template <class TDbAccessor>
 std::unique_ptr<LogicalOperator> RewriteWithJoinRewriter(std::unique_ptr<LogicalOperator> root_op,
                                                          SymbolTable *symbol_table, AstStorage *ast_storage,
                                                          TDbAccessor *db) {
-  impl::JoinRewriter<TDbAccessor> rewriter(symbol_table, ast_storage, db);
-  root_op->Accept(rewriter);
-  if (rewriter.new_root_) {
+  auto new_root = impl::RunIndexSubstitution<impl::JoinRewriter<TDbAccessor>>(*root_op, symbol_table, ast_storage, db);
+  if (new_root) {
     // This shouldn't happen in real use cases because, as JoinRewriter removes Filter operations, they cannot be the
     // root operator. In case we somehow missed this, raise NotYetImplemented instead of a MG_ASSERT crashing the
     // application.

--- a/src/query/plan/rewrite/parallel_rewrite.hpp
+++ b/src/query/plan/rewrite/parallel_rewrite.hpp
@@ -24,6 +24,7 @@
 #include "query/dependant_symbol_visitor.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan/read_write_type_checker.hpp"
+#include "query/plan/rewrite/index_substitution_rewriter.hpp"
 #include "utils/typeinfo.hpp"
 
 namespace memgraph::query::plan {
@@ -31,7 +32,7 @@ namespace memgraph::query::plan {
 namespace impl {
 
 template <class TDbAccessor>
-class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
+class ParallelRewriter final : public BoundViewScopeRewriter {
  public:
   ParallelRewriter(SymbolTable *symbolTable, AstStorage *astStorage, TDbAccessor *db, size_t num_threads)
       : symbol_table(symbolTable), ast_storage(astStorage), db(db), num_threads_(num_threads) {}
@@ -44,9 +45,9 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   ~ParallelRewriter() override = default;
 
-  using HierarchicalLogicalOperatorVisitor::PostVisit;
-  using HierarchicalLogicalOperatorVisitor::PreVisit;
-  using HierarchicalLogicalOperatorVisitor::Visit;
+  using BoundViewScopeRewriter::PostVisit;
+  using BoundViewScopeRewriter::PreVisit;
+  using BoundViewScopeRewriter::Visit;
 
   bool Visit(Once &) override { return true; }
 
@@ -133,22 +134,9 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
 
 #undef DEFAULT_VISITS
 
-  // A `CALL { USE ... }` scope body scans a bound projection, not the real graph.
-  // A parallel scan reads the real graph, so parallelizing a scan inside the scope
-  // would read the wrong graph - the same correctness bug ADR 0004 describes for
-  // the index rewriters, which is why they stop at BindGraphView too. Do not
-  // descend into the body; the plan outside the scope is still parallelized.
-  // (Unifying this guard with the index rewriters' IndexSubstitutionRewriter base
-  // under one scope-guard base is a possible later cleanup - see issue 45.)
-  bool PreVisit(BindGraphView &op) override {
-    prev_ops_.push_back(&op);
-    return false;
-  }
-
-  bool PostVisit(BindGraphView & /*op*/) override {
-    prev_ops_.pop_back();
-    return true;
-  }
+  // The BindGraphView (USE-scope) guard that keeps this rewriter out of a bound
+  // projection's scan is inherited from BoundViewScopeRewriter, shared with the
+  // index-substitution rewriters.
 
   // Single threaded Aggregate (potentially parallelizable)
   bool PreVisit(Aggregate &op) override {
@@ -262,7 +250,6 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
   SymbolTable *symbol_table;
   AstStorage *ast_storage;
   TDbAccessor *db;
-  std::vector<LogicalOperator *> prev_ops_;
   size_t num_threads_;
 
   /**

--- a/src/query/plan/rewrite/parallel_rewrite.hpp
+++ b/src/query/plan/rewrite/parallel_rewrite.hpp
@@ -133,6 +133,23 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
 
 #undef DEFAULT_VISITS
 
+  // A `CALL { USE ... }` scope body scans a bound projection, not the real graph.
+  // A parallel scan reads the real graph, so parallelizing a scan inside the scope
+  // would read the wrong graph - the same correctness bug ADR 0004 describes for
+  // the index rewriters, which is why they stop at BindGraphView too. Do not
+  // descend into the body; the plan outside the scope is still parallelized.
+  // (Unifying this guard with the index rewriters' IndexSubstitutionRewriter base
+  // under one scope-guard base is a possible later cleanup - see issue 45.)
+  bool PreVisit(BindGraphView &op) override {
+    prev_ops_.push_back(&op);
+    return false;
+  }
+
+  bool PostVisit(BindGraphView & /*op*/) override {
+    prev_ops_.pop_back();
+    return true;
+  }
+
   // Single threaded Aggregate (potentially parallelizable)
   bool PreVisit(Aggregate &op) override {
     // Special case for DISTINCT operator - we don't support parallelizing DISTINCT operators

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -488,7 +488,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                       pending_comprehensions,
                                       write_occurred,
                                       call_sub->cypher_query_->pre_query_directives_.commit_frequency_,
-                                      scoped_variables);
+                                      scoped_variables,
+                                      call_sub->use_graph_);
             if (context.is_write_query && !has_periodic_commit) {
               input_op = std::make_unique<Accumulate>(
                   std::move(input_op), input_op->ModifiedSymbols(*context.symbol_table), is_root_query);
@@ -1370,7 +1371,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
       std::unique_ptr<LogicalOperator> last_op, std::shared_ptr<QueryParts> subquery, SymbolTable &symbol_table,
       AstStorage &storage, std::unordered_map<Symbol, PatternComprehensionMatching> & /*pending_comprehensions*/,
       bool /*write_occurred*/, Expression *commit_frequency,
-      const std::optional<std::unordered_set<Symbol>> &scoped_variables = std::nullopt) {
+      const std::optional<std::unordered_set<Symbol>> &scoped_variables = std::nullopt,
+      Expression *use_graph = nullptr) {
     std::unordered_set<Symbol> outer_scope_bound_symbols;
     outer_scope_bound_symbols.insert(std::make_move_iterator(context_->bound_symbols.begin()),
                                      std::make_move_iterator(context_->bound_symbols.end()));
@@ -1397,6 +1399,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     auto subquery_has_return = true;
     if (subquery_op->GetTypeInfo() == EmptyResult::kType) {
       subquery_has_return = false;
+    }
+
+    // `CALL { USE <expr> ... }`: bind the projection as the scope's ambient graph
+    // for the body's pulls.
+    if (use_graph != nullptr) {
+      subquery_op = std::make_unique<BindGraphView>(std::move(subquery_op), use_graph);
     }
 
     bool has_periodic_commit = commit_frequency != nullptr;

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -276,6 +276,9 @@ auto LowerUnwind(query::Unwind &unwind, eclass pipe, LoweringCtx &ctx) -> eclass
 
 auto LowerCallSubquery(query::CallSubquery &cs, eclass pipe, LoweringCtx &ctx) -> eclass {
   // Minimum scope: non-importing CALL { ... } RETURN ...
+  // A USE scope rebinds the ambient graph to a projection; plan_v2 has no such
+  // awareness and would scan the real graph, so reject it before lowering.
+  if (cs.use_graph_ != nullptr) ThrowNotImplementedYet("USE scope (projection) in CALL subquery");
   if (cs.has_variable_scope_) ThrowNotImplementedYet("importing CALL with explicit scope clause");
   if (cs.all_variables_scoped_) ThrowNotImplementedYet("CALL with implicit star scope clause");
   DMG_ASSERT(cs.cypher_query_ != nullptr && cs.cypher_query_->single_query_ != nullptr,

--- a/src/query/projection_schema.hpp
+++ b/src/query/projection_schema.hpp
@@ -1,0 +1,35 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace memgraph::query {
+
+// Describes one derive() projection in a query result, so a projection-aware client can style the
+// overlay nodes it produced. The overlay nodes carry `ref` (a plain Int property); this entry,
+// delivered once in the result header, tells the client which of those nodes' property keys are
+// computed overlays and what edge type connects them. Built statically from the plan at prepare
+// time, so it is available before the first record streams.
+struct ProjectionSchema {
+  // The schema reference shared by every overlay node from this derive(): the output symbol's plan
+  // position, matching the value carried in the node's reserved tag property.
+  int64_t ref;
+  // Property keys bound to the overlay (computed, not read through from the origin).
+  std::vector<std::string> overlay;
+  // The virtual edge type connecting the projection's nodes.
+  std::string edge_type;
+};
+
+}  // namespace memgraph::query

--- a/src/query/projection_schema.hpp
+++ b/src/query/projection_schema.hpp
@@ -22,7 +22,7 @@ namespace memgraph::query {
 // delivered once in the result header, tells the client which of those nodes' property keys are
 // computed overlays and what edge type connects them. Built statically from the plan at prepare
 // time, so it is available before the first record streams.
-struct ProjectionSchema {
+struct ProjectionSchemaEntry {
   // The schema reference shared by every overlay node from this derive(): the output symbol's plan
   // position, matching the value carried in the node's reserved tag property.
   int64_t ref;

--- a/src/query/subgraph_graph_view.hpp
+++ b/src/query/subgraph_graph_view.hpp
@@ -1,0 +1,63 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "query/db_accessor.hpp"
+#include "query/graph.hpp"
+#include "query/graph_view.hpp"
+#include "storage/v2/id_types.hpp"
+
+namespace memgraph::query {
+
+// A project() subgraph seen as a graph to scan: a scan yields its member real
+// vertices, and expansion filters a real vertex's edges to the subgraph's edge
+// membership. Topology is the membership sets held on Graph; names share the real
+// accessor's namespace, since a subgraph mints no ids of its own.
+//
+// It is a view layered over the real graph by membership: a scan over it yields a
+// member vertex as the common scan element, so the read operators run over a
+// subgraph the same way they run over the real graph. Edge membership is exposed
+// here for the expand path rather than on GraphView.
+class SubgraphGraphView final : public GraphView {
+  Graph *graph_;
+  DbAccessor *names_;
+
+ public:
+  SubgraphGraphView(Graph *graph, DbAccessor *names) : graph_(graph), names_(names) {}
+
+  // True if the edge is a member of the subgraph. Expansion drops non-member
+  // edges so a match stays within the subgraph.
+  [[nodiscard]] bool ContainsEdge(const EdgeAccessor &edge) const { return graph_->edges().contains(edge); }
+
+  // The borrowed subgraph, for wrapping in a SubgraphDbAccessor when this view
+  // is the ambient graph of a procedure call.
+  [[nodiscard]] Graph *graph() const { return graph_; }
+
+  VertexRange Vertices(storage::View /*view*/) override { return VertexRange{VerticesIterable(&graph_->vertices())}; }
+
+  storage::LabelId NameToLabel(std::string_view name) override { return names_->NameToLabel(name); }
+
+  const std::string &LabelToName(storage::LabelId label) const override { return names_->LabelToName(label); }
+
+  storage::PropertyId NameToProperty(std::string_view name) override { return names_->NameToProperty(name); }
+
+  const std::string &PropertyToName(storage::PropertyId prop) const override { return names_->PropertyToName(prop); }
+
+  storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return names_->NameToEdgeType(name); }
+
+  const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return names_->EdgeTypeToName(type); }
+};
+
+}  // namespace memgraph::query

--- a/src/query/subgraph_graph_view.hpp
+++ b/src/query/subgraph_graph_view.hpp
@@ -34,10 +34,9 @@ namespace memgraph::query {
 // here for the expand path rather than on GraphView.
 class SubgraphGraphView final : public GraphView {
   Graph *graph_;
-  DbAccessor *names_;
 
  public:
-  SubgraphGraphView(Graph *graph, DbAccessor *names) : graph_(graph), names_(names) {}
+  SubgraphGraphView(Graph *graph, DbAccessor *names) : GraphView(names), graph_(graph) {}
 
   // True if the edge is a member of the subgraph. Expansion drops non-member
   // edges so a match stays within the subgraph.
@@ -63,17 +62,21 @@ class SubgraphGraphView final : public GraphView {
                                      : vertex.InEdges(view, edge_types, hops));
   }
 
-  storage::LabelId NameToLabel(std::string_view name) override { return names_->NameToLabel(name); }
-
-  const std::string &LabelToName(storage::LabelId label) const override { return names_->LabelToName(label); }
-
-  storage::PropertyId NameToProperty(std::string_view name) override { return names_->NameToProperty(name); }
-
-  const std::string &PropertyToName(storage::PropertyId prop) const override { return names_->PropertyToName(prop); }
-
-  storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return names_->NameToEdgeType(name); }
-
-  const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return names_->EdgeTypeToName(type); }
+  // The subgraph's member-filtered degree: every incident real edge is examined, only members counted.
+  // A synthetic node reaching a subgraph view is no member and reports {0, 0}.
+  std::pair<int64_t, int64_t> Degree(const ScanVertex &from, storage::View view) override {
+    const auto *vertex = std::get_if<VertexAccessor>(&from);
+    if (vertex == nullptr) return {0, 0};
+    const auto count_members = [&](storage::Result<EdgeVertexAccessorResult> &&result) -> int64_t {
+      auto edges = UnwrapEdges(std::move(result));
+      int64_t count = 0;
+      for (const auto &edge : edges.edges) {
+        if (ContainsEdge(edge)) ++count;
+      }
+      return count;
+    };
+    return {count_members(vertex->InEdges(view)), count_members(vertex->OutEdges(view))};
+  }
 
  private:
   // Real-vertex edges filtered to the subgraph's membership: expansion stays within

--- a/src/query/subgraph_graph_view.hpp
+++ b/src/query/subgraph_graph_view.hpp
@@ -11,8 +11,10 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "query/db_accessor.hpp"
 #include "query/graph.hpp"
@@ -47,6 +49,20 @@ class SubgraphGraphView final : public GraphView {
 
   VertexRange Vertices(storage::View /*view*/) override { return VertexRange{VerticesIterable(&graph_->vertices())}; }
 
+  EdgeRange OutEdges(const ScanVertex &from, storage::View view, const std::vector<storage::EdgeTypeId> &edge_types,
+                     const std::optional<ScanVertex> &existing_dest, HopsLimit *hops) override {
+    const auto &vertex = std::get<VertexAccessor>(from);
+    return MemberEdges(existing_dest ? vertex.OutEdges(view, edge_types, std::get<VertexAccessor>(*existing_dest), hops)
+                                     : vertex.OutEdges(view, edge_types, hops));
+  }
+
+  EdgeRange InEdges(const ScanVertex &from, storage::View view, const std::vector<storage::EdgeTypeId> &edge_types,
+                    const std::optional<ScanVertex> &existing_dest, HopsLimit *hops) override {
+    const auto &vertex = std::get<VertexAccessor>(from);
+    return MemberEdges(existing_dest ? vertex.InEdges(view, edge_types, std::get<VertexAccessor>(*existing_dest), hops)
+                                     : vertex.InEdges(view, edge_types, hops));
+  }
+
   storage::LabelId NameToLabel(std::string_view name) override { return names_->NameToLabel(name); }
 
   const std::string &LabelToName(storage::LabelId label) const override { return names_->LabelToName(label); }
@@ -58,6 +74,20 @@ class SubgraphGraphView final : public GraphView {
   storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return names_->NameToEdgeType(name); }
 
   const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return names_->EdgeTypeToName(type); }
+
+ private:
+  // Real-vertex edges filtered to the subgraph's membership: expansion stays within
+  // the subgraph. All traversed real edges count toward hops (expanded_count), even
+  // the non-member ones dropped from the range.
+  EdgeRange MemberEdges(storage::Result<EdgeVertexAccessorResult> &&result) const {
+    auto edges = UnwrapEdges(std::move(result));
+    std::vector<EdgeAccessor> kept;
+    kept.reserve(edges.edges.size());
+    for (auto &edge : edges.edges) {
+      if (ContainsEdge(edge)) kept.push_back(std::move(edge));
+    }
+    return EdgeRange{std::move(kept), edges.expanded_count};
+  }
 };
 
 }  // namespace memgraph::query

--- a/src/query/synthetic_gid.hpp
+++ b/src/query/synthetic_gid.hpp
@@ -12,7 +12,10 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <limits>
+#include <mutex>
+#include <unordered_map>
 
 #include "storage/v2/id_types.hpp"
 
@@ -25,5 +28,26 @@ inline storage::Gid NextSyntheticGid() {
   static std::atomic<uint64_t> counter{std::numeric_limits<uint64_t>::max()};
   return storage::Gid::FromUint(counter.fetch_sub(1, std::memory_order_relaxed));
 }
+
+// Projects process-global synthetic Gids onto small, query-local external ids. A synthetic Gid is
+// unique for the life of the process, which keeps virtual-entity identity collision-free but makes
+// the user-facing id() of a virtual node depend on how many were made earlier. This mapper hands out
+// dense negative ids (-1, -2, ...) the first time it sees each Gid, so within one query the author
+// gets stable, predictable identifiers and repeated references to the same entity share an id, while
+// a new query (a new mapper) starts again at -1.
+class SyntheticIdMapper {
+ public:
+  int64_t ExternalId(storage::Gid internal) {
+    auto guard = std::lock_guard{mutex_};
+    auto [it, inserted] = mapping_.try_emplace(internal.AsUint(), next_);
+    if (inserted) --next_;
+    return it->second;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::unordered_map<uint64_t, int64_t> mapping_;
+  int64_t next_{-1};
+};
 
 }  // namespace memgraph::query

--- a/src/query/synthetic_gid.hpp
+++ b/src/query/synthetic_gid.hpp
@@ -50,4 +50,12 @@ class SyntheticIdMapper {
   int64_t next_{-1};
 };
 
+// The single synthetic-axis id fallback: a mapper maps the synthetic Gid to the query-local external
+// id id() reports; with no mapper the raw synthetic Gid is used, read as a signed int so the query and
+// wire axes agree. This is the synthetic axis only - a real (overlay) node serializes at its origin's
+// unsigned real Gid, a separate axis that does not go through here.
+inline int64_t ExternalId(storage::Gid gid, SyntheticIdMapper *mapper) {
+  return mapper != nullptr ? mapper->ExternalId(gid) : gid.AsInt();
+}
+
 }  // namespace memgraph::query

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -20,6 +20,7 @@
 #include "query/cypher_query_interpreter.hpp"
 #include "query/db_accessor.hpp"
 #include "query/frontend/ast/ast.hpp"
+#include "query/graph_view.hpp"
 #include "query/interpret/frame.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan_v2/frontend/egraph_converter.hpp"
@@ -248,6 +249,11 @@ void Trigger::Execute(DbAccessor *dba, dbms::DatabaseAccess db_acc, utils::Memor
 
   ExecutionContext ctx;
   ctx.db_accessor = dba;
+  // The read operators run over the ambient graph view; bind the real graph as
+  // the identity view, as PullPlan does for ordinary queries. Owned here for the
+  // duration of this execution (the cursor is pulled below).
+  DbAccessorGraphView identity_view{dba};
+  ctx.evaluation_context.graph_view = &identity_view;
   ctx.symbol_table = plan.symbol_table();
   ctx.evaluation_context.timestamp = QueryTimestamp();
   ctx.evaluation_context.parameters = parsed_statements_.parameters;

--- a/src/query/virtual_edge.hpp
+++ b/src/query/virtual_edge.hpp
@@ -12,6 +12,8 @@
 #pragma once
 
 #include <memory>
+#include <optional>
+#include <variant>
 
 #include <boost/functional/hash.hpp>
 
@@ -26,44 +28,44 @@
 
 namespace memgraph::query {
 
-// Endpoints are shared_ptrs into a VirtualGraph's node map — each edge owns its
-// own refcount on its two endpoint nodes, so edges escaping their source graph
-// (via collect(e), subquery returns, etc.) keep their own endpoints alive even
-// after the source VirtualGraph is destroyed.
+// A typed edge in a derived view, with its own synthetic gid. Each endpoint is either a resolved
+// virtual node or an unresolved import handle (an int64_t the user passed to virtualEdge by gid),
+// settled per endpoint so the two may be mixed. A resolved endpoint is a shared_ptr into a
+// VirtualGraph's node map, so each edge owns a refcount on its endpoint nodes and edges escaping
+// their source graph (collect(e), subquery returns) keep them alive after the graph is destroyed.
+// An unresolved endpoint is bound to a node at projection assembly, by matching its handle against
+// the node handles.
 class VirtualEdge final {
  public:
   using allocator_type = utils::Allocator<VirtualEdge>;
   using property_map = utils::pmr::unordered_map<storage::PropertyId, storage::PropertyValue>;
+  // A resolved node, or an unresolved import handle awaiting binding at projection assembly.
+  using Endpoint = std::variant<std::shared_ptr<const VirtualNode>, int64_t>;
 
-  VirtualEdge(std::shared_ptr<const VirtualNode> from, std::shared_ptr<const VirtualNode> to,
-              utils::pmr::string edge_type_name, allocator_type alloc = {})
-      : from_(std::move(from)),
-        to_(std::move(to)),
-        impl_(std::make_unique<Impl>(std::move(edge_type_name), property_map{alloc}, alloc)),
+  VirtualEdge(Endpoint from, Endpoint to, utils::pmr::string edge_type_name, allocator_type alloc = {})
+      : impl_(std::make_unique<Impl>(std::move(from), std::move(to), std::move(edge_type_name), property_map{alloc},
+                                     alloc)),
         gid_(NextSyntheticGid()) {}
 
-  // Rebound copy: preserves identity (gid, type, props) but repoints from_/to_
+  // Rebound copy: preserves identity (gid, type, props) but repoints the endpoints
   // at different VirtualNodes. Used when VirtualGraph duplicates its node map
   // under a new allocator, and by Merge when alias resolution maps the source
   // edge's endpoints to canonical nodes with different synthetic gids.
   VirtualEdge(const VirtualEdge &other, std::shared_ptr<const VirtualNode> new_from,
               std::shared_ptr<const VirtualNode> new_to, allocator_type alloc)
-      : from_(std::move(new_from)),
-        to_(std::move(new_to)),
-        impl_(std::make_unique<Impl>(other.impl_->edge_type_name, other.impl_->properties, alloc)),
+      : impl_(std::make_unique<Impl>(Endpoint{std::move(new_from)}, Endpoint{std::move(new_to)},
+                                     other.impl_->edge_type_name, other.impl_->properties, alloc)),
         gid_(other.gid_) {}
 
   VirtualEdge(const VirtualEdge &other, allocator_type alloc)
-      : from_(other.from_),
-        to_(other.to_),
-        impl_(std::make_unique<Impl>(other.impl_->edge_type_name, other.impl_->properties, alloc)),
+      : impl_(std::make_unique<Impl>(other.impl_->from, other.impl_->to, other.impl_->edge_type_name,
+                                     other.impl_->properties, alloc)),
         gid_(other.gid_) {}
 
   VirtualEdge(VirtualEdge &&other, allocator_type alloc)
-      : from_(std::move(other.from_)),
-        to_(std::move(other.to_)),
-        impl_(
-            std::make_unique<Impl>(std::move(other.impl_->edge_type_name), std::move(other.impl_->properties), alloc)),
+      : impl_(std::make_unique<Impl>(std::move(other.impl_->from), std::move(other.impl_->to),
+                                     std::move(other.impl_->edge_type_name), std::move(other.impl_->properties),
+                                     alloc)),
         gid_(other.gid_) {}
 
   VirtualEdge(const VirtualEdge &other) : VirtualEdge(other, other.impl_->edge_type_name.get_allocator()) {}
@@ -73,8 +75,6 @@ class VirtualEdge final {
   VirtualEdge &operator=(const VirtualEdge &other) {
     if (this != &other) {
       DMG_ASSERT(impl_ && other.impl_, "Assignment to/from moved-from VirtualEdge");
-      from_ = other.from_;
-      to_ = other.to_;
       *impl_ = *other.impl_;
       gid_ = other.gid_;
     }
@@ -84,19 +84,30 @@ class VirtualEdge final {
   VirtualEdge &operator=(VirtualEdge &&) = default;
   ~VirtualEdge() = default;
 
-  [[nodiscard]] auto From() const noexcept -> const VirtualNode & { return *from_; }
+  // The endpoint node, when resolved. An unresolved (handle) endpoint has no node yet; reaching for
+  // one before assembly binds it (startNode/endNode) is a query error.
+  [[nodiscard]] auto From() const -> const VirtualNode & { return EndpointNode(impl_->from); }
 
-  [[nodiscard]] auto To() const noexcept -> const VirtualNode & { return *to_; }
+  [[nodiscard]] auto To() const -> const VirtualNode & { return EndpointNode(impl_->to); }
 
-  [[nodiscard]] auto FromGid() const noexcept -> storage::Gid { return from_->Gid(); }
+  // The endpoint gid: a resolved endpoint's synthetic node gid, or the handle itself when
+  // unresolved. Bolt serialization, the VirtualGraph in/out index, and edge equality read through
+  // these, so they work for both endpoint forms.
+  [[nodiscard]] auto FromGid() const noexcept -> storage::Gid { return EndpointGid(impl_->from); }
 
-  [[nodiscard]] auto ToGid() const noexcept -> storage::Gid { return to_->Gid(); }
+  [[nodiscard]] auto ToGid() const noexcept -> storage::Gid { return EndpointGid(impl_->to); }
+
+  // The unresolved import handle on an endpoint, or none if it is a resolved node. Projection
+  // assembly reads these to bind the edge's endpoints to nodes by matching handles.
+  [[nodiscard]] auto FromHandle() const noexcept -> std::optional<int64_t> { return EndpointHandle(impl_->from); }
+
+  [[nodiscard]] auto ToHandle() const noexcept -> std::optional<int64_t> { return EndpointHandle(impl_->to); }
 
   [[nodiscard]] auto EdgeTypeName() const noexcept -> const utils::pmr::string & { return impl_->edge_type_name; }
 
   [[nodiscard]] auto Gid() const noexcept -> storage::Gid { return gid_; }
 
-  [[nodiscard]] size_t Hash() const noexcept { return HashKey(from_->Gid(), to_->Gid(), impl_->edge_type_name); }
+  [[nodiscard]] size_t Hash() const noexcept { return HashKey(FromGid(), ToGid(), impl_->edge_type_name); }
 
   [[nodiscard]] auto GetProperty(storage::PropertyId key) const -> storage::PropertyValue {
     if (const auto it = impl_->properties.find(key); it != impl_->properties.end()) return it->second;
@@ -111,11 +122,28 @@ class VirtualEdge final {
 
   // Semantic equality on (from_gid, to_gid, type). Drives dedup via unordered_set<VirtualEdge>.
   bool operator==(const VirtualEdge &other) const noexcept {
-    return from_->Gid() == other.from_->Gid() && to_->Gid() == other.to_->Gid() &&
+    return FromGid() == other.FromGid() && ToGid() == other.ToGid() &&
            impl_->edge_type_name == other.impl_->edge_type_name;
   }
 
  private:
+  static storage::Gid EndpointGid(const Endpoint &endpoint) noexcept {
+    if (const auto *node = std::get_if<std::shared_ptr<const VirtualNode>>(&endpoint)) return (*node)->Gid();
+    return storage::Gid::FromInt(std::get<int64_t>(endpoint));
+  }
+
+  static const VirtualNode &EndpointNode(const Endpoint &endpoint) {
+    if (const auto *node = std::get_if<std::shared_ptr<const VirtualNode>>(&endpoint)) return **node;
+    throw QueryRuntimeException(
+        "This virtual edge has an unresolved import-handle endpoint; bind it by assembling a "
+        "projection from node and edge lists before reaching for its endpoint nodes.");
+  }
+
+  static std::optional<int64_t> EndpointHandle(const Endpoint &endpoint) noexcept {
+    if (const auto *handle = std::get_if<int64_t>(&endpoint)) return *handle;
+    return std::nullopt;
+  }
+
   static size_t HashKey(storage::Gid from_gid, storage::Gid to_gid, std::string_view type) noexcept {
     size_t seed = 0;
     boost::hash_combine(seed, std::hash<storage::Gid>{}(from_gid));
@@ -124,19 +152,24 @@ class VirtualEdge final {
     return seed;
   }
 
+  // Endpoints live in the heap-allocated Impl, not inline, so a VirtualEdge stays small and the
+  // mgp_edge size budget that embeds it does not grow.
   struct Impl {
+    Endpoint from;
+    Endpoint to;
     utils::pmr::string edge_type_name;
     property_map properties;
 
-    Impl(const utils::pmr::string &name, const property_map &props, allocator_type alloc)
-        : edge_type_name(name, alloc), properties(props, alloc) {}
+    Impl(Endpoint from, Endpoint to, const utils::pmr::string &name, const property_map &props, allocator_type alloc)
+        : from(std::move(from)), to(std::move(to)), edge_type_name(name, alloc), properties(props, alloc) {}
 
-    Impl(utils::pmr::string &&name, property_map &&props, allocator_type alloc)
-        : edge_type_name(std::move(name), alloc), properties(std::move(props), alloc) {}
+    Impl(Endpoint from, Endpoint to, utils::pmr::string &&name, property_map &&props, allocator_type alloc)
+        : from(std::move(from)),
+          to(std::move(to)),
+          edge_type_name(std::move(name), alloc),
+          properties(std::move(props), alloc) {}
   };
 
-  std::shared_ptr<const VirtualNode> from_;
-  std::shared_ptr<const VirtualNode> to_;
   std::unique_ptr<Impl> impl_;
   storage::Gid gid_;
 };

--- a/src/query/virtual_edge.hpp
+++ b/src/query/virtual_edge.hpp
@@ -109,6 +109,14 @@ class VirtualEdge final {
 
   [[nodiscard]] size_t Hash() const noexcept { return HashKey(FromGid(), ToGid(), impl_->edge_type_name); }
 
+  // Read, in the EdgeAccessor shape, so one call site reads a property from either a real edge or a
+  // virtual edge. A virtual edge has no origin to read through, so the view is unused and the read
+  // cannot fail; the Result is returned for one uniform shape.
+  [[nodiscard]] auto GetProperty(storage::View /*view*/, storage::PropertyId key) const
+      -> storage::Result<storage::PropertyValue> {
+    return GetProperty(key);
+  }
+
   [[nodiscard]] auto GetProperty(storage::PropertyId key) const -> storage::PropertyValue {
     if (const auto it = impl_->properties.find(key); it != impl_->properties.end()) return it->second;
     return storage::PropertyValue{};

--- a/src/query/virtual_graph.cpp
+++ b/src/query/virtual_graph.cpp
@@ -184,11 +184,10 @@ constexpr auto kPropertyPolicy = "propertyPolicy";
 // 'overlay'-bound keys, plus the provenance ref. Role-independent - a projection's source and target
 // nodes share one instance - so per-role labels and property overrides are applied per node in
 // BuildDerivedNode. A binding other than hidden/overlay/origin is a construction error.
-std::shared_ptr<const ProjectionSchema> MakeProjectionSchema(const TypedValue::TMap &options, int64_t projection_ref,
-                                                             DbAccessor *db_accessor,
-                                                             VirtualNode::allocator_type alloc) {
-  ProjectionSchema::key_set hidden{alloc};
-  ProjectionSchema::key_set overlay_bound{alloc};
+std::shared_ptr<const PropertyBinding> MakePropertyBinding(const TypedValue::TMap &options, int64_t projection_ref,
+                                                           DbAccessor *db_accessor, VirtualNode::allocator_type alloc) {
+  PropertyBinding::key_set hidden{alloc};
+  PropertyBinding::key_set overlay_bound{alloc};
   if (const auto policy_it = options.find(kPropertyPolicy); policy_it != options.end()) {
     if (policy_it->second.type() != TypedValue::Type::Map) {
       throw QueryRuntimeException("derive() option '{}' must be a map of property names to bindings.", kPropertyPolicy);
@@ -210,14 +209,14 @@ std::shared_ptr<const ProjectionSchema> MakeProjectionSchema(const TypedValue::T
       }
     }
   }
-  return std::make_shared<const ProjectionSchema>(std::move(hidden), std::move(overlay_bound), projection_ref);
+  return std::make_shared<const PropertyBinding>(std::move(hidden), std::move(overlay_bound), projection_ref);
 }
 
 // Builds one overlay node over a real vertex: its label override (or the origin's labels) and its
 // per-node overlay property values. The static binding + ref come from the shared `schema`. A key
 // the policy bound 'origin' may not also carry an overlay value here - a construction conflict.
 VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key, std::string_view props_key,
-                             const TypedValue::TMap &options, const std::shared_ptr<const ProjectionSchema> &schema,
+                             const TypedValue::TMap &options, const std::shared_ptr<const PropertyBinding> &schema,
                              DbAccessor *db_accessor, VirtualNode::allocator_type alloc) {
   VirtualNode::label_list labels{alloc};
   if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
@@ -292,7 +291,7 @@ void AddPathToProjection(const TypedValue &path_value, const TypedValue &options
   const auto alloc = projected_graph.get_allocator();
   // The static binding + ref are role-independent, so build the schema once and share it across
   // both endpoints' overlay nodes (and, via the dedup, across rows).
-  const auto schema = MakeProjectionSchema(options, projection_ref, db_accessor, alloc);
+  const auto schema = MakePropertyBinding(options, projection_ref, db_accessor, alloc);
   auto canonical = [&](const VertexAccessor &real_vertex,
                        std::string_view labels_key,
                        std::string_view props_key) -> std::shared_ptr<const VirtualNode> {

--- a/src/query/virtual_graph.cpp
+++ b/src/query/virtual_graph.cpp
@@ -180,7 +180,7 @@ void ApplyPropertyMap(const TypedValue::TMap &options, std::string_view key, DbA
 
 constexpr auto kPropertyPolicy = "propertyPolicy";
 
-// Builds a derive()'s shared, static schema from its propertyPolicy: the hidden keys and the
+// Builds a derive()'s shared, static binding from its propertyPolicy: the hidden keys and the
 // 'overlay'-bound keys, plus the provenance ref. Role-independent - a projection's source and target
 // nodes share one instance - so per-role labels and property overrides are applied per node in
 // BuildDerivedNode. A binding other than hidden/overlay/origin is a construction error.
@@ -213,10 +213,10 @@ std::shared_ptr<const PropertyBinding> MakePropertyBinding(const TypedValue::TMa
 }
 
 // Builds one overlay node over a real vertex: its label override (or the origin's labels) and its
-// per-node overlay property values. The static binding + ref come from the shared `schema`. A key
+// per-node overlay property values. The static binding + ref come from the shared `binding`. A key
 // the policy bound 'origin' may not also carry an overlay value here - a construction conflict.
 VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key, std::string_view props_key,
-                             const TypedValue::TMap &options, const std::shared_ptr<const PropertyBinding> &schema,
+                             const TypedValue::TMap &options, const std::shared_ptr<const PropertyBinding> &binding,
                              DbAccessor *db_accessor, VirtualNode::allocator_type alloc) {
   VirtualNode::label_list labels{alloc};
   if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
@@ -242,7 +242,7 @@ VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view
   // The overlay holds only the explicitly-overridden properties; every other property is read
   // through the origin lazily, so a projection never copies the origin's properties (e.g. vector
   // embeddings) unless they are actually read. These override keys carry a value, so they are
-  // overlay-bound through the overlay store itself - IsOverlayBound checks it before the schema.
+  // overlay-bound through the overlay store itself - IsOverlayBound checks it before the binding.
   VirtualNode::property_map overlay{alloc};
   if (options.find(props_key) != options.end()) {
     ApplyPropertyMap(options, props_key, db_accessor, [&](storage::PropertyId id, storage::PropertyValue pv) {
@@ -254,15 +254,15 @@ VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view
   // overlaid here - rejected at construction rather than resolved silently.
   if (const auto policy_it = options.find(kPropertyPolicy);
       policy_it != options.end() && policy_it->second.type() == TypedValue::Type::Map) {
-    for (const auto &[name, binding] : policy_it->second.ValueMap()) {
-      if (binding.type() == TypedValue::Type::String && binding.ValueString() == "origin" &&
+    for (const auto &[name, policy] : policy_it->second.ValueMap()) {
+      if (policy.type() == TypedValue::Type::String && policy.ValueString() == "origin" &&
           overlay.contains(db_accessor->NameToProperty(name))) {
         throw QueryRuntimeException("derive() property '{}' is both overlaid and bound to origin.", name);
       }
     }
   }
 
-  return {std::move(labels), std::move(overlay), alloc, std::optional<VertexAccessor>{real_vertex}, schema};
+  return {std::move(labels), std::move(overlay), alloc, std::optional<VertexAccessor>{real_vertex}, binding};
 }
 
 }  // namespace
@@ -289,9 +289,9 @@ void AddPathToProjection(const TypedValue &path_value, const TypedValue &options
   if (path_vertices.empty()) return;
 
   const auto alloc = projected_graph.get_allocator();
-  // The static binding + ref are role-independent, so build the schema once and share it across
+  // The static binding + ref are role-independent, so build the binding once and share it across
   // both endpoints' overlay nodes (and, via the dedup, across rows).
-  const auto schema = MakePropertyBinding(options, projection_ref, db_accessor, alloc);
+  const auto binding = MakePropertyBinding(options, projection_ref, db_accessor, alloc);
   auto canonical = [&](const VertexAccessor &real_vertex,
                        std::string_view labels_key,
                        std::string_view props_key) -> std::shared_ptr<const VirtualNode> {
@@ -299,7 +299,7 @@ void AddPathToProjection(const TypedValue &path_value, const TypedValue &options
     if (const auto it = dedup.find(real_gid); it != dedup.end()) {
       return projected_graph.FindNode(it->second);
     }
-    auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, schema, db_accessor, alloc);
+    auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, binding, db_accessor, alloc);
     const auto synth_gid = new_node.Gid();
     dedup[real_gid] = synth_gid;
     projected_graph.InsertNode(std::move(new_node));

--- a/src/query/virtual_graph.cpp
+++ b/src/query/virtual_graph.cpp
@@ -11,9 +11,14 @@
 
 #include "query/virtual_graph.hpp"
 
+#include <algorithm>
+#include <memory>
 #include <optional>
+#include <string_view>
 
+#include "query/db_accessor.hpp"
 #include "query/exceptions.hpp"
+#include "query/typed_value.hpp"
 #include "utils/logging.hpp"
 #include "utils/pmr/unordered_map.hpp"
 
@@ -154,6 +159,187 @@ VirtualGraph AssembleVirtualGraph(std::span<const VirtualNode> nodes, std::span<
     graph.InsertEdgeIfNew(VirtualEdge(edge, std::move(from), std::move(to), edge_alloc));
   }
   return graph;
+}
+
+namespace {
+
+// Applies a derive() option that is a {propertyName: value} map, resolving each name to an id and
+// calling setter(id, value). Absent option or null db_accessor is a no-op; a non-map option errors.
+template <class Setter>
+void ApplyPropertyMap(const TypedValue::TMap &options, std::string_view key, DbAccessor *db_accessor, Setter &&setter) {
+  const auto it = options.find(key);
+  if (it == options.end() || !db_accessor) return;
+  if (it->second.type() != TypedValue::Type::Map) {
+    throw QueryRuntimeException("derive() option '{}' must be a map of property names to values.", key);
+  }
+  auto *name_id_mapper = db_accessor->GetStorageAccessor()->GetNameIdMapper();
+  for (const auto &[name, val] : it->second.ValueMap()) {
+    setter(db_accessor->NameToProperty(name), val.ToPropertyValue(name_id_mapper));
+  }
+}
+
+// Builds one overlay node over a real vertex from the derive() options: its label override (or the
+// origin's labels), its overlay property values, and the static per-property binding (hidden /
+// overlay / origin), rejecting a key bound both to origin and overlaid.
+VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key, std::string_view props_key,
+                             const TypedValue::TMap &options, int64_t projection_ref, DbAccessor *db_accessor,
+                             VirtualNode::allocator_type alloc) {
+  static constexpr auto kPropertyPolicy = "propertyPolicy";
+
+  VirtualNode::label_list labels{alloc};
+  if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
+    if (labels_it->second.type() != TypedValue::Type::List) {
+      throw QueryRuntimeException("derive() option '{}' must be a list of label strings.", labels_key);
+    }
+    for (const auto &label : labels_it->second.ValueList()) {
+      if (label.type() != TypedValue::Type::String) {
+        throw QueryRuntimeException("derive() option '{}' must contain only strings.", labels_key);
+      }
+      labels.emplace_back(label.ValueString());
+    }
+  } else {
+    // no labels option -> inherit every label from the original vertex
+    auto maybe_labels = real_vertex.Labels(storage::View::NEW);
+    if (!maybe_labels) throw QueryRuntimeException("derive() could not read labels of a path vertex.");
+    for (const auto label_id : *maybe_labels) {
+      const auto &name = db_accessor->LabelToName(label_id);
+      labels.emplace_back(name.data(), name.size());
+    }
+  }
+
+  // The overlay holds only the explicitly-overridden properties; every other property is read
+  // through the origin lazily, so a projection never copies the origin's properties (e.g. vector
+  // embeddings) unless they are actually read.
+  // overlay_bound names every key whose read and write target this node's overlay: the
+  // construction-time override keys below and the 'overlay' propertyPolicy bindings. Every other
+  // key on the resulting overlay node is origin-bound, so a write to it persists to the origin.
+  VirtualNode::property_map overlay{alloc};
+  VirtualNode::key_set overlay_bound{alloc};
+  if (options.find(props_key) != options.end()) {
+    ApplyPropertyMap(options, props_key, db_accessor, [&](storage::PropertyId id, storage::PropertyValue pv) {
+      overlay.insert_or_assign(id, std::move(pv));
+      overlay_bound.push_back(id);
+    });
+  }
+
+  // The static property policy: per property, 'hidden' makes it invisible, 'origin' binds it to
+  // the origin (read-through), 'overlay' allows an overlay value to shadow. Read source and write
+  // target are coupled, so a key bound to 'origin' may not also be overlaid - that is a conflict
+  // rejected at construction rather than resolved silently.
+  VirtualNode::hidden_keys hidden{alloc};
+  if (const auto policy_it = options.find(kPropertyPolicy); policy_it != options.end()) {
+    if (policy_it->second.type() != TypedValue::Type::Map) {
+      throw QueryRuntimeException("derive() option '{}' must be a map of property names to bindings.", kPropertyPolicy);
+    }
+    for (const auto &[name, binding] : policy_it->second.ValueMap()) {
+      if (binding.type() != TypedValue::Type::String) {
+        throw QueryRuntimeException(
+            "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
+      }
+      const auto id = db_accessor->NameToProperty(name);
+      const auto &value = binding.ValueString();
+      if (value == "hidden") {
+        hidden.push_back(id);
+      } else if (value == "origin") {
+        if (overlay.contains(id)) {
+          throw QueryRuntimeException("derive() property '{}' is both overlaid and bound to origin.", name);
+        }
+      } else if (value == "overlay") {
+        overlay_bound.push_back(id);
+      } else {
+        throw QueryRuntimeException(
+            "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
+      }
+    }
+  }
+
+  return {std::move(labels),
+          std::move(overlay),
+          alloc,
+          std::optional<VertexAccessor>{real_vertex},
+          std::move(hidden),
+          std::move(overlay_bound),
+          projection_ref};
+}
+
+}  // namespace
+
+void AddPathToProjection(const TypedValue &path_value, const TypedValue &options_value, VirtualGraph &projected_graph,
+                         DerivedNodeDedup &dedup, int64_t projection_ref, DbAccessor *db_accessor) {
+  static constexpr auto kVirtualEdgeType = "virtualEdgeType";
+  static constexpr auto kSourceLabels = "sourceNodeLabels";
+  static constexpr auto kSourceProperties = "sourceNodeProperties";
+  static constexpr auto kTargetLabels = "targetNodeLabels";
+  static constexpr auto kTargetProperties = "targetNodeProperties";
+  static constexpr auto kRelationshipProperties = "relationshipProperties";
+  static constexpr auto kUndirectedEdgeTypes = "undirectedEdgeTypes";
+
+  if (path_value.type() != TypedValue::Type::Path) {
+    throw QueryRuntimeException("derive() requires a path as argument 1.");
+  }
+  if (options_value.type() != TypedValue::Type::Map) {
+    throw QueryRuntimeException("derive() argument 2 must be a map of options (e.g. {virtualEdgeType: 'TYPE'}).");
+  }
+  const auto &options = options_value.ValueMap();
+
+  const auto &path_vertices = path_value.ValuePath().vertices();
+  if (path_vertices.empty()) return;
+
+  const auto alloc = projected_graph.get_allocator();
+  auto canonical = [&](const VertexAccessor &real_vertex,
+                       std::string_view labels_key,
+                       std::string_view props_key) -> std::shared_ptr<const VirtualNode> {
+    const auto real_gid = real_vertex.Gid();
+    if (const auto it = dedup.find(real_gid); it != dedup.end()) {
+      return projected_graph.FindNode(it->second);
+    }
+    auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, projection_ref, db_accessor, alloc);
+    const auto synth_gid = new_node.Gid();
+    dedup[real_gid] = synth_gid;
+    projected_graph.InsertNode(std::move(new_node));
+    return projected_graph.FindNode(synth_gid);
+  };
+
+  auto stored_from = canonical(path_vertices.front(), kSourceLabels, kSourceProperties);
+
+  if (path_vertices.size() < 2) return;
+
+  // The path has edges, so a virtual edge type is now required. It is not needed to project a
+  // single-vertex path's overlay node, so a bare derive(p, {}) over one node is allowed.
+  const auto type_it = options.find(kVirtualEdgeType);
+  if (type_it == options.end() || type_it->second.type() != TypedValue::Type::String) {
+    throw QueryRuntimeException("derive() requires a 'virtualEdgeType' string option when the path has edges.");
+  }
+  const auto &type_name = type_it->second.ValueString();
+  const bool type_is_undirected = [&] {
+    const auto it = options.find(kUndirectedEdgeTypes);
+    if (it == options.end()) return false;
+    if (it->second.type() != TypedValue::Type::List) {
+      throw QueryRuntimeException("derive() option '{}' must be a list of edge-type strings.", kUndirectedEdgeTypes);
+    }
+    const auto &list = it->second.ValueList();
+    if (std::ranges::any_of(list, [](const auto &e) { return e.type() != TypedValue::Type::String; })) {
+      throw QueryRuntimeException("derive() option '{}' entries must be strings.", kUndirectedEdgeTypes);
+    }
+    return std::ranges::any_of(list,
+                               [&](const auto &e) { return e.ValueString() == "*" || e.ValueString() == type_name; });
+  }();
+
+  auto stored_to = canonical(path_vertices.back(), kTargetLabels, kTargetProperties);
+
+  auto build_edge = [&](std::shared_ptr<const VirtualNode> from, std::shared_ptr<const VirtualNode> to) {
+    VirtualEdge e(std::move(from), std::move(to), utils::pmr::string{type_name, alloc}, alloc);
+    ApplyPropertyMap(
+        options, kRelationshipProperties, db_accessor, [&](storage::PropertyId id, storage::PropertyValue pv) {
+          e.SetProperty(id, std::move(pv));
+        });
+    return e;
+  };
+
+  projected_graph.InsertEdgeIfNew(build_edge(stored_from, stored_to));
+  if (type_is_undirected && stored_from.get() != stored_to.get()) {
+    projected_graph.InsertEdgeIfNew(build_edge(std::move(stored_to), std::move(stored_from)));
+  }
 }
 
 }  // namespace memgraph::query

--- a/src/query/virtual_graph.cpp
+++ b/src/query/virtual_graph.cpp
@@ -11,7 +11,11 @@
 
 #include "query/virtual_graph.hpp"
 
+#include <optional>
+
+#include "query/exceptions.hpp"
 #include "utils/logging.hpp"
+#include "utils/pmr/unordered_map.hpp"
 
 namespace memgraph::query {
 
@@ -110,6 +114,46 @@ void VirtualGraph::Merge(const VirtualGraph &other, const VirtualGraphAliasMap &
     DMG_ASSERT(from_shared && to_shared, "merge alias resolution failed");
     InsertEdgeIfNew(VirtualEdge(edge, std::move(from_shared), std::move(to_shared), edge_alloc));
   }
+}
+
+VirtualGraph AssembleVirtualGraph(std::span<const VirtualNode> nodes, std::span<const VirtualEdge> edges,
+                                  DanglingEdgePolicy policy, VirtualGraph::allocator_type alloc) {
+  VirtualGraph graph(alloc);
+
+  // The synthetic gid of the node carrying each import handle, so a handle endpoint binds to a node.
+  utils::pmr::unordered_map<int64_t, storage::Gid> handle_to_gid(alloc.resource());
+  for (const auto &node : nodes) {
+    const auto &inserted = graph.InsertNode(node);
+    if (const auto handle = inserted.Handle()) {
+      const auto [it, added] = handle_to_gid.try_emplace(*handle, inserted.Gid());
+      if (!added && it->second != inserted.Gid()) {
+        throw QueryRuntimeException("Duplicate import handle {} in the virtualGraph() node list.", *handle);
+      }
+    }
+  }
+
+  // Bind an endpoint to a listed node: a handle endpoint by matching handle, a resolved endpoint by
+  // its synthetic gid. Returns nullptr when no listed node matches (the endpoint is dangling).
+  const auto bind = [&](std::optional<int64_t> handle, storage::Gid gid) -> std::shared_ptr<const VirtualNode> {
+    if (handle) {
+      const auto it = handle_to_gid.find(*handle);
+      if (it == handle_to_gid.end()) return nullptr;
+      return graph.FindNode(it->second);
+    }
+    return graph.FindNode(gid);
+  };
+
+  const VirtualEdge::allocator_type edge_alloc(alloc.resource());
+  for (const auto &edge : edges) {
+    auto from = bind(edge.FromHandle(), edge.FromGid());
+    auto to = bind(edge.ToHandle(), edge.ToGid());
+    if (!from || !to) {
+      if (policy == DanglingEdgePolicy::kDrop) continue;
+      throw QueryRuntimeException("virtualGraph() edge references a node absent from the node list (dangling edge).");
+    }
+    graph.InsertEdgeIfNew(VirtualEdge(edge, std::move(from), std::move(to), edge_alloc));
+  }
+  return graph;
 }
 
 }  // namespace memgraph::query

--- a/src/query/virtual_graph.cpp
+++ b/src/query/virtual_graph.cpp
@@ -178,14 +178,47 @@ void ApplyPropertyMap(const TypedValue::TMap &options, std::string_view key, DbA
   }
 }
 
-// Builds one overlay node over a real vertex from the derive() options: its label override (or the
-// origin's labels), its overlay property values, and the static per-property binding (hidden /
-// overlay / origin), rejecting a key bound both to origin and overlaid.
-VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key, std::string_view props_key,
-                             const TypedValue::TMap &options, int64_t projection_ref, DbAccessor *db_accessor,
-                             VirtualNode::allocator_type alloc) {
-  static constexpr auto kPropertyPolicy = "propertyPolicy";
+constexpr auto kPropertyPolicy = "propertyPolicy";
 
+// Builds a derive()'s shared, static schema from its propertyPolicy: the hidden keys and the
+// 'overlay'-bound keys, plus the provenance ref. Role-independent - a projection's source and target
+// nodes share one instance - so per-role labels and property overrides are applied per node in
+// BuildDerivedNode. A binding other than hidden/overlay/origin is a construction error.
+std::shared_ptr<const ProjectionSchema> MakeProjectionSchema(const TypedValue::TMap &options, int64_t projection_ref,
+                                                             DbAccessor *db_accessor,
+                                                             VirtualNode::allocator_type alloc) {
+  ProjectionSchema::key_set hidden{alloc};
+  ProjectionSchema::key_set overlay_bound{alloc};
+  if (const auto policy_it = options.find(kPropertyPolicy); policy_it != options.end()) {
+    if (policy_it->second.type() != TypedValue::Type::Map) {
+      throw QueryRuntimeException("derive() option '{}' must be a map of property names to bindings.", kPropertyPolicy);
+    }
+    for (const auto &[name, binding] : policy_it->second.ValueMap()) {
+      if (binding.type() != TypedValue::Type::String) {
+        throw QueryRuntimeException(
+            "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
+      }
+      const auto id = db_accessor->NameToProperty(name);
+      const auto &value = binding.ValueString();
+      if (value == "hidden") {
+        hidden.push_back(id);
+      } else if (value == "overlay") {
+        overlay_bound.push_back(id);
+      } else if (value != "origin") {
+        throw QueryRuntimeException(
+            "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
+      }
+    }
+  }
+  return std::make_shared<const ProjectionSchema>(std::move(hidden), std::move(overlay_bound), projection_ref);
+}
+
+// Builds one overlay node over a real vertex: its label override (or the origin's labels) and its
+// per-node overlay property values. The static binding + ref come from the shared `schema`. A key
+// the policy bound 'origin' may not also carry an overlay value here - a construction conflict.
+VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key, std::string_view props_key,
+                             const TypedValue::TMap &options, const std::shared_ptr<const ProjectionSchema> &schema,
+                             DbAccessor *db_accessor, VirtualNode::allocator_type alloc) {
   VirtualNode::label_list labels{alloc};
   if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
     if (labels_it->second.type() != TypedValue::Type::List) {
@@ -209,57 +242,28 @@ VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view
 
   // The overlay holds only the explicitly-overridden properties; every other property is read
   // through the origin lazily, so a projection never copies the origin's properties (e.g. vector
-  // embeddings) unless they are actually read.
-  // overlay_bound names every key whose read and write target this node's overlay: the
-  // construction-time override keys below and the 'overlay' propertyPolicy bindings. Every other
-  // key on the resulting overlay node is origin-bound, so a write to it persists to the origin.
+  // embeddings) unless they are actually read. These override keys carry a value, so they are
+  // overlay-bound through the overlay store itself - IsOverlayBound checks it before the schema.
   VirtualNode::property_map overlay{alloc};
-  VirtualNode::key_set overlay_bound{alloc};
   if (options.find(props_key) != options.end()) {
     ApplyPropertyMap(options, props_key, db_accessor, [&](storage::PropertyId id, storage::PropertyValue pv) {
-      overlay.insert_or_assign(id, std::move(pv));
-      overlay_bound.push_back(id);
+      overlay.insert_or_assign(id, pv);
     });
   }
 
-  // The static property policy: per property, 'hidden' makes it invisible, 'origin' binds it to
-  // the origin (read-through), 'overlay' allows an overlay value to shadow. Read source and write
-  // target are coupled, so a key bound to 'origin' may not also be overlaid - that is a conflict
-  // rejected at construction rather than resolved silently.
-  VirtualNode::hidden_keys hidden{alloc};
-  if (const auto policy_it = options.find(kPropertyPolicy); policy_it != options.end()) {
-    if (policy_it->second.type() != TypedValue::Type::Map) {
-      throw QueryRuntimeException("derive() option '{}' must be a map of property names to bindings.", kPropertyPolicy);
-    }
+  // Read source and write target are coupled, so a key the policy bound 'origin' may not also be
+  // overlaid here - rejected at construction rather than resolved silently.
+  if (const auto policy_it = options.find(kPropertyPolicy);
+      policy_it != options.end() && policy_it->second.type() == TypedValue::Type::Map) {
     for (const auto &[name, binding] : policy_it->second.ValueMap()) {
-      if (binding.type() != TypedValue::Type::String) {
-        throw QueryRuntimeException(
-            "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
-      }
-      const auto id = db_accessor->NameToProperty(name);
-      const auto &value = binding.ValueString();
-      if (value == "hidden") {
-        hidden.push_back(id);
-      } else if (value == "origin") {
-        if (overlay.contains(id)) {
-          throw QueryRuntimeException("derive() property '{}' is both overlaid and bound to origin.", name);
-        }
-      } else if (value == "overlay") {
-        overlay_bound.push_back(id);
-      } else {
-        throw QueryRuntimeException(
-            "derive() '{}' binding for '{}' must be 'origin', 'overlay', or 'hidden'.", kPropertyPolicy, name);
+      if (binding.type() == TypedValue::Type::String && binding.ValueString() == "origin" &&
+          overlay.contains(db_accessor->NameToProperty(name))) {
+        throw QueryRuntimeException("derive() property '{}' is both overlaid and bound to origin.", name);
       }
     }
   }
 
-  return {std::move(labels),
-          std::move(overlay),
-          alloc,
-          std::optional<VertexAccessor>{real_vertex},
-          std::move(hidden),
-          std::move(overlay_bound),
-          projection_ref};
+  return {std::move(labels), std::move(overlay), alloc, std::optional<VertexAccessor>{real_vertex}, schema};
 }
 
 }  // namespace
@@ -286,6 +290,9 @@ void AddPathToProjection(const TypedValue &path_value, const TypedValue &options
   if (path_vertices.empty()) return;
 
   const auto alloc = projected_graph.get_allocator();
+  // The static binding + ref are role-independent, so build the schema once and share it across
+  // both endpoints' overlay nodes (and, via the dedup, across rows).
+  const auto schema = MakeProjectionSchema(options, projection_ref, db_accessor, alloc);
   auto canonical = [&](const VertexAccessor &real_vertex,
                        std::string_view labels_key,
                        std::string_view props_key) -> std::shared_ptr<const VirtualNode> {
@@ -293,7 +300,7 @@ void AddPathToProjection(const TypedValue &path_value, const TypedValue &options
     if (const auto it = dedup.find(real_gid); it != dedup.end()) {
       return projected_graph.FindNode(it->second);
     }
-    auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, projection_ref, db_accessor, alloc);
+    auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, schema, db_accessor, alloc);
     const auto synth_gid = new_node.Gid();
     dedup[real_gid] = synth_gid;
     projected_graph.InsertNode(std::move(new_node));

--- a/src/query/virtual_graph.hpp
+++ b/src/query/virtual_graph.hpp
@@ -23,6 +23,9 @@
 
 namespace memgraph::query {
 
+class TypedValue;
+class DbAccessor;
+
 // Maps synthetic gids in one VirtualGraph (the "aliased" one) to the synthetic
 // gid of the canonical VirtualNode in another VirtualGraph.
 using VirtualGraphAliasMap = utils::pmr::unordered_map<storage::Gid, storage::Gid>;
@@ -88,5 +91,20 @@ enum class DanglingEdgePolicy { kError, kDrop };
 // from/to/type). A dangling edge aborts the assembly under kError or is omitted under kDrop.
 VirtualGraph AssembleVirtualGraph(std::span<const VirtualNode> nodes, std::span<const VirtualEdge> edges,
                                   DanglingEdgePolicy policy, VirtualGraph::allocator_type alloc);
+
+// The real-vertex-gid -> canonical-synthetic-gid map derive()/project() assembly uses to deduplicate
+// a path endpoint that recurs across rows: the first occurrence builds an overlay node, later ones
+// reuse it. Owned by the aggregation slot and threaded into AddPathToProjection.
+using DerivedNodeDedup = utils::pmr::unordered_map<storage::Gid, storage::Gid>;
+
+// Collapse a derive() path to a single synthetic overlay edge between its endpoints (intermediate
+// vertices are ignored by design), adding the endpoint overlay nodes and the edge to
+// projected_graph. Each endpoint reads through to its real origin lazily; options carries the
+// label / property / edge-type / binding configuration. dedup canonicalizes endpoints that recur
+// across rows; projection_ref is the schema reference stamped on the overlay nodes (or
+// VirtualNode::kNoProjectionRef). This is the aggregation counterpart to AssembleVirtualGraph's list
+// assembly - the Aggregate operator drives it per row - so all VirtualGraph construction lives here.
+void AddPathToProjection(const TypedValue &path_value, const TypedValue &options_value, VirtualGraph &projected_graph,
+                         DerivedNodeDedup &dedup, int64_t projection_ref, DbAccessor *db_accessor);
 
 }  // namespace memgraph::query

--- a/src/query/virtual_graph.hpp
+++ b/src/query/virtual_graph.hpp
@@ -77,4 +77,16 @@ class VirtualGraph final {
   adjacency_map in_index_;
 };
 
+// What to do with a dangling edge - one whose endpoint resolves to no node in the node list - when
+// assembling a projection from lists.
+enum class DanglingEdgePolicy { kError, kDrop };
+
+// Assemble a projection from lists of synthetic nodes and edges. Nodes are inserted (deduplicated by
+// synthetic gid) and indexed by their import handle; a duplicate handle is an error. Each edge's
+// endpoints are bound to a listed node - an unresolved (handle) endpoint by matching handle, a
+// resolved endpoint by synthetic-gid membership - then the edge is inserted (deduplicated by
+// from/to/type). A dangling edge aborts the assembly under kError or is omitted under kDrop.
+VirtualGraph AssembleVirtualGraph(std::span<const VirtualNode> nodes, std::span<const VirtualEdge> edges,
+                                  DanglingEdgePolicy policy, VirtualGraph::allocator_type alloc);
+
 }  // namespace memgraph::query

--- a/src/query/virtual_graph_view.hpp
+++ b/src/query/virtual_graph_view.hpp
@@ -11,9 +11,12 @@
 
 #pragma once
 
+#include <algorithm>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "query/db_accessor.hpp"
 #include "query/graph_view.hpp"
@@ -29,10 +32,11 @@ namespace memgraph::query {
 // mints no label/property/edge-type ids of its own.
 //
 // It is the projection GraphView: a scan over it yields the projection's nodes
-// as the common scan element, so the read operators run over a projection the
-// same way they run over the real graph. Edge expansion stays on the element, so
-// OutEdges/InEdges are exposed here for the projection's expand surface rather
-// than on GraphView.
+// as the common scan element, and OutEdges/InEdges expand a node's edges, so the
+// read operators run over a projection the same way they run over the real graph.
+// A real vertex reaching this view (an outer-scope vertex used inside a USE block)
+// is not a projection node and has no edges here. The span-returning OutEdges/
+// InEdges below remain for the mgp procedure path.
 class VirtualGraphView final : public GraphView {
   VirtualGraph *graph_;
   DbAccessor *names_;
@@ -52,6 +56,22 @@ class VirtualGraphView final : public GraphView {
 
   std::span<const VirtualEdge *const> InEdges(storage::Gid node) const { return graph_->InEdges(node); }
 
+  EdgeRange OutEdges(const ScanVertex &from, storage::View /*view*/, const std::vector<storage::EdgeTypeId> &edge_types,
+                     const std::optional<ScanVertex> &existing_dest, HopsLimit * /*hops*/) override {
+    const auto *node = std::get_if<VirtualNode>(&from);
+    if (node == nullptr)
+      return EdgeRange{std::vector<const VirtualEdge *>{}, 0};  // a real vertex is no projection node
+    return FilterEdges(graph_->OutEdges(node->Gid()), edge_types, existing_dest, /*neighbor_is_to=*/true);
+  }
+
+  EdgeRange InEdges(const ScanVertex &from, storage::View /*view*/, const std::vector<storage::EdgeTypeId> &edge_types,
+                    const std::optional<ScanVertex> &existing_dest, HopsLimit * /*hops*/) override {
+    const auto *node = std::get_if<VirtualNode>(&from);
+    if (node == nullptr)
+      return EdgeRange{std::vector<const VirtualEdge *>{}, 0};  // a real vertex is no projection node
+    return FilterEdges(graph_->InEdges(node->Gid()), edge_types, existing_dest, /*neighbor_is_to=*/false);
+  }
+
   storage::LabelId NameToLabel(std::string_view name) override { return names_->NameToLabel(name); }
 
   const std::string &LabelToName(storage::LabelId label) const override { return names_->LabelToName(label); }
@@ -63,6 +83,39 @@ class VirtualGraphView final : public GraphView {
   storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return names_->NameToEdgeType(name); }
 
   const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return names_->EdgeTypeToName(type); }
+
+ private:
+  // Keep the projection edges whose type is in edge_types (empty = any) and, when a
+  // destination endpoint is already bound, only the edge reaching it. neighbor_is_to
+  // picks the far end for the current direction: the target for an out-edge, the
+  // source for an in-edge. Projection edges carry type names, so the requested type
+  // ids are resolved to names once per call.
+  EdgeRange FilterEdges(std::span<const VirtualEdge *const> edges, const std::vector<storage::EdgeTypeId> &edge_types,
+                        const std::optional<ScanVertex> &existing_dest, bool neighbor_is_to) const {
+    std::vector<std::string_view> allowed;
+    allowed.reserve(edge_types.size());
+    for (const auto type : edge_types) allowed.emplace_back(names_->EdgeTypeToName(type));
+
+    std::optional<storage::Gid> dest_gid;
+    if (existing_dest) dest_gid = std::get<VirtualNode>(*existing_dest).Gid();
+
+    // Every incident edge is examined; the count is taken before filtering so a
+    // projection accounts the same traversal as the real graph (EdgeRange comment).
+    const auto examined = static_cast<int64_t>(edges.size());
+    std::vector<const VirtualEdge *> kept;
+    kept.reserve(edges.size());
+    for (const auto *edge : edges) {
+      if (!allowed.empty() && std::ranges::find(allowed, std::string_view{edge->EdgeTypeName()}) == allowed.end()) {
+        continue;
+      }
+      if (dest_gid) {
+        const auto neighbor = neighbor_is_to ? edge->ToGid() : edge->FromGid();
+        if (neighbor != *dest_gid) continue;
+      }
+      kept.push_back(edge);
+    }
+    return EdgeRange{std::move(kept), examined};
+  }
 };
 
 }  // namespace memgraph::query

--- a/src/query/virtual_graph_view.hpp
+++ b/src/query/virtual_graph_view.hpp
@@ -1,0 +1,68 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "query/db_accessor.hpp"
+#include "query/graph_view.hpp"
+#include "query/virtual_edge.hpp"
+#include "query/virtual_graph.hpp"
+#include "storage/v2/id_types.hpp"
+
+namespace memgraph::query {
+
+// The projection seen as a graph to scan: iterate its nodes, iterate a node's
+// out-edges and in-edges, and map names to/from ids. Topology comes from the
+// VirtualGraph; names share the real accessor's namespace, since a projection
+// mints no label/property/edge-type ids of its own.
+//
+// It is the projection GraphView: a scan over it yields the projection's nodes
+// as the common scan element, so the read operators run over a projection the
+// same way they run over the real graph. Edge expansion stays on the element, so
+// OutEdges/InEdges are exposed here for the projection's expand surface rather
+// than on GraphView.
+class VirtualGraphView final : public GraphView {
+  VirtualGraph *graph_;
+  DbAccessor *names_;
+
+ public:
+  VirtualGraphView(VirtualGraph *graph, DbAccessor *names) : graph_(graph), names_(names) {}
+
+  VirtualNodeRange Nodes() const { return VirtualNodeRange{graph_->nodes()}; }
+
+  // The borrowed projection, for wrapping in a VirtualGraphDbAccessor when this
+  // view is the ambient graph of a procedure call.
+  [[nodiscard]] VirtualGraph *graph() const { return graph_; }
+
+  VertexRange Vertices(storage::View /*view*/) override { return VertexRange{Nodes()}; }
+
+  std::span<const VirtualEdge *const> OutEdges(storage::Gid node) const { return graph_->OutEdges(node); }
+
+  std::span<const VirtualEdge *const> InEdges(storage::Gid node) const { return graph_->InEdges(node); }
+
+  storage::LabelId NameToLabel(std::string_view name) override { return names_->NameToLabel(name); }
+
+  const std::string &LabelToName(storage::LabelId label) const override { return names_->LabelToName(label); }
+
+  storage::PropertyId NameToProperty(std::string_view name) override { return names_->NameToProperty(name); }
+
+  const std::string &PropertyToName(storage::PropertyId prop) const override { return names_->PropertyToName(prop); }
+
+  storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return names_->NameToEdgeType(name); }
+
+  const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return names_->EdgeTypeToName(type); }
+};
+
+}  // namespace memgraph::query

--- a/src/query/virtual_graph_view.hpp
+++ b/src/query/virtual_graph_view.hpp
@@ -39,10 +39,9 @@ namespace memgraph::query {
 // InEdges below remain for the mgp procedure path.
 class VirtualGraphView final : public GraphView {
   VirtualGraph *graph_;
-  DbAccessor *names_;
 
  public:
-  VirtualGraphView(VirtualGraph *graph, DbAccessor *names) : graph_(graph), names_(names) {}
+  VirtualGraphView(VirtualGraph *graph, DbAccessor *names) : GraphView(names), graph_(graph) {}
 
   VirtualNodeRange Nodes() const { return VirtualNodeRange{graph_->nodes()}; }
 
@@ -72,17 +71,14 @@ class VirtualGraphView final : public GraphView {
     return FilterEdges(graph_->InEdges(node->Gid()), edge_types, existing_dest, /*neighbor_is_to=*/false);
   }
 
-  storage::LabelId NameToLabel(std::string_view name) override { return names_->NameToLabel(name); }
-
-  const std::string &LabelToName(storage::LabelId label) const override { return names_->LabelToName(label); }
-
-  storage::PropertyId NameToProperty(std::string_view name) override { return names_->NameToProperty(name); }
-
-  const std::string &PropertyToName(storage::PropertyId prop) const override { return names_->PropertyToName(prop); }
-
-  storage::EdgeTypeId NameToEdgeType(std::string_view name) override { return names_->NameToEdgeType(name); }
-
-  const std::string &EdgeTypeToName(storage::EdgeTypeId type) const override { return names_->EdgeTypeToName(type); }
+  // The projection's edge counts for a projection node; a real vertex is no projection node and has
+  // no edges here.
+  std::pair<int64_t, int64_t> Degree(const ScanVertex &from, storage::View /*view*/) override {
+    const auto *node = std::get_if<VirtualNode>(&from);
+    if (node == nullptr) return {0, 0};
+    return {static_cast<int64_t>(graph_->InEdges(node->Gid()).size()),
+            static_cast<int64_t>(graph_->OutEdges(node->Gid()).size())};
+  }
 
  private:
   // Keep the projection edges whose type is in edge_types (empty = any) and, when a

--- a/src/query/virtual_node.hpp
+++ b/src/query/virtual_node.hpp
@@ -29,6 +29,41 @@
 
 namespace memgraph::query {
 
+// The static, shared description of one derive() projection's binding: which keys are hidden and
+// which are overlay-bound by the propertyPolicy, plus the provenance ref. Built once from the
+// derive() config and shared (via shared_ptr) by every overlay node the projection produces - the
+// policy and ref are role-independent, so a projection's source and target nodes share one instance.
+// Node-local overlay values and the node's labels stay on the node; only this role-independent part
+// is shared. Construction-time property overrides are overlay-bound through the node's own overlay
+// store (they carry a value there), so they need not be listed here.
+class ProjectionSchema {
+ public:
+  using key_set = utils::pmr::vector<storage::PropertyId>;
+  static constexpr int64_t kNoRef = -1;
+
+  ProjectionSchema(key_set hidden, key_set overlay_bound, int64_t ref = kNoRef)
+      : hidden_(std::move(hidden)), overlay_bound_(std::move(overlay_bound)), ref_(ref) {}
+
+  [[nodiscard]] bool IsHidden(storage::PropertyId key) const {
+    return std::ranges::find(hidden_, key) != hidden_.end();
+  }
+
+  // True if the propertyPolicy bound this key 'overlay'. A construction-time override key is
+  // overlay-bound through the node's overlay store (it carries a value), not here.
+  [[nodiscard]] bool IsOverlayBoundByPolicy(storage::PropertyId key) const {
+    return std::ranges::find(overlay_bound_, key) != overlay_bound_.end();
+  }
+
+  [[nodiscard]] bool HasRef() const noexcept { return ref_ != kNoRef; }
+
+  [[nodiscard]] int64_t Ref() const noexcept { return ref_; }
+
+ private:
+  key_set hidden_;
+  key_set overlay_bound_;
+  int64_t ref_;
+};
+
 // A node in a derived view. Holds its own overlay property store and, optionally, a reference to an
 // origin real vertex. With no origin it is a synthetic node (the overlay is its only store). With an
 // origin it is an overlay node: property reads fall through to the origin lazily (never copied),
@@ -47,23 +82,21 @@ class VirtualNode final {
   static constexpr int64_t kNoProjectionRef = -1;
 
   VirtualNode(label_list labels, property_map properties, allocator_type alloc = {},
-              std::optional<VertexAccessor> origin = std::nullopt, hidden_keys hidden = {}, key_set overlay_bound = {},
-              int64_t projection_ref = kNoProjectionRef)
+              std::optional<VertexAccessor> origin = std::nullopt,
+              std::shared_ptr<const ProjectionSchema> schema = nullptr)
       : gid_(NextSyntheticGid()),
-        impl_(std::make_unique<Impl>(std::move(labels), std::move(properties), std::move(origin), std::move(hidden),
-                                     std::move(overlay_bound), projection_ref, std::nullopt, alloc)) {}
+        impl_(std::make_unique<Impl>(std::move(labels), std::move(properties), std::move(origin), std::move(schema),
+                                     std::nullopt, alloc)) {}
 
   VirtualNode(const VirtualNode &other, allocator_type alloc)
       : gid_(other.gid_),
         impl_(std::make_unique<Impl>(other.impl_->labels, other.impl_->properties, other.impl_->origin,
-                                     other.impl_->hidden, other.impl_->overlay_bound, other.impl_->projection_ref,
-                                     other.impl_->handle, alloc)) {}
+                                     other.impl_->schema, other.impl_->handle, alloc)) {}
 
   VirtualNode(VirtualNode &&other, allocator_type alloc)
       : gid_(other.gid_),
         impl_(std::make_unique<Impl>(std::move(other.impl_->labels), std::move(other.impl_->properties),
-                                     std::move(other.impl_->origin), std::move(other.impl_->hidden),
-                                     std::move(other.impl_->overlay_bound), other.impl_->projection_ref,
+                                     std::move(other.impl_->origin), std::move(other.impl_->schema),
                                      other.impl_->handle, alloc)) {}
 
   VirtualNode(const VirtualNode &other) : VirtualNode(other, other.impl_->labels.get_allocator()) {}
@@ -101,23 +134,27 @@ class VirtualNode final {
 
   // True if this node references a projection-schema entry (set for overlay nodes from a derive()
   // whose schema is statically known). The reference is the schema table key carried on the wire.
-  [[nodiscard]] auto HasProjectionRef() const noexcept -> bool { return impl_->projection_ref != kNoProjectionRef; }
+  [[nodiscard]] auto HasProjectionRef() const noexcept -> bool { return impl_->schema && impl_->schema->HasRef(); }
 
-  [[nodiscard]] auto ProjectionRef() const noexcept -> int64_t { return impl_->projection_ref; }
+  [[nodiscard]] auto ProjectionRef() const noexcept -> int64_t {
+    return impl_->schema ? impl_->schema->Ref() : kNoProjectionRef;
+  }
 
   // A hidden key is invisible to reads and to function calls over the node, regardless of whether
-  // the origin or the overlay holds a value for it.
+  // the origin or the overlay holds a value for it. A synthetic node (no schema) hides nothing.
   [[nodiscard]] auto IsHidden(storage::PropertyId key) const noexcept -> bool {
-    return std::find(impl_->hidden.begin(), impl_->hidden.end(), key) != impl_->hidden.end();
+    return impl_->schema && impl_->schema->IsHidden(key);
   }
 
   // An overlay-bound key reads from and writes to this node's overlay store. A key is overlay-bound
-  // if it is declared so at construction (a 'overlay' propertyPolicy binding or a construction-time
-  // override value); every other key on an overlay node is origin-bound. Read source and write
-  // target are coupled to one store per key, so this single predicate decides both.
+  // if it holds an overlay value here (a construction-time override, or a value set on the node) or
+  // the schema's propertyPolicy bound it 'overlay'; every other key on an overlay node is
+  // origin-bound. Read source and write target are coupled to one store per key, so this single
+  // predicate decides both. A synthetic node has no origin, so its writes always hit the overlay
+  // regardless of this predicate.
   [[nodiscard]] auto IsOverlayBound(storage::PropertyId key) const noexcept -> bool {
     return impl_->properties.find(key) != impl_->properties.end() ||
-           std::find(impl_->overlay_bound.begin(), impl_->overlay_bound.end(), key) != impl_->overlay_bound.end();
+           (impl_->schema && impl_->schema->IsOverlayBoundByPolicy(key));
   }
 
   // Read, in the VertexAccessor shape: a single call site reads a property from either a real
@@ -211,30 +248,21 @@ class VirtualNode final {
     label_list labels;
     property_map properties;
     std::optional<VertexAccessor> origin;
-    hidden_keys hidden;
-    key_set overlay_bound;
-    int64_t projection_ref;
+    // The static per-projection binding + ref, shared across the projection's nodes; null for a
+    // synthetic node (which hides nothing and binds every overlay-valued key).
+    std::shared_ptr<const ProjectionSchema> schema;
     std::optional<int64_t> handle;
 
     Impl(const label_list &lbls, const property_map &props, const std::optional<VertexAccessor> &orig,
-         const hidden_keys &hid, const key_set &ovl, int64_t proj_ref, std::optional<int64_t> hndl,
-         allocator_type alloc)
-        : labels(lbls, alloc),
-          properties(props, alloc),
-          origin(orig),
-          hidden(hid, alloc),
-          overlay_bound(ovl, alloc),
-          projection_ref(proj_ref),
-          handle(hndl) {}
+         std::shared_ptr<const ProjectionSchema> sch, std::optional<int64_t> hndl, allocator_type alloc)
+        : labels(lbls, alloc), properties(props, alloc), origin(orig), schema(std::move(sch)), handle(hndl) {}
 
-    Impl(label_list &&lbls, property_map &&props, std::optional<VertexAccessor> &&orig, hidden_keys &&hid,
-         key_set &&ovl, int64_t proj_ref, std::optional<int64_t> hndl, allocator_type alloc)
+    Impl(label_list &&lbls, property_map &&props, std::optional<VertexAccessor> &&orig,
+         std::shared_ptr<const ProjectionSchema> sch, std::optional<int64_t> hndl, allocator_type alloc)
         : labels(std::move(lbls), alloc),
           properties(std::move(props), alloc),
           origin(std::move(orig)),
-          hidden(std::move(hid), alloc),
-          overlay_bound(std::move(ovl), alloc),
-          projection_ref(proj_ref),
+          schema(std::move(sch)),
           handle(hndl) {}
   };
 

--- a/src/query/virtual_node.hpp
+++ b/src/query/virtual_node.hpp
@@ -83,20 +83,20 @@ class VirtualNode final {
 
   VirtualNode(label_list labels, property_map properties, allocator_type alloc = {},
               std::optional<VertexAccessor> origin = std::nullopt,
-              std::shared_ptr<const PropertyBinding> schema = nullptr)
+              std::shared_ptr<const PropertyBinding> binding = nullptr)
       : gid_(NextSyntheticGid()),
-        impl_(std::make_unique<Impl>(std::move(labels), std::move(properties), std::move(origin), std::move(schema),
+        impl_(std::make_unique<Impl>(std::move(labels), std::move(properties), std::move(origin), std::move(binding),
                                      std::nullopt, alloc)) {}
 
   VirtualNode(const VirtualNode &other, allocator_type alloc)
       : gid_(other.gid_),
         impl_(std::make_unique<Impl>(other.impl_->labels, other.impl_->properties, other.impl_->origin,
-                                     other.impl_->schema, other.impl_->handle, alloc)) {}
+                                     other.impl_->binding, other.impl_->handle, alloc)) {}
 
   VirtualNode(VirtualNode &&other, allocator_type alloc)
       : gid_(other.gid_),
         impl_(std::make_unique<Impl>(std::move(other.impl_->labels), std::move(other.impl_->properties),
-                                     std::move(other.impl_->origin), std::move(other.impl_->schema),
+                                     std::move(other.impl_->origin), std::move(other.impl_->binding),
                                      other.impl_->handle, alloc)) {}
 
   VirtualNode(const VirtualNode &other) : VirtualNode(other, other.impl_->labels.get_allocator()) {}
@@ -134,27 +134,27 @@ class VirtualNode final {
 
   // True if this node references a projection-schema entry (set for overlay nodes from a derive()
   // whose schema is statically known). The reference is the schema table key carried on the wire.
-  [[nodiscard]] auto HasProjectionRef() const noexcept -> bool { return impl_->schema && impl_->schema->HasRef(); }
+  [[nodiscard]] auto HasProjectionRef() const noexcept -> bool { return impl_->binding && impl_->binding->HasRef(); }
 
   [[nodiscard]] auto ProjectionRef() const noexcept -> int64_t {
-    return impl_->schema ? impl_->schema->Ref() : kNoProjectionRef;
+    return impl_->binding ? impl_->binding->Ref() : kNoProjectionRef;
   }
 
   // A hidden key is invisible to reads and to function calls over the node, regardless of whether
-  // the origin or the overlay holds a value for it. A synthetic node (no schema) hides nothing.
+  // the origin or the overlay holds a value for it. A synthetic node (no binding) hides nothing.
   [[nodiscard]] auto IsHidden(storage::PropertyId key) const noexcept -> bool {
-    return impl_->schema && impl_->schema->IsHidden(key);
+    return impl_->binding && impl_->binding->IsHidden(key);
   }
 
   // An overlay-bound key reads from and writes to this node's overlay store. A key is overlay-bound
   // if it holds an overlay value here (a construction-time override, or a value set on the node) or
-  // the schema's propertyPolicy bound it 'overlay'; every other key on an overlay node is
+  // the binding's propertyPolicy bound it 'overlay'; every other key on an overlay node is
   // origin-bound. Read source and write target are coupled to one store per key, so this single
   // predicate decides both. A synthetic node has no origin, so its writes always hit the overlay
   // regardless of this predicate.
   [[nodiscard]] auto IsOverlayBound(storage::PropertyId key) const noexcept -> bool {
     return impl_->properties.find(key) != impl_->properties.end() ||
-           (impl_->schema && impl_->schema->IsOverlayBoundByPolicy(key));
+           (impl_->binding && impl_->binding->IsOverlayBoundByPolicy(key));
   }
 
   // Read, in the VertexAccessor shape: a single call site reads a property from either a real
@@ -250,19 +250,19 @@ class VirtualNode final {
     std::optional<VertexAccessor> origin;
     // The static per-projection binding + ref, shared across the projection's nodes; null for a
     // synthetic node (which hides nothing and binds every overlay-valued key).
-    std::shared_ptr<const PropertyBinding> schema;
+    std::shared_ptr<const PropertyBinding> binding;
     std::optional<int64_t> handle;
 
     Impl(const label_list &lbls, const property_map &props, const std::optional<VertexAccessor> &orig,
          std::shared_ptr<const PropertyBinding> sch, std::optional<int64_t> hndl, allocator_type alloc)
-        : labels(lbls, alloc), properties(props, alloc), origin(orig), schema(std::move(sch)), handle(hndl) {}
+        : labels(lbls, alloc), properties(props, alloc), origin(orig), binding(std::move(sch)), handle(hndl) {}
 
     Impl(label_list &&lbls, property_map &&props, std::optional<VertexAccessor> &&orig,
          std::shared_ptr<const PropertyBinding> sch, std::optional<int64_t> hndl, allocator_type alloc)
         : labels(std::move(lbls), alloc),
           properties(std::move(props), alloc),
           origin(std::move(orig)),
-          schema(std::move(sch)),
+          binding(std::move(sch)),
           handle(hndl) {}
   };
 

--- a/src/query/virtual_node.hpp
+++ b/src/query/virtual_node.hpp
@@ -120,19 +120,27 @@ class VirtualNode final {
            std::find(impl_->overlay_bound.begin(), impl_->overlay_bound.end(), key) != impl_->overlay_bound.end();
   }
 
-  // Read: hidden keys yield null; an overlay key shadows the origin; otherwise fall through to the
-  // origin lazily (latest transaction view, never cached); otherwise null.
-  [[nodiscard]] auto GetProperty(storage::PropertyId key) const -> storage::PropertyValue {
+  // Read, in the VertexAccessor shape: a single call site reads a property from either a real
+  // vertex or a projected node. Hidden keys yield null; an overlay key shadows the origin;
+  // otherwise the read falls through to the origin lazily under the given view (never cached);
+  // otherwise null. An overlay-only read cannot fail but still returns a Result for one uniform
+  // shape, and an origin read-through forwards both the view and the origin's Result.
+  [[nodiscard]] auto GetProperty(storage::View view, storage::PropertyId key) const
+      -> storage::Result<storage::PropertyValue> {
     if (IsHidden(key)) return storage::PropertyValue{};
     if (const auto it = impl_->properties.find(key); it != impl_->properties.end()) return it->second;
-    if (impl_->origin) {
-      auto maybe_value = impl_->origin->GetProperty(storage::View::NEW, key);
-      if (!maybe_value.has_value()) {
-        throw QueryRuntimeException("Reading a property of a projected node's origin failed.");
-      }
-      return std::move(*maybe_value);
-    }
+    if (impl_->origin) return impl_->origin->GetProperty(view, key);
     return storage::PropertyValue{};
+  }
+
+  // The bare read used by callers without a view (the procedure and function paths): the origin is
+  // read under the latest transaction view, and an origin failure throws as before.
+  [[nodiscard]] auto GetProperty(storage::PropertyId key) const -> storage::PropertyValue {
+    auto maybe_value = GetProperty(storage::View::NEW, key);
+    if (!maybe_value.has_value()) {
+      throw QueryRuntimeException("Reading a property of a projected node's origin failed.");
+    }
+    return std::move(*maybe_value);
   }
 
   // Write: a synthetic node (no origin) always writes its overlay. On an overlay node, an
@@ -165,15 +173,15 @@ class VirtualNode final {
 
   void ClearProperties() { impl_->properties.clear(); }
 
-  // Merged view: origin properties (read lazily) with overlay keys shadowing them. Returned by
-  // value because the merge is not stored - origin properties are never copied into the overlay.
-  [[nodiscard]] auto Properties() const -> property_map {
+  // Merged view in the VertexAccessor shape: origin properties (read lazily under the given view)
+  // with overlay keys shadowing them, hidden keys omitted. Returned by value because the merge is
+  // not stored - origin properties are never copied into the overlay. An origin read-through
+  // forwards both the view and the origin's Result.
+  [[nodiscard]] auto Properties(storage::View view) const -> storage::Result<property_map> {
     property_map merged{impl_->properties.get_allocator()};
     if (impl_->origin) {
-      auto maybe_props = impl_->origin->Properties(storage::View::NEW);
-      if (!maybe_props.has_value()) {
-        throw QueryRuntimeException("Reading properties of a projected node's origin failed.");
-      }
+      auto maybe_props = impl_->origin->Properties(view);
+      if (!maybe_props.has_value()) return std::unexpected{maybe_props.error()};
       for (auto &[id, value] : *maybe_props) {
         if (!IsHidden(id)) merged.insert_or_assign(id, std::move(value));
       }
@@ -182,6 +190,16 @@ class VirtualNode final {
       if (!IsHidden(id)) merged.insert_or_assign(id, value);
     }
     return merged;
+  }
+
+  // The bare merged view used by callers without a view (the procedure and function paths): the
+  // origin is read under the latest transaction view, and an origin failure throws as before.
+  [[nodiscard]] auto Properties() const -> property_map {
+    auto maybe_props = Properties(storage::View::NEW);
+    if (!maybe_props.has_value()) {
+      throw QueryRuntimeException("Reading properties of a projected node's origin failed.");
+    }
+    return std::move(*maybe_props);
   }
 
   bool operator==(const VirtualNode &other) const noexcept { return gid_ == other.gid_; }

--- a/src/query/virtual_node.hpp
+++ b/src/query/virtual_node.hpp
@@ -11,11 +11,16 @@
 
 #pragma once
 
+#include <algorithm>
 #include <memory>
+#include <optional>
 
+#include "query/exceptions.hpp"
 #include "query/synthetic_gid.hpp"
+#include "query/vertex_accessor.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/property_value.hpp"
+#include "storage/v2/view.hpp"
 #include "utils/logging.hpp"
 #include "utils/memory.hpp"
 #include "utils/pmr/string.hpp"
@@ -24,22 +29,42 @@
 
 namespace memgraph::query {
 
-// Standalone graph node with no provenance back to any real vertex.
+// A node in a derived view. Holds its own overlay property store and, optionally, a reference to an
+// origin real vertex. With no origin it is a synthetic node (the overlay is its only store). With an
+// origin it is an overlay node: property reads fall through to the origin lazily (never copied),
+// and an overlay key shadows the origin value for that key.
 class VirtualNode final {
  public:
   using allocator_type = utils::Allocator<VirtualNode>;
   using label_list = utils::pmr::vector<utils::pmr::string>;
   using property_map = utils::pmr::unordered_map<storage::PropertyId, storage::PropertyValue>;
+  using key_set = utils::pmr::vector<storage::PropertyId>;
+  using hidden_keys = key_set;
 
-  VirtualNode(label_list labels, property_map properties, allocator_type alloc = {})
-      : gid_(NextSyntheticGid()), impl_(std::make_unique<Impl>(std::move(labels), std::move(properties), alloc)) {}
+  // A node carrying no projection reference belongs to no derive() projection (a synthetic node, or
+  // an overlay node built before provenance was wired). Overlay nodes from one derive() site share a
+  // single non-negative reference into the result's projection-schema table.
+  static constexpr int64_t kNoProjectionRef = -1;
+
+  VirtualNode(label_list labels, property_map properties, allocator_type alloc = {},
+              std::optional<VertexAccessor> origin = std::nullopt, hidden_keys hidden = {}, key_set overlay_bound = {},
+              int64_t projection_ref = kNoProjectionRef)
+      : gid_(NextSyntheticGid()),
+        impl_(std::make_unique<Impl>(std::move(labels), std::move(properties), std::move(origin), std::move(hidden),
+                                     std::move(overlay_bound), projection_ref, std::nullopt, alloc)) {}
 
   VirtualNode(const VirtualNode &other, allocator_type alloc)
-      : gid_(other.gid_), impl_(std::make_unique<Impl>(other.impl_->labels, other.impl_->properties, alloc)) {}
+      : gid_(other.gid_),
+        impl_(std::make_unique<Impl>(other.impl_->labels, other.impl_->properties, other.impl_->origin,
+                                     other.impl_->hidden, other.impl_->overlay_bound, other.impl_->projection_ref,
+                                     other.impl_->handle, alloc)) {}
 
   VirtualNode(VirtualNode &&other, allocator_type alloc)
       : gid_(other.gid_),
-        impl_(std::make_unique<Impl>(std::move(other.impl_->labels), std::move(other.impl_->properties), alloc)) {}
+        impl_(std::make_unique<Impl>(std::move(other.impl_->labels), std::move(other.impl_->properties),
+                                     std::move(other.impl_->origin), std::move(other.impl_->hidden),
+                                     std::move(other.impl_->overlay_bound), other.impl_->projection_ref,
+                                     other.impl_->handle, alloc)) {}
 
   VirtualNode(const VirtualNode &other) : VirtualNode(other, other.impl_->labels.get_allocator()) {}
 
@@ -63,29 +88,136 @@ class VirtualNode final {
 
   [[nodiscard]] auto Labels() const noexcept -> const label_list & { return impl_->labels; }
 
+  [[nodiscard]] auto HasOrigin() const noexcept -> bool { return impl_->origin.has_value(); }
+
+  // The import handle: the integer a user passed to virtualNode(), used at list assembly to wire
+  // edge endpoints to this node by reference. It is not the node's identity (that is the synthetic
+  // gid) and is never serialized. A node built by derive() carries none.
+  [[nodiscard]] auto Handle() const noexcept -> std::optional<int64_t> { return impl_->handle; }
+
+  void SetHandle(std::optional<int64_t> handle) noexcept { impl_->handle = handle; }
+
+  [[nodiscard]] auto Origin() const noexcept -> const std::optional<VertexAccessor> & { return impl_->origin; }
+
+  // True if this node references a projection-schema entry (set for overlay nodes from a derive()
+  // whose schema is statically known). The reference is the schema table key carried on the wire.
+  [[nodiscard]] auto HasProjectionRef() const noexcept -> bool { return impl_->projection_ref != kNoProjectionRef; }
+
+  [[nodiscard]] auto ProjectionRef() const noexcept -> int64_t { return impl_->projection_ref; }
+
+  // A hidden key is invisible to reads and to function calls over the node, regardless of whether
+  // the origin or the overlay holds a value for it.
+  [[nodiscard]] auto IsHidden(storage::PropertyId key) const noexcept -> bool {
+    return std::find(impl_->hidden.begin(), impl_->hidden.end(), key) != impl_->hidden.end();
+  }
+
+  // An overlay-bound key reads from and writes to this node's overlay store. A key is overlay-bound
+  // if it is declared so at construction (a 'overlay' propertyPolicy binding or a construction-time
+  // override value); every other key on an overlay node is origin-bound. Read source and write
+  // target are coupled to one store per key, so this single predicate decides both.
+  [[nodiscard]] auto IsOverlayBound(storage::PropertyId key) const noexcept -> bool {
+    return impl_->properties.find(key) != impl_->properties.end() ||
+           std::find(impl_->overlay_bound.begin(), impl_->overlay_bound.end(), key) != impl_->overlay_bound.end();
+  }
+
+  // Read: hidden keys yield null; an overlay key shadows the origin; otherwise fall through to the
+  // origin lazily (latest transaction view, never cached); otherwise null.
   [[nodiscard]] auto GetProperty(storage::PropertyId key) const -> storage::PropertyValue {
+    if (IsHidden(key)) return storage::PropertyValue{};
     if (const auto it = impl_->properties.find(key); it != impl_->properties.end()) return it->second;
+    if (impl_->origin) {
+      auto maybe_value = impl_->origin->GetProperty(storage::View::NEW, key);
+      if (!maybe_value.has_value()) {
+        throw QueryRuntimeException("Reading a property of a projected node's origin failed.");
+      }
+      return std::move(*maybe_value);
+    }
     return storage::PropertyValue{};
   }
 
+  // Write: a synthetic node (no origin) always writes its overlay. On an overlay node, an
+  // overlay-bound key writes the overlay (compute-only, never persisted); an origin-bound or
+  // undeclared key persists to the origin vertex, and any stale overlay entry for that key is
+  // cleared so a later read does not shadow the just-persisted value.
   void SetProperty(storage::PropertyId key, storage::PropertyValue value) {
+    if (impl_->origin && !IsOverlayBound(key)) {
+      auto result = impl_->origin->SetProperty(key, value);
+      if (!result.has_value()) {
+        throw QueryRuntimeException("Writing a property to a projected node's origin failed.");
+      }
+      impl_->properties.erase(key);
+      return;
+    }
     impl_->properties.insert_or_assign(key, std::move(value));
   }
 
-  [[nodiscard]] auto Properties() const noexcept -> const property_map & { return impl_->properties; }
+  void RemoveProperty(storage::PropertyId key) {
+    if (impl_->origin && !IsOverlayBound(key)) {
+      auto result = impl_->origin->RemoveProperty(key);
+      if (!result.has_value()) {
+        throw QueryRuntimeException("Removing a property from a projected node's origin failed.");
+      }
+      impl_->properties.erase(key);
+      return;
+    }
+    impl_->properties.erase(key);
+  }
+
+  void ClearProperties() { impl_->properties.clear(); }
+
+  // Merged view: origin properties (read lazily) with overlay keys shadowing them. Returned by
+  // value because the merge is not stored - origin properties are never copied into the overlay.
+  [[nodiscard]] auto Properties() const -> property_map {
+    property_map merged{impl_->properties.get_allocator()};
+    if (impl_->origin) {
+      auto maybe_props = impl_->origin->Properties(storage::View::NEW);
+      if (!maybe_props.has_value()) {
+        throw QueryRuntimeException("Reading properties of a projected node's origin failed.");
+      }
+      for (auto &[id, value] : *maybe_props) {
+        if (!IsHidden(id)) merged.insert_or_assign(id, std::move(value));
+      }
+    }
+    for (const auto &[id, value] : impl_->properties) {
+      if (!IsHidden(id)) merged.insert_or_assign(id, value);
+    }
+    return merged;
+  }
 
   bool operator==(const VirtualNode &other) const noexcept { return gid_ == other.gid_; }
 
  private:
+  // The origin lives in the heap-allocated Impl, not inline, so a VirtualNode stays small and the
+  // mgp_vertex/mgp_edge size budgets that embed it do not grow.
   struct Impl {
     label_list labels;
     property_map properties;
+    std::optional<VertexAccessor> origin;
+    hidden_keys hidden;
+    key_set overlay_bound;
+    int64_t projection_ref;
+    std::optional<int64_t> handle;
 
-    Impl(const label_list &lbls, const property_map &props, allocator_type alloc)
-        : labels(lbls, alloc), properties(props, alloc) {}
+    Impl(const label_list &lbls, const property_map &props, const std::optional<VertexAccessor> &orig,
+         const hidden_keys &hid, const key_set &ovl, int64_t proj_ref, std::optional<int64_t> hndl,
+         allocator_type alloc)
+        : labels(lbls, alloc),
+          properties(props, alloc),
+          origin(orig),
+          hidden(hid, alloc),
+          overlay_bound(ovl, alloc),
+          projection_ref(proj_ref),
+          handle(hndl) {}
 
-    Impl(label_list &&lbls, property_map &&props, allocator_type alloc)
-        : labels(std::move(lbls), alloc), properties(std::move(props), alloc) {}
+    Impl(label_list &&lbls, property_map &&props, std::optional<VertexAccessor> &&orig, hidden_keys &&hid,
+         key_set &&ovl, int64_t proj_ref, std::optional<int64_t> hndl, allocator_type alloc)
+        : labels(std::move(lbls), alloc),
+          properties(std::move(props), alloc),
+          origin(std::move(orig)),
+          hidden(std::move(hid), alloc),
+          overlay_bound(std::move(ovl), alloc),
+          projection_ref(proj_ref),
+          handle(hndl) {}
   };
 
   storage::Gid gid_;

--- a/src/query/virtual_node.hpp
+++ b/src/query/virtual_node.hpp
@@ -36,12 +36,12 @@ namespace memgraph::query {
 // Node-local overlay values and the node's labels stay on the node; only this role-independent part
 // is shared. Construction-time property overrides are overlay-bound through the node's own overlay
 // store (they carry a value there), so they need not be listed here.
-class ProjectionSchema {
+class PropertyBinding {
  public:
   using key_set = utils::pmr::vector<storage::PropertyId>;
   static constexpr int64_t kNoRef = -1;
 
-  ProjectionSchema(key_set hidden, key_set overlay_bound, int64_t ref = kNoRef)
+  PropertyBinding(key_set hidden, key_set overlay_bound, int64_t ref = kNoRef)
       : hidden_(std::move(hidden)), overlay_bound_(std::move(overlay_bound)), ref_(ref) {}
 
   [[nodiscard]] bool IsHidden(storage::PropertyId key) const {
@@ -83,7 +83,7 @@ class VirtualNode final {
 
   VirtualNode(label_list labels, property_map properties, allocator_type alloc = {},
               std::optional<VertexAccessor> origin = std::nullopt,
-              std::shared_ptr<const ProjectionSchema> schema = nullptr)
+              std::shared_ptr<const PropertyBinding> schema = nullptr)
       : gid_(NextSyntheticGid()),
         impl_(std::make_unique<Impl>(std::move(labels), std::move(properties), std::move(origin), std::move(schema),
                                      std::nullopt, alloc)) {}
@@ -250,15 +250,15 @@ class VirtualNode final {
     std::optional<VertexAccessor> origin;
     // The static per-projection binding + ref, shared across the projection's nodes; null for a
     // synthetic node (which hides nothing and binds every overlay-valued key).
-    std::shared_ptr<const ProjectionSchema> schema;
+    std::shared_ptr<const PropertyBinding> schema;
     std::optional<int64_t> handle;
 
     Impl(const label_list &lbls, const property_map &props, const std::optional<VertexAccessor> &orig,
-         std::shared_ptr<const ProjectionSchema> sch, std::optional<int64_t> hndl, allocator_type alloc)
+         std::shared_ptr<const PropertyBinding> sch, std::optional<int64_t> hndl, allocator_type alloc)
         : labels(lbls, alloc), properties(props, alloc), origin(orig), schema(std::move(sch)), handle(hndl) {}
 
     Impl(label_list &&lbls, property_map &&props, std::optional<VertexAccessor> &&orig,
-         std::shared_ptr<const ProjectionSchema> sch, std::optional<int64_t> hndl, allocator_type alloc)
+         std::shared_ptr<const PropertyBinding> sch, std::optional<int64_t> hndl, allocator_type alloc)
         : labels(std::move(lbls), alloc),
           properties(std::move(props), alloc),
           origin(std::move(orig)),

--- a/src/utils/typeinfo.hpp
+++ b/src/utils/typeinfo.hpp
@@ -105,6 +105,7 @@ enum class TypeId : uint64_t {
   AGGREGATE_PARALLEL,
   PARALLEL_MERGE,
   ORDERBY_PARALLEL,
+  BIND_GRAPH_VIEW,
 
   // Replication
   // NOTE: these NEED to be stable in the 2000+ range (see rpc version)

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -65,6 +65,9 @@ target_link_libraries(${test_prefix}skip_list_vs_stl mg-utils)
 add_benchmark(expansion.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp)
 target_link_libraries(${test_prefix}expansion mg-query mg-communication mg-license)
 
+add_benchmark(query_graph_view_scan.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp)
+target_link_libraries(${test_prefix}query_graph_view_scan mg-query mg-communication mg-license)
+
 add_benchmark(storage_v2_gc.cpp)
 target_link_libraries(${test_prefix}storage_v2_gc mg::storage)
 

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -65,6 +65,9 @@ target_link_libraries(${test_prefix}skip_list_vs_stl mg-utils)
 add_benchmark(expansion.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp)
 target_link_libraries(${test_prefix}expansion mg-query mg-communication mg-license)
 
+add_benchmark(var_length_expansion.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp)
+target_link_libraries(${test_prefix}var_length_expansion mg-query mg-communication mg-license)
+
 add_benchmark(query_graph_view_scan.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp)
 target_link_libraries(${test_prefix}query_graph_view_scan mg-query mg-communication mg-license)
 

--- a/tests/benchmark/query_graph_view_scan.cpp
+++ b/tests/benchmark/query_graph_view_scan.cpp
@@ -1,0 +1,112 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Isolates the per-row cost of routing an unlabeled full scan through the
+// GraphView seam. RawIterate reads the real graph through VerticesIterable
+// directly (the pre-seam path, and the path ScanAllByLabel still takes).
+// ViaVertexRange reads the same vertices through VertexRange, the variant the
+// seam interposes: every ScanAll now takes this path because the interpreter
+// binds the identity GraphView unconditionally. The delta is the variant tax.
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <variant>
+
+#include "dbms/database.hpp"
+#include "query/db_accessor.hpp"
+#include "query/graph_view.hpp"
+#include "replication/state.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/view.hpp"
+#include "system/system.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/logging.hpp"
+#include "utils/rw_spin_lock.hpp"
+#include "utils/synchronized.hpp"
+
+namespace {
+
+std::filesystem::path data_directory{std::filesystem::temp_directory_path() / "graph-view-scan-benchmark"};
+
+class ScanBenchFixture : public benchmark::Fixture {
+ protected:
+  std::optional<memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock>>
+      repl_state;
+  std::optional<memgraph::utils::Gatekeeper<memgraph::dbms::Database>> db_gk;
+
+  void SetUp(const benchmark::State &state) override {
+    repl_state.emplace(std::nullopt);
+    memgraph::storage::Config config{};
+    config.durability.storage_directory = data_directory;
+    config.disk.main_storage_directory = data_directory / "disk";
+    db_gk.emplace(std::move(config));
+
+    auto db_acc_opt = db_gk->access();
+    MG_ASSERT(db_acc_opt, "Failed to access db");
+    auto &db_acc = *db_acc_opt;
+
+    auto storage_acc = db_acc->Access(memgraph::storage::StorageAccessType::WRITE);
+    memgraph::query::DbAccessor dba{storage_acc.get()};
+    for (int64_t i = 0; i < state.range(0); i++) dba.InsertVertex();
+    MG_ASSERT(dba.Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  void TearDown(const benchmark::State &) override {
+    db_gk.reset();
+    repl_state.reset();
+    std::filesystem::remove_all(data_directory);
+  }
+};
+
+}  // namespace
+
+BENCHMARK_DEFINE_F(ScanBenchFixture, RawIterate)(benchmark::State &state) {
+  auto db_acc_opt = db_gk->access();
+  auto &db_acc = *db_acc_opt;
+  auto storage_acc = db_acc->Access(memgraph::storage::StorageAccessType::READ);
+  memgraph::query::DbAccessor dba{storage_acc.get()};
+
+  for (auto _ : state) {
+    uint64_t sum = 0;
+    for (const auto &vertex : dba.Vertices(memgraph::storage::View::OLD)) {
+      sum += vertex.Gid().AsUint();
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+
+BENCHMARK_DEFINE_F(ScanBenchFixture, ViaVertexRange)(benchmark::State &state) {
+  auto db_acc_opt = db_gk->access();
+  auto &db_acc = *db_acc_opt;
+  auto storage_acc = db_acc->Access(memgraph::storage::StorageAccessType::READ);
+  memgraph::query::DbAccessor dba{storage_acc.get()};
+
+  for (auto _ : state) {
+    uint64_t sum = 0;
+    for (auto scanned : memgraph::query::VertexRange{dba.Vertices(memgraph::storage::View::OLD)}) {
+      // Mirror WriteScannedVertex: the deref already materialized a ScanVertex
+      // variant; a second visit extracts the element, as the cursor does to
+      // write it to the frame.
+      std::visit([&](const auto &element) { sum += element.Gid().AsUint(); }, scanned);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+  state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+
+BENCHMARK_REGISTER_F(ScanBenchFixture, RawIterate)->RangeMultiplier(8)->Range(1 << 10, 1 << 22);
+BENCHMARK_REGISTER_F(ScanBenchFixture, ViaVertexRange)->RangeMultiplier(8)->Range(1 << 10, 1 << 22);
+
+BENCHMARK_MAIN();

--- a/tests/benchmark/var_length_expansion.cpp
+++ b/tests/benchmark/var_length_expansion.cpp
@@ -1,0 +1,141 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Hot-path benchmark for the variable-length expansion family (DFS / BFS / weighted shortest path)
+// over the real graph. Used to confirm the traversal-policy unification introduces no regression on
+// the real path (ADR 0005 / issue 43 Stage E). The graph is a deterministic circulant graph so
+// every run traverses identical topology.
+
+#include <benchmark/benchmark.h>
+#include <memory>
+
+#include "communication/result_stream_faker.hpp"
+#include "query/auth_checker.hpp"
+#include "query/config.hpp"
+#include "query/interpreter.hpp"
+#include "query/interpreter_context.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/logging.hpp"
+#include "utils/synchronized.hpp"
+
+std::filesystem::path data_directory{std::filesystem::temp_directory_path() / "var-length-expansion-benchmark"};
+
+// A circulant graph: N vertices, each vertex i has out-edges to (i+1)..(i+kDegree) mod N. Uniform
+// branching gives a dense, deterministic multi-hop workload.
+static constexpr int kNumVertices = 4000;
+static constexpr int kDegree = 5;
+
+class VarLengthBenchFixture : public benchmark::Fixture {
+ protected:
+  std::optional<memgraph::system::System> system;
+  std::optional<memgraph::query::AllowEverythingAuthChecker> auth_checker;
+  std::optional<memgraph::query::InterpreterContext> interpreter_context;
+  std::optional<memgraph::query::Interpreter> interpreter;
+  std::optional<memgraph::utils::Gatekeeper<memgraph::dbms::Database>> db_gk;
+  std::optional<memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock>>
+      repl_state;
+
+  void SetUp(const benchmark::State & /*state*/) override {
+    repl_state.emplace(std::nullopt);
+    memgraph::storage::Config config{};
+    config.durability.storage_directory = data_directory;
+    config.disk.main_storage_directory = data_directory / "disk";
+    db_gk.emplace(std::move(config));
+    auto db_acc_opt = db_gk->access();
+    MG_ASSERT(db_acc_opt, "Failed to access db");
+    auto &db_acc = *db_acc_opt;
+
+    system.emplace();
+    auth_checker.emplace();
+    interpreter_context.emplace(memgraph::query::InterpreterConfig{},
+                                nullptr,
+                                nullptr,
+                                nullptr,
+                                &repl_state.value(),
+                                *system,
+                                nullptr
+#ifdef MG_ENTERPRISE
+                                ,
+                                nullptr,
+                                nullptr
+#endif
+    );
+
+    auto label = db_acc->storage()->NameToLabel("Start");
+    {
+      auto dba = db_acc->Access(memgraph::storage::WRITE);
+      auto edge_type = dba->NameToEdgeType("E");
+      std::vector<memgraph::storage::VertexAccessor> vertices;
+      vertices.reserve(kNumVertices);
+      for (int i = 0; i < kNumVertices; i++) vertices.push_back(dba->CreateVertex());
+      MG_ASSERT(vertices[0].AddLabel(label).has_value());
+      for (int i = 0; i < kNumVertices; i++) {
+        for (int d = 1; d <= kDegree; d++) {
+          auto &dest = vertices[(i + d) % kNumVertices];
+          MG_ASSERT(dba->CreateEdge(&vertices[i], &dest, edge_type).has_value());
+        }
+      }
+      MG_ASSERT(dba->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    {
+      auto unique_acc = db_acc->UniqueAccess();
+      MG_ASSERT(unique_acc->CreateIndex(label).has_value());
+      MG_ASSERT(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    interpreter.emplace(&*interpreter_context, std::move(db_acc));
+    interpreter->SetUser(auth_checker->GenQueryUser(std::nullopt, {}));
+  }
+
+  void TearDown(const benchmark::State & /*state*/) override {
+    interpreter = std::nullopt;
+    interpreter_context = std::nullopt;
+    db_gk.reset();
+    auth_checker.reset();
+    system.reset();
+    std::filesystem::remove_all(data_directory);
+  }
+
+  void Run(const char *query, benchmark::State &state) {
+    while (state.KeepRunning()) {
+      ResultStreamFaker results(interpreter->current_db_.db_acc_->get()->storage());
+      interpreter->Prepare(query, memgraph::query::no_params_fn, {});
+      interpreter->PullAll(&results);
+    }
+  }
+};
+
+// Depth-first variable-length: explores every distinct-edge path within the bound.
+BENCHMARK_DEFINE_F(VarLengthBenchFixture, VarLengthDFS)(benchmark::State &state) {
+  Run("MATCH (s:Start)-[*1..4]->(d) RETURN count(d)", state);
+}
+
+BENCHMARK_REGISTER_F(VarLengthBenchFixture, VarLengthDFS)->Unit(benchmark::kMillisecond);
+
+// Single-source breadth-first: reaches every node at its shortest depth once.
+BENCHMARK_DEFINE_F(VarLengthBenchFixture, BFS)(benchmark::State &state) {
+  Run("MATCH (s:Start)-[*BFS 1..10]->(d) RETURN count(d)", state);
+}
+
+BENCHMARK_REGISTER_F(VarLengthBenchFixture, BFS)->Unit(benchmark::kMillisecond);
+
+// Weighted shortest path with a unit-weight lambda: Dijkstra over the whole reachable set.
+BENCHMARK_DEFINE_F(VarLengthBenchFixture, WeightedShortestPath)(benchmark::State &state) {
+  Run("MATCH (s:Start)-[e *wShortest 10 (r, n | 1) w]->(d) RETURN count(d)", state);
+}
+
+BENCHMARK_REGISTER_F(VarLengthBenchFixture, WeightedShortestPath)->Unit(benchmark::kMillisecond);
+
+int main(int argc, char **argv) {
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}

--- a/tests/e2e/fine_grained_access/property_fga_tests.py
+++ b/tests/e2e/fine_grained_access/property_fga_tests.py
@@ -145,6 +145,88 @@ def test_derive_strips_denied_property():
     assert result[0][2] is None
 
 
+def test_derive_overlay_bound_override_is_visible():
+    # An overlay-bound override is the author's own computed value, not the origin's protected data,
+    # so it is visible even though its key name is denied on the origin's label.
+    result = common.execute_and_fetch_all(
+        user_cursor(),
+        """
+        MATCH p = (:Person {name: 'Start'})-[:KNOWS]->(:Employee)
+        WITH derive(p, {virtualEdgeType: 'V', targetNodeProperties: {ssn: 'masked'}}) AS g
+        UNWIND g.nodes AS n
+        WITH n WHERE 'Employee' IN labels(n)
+        RETURN n.ssn AS ssn, 'ssn' IN keys(n) AS has_ssn
+        """,
+    )
+    assert len(result) == 1
+    assert result[0][0] == "masked"
+    assert result[0][1] is True
+
+
+def test_derive_relabel_does_not_bypass_origin_deny():
+    # Relabelling the overlay must not evade the origin's per-property deny; the check keys off the
+    # origin's real labels, not the presented labels.
+    result = common.execute_and_fetch_all(
+        user_cursor(),
+        """
+        MATCH p = (:Person {name: 'Start'})-[:KNOWS]->(:Employee)
+        WITH derive(p, {virtualEdgeType: 'V', sourceNodeLabels: ['Colleague']}) AS g
+        UNWIND g.nodes AS n
+        WITH n WHERE 'Colleague' IN labels(n)
+        RETURN n.ssn AS ssn, 'ssn' IN keys(n) AS has_ssn
+        """,
+    )
+    assert len(result) == 1
+    assert result[0][0] is None
+    assert result[0][1] is False
+
+
+def test_derive_return_node_omits_denied_property():
+    # RETURN n over an overlay serializes the node over Bolt; the denied origin property is omitted.
+    result = common.execute_and_fetch_all(
+        user_cursor(),
+        """
+        MATCH p = (:Person {name: 'Start'})-[:KNOWS]->(:Employee)
+        WITH derive(p, {virtualEdgeType: 'V'}) AS g
+        UNWIND g.nodes AS n
+        WITH n WHERE 'Employee' IN labels(n)
+        RETURN n
+        """,
+    )
+    assert len(result) == 1
+    node = result[0][0]
+    assert node.properties["name"] == "Alice"
+    assert "ssn" not in node.properties
+
+
+def test_synthetic_node_property_is_visible():
+    # A synthetic node (no origin) mints no real-graph data, so property FGA does not apply to it.
+    result = common.execute_and_fetch_all(
+        user_cursor(),
+        "RETURN virtualNode(1, ['Employee'], {ssn: 'synthetic'}).ssn AS ssn;",
+    )
+    assert len(result) == 1
+    assert result[0][0] == "synthetic"
+
+
+def test_derive_returned_whole_graph_redacts_denied_property():
+    # Returning the whole projection value (RETURN g) serializes it via ToBoltVirtualGraph; a denied
+    # origin property on an overlay member must be redacted there too, matching RETURN n.
+    result = common.execute_and_fetch_all(
+        user_cursor(),
+        """
+        MATCH p = (:Person {name: 'Start'})-[:KNOWS]->(:Employee)
+        WITH derive(p, {virtualEdgeType: 'V'}) AS g
+        RETURN g;
+        """,
+    )
+    assert len(result) == 1
+    g = result[0][0]
+    employee = next(n for n in g["nodes"] if "Employee" in n.labels)
+    assert employee.properties["name"] == "Alice"
+    assert "ssn" not in employee.properties
+
+
 def test_show_schema_info_omits_denied_properties():
     schema = json.loads(common.execute_and_fetch_all(user_cursor(), "SHOW SCHEMA INFO;")[0][0])
     employee = next(n for n in schema["nodes"] if "Employee" in n["labels"])

--- a/tests/e2e/write_procedures/read_subgraph.py
+++ b/tests/e2e/write_procedures/read_subgraph.py
@@ -343,5 +343,110 @@ def test_subgraph_remove_vertex_and_out_edges_get_vertices(multi_db):
     )
 
 
+@pytest.mark.parametrize("multi_db", [False, True], indirect=True)
+def test_algorithm_reads_real_properties_over_subgraph(multi_db):
+    """An algorithm-shaped procedure run over a project() subgraph reads the real
+    property values of the subgraph's nodes and yields real node accessors.
+
+    read.community_label iterates the subgraph's vertices, groups them by a
+    property read over the subgraph, and yields (node, community_id). The grouping
+    it returns must match the real 'dept' values, and the yielded node's id and
+    properties must resolve to the real store.
+    """
+    cursor = multi_db.cursor()
+    execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+    execute_and_fetch_all(
+        cursor,
+        """
+        CREATE (a:Person {name: 'A', dept: 'eng'}),
+               (b:Person {name: 'B', dept: 'eng'}),
+               (c:Person {name: 'C', dept: 'sales'}),
+               (a)-[:KNOWS]->(b),
+               (b)-[:KNOWS]->(c);
+        """,
+    )
+
+    results = execute_and_fetch_all(
+        cursor,
+        """
+        MATCH p=(:Person)-[:KNOWS]->(:Person)
+        WITH project(p) AS graph
+        CALL read.community_label(graph, 'dept') YIELD node, community_id
+        RETURN node.name AS name, node.dept AS dept, id(node) AS nid, community_id AS cid
+        ORDER BY name;
+        """,
+    )
+
+    # All three people lie on a KNOWS edge, so the subgraph contains all of them,
+    # each yielded once.
+    assert [r[0] for r in results] == ["A", "B", "C"]
+
+    # community_label groups by the 'dept' property read over the subgraph.
+    by_name = {r[0]: r for r in results}
+    assert by_name["A"][3] == by_name["B"][3], "A and B both in eng -> same community"
+    assert by_name["A"][3] != by_name["C"][3], "C in sales -> different community"
+
+    # The yielded nodes are real accessors: their dept reads the real value, and
+    # id(node) matches the id of the real node in the store.
+    assert by_name["A"][1] == "eng"
+    assert by_name["C"][1] == "sales"
+    real_ids = {name: nid for name, nid in execute_and_fetch_all(cursor, "MATCH (n:Person) RETURN n.name, id(n);")}
+    for name, _dept, nid, _cid in results:
+        assert nid == real_ids[name]
+
+    execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+
+
+@pytest.mark.parametrize("multi_db", [False, True], indirect=True)
+def test_write_back_to_real_node_persists(multi_db):
+    """A SET on a node yielded by an algorithm run over a project() subgraph
+    persists to the real store.
+
+    read.community_label yields (node, community_id) over the subgraph; the outer
+    query writes community_id onto each yielded node. The property is new
+    (previously absent), so the write must create it, and a follow-up query in a
+    separate statement must read back the written values from the real nodes.
+    """
+    cursor = multi_db.cursor()
+    execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+    execute_and_fetch_all(
+        cursor,
+        """
+        CREATE (a:Person {name: 'A', dept: 'eng'}),
+               (b:Person {name: 'B', dept: 'eng'}),
+               (c:Person {name: 'C', dept: 'sales'}),
+               (a)-[:KNOWS]->(b),
+               (b)-[:KNOWS]->(c);
+        """,
+    )
+
+    # Write the algorithm output back onto the real nodes.
+    execute_and_fetch_all(
+        cursor,
+        """
+        MATCH p=(:Person)-[:KNOWS]->(:Person)
+        WITH project(p) AS graph
+        CALL read.community_label(graph, 'dept') YIELD node, community_id
+        SET node.community = community_id;
+        """,
+    )
+
+    # A separate statement reads the written values back from the real nodes.
+    written = {
+        name: community
+        for name, community in execute_and_fetch_all(
+            cursor, "MATCH (n:Person) RETURN n.name, n.community ORDER BY n.name;"
+        )
+    }
+
+    # The previously-absent 'community' property was created on every node.
+    assert all(community is not None for community in written.values())
+    # The persisted values match the grouping the algorithm computed.
+    assert written["A"] == written["B"], "A and B both in eng -> same community"
+    assert written["A"] != written["C"], "C in sales -> different community"
+
+    execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/write_procedures/virtual_graph.py
+++ b/tests/e2e/write_procedures/virtual_graph.py
@@ -1364,6 +1364,47 @@ class TestUseScopeOverSubgraph:
         real = execute_and_fetch_all(cursor, "MATCH (b:B {id: 1}) RETURN degree(b) AS d;")
         assert real == [(2,)]
 
+    def test_use_scope_over_subgraph_variable_length_respects_membership(self, connection):
+        """Variable-length expansion stays within membership too, exactly as single-hop: a path
+        cannot leak out of the subgraph via a non-member edge (issue 49). The subgraph holds a->b;
+        the real graph also has b->c (same type), reachable only via a non-member edge."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(
+            cursor,
+            "CREATE (a:A {name: 'a'})-[:R]->(b:B {name: 'b'}), (b)-[:R]->(:C {name: 'c'});",
+        )
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:A)-[:R]->(:B)
+            WITH project(p) AS sg
+            CALL { USE sg MATCH (x:A)-[:R*1..3]->(y) RETURN y.name AS yn }
+            RETURN yn ORDER BY yn;
+            """,
+        )
+        assert results == [("b",)]
+
+    def test_use_scope_over_subgraph_bfs_respects_membership(self, connection):
+        """The shortest-path family (here BFS) respects subgraph membership as well: the same
+        member-filtered traversal applies to every arm, not just plain variable-length (issue 49)."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(
+            cursor,
+            "CREATE (a:A {name: 'a'})-[:R]->(b:B {name: 'b'}), (b)-[:R]->(:C {name: 'c'});",
+        )
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:A)-[:R]->(:B)
+            WITH project(p) AS sg
+            CALL { USE sg MATCH (x:A)-[*BFS]->(y) RETURN y.name AS yn }
+            RETURN yn ORDER BY yn;
+            """,
+        )
+        assert results == [("b",)]
+
 
 class TestUseScopeProceduresHonorAmbientView:
     """Inside a `CALL { USE g ... }` scope, an unmodified read procedure that

--- a/tests/e2e/write_procedures/virtual_graph.py
+++ b/tests/e2e/write_procedures/virtual_graph.py
@@ -284,6 +284,24 @@ class TestVirtualEdgeConstructor:
 
 
 class TestVirtualGraphConstructor:
+    def test_return_graph_value_serializes_as_nodes_and_edges(self, connection):
+        """RETURN of a whole projection value decodes client-side as a map of node and edge lists
+        (the ToBoltVirtualGraph path, distinct from consuming the value via USE or a procedure)."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 10}), virtualNode(2, 'N', {x: 20})] AS ns, [virtualEdge('R', 1, 2)] AS es
+            RETURN virtualGraph(ns, es) AS g;
+            """,
+        )
+        assert len(results) == 1
+        g = results[0][0]
+        assert set(g.keys()) == {"nodes", "edges"}
+        assert {n.properties["x"] for n in g["nodes"]} == {10, 20}
+        assert len(g["edges"]) == 1
+        assert g["edges"][0].type == "R"
+
     def test_assembles_graph_consumable_by_procedure(self, connection):
         """virtualGraph(nodes, edges) imports a graph from lists; an edge given by
         handles binds to the listed nodes, and a procedure can read it."""

--- a/tests/e2e/write_procedures/virtual_graph.py
+++ b/tests/e2e/write_procedures/virtual_graph.py
@@ -856,5 +856,453 @@ class TestBoltProvenanceTag:
             assert self.TAG not in o.properties, "a projection with non-literal options carries no tag"
 
 
+class TestUseScope:
+    def test_use_scope_scans_projection(self, connection):
+        """`CALL { USE g MATCH (n) ... }` runs the MATCH over the bound
+        projection, returning its nodes."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 10}), virtualNode(2, 'N', {x: 20})] AS nodes, [] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (n) RETURN n.x AS x }
+            RETURN x ORDER BY x;
+            """,
+        )
+        assert results == [(10,), (20,)]
+
+    def test_use_scope_is_scoped_to_the_projection(self, connection):
+        """The bound view applies inside the block only: a MATCH outside sees the
+        real graph, a MATCH inside sees the projection."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "CREATE (:Real), (:Real), (:Real);")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH (r) WITH count(r) AS real_count
+            WITH real_count, virtualGraph([virtualNode(1, 'N', {x: 10})], []) AS g
+            CALL { USE g MATCH (n) RETURN n.x AS x }
+            RETURN real_count, x;
+            """,
+        )
+        assert results == [(3, 10)]
+
+    def test_write_in_use_scope_errors(self, connection):
+        """A USE scope is read-only: a write clause inside it is rejected."""
+        cursor = connection.cursor()
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(
+                cursor,
+                """
+                WITH virtualGraph([virtualNode(1, 'N', {})], []) AS g
+                CALL { USE g CREATE (n) }
+                RETURN 1;
+                """,
+            )
+
+    def test_use_scope_expands_directed(self, connection):
+        """A directed expand inside the scope returns the projection's edge with
+        both endpoints bound to projection nodes."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2})] AS nodes,
+                 [virtualEdge('R', 1, 2)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a)-[r]->(b) RETURN a.x AS ax, type(r) AS t, b.x AS bx }
+            RETURN ax, t, bx;
+            """,
+        )
+        assert results == [(1, "R", 2)]
+
+    def test_use_scope_expands_undirected(self, connection):
+        """An undirected expand traverses the edge from both ends."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2})] AS nodes,
+                 [virtualEdge('R', 1, 2)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a)-[r]-(b) RETURN a.x AS ax, b.x AS bx }
+            RETURN ax, bx ORDER BY ax;
+            """,
+        )
+        assert results == [(1, 2), (2, 1)]
+
+    def test_use_scope_expands_type_filtered(self, connection):
+        """An edge-type filter selects only edges of that type."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('S', 1, 2)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a)-[r:R]->(b) RETURN type(r) AS t }
+            RETURN t;
+            """,
+        )
+        assert results == [("R",)]
+
+    def test_use_scope_expands_self_loop(self, connection):
+        """A self-loop is reachable expanding either direction; both endpoints are
+        the same projection node."""
+        cursor = connection.cursor()
+        out_rows = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 7})] AS nodes, [virtualEdge('R', 1, 1)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a)-[r]->(b) RETURN a.x AS ax, b.x AS bx }
+            RETURN ax, bx;
+            """,
+        )
+        assert out_rows == [(7, 7)]
+
+        in_rows = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 7})] AS nodes, [virtualEdge('R', 1, 1)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a)<-[r]-(b) RETURN a.x AS ax, b.x AS bx }
+            RETURN ax, bx;
+            """,
+        )
+        assert in_rows == [(7, 7)]
+
+    def test_use_scope_label_filter(self, connection):
+        """A label-filtered MATCH returns only the projection nodes with that
+        label, via a full scan plus filter."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'A', {x: 1}), virtualNode(2, 'B', {x: 2}), virtualNode(3, 'A', {x: 3})] AS nodes,
+                 [] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (n:A) RETURN n.x AS x }
+            RETURN x ORDER BY x;
+            """,
+        )
+        assert results == [(1,), (3,)]
+
+    def test_use_scope_label_filter_ignores_real_index(self, connection):
+        """A label scan over a projection stays a full scan even when the real
+        graph has an index on that label: the projection is read, not the real
+        graph."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "CREATE INDEX ON :A")
+        execute_and_fetch_all(cursor, "CREATE (:A {x: 100})")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'A', {x: 1}), virtualNode(2, 'B', {x: 2})] AS nodes, [] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (n:A) RETURN n.x AS x }
+            RETURN x ORDER BY x;
+            """,
+        )
+        assert results == [(1,)]
+
+    def test_use_scope_property_predicate(self, connection):
+        """A WHERE property predicate filters projection nodes by scan."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 10}), virtualNode(2, 'N', {x: 20}), virtualNode(3, 'N', {x: 30})] AS nodes,
+                 [] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (n) WHERE n.x > 15 RETURN n.x AS x }
+            RETURN x ORDER BY x;
+            """,
+        )
+        assert results == [(20,), (30,)]
+
+
+class TestUseScopeOverDerive:
+    """A USE scope over a derive() overlay projection: reads inside the scope go
+    through to the origin per the per-property binding."""
+
+    def _make_path(self, cursor):
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 7, secret: 42})-[:R]->(:N {id: 2, v: 9, secret: 43});")
+
+    def test_use_scope_over_derive_reads_through(self, connection):
+        """A MATCH inside the scope returns the origin's property values, and a
+        predicate over a read-through value filters correctly."""
+        cursor = connection.cursor()
+        self._make_path(cursor)
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            CALL { USE g MATCH (n) WHERE n.v > 8 RETURN n.id AS id, n.v AS v }
+            RETURN id, v ORDER BY id;
+            """,
+        )
+        assert results == [(2, 9)]
+
+    def test_use_scope_over_derive_overlay_shadows(self, connection):
+        """An overlay-bound key shadows the origin value inside the scope."""
+        cursor = connection.cursor()
+        self._make_path(cursor)
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {v: 'overlay'}, sourceNodeProperties: {v: 100}}) AS g
+            CALL { USE g MATCH (n) WHERE n.id = 1 RETURN n.v AS v }
+            RETURN v;
+            """,
+        )
+        assert results == [(100,)]
+
+    def test_use_scope_over_derive_hidden_invisible(self, connection):
+        """A hidden key is invisible to reads and to predicates inside the scope:
+        the read yields null and `WHERE n.secret IS NULL` matches every node."""
+        cursor = connection.cursor()
+        self._make_path(cursor)
+        read = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {secret: 'hidden'}}) AS g
+            CALL { USE g MATCH (n) WHERE n.id = 1 RETURN n.secret AS s }
+            RETURN s;
+            """,
+        )
+        assert read == [(None,)]
+
+        pred = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {secret: 'hidden'}}) AS g
+            CALL { USE g MATCH (n) WHERE n.secret IS NULL RETURN n.id AS id }
+            RETURN id ORDER BY id;
+            """,
+        )
+        assert pred == [(1,), (2,)]
+
+    def test_use_scope_over_derive_expands_with_read_through_endpoints(self, connection):
+        """Expanding the derived edge inside the scope binds endpoints that read
+        through to their origins."""
+        cursor = connection.cursor()
+        self._make_path(cursor)
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            CALL { USE g MATCH (a)-[r]->(b) RETURN a.id AS aid, type(r) AS t, b.id AS bid }
+            RETURN aid, t, bid;
+            """,
+        )
+        assert results == [(1, "E", 2)]
+
+    def test_use_scope_over_derive_degree_counts_projection_edges(self, connection):
+        """degree/outDegree/inDegree over a projection node count the projection's
+        edges, which differ from the node's real-graph degree."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        # a has real out-degree 2.
+        execute_and_fetch_all(cursor, "CREATE (a:N {id: 1})-[:R]->(:N {id: 2}), (a)-[:R]->(:N {id: 3});")
+        # The projection derived from the single path a->b has one edge.
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            CALL { USE g MATCH (n) WHERE n.id = 1 RETURN degree(n) AS d, outDegree(n) AS od, inDegree(n) AS ind }
+            RETURN d, od, ind;
+            """,
+        )
+        assert results == [(1, 1, 0)]
+        real = execute_and_fetch_all(cursor, "MATCH (a:N {id: 1}) RETURN outDegree(a) AS od;")
+        assert real == [(2,)]
+
+    def test_use_scope_reads_virtual_edge_property(self, connection):
+        """A projected edge reads a property through the same call site as a real
+        edge, by name lookup and by subscript."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1})-[:R]->(:N {id: 2});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', relationshipProperties: {weight: 99}}) AS g
+            CALL { USE g MATCH ()-[r]->() RETURN r.weight AS by_name, r['weight'] AS by_subscript }
+            RETURN by_name, by_subscript;
+            """,
+        )
+        assert results == [(99, 99)]
+
+
+class TestUseScopeOverSubgraph:
+    """A USE scope over a project() subgraph: scans its real member nodes and
+    keeps expansion within membership, through the same seam as projections."""
+
+    def test_use_scope_over_subgraph_scans_members(self, connection):
+        """A MATCH inside the scope returns only the subgraph's member nodes, not
+        other real-graph nodes."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:A {name: 'a'})-[:R]->(:B {name: 'b'}), (:C {name: 'c'});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:A)-[:R]->(:B)
+            WITH project(p) AS sg
+            CALL { USE sg MATCH (n) RETURN n.name AS name }
+            RETURN name ORDER BY name;
+            """,
+        )
+        assert results == [("a",), ("b",)]
+
+    def test_use_scope_over_subgraph_expansion_respects_membership(self, connection):
+        """Expanding inside the scope stays within the subgraph: a member node's
+        edge to a non-member is not traversed."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(
+            cursor,
+            "CREATE (a:A {name: 'a'})-[:R]->(b:B {name: 'b'}), (b)-[:R2]->(:C {name: 'c'});",
+        )
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:A)-[:R]->(:B)
+            WITH project(p) AS sg
+            CALL { USE sg MATCH (x)-[r]->(y) RETURN x.name AS xn, y.name AS yn }
+            RETURN xn, yn ORDER BY xn;
+            """,
+        )
+        assert results == [("a", "b")]
+
+    def test_use_scope_over_subgraph_degree_counts_member_edges(self, connection):
+        """degree over a subgraph member counts only member edges, differing from
+        the node's real-graph degree."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        # b has real degree 2: an in-edge from a and an out-edge to c.
+        execute_and_fetch_all(cursor, "CREATE (a:A)-[:R]->(b:B {id: 1}), (b)-[:R2]->(:C);")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:A)-[:R]->(:B)
+            WITH project(p) AS sg
+            CALL { USE sg MATCH (n:B) RETURN degree(n) AS d, inDegree(n) AS ind, outDegree(n) AS od }
+            RETURN d, ind, od;
+            """,
+        )
+        assert results == [(1, 1, 0)]
+        real = execute_and_fetch_all(cursor, "MATCH (b:B {id: 1}) RETURN degree(b) AS d;")
+        assert real == [(2,)]
+
+
+class TestUseScopeProceduresHonorAmbientView:
+    """Inside a `CALL { USE g ... }` scope, an unmodified read procedure that
+    reads `ctx.graph` operates on the bound view, not the real graph. The
+    procedures here take no graph argument, so the only graph they can see is
+    the ambient one routed in by the USE scope."""
+
+    def test_ambient_virtualgraph_view_iterates_projection_vertices(self, connection):
+        """An ambient virtualGraph projection: an unmodified vertex-iterating
+        procedure yields the projection's nodes."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 10}), virtualNode(2, 'N', {x: 20})] AS nodes, [] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g CALL read.subgraph_get_vertices() YIELD node RETURN node.x AS x }
+            RETURN x ORDER BY x;
+            """,
+        )
+        assert results == [(10,), (20,)]
+
+    def test_ambient_virtualgraph_view_expands_projection_edges(self, connection):
+        """An ambient virtualGraph projection: an unmodified edge-expanding
+        procedure traverses the projection's edges."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2})] AS nodes,
+                 [virtualEdge('R', 1, 2)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 1}) CALL read.subgraph_get_out_edges(a) YIELD edge RETURN type(edge) AS t }
+            RETURN t;
+            """,
+        )
+        assert results == [("R",)]
+
+    def test_ambient_subgraph_view_iterates_member_vertices(self, connection):
+        """An ambient project() subgraph: an unmodified vertex-iterating procedure
+        yields only the subgraph's member nodes."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:A {name: 'a'})-[:R]->(:B {name: 'b'}), (:C {name: 'c'});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:A)-[:R]->(:B)
+            WITH project(p) AS sg
+            CALL { USE sg CALL read.subgraph_get_vertices() YIELD node RETURN node.name AS name }
+            RETURN name ORDER BY name;
+            """,
+        )
+        assert results == [("a",), ("b",)]
+
+    def test_ambient_subgraph_view_expands_member_edges(self, connection):
+        """An ambient project() subgraph: an unmodified edge-expanding procedure
+        traverses a member node's edges through the bound subgraph."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:A {name: 'a'})-[:R]->(:B {name: 'b'}), (:C {name: 'c'});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:A)-[:R]->(:B)
+            WITH project(p) AS sg
+            CALL { USE sg MATCH (x:A) CALL read.subgraph_get_out_edges(x) YIELD edge RETURN type(edge) AS t }
+            RETURN t;
+            """,
+        )
+        assert results == [("R",)]
+
+    def test_procedure_outside_use_scope_sees_real_graph(self, connection):
+        """With no USE scope, the same procedure reads the real graph."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:Real {name: 'r1'}), (:Real {name: 'r2'});")
+        results = execute_and_fetch_all(
+            cursor,
+            "CALL read.subgraph_get_vertices() YIELD node RETURN node.name AS name ORDER BY name;",
+        )
+        assert results == [("r1",), ("r2",)]
+
+    def test_explicit_graph_argument_wins_over_ambient_view(self, connection):
+        """An explicit graph argument takes precedence over the ambient view:
+        `USE h { CALL proc(g) }` runs the procedure over g, not h."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualGraph([virtualNode(1, 'N', {x: 10})], []) AS g,
+                 virtualGraph([virtualNode(2, 'N', {x: 20})], []) AS h
+            CALL (g) { USE h CALL read.subgraph_get_vertices(g) YIELD node RETURN node.x AS x }
+            RETURN x;
+            """,
+        )
+        assert results == [(10,)]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/write_procedures/virtual_graph.py
+++ b/tests/e2e/write_procedures/virtual_graph.py
@@ -11,6 +11,7 @@
 
 import sys
 
+import mgclient
 import pytest
 from common import execute_and_fetch_all
 
@@ -121,6 +122,738 @@ class TestVirtualEdgesWithProcedures:
         by_person = {r[0]: r[1] for r in results}
         assert by_person["A1"] == by_person["A2"], "A1 and A2 both in eng → same community"
         assert by_person["A1"] != by_person["A3"], "A3 in sales → different community"
+
+
+class TestVirtualNodeConstructor:
+    def test_construct_with_label_list(self, connection):
+        """virtualNode(gid, [labels], props) yields a synthetic node carrying the
+        given labels and properties."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(1, ['Expert', 'Analyst'], {score: 42, name: 'A'}) AS n
+            RETURN labels(n) AS labels, n.score AS score, n.name AS name;
+            """,
+        )
+
+        assert len(results) == 1
+        labels, score, name = results[0]
+        assert sorted(labels) == ["Analyst", "Expert"]
+        assert score == 42
+        assert name == "A"
+
+    def test_construct_with_single_label(self, connection):
+        """The single-label form virtualNode(gid, 'Label', props) is accepted and
+        yields a node with that one label."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            "WITH virtualNode(1, 'Expert', {score: 42}) AS n RETURN labels(n) AS labels, n.score AS score;",
+        )
+
+        assert len(results) == 1
+        assert results[0][0] == ["Expert"]
+        assert results[0][1] == 42
+
+    def test_synthetic_id_distinct_from_real(self, connection):
+        """A constructed node carries a synthetic GID (counted down from the top of
+        the id space), never the user-supplied handle and never a real node's id."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:Real);")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH (r:Real)
+            WITH r, virtualNode(1, 'V', {}) AS n
+            RETURN id(n) AS vnid, id(r) AS rid;
+            """,
+        )
+
+        assert len(results) == 1
+        vnid, rid = results[0]
+        # Real gids count up from 0; synthetic gids count down from UINT64_MAX and
+        # decode as negative signed ints. The synthetic id is not the handle (1).
+        assert vnid < 0
+        assert vnid != rid
+        assert vnid != 1
+
+
+class TestVirtualEdgeConstructor:
+    def test_construct_between_virtual_nodes(self, connection):
+        """virtualEdge(type, from, to) given two virtual nodes wires an edge whose
+        endpoints are those nodes' synthetic ids; it carries its type and its own
+        synthetic id."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(1, 'A', {}) AS a, virtualNode(2, 'B', {}) AS b
+            WITH a, b, virtualEdge('KNOWS', a, b) AS e
+            RETURN e, id(a) AS aid, id(b) AS bid, id(e) AS eid, type(e) AS etype;
+            """,
+        )
+
+        assert len(results) == 1
+        e, aid, bid, eid, etype = results[0]
+        assert etype == "KNOWS"
+        assert e.type == "KNOWS"
+        # Endpoints are the nodes' synthetic ids; the edge carries its own synthetic id.
+        assert e.start_id == aid
+        assert e.end_id == bid
+        assert aid < 0 and bid < 0 and eid < 0
+
+    def test_construct_between_gid_handles(self, connection):
+        """virtualEdge(type, 1, 2) given gid handles wires an edge between those
+        gids; standalone it serializes with the handles as its endpoints, awaiting
+        binding to nodes at projection assembly."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            "WITH virtualEdge('LINKS', 1, 2) AS e RETURN e, id(e) AS eid, type(e) AS etype;",
+        )
+
+        assert len(results) == 1
+        e, eid, etype = results[0]
+        assert etype == "LINKS"
+        assert e.type == "LINKS"
+        assert e.start_id == 1
+        assert e.end_id == 2
+        assert eid < 0
+
+    def test_mixed_node_and_handle_endpoints(self, connection):
+        """The two endpoint forms may be mixed: one virtual node, one gid handle."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(7, 'A', {}) AS a
+            WITH a, virtualEdge('M', a, 2) AS e
+            RETURN e, id(a) AS aid;
+            """,
+        )
+
+        assert len(results) == 1
+        e, aid = results[0]
+        assert e.start_id == aid
+        assert aid < 0
+        assert e.end_id == 2
+
+    def test_real_vertex_endpoint_is_rejected(self, connection):
+        """A real vertex is not a valid endpoint; the error points at id() as the
+        way to wire a real node by handle."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:Real);")
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(cursor, "MATCH (r:Real) RETURN virtualEdge('T', r, r) AS e;")
+
+    def test_endpoint_node_of_unresolved_edge_errors(self, connection):
+        """startNode/endNode on an edge with an unresolved handle endpoint is an
+        error: it has no endpoint node until assembly binds it."""
+        cursor = connection.cursor()
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(cursor, "WITH virtualEdge('T', 1, 2) AS e RETURN startNode(e);")
+
+
+class TestVirtualGraphConstructor:
+    def test_assembles_graph_consumable_by_procedure(self, connection):
+        """virtualGraph(nodes, edges) imports a graph from lists; an edge given by
+        handles binds to the listed nodes, and a procedure can read it."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'Person', {name: 'A'}), virtualNode(2, 'Person', {name: 'B'})] AS nodes,
+                 [virtualEdge('KNOWS', 1, 2)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            UNWIND g.nodes AS n
+            CALL read.subgraph_edge_info(g, n) YIELD edge_type, weight
+            RETURN edge_type;
+            """,
+        )
+
+        # Node 1 has an out-edge to node 2; node 2 has none, so a single edge record.
+        assert len(results) == 1
+        assert results[0][0] == "KNOWS"
+
+    def test_dangling_edge_errors_by_default(self, connection):
+        """An edge whose endpoint matches no listed node aborts construction by
+        default."""
+        cursor = connection.cursor()
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(
+                cursor,
+                """
+                WITH [virtualNode(1, 'N', {})] AS nodes, [virtualEdge('R', 1, 2)] AS edges
+                RETURN virtualGraph(nodes, edges) AS g;
+                """,
+            )
+
+    def test_drop_mode_omits_dangling_edge(self, connection):
+        """onDanglingEdge: 'drop' omits the dangling edge and the construction
+        succeeds with the surviving nodes."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {})] AS nodes, [virtualEdge('R', 1, 2)] AS edges
+            WITH virtualGraph(nodes, edges, {onDanglingEdge: 'drop'}) AS g
+            RETURN size(g.nodes) AS node_count, size(g.edges) AS edge_count;
+            """,
+        )
+
+        assert len(results) == 1
+        assert results[0][0] == 1  # the one supplied node
+        assert results[0][1] == 0  # the dangling edge was dropped
+
+    def test_nulls_in_lists_are_skipped(self, connection):
+        """Nulls in either list are ignored rather than rejected."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {}), null] AS nodes, [null] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            RETURN size(g.nodes) AS node_count;
+            """,
+        )
+
+        assert len(results) == 1
+        assert results[0][0] == 1
+
+    def test_real_node_in_list_is_rejected(self, connection):
+        """A real vertex is not a synthetic element; the node list rejects it."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:Real);")
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(cursor, "MATCH (r:Real) RETURN virtualGraph([r], []) AS g;")
+
+
+class TestDeriveOverlayReadThrough:
+    def test_bare_derive_projects_single_node_without_edge_type(self, connection):
+        """A virtualEdgeType is only needed to project edges. derive(p, {}) over a
+        single-vertex path yields the overlay node, reading through to its origin,
+        with no edge type required."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 7});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})
+            WITH derive(p, {}) AS g
+            UNWIND g.nodes AS n
+            RETURN n.v AS v;
+            """,
+        )
+        assert len(results) == 1
+        assert results[0][0] == 7  # read through to the origin
+
+    def test_bare_derive_errors_when_path_has_edges(self, connection):
+        """A path with edges still requires a virtualEdgeType to name the derived
+        edge."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1})-[:R]->(:N {id: 2});")
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(
+                cursor,
+                "MATCH p=(:N {id: 1})-[:R]->(:N {id: 2}) WITH derive(p, {}) AS g RETURN g;",
+            )
+
+    def test_reads_origin_property_value(self, connection):
+        """An overlay node from derive() with no property override reads its origin's
+        property values."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 7})-[:R]->(:N {id: 2, v: 9});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            UNWIND g.nodes AS n
+            RETURN n.id AS id, n.v AS v ORDER BY id;
+            """,
+        )
+        assert results == [(1, 7), (2, 9)]
+
+    def test_read_is_lazy_not_a_copy(self, connection):
+        """Reads fall through to the origin at read time, not a snapshot taken at
+        construction: mutating the origin after derive() is visible through the
+        overlay node. A copy would still show the pre-mutation value.
+        """
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(a:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g, a
+            SET a.v = 100
+            RETURN [n IN g.nodes | n.v] AS vs;
+            """,
+        )
+        # origin a.v is now 100, b.v stays 2; read-through reflects the mutation.
+        assert sorted(results[0][0]) == [2, 100]
+
+    def test_overlay_node_exposes_origin_properties(self, connection):
+        """properties() over an overlay node returns the merged view (origin keys read
+        through), so a returned overlay node carries its origin's properties."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 7})-[:R]->(:N {id: 2, v: 9});")
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            UNWIND g.nodes AS n
+            WITH n WHERE n.id = 1
+            RETURN properties(n) AS props;
+            """,
+        )
+        assert results[0][0] == {"id": 1, "v": 7}
+
+
+class TestDerivePerPropertyBinding:
+    def _make_path(self, cursor):
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 7, secret: 42})-[:R]->(:N {id: 2, v: 9});")
+
+    def test_hidden_property_invisible_to_reads(self, connection):
+        """A property bound 'hidden' is absent from reads and from function calls over the
+        node, while an unlisted property still reads through to the origin."""
+        cursor = connection.cursor()
+        self._make_path(cursor)
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {secret: 'hidden'}}) AS g
+            UNWIND g.nodes AS n
+            WITH n WHERE n.id = 1
+            RETURN n.secret AS secret, n.v AS v, properties(n) AS props;
+            """,
+        )
+        secret, v, props = results[0]
+        assert secret is None
+        assert v == 7  # unlisted -> read-through
+        assert props == {"id": 1, "v": 7}  # 'secret' hidden from properties()
+
+    def test_overlay_binding_with_override_shadows(self, connection):
+        """A key bound 'overlay' with a sourceNodeProperties override shadows the origin
+        value on read, and is not treated as a conflict."""
+        cursor = connection.cursor()
+        self._make_path(cursor)
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {
+                virtualEdgeType: 'E',
+                propertyPolicy: {v: 'overlay'},
+                sourceNodeProperties: {v: 100}
+            }) AS g
+            UNWIND g.nodes AS n
+            WITH n WHERE n.id = 1
+            RETURN n.v AS v;
+            """,
+        )
+        assert results[0][0] == 100
+
+    def test_overlay_and_origin_binding_conflict_errors(self, connection):
+        """Overlaying a key and binding it to 'origin' is a construction-time error."""
+        cursor = connection.cursor()
+        self._make_path(cursor)
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(
+                cursor,
+                """
+                MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+                WITH derive(p, {
+                    virtualEdgeType: 'E',
+                    propertyPolicy: {v: 'origin'},
+                    sourceNodeProperties: {v: 100}
+                }) AS g
+                RETURN g;
+                """,
+            )
+
+
+class TestVirtualNodeSet:
+    def test_set_single_property_overwrites_and_adds(self, connection):
+        """SET n.key = value on a synthetic node overwrites an existing overlay key
+        and creates a previously-absent one; a read in the same query sees the write."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(1, 'V', {x: 1}) AS n
+            SET n.x = 2
+            SET n.y = 9
+            RETURN n.x AS x, n.y AS y;
+            """,
+        )
+        assert results == [(2, 9)]
+
+    def test_set_single_property_null_removes_key(self, connection):
+        """SET n.key = null removes the overlay key, matching real-node semantics."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(1, 'V', {x: 1, y: 2}) AS n
+            SET n.x = null
+            RETURN n.x AS x, properties(n) AS props;
+            """,
+        )
+        assert len(results) == 1
+        x, props = results[0]
+        assert x is None
+        assert props == {"y": 2}
+
+    def test_set_map_merge_updates_overlay(self, connection):
+        """SET n += {..} merges the map into the overlay, keeping untouched keys."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(1, 'V', {x: 1}) AS n
+            SET n += {y: 2, z: 3}
+            RETURN properties(n) AS props;
+            """,
+        )
+        assert results[0][0] == {"x": 1, "y": 2, "z": 3}
+
+    def test_set_map_replace_clears_overlay(self, connection):
+        """SET n = {..} replaces the whole overlay: prior keys are gone."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(1, 'V', {x: 1, y: 2}) AS n
+            SET n = {z: 3}
+            RETURN properties(n) AS props;
+            """,
+        )
+        assert results[0][0] == {"z": 3}
+
+    def test_set_does_not_error_on_synthetic_node(self, connection):
+        """A SET on a synthetic node never raises, regardless of form."""
+        cursor = connection.cursor()
+        # Each form should run without raising.
+        execute_and_fetch_all(cursor, "WITH virtualNode(1, 'V', {}) AS n SET n.a = 1 RETURN n;")
+        execute_and_fetch_all(cursor, "WITH virtualNode(1, 'V', {}) AS n SET n += {b: 1} RETURN n;")
+        execute_and_fetch_all(cursor, "WITH virtualNode(1, 'V', {a: 1}) AS n SET n = {c: 1} RETURN n;")
+
+
+class TestOverlayWriteBack:
+    """SET through a derive() overlay node routes per the static per-property binding:
+    a declared 'overlay' key mutates the overlay (compute-only, never persisted), while
+    an 'origin'-bound or undeclared key persists to the real origin vertex."""
+
+    def test_undeclared_key_persists_to_origin(self, connection):
+        """A SET to a key the projection does not declare targets the origin and persists
+        to the real node, observed by a follow-up MATCH in a separate query."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+
+        execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            UNWIND g.nodes AS n
+            SET n.rank = 7
+            RETURN count(*);
+            """,
+        )
+
+        persisted = execute_and_fetch_all(cursor, "MATCH (m:N) RETURN m.id AS id, m.rank AS rank ORDER BY id;")
+        assert persisted == [(1, 7), (2, 7)]
+
+    def test_origin_bound_key_persists_to_origin(self, connection):
+        """A SET to a key bound 'origin' by propertyPolicy persists to the real node."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+
+        execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {v: 'origin'}}) AS g
+            UNWIND g.nodes AS n
+            SET n.v = 99
+            RETURN count(*);
+            """,
+        )
+
+        persisted = execute_and_fetch_all(cursor, "MATCH (m:N) RETURN m.id AS id, m.v AS v ORDER BY id;")
+        assert persisted == [(1, 99), (2, 99)]
+
+    def test_overlay_key_updates_overlay_and_does_not_persist(self, connection):
+        """A SET to a key declared 'overlay' (with no origin override value) mutates the
+        overlay - the in-query read shows the new value - but the real node is untouched."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+
+        in_query = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {v: 'overlay'}}) AS g
+            UNWIND g.nodes AS n
+            SET n.v = 99
+            RETURN collect(n.v) AS vs;
+            """,
+        )
+        assert in_query[0][0] == [99, 99]
+
+        persisted = execute_and_fetch_all(cursor, "MATCH (m:N) RETURN m.id AS id, m.v AS v ORDER BY id;")
+        assert persisted == [(1, 1), (2, 2)], "overlay write must not touch the real node"
+
+    def test_read_after_write_through_overlay_has_no_stale_shadow(self, connection):
+        """After an origin-bound write, reading the same key through the overlay node returns
+        the just-written value (read-through reflects the persisted write, no stale overlay)."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            UNWIND g.nodes AS n
+            SET n.v = n.v + 100
+            RETURN n.id AS id, n.v AS v ORDER BY id;
+            """,
+        )
+        assert results == [(1, 101), (2, 102)]
+
+        persisted = execute_and_fetch_all(cursor, "MATCH (m:N) RETURN m.id AS id, m.v AS v ORDER BY id;")
+        assert persisted == [(1, 101), (2, 102)]
+
+    def test_algorithm_write_back_persists_scores_onto_origin(self, connection):
+        """An algorithm-shaped procedure over a derive() projection yields overlay nodes; a
+        SET on a yielded node persists the computed score onto the real origin node."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(
+            cursor,
+            """
+            CREATE (a1:Person {name: 'A1', dept: 'eng'}),
+                   (a2:Person {name: 'A2', dept: 'eng'}),
+                   (a3:Person {name: 'A3', dept: 'sales'}),
+                   (c1:Company {name: 'ACME'}),
+                   (a1)-[:WORKS_AT]->(c1),
+                   (a2)-[:WORKS_AT]->(c1),
+                   (a3)-[:WORKS_AT]->(c1);
+            """,
+        )
+
+        execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(a:Person)-[:WORKS_AT]->(:Company)<-[:WORKS_AT]-(b:Person)
+            WHERE id(a) < id(b)
+            WITH derive(p, {
+                virtualEdgeType: 'COLLEAGUES',
+                sourceNodeProperties: {dept: a.dept},
+                targetNodeProperties: {dept: b.dept}
+            }) AS subgraph
+            CALL read.community_label(subgraph, 'dept') YIELD node, community_id
+            SET node.community = community_id
+            RETURN count(*);
+            """,
+        )
+
+        persisted = execute_and_fetch_all(
+            cursor, "MATCH (p:Person) RETURN p.name AS name, p.community AS community ORDER BY name;"
+        )
+        by_person = {name: community for name, community in persisted}
+        assert all(c is not None for c in by_person.values()), "community must persist on every real node"
+        assert by_person["A1"] == by_person["A2"], "A1 and A2 both in eng -> same community"
+        assert by_person["A1"] != by_person["A3"], "A3 in sales -> different community"
+
+
+class TestBoltOverlaySerialization:
+    """An overlay node serializes over Bolt at its origin's identity (so a client maps it
+    back to the real node) with the merged property view; a synthetic node keeps its
+    synthetic id. The Bolt Node structure shape is unchanged - only which id and which
+    properties are written."""
+
+    def test_overlay_node_serializes_at_origin_id_with_merged_properties(self, connection):
+        """Each overlay node decodes with its origin's Bolt id and the origin's property
+        map (no override given, so the merged view equals the origin's properties)."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+
+        reals = execute_and_fetch_all(cursor, "MATCH (m:N) RETURN m;")
+        real_by_pid = {node.properties["id"]: node for (node,) in reals}
+
+        rows = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            UNWIND g.nodes AS o
+            RETURN o;
+            """,
+        )
+
+        assert len(rows) == 2
+        for (overlay,) in rows:
+            real = real_by_pid[overlay.properties["id"]]
+            assert overlay.id == real.id, "overlay node must serialize at its origin's Bolt id"
+            origin_props = {k: v for k, v in overlay.properties.items() if not k.startswith("__mg")}
+            assert origin_props == real.properties
+            assert overlay.labels == real.labels
+
+    def test_overlay_value_shadows_origin_in_serialized_map(self, connection):
+        """A construction-time override shadows the origin value in the serialized property
+        map, while the node still carries its origin's id."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+
+        real_source = {
+            node.properties["id"]: node for (node,) in execute_and_fetch_all(cursor, "MATCH (m:N) RETURN m;")
+        }[1]
+
+        rows = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E', sourceNodeProperties: {v: 999}}) AS g
+            UNWIND g.nodes AS o
+            RETURN o;
+            """,
+        )
+
+        source = next(o for (o,) in rows if o.properties["id"] == 1)
+        assert source.id == real_source.id
+        assert source.properties["v"] == 999, "overlay value shadows the origin in the serialized map"
+
+    def test_synthetic_node_keeps_synthetic_id(self, connection):
+        """A synthetic node (no origin) serializes with its own synthetic id, distinct from
+        any real node's id."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:Real);")
+
+        real = execute_and_fetch_all(cursor, "MATCH (r:Real) RETURN r;")[0][0]
+        synthetic = execute_and_fetch_all(cursor, "RETURN virtualNode(1, 'V', {x: 1}) AS n;")[0][0]
+
+        assert synthetic.id < 0, "synthetic gids count down from the top of the id space"
+        assert synthetic.id != real.id
+        assert synthetic.properties == {"x": 1}
+
+
+class TestBoltProvenanceTag:
+    """Each overlay node from derive() carries a reserved projection-tag property
+    (__mg_overlay_ref, a plain Int) referencing its projection-schema entry. Every overlay
+    node from one derive() shares the tag value (one schema entry per derive() site). Real
+    nodes and synthetic virtualNode() nodes carry no tag. The tag is an ordinary Int
+    property, so a generic client decodes the result unchanged and scalar values are sent
+    unwrapped."""
+
+    TAG = "__mg_overlay_ref"
+
+    def test_overlay_nodes_carry_a_shared_int_tag(self, connection):
+        """Both overlay nodes from a single derive() carry __mg_overlay_ref as an int, and
+        the value is the same on both - they reference one schema entry."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 1})-[:R]->(:N {id: 2, v: 2});")
+
+        rows = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            UNWIND g.nodes AS o
+            RETURN o;
+            """,
+        )
+
+        assert len(rows) == 2
+        tags = [o.properties.get(self.TAG) for (o,) in rows]
+        assert all(isinstance(t, int) for t in tags), "every overlay node carries an int tag"
+        assert tags[0] == tags[1], "all overlay nodes from one derive() share the tag value"
+
+    def test_real_node_carries_no_tag(self, connection):
+        """A node from a plain MATCH belongs to no projection, so it carries no tag."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 7});")
+
+        real = execute_and_fetch_all(cursor, "MATCH (n:N) RETURN n;")[0][0]
+        assert self.TAG not in real.properties
+
+    def test_synthetic_node_carries_no_tag(self, connection):
+        """A synthetic virtualNode() has no origin and no projection, so it carries no tag;
+        its scalar properties arrive unwrapped."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+
+        synthetic = execute_and_fetch_all(cursor, "RETURN virtualNode(1, 'V', {x: 1}) AS n;")[0][0]
+        assert self.TAG not in synthetic.properties
+        assert synthetic.properties == {"x": 1}
+
+    def test_tagged_overlay_keeps_origin_scalars_unwrapped(self, connection):
+        """Tagging the node does not wrap the origin's scalar property values - they decode
+        as plain scalars alongside the int tag."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1, v: 7, name: 'x'})-[:R]->(:N {id: 2});")
+
+        rows = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, {virtualEdgeType: 'E'}) AS g
+            UNWIND g.nodes AS o
+            RETURN o;
+            """,
+        )
+
+        source = next(o for (o,) in rows if o.properties.get("id") == 1)
+        assert source.properties["v"] == 7
+        assert source.properties["name"] == "x"
+
+    def test_param_options_derive_emits_no_tag(self, connection):
+        """When derive() options are not a static map literal (here, the whole options map
+        is a query parameter), the projection schema is unknowable before execution. The
+        overlay nodes still serialize at their origin identity, but carry no tag - there is
+        no schema entry for a projection-aware client to point them at."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:N {id: 1})-[:R]->(:N {id: 2});")
+
+        rows = execute_and_fetch_all(
+            cursor,
+            """
+            MATCH p=(:N {id: 1})-[:R]->(:N {id: 2})
+            WITH derive(p, $opts) AS g
+            UNWIND g.nodes AS o
+            RETURN o;
+            """,
+            {"opts": {"virtualEdgeType": "E"}},
+        )
+
+        assert len(rows) == 2
+        for (o,) in rows:
+            assert self.TAG not in o.properties, "a projection with non-literal options carries no tag"
 
 
 if __name__ == "__main__":

--- a/tests/e2e/write_procedures/virtual_graph.py
+++ b/tests/e2e/write_procedures/virtual_graph.py
@@ -143,6 +143,32 @@ class TestVirtualNodeConstructor:
         assert score == 42
         assert name == "A"
 
+    def test_property_size_matches_real_node(self, connection):
+        """propertySize over a synthetic node reports the value's encoded size, the
+        same metric as a real node carrying that property (transparency); an absent
+        key reports 0."""
+        cursor = connection.cursor()
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(cursor, "CREATE (:Ref {name: 'hello', score: 42});")
+
+        real_name, real_score = execute_and_fetch_all(
+            cursor,
+            "MATCH (n:Ref) RETURN propertySize(n, 'name') AS name, propertySize(n, 'score') AS score;",
+        )[0]
+        virtual_name, virtual_score, virtual_absent = execute_and_fetch_all(
+            cursor,
+            """
+            WITH virtualNode(1, ['Ref'], {name: 'hello', score: 42}) AS n
+            RETURN propertySize(n, 'name') AS name,
+                   propertySize(n, 'score') AS score,
+                   propertySize(n, 'absent') AS absent;
+            """,
+        )[0]
+
+        assert virtual_name == real_name > 0
+        assert virtual_score == real_score > 0
+        assert virtual_absent == 0
+
     def test_construct_with_single_label(self, connection):
         """The single-label form virtualNode(gid, 'Label', props) is accepted and
         yields a node with that one label."""

--- a/tests/e2e/write_procedures/virtual_graph.py
+++ b/tests/e2e/write_procedures/virtual_graph.py
@@ -1066,6 +1066,121 @@ class TestUseScope:
         )
         assert results == [(20,), (30,)]
 
+    def test_use_scope_variable_length(self, connection):
+        """A depth-first variable-length pattern inside the scope walks the projection's
+        edge index: *1..2 from node 1 along the R chain reaches nodes 2 and 3."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 1})-[r:R*1..2]->(b) RETURN b.x AS bx }
+            RETURN bx ORDER BY bx;
+            """,
+        )
+        assert results == [(2,), (3,)]
+
+    def test_use_scope_variable_length_bounded(self, connection):
+        """The upper bound is honoured: *1..1 stops after a single hop."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 1})-[r:R*1..1]->(b) RETURN b.x AS bx }
+            RETURN bx ORDER BY bx;
+            """,
+        )
+        assert results == [(2,)]
+
+    def test_use_scope_breadth_first(self, connection):
+        """The natural (a)-[*BFS]->(b) form is a single-source BFS over the projection,
+        reaching each node at its shortest depth: node 2 at depth 1, node 3 at depth 2."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 1})-[e *BFS 1..10]->(b) RETURN b.x AS bx, size(e) AS len }
+            RETURN bx, len ORDER BY bx;
+            """,
+        )
+        assert results == [(2, 1), (3, 2)]
+
+    def test_use_scope_shortest_path_between_bound_nodes(self, connection):
+        """Both endpoints pre-bound (WITH barrier) makes the *BFS an s-t shortest path,
+        which walks the projection bidirectionally and reconstructs the path."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 1}), (b {x: 3}) WITH a, b MATCH (a)-[e *BFS]->(b) RETURN size(e) AS len }
+            RETURN len;
+            """,
+        )
+        assert results == [(2,)]
+
+    def test_use_scope_weighted_shortest_path(self, connection):
+        """Weighted shortest path over the projection: the weight lambda reads a virtual
+        node property. Node 4 is reached by the cheaper 1->2->4 (weight 2), not 1->3->4
+        (weight 101); node 3 sits at weight 100."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 0}), virtualNode(2, 'N', {x: 1}), virtualNode(3, 'N', {x: 100}),
+                  virtualNode(4, 'N', {x: 1})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('R', 2, 4), virtualEdge('R', 1, 3), virtualEdge('R', 3, 4)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 0})-[e *wShortest 10 (edge, n | n.x) w]->(b) RETURN w AS weight, size(e) AS len }
+            RETURN weight, len ORDER BY weight;
+            """,
+        )
+        assert results == [(1, 1), (2, 2), (100, 1)]
+
+    def test_use_scope_all_shortest_paths(self, connection):
+        """All-shortest paths enumerates every equal-cost path: in the unit-weight diamond,
+        node 4 is reached by two shortest paths (via 2 and via 3), so it appears twice."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3}),
+                  virtualNode(4, 'N', {x: 4})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('R', 1, 3), virtualEdge('R', 2, 4), virtualEdge('R', 3, 4)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 1})-[e *allShortest 10 (edge, n | 1) w]->(b) RETURN b.x AS bx, size(e) AS len }
+            RETURN bx, len ORDER BY bx, len;
+            """,
+        )
+        assert results == [(2, 1), (3, 1), (4, 2), (4, 2)]
+
+    def test_use_scope_k_shortest_paths(self, connection):
+        """K-shortest paths enumerates the loopless paths between two bound nodes: the
+        diamond's two length-2 paths 1->2->4 and 1->3->4 are both returned."""
+        cursor = connection.cursor()
+        results = execute_and_fetch_all(
+            cursor,
+            """
+            WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3}),
+                  virtualNode(4, 'N', {x: 4})] AS nodes,
+                 [virtualEdge('R', 1, 2), virtualEdge('R', 2, 4), virtualEdge('R', 1, 3), virtualEdge('R', 3, 4)] AS edges
+            WITH virtualGraph(nodes, edges) AS g
+            CALL { USE g MATCH (a {x: 1}), (b {x: 4}) WITH a, b MATCH (a)-[r *kshortest..10]->(b) RETURN size(r) AS len }
+            RETURN len ORDER BY len;
+            """,
+        )
+        assert results == [(2,), (2,)]
+
 
 class TestUseScopeOverDerive:
     """A USE scope over a derive() overlay projection: reads inside the scope go

--- a/tests/manual/single_query.cpp
+++ b/tests/manual/single_query.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
   ResultStreamFaker stream(db_acc->storage());
   memgraph::query::AllowEverythingAuthChecker auth_checker;
   interpreter.SetUser(auth_checker.GenQueryUser(std::nullopt, {}));
-  auto [header, _1, qid, _2] = interpreter.Prepare(argv[1], memgraph::query::no_params_fn, {});
+  auto [header, _1, qid, _2, _3] = interpreter.Prepare(argv[1], memgraph::query::no_params_fn, {});
   stream.Header(header);
   auto summary = interpreter.PullAll(&stream);
   stream.Summary(summary);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -310,6 +310,11 @@ add_unit_test(query_graph_view
     LINK_TARGETS mg-query storage_test_utils mg-glue mg-auth
 )
 
+add_unit_test(query_overlay_authorization
+    SOURCES query_overlay_authorization.cpp
+    LINK_TARGETS mg-query storage_test_utils
+)
+
 
 # END query/procedure
 add_unit_test(query_profile

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -305,6 +305,11 @@ add_unit_test(query_virtual_graph
     INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include
 )
 
+add_unit_test(query_graph_view
+    SOURCES query_graph_view.cpp
+    LINK_TARGETS mg-query storage_test_utils mg-glue mg-auth
+)
+
 
 # END query/procedure
 add_unit_test(query_profile

--- a/tests/unit/bolt_encoder.cpp
+++ b/tests/unit/bolt_encoder.cpp
@@ -11,12 +11,14 @@
 
 #include <array>
 #include <bit>
+#include <cstring>
 #include <memory>
 #include <span>
 
 #include "bolt_common.hpp"
 #include "bolt_testdata.hpp"
 #include "communication/bolt/v1/codes.hpp"
+#include "communication/bolt/v1/decoder/decoder.hpp"
 #include "communication/bolt/v1/encoder/encoder.hpp"
 #include "disk_test_utils.hpp"
 #include "glue/communication.hpp"
@@ -83,6 +85,36 @@ TestBuffer encoder_buffer(output_stream);
 memgraph::communication::bolt::Encoder<TestBuffer> bolt_encoder(encoder_buffer);
 std::vector<uint8_t> &output = output_stream.output;
 
+// Feeds already-encoded bytes back to a Decoder, so a Value can be round-tripped through the wire
+// format the way a generic client would decode it.
+class ReadbackBuffer {
+ public:
+  explicit ReadbackBuffer(std::vector<uint8_t> data) : data_(std::move(data)) {}
+
+  bool Read(uint8_t *out, size_t len) {
+    if (pos_ + len > data_.size()) return false;
+    std::memcpy(out, data_.data() + pos_, len);
+    pos_ += len;
+    return true;
+  }
+
+ private:
+  std::vector<uint8_t> data_;
+  size_t pos_{0};
+};
+
+Value RoundTrip(const Value &value) {
+  TestOutputStream out;
+  TestBuffer buffer(out);
+  memgraph::communication::bolt::BaseEncoder<TestBuffer> encoder(buffer);
+  encoder.WriteValue(value);
+  ReadbackBuffer readback(out.output);
+  memgraph::communication::bolt::Decoder<ReadbackBuffer> decoder(readback);
+  Value decoded;
+  EXPECT_TRUE(decoder.ReadValue(&decoded));
+  return decoded;
+}
+
 struct BoltEncoder : ::testing::Test {
   // In newer gtest library (1.8.1+) this is changed to SetUpTestSuite
   static void SetUpTestCase() { InitializeData(data, SIZE); }
@@ -91,6 +123,56 @@ struct BoltEncoder : ::testing::Test {
 };
 
 }  // namespace
+
+// The projection-schema table is a once-per-result map sent in the RUN header so a projection-aware
+// client can style overlay nodes. Its entries are plain nested maps, lists, and strings, so a
+// generic Bolt decoder reads it with no special handling. The table is keyed by each projection's
+// reference (a stringified Int), pointing at a small extensible map of the overlay key names and the
+// virtual edge type.
+TEST_F(BoltEncoder, ProjectionSchemaTableRoundTrips) {
+  bolt_map_t entry;
+  entry.emplace("overlay", std::vector<Value>{Value{"score"}, Value{"rank"}});
+  entry.emplace("edgeType", Value{"DERIVED"});
+  bolt_map_t table;
+  table.emplace("3", Value{std::move(entry)});
+
+  Value decoded = RoundTrip(Value{std::move(table)});
+
+  ASSERT_EQ(decoded.type(), Value::Type::Map);
+  const auto &decoded_table = decoded.ValueMap();
+  ASSERT_EQ(decoded_table.size(), 1U);
+  ASSERT_EQ(decoded_table.count("3"), 1U);
+
+  const auto &decoded_entry = decoded_table.at("3").ValueMap();
+  ASSERT_EQ(decoded_entry.at("edgeType").type(), Value::Type::String);
+  EXPECT_EQ(decoded_entry.at("edgeType").ValueString(), "DERIVED");
+
+  const auto &overlay = decoded_entry.at("overlay").ValueList();
+  ASSERT_EQ(overlay.size(), 2U);
+  EXPECT_EQ(overlay[0].ValueString(), "score");
+  EXPECT_EQ(overlay[1].ValueString(), "rank");
+}
+
+// An overlay node carries its projection reference as the reserved __mg_overlay_ref property, a plain
+// Int. Provenance never wraps a scalar property value (no {__type, __value} envelope), so the tag and
+// the origin's own scalars decode as ordinary values that a generic client consumes directly.
+TEST_F(BoltEncoder, ProjectionTagAndScalarsAreUnwrapped) {
+  bolt_map_t properties;
+  properties.emplace("__mg_overlay_ref", Value{static_cast<int64_t>(3)});
+  properties.emplace("id", Value{static_cast<int64_t>(42)});
+  properties.emplace("name", Value{"alice"});
+
+  Value decoded = RoundTrip(Value{std::move(properties)});
+
+  ASSERT_EQ(decoded.type(), Value::Type::Map);
+  const auto &decoded_props = decoded.ValueMap();
+  ASSERT_EQ(decoded_props.at("__mg_overlay_ref").type(), Value::Type::Int);
+  EXPECT_EQ(decoded_props.at("__mg_overlay_ref").ValueInt(), 3);
+  ASSERT_EQ(decoded_props.at("id").type(), Value::Type::Int);
+  EXPECT_EQ(decoded_props.at("id").ValueInt(), 42);
+  ASSERT_EQ(decoded_props.at("name").type(), Value::Type::String);
+  EXPECT_EQ(decoded_props.at("name").ValueString(), "alice");
+}
 
 TEST_F(BoltEncoder, NullAndBool) {
   std::vector<Value> vals;

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -69,12 +69,12 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
     throw ClientError("client sent invalid query");
   }
 
-  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare() {
+  memgraph::communication::bolt::PreparedRunMetadata InterpretPrepare() {
     if (query_ == kQueryReturn42 || query_ == kQueryEmpty || query_ == kQueryReturnMultiple) {
-      return {{"result_name"}, {}};
+      return {{"result_name"}, {}, {}};
     }
     if (query_ == kQueryShowTx) {
-      return {{"username", "transaction_id", "query", "status", "metadata"}, {}};
+      return {{"username", "transaction_id", "query", "status", "metadata"}, {}, {}};
     }
     throw ClientError("client sent invalid query");
   }

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -39,6 +39,7 @@
 #include "query/frontend/ast/query/user_profile.hpp"
 #include "query/frontend/opencypher/parser.hpp"
 #include "query/frontend/semantic/rw_checker.hpp"
+#include "query/frontend/semantic/symbol_generator.hpp"
 #include "query/frontend/stripped.hpp"
 #include "query/parameters.hpp"
 #include "query/procedure/cypher_types.hpp"
@@ -7784,6 +7785,33 @@ TEST_P(CypherMainVisitorTest, CallSubqueryThrow) {
   TestInvalidQuery<SyntaxException>("MATCH (n) CALL (n.prop) { RETURN 1 AS x } RETURN n", ast_generator);
 }
 
+TEST_P(CypherMainVisitorTest, CallSubqueryUseScope) {
+  auto &ast_generator = *GetParam();
+
+  auto symbol_table_of = [&](const std::string &query_string) {
+    auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery(query_string));
+    MG_ASSERT(query, "expected a cypher query");
+    return memgraph::query::MakeSymbolTable(query);
+  };
+
+  // A read-only USE scope passes semantic analysis.
+  EXPECT_NO_THROW(symbol_table_of("WITH 1 AS g CALL { USE g MATCH (n) RETURN n } RETURN n"));
+
+  // A write clause inside a USE scope is rejected.
+  EXPECT_THROW(symbol_table_of("WITH 1 AS g CALL { USE g CREATE (n) } RETURN 1"), SemanticException);
+  EXPECT_THROW(symbol_table_of("WITH 1 AS g, 2 AS n CALL (n) { USE g SET n.x = 1 } RETURN n"), SemanticException);
+  EXPECT_THROW(symbol_table_of("WITH 1 AS g, 2 AS n CALL (n) { USE g DELETE n } RETURN 1"), SemanticException);
+  EXPECT_THROW(symbol_table_of("WITH 1 AS g, 2 AS n CALL (n) { USE g REMOVE n.x } RETURN n"), SemanticException);
+
+  // A second level of USE nesting is rejected (v1 is single-level).
+  EXPECT_THROW(
+      symbol_table_of("WITH 1 AS g, 2 AS h CALL { USE g CALL { USE h MATCH (n) RETURN n } RETURN n } RETURN n"),
+      SemanticException);
+
+  // A plain nested subquery inside a USE scope is read-only too: its write is rejected.
+  EXPECT_THROW(symbol_table_of("WITH 1 AS g CALL { USE g CALL { CREATE (n) } RETURN 1 } RETURN 1"), SemanticException);
+}
+
 TEST_P(CypherMainVisitorTest, CallSubquery) {
   auto &ast_generator = *GetParam();
 
@@ -7797,7 +7825,26 @@ TEST_P(CypherMainVisitorTest, CallSubquery) {
 
     const auto *match = dynamic_cast<Match *>(subquery->single_query_->clauses_[0]);
     ASSERT_TRUE(match);
+    // An ordinary subquery binds no scope graph.
+    EXPECT_EQ(call_subquery->use_graph_, nullptr);
     CheckRWType(query, kRead);
+  }
+
+  {
+    // `CALL { USE <expr> ... }` binds the expression as the subquery's scope graph.
+    const auto *query = dynamic_cast<CypherQuery *>(
+        ast_generator.ParseQuery("MATCH (n) CALL { USE g MATCH (m) RETURN m } RETURN n, m"));
+    const auto *call_subquery = dynamic_cast<CallSubquery *>(query->single_query_->clauses_[1]);
+    ASSERT_TRUE(call_subquery);
+
+    const auto *use_graph = dynamic_cast<Identifier *>(call_subquery->use_graph_);
+    ASSERT_TRUE(use_graph);
+    EXPECT_EQ(use_graph->name_, "g");
+
+    const auto *subquery = dynamic_cast<CypherQuery *>(call_subquery->cypher_query_);
+    ASSERT_TRUE(subquery);
+    const auto *match = dynamic_cast<Match *>(subquery->single_query_->clauses_[0]);
+    ASSERT_TRUE(match);
   }
 
   {

--- a/tests/unit/glue_communication.cpp
+++ b/tests/unit/glue_communication.cpp
@@ -164,6 +164,22 @@ TEST_F(ToBoltTest, PropertyFGAOverlayOmitsDeniedOriginProperty) {
   EXPECT_FALSE(props.contains("ssn"));
 }
 
+TEST_F(ToBoltTest, PropertyFGAOverlayOriginLabelReadFailurePropagates) {
+  // When the origin's labels cannot be read (here: the origin vertex is deleted), the per-property FGA
+  // decision cannot be made. ToBoltVertex must propagate the storage error rather than silently drop
+  // or expose properties, matching how the query-side readers (eval, properties()) surface the same
+  // failure - the single OverlayReadAuthorization decision, reacted to per caller.
+  auto acc = storage->Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  ASSERT_TRUE(vertex.AddLabel(acc->NameToLabel("Employee")).has_value());
+  ASSERT_TRUE(acc->DeleteVertex(&vertex).has_value());
+
+  memgraph::query::VirtualNode overlay({"Employee"}, {}, {}, std::optional<memgraph::query::VertexAccessor>{vertex});
+  StubPropertyFGAChecker checker(storage.get(), {{"Employee", "ssn"}});
+  auto result = memgraph::glue::ToBoltVertex(overlay, *storage, memgraph::storage::View::NEW, &checker);
+  EXPECT_FALSE(result.has_value());
+}
+
 TEST_F(ToBoltTest, PropertyFGAOverlayBoundOverrideExemptFromOriginDeny) {
   // An overlay-bound override is the author's computed value, not the origin's protected data, so it
   // is serialized even when its key name is denied on the origin's label.

--- a/tests/unit/glue_communication.cpp
+++ b/tests/unit/glue_communication.cpp
@@ -175,12 +175,12 @@ TEST_F(ToBoltTest, PropertyFGAOverlayBoundOverrideExemptFromOriginDeny) {
   ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
 
   auto ssn_id = acc->NameToProperty("ssn");
+  // ssn is overlaid with "masked": it is overlay-bound through the overlay store (it carries a
+  // value), so no ProjectionSchema is needed to bind it.
   memgraph::query::VirtualNode overlay({"Employee"},
                                        {{ssn_id, memgraph::storage::PropertyValue("masked")}},
                                        {},
-                                       std::optional<memgraph::query::VertexAccessor>{vertex},
-                                       {},
-                                       memgraph::query::VirtualNode::key_set{ssn_id});
+                                       std::optional<memgraph::query::VertexAccessor>{vertex});
   StubPropertyFGAChecker checker(storage.get(), {{"Employee", "ssn"}});
   auto result = memgraph::glue::ToBoltVertex(overlay, *storage, memgraph::storage::View::NEW, &checker);
   ASSERT_TRUE(result.has_value());

--- a/tests/unit/glue_communication.cpp
+++ b/tests/unit/glue_communication.cpp
@@ -14,6 +14,10 @@
 #include "communication/bolt/v1/value.hpp"
 #include "glue/communication.hpp"
 #include "helpers/stub_property_fga_checker.hpp"
+#include "query/db_accessor.hpp"
+#include "query/virtual_edge.hpp"
+#include "query/virtual_graph.hpp"
+#include "query/virtual_node.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "tests/test_commit_args_helper.hpp"
 
@@ -135,6 +139,107 @@ TEST_F(ToBoltTest, PropertyFGAMultiLabelDenyOnAnyLabelDenies) {
   auto const &props = result->properties;
   ASSERT_EQ(props.size(), 1);
   EXPECT_EQ(props.at("name").ValueString(), "Bob");
+  EXPECT_FALSE(props.contains("ssn"));
+}
+
+TEST_F(ToBoltTest, PropertyFGAOverlayOmitsDeniedOriginProperty) {
+  // An overlay node reads its origin's properties through; a denied origin property is omitted over
+  // Bolt exactly as it is for the real origin vertex.
+  auto acc = storage->Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  ASSERT_TRUE(vertex.AddLabel(acc->NameToLabel("Employee")).has_value());
+  ASSERT_TRUE(vertex.SetProperty(acc->NameToProperty("name"), memgraph::storage::PropertyValue("Alice")).has_value());
+  ASSERT_TRUE(
+      vertex.SetProperty(acc->NameToProperty("ssn"), memgraph::storage::PropertyValue("123-45-6789")).has_value());
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+  memgraph::query::VirtualNode overlay({"Employee"}, {}, {}, std::optional<memgraph::query::VertexAccessor>{vertex});
+  StubPropertyFGAChecker checker(storage.get(), {{"Employee", "ssn"}});
+  auto result = memgraph::glue::ToBoltVertex(overlay, *storage, memgraph::storage::View::NEW, &checker);
+  ASSERT_TRUE(result.has_value());
+
+  auto const &props = result->properties;
+  EXPECT_EQ(props.at("name").ValueString(), "Alice");
+  EXPECT_FALSE(props.contains("ssn"));
+}
+
+TEST_F(ToBoltTest, PropertyFGAOverlayBoundOverrideExemptFromOriginDeny) {
+  // An overlay-bound override is the author's computed value, not the origin's protected data, so it
+  // is serialized even when its key name is denied on the origin's label.
+  auto acc = storage->Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  ASSERT_TRUE(vertex.AddLabel(acc->NameToLabel("Employee")).has_value());
+  ASSERT_TRUE(vertex.SetProperty(acc->NameToProperty("name"), memgraph::storage::PropertyValue("Alice")).has_value());
+  ASSERT_TRUE(
+      vertex.SetProperty(acc->NameToProperty("ssn"), memgraph::storage::PropertyValue("123-45-6789")).has_value());
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+  auto ssn_id = acc->NameToProperty("ssn");
+  memgraph::query::VirtualNode overlay({"Employee"},
+                                       {{ssn_id, memgraph::storage::PropertyValue("masked")}},
+                                       {},
+                                       std::optional<memgraph::query::VertexAccessor>{vertex},
+                                       {},
+                                       memgraph::query::VirtualNode::key_set{ssn_id});
+  StubPropertyFGAChecker checker(storage.get(), {{"Employee", "ssn"}});
+  auto result = memgraph::glue::ToBoltVertex(overlay, *storage, memgraph::storage::View::NEW, &checker);
+  ASSERT_TRUE(result.has_value());
+
+  auto const &props = result->properties;
+  EXPECT_EQ(props.at("name").ValueString(), "Alice");
+  EXPECT_EQ(props.at("ssn").ValueString(), "masked");
+}
+
+TEST_F(ToBoltTest, PropertyFGASyntheticNodeNotFiltered) {
+  // A synthetic node has no origin and mints no real-graph data, so property FGA does not apply.
+  auto acc = storage->Access(memgraph::storage::WRITE);
+  auto ssn_id = acc->NameToProperty("ssn");
+  memgraph::query::VirtualNode synthetic({"Employee"}, {{ssn_id, memgraph::storage::PropertyValue("x")}});
+  StubPropertyFGAChecker checker(storage.get(), {{"Employee", "ssn"}});
+  auto result = memgraph::glue::ToBoltVertex(synthetic, *storage, memgraph::storage::View::NEW, &checker);
+  ASSERT_TRUE(result.has_value());
+
+  auto const &props = result->properties;
+  EXPECT_EQ(props.at("ssn").ValueString(), "x");
+}
+
+TEST_F(ToBoltTest, ToBoltVirtualGraphSerializesNodesAndEdges) {
+  // A whole projection value returned to a client (RETURN g) serializes as a map of node and edge
+  // lists. This path (ToBoltVirtualGraph) is distinct from consuming the value via USE or a procedure.
+  memgraph::query::VirtualGraph vg(memgraph::utils::NewDeleteResource());
+  auto g1 = vg.InsertNode(memgraph::query::VirtualNode({"N"}, {})).Gid();
+  auto g2 = vg.InsertNode(memgraph::query::VirtualNode({"N"}, {})).Gid();
+  vg.InsertEdgeIfNew(memgraph::query::VirtualEdge(vg.FindNode(g1), vg.FindNode(g2), "R"));
+
+  auto result = memgraph::glue::ToBoltVirtualGraph(vg, *storage, memgraph::storage::View::NEW, nullptr);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->at("nodes").ValueList().size(), 2);
+  ASSERT_EQ(result->at("edges").ValueList().size(), 1);
+  EXPECT_EQ(result->at("edges").ValueList()[0].ValueEdge().type, "R");
+}
+
+TEST_F(ToBoltTest, ToBoltVirtualGraphRedactsDeniedOverlayProperty) {
+  // A projection returned whole (RETURN g) must redact a denied origin property on an overlay member,
+  // just as returning that node directly does - the FGA path threads through ToBoltVirtualGraph.
+  auto acc = storage->Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  ASSERT_TRUE(vertex.AddLabel(acc->NameToLabel("Employee")).has_value());
+  ASSERT_TRUE(vertex.SetProperty(acc->NameToProperty("name"), memgraph::storage::PropertyValue("Alice")).has_value());
+  ASSERT_TRUE(
+      vertex.SetProperty(acc->NameToProperty("ssn"), memgraph::storage::PropertyValue("123-45-6789")).has_value());
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+  memgraph::query::VirtualGraph vg(memgraph::utils::NewDeleteResource());
+  vg.InsertNode(
+      memgraph::query::VirtualNode({"Employee"}, {}, {}, std::optional<memgraph::query::VertexAccessor>{vertex}));
+  StubPropertyFGAChecker checker(storage.get(), {{"Employee", "ssn"}});
+
+  auto result = memgraph::glue::ToBoltVirtualGraph(vg, *storage, memgraph::storage::View::NEW, &checker);
+  ASSERT_TRUE(result.has_value());
+  auto const &nodes = result->at("nodes").ValueList();
+  ASSERT_EQ(nodes.size(), 1);
+  auto const &props = nodes[0].ValueVertex().properties;
+  EXPECT_EQ(props.at("name").ValueString(), "Alice");
   EXPECT_FALSE(props.contains("ssn"));
 }
 

--- a/tests/unit/glue_communication.cpp
+++ b/tests/unit/glue_communication.cpp
@@ -15,6 +15,7 @@
 #include "glue/communication.hpp"
 #include "helpers/stub_property_fga_checker.hpp"
 #include "query/db_accessor.hpp"
+#include "query/synthetic_gid.hpp"
 #include "query/virtual_edge.hpp"
 #include "query/virtual_graph.hpp"
 #include "query/virtual_node.hpp"
@@ -241,6 +242,96 @@ TEST_F(ToBoltTest, ToBoltVirtualGraphRedactsDeniedOverlayProperty) {
   auto const &props = nodes[0].ValueVertex().properties;
   EXPECT_EQ(props.at("name").ValueString(), "Alice");
   EXPECT_FALSE(props.contains("ssn"));
+}
+
+// --- Issue 40: virtual element ids serialize on the same query-local external axis as id() ---
+
+TEST_F(ToBoltTest, SyntheticNodeBoltIdUsesExternalMapper) {
+  // With the query's mapper threaded in, a synthetic node serializes at the query-local external id
+  // id() reports (a small negative), not its raw synthetic gid.
+  memgraph::query::SyntheticIdMapper mapper;
+  memgraph::query::VirtualNode synthetic({"N"}, {});
+  auto const expected = mapper.ExternalId(synthetic.Gid());
+  auto result = memgraph::glue::ToBoltVertex(synthetic, *storage, memgraph::storage::View::NEW, nullptr, &mapper);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_LT(expected, 0);
+  EXPECT_EQ(result->id.AsInt(), expected);
+}
+
+TEST_F(ToBoltTest, SyntheticNodeBoltIdWithoutMapperKeepsRawGid) {
+  // A null mapper (non-query serialization paths) falls back to the raw synthetic gid.
+  memgraph::query::VirtualNode synthetic({"N"}, {});
+  auto result = memgraph::glue::ToBoltVertex(synthetic, *storage, memgraph::storage::View::NEW, nullptr, nullptr);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->id.AsUint(), synthetic.Gid().AsUint());
+}
+
+TEST_F(ToBoltTest, OverlayNodeBoltIdStaysOnOriginAxis) {
+  // An overlay node serializes at its origin's real id regardless of the mapper - the real gid axis
+  // is unchanged, so a client still maps it back to the real node.
+  auto acc = storage->Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  auto const origin_gid = vertex.Gid();
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  memgraph::query::SyntheticIdMapper mapper;
+  memgraph::query::VirtualNode overlay({"N"}, {}, {}, std::optional<memgraph::query::VertexAccessor>{vertex});
+  auto result = memgraph::glue::ToBoltVertex(overlay, *storage, memgraph::storage::View::NEW, nullptr, &mapper);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->id.AsUint(), origin_gid.AsUint());
+}
+
+TEST_F(ToBoltTest, VirtualEdgeResolvedEndpointsUseExternalMapper) {
+  // A virtual edge between resolved nodes serializes its endpoints and its own id on id()'s external
+  // axis, through the same mapper instance id() used (e2e test_construct_between_virtual_nodes).
+  memgraph::query::VirtualGraph vg(memgraph::utils::NewDeleteResource());
+  auto ga = vg.InsertNode(memgraph::query::VirtualNode({"A"}, {})).Gid();
+  auto gb = vg.InsertNode(memgraph::query::VirtualNode({"B"}, {})).Gid();
+  memgraph::query::VirtualEdge ve(vg.FindNode(ga), vg.FindNode(gb), "KNOWS");
+
+  memgraph::query::SyntheticIdMapper mapper;
+  auto const aid = mapper.ExternalId(ga);  // as id(a) assigns during the pull
+  auto const bid = mapper.ExternalId(gb);
+
+  memgraph::query::TypedValue tv(ve);
+  auto result = memgraph::glue::ToBoltValue(tv, storage.get(), memgraph::storage::View::NEW, nullptr, &mapper);
+  ASSERT_TRUE(result.has_value());
+  auto const &edge = result->ValueEdge();
+  EXPECT_EQ(edge.from.AsInt(), aid);
+  EXPECT_EQ(edge.to.AsInt(), bid);
+  EXPECT_EQ(edge.id.AsInt(), mapper.ExternalId(ve.Gid()));
+  EXPECT_LT(edge.id.AsInt(), 0);
+}
+
+TEST_F(ToBoltTest, VirtualEdgeHandleEndpointsStayRaw) {
+  // An unresolved (handle) endpoint references an import key, not a node identity, so it serializes
+  // as the raw handle and is never mapped (e2e test_construct_between_gid_handles).
+  memgraph::query::VirtualEdge ve(int64_t{1}, int64_t{2}, "LINKS");
+  memgraph::query::SyntheticIdMapper mapper;
+  memgraph::query::TypedValue tv(ve);
+  auto result = memgraph::glue::ToBoltValue(tv, storage.get(), memgraph::storage::View::NEW, nullptr, &mapper);
+  ASSERT_TRUE(result.has_value());
+  auto const &edge = result->ValueEdge();
+  EXPECT_EQ(edge.from.AsInt(), 1);
+  EXPECT_EQ(edge.to.AsInt(), 2);
+}
+
+TEST_F(ToBoltTest, VirtualEdgeMixedEndpointsMapResolvedButNotHandle) {
+  // The two endpoint forms may be mixed: the resolved end maps onto id()'s axis, the handle end
+  // stays raw (e2e test_mixed_node_and_handle_endpoints).
+  memgraph::query::VirtualGraph vg(memgraph::utils::NewDeleteResource());
+  auto ga = vg.InsertNode(memgraph::query::VirtualNode({"A"}, {})).Gid();
+  memgraph::query::VirtualEdge ve(vg.FindNode(ga), int64_t{2}, "M");
+
+  memgraph::query::SyntheticIdMapper mapper;
+  auto const aid = mapper.ExternalId(ga);
+
+  memgraph::query::TypedValue tv(ve);
+  auto result = memgraph::glue::ToBoltValue(tv, storage.get(), memgraph::storage::View::NEW, nullptr, &mapper);
+  ASSERT_TRUE(result.has_value());
+  auto const &edge = result->ValueEdge();
+  EXPECT_LT(aid, 0);
+  EXPECT_EQ(edge.from.AsInt(), aid);
+  EXPECT_EQ(edge.to.AsInt(), 2);
 }
 
 #endif

--- a/tests/unit/glue_communication.cpp
+++ b/tests/unit/glue_communication.cpp
@@ -177,7 +177,7 @@ TEST_F(ToBoltTest, PropertyFGAOverlayBoundOverrideExemptFromOriginDeny) {
 
   auto ssn_id = acc->NameToProperty("ssn");
   // ssn is overlaid with "masked": it is overlay-bound through the overlay store (it carries a
-  // value), so no ProjectionSchema is needed to bind it.
+  // value), so no PropertyBinding is needed to bind it.
   memgraph::query::VirtualNode overlay({"Employee"},
                                        {{ssn_id, memgraph::storage::PropertyValue("masked")}},
                                        {},

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -766,6 +766,159 @@ TYPED_TEST(InterpreterTest, CallUseScopeExpandsTypeFiltered) {
   EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "R");
 }
 
+// Variable-length expansion over a projection walks the overlay's edge index for
+// each hop; *1..2 from node 1 reaches nodes 2 and 3 along the R chain.
+TYPED_TEST(InterpreterTest, CallUseScopeExpandsVariableLength) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 1})-[r:R*1..2]->(b) RETURN b.x AS bx } "
+      "RETURN bx ORDER BY bx");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+// The upper bound is honoured: *1..1 stops after a single hop.
+TYPED_TEST(InterpreterTest, CallUseScopeExpandsVariableLengthBounded) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 1})-[r:R*1..1]->(b) RETURN b.x AS bx } "
+      "RETURN bx ORDER BY bx");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
+// The natural (a)-[*BFS]->(b) form plans as a single-source BFS; over a projection it
+// reaches every node at its shortest depth. From node 1: node 2 at depth 1, node 3 at depth 2.
+TYPED_TEST(InterpreterTest, CallUseScopeBreadthFirst) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 1})-[e *BFS]->(b) RETURN b.x AS bx, size(e) AS len } "
+      "RETURN bx, len ORDER BY bx");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[1][1].ValueInt(), 2);
+}
+
+// A depth-bounded BFS over a projection stops at the upper bound.
+TYPED_TEST(InterpreterTest, CallUseScopeBreadthFirstBounded) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 1})-[e *BFS 1..1]->(b) RETURN b.x AS bx } "
+      "RETURN bx ORDER BY bx");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
+// Weighted shortest path over a projection: the weight lambda reads a VirtualNode property through
+// the unified GetProperty. Node 4 is reached by 1->2->4 (weight 1+1=2), not the costly 1->3->4
+// (100+1); node 3 sits at weight 100. Proves Dijkstra picks the cheaper multi-hop path over a
+// projection and binds the running total.
+TYPED_TEST(InterpreterTest, CallUseScopeWeightedShortestPath) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 0}), virtualNode(2, 'N', {x: 1}), virtualNode(3, 'N', {x: 100}), "
+      "virtualNode(4, 'N', {x: 1})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 4), virtualEdge('R', 1, 3), virtualEdge('R', 3, 4)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 0})-[e *wShortest 10 (edge, n | n.x) w]->(b) "
+      "RETURN w AS weight, size(e) AS len } "
+      "RETURN weight, len ORDER BY weight");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);  // node 2, one hop
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);  // node 4, cheaper two-hop route
+  EXPECT_EQ(stream.GetResults()[1][1].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 100);  // node 3, one hop
+  EXPECT_EQ(stream.GetResults()[2][1].ValueInt(), 1);
+}
+
+// Weighted shortest path to a pre-bound sink over a projection exercises the existing_node early-out:
+// only the cheapest path to node 4 (x: 2), weight 1+2=3 via 1->2->4, is returned.
+TYPED_TEST(InterpreterTest, CallUseScopeWeightedShortestPathToBoundSink) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 0}), virtualNode(2, 'N', {x: 1}), virtualNode(3, 'N', {x: 100}), "
+      "virtualNode(4, 'N', {x: 2})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 4), virtualEdge('R', 1, 3), virtualEdge('R', 3, 4)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 0}), (b {x: 2}) WITH a, b MATCH (a)-[e *wShortest 10 (edge, n | n.x) w]->(b) "
+      "RETURN w AS weight, size(e) AS len } "
+      "RETURN weight, len");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 2);
+}
+
+// All-shortest paths over a projection enumerates every equal-cost path. In the diamond with unit
+// weights, node 4 is reached by two shortest paths (via 2 and via 3), so it appears twice.
+TYPED_TEST(InterpreterTest, CallUseScopeAllShortestPaths) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3}), "
+      "virtualNode(4, 'N', {x: 4})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 1, 3), virtualEdge('R', 2, 4), virtualEdge('R', 3, 4)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 1})-[e *allShortest 10 (edge, n | 1) w]->(b) RETURN b.x AS bx, size(e) AS len } "
+      "RETURN bx, len ORDER BY bx, len");
+  ASSERT_EQ(stream.GetResults().size(), 4U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);  // one path, one hop
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);  // one path, one hop
+  EXPECT_EQ(stream.GetResults()[1][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 4);  // two equal shortest paths to node 4, both 2 hops
+  EXPECT_EQ(stream.GetResults()[2][1].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[3][0].ValueInt(), 4);
+  EXPECT_EQ(stream.GetResults()[3][1].ValueInt(), 2);
+}
+
+// K-shortest paths over a projection enumerates the loopless paths between two bound nodes in
+// increasing length. In the diamond, both 1->2->4 and 1->3->4 (length 2) are returned.
+TYPED_TEST(InterpreterTest, CallUseScopeKShortestPaths) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3}), "
+      "virtualNode(4, 'N', {x: 4})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 4), virtualEdge('R', 1, 3), virtualEdge('R', 3, 4)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 1}), (b {x: 4}) WITH a, b MATCH (a)-[r *kshortest..10]->(b) RETURN size(r) AS len } "
+      "RETURN len ORDER BY len");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+}
+
+// s-t shortest path over a projection: both endpoints pre-bound makes the *BFS an
+// STShortestPath, which walks the overlay bidirectionally and reconstructs the path.
+TYPED_TEST(InterpreterTest, CallUseScopeShortestPathBetweenBoundNodes) {
+  // The WITH barrier binds both endpoints before the expand, so the *BFS plans as an STShortestPath.
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 1}), (b {x: 3}) WITH a, b MATCH (a)-[e *BFS]->(b) RETURN size(e) AS len } "
+      "RETURN len");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
+// A directed s-t shortest path finds no path against the edge direction.
+TYPED_TEST(InterpreterTest, CallUseScopeShortestPathRespectsDirection) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2}), virtualNode(3, 'N', {x: 3})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('R', 2, 3)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a {x: 3}), (b {x: 1}) WITH a, b MATCH (a)-[e *BFS]->(b) RETURN size(e) AS len } "
+      "RETURN len");
+  EXPECT_EQ(stream.GetResults().size(), 0U);
+}
+
 // A self-loop is reachable expanding either direction; its two endpoints are the
 // same projection node.
 TYPED_TEST(InterpreterTest, CallUseScopeExpandsSelfLoop) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1158,6 +1158,31 @@ TYPED_TEST(InterpreterTest, CallUseScopeBreadthFirstOverSubgraphRespectsMembersh
   EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "b");
 }
 
+// A named path (p=...) over a projection cannot be assembled - query::Path holds real accessors,
+// not virtual ones. This must raise a clear query error, never abort (DMG_ASSERT) or surface a
+// cryptic TypedValue type error. It is a v1 boundary (issue 50).
+TYPED_TEST(InterpreterTest, CallUseScopeNamedPathOverProjectionErrors) {
+  ASSERT_THROW(this->Interpret("WITH [virtualNode(1, 'N', {}), virtualNode(2, 'N', {})] AS nodes, "
+                               "[virtualEdge('R', 1, 2)] AS edges "
+                               "WITH virtualGraph(nodes, edges) AS g "
+                               "CALL { USE g MATCH p=(a)-[:R]->(b) RETURN p } "
+                               "RETURN p"),
+               memgraph::query::QueryRuntimeException);
+}
+
+// A named path over a subgraph works: a subgraph's elements are real accessors, so query::Path
+// assembles normally (issue 50 boundary is specific to projections).
+TYPED_TEST(InterpreterTest, CallUseScopeNamedPathOverSubgraphWorks) {
+  this->Interpret("CREATE (:A {name: 'a'})-[:R]->(:B {name: 'b'});");
+  auto stream = this->Interpret(
+      "MATCH q=(:A)-[:R]->(:B) "
+      "WITH project(q) AS sg "
+      "CALL { USE sg MATCH p=(x:A)-[:R]->(y) RETURN length(p) AS len } "
+      "RETURN len");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+}
+
 // degree/inDegree/outDegree over a projection node inside a USE scope count the
 // projection's edges, which differ from the node's real-graph degree.
 TYPED_TEST(InterpreterTest, CallUseScopeDegreeOverProjection) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -698,6 +698,392 @@ TYPED_TEST(InterpreterTest, ParametersAsPropertyMap) {
   }
 }
 
+// `CALL { USE g MATCH (n) ... }` scans the bound projection's nodes.
+TYPED_TEST(InterpreterTest, CallUseScopeScansProjection) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 10}), virtualNode(2, 'N', {x: 20})] AS nodes, [] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (n) RETURN n.x AS x } "
+      "RETURN x ORDER BY x");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "x");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 10);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 20);
+}
+
+// The scope binds the projection inside the block only: a MATCH outside sees the
+// real graph, a MATCH inside sees the projection.
+TYPED_TEST(InterpreterTest, CallUseScopeIsScopedToTheProjection) {
+  this->Interpret("CREATE (:Real), (:Real), (:Real)");
+  auto stream = this->Interpret(
+      "MATCH (r) WITH count(r) AS real_count "
+      "WITH real_count, virtualGraph([virtualNode(1, 'N', {x: 10})], []) AS g "
+      "CALL { USE g MATCH (n) RETURN n.x AS x } "
+      "RETURN real_count, x");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 10);
+}
+
+// A directed expand inside a USE scope resolves a projection node's edge; both
+// endpoints bind back to projection nodes.
+TYPED_TEST(InterpreterTest, CallUseScopeExpandsDirected) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2})] AS nodes, [virtualEdge('R', 1, 2)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a)-[r]->(b) RETURN a.x AS ax, type(r) AS t, b.x AS bx } "
+      "RETURN ax, t, bx");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueString(), "R");
+  EXPECT_EQ(stream.GetResults()[0][2].ValueInt(), 2);
+}
+
+// An undirected expand traverses the edge from both ends.
+TYPED_TEST(InterpreterTest, CallUseScopeExpandsUndirected) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2})] AS nodes, [virtualEdge('R', 1, 2)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a)-[r]-(b) RETURN a.x AS ax, b.x AS bx } "
+      "RETURN ax, bx ORDER BY ax");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][1].ValueInt(), 1);
+}
+
+// An edge-type filter selects only edges of that type.
+TYPED_TEST(InterpreterTest, CallUseScopeExpandsTypeFiltered) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 1}), virtualNode(2, 'N', {x: 2})] AS nodes, "
+      "[virtualEdge('R', 1, 2), virtualEdge('S', 1, 2)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a)-[r:R]->(b) RETURN type(r) AS t } "
+      "RETURN t");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "R");
+}
+
+// A self-loop is reachable expanding either direction; its two endpoints are the
+// same projection node.
+TYPED_TEST(InterpreterTest, CallUseScopeExpandsSelfLoop) {
+  auto out = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 7})] AS nodes, [virtualEdge('R', 1, 1)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a)-[r]->(b) RETURN a.x AS ax, b.x AS bx } "
+      "RETURN ax, bx");
+  ASSERT_EQ(out.GetResults().size(), 1U);
+  EXPECT_EQ(out.GetResults()[0][0].ValueInt(), 7);
+  EXPECT_EQ(out.GetResults()[0][1].ValueInt(), 7);
+
+  auto in = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 7})] AS nodes, [virtualEdge('R', 1, 1)] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (a)<-[r]-(b) RETURN a.x AS ax, b.x AS bx } "
+      "RETURN ax, bx");
+  ASSERT_EQ(in.GetResults().size(), 1U);
+  EXPECT_EQ(in.GetResults()[0][0].ValueInt(), 7);
+  EXPECT_EQ(in.GetResults()[0][1].ValueInt(), 7);
+}
+
+// A label-filtered MATCH inside a USE scope returns only the projection nodes
+// carrying that label, by full scan plus filter.
+TYPED_TEST(InterpreterTest, CallUseScopeLabelFilter) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'A', {x: 1}), virtualNode(2, 'B', {x: 2}), virtualNode(3, 'A', {x: 3})] AS nodes, "
+      "[] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (n:A) RETURN n.x AS x } "
+      "RETURN x ORDER BY x");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+// A label-filtered scan over a projection stays a full scan even when the real
+// graph has an index on that label: the projection is read, not the real graph.
+TYPED_TEST(InterpreterTest, CallUseScopeLabelFilterIgnoresRealIndex) {
+  this->Interpret("CREATE INDEX ON :A");
+  this->Interpret("CREATE (:A {x: 100})");
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'A', {x: 1}), virtualNode(2, 'B', {x: 2})] AS nodes, [] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (n:A) RETURN n.x AS x } "
+      "RETURN x ORDER BY x");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+}
+
+// A label+property equality match inside a USE scope stays a full scan even when
+// the real graph carries a composite index on that label and property: the
+// projection's matching node is returned, not the real graph's.
+TYPED_TEST(InterpreterTest, CallUseScopeLabelPropertyEqualityIgnoresRealIndex) {
+  this->Interpret("CREATE INDEX ON :A(x)");
+  this->Interpret("CREATE (:A {x: 1})");
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'A', {x: 1, tag: 11}), virtualNode(2, 'A', {x: 2, tag: 22})] AS nodes, [] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (n:A {x: 1}) RETURN n.tag AS tag } "
+      "RETURN tag");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 11);
+}
+
+// A label+property range match inside a USE scope stays a full scan even when the
+// real graph carries a composite index on that label and property: only the
+// projection nodes satisfying the range are returned, not the real graph's.
+TYPED_TEST(InterpreterTest, CallUseScopeLabelPropertyRangeIgnoresRealIndex) {
+  this->Interpret("CREATE INDEX ON :A(x)");
+  this->Interpret("CREATE (:A {x: 100})");
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'A', {x: 5, tag: 11}), virtualNode(2, 'A', {x: 1, tag: 22})] AS nodes, [] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (n:A) WHERE n.x > 3 RETURN n.tag AS tag } "
+      "RETURN tag ORDER BY tag");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 11);
+}
+
+// An id predicate inside a USE scope over a project() subgraph stays a full scan
+// of the members: a real vertex outside the subgraph is not reachable by its id,
+// and a member is. Were the id lookup to resolve through the real accessor it
+// would return the non-member.
+TYPED_TEST(InterpreterTest, CallUseScopeIdFilterScansSubgraphMembers) {
+  this->Interpret("CREATE (:A {name: 'a'})-[:R]->(:B {name: 'b'}), (:C {name: 'c'})");
+  const auto id_of = [this](const std::string &query) { return this->Interpret(query).GetResults()[0][0].ValueInt(); };
+  const auto member_id = id_of("MATCH (b:B) RETURN id(b)");
+  const auto non_member_id = id_of("MATCH (c:C) RETURN id(c)");
+
+  auto absent = this->Interpret(
+      "MATCH p=(:A)-[:R]->(:B) WITH project(p) AS sg "
+      "CALL { USE sg MATCH (n) WHERE id(n) = $cid RETURN n.name AS name } "
+      "RETURN count(name) AS cnt",
+      {{"cid", memgraph::storage::ExternalPropertyValue(non_member_id)}});
+  ASSERT_EQ(absent.GetResults().size(), 1U);
+  EXPECT_EQ(absent.GetResults()[0][0].ValueInt(), 0);
+
+  auto present = this->Interpret(
+      "MATCH p=(:A)-[:R]->(:B) WITH project(p) AS sg "
+      "CALL { USE sg MATCH (n) WHERE id(n) = $bid RETURN n.name AS name } "
+      "RETURN name",
+      {{"bid", memgraph::storage::ExternalPropertyValue(member_id)}});
+  ASSERT_EQ(present.GetResults().size(), 1U);
+  EXPECT_EQ(present.GetResults()[0][0].ValueString(), "b");
+}
+
+// A WHERE property predicate inside a USE scope filters projection nodes by scan.
+TYPED_TEST(InterpreterTest, CallUseScopePropertyPredicate) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 10}), virtualNode(2, 'N', {x: 20}), virtualNode(3, 'N', {x: 30})] AS nodes, "
+      "[] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (n) WHERE n.x > 15 RETURN n.x AS x } "
+      "RETURN x ORDER BY x");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 20);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 30);
+}
+
+// A projection node reads a property through the same call site as a real vertex,
+// by name lookup and by subscript.
+TYPED_TEST(InterpreterTest, CallUseScopeReadsPropertyAndSubscript) {
+  auto stream = this->Interpret(
+      "WITH [virtualNode(1, 'N', {x: 42})] AS nodes, [] AS edges "
+      "WITH virtualGraph(nodes, edges) AS g "
+      "CALL { USE g MATCH (n) RETURN n.x AS by_name, n['x'] AS by_subscript, n.missing AS absent } "
+      "RETURN by_name, by_subscript, absent");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 42);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 42);
+  EXPECT_EQ(stream.GetResults()[0][2].type(), memgraph::communication::bolt::Value::Type::Null);
+}
+
+// A USE scope over a derive() overlay projection reads through to the origin: a
+// MATCH inside the scope returns the origin's property values, and a predicate
+// over a read-through value filters correctly.
+TYPED_TEST(InterpreterTest, CallUseScopeOverDeriveReadsThrough) {
+  this->Interpret("CREATE (:N {id: 1, v: 7})-[:R]->(:N {id: 2, v: 9})");
+  auto stream = this->Interpret(
+      "MATCH p=(:N {id: 1})-[:R]->(:N {id: 2}) "
+      "WITH derive(p, {virtualEdgeType: 'E'}) AS g "
+      "CALL { USE g MATCH (n) WHERE n.v > 8 RETURN n.id AS id, n.v AS v } "
+      "RETURN id, v ORDER BY id");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 9);
+}
+
+// An overlay-bound key shadows the origin value inside a USE scope.
+TYPED_TEST(InterpreterTest, CallUseScopeOverDeriveOverlayShadows) {
+  this->Interpret("CREATE (:N {id: 1, v: 7})-[:R]->(:N {id: 2, v: 9})");
+  auto stream = this->Interpret(
+      "MATCH p=(:N {id: 1})-[:R]->(:N {id: 2}) "
+      "WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {v: 'overlay'}, sourceNodeProperties: {v: 100}}) AS g "
+      "CALL { USE g MATCH (n) WHERE n.id = 1 RETURN n.v AS v } "
+      "RETURN v");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 100);
+}
+
+// A hidden key is invisible to reads and to predicates inside a USE scope: the
+// read yields null, and `WHERE n.secret IS NULL` matches every node.
+TYPED_TEST(InterpreterTest, CallUseScopeOverDeriveHiddenInvisible) {
+  this->Interpret("CREATE (:N {id: 1, secret: 42})-[:R]->(:N {id: 2, secret: 43})");
+  auto read = this->Interpret(
+      "MATCH p=(:N {id: 1})-[:R]->(:N {id: 2}) "
+      "WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {secret: 'hidden'}}) AS g "
+      "CALL { USE g MATCH (n) WHERE n.id = 1 RETURN n.secret AS s } "
+      "RETURN s");
+  ASSERT_EQ(read.GetResults().size(), 1U);
+  EXPECT_EQ(read.GetResults()[0][0].type(), memgraph::communication::bolt::Value::Type::Null);
+
+  auto pred = this->Interpret(
+      "MATCH p=(:N {id: 1})-[:R]->(:N {id: 2}) "
+      "WITH derive(p, {virtualEdgeType: 'E', propertyPolicy: {secret: 'hidden'}}) AS g "
+      "CALL { USE g MATCH (n) WHERE n.secret IS NULL RETURN n.id AS id } "
+      "RETURN id ORDER BY id");
+  ASSERT_EQ(pred.GetResults().size(), 2U);
+  EXPECT_EQ(pred.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(pred.GetResults()[1][0].ValueInt(), 2);
+}
+
+// A USE scope over a project() subgraph scans only the subgraph's member nodes,
+// not other real-graph nodes.
+TYPED_TEST(InterpreterTest, CallUseScopeOverSubgraphScansMembers) {
+  this->Interpret("CREATE (:A {name: 'a'})-[:R]->(:B {name: 'b'}), (:C {name: 'c'})");
+  auto stream = this->Interpret(
+      "MATCH p=(:A)-[:R]->(:B) "
+      "WITH project(p) AS sg "
+      "CALL { USE sg MATCH (n) RETURN n.name AS name } "
+      "RETURN name ORDER BY name");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "a");
+  EXPECT_EQ(stream.GetResults()[1][0].ValueString(), "b");
+}
+
+// Expansion inside a USE scope over a subgraph stays within membership: a member
+// node's edge to a non-member is not traversed.
+TYPED_TEST(InterpreterTest, CallUseScopeOverSubgraphExpansionRespectsMembership) {
+  this->Interpret("CREATE (a:A {name: 'a'})-[:R]->(b:B {name: 'b'}), (b)-[:R2]->(:C {name: 'c'})");
+  auto stream = this->Interpret(
+      "MATCH p=(:A)-[:R]->(:B) "
+      "WITH project(p) AS sg "
+      "CALL { USE sg MATCH (x)-[r]->(y) RETURN x.name AS xn, y.name AS yn } "
+      "RETURN xn, yn ORDER BY xn");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "a");
+  EXPECT_EQ(stream.GetResults()[0][1].ValueString(), "b");
+}
+
+// degree/inDegree/outDegree over a projection node inside a USE scope count the
+// projection's edges, which differ from the node's real-graph degree.
+TYPED_TEST(InterpreterTest, CallUseScopeDegreeOverProjection) {
+  // a has real out-degree 2.
+  this->Interpret("CREATE (a:N {id: 1})-[:R]->(:N {id: 2}), (a)-[:R]->(:N {id: 3})");
+  // The projection derived from the single path a->b has one edge, so a's
+  // projection out-degree is 1.
+  auto stream = this->Interpret(
+      "MATCH p=(:N {id: 1})-[:R]->(:N {id: 2}) "
+      "WITH derive(p, {virtualEdgeType: 'E'}) AS g "
+      "CALL { USE g MATCH (n) WHERE n.id = 1 RETURN degree(n) AS d, outDegree(n) AS od, inDegree(n) AS ind } "
+      "RETURN d, od, ind");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][2].ValueInt(), 0);
+
+  // The same node's real-graph out-degree is 2, differing from the projection.
+  auto real = this->Interpret("MATCH (a:N {id: 1}) RETURN outDegree(a) AS od");
+  ASSERT_EQ(real.GetResults().size(), 1U);
+  EXPECT_EQ(real.GetResults()[0][0].ValueInt(), 2);
+}
+
+// degree over a subgraph member inside a USE scope counts only member edges,
+// differing from the node's real-graph degree.
+TYPED_TEST(InterpreterTest, CallUseScopeDegreeOverSubgraph) {
+  // b has real degree 2: an in-edge from a and an out-edge to c.
+  this->Interpret("CREATE (a:A)-[:R]->(b:B {id: 1}), (b)-[:R2]->(:C)");
+  // The subgraph holds only the a->b edge, so b's subgraph degree is 1.
+  auto stream = this->Interpret(
+      "MATCH p=(:A)-[:R]->(:B) "
+      "WITH project(p) AS sg "
+      "CALL { USE sg MATCH (n:B) RETURN degree(n) AS d, inDegree(n) AS ind, outDegree(n) AS od } "
+      "RETURN d, ind, od");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][2].ValueInt(), 0);
+
+  // The same node's real-graph degree is 2, differing from the subgraph.
+  auto real = this->Interpret("MATCH (b:B {id: 1}) RETURN degree(b) AS d");
+  ASSERT_EQ(real.GetResults().size(), 1U);
+  EXPECT_EQ(real.GetResults()[0][0].ValueInt(), 2);
+}
+
+// A projected edge reads a property through the same call site as a real edge,
+// by name lookup and by subscript - no edge-kind branch.
+TYPED_TEST(InterpreterTest, CallUseScopeReadsVirtualEdgeProperty) {
+  this->Interpret("CREATE (:N {id: 1})-[:R]->(:N {id: 2})");
+  auto stream = this->Interpret(
+      "MATCH p=(:N {id: 1})-[:R]->(:N {id: 2}) "
+      "WITH derive(p, {virtualEdgeType: 'E', relationshipProperties: {weight: 99}}) AS g "
+      "CALL { USE g MATCH ()-[r]->() RETURN r.weight AS by_name, r['weight'] AS by_subscript, r.missing AS absent } "
+      "RETURN by_name, by_subscript, absent");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 99);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 99);
+  EXPECT_EQ(stream.GetResults()[0][2].type(), memgraph::communication::bolt::Value::Type::Null);
+}
+
+// degree over a literal virtual node outside any USE scope counts its ambient
+// topology, which is none: a node built by virtualNode() carries no edges, so
+// every degree is zero.
+TYPED_TEST(InterpreterTest, DegreeOverLiteralVirtualNodeIsZero) {
+  auto stream = this->Interpret(
+      "RETURN degree(virtualNode(1, 'N', {})) AS d, inDegree(virtualNode(2, 'N', {})) AS ind, "
+      "outDegree(virtualNode(3, 'N', {})) AS od");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 0);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 0);
+  EXPECT_EQ(stream.GetResults()[0][2].ValueInt(), 0);
+}
+
+// A real vertex imported into a USE scope over a projection is not a node of
+// that projection, so its degree in the ambient graph is zero. The scope must
+// not leak the vertex's real-graph degree.
+TYPED_TEST(InterpreterTest, DegreeOverRealVertexImportedIntoProjectionScopeIsZero) {
+  this->Interpret("CREATE (a:N {id: 1})-[:R]->(:N {id: 2}), (a)-[:R]->(:N {id: 3})");
+  auto stream = this->Interpret(
+      "MATCH (r:N {id: 1}) WITH r, virtualGraph([virtualNode(1, 'N', {})], []) AS g "
+      "CALL (r) { USE g RETURN degree(r) AS d, inDegree(r) AS ind, outDegree(r) AS od } "
+      "RETURN d, ind, od");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 0);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 0);
+  EXPECT_EQ(stream.GetResults()[0][2].ValueInt(), 0);
+
+  // Outside the projection scope the same vertex has real-graph out-degree 2.
+  auto real = this->Interpret("MATCH (r:N {id: 1}) RETURN outDegree(r) AS od");
+  ASSERT_EQ(real.GetResults().size(), 1U);
+  EXPECT_EQ(real.GetResults()[0][0].ValueInt(), 2);
+}
+
+// Expansion from a real vertex imported into a USE scope over a projection
+// yields nothing: the vertex is not a node of the projection, so it has no edges
+// in the ambient graph, consistent with its zero degree. The real graph's
+// neighbours are not leaked into the scope.
+TYPED_TEST(InterpreterTest, ExpandFromRealVertexImportedIntoProjectionScopeYieldsNothing) {
+  this->Interpret("CREATE (a:N {id: 1})-[:R]->(:N {id: 2}), (a)-[:R]->(:N {id: 3})");
+  auto stream = this->Interpret(
+      "MATCH (r:N {id: 1}) WITH r, virtualGraph([virtualNode(1, 'N', {})], []) AS g "
+      "CALL (r) { USE g MATCH (r)-[e]->(x) RETURN x } "
+      "RETURN count(*) AS c");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 0);
+}
+
 // Test bfs end to end.
 TYPED_TEST(InterpreterTest, Bfs) {
   srand(0);

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1130,6 +1130,34 @@ TYPED_TEST(InterpreterTest, CallUseScopeOverSubgraphExpansionRespectsMembership)
   EXPECT_EQ(stream.GetResults()[0][1].ValueString(), "b");
 }
 
+// Variable-length expansion inside a USE scope over a subgraph stays within membership,
+// exactly as single-hop does: a member node's edge to a non-member is not traversed, so a
+// path cannot leak out of the subgraph (issue 49). The subgraph holds a->b; the real graph
+// also has b->c, reachable only via a non-member edge.
+TYPED_TEST(InterpreterTest, CallUseScopeVariableLengthOverSubgraphRespectsMembership) {
+  this->Interpret("CREATE (a:A {name: 'a'})-[:R]->(b:B {name: 'b'}), (b)-[:R]->(:C {name: 'c'})");
+  auto stream = this->Interpret(
+      "MATCH p=(:A)-[:R]->(:B) "
+      "WITH project(p) AS sg "
+      "CALL { USE sg MATCH (x:A)-[:R*1..3]->(y) RETURN y.name AS yn } "
+      "RETURN yn ORDER BY yn");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "b");
+}
+
+// The shortest-path family (here BFS) also respects subgraph membership inside a USE scope: the
+// same member-filtered traversal applies to every arm, not just plain variable-length (issue 49).
+TYPED_TEST(InterpreterTest, CallUseScopeBreadthFirstOverSubgraphRespectsMembership) {
+  this->Interpret("CREATE (a:A {name: 'a'})-[:R]->(b:B {name: 'b'}), (b)-[:R]->(:C {name: 'c'})");
+  auto stream = this->Interpret(
+      "MATCH p=(:A)-[:R]->(:B) "
+      "WITH project(p) AS sg "
+      "CALL { USE sg MATCH (x:A)-[*BFS]->(y) RETURN y.name AS yn } "
+      "RETURN yn ORDER BY yn");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "b");
+}
+
 // degree/inDegree/outDegree over a projection node inside a USE scope count the
 // projection's edges, which differ from the node's real-graph degree.
 TYPED_TEST(InterpreterTest, CallUseScopeDegreeOverProjection) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1102,6 +1102,27 @@ TYPED_TEST(InterpreterTest, CallUseScopeOverDeriveHiddenInvisible) {
   EXPECT_EQ(pred.GetResults()[1][0].ValueInt(), 2);
 }
 
+// derive()'s virtualEdgeType may be a per-row expression (type(r)) rather than a constant. The
+// prepare-time projection-schema extraction cannot evaluate it statically, but that must not fail the
+// query - the executor evaluates the config per row. undirectedEdgeTypes then makes the listed types'
+// edges count in both directions. Regression for the GQL Behave aggregations scenarios that a
+// non-constant virtualEdgeType previously aborted at prepare time.
+TYPED_TEST(InterpreterTest, DeriveWithDynamicVirtualEdgeType) {
+  this->Interpret("CREATE (a:N {x: 1})-[:R1]->(b:N {x: 2}), (b)-[:R2]->(c:N {x: 3}), (c)-[:R3]->(a)");
+  auto stream = this->Interpret(
+      "MATCH p=(:N)-[r]->(:N) "
+      "WITH derive(p, {virtualEdgeType: type(r), undirectedEdgeTypes: ['R1', 'R2']}) AS g "
+      "UNWIND g.edges AS e WITH type(e) AS t, count(*) AS c "
+      "RETURN t, c ORDER BY t");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueString(), "R1");
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueString(), "R2");
+  EXPECT_EQ(stream.GetResults()[1][1].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueString(), "R3");
+  EXPECT_EQ(stream.GetResults()[2][1].ValueInt(), 1);
+}
+
 // A USE scope over a project() subgraph scans only the subgraph's member nodes,
 // not other real-graph nodes.
 TYPED_TEST(InterpreterTest, CallUseScopeOverSubgraphScansMembers) {

--- a/tests/unit/interpreter_faker.hpp
+++ b/tests/unit/interpreter_faker.hpp
@@ -23,7 +23,7 @@ struct InterpreterFaker {
   }
 
   auto Prepare(const std::string &query, const memgraph::storage::ExternalPropertyValue::map_t &params = {}) {
-    const auto [header, _1, qid, _2] = interpreter.Prepare(query, [=](auto *) { return params; }, {});
+    const auto [header, _1, qid, _2, _3] = interpreter.Prepare(query, [=](auto *) { return params; }, {});
     auto &db = interpreter.current_db_.db_acc_;
     ResultStreamFaker stream(db ? db->get()->storage() : nullptr);
     stream.Header(header);

--- a/tests/unit/query_dump.cpp
+++ b/tests/unit/query_dump.cpp
@@ -340,7 +340,7 @@ auto Execute(memgraph::query::InterpreterContext *context, memgraph::dbms::Datab
   interpreter.SetUser(auth_checker.GenQueryUser(std::nullopt, {}));
   ResultStreamFaker stream(db->storage());
 
-  auto [header, _1, qid, _2] = interpreter.Prepare(query, memgraph::query::no_params_fn, {});
+  auto [header, _1, qid, _2, _3] = interpreter.Prepare(query, memgraph::query::no_params_fn, {});
   stream.Header(header);
   auto summary = interpreter.PullAll(&stream);
   stream.Summary(summary);
@@ -1609,7 +1609,7 @@ class StatefulInterpreter {
   auto Execute(const std::string &query) {
     ResultStreamFaker stream(interpreter_.current_db_.db_acc_->get()->storage());
 
-    auto [header, _1, qid, _2] = interpreter_.Prepare(query, memgraph::query::no_params_fn, {});
+    auto [header, _1, qid, _2, _3] = interpreter_.Prepare(query, memgraph::query::no_params_fn, {});
     stream.Header(header);
     auto summary = interpreter_.PullAll(&stream);
     stream.Summary(summary);

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2713,7 +2713,7 @@ TYPED_TEST(FunctionTest, PropertySizeOverVirtualElements) {
       {},
       {},
       std::optional<VertexAccessor>{real},
-      std::make_shared<const ProjectionSchema>(ProjectionSchema::key_set{name_id}, ProjectionSchema::key_set{}));
+      std::make_shared<const PropertyBinding>(PropertyBinding::key_set{name_id}, PropertyBinding::key_set{}));
   EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", hidden, "name").ValueInt(), 0);
 
   // Key present in the mapper but absent on the node: 0.

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2376,6 +2376,32 @@ TYPED_TEST(FunctionTest, Keys) {
   ASSERT_THROW(this->EvaluateFunction("KEYS", 2), QueryRuntimeException);
 }
 
+TYPED_TEST(FunctionTest, Values) {
+  // values() must report its own name in errors, not 'keys' (its body was copy-pasted from Keys).
+  try {
+    this->EvaluateFunction("VALUES");  // 0 args -> FType arg-count error, which embeds the function name
+    FAIL() << "expected a QueryRuntimeException for a 0-arg values() call";
+  } catch (const QueryRuntimeException &e) {
+    const std::string msg = e.what();
+    EXPECT_NE(msg.find("values"), std::string::npos) << "error should name values(): " << msg;
+    EXPECT_EQ(msg.find("keys"), std::string::npos) << "error should not say keys: " << msg;
+  }
+
+  ASSERT_TRUE(this->EvaluateFunction("VALUES", TypedValue()).IsNull());
+  auto v1 = this->dba.InsertVertex();
+  ASSERT_TRUE(v1.SetProperty(this->dba.NameToProperty("height"), memgraph::storage::PropertyValue(5)).has_value());
+  ASSERT_TRUE(v1.SetProperty(this->dba.NameToProperty("age"), memgraph::storage::PropertyValue(10)).has_value());
+  this->dba.AdvanceCommand();
+
+  auto prop_values_to_int = [](TypedValue t) {
+    std::vector<int> values;
+    for (auto v : t.ValueList()) values.emplace_back(v.ValueInt());
+    return values;
+  };
+  ASSERT_THAT(prop_values_to_int(this->EvaluateFunction("VALUES", v1)), UnorderedElementsAre(5, 10));
+  ASSERT_THROW(this->EvaluateFunction("VALUES", 2), QueryRuntimeException);
+}
+
 TYPED_TEST(FunctionTest, Tail) {
   ASSERT_THROW(this->EvaluateFunction("TAIL"), QueryRuntimeException);
   ASSERT_TRUE(this->EvaluateFunction("TAIL", TypedValue()).IsNull());
@@ -2592,19 +2618,187 @@ TYPED_TEST(FunctionTest, ElementId) {
   EXPECT_THROW(this->EvaluateFunction("ELEMENTID", va, *ea), QueryRuntimeException);
 }
 
+TYPED_TEST(FunctionTest, IdOnVirtualAndOverlayNodes) {
+  auto real = this->dba.InsertVertex();
+  this->dba.AdvanceCommand();
+  const auto real_id = this->EvaluateFunction("ID", real).ValueInt();
+
+  // A synthetic node (no origin) reports a dense query-local external id, not its raw synthetic gid.
+  // It is the first virtual entity seen in this query, so it maps to -1, and repeat references and
+  // virtual_id() correlate to the same value.
+  VirtualNode synthetic({"L"}, {});
+  const auto external = this->EvaluateFunction("ID", synthetic).ValueInt();
+  EXPECT_EQ(external, -1);
+  EXPECT_EQ(this->EvaluateFunction("ID", synthetic).ValueInt(), external);
+  EXPECT_EQ(this->EvaluateFunction("VIRTUAL_ID", synthetic).ValueInt(), external);
+
+  // An overlay node reports its origin's real id, so id() is the entity's identity in the real graph.
+  VirtualNode overlay({"L"}, {}, {}, std::optional<VertexAccessor>{real});
+  EXPECT_EQ(this->EvaluateFunction("ID", overlay).ValueInt(), real_id);
+}
+
+TYPED_TEST(FunctionTest, VirtualId) {
+  auto real = this->dba.InsertVertex();
+  auto real_edge = this->dba.InsertEdge(&real, &real, this->dba.NameToEdgeType("edge"));
+  ASSERT_TRUE(real_edge.has_value());
+  this->dba.AdvanceCommand();
+
+  // A real vertex or edge has no overlay-local id.
+  EXPECT_TRUE(this->EvaluateFunction("VIRTUAL_ID", TypedValue()).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction("VIRTUAL_ID", real).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction("VIRTUAL_ID", *real_edge).IsNull());
+
+  // A synthetic node, an overlay node, and a virtual edge each get a distinct negative external id.
+  VirtualNode synthetic({"L"}, {});
+  VirtualNode overlay({"L"}, {}, {}, std::optional<VertexAccessor>{real});
+  auto from = std::make_shared<const VirtualNode>(VirtualNode({"L"}, {}));
+  auto to = std::make_shared<const VirtualNode>(VirtualNode({"L"}, {}));
+  VirtualEdge vedge(from, to, "T");
+
+  const auto synthetic_id = this->EvaluateFunction("VIRTUAL_ID", synthetic).ValueInt();
+  const auto overlay_id = this->EvaluateFunction("VIRTUAL_ID", overlay).ValueInt();
+  const auto edge_id = this->EvaluateFunction("VIRTUAL_ID", vedge).ValueInt();
+  EXPECT_LT(synthetic_id, 0);
+  EXPECT_LT(overlay_id, 0);
+  EXPECT_LT(edge_id, 0);
+  EXPECT_NE(synthetic_id, overlay_id);
+  EXPECT_NE(synthetic_id, edge_id);
+  EXPECT_NE(overlay_id, edge_id);
+
+  EXPECT_THROW(this->EvaluateFunction("VIRTUAL_ID"), QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction("VIRTUAL_ID", 0), QueryRuntimeException);
+}
+
 TYPED_TEST(FunctionTest, ElementIdVirtual) {
   auto vn1 = std::make_shared<const memgraph::query::VirtualNode>(memgraph::query::VirtualNode({"L1"}, {}));
   auto vn2 = std::make_shared<const memgraph::query::VirtualNode>(memgraph::query::VirtualNode({"L2"}, {}));
   auto ve = memgraph::query::VirtualEdge(vn1, vn2, "ET");
-  // Virtual elements return their own (synthetic) gids, consistent with id().
-  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(*vn1)).ValueString(),
-            std::to_string(vn1->CypherId()).c_str());
-  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(*vn2)).ValueString(),
-            std::to_string(vn2->CypherId()).c_str());
-  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(ve)).ValueString(),
-            std::to_string(ve.Gid().AsInt()).c_str());
-  EXPECT_EQ(this->EvaluateFunction("ID", TypedValue(*vn1)).ValueInt(), vn1->CypherId());
-  EXPECT_EQ(this->EvaluateFunction("ID", TypedValue(ve)).ValueInt(), ve.Gid().AsInt());
+  // Virtual elements expose their query-local external id; elementId() is its string form, consistent
+  // with id(), and distinct elements get distinct ids.
+  const auto vn1_id = this->EvaluateFunction("ID", TypedValue(*vn1)).ValueInt();
+  const auto ve_id = this->EvaluateFunction("ID", TypedValue(ve)).ValueInt();
+  EXPECT_LT(vn1_id, 0);
+  EXPECT_LT(ve_id, 0);
+  EXPECT_NE(vn1_id, ve_id);
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(*vn1)).ValueString(), std::to_string(vn1_id).c_str());
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(ve)).ValueString(), std::to_string(ve_id).c_str());
+  EXPECT_NE(this->EvaluateFunction("ELEMENTID", TypedValue(*vn2)).ValueString(),
+            this->EvaluateFunction("ELEMENTID", TypedValue(*vn1)).ValueString());
+}
+
+TYPED_TEST(FunctionTest, PropertySizeOverVirtualElements) {
+  // A real element carrying a property is the transparency oracle: a virtual element with the same
+  // value reports the same encoded size, an overlay reads through to its origin, and a hidden or
+  // absent key contributes 0.
+  auto real = this->dba.InsertVertex();
+  const auto name_id = this->dba.NameToProperty("name");
+  this->dba.NameToProperty("other");  // registered in the mapper but never set on any element
+  ASSERT_TRUE(real.SetProperty(name_id, memgraph::storage::PropertyValue("hello")).has_value());
+  this->dba.AdvanceCommand();
+
+  const auto real_size = this->EvaluateFunction("PROPERTYSIZE", real, "name").ValueInt();
+  ASSERT_GT(real_size, 0);
+
+  // Synthetic node: the overlay value's size equals the real node's.
+  VirtualNode synthetic({"L"}, {{name_id, memgraph::storage::PropertyValue("hello")}});
+  EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", synthetic, "name").ValueInt(), real_size);
+
+  // Overlay node with no overlay for the key: reads through to the origin, so it matches the real node.
+  VirtualNode overlay({"L"}, {}, {}, std::optional<VertexAccessor>{real});
+  EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", overlay, "name").ValueInt(), real_size);
+
+  // Hidden key: invisible, contributes 0 even though the origin holds a value for it.
+  VirtualNode hidden({"L"}, {}, {}, std::optional<VertexAccessor>{real}, VirtualNode::hidden_keys{name_id});
+  EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", hidden, "name").ValueInt(), 0);
+
+  // Key present in the mapper but absent on the node: 0.
+  EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", synthetic, "other").ValueInt(), 0);
+
+  // Virtual edge: the overlay value's size matches a real edge carrying the same value.
+  auto v2 = this->dba.InsertVertex();
+  auto real_edge = this->dba.InsertEdge(&real, &v2, this->dba.NameToEdgeType("T"));
+  ASSERT_TRUE(real_edge.has_value());
+  ASSERT_TRUE(real_edge->SetProperty(name_id, memgraph::storage::PropertyValue("hello")).has_value());
+  this->dba.AdvanceCommand();
+  const auto real_edge_size = this->EvaluateFunction("PROPERTYSIZE", *real_edge, "name").ValueInt();
+  ASSERT_GT(real_edge_size, 0);
+
+  auto from = std::make_shared<const VirtualNode>(VirtualNode({"L"}, {}));
+  auto to = std::make_shared<const VirtualNode>(VirtualNode({"L"}, {}));
+  VirtualEdge vedge(from, to, "T");
+  vedge.SetProperty(name_id, memgraph::storage::PropertyValue("hello"));
+  EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", TypedValue(vedge), "name").ValueInt(), real_edge_size);
+}
+
+TYPED_TEST(FunctionTest, KeysValuesPreserveStoredOrderOnRealElements) {
+  // keys()/values() over a real element iterate the stored PropertyId order (deterministic), not a
+  // hash order. Registering names in a known order fixes their PropertyId order (ids are assigned in
+  // first-seen order), independent of the order the properties are then set.
+  auto v = this->dba.InsertVertex();
+  const auto alpha = this->dba.NameToProperty("alpha");
+  const auto bravo = this->dba.NameToProperty("bravo");
+  const auto charlie = this->dba.NameToProperty("charlie");
+  ASSERT_TRUE(v.SetProperty(charlie, memgraph::storage::PropertyValue(3)).has_value());
+  ASSERT_TRUE(v.SetProperty(alpha, memgraph::storage::PropertyValue(1)).has_value());
+  ASSERT_TRUE(v.SetProperty(bravo, memgraph::storage::PropertyValue(2)).has_value());
+  this->dba.AdvanceCommand();
+
+  std::vector<std::string> keys;
+  for (const auto &k : this->EvaluateFunction("KEYS", v).ValueList()) keys.emplace_back(k.ValueString());
+  EXPECT_THAT(keys, testing::ElementsAre("alpha", "bravo", "charlie"));
+
+  std::vector<int> values;
+  for (const auto &val : this->EvaluateFunction("VALUES", v).ValueList()) values.emplace_back(val.ValueInt());
+  EXPECT_THAT(values, testing::ElementsAre(1, 2, 3));
+}
+
+TYPED_TEST(FunctionTest, OverlayPropertyReadHonoursCallerView) {
+  // The function view in this fixture is OLD. An overlay node's read-through must honour the
+  // caller's view, so properties()/values() over the overlay match the real node even when the
+  // origin has an uncommitted (NEW-only) change in the current command. Regression: the shared
+  // virtual read pinned View::NEW and leaked the uncommitted value.
+  auto real = this->dba.InsertVertex();
+  const auto p = this->dba.NameToProperty("p");
+  ASSERT_TRUE(real.SetProperty(p, memgraph::storage::PropertyValue(1)).has_value());
+  this->dba.AdvanceCommand();                                                         // p=1 committed to the command
+  ASSERT_TRUE(real.SetProperty(p, memgraph::storage::PropertyValue(2)).has_value());  // NEW=2, OLD=1, uncommitted
+
+  VirtualNode overlay({"L"}, {}, {}, std::optional<VertexAccessor>{real});
+
+  auto p_of_map = [](const TypedValue &props_map) {
+    for (const auto &kv : props_map.ValueMap())
+      if (std::string(kv.first) == "p") return kv.second.ValueInt();
+    return int64_t{-1};
+  };
+  auto only = [](const TypedValue &list) { return list.ValueList().at(0).ValueInt(); };
+
+  // The real node under OLD sees the pre-change value; the overlay read-through must agree.
+  ASSERT_EQ(p_of_map(this->EvaluateFunction("PROPERTIES", real)), 1);
+  EXPECT_EQ(p_of_map(this->EvaluateFunction("PROPERTIES", overlay)), 1);
+  ASSERT_EQ(only(this->EvaluateFunction("VALUES", real)), 1);
+  EXPECT_EQ(only(this->EvaluateFunction("VALUES", overlay)), 1);
+}
+
+TYPED_TEST(FunctionTest, VirtualOriginReadFailureNamesCallingFunction) {
+  // When an overlay node's origin can no longer be read, keys()/values()/properties() each name the
+  // calling function in the diagnostic (regression guard: the message used to hardcode "properties").
+  auto real = this->dba.InsertVertex();
+  this->dba.AdvanceCommand();
+  VirtualNode overlay({"L"}, {}, {}, std::optional<VertexAccessor>{real});
+  ASSERT_TRUE(this->dba.RemoveVertex(&real).has_value());
+  this->dba.AdvanceCommand();  // origin now deleted in this command's OLD view
+
+  auto message_of = [&](const char *func) -> std::string {
+    try {
+      this->EvaluateFunction(func, overlay);
+      return "<no throw>";
+    } catch (const QueryRuntimeException &e) {
+      return e.what();
+    }
+  };
+  EXPECT_THAT(message_of("KEYS"), testing::HasSubstr("keys"));
+  EXPECT_THAT(message_of("VALUES"), testing::HasSubstr("values"));
+  EXPECT_THAT(message_of("PROPERTIES"), testing::HasSubstr("properties"));
 }
 
 TYPED_TEST(FunctionTest, ToStringNull) { EXPECT_TRUE(this->EvaluateFunction("TOSTRING", TypedValue()).IsNull()); }

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2708,7 +2708,12 @@ TYPED_TEST(FunctionTest, PropertySizeOverVirtualElements) {
   EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", overlay, "name").ValueInt(), real_size);
 
   // Hidden key: invisible, contributes 0 even though the origin holds a value for it.
-  VirtualNode hidden({"L"}, {}, {}, std::optional<VertexAccessor>{real}, VirtualNode::hidden_keys{name_id});
+  VirtualNode hidden(
+      {"L"},
+      {},
+      {},
+      std::optional<VertexAccessor>{real},
+      std::make_shared<const ProjectionSchema>(ProjectionSchema::key_set{name_id}, ProjectionSchema::key_set{}));
   EXPECT_EQ(this->EvaluateFunction("PROPERTYSIZE", hidden, "name").ValueInt(), 0);
 
   // Key present in the mapper but absent on the node: 0.

--- a/tests/unit/query_graph_view.cpp
+++ b/tests/unit/query_graph_view.cpp
@@ -11,14 +11,19 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <set>
+#include <utility>
 #include <variant>
+#include <vector>
 
 #include "query/context.hpp"
 #include "query/db_accessor.hpp"
+#include "query/graph.hpp"
 #include "query/graph_view.hpp"
 #include "query/interpret/frame.hpp"
 #include "query/plan/operator.hpp"
+#include "query/subgraph_graph_view.hpp"
 #include "query/virtual_graph.hpp"
 #include "query/virtual_graph_view.hpp"
 #include "query/virtual_node.hpp"
@@ -374,6 +379,153 @@ TEST_F(VirtualGraphViewTest, NameMappingSharesTheRealNamespace) {
   EXPECT_EQ(label, dba_.NameToLabel("Person"));
   EXPECT_EQ(prop, dba_.NameToProperty("name"));
   EXPECT_EQ(edge_type, dba_.NameToEdgeType("KNOWS"));
+}
+
+// --- Edge expansion through the GraphView seam (Stage A) -------------------
+//
+// The base GraphView OutEdges/InEdges are exercised on each concrete view: the
+// identity view forwards to the real accessor (keeping storage-level type and
+// destination pushdown), the projection view reads its own in/out index, and the
+// subgraph view forwards to the real accessor then drops non-member edges.
+
+// Collects a projection expansion into (from, to) gid pairs.
+std::vector<std::pair<Gid, Gid>> VirtualPairs(EdgeRange range) {
+  std::vector<std::pair<Gid, Gid>> pairs;
+  for (auto edge : range) {
+    const auto &ve = std::get<VirtualEdge>(edge);
+    pairs.emplace_back(ve.FromGid(), ve.ToGid());
+  }
+  return pairs;
+}
+
+// Collects a real expansion into the set of reached (To/From) vertex gids.
+std::set<Gid> RealEndpoints(EdgeRange range, bool out) {
+  std::set<Gid> gids;
+  for (auto edge : range) {
+    const auto &ea = std::get<EdgeAccessor>(edge);
+    gids.insert(out ? ea.To().Gid() : ea.From().Gid());
+  }
+  return gids;
+}
+
+// A directed projection edge appears among its source's out-edges and its
+// target's in-edges only, expanded through the seam rather than the concrete view.
+TEST_F(VirtualGraphViewTest, SeamExpandsProjectionEdgeDirectionally) {
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"A"}));
+  nodes.push_back(HandledNode(2, {"B"}));
+  const auto src = nodes[0].Gid();
+  const auto dst = nodes[1].Gid();
+  std::vector<VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "KNOWS");
+  auto graph = AssembleVirtualGraph(nodes, edges, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  const auto outs = VirtualPairs(view.OutEdges(ScanVertex{nodes[0]}, View::NEW, {}, std::nullopt, nullptr));
+  ASSERT_EQ(outs.size(), 1U);
+  EXPECT_EQ(outs[0], std::make_pair(src, dst));
+
+  const auto ins = VirtualPairs(view.InEdges(ScanVertex{nodes[1]}, View::NEW, {}, std::nullopt, nullptr));
+  ASSERT_EQ(ins.size(), 1U);
+  EXPECT_EQ(ins[0], std::make_pair(src, dst));
+
+  // Wrong direction against each endpoint is empty.
+  EXPECT_TRUE(VirtualPairs(view.InEdges(ScanVertex{nodes[0]}, View::NEW, {}, std::nullopt, nullptr)).empty());
+  EXPECT_TRUE(VirtualPairs(view.OutEdges(ScanVertex{nodes[1]}, View::NEW, {}, std::nullopt, nullptr)).empty());
+}
+
+// An edge-type filter keeps only edges of a requested type.
+TEST_F(VirtualGraphViewTest, SeamFiltersProjectionEdgesByType) {
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1));
+  nodes.push_back(HandledNode(2));
+  nodes.push_back(HandledNode(3));
+  std::vector<VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "KNOWS");
+  edges.emplace_back(int64_t{1}, int64_t{3}, "LIKES");
+  auto graph = AssembleVirtualGraph(nodes, edges, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  const std::vector<storage::EdgeTypeId> only_knows{dba_.NameToEdgeType("KNOWS")};
+  const auto outs = VirtualPairs(view.OutEdges(ScanVertex{nodes[0]}, View::NEW, only_knows, std::nullopt, nullptr));
+  ASSERT_EQ(outs.size(), 1U);
+  EXPECT_EQ(outs[0].second, nodes[1].Gid());
+}
+
+// An already-bound destination keeps only the edge that reaches it.
+TEST_F(VirtualGraphViewTest, SeamFiltersProjectionEdgesByExistingDest) {
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1));
+  nodes.push_back(HandledNode(2));
+  nodes.push_back(HandledNode(3));
+  std::vector<VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "R");
+  edges.emplace_back(int64_t{1}, int64_t{3}, "R");
+  auto graph = AssembleVirtualGraph(nodes, edges, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  const std::optional<ScanVertex> dest{ScanVertex{nodes[1]}};
+  const auto outs = VirtualPairs(view.OutEdges(ScanVertex{nodes[0]}, View::NEW, {}, dest, nullptr));
+  ASSERT_EQ(outs.size(), 1U);
+  EXPECT_EQ(outs[0].second, nodes[1].Gid());
+}
+
+// The identity view expands a real vertex's edges through the seam, pushing the
+// type and destination filters down to the real accessor.
+TEST_F(GraphViewTest, SeamExpandsRealEdgesWithPushdown) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  auto a = dba.InsertVertex();
+  auto b = dba.InsertVertex();
+  auto c = dba.InsertVertex();
+  const auto knows = dba.NameToEdgeType("KNOWS");
+  const auto likes = dba.NameToEdgeType("LIKES");
+  ASSERT_TRUE(dba.InsertEdge(&a, &b, knows).has_value());
+  ASSERT_TRUE(dba.InsertEdge(&a, &c, likes).has_value());
+  dba.AdvanceCommand();
+
+  DbAccessorGraphView view{&dba};
+  const ScanVertex from{a};
+
+  EXPECT_EQ(RealEndpoints(view.OutEdges(from, View::NEW, {}, std::nullopt, nullptr), /*out=*/true),
+            (std::set<Gid>{b.Gid(), c.Gid()}));
+
+  const std::vector<storage::EdgeTypeId> only_knows{knows};
+  EXPECT_EQ(RealEndpoints(view.OutEdges(from, View::NEW, only_knows, std::nullopt, nullptr), true),
+            (std::set<Gid>{b.Gid()}));
+
+  const std::optional<ScanVertex> dest{ScanVertex{c}};
+  EXPECT_EQ(RealEndpoints(view.OutEdges(from, View::NEW, {}, dest, nullptr), true), (std::set<Gid>{c.Gid()}));
+
+  // In-edges of b are a's edge, seen from the other end.
+  EXPECT_EQ(RealEndpoints(view.InEdges(ScanVertex{b}, View::NEW, {}, std::nullopt, nullptr), /*out=*/false),
+            (std::set<Gid>{a.Gid()}));
+}
+
+// The subgraph view forwards to the real accessor and then drops edges that are
+// not members of the subgraph, so expansion stays within it.
+TEST_F(GraphViewTest, SeamDropsNonMemberSubgraphEdges) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  auto a = dba.InsertVertex();
+  auto b = dba.InsertVertex();
+  auto c = dba.InsertVertex();
+  const auto t = dba.NameToEdgeType("R");
+  auto member = dba.InsertEdge(&a, &b, t);
+  auto non_member = dba.InsertEdge(&a, &c, t);
+  ASSERT_TRUE(member.has_value());
+  ASSERT_TRUE(non_member.has_value());
+  dba.AdvanceCommand();
+
+  Graph graph{memgraph::utils::NewDeleteResource()};
+  graph.InsertVertex(a);
+  graph.InsertVertex(b);
+  graph.InsertEdge(*member);  // a->b is a member; a->c is not
+  SubgraphGraphView view{&graph, &dba};
+
+  // Only the member edge survives; the non-member edge to c is dropped.
+  EXPECT_EQ(RealEndpoints(view.OutEdges(ScanVertex{a}, View::NEW, {}, std::nullopt, nullptr), /*out=*/true),
+            (std::set<Gid>{b.Gid()}));
 }
 
 }  // namespace memgraph::query::test

--- a/tests/unit/query_graph_view.cpp
+++ b/tests/unit/query_graph_view.cpp
@@ -13,6 +13,7 @@
 
 #include <optional>
 #include <set>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -22,8 +23,10 @@
 #include "query/graph.hpp"
 #include "query/graph_view.hpp"
 #include "query/interpret/frame.hpp"
+#include "query/path.hpp"
 #include "query/plan/operator.hpp"
 #include "query/subgraph_graph_view.hpp"
+#include "query/typed_value.hpp"
 #include "query/virtual_graph.hpp"
 #include "query/virtual_graph_view.hpp"
 #include "query/virtual_node.hpp"
@@ -526,6 +529,36 @@ TEST_F(GraphViewTest, SeamDropsNonMemberSubgraphEdges) {
   // Only the member edge survives; the non-member edge to c is dropped.
   EXPECT_EQ(RealEndpoints(view.OutEdges(ScanVertex{a}, View::NEW, {}, std::nullopt, nullptr), /*out=*/true),
             (std::set<Gid>{b.Gid()}));
+}
+
+// AddPathToProjection collapses a real path into an overlay projection directly -
+// no Aggregate operator or plan - so the derive()/project() assembly is unit-testable
+// in isolation now that it lives in the virtual_graph module.
+TEST_F(GraphViewTest, AddPathToProjectionBuildsOverlayGraph) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  auto a = dba.InsertVertex();
+  auto b = dba.InsertVertex();
+  auto edge = dba.InsertEdge(&a, &b, dba.NameToEdgeType("R"));
+  ASSERT_TRUE(edge.has_value());
+  dba.AdvanceCommand();
+
+  auto *mem = memgraph::utils::NewDeleteResource();
+  TypedValue::TMap options(mem);
+  options.emplace(TypedValue::TString{"virtualEdgeType", mem}, TypedValue{"E", mem});
+  const TypedValue options_value{std::move(options), mem};
+  const TypedValue path_value{Path{a, *edge, b}, mem};
+
+  VirtualGraph graph{mem};
+  DerivedNodeDedup dedup{mem};
+  AddPathToProjection(path_value, options_value, graph, dedup, VirtualNode::kNoProjectionRef, &dba);
+
+  // The path collapses to two overlay nodes (over the real endpoints) and one 'E'
+  // synthetic edge; each overlay reads through to its real origin.
+  EXPECT_EQ(graph.nodes().size(), 2U);
+  ASSERT_EQ(graph.edges().size(), 1U);
+  EXPECT_EQ(std::string_view{graph.edges().begin()->EdgeTypeName()}, "E");
+  for (const auto &[gid, node] : graph.nodes()) EXPECT_TRUE(node->HasOrigin());
 }
 
 }  // namespace memgraph::query::test

--- a/tests/unit/query_graph_view.cpp
+++ b/tests/unit/query_graph_view.cpp
@@ -1,0 +1,379 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <variant>
+
+#include "query/context.hpp"
+#include "query/db_accessor.hpp"
+#include "query/graph_view.hpp"
+#include "query/interpret/frame.hpp"
+#include "query/plan/operator.hpp"
+#include "query/virtual_graph.hpp"
+#include "query/virtual_graph_view.hpp"
+#include "query/virtual_node.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/storage.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/memory.hpp"
+
+#ifdef MG_ENTERPRISE
+#include "auth/models.hpp"
+#include "glue/auth_checker.hpp"
+#include "license/license.hpp"
+#include "query/frontend/ast/ast.hpp"
+#endif
+
+namespace memgraph::query::test {
+
+using storage::Gid;
+using storage::View;
+
+class GraphViewTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<storage::Storage> storage_ = std::make_unique<storage::InMemoryStorage>();
+
+  // Inserts `count` vertices and returns their gids.
+  std::set<Gid> InsertVertices(int count) {
+    std::set<Gid> gids;
+    auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+    auto dba = DbAccessor(acc.get());
+    for (int i = 0; i < count; ++i) gids.insert(dba.InsertVertex().Gid());
+    EXPECT_TRUE(dba.Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+    return gids;
+  }
+};
+
+// The identity view scans exactly the vertices in the real graph.
+TEST_F(GraphViewTest, IdentityViewYieldsAllVertices) {
+  const auto expected = InsertVertices(5);
+
+  auto acc = storage_->Access(storage::StorageAccessType::READ);
+  auto dba = DbAccessor(acc.get());
+  DbAccessorGraphView view{&dba};
+
+  std::set<Gid> scanned;
+  for (auto vertex : view.Vertices(View::NEW)) scanned.insert(std::get<VertexAccessor>(vertex).Gid());
+
+  EXPECT_EQ(scanned, expected);
+}
+
+// Names resolve through the view to the same ids the underlying accessor uses,
+// and round-trip back to the same names.
+TEST_F(GraphViewTest, NameMappingRoundTripsThroughView) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  auto dba = DbAccessor(acc.get());
+  DbAccessorGraphView view{&dba};
+
+  const auto label = view.NameToLabel("Person");
+  const auto prop = view.NameToProperty("name");
+  const auto edge_type = view.NameToEdgeType("KNOWS");
+
+  EXPECT_EQ(view.LabelToName(label), "Person");
+  EXPECT_EQ(view.PropertyToName(prop), "name");
+  EXPECT_EQ(view.EdgeTypeToName(edge_type), "KNOWS");
+
+  // The view shares the accessor's namespace; it does not mint its own ids.
+  EXPECT_EQ(label, dba.NameToLabel("Person"));
+  EXPECT_EQ(prop, dba.NameToProperty("name"));
+  EXPECT_EQ(edge_type, dba.NameToEdgeType("KNOWS"));
+}
+
+// ScanAll scans the graph bound into the execution context, not the context's
+// own accessor. Binding a view over a populated graph while the accessor sees an
+// empty one, ScanAll must yield the populated graph's vertices.
+TEST_F(GraphViewTest, ScanAllReadsThroughBoundView) {
+  const auto bound_gids = InsertVertices(3);
+
+  // A second, empty storage that the context's own accessor points at.
+  auto empty_storage = std::make_unique<storage::InMemoryStorage>();
+  auto empty_acc = empty_storage->Access(storage::StorageAccessType::READ);
+  auto empty_dba = DbAccessor(empty_acc.get());
+
+  auto bound_acc = storage_->Access(storage::StorageAccessType::READ);
+  auto bound_dba = DbAccessor(bound_acc.get());
+  DbAccessorGraphView bound_view{&bound_dba};
+
+  SymbolTable symbol_table;
+  auto symbol = symbol_table.CreateSymbol("n", true);
+  auto scan_all = std::make_shared<plan::ScanAll>(nullptr, symbol, View::NEW);
+
+  memgraph::metrics::DatabaseMetricHandles metric_handles;
+  ExecutionContext context{.db_accessor = &empty_dba};
+  context.evaluation_context.graph_view = &bound_view;
+  context.symbol_table = symbol_table;
+  context.evaluation_context.memory = memgraph::utils::NewDeleteResource();
+  context.metric_handles = &metric_handles;
+
+  Frame frame(symbol_table.max_position());
+  auto cursor = scan_all->MakeCursor(memgraph::utils::NewDeleteResource(), metric_handles);
+  std::set<Gid> scanned;
+  while (cursor->Pull(frame, context)) scanned.insert(frame[symbol].ValueVertex().Gid());
+
+  EXPECT_EQ(scanned, bound_gids);
+}
+
+// A synthetic node carrying an import handle, so AssembleVirtualGraph can wire
+// edges to it by handle.
+VirtualNode HandledNode(int64_t handle, VirtualNode::label_list labels = {}) {
+  VirtualNode node{std::move(labels), {}};
+  node.SetHandle(handle);
+  return node;
+}
+
+class VirtualGraphViewTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<storage::Storage> storage_ = std::make_unique<storage::InMemoryStorage>();
+
+  // A DbAccessor over an empty real graph, used only for the shared name space.
+  std::unique_ptr<storage::Storage::Accessor> acc_ = storage_->Access(storage::StorageAccessType::READ);
+  DbAccessor dba_{acc_.get()};
+};
+
+// The projection view scans exactly the nodes in the VirtualGraph.
+TEST_F(VirtualGraphViewTest, ViewYieldsAllNodes) {
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"A"}));
+  nodes.push_back(HandledNode(2, {"B"}));
+  nodes.push_back(HandledNode(3, {"C"}));
+  std::set<Gid> expected{nodes[0].Gid(), nodes[1].Gid(), nodes[2].Gid()};
+
+  auto graph = AssembleVirtualGraph(nodes, {}, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  std::set<Gid> scanned;
+  for (const auto &node : view.Nodes()) scanned.insert(node.Gid());
+
+  EXPECT_EQ(scanned, expected);
+}
+
+// Out-edges and in-edges of a node are direction-respecting: a directed edge
+// appears among its source's out-edges and its target's in-edges only.
+TEST_F(VirtualGraphViewTest, ViewYieldsDirectedEdgesOfANode) {
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"A"}));
+  nodes.push_back(HandledNode(2, {"B"}));
+  const auto src = nodes[0].Gid();
+  const auto dst = nodes[1].Gid();
+
+  std::vector<VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "KNOWS");
+
+  auto graph = AssembleVirtualGraph(nodes, edges, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  ASSERT_EQ(view.OutEdges(src).size(), 1);
+  EXPECT_EQ(view.OutEdges(src)[0]->FromGid(), src);
+  EXPECT_EQ(view.OutEdges(src)[0]->ToGid(), dst);
+
+  ASSERT_EQ(view.InEdges(dst).size(), 1);
+  EXPECT_EQ(view.InEdges(dst)[0]->ToGid(), dst);
+
+  // The edge does not appear against the wrong endpoint or wrong direction.
+  EXPECT_TRUE(view.InEdges(src).empty());
+  EXPECT_TRUE(view.OutEdges(dst).empty());
+}
+
+// A self-loop is both an out-edge and an in-edge of its node.
+TEST_F(VirtualGraphViewTest, ViewYieldsSelfLoopInBothDirections) {
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"A"}));
+  const auto self = nodes[0].Gid();
+
+  std::vector<VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{1}, "SELF");
+
+  auto graph = AssembleVirtualGraph(nodes, edges, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  ASSERT_EQ(view.OutEdges(self).size(), 1);
+  ASSERT_EQ(view.InEdges(self).size(), 1);
+  EXPECT_EQ(view.OutEdges(self)[0]->Gid(), view.InEdges(self)[0]->Gid());
+  EXPECT_EQ(view.OutEdges(self)[0]->FromGid(), self);
+  EXPECT_EQ(view.OutEdges(self)[0]->ToGid(), self);
+}
+
+// ScanAll routed through a bound projection view yields the projection's nodes
+// as VirtualNode values on the frame, the same operator that scans the real graph.
+TEST_F(VirtualGraphViewTest, ScanAllOverProjectionYieldsVirtualNodes) {
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"A"}));
+  nodes.push_back(HandledNode(2, {"B"}));
+  std::set<Gid> expected{nodes[0].Gid(), nodes[1].Gid()};
+  auto graph = AssembleVirtualGraph(nodes, {}, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  SymbolTable symbol_table;
+  auto symbol = symbol_table.CreateSymbol("n", true);
+  auto scan_all = std::make_shared<plan::ScanAll>(nullptr, symbol, View::NEW);
+
+  memgraph::metrics::DatabaseMetricHandles metric_handles;
+  ExecutionContext context{.db_accessor = &dba_};
+  context.evaluation_context.graph_view = &view;
+  context.symbol_table = symbol_table;
+  context.evaluation_context.memory = memgraph::utils::NewDeleteResource();
+  context.metric_handles = &metric_handles;
+
+  Frame frame(symbol_table.max_position());
+  auto cursor = scan_all->MakeCursor(memgraph::utils::NewDeleteResource(), metric_handles);
+  std::set<Gid> scanned;
+  while (cursor->Pull(frame, context)) scanned.insert(frame[symbol].ValueVirtualNode().Gid());
+
+  EXPECT_EQ(scanned, expected);
+}
+
+#ifdef MG_ENTERPRISE
+// A scanned overlay node is subject to the same fine-grained visibility decision
+// as its origin vertex: an overlay over a vertex whose label the user is denied
+// is filtered from the scan, so its read-through to the origin can never expose
+// data the user could not read on the origin directly. A synthetic node carries
+// no origin and stays visible.
+TEST_F(VirtualGraphViewTest, ScanFiltersOverlayWhoseOriginIsDenied) {
+  memgraph::license::global_license_checker.EnableTesting();
+
+  auto wacc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{wacc.get()};
+  auto public_origin = dba.InsertVertex();
+  ASSERT_TRUE(public_origin.AddLabel(dba.NameToLabel("Public")).has_value());
+  auto secret_origin = dba.InsertVertex();
+  ASSERT_TRUE(secret_origin.AddLabel(dba.NameToLabel("Secret")).has_value());
+  dba.AdvanceCommand();
+
+  std::vector<VirtualNode> nodes;
+  nodes.emplace_back(
+      VirtualNode::label_list{}, VirtualNode::property_map{}, VirtualNode::allocator_type{}, public_origin);
+  nodes.back().SetHandle(1);
+  const auto public_overlay_gid = nodes.back().Gid();
+  nodes.emplace_back(
+      VirtualNode::label_list{}, VirtualNode::property_map{}, VirtualNode::allocator_type{}, secret_origin);
+  nodes.back().SetHandle(2);
+  const auto secret_overlay_gid = nodes.back().Gid();
+  nodes.push_back(HandledNode(3));
+  const auto synthetic_gid = nodes.back().Gid();
+
+  auto graph = AssembleVirtualGraph(nodes, {}, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba};
+
+  memgraph::auth::User user{"test"};
+  user.db_access().GrantAll();
+  user.fine_grained_access_handler().label_permissions().Grant({"Public"}, memgraph::auth::kAllLabelPermissions);
+  user.fine_grained_access_handler().label_permissions().Deny({"Secret"}, memgraph::auth::kAllLabelPermissions);
+  std::shared_ptr<FineGrainedAuthChecker> checker =
+      std::make_shared<memgraph::glue::FineGrainedAuthChecker>(user, &dba);
+
+  ASSERT_TRUE(checker->Has(public_origin, View::NEW, AuthQuery::FineGrainedPrivilege::READ));
+  ASSERT_FALSE(checker->Has(secret_origin, View::NEW, AuthQuery::FineGrainedPrivilege::READ));
+
+  SymbolTable symbol_table;
+  auto symbol = symbol_table.CreateSymbol("n", true);
+  auto scan_all = std::make_shared<plan::ScanAll>(nullptr, symbol, View::NEW);
+
+  memgraph::metrics::DatabaseMetricHandles metric_handles;
+  ExecutionContext context{.db_accessor = &dba};
+  context.evaluation_context.graph_view = &view;
+  context.symbol_table = symbol_table;
+  context.evaluation_context.memory = memgraph::utils::NewDeleteResource();
+  context.metric_handles = &metric_handles;
+  context.auth_checker = checker.get();
+
+  Frame frame(symbol_table.max_position());
+  auto cursor = scan_all->MakeCursor(memgraph::utils::NewDeleteResource(), metric_handles);
+  std::set<Gid> scanned;
+  while (cursor->Pull(frame, context)) scanned.insert(frame[symbol].ValueVirtualNode().Gid());
+
+  // The overlay over the denied origin is filtered; the granted overlay and the
+  // synthetic node remain.
+  EXPECT_EQ(scanned, (std::set<Gid>{public_overlay_gid, synthetic_gid}));
+  EXPECT_EQ(scanned.count(secret_overlay_gid), 0U);
+}
+#endif
+
+#ifdef MG_ENTERPRISE
+// An overlay node reached by edge expansion (not by a scan) is also subject to
+// its origin's fine-grained visibility: expanding to an overlay over a denied
+// origin drops the edge, so a denied origin cannot be read through an expansion
+// any more than through a scan.
+TEST_F(VirtualGraphViewTest, ExpandToOverlayWhoseOriginIsDeniedIsFiltered) {
+  memgraph::license::global_license_checker.EnableTesting();
+
+  auto wacc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{wacc.get()};
+  auto secret_origin = dba.InsertVertex();
+  ASSERT_TRUE(secret_origin.AddLabel(dba.NameToLabel("Secret")).has_value());
+  dba.AdvanceCommand();
+
+  // A synthetic source node with an out-edge to an overlay node over the denied
+  // origin.
+  std::vector<VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"Src"}));
+  nodes.emplace_back(
+      VirtualNode::label_list{}, VirtualNode::property_map{}, VirtualNode::allocator_type{}, secret_origin);
+  nodes.back().SetHandle(2);
+  const auto denied_gid = nodes.back().Gid();
+  std::vector<VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "R");
+  auto graph = AssembleVirtualGraph(nodes, edges, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba};
+
+  memgraph::auth::User user{"test"};
+  user.db_access().GrantAll();
+  user.fine_grained_access_handler().label_permissions().Deny({"Secret"}, memgraph::auth::kAllLabelPermissions);
+  std::shared_ptr<FineGrainedAuthChecker> checker =
+      std::make_shared<memgraph::glue::FineGrainedAuthChecker>(user, &dba);
+
+  SymbolTable symbol_table;
+  auto src = symbol_table.CreateSymbol("a", true);
+  auto dst = symbol_table.CreateSymbol("m", true);
+  auto edge = symbol_table.CreateSymbol("e", true);
+  auto scan = std::make_shared<plan::ScanAll>(nullptr, src, View::NEW);
+  auto expand = std::make_shared<plan::Expand>(
+      scan, src, dst, edge, EdgeAtom::Direction::OUT, std::vector<storage::EdgeTypeId>{}, false, View::NEW);
+
+  memgraph::metrics::DatabaseMetricHandles metric_handles;
+  ExecutionContext context{.db_accessor = &dba};
+  context.evaluation_context.graph_view = &view;
+  context.symbol_table = symbol_table;
+  context.evaluation_context.memory = memgraph::utils::NewDeleteResource();
+  context.metric_handles = &metric_handles;
+  context.auth_checker = checker.get();
+
+  Frame frame(symbol_table.max_position());
+  auto cursor = expand->MakeCursor(memgraph::utils::NewDeleteResource(), metric_handles);
+  std::set<Gid> reached;
+  while (cursor->Pull(frame, context)) reached.insert(frame[dst].ValueVirtualNode().Gid());
+
+  // The overlay over the denied origin is not reachable; the edge to it is
+  // dropped exactly as the scan would drop the node.
+  EXPECT_EQ(reached.count(denied_gid), 0U);
+}
+#endif
+
+// Names resolve through the view to the same ids the shared accessor uses.
+TEST_F(VirtualGraphViewTest, NameMappingSharesTheRealNamespace) {
+  auto graph = AssembleVirtualGraph({}, {}, DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  VirtualGraphView view{&graph, &dba_};
+
+  const auto label = view.NameToLabel("Person");
+  const auto prop = view.NameToProperty("name");
+  const auto edge_type = view.NameToEdgeType("KNOWS");
+
+  EXPECT_EQ(view.LabelToName(label), "Person");
+  EXPECT_EQ(view.PropertyToName(prop), "name");
+  EXPECT_EQ(view.EdgeTypeToName(edge_type), "KNOWS");
+
+  EXPECT_EQ(label, dba_.NameToLabel("Person"));
+  EXPECT_EQ(prop, dba_.NameToProperty("name"));
+  EXPECT_EQ(edge_type, dba_.NameToEdgeType("KNOWS"));
+}
+
+}  // namespace memgraph::query::test

--- a/tests/unit/query_overlay_authorization.cpp
+++ b/tests/unit/query_overlay_authorization.cpp
@@ -118,4 +118,19 @@ TEST_F(OverlayReadAuthorizationTest, OverlayBoundOverrideExempt) {
   EXPECT_TRUE(auth->IsReadable(overlay, ssn));
 }
 
+TEST_F(OverlayReadAuthorizationTest, OriginLabelReadFailureIsSurfaced) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  auto origin = InsertLabelled(dba, "Secret");
+  const tests::StubPropertyFGAChecker<DbAccessor> checker{&dba, {{"Secret", "ssn"}}};
+
+  // Deleting the origin makes reading its labels fail. For() must surface that error rather than
+  // silently deciding visibility, so each caller (eval fails closed, functions throw, Bolt propagates)
+  // reacts in its own way from one place - the drift this module was introduced to remove.
+  ASSERT_TRUE(dba.RemoveVertex(&origin).has_value());
+  VirtualNode overlay{{}, {}, VirtualNode::allocator_type{}, origin};
+  auto auth = OverlayReadAuthorization::For(overlay, View::NEW, &checker);
+  EXPECT_FALSE(auth.has_value());
+}
+
 }  // namespace memgraph::query::test

--- a/tests/unit/query_overlay_authorization.cpp
+++ b/tests/unit/query_overlay_authorization.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include "helpers/stub_property_fga_checker.hpp"
+#include "query/db_accessor.hpp"
+#include "query/overlay_authorization.hpp"
+#include "query/synthetic_gid.hpp"
+#include "query/virtual_node.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/storage.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/memory.hpp"
+
+namespace memgraph::query::test {
+
+using storage::Gid;
+using storage::View;
+
+// ---- ExternalId: the single synthetic-axis id fallback ----
+
+TEST(SyntheticExternalId, UsesMapperWhenPresent) {
+  SyntheticIdMapper mapper;
+  const auto a = Gid::FromUint(1000);
+  const auto b = Gid::FromUint(2000);
+  // The mapper hands out dense negative ids and repeats them for the same Gid.
+  EXPECT_EQ(ExternalId(a, &mapper), -1);
+  EXPECT_EQ(ExternalId(b, &mapper), -2);
+  EXPECT_EQ(ExternalId(a, &mapper), -1);
+}
+
+TEST(SyntheticExternalId, FallsBackToSignedRawGidWhenNull) {
+  // With no mapper the raw Gid is read as a signed int - the same axis id() and the wire agree on.
+  const auto g = Gid::FromUint(42);
+  EXPECT_EQ(ExternalId(g, nullptr), g.AsInt());
+}
+
+// ---- OverlayReadAuthorization: one per-property READ decision for overlay/synthetic nodes ----
+
+class OverlayReadAuthorizationTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<storage::Storage> storage_ = std::make_unique<storage::InMemoryStorage>();
+
+  // Inserts a vertex with a single label and returns its accessor (kept valid by the passed dba).
+  static VertexAccessor InsertLabelled(DbAccessor &dba, std::string_view label) {
+    auto v = dba.InsertVertex();
+    EXPECT_TRUE(v.AddLabel(dba.NameToLabel(label)).has_value());
+    return v;
+  }
+};
+
+TEST_F(OverlayReadAuthorizationTest, SyntheticNodeAlwaysReadable) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  const auto ssn = dba.NameToProperty("ssn");
+  const tests::StubPropertyFGAChecker<DbAccessor> checker{&dba, {{"Secret", "ssn"}}};
+
+  // A synthetic node has no origin, so it mints no real-graph data and is fully readable.
+  VirtualNode synthetic{{"Secret"}, {}};
+  auto auth = OverlayReadAuthorization::For(synthetic, View::NEW, &checker);
+  ASSERT_TRUE(auth.has_value());
+  EXPECT_TRUE(auth->IsReadable(synthetic, ssn));
+}
+
+TEST_F(OverlayReadAuthorizationTest, NullCheckerAllReadable) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  const auto ssn = dba.NameToProperty("ssn");
+  auto origin = InsertLabelled(dba, "Secret");
+
+  VirtualNode overlay{{}, {}, VirtualNode::allocator_type{}, origin};
+  auto auth = OverlayReadAuthorization::For(overlay, View::NEW, nullptr);
+  ASSERT_TRUE(auth.has_value());
+  EXPECT_TRUE(auth->IsReadable(overlay, ssn));
+}
+
+TEST_F(OverlayReadAuthorizationTest, OriginReadThroughGatedByPermission) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  const auto ssn = dba.NameToProperty("ssn");
+  const auto name = dba.NameToProperty("name");
+  auto origin = InsertLabelled(dba, "Secret");
+  const tests::StubPropertyFGAChecker<DbAccessor> checker{&dba, {{"Secret", "ssn"}}};
+
+  // An overlay over the origin reads through: the denied (Secret, ssn) property is hidden, an
+  // un-denied property stays visible.
+  VirtualNode overlay{{}, {}, VirtualNode::allocator_type{}, origin};
+  auto auth = OverlayReadAuthorization::For(overlay, View::NEW, &checker);
+  ASSERT_TRUE(auth.has_value());
+  EXPECT_FALSE(auth->IsReadable(overlay, ssn));
+  EXPECT_TRUE(auth->IsReadable(overlay, name));
+}
+
+TEST_F(OverlayReadAuthorizationTest, OverlayBoundOverrideExempt) {
+  auto acc = storage_->Access(storage::StorageAccessType::WRITE);
+  DbAccessor dba{acc.get()};
+  const auto ssn = dba.NameToProperty("ssn");
+  auto origin = InsertLabelled(dba, "Secret");
+  const tests::StubPropertyFGAChecker<DbAccessor> checker{&dba, {{"Secret", "ssn"}}};
+
+  // The overlay carries its own ssn value: an overlay-bound override is the author's own computed
+  // value and is exempt from the origin's per-property permission, even though (Secret, ssn) is denied.
+  VirtualNode overlay{{}, {{ssn, storage::PropertyValue(1)}}, VirtualNode::allocator_type{}, origin};
+  ASSERT_TRUE(overlay.IsOverlayBound(ssn));
+  auto auth = OverlayReadAuthorization::For(overlay, View::NEW, &checker);
+  ASSERT_TRUE(auth.has_value());
+  EXPECT_TRUE(auth->IsReadable(overlay, ssn));
+}
+
+}  // namespace memgraph::query::test

--- a/tests/unit/query_plan_common.hpp
+++ b/tests/unit/query_plan_common.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <deque>
 #include <iterator>
 #include <memory>
 #include <vector>
@@ -22,6 +23,7 @@
 #include "query/context.hpp"
 #include "query/db_accessor.hpp"
 #include "query/frontend/semantic/symbol_table.hpp"
+#include "query/graph_view.hpp"
 #include "query/interpret/frame.hpp"
 #include "query/plan/operator.hpp"
 #include "storage/v2/id_types.hpp"
@@ -40,6 +42,15 @@ inline memgraph::metrics::DatabaseMetricHandles &TestMetricHandles() {
   return h;
 }
 
+// Binds the real graph as the ambient identity view, as PullPlan and the trigger
+// executor do in production, so the read operators always run through a bound
+// GraphView. ExecutionContext is copied to parallel workers and so cannot own the
+// view; the views live in this test-lifetime store (stable addresses) instead.
+inline void BindTestIdentityView(ExecutionContext &context, memgraph::query::DbAccessor *dba) {
+  static std::deque<DbAccessorGraphView> identity_views;
+  context.evaluation_context.graph_view = &identity_views.emplace_back(dba);
+}
+
 ExecutionContext MakeContext(const AstStorage &storage, const SymbolTable &symbol_table,
                              memgraph::query::DbAccessor *dba) {
   ExecutionContext context{.db_accessor = dba};
@@ -48,6 +59,7 @@ ExecutionContext MakeContext(const AstStorage &storage, const SymbolTable &symbo
   context.evaluation_context.labels = NamesToLabels(storage.labels_, dba);
   context.evaluation_context.edgetypes = NamesToEdgeTypes(storage.edge_types_, dba);
   context.metric_handles = &TestMetricHandles();
+  BindTestIdentityView(context, dba);
   return context;
 }
 #ifdef MG_ENTERPRISE
@@ -61,6 +73,7 @@ ExecutionContext MakeContextWithFineGrainedChecker(const AstStorage &storage, co
   context.evaluation_context.edgetypes = NamesToEdgeTypes(storage.edge_types_, dba);
   context.auth_checker = auth_checker;
   context.metric_handles = &TestMetricHandles();
+  BindTestIdentityView(context, dba);
   return context;
 }
 #endif

--- a/tests/unit/query_plan_edge_cases.cpp
+++ b/tests/unit/query_plan_edge_cases.cpp
@@ -111,7 +111,7 @@ class QueryExecution : public testing::Test {
   auto Execute(const std::string &query) {
     ResultStreamFaker stream(this->db_acc_->get()->storage());
 
-    auto [header, _1, qid, _2] = interpreter_->Prepare(query, memgraph::query::no_params_fn, {});
+    auto [header, _1, qid, _2, _3] = interpreter_->Prepare(query, memgraph::query::no_params_fn, {});
     stream.Header(header);
     auto summary = interpreter_->PullAll(&stream);
     stream.Summary(summary);

--- a/tests/unit/query_plan_v2_pipeline.cpp
+++ b/tests/unit/query_plan_v2_pipeline.cpp
@@ -402,6 +402,26 @@ TEST_F(PlannerV2PipelineTest, ExtractedSymbolPositionsResolveInCompactTable) {
                                    }();
 }
 
+// plan_v2 has no USE-scope support: a `CALL { USE g ... }` must surface loudly
+// rather than silently dropping the binding and scanning the real graph. The
+// binding is to a literal so the only construct plan_v2 cannot lower is USE -
+// the throw isolates the missing USE guard, not an unlowerable graph value.
+TEST_F(PlannerV2PipelineTest, UseScopeInCallSubquerySurfacesNotYetImplemented) {
+  auto *cypher_query = ParseQuery("WITH 1 AS g CALL { USE g RETURN 1 AS y } RETURN y;");
+  ASSERT_NE(cypher_query, nullptr);
+  symbol_table_ = MakeSymbolTable(cypher_query);
+  EXPECT_THROW((void)ConvertToEgraph(*cypher_query, symbol_table_), NotYetImplemented);
+}
+
+// Positive control: the same subquery shape without USE lowers cleanly, so the
+// throw above is attributable to USE and not to the CALL block itself.
+TEST_F(PlannerV2PipelineTest, NonUseCallSubqueryLowersWithoutThrow) {
+  auto *cypher_query = ParseQuery("WITH 1 AS g CALL { RETURN 1 AS y } RETURN y;");
+  ASSERT_NE(cypher_query, nullptr);
+  symbol_table_ = MakeSymbolTable(cypher_query);
+  EXPECT_NO_THROW((void)ConvertToEgraph(*cypher_query, symbol_table_));
+}
+
 // clang-format off
 INSTANTIATE_TEST_SUITE_P(
     InlineRewrites,

--- a/tests/unit/query_pretty_print.cpp
+++ b/tests/unit/query_pretty_print.cpp
@@ -18,6 +18,8 @@
 #include "disk_test_utils.hpp"
 #include "query/frontend/ast/ast.hpp"
 #include "query/frontend/ast/pretty_print.hpp"
+#include "query/plan/operator.hpp"
+#include "query/plan/pretty_print.hpp"
 #include "query_common.hpp"
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
@@ -49,6 +51,22 @@ class ExpressionPrettyPrinterTest : public ::testing::Test {
 
 using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage>;
 TYPED_TEST_SUITE(ExpressionPrettyPrinterTest, StorageTypes);
+
+TYPED_TEST(ExpressionPrettyPrinterTest, BindGraphViewPlanIsNamed) {
+  // A USE scope (CALL { USE <graph> ... }) plans to a BindGraphView wrapping the
+  // subquery. The printer must name it and render the USE target rather than
+  // falling through to the "Unknown operator!" default.
+  auto once = std::make_shared<memgraph::query::plan::Once>();
+  auto bind = std::make_shared<memgraph::query::plan::BindGraphView>(once, IDENT("sg"));
+
+  std::stringstream ss;
+  memgraph::query::plan::PrettyPrint(this->dba, bind.get(), &ss);
+  const auto output = ss.str();
+
+  EXPECT_THAT(output, testing::HasSubstr("BindGraphView"));
+  EXPECT_THAT(output, testing::HasSubstr("USE"));
+  EXPECT_THAT(output, testing::Not(testing::HasSubstr("Unknown operator")));
+}
 
 TYPED_TEST(ExpressionPrettyPrinterTest, Literals) {
   // 1

--- a/tests/unit/query_virtual_graph.cpp
+++ b/tests/unit/query_virtual_graph.cpp
@@ -10,8 +10,11 @@
 // licenses/APL.txt.
 
 #include <unordered_set>
+#include <vector>
 
 #include "gtest/gtest.h"
+
+#include "query/exceptions.hpp"
 
 #include "query/virtual_edge.hpp"
 #include "query/virtual_graph.hpp"
@@ -45,6 +48,35 @@ TEST(VirtualGraphTest, AccessorsAndIdentity) {
   set.insert(ve2);
   set.insert(ve_other_type);
   EXPECT_EQ(set.size(), 2);
+}
+
+TEST(VirtualGraphTest, EdgeHoldsUnresolvedHandleEndpoints) {
+  // virtualEdge("T", 1, 2) with gid arguments holds unresolved import-handle endpoints, bound to
+  // nodes only at projection assembly. Standalone, each endpoint's gid is the handle itself.
+  memgraph::query::VirtualEdge ve(int64_t{1}, int64_t{2}, "T");
+
+  EXPECT_EQ(ve.FromGid().AsInt(), 1);
+  EXPECT_EQ(ve.ToGid().AsInt(), 2);
+  EXPECT_EQ(ve.FromHandle(), 1);
+  EXPECT_EQ(ve.ToHandle(), 2);
+  EXPECT_EQ(ve.EdgeTypeName(), "T");
+
+  // An unresolved endpoint has no node; reaching for one (startNode/endNode) is an error.
+  EXPECT_THROW((void)ve.From(), memgraph::query::QueryRuntimeException);
+  EXPECT_THROW((void)ve.To(), memgraph::query::QueryRuntimeException);
+}
+
+TEST(VirtualGraphTest, EdgeMixesHandleAndNodeEndpoints) {
+  auto node = std::make_shared<const memgraph::query::VirtualNode>(memgraph::query::VirtualNode({"L"}, {}));
+  const memgraph::query::VirtualEdge ve(node, int64_t{5}, "T");
+
+  // The resolved end exposes its node; the handle end exposes its handle and throws for a node.
+  EXPECT_EQ(ve.FromGid(), node->Gid());
+  EXPECT_EQ(ve.From().Gid(), node->Gid());
+  EXPECT_EQ(ve.FromHandle(), std::nullopt);
+  EXPECT_EQ(ve.ToGid().AsInt(), 5);
+  EXPECT_EQ(ve.ToHandle(), 5);
+  EXPECT_THROW((void)ve.To(), memgraph::query::QueryRuntimeException);
 }
 
 TEST(VirtualGraphTest, VirtualGraphFiltersEdgesByVertex) {
@@ -154,6 +186,113 @@ TEST(VirtualGraphTest, StoresAndReadsProperties) {
   ve.SetProperty(pa, memgraph::storage::PropertyValue(99));
   EXPECT_EQ(ve.GetProperty(pa), memgraph::storage::PropertyValue(99));
   EXPECT_EQ(ve.Properties().size(), 2);
+}
+
+TEST(VirtualGraphTest, NodeCarriesImportHandleDistinctFromIdentity) {
+  // A synthetic node built by virtualNode() carries an import handle, used at list assembly to
+  // wire edge endpoints by reference. The handle is not the node's identity (still a synthetic gid).
+  memgraph::query::VirtualNode handled({"L"}, {});
+  handled.SetHandle(7);
+  EXPECT_EQ(handled.Handle(), 7);
+  EXPECT_NE(handled.Gid().AsInt(), 7);
+
+  // A node built without a handle (e.g. by derive()) carries none.
+  const memgraph::query::VirtualNode unhandled({"L"}, {});
+  EXPECT_EQ(unhandled.Handle(), std::nullopt);
+
+  // The handle survives a copy.
+  const memgraph::query::VirtualNode copy = handled;
+  EXPECT_EQ(copy.Handle(), 7);
+}
+
+namespace {
+// Builds a synthetic node carrying an import handle, as virtualNode(handle, ...) would.
+memgraph::query::VirtualNode HandledNode(int64_t handle, memgraph::query::VirtualNode::label_list labels = {}) {
+  memgraph::query::VirtualNode node{std::move(labels), {}};
+  node.SetHandle(handle);
+  return node;
+}
+}  // namespace
+
+TEST(VirtualGraphTest, AssembleBindsEdgesToNodesByHandle) {
+  std::vector<memgraph::query::VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"A"}));
+  nodes.push_back(HandledNode(2, {"B"}));
+  const auto n1_gid = nodes[0].Gid();
+  const auto n2_gid = nodes[1].Gid();
+
+  std::vector<memgraph::query::VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "KNOWS");
+
+  auto graph = memgraph::query::AssembleVirtualGraph(
+      nodes, edges, memgraph::query::DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+
+  EXPECT_EQ(graph.nodes().size(), 2);
+  ASSERT_EQ(graph.edges().size(), 1);
+  // The handle endpoints are bound to the listed nodes: the edge now points at their synthetic gids.
+  const auto &e = *graph.edges().begin();
+  EXPECT_EQ(e.FromGid(), n1_gid);
+  EXPECT_EQ(e.ToGid(), n2_gid);
+}
+
+TEST(VirtualGraphTest, AssembleErrorsOnDanglingEdge) {
+  std::vector<memgraph::query::VirtualNode> nodes;
+  nodes.push_back(HandledNode(1));
+  std::vector<memgraph::query::VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "KNOWS");  // handle 2 has no node
+
+  EXPECT_THROW(memgraph::query::AssembleVirtualGraph(
+                   nodes, edges, memgraph::query::DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource()),
+               memgraph::query::QueryRuntimeException);
+}
+
+TEST(VirtualGraphTest, AssembleDropsDanglingEdgeKeepingOthers) {
+  std::vector<memgraph::query::VirtualNode> nodes;
+  nodes.push_back(HandledNode(1));
+  nodes.push_back(HandledNode(2));
+  std::vector<memgraph::query::VirtualEdge> edges;
+  edges.emplace_back(int64_t{1}, int64_t{2}, "OK");       // both endpoints present
+  edges.emplace_back(int64_t{1}, int64_t{3}, "DANGLES");  // handle 3 has no node
+
+  auto graph = memgraph::query::AssembleVirtualGraph(
+      nodes, edges, memgraph::query::DanglingEdgePolicy::kDrop, memgraph::utils::NewDeleteResource());
+
+  EXPECT_EQ(graph.nodes().size(), 2);
+  EXPECT_EQ(graph.edges().size(), 1);  // the dangling edge is omitted, the other kept
+}
+
+TEST(VirtualGraphTest, AssembleErrorsOnDuplicateHandleEvenUnderDrop) {
+  std::vector<memgraph::query::VirtualNode> nodes;
+  nodes.push_back(HandledNode(1, {"A"}));
+  nodes.push_back(HandledNode(1, {"B"}));  // same handle on a distinct node
+  std::vector<memgraph::query::VirtualEdge> edges;
+
+  // A duplicate handle is an ambiguity, not a dangling edge: it errors regardless of policy.
+  EXPECT_THROW(memgraph::query::AssembleVirtualGraph(
+                   nodes, edges, memgraph::query::DanglingEdgePolicy::kDrop, memgraph::utils::NewDeleteResource()),
+               memgraph::query::QueryRuntimeException);
+}
+
+TEST(VirtualGraphTest, AssembleBindsResolvedNodeEndpointByGid) {
+  // An edge whose endpoints are resolved node objects (the node-form of virtualEdge).
+  auto a = std::make_shared<const memgraph::query::VirtualNode>(HandledNode(1, {"A"}));
+  auto b = std::make_shared<const memgraph::query::VirtualNode>(HandledNode(2, {"B"}));
+  std::vector<memgraph::query::VirtualEdge> edges;
+  edges.emplace_back(a, b, "KNOWS");
+
+  std::vector<memgraph::query::VirtualNode> both;
+  both.push_back(*a);
+  both.push_back(*b);
+  auto graph = memgraph::query::AssembleVirtualGraph(
+      both, edges, memgraph::query::DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource());
+  EXPECT_EQ(graph.edges().size(), 1);  // resolved endpoints bound by synthetic-gid membership
+
+  // With one endpoint's node absent from the list, the resolved endpoint is dangling.
+  std::vector<memgraph::query::VirtualNode> only_a;
+  only_a.push_back(*a);
+  EXPECT_THROW(memgraph::query::AssembleVirtualGraph(
+                   only_a, edges, memgraph::query::DanglingEdgePolicy::kError, memgraph::utils::NewDeleteResource()),
+               memgraph::query::QueryRuntimeException);
 }
 
 TEST(VirtualGraphTest, InsertIfNewDedupsDistinctEdgeGidsByTriple) {


### PR DESCRIPTION
## Cypher over subgraphs and projections

Run declarative Cypher over a derived view of the graph instead of the whole store, and write computed values back. Two kinds of view:

- **Subgraph** with `project(path)`: a membership-filtered set of real nodes and edges, so writes persist.
- **Projection** with `derive(path, config)` or `virtualGraph(nodes, edges)`: virtual nodes and edges, where an overlay node maps back to a real origin, reads its properties lazily, and can shadow them with computed values.

A view is bound as the ambient graph for a block with `CALL { USE g ... }`; match, expand, built-in functions, and the variable-length and shortest-path family all run over it.

### New capabilities

- `CALL { USE g ... }` runs a subquery against a bound view `g`.
- `derive(path, {...})` overlays computed nodes over a matched path, with per-property control via `propertyPolicy` (`origin` / `overlay` / `hidden`), plus `sourceNodeProperties` / `targetNodeProperties` and `undirectedEdgeTypes`.
- `virtualGraph(nodes, edges, config?)` assembles a projection from lists built with `virtualNode(...)` and `virtualEdge(...)`, importing an external graph in one statement.
- Variable-length and shortest-path expansion over a view.
- `id()` and `virtual_id()` return stable, query-local ids for virtual elements; per-property fine-grained access control is enforced on overlay reads.

### Examples

Each of these does something plain Cypher cannot express on the stored graph.

**Mixed edge direction in a multi-hop traversal.** A single pattern cannot make one relationship type undirected while another stays directed. A projection can: here `CITES` stays directed but `SIMILAR_TO` counts as mutual, across a three-hop walk for recommendations. The papers carry large embedding vectors, and the projection reads a property only when it is used (here for the rows returned), never while walking:

```cypher
MATCH p = (:Paper)-[r:CITES|SIMILAR_TO]->(:Paper)
WITH derive(p, {virtualEdgeType: type(r), undirectedEdgeTypes: ['SIMILAR_TO']}) AS g
CALL { USE g
       MATCH (:Paper {id: 1})-[:CITES|SIMILAR_TO *1..3]->(rec)
       WHERE rec.id <> 1
       RETURN DISTINCT rec.id AS id, rec.embedding AS embedding }
RETURN id, embedding
```

Return the node `rec` instead and add `SET rec.recommended = true` after the block to persist the result on the real papers.

**Shortest path with per-type direction.** Shortest hop count where `FRIEND` is mutual but `MENTOR` is one-way, which no single shortest-path pattern expresses:

```cypher
MATCH p = (:Person)-[r:FRIEND|MENTOR]->(:Person)
WITH derive(p, {virtualEdgeType: type(r), undirectedEdgeTypes: ['FRIEND']}) AS g
CALL { USE g
       MATCH (:Person {name: 'B'})-[e:FRIEND|MENTOR *BFS]->(:Person {name: 'A'})
       RETURN size(e) AS hops }
RETURN hops
```

**Query a graph that is not stored.** Assemble nodes and edges on the fly (for example rows exported from another system) and run a query over them, without first creating them in the database:

```cypher
WITH virtualGraph(
       [virtualNode(1, 'Person', {name: 'CEO'}), virtualNode(2, 'Person', {name: 'VP'}), virtualNode(3, 'Person', {name: 'IC'})],
       [virtualEdge('MANAGES', 1, 2), virtualEdge('MANAGES', 2, 3)]) AS org
CALL { USE org MATCH (:Person {name: 'CEO'})-[:MANAGES*]->(report) RETURN report.name AS name }
RETURN name
```

**Remove a field from what a query can see.** Give a subquery a view of the org graph with `salary` removed, so even a generic read like `properties(n)` cannot surface it:

```cypher
MATCH p = (:Employee)-[:REPORTS_TO]->(:Employee)
WITH derive(p, {virtualEdgeType: 'REPORTS_TO', propertyPolicy: {salary: 'hidden'}}) AS org
CALL { USE org MATCH (e) RETURN properties(e) AS visible }
RETURN visible
```

A `project()` subgraph is different in kind: it behaves like the real graph restricted to a chosen slice, so most single queries over it can also be written with plain filters. Its distinct value is handing that slice to a graph algorithm, which then sees only the subgraph.

### Current limitations (version 1)

These apply inside a `CALL { USE g ... }` block and are reported as clear errors, not silent wrong results. A `project()` subgraph is made of the real graph's own nodes and edges, so it behaves like a normal graph; the restrictions are mainly about `derive()` projections, whose elements are virtual.

- **The block is read-only.** Inside `USE` you can `MATCH`, traverse, and `RETURN`, but not `CREATE` / `SET` / `REMOVE` / `DELETE`. Apply writes after the block, on what it returns (as in the recommendation example).
- **No nested `USE`.** One view is bound at a time; a `USE` block cannot contain another.
- **No index scans inside the block.** Matches scan the whole view rather than using label or property indexes, so keep the view small (a projection usually is).
- **Over a `derive()` projection: no named paths and no variable-length lambdas.** You cannot capture a named path (`MATCH path = (...)`) or use the inline filter/weight form `[:REL *1..3 (e, n | ...)]` while traversing a projection, because both need real graph elements; return endpoints, node and edge values, or a relationship-list length instead (as the shortest-path example does). Both work over a `project()` subgraph.
