### PR TITLE
Feature (Defunct Recovery / 3) - make all data-driven recovery failures defunct-able

### DIFF
--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -540,8 +540,12 @@ void RecoverDerivedState(utils::SkipListDb<Vertex> *vertices, [[maybe_unused]] u
     edges_metadata->RebuildFrom(*vertices, GetParallelExecInfo(recovery_info, config, db_arena_pool));
     // Every recovered edge must have an edge-metadata entry; fail at recovery rather
     // than later in GC or via lookups.
-    DMG_ASSERT(edges_metadata->size() == edges->size(),
-               "Edge metadata count does not match edge count after recovery!");
+    if (edges_metadata->size() != edges->size()) {
+      if (config.durability.allow_recovery_failure) {
+        throw RecoveryFailure("Edge metadata count does not match edge count after recovery!");
+      }
+      LOG_FATAL("Edge metadata count does not match edge count after recovery!");
+    }
   }
 
   RecoverIndicesAndStats(indices_constraints.indices,
@@ -590,7 +594,12 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
   auto *const epoch_history = &repl_storage_state.history;
 
   auto const maybe_snapshot_files = GetSnapshotFiles(snapshot_directory_);
-  MG_ASSERT(maybe_snapshot_files.has_value(), "Couldn't recover data because of the failure to read snapshot files");
+  if (!maybe_snapshot_files.has_value()) {
+    if (config.durability.allow_recovery_failure) {
+      throw RecoveryFailure("Couldn't recover data because of the failure to read snapshot files");
+    }
+    LOG_FATAL("Couldn't recover data because of the failure to read snapshot files");
+  }
   auto const &snapshot_files = *maybe_snapshot_files;
 
   RecoveryInfo recovery_info;
@@ -683,7 +692,13 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
         spdlog::error("Recovery failure while reading wal file: {}", e.what());
       }
     }
-    MG_ASSERT(!error_code, "Couldn't recover data because an error occurred: {}!", error_code.message());
+    if (error_code) {
+      if (config.durability.allow_recovery_failure) {
+        throw RecoveryFailure(
+            fmt::format("Couldn't recover data because an error occurred: {}!", error_code.message()));
+      }
+      LOG_FATAL("Couldn't recover data because an error occurred: {}!", error_code.message());
+    }
 
     if (wal_files.empty()) {
       spdlog::warn(utils::MessageWithLink("No snapshot or WAL file found.", "https://memgr.ph/durability"));
@@ -702,7 +717,12 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
                   repl_storage_state.epoch_.id());
   }
   auto const maybe_wal_files = GetWalFiles(wal_directory_, std::string{uuid});
-  MG_ASSERT(maybe_wal_files.has_value(), "Couldn't recover data because of the failure to read wal files");
+  if (!maybe_wal_files.has_value()) {
+    if (config.durability.allow_recovery_failure) {
+      throw RecoveryFailure("Couldn't recover data because of the failure to read wal files");
+    }
+    LOG_FATAL("Couldn't recover data because of the failure to read wal files");
+  }
 
   if (auto const &wal_files = *maybe_wal_files; !wal_files.empty()) {
     spdlog::info("Checking WAL files.");
@@ -718,6 +738,9 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
           // We didn't recover from a snapshot, and we must have all WAL files
           // starting from the first one (seq_num == 0) to be able to recover
           // data from them.
+          if (config.durability.allow_recovery_failure) {
+            throw RecoveryFailure("There are missing prefix WAL files and data can't be recovered without them!");
+          }
           LOG_FATAL(
               "There are missing prefix WAL files and data can't be "
               "recovered without them!");
@@ -725,6 +748,11 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
           // We recovered from a snapshot and we must have at least one WAL file
           // that has at least one delta that was created before the snapshot in order to
           // verify that nothing is missing from the beginning of the WAL chain.
+          if (config.durability.allow_recovery_failure) {
+            throw RecoveryFailure(
+                "You must have at least one WAL file that contains at least one delta that was created before the "
+                "snapshot file!");
+          }
           LOG_FATAL(
               "You must have at least one WAL file that contains at least one "
               "delta that was created before the snapshot file!");
@@ -737,6 +765,10 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
 
     for (const auto &wal_file : wal_files) {
       if (previous_seq_num && (wal_file.seq_num - *previous_seq_num) > 1) {
+        if (config.durability.allow_recovery_failure) {
+          throw RecoveryFailure(
+              fmt::format("You are missing a WAL file with the sequence number {}!", *previous_seq_num + 1));
+        }
         LOG_FATAL("You are missing a WAL file with the sequence number {}!", *previous_seq_num + 1);
       }
       previous_seq_num = wal_file.seq_num;
@@ -784,6 +816,10 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
         }
 
       } catch (const RecoveryFailure &e) {
+        if (config.durability.allow_recovery_failure) {
+          throw RecoveryFailure(
+              fmt::format("Couldn't recover WAL deltas from {} because of: {}", wal_file.path.string(), e.what()));
+        }
         LOG_FATAL("Couldn't recover WAL deltas from {} because of: {}", wal_file.path, e.what());
       }
     }

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -24,7 +24,9 @@
 #include <csignal>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <map>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -1780,6 +1782,241 @@ TEST_P(DurabilityTest, SnapshotCorruptCrashesWhenRecoveryFailureNotAllowed) {
                  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
                }()),
                "");
+}
+
+// Helper: create a WAL-only durability set (no snapshot) made of several small WAL files,
+// each containing one committed transaction, so the WAL chain spans multiple sequence numbers.
+inline void CreateMultiWalChain(const std::filesystem::path &storage_directory, bool properties_on_edges,
+                                uint64_t count) {
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory,
+                     .snapshot_wal_mode =
+                         memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                     .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
+                     .wal_file_size_kibibytes = 1,
+                     .wal_file_flush_every_n_tx = 1},
+      .salient = {.items = {.properties_on_edges = properties_on_edges, .enable_schema_info = true}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+  for (uint64_t i = 0; i < count; ++i) {
+    auto acc = db.Access(memgraph::storage::WRITE);
+    acc->CreateVertex();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
+// With the flag on, a corrupt WAL delta brings the database up defunct + empty instead of
+// crashing, leaving the on-disk WAL files untouched.
+TEST_P(DurabilityTest, WalDeltaCorruptDefunctWhenRecoveryFailureAllowed) {
+  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  ASSERT_EQ(GetSnapshotsList().size(), 0);
+  ASSERT_GE(GetWalsList().size(), 2);
+
+  // Corrupt the deltas of a non-first WAL file so the structural chain checks pass but the
+  // delta-level LoadWal fails.
+  {
+    auto wals = GetWalsList();  // sorted newest-first
+    DestroyWalFirstDelta(wals[wals.size() - 2]);
+  }
+
+  auto const wals_before = GetWalsList();
+  std::map<std::filesystem::path, uint64_t> sizes_before;
+  for (auto const &p : wals_before) sizes_before[p] = std::filesystem::file_size(p);
+
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory,
+                     .recover_on_startup = true,
+                     .allow_recovery_failure = true},
+      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+
+  EXPECT_TRUE(db.storage()->IsDefunct());
+  auto const info = db.storage()->GetBaseInfo();
+  EXPECT_EQ(info.vertex_count, 0);
+  EXPECT_EQ(info.edge_count, 0);
+
+  // On-disk WAL files are left byte-for-byte untouched.
+  EXPECT_EQ(GetWalsList().size(), wals_before.size());
+  EXPECT_EQ(GetBackupWalsList().size(), 0);
+  for (auto const &p : wals_before) {
+    ASSERT_TRUE(std::filesystem::exists(p));
+    EXPECT_EQ(std::filesystem::file_size(p), sizes_before[p]);
+  }
+}
+
+// With the flag off (default), a corrupt WAL delta still aborts startup.
+TEST_P(DurabilityTest, WalDeltaCorruptCrashesWhenRecoveryFailureNotAllowed) {
+  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  ASSERT_GE(GetWalsList().size(), 2);
+  {
+    auto wals = GetWalsList();
+    DestroyWalFirstDelta(wals[wals.size() - 2]);
+  }
+
+  ASSERT_DEATH(([&]() {
+                 memgraph::storage::Config config{
+                     .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+                     .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+                 };
+                 memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+               }()),
+               "");
+}
+
+// A WAL-only set whose first (seq_num == 0) file is missing must produce a defunct tenant with
+// the flag on (missing prefix WAL), and remain fatal with the flag off.
+TEST_P(DurabilityTest, WalMissingPrefixDefunctWhenRecoveryFailureAllowed) {
+  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  ASSERT_EQ(GetSnapshotsList().size(), 0);
+  ASSERT_GE(GetWalsList().size(), 2);
+
+  // Remove the oldest WAL file (the one with seq_num == 0). GetWalsList() is sorted newest-first.
+  {
+    auto wals = GetWalsList();
+    ASSERT_TRUE(std::filesystem::remove(wals.back()));
+  }
+
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory,
+                     .recover_on_startup = true,
+                     .allow_recovery_failure = true},
+      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+
+  EXPECT_TRUE(db.storage()->IsDefunct());
+  EXPECT_EQ(db.storage()->GetBaseInfo().vertex_count, 0);
+}
+
+TEST_P(DurabilityTest, WalMissingPrefixCrashesWhenRecoveryFailureNotAllowed) {
+  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  ASSERT_GE(GetWalsList().size(), 2);
+  {
+    auto wals = GetWalsList();
+    ASSERT_TRUE(std::filesystem::remove(wals.back()));
+  }
+
+  ASSERT_DEATH(([&]() {
+                 memgraph::storage::Config config{
+                     .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+                     .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+                 };
+                 memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+               }()),
+               "");
+}
+
+// A WAL chain with a sequence-number gap (a middle WAL removed) must produce a defunct tenant
+// with the flag on, and remain fatal with the flag off.
+TEST_P(DurabilityTest, WalSeqNumGapDefunctWhenRecoveryFailureAllowed) {
+  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  ASSERT_EQ(GetSnapshotsList().size(), 0);
+  ASSERT_GE(GetWalsList().size(), 3);
+
+  // Remove a middle WAL file to introduce a sequence-number gap while keeping the prefix
+  // (seq_num == 0) file present. GetWalsList() is sorted newest-first, so back() is the prefix.
+  {
+    auto wals = GetWalsList();
+    ASSERT_TRUE(std::filesystem::remove(wals[wals.size() - 2]));
+  }
+
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory,
+                     .recover_on_startup = true,
+                     .allow_recovery_failure = true},
+      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+
+  EXPECT_TRUE(db.storage()->IsDefunct());
+  EXPECT_EQ(db.storage()->GetBaseInfo().vertex_count, 0);
+}
+
+TEST_P(DurabilityTest, WalSeqNumGapCrashesWhenRecoveryFailureNotAllowed) {
+  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  ASSERT_GE(GetWalsList().size(), 3);
+  {
+    auto wals = GetWalsList();
+    ASSERT_TRUE(std::filesystem::remove(wals[wals.size() - 2]));
+  }
+
+  ASSERT_DEATH(([&]() {
+                 memgraph::storage::Config config{
+                     .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+                     .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+                 };
+                 memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+               }()),
+               "");
+}
+
+// Byte-flip robustness: copy a real WAL file, flip the byte at each offset in turn, and attempt
+// recovery with the flag on. The corruption must always be detected (defunct + empty) rather than
+// crashing the process.
+TEST_P(DurabilityTest, WalByteFlipDefunctRobustness) {
+  CreateMultiWalChain(storage_directory, GetParam(), 200);
+  ASSERT_GE(GetWalsList().size(), 1);
+
+  // Snapshot a pristine copy of the whole durability directory so each iteration starts clean.
+  auto const pristine_dir = std::filesystem::temp_directory_path() / "MG_test_unit_storage_v2_durability_pristine";
+  std::filesystem::remove_all(pristine_dir);
+  std::filesystem::copy(storage_directory, pristine_dir, std::filesystem::copy_options::recursive);
+
+  // Target the last (newest) WAL file; it is small enough to scan exhaustively.
+  auto const target_wal = GetWalsList().front();
+  auto const wal_size = std::filesystem::file_size(target_wal);
+  ASSERT_GT(wal_size, 0u);
+
+  // Keep the runtime bounded by sampling a stride of byte offsets across the file.
+  uint64_t const stride = std::max<uint64_t>(1, wal_size / 256);
+  for (uint64_t offset = 0; offset < wal_size; offset += stride) {
+    // Restore the pristine durability directory.
+    std::filesystem::remove_all(storage_directory);
+    std::filesystem::copy(pristine_dir, storage_directory, std::filesystem::copy_options::recursive);
+
+    // Flip a single byte in the target WAL.
+    {
+      std::fstream f(target_wal, std::ios::binary | std::ios::in | std::ios::out);
+      ASSERT_TRUE(f.is_open());
+      f.seekg(static_cast<std::streamoff>(offset));
+      char b = 0;
+      f.read(&b, 1);
+      b = static_cast<char>(~static_cast<uint8_t>(b));
+      f.seekp(static_cast<std::streamoff>(offset));
+      f.write(&b, 1);
+      f.close();
+    }
+
+    // Recover with the flag on: this must never abort/crash the process. A flipped byte can make a
+    // delta decode an absurd allocation size, which surfaces as a thrown std::bad_alloc rather than
+    // a RecoveryFailure; that still leaves the process alive, which is what this test guards. When
+    // construction succeeds, a failed recovery must yield a defunct + empty DB.
+    memgraph::storage::Config config{
+        .durability = {.storage_directory = storage_directory,
+                       .recover_on_startup = true,
+                       .allow_recovery_failure = true},
+        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+    };
+    try {
+      memgraph::dbms::Database db{config};
+      const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+      if (db.storage()->IsDefunct()) {
+        EXPECT_EQ(db.storage()->GetBaseInfo().vertex_count, 0) << "defunct DB at byte offset " << offset;
+      }
+    } catch (const std::exception &) {
+      // Tolerated: corruption detected via a thrown exception during construction; no crash.
+    }
+  }
+
+  std::filesystem::remove_all(pristine_dir);
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -1995,9 +1995,9 @@ TEST_P(DurabilityTest, WalByteFlipDefunctRobustness) {
       f.close();
     }
 
-    // Recover with the flag on: this must never abort/crash the process. A flipped byte can make a
-    // delta decode an absurd allocation size, which surfaces as a thrown std::bad_alloc rather than
-    // a RecoveryFailure; that still leaves the process alive, which is what this test guards. When
+    // Recover with the flag on: this must never abort/crash the process. A flipped length byte can
+    // make a delta request an absurd allocation; the ReadSize bound turns that into a RecoveryFailure
+    // (-> defunct) instead of an escaping std::bad_alloc, so bad_alloc must never escape here. When
     // construction succeeds, a failed recovery must yield a defunct + empty DB.
     memgraph::storage::Config config{
         .durability = {.storage_directory = storage_directory,
@@ -2011,8 +2011,12 @@ TEST_P(DurabilityTest, WalByteFlipDefunctRobustness) {
       if (db.storage()->IsDefunct()) {
         EXPECT_EQ(db.storage()->GetBaseInfo().vertex_count, 0) << "defunct DB at byte offset " << offset;
       }
+    } catch (const std::bad_alloc &) {
+      ADD_FAILURE() << "std::bad_alloc escaped recovery at byte offset " << offset
+                    << "; a corrupt length field must surface as RecoveryFailure (defunct), not bad_alloc";
     } catch (const std::exception &) {
-      // Tolerated: corruption detected via a thrown exception during construction; no crash.
+      // Other corruption shapes may still be reported via a thrown exception during construction;
+      // the guarantee tested here is process survival plus no bad_alloc from length fields.
     }
   }
 

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -1809,9 +1809,9 @@ inline void CreateMultiWalChain(const std::filesystem::path &storage_directory, 
 // With the flag on, a corrupt WAL delta brings the database up defunct + empty instead of
 // crashing, leaving the on-disk WAL files untouched.
 TEST_P(DurabilityTest, WalDeltaCorruptDefunctWhenRecoveryFailureAllowed) {
-  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  CreateMultiWalChain(storage_directory, GetParam(), 100);
   ASSERT_EQ(GetSnapshotsList().size(), 0);
-  ASSERT_GE(GetWalsList().size(), 2);
+  ASSERT_EQ(GetWalsList().size(), 6);
 
   // Corrupt the deltas of a non-first WAL file so the structural chain checks pass but the
   // delta-level LoadWal fails.
@@ -1849,8 +1849,8 @@ TEST_P(DurabilityTest, WalDeltaCorruptDefunctWhenRecoveryFailureAllowed) {
 
 // With the flag off (default), a corrupt WAL delta still aborts startup.
 TEST_P(DurabilityTest, WalDeltaCorruptCrashesWhenRecoveryFailureNotAllowed) {
-  CreateMultiWalChain(storage_directory, GetParam(), 1000);
-  ASSERT_GE(GetWalsList().size(), 2);
+  CreateMultiWalChain(storage_directory, GetParam(), 100);
+  ASSERT_EQ(GetWalsList().size(), 6);
   {
     auto wals = GetWalsList();
     DestroyWalFirstDelta(wals[wals.size() - 2]);
@@ -1870,9 +1870,9 @@ TEST_P(DurabilityTest, WalDeltaCorruptCrashesWhenRecoveryFailureNotAllowed) {
 // A WAL-only set whose first (seq_num == 0) file is missing must produce a defunct tenant with
 // the flag on (missing prefix WAL), and remain fatal with the flag off.
 TEST_P(DurabilityTest, WalMissingPrefixDefunctWhenRecoveryFailureAllowed) {
-  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  CreateMultiWalChain(storage_directory, GetParam(), 100);
   ASSERT_EQ(GetSnapshotsList().size(), 0);
-  ASSERT_GE(GetWalsList().size(), 2);
+  ASSERT_EQ(GetWalsList().size(), 6);
 
   // Remove the oldest WAL file (the one with seq_num == 0). GetWalsList() is sorted newest-first.
   {
@@ -1894,8 +1894,8 @@ TEST_P(DurabilityTest, WalMissingPrefixDefunctWhenRecoveryFailureAllowed) {
 }
 
 TEST_P(DurabilityTest, WalMissingPrefixCrashesWhenRecoveryFailureNotAllowed) {
-  CreateMultiWalChain(storage_directory, GetParam(), 1000);
-  ASSERT_GE(GetWalsList().size(), 2);
+  CreateMultiWalChain(storage_directory, GetParam(), 100);
+  ASSERT_EQ(GetWalsList().size(), 6);
   {
     auto wals = GetWalsList();
     ASSERT_TRUE(std::filesystem::remove(wals.back()));
@@ -1915,9 +1915,9 @@ TEST_P(DurabilityTest, WalMissingPrefixCrashesWhenRecoveryFailureNotAllowed) {
 // A WAL chain with a sequence-number gap (a middle WAL removed) must produce a defunct tenant
 // with the flag on, and remain fatal with the flag off.
 TEST_P(DurabilityTest, WalSeqNumGapDefunctWhenRecoveryFailureAllowed) {
-  CreateMultiWalChain(storage_directory, GetParam(), 1000);
+  CreateMultiWalChain(storage_directory, GetParam(), 100);
   ASSERT_EQ(GetSnapshotsList().size(), 0);
-  ASSERT_GE(GetWalsList().size(), 3);
+  ASSERT_EQ(GetWalsList().size(), 6);
 
   // Remove a middle WAL file to introduce a sequence-number gap while keeping the prefix
   // (seq_num == 0) file present. GetWalsList() is sorted newest-first, so back() is the prefix.

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -1811,7 +1811,7 @@ inline void CreateMultiWalChain(const std::filesystem::path &storage_directory, 
 TEST_P(DurabilityTest, WalDeltaCorruptDefunctWhenRecoveryFailureAllowed) {
   CreateMultiWalChain(storage_directory, GetParam(), 100);
   ASSERT_EQ(GetSnapshotsList().size(), 0);
-  ASSERT_EQ(GetWalsList().size(), 6);
+  ASSERT_GE(GetWalsList().size(), 3);
 
   // Corrupt the deltas of a non-first WAL file so the structural chain checks pass but the
   // delta-level LoadWal fails.
@@ -1850,7 +1850,7 @@ TEST_P(DurabilityTest, WalDeltaCorruptDefunctWhenRecoveryFailureAllowed) {
 // With the flag off (default), a corrupt WAL delta still aborts startup.
 TEST_P(DurabilityTest, WalDeltaCorruptCrashesWhenRecoveryFailureNotAllowed) {
   CreateMultiWalChain(storage_directory, GetParam(), 100);
-  ASSERT_EQ(GetWalsList().size(), 6);
+  ASSERT_GE(GetWalsList().size(), 3);
   {
     auto wals = GetWalsList();
     DestroyWalFirstDelta(wals[wals.size() - 2]);
@@ -1872,7 +1872,7 @@ TEST_P(DurabilityTest, WalDeltaCorruptCrashesWhenRecoveryFailureNotAllowed) {
 TEST_P(DurabilityTest, WalMissingPrefixDefunctWhenRecoveryFailureAllowed) {
   CreateMultiWalChain(storage_directory, GetParam(), 100);
   ASSERT_EQ(GetSnapshotsList().size(), 0);
-  ASSERT_EQ(GetWalsList().size(), 6);
+  ASSERT_GE(GetWalsList().size(), 3);
 
   // Remove the oldest WAL file (the one with seq_num == 0). GetWalsList() is sorted newest-first.
   {
@@ -1895,7 +1895,7 @@ TEST_P(DurabilityTest, WalMissingPrefixDefunctWhenRecoveryFailureAllowed) {
 
 TEST_P(DurabilityTest, WalMissingPrefixCrashesWhenRecoveryFailureNotAllowed) {
   CreateMultiWalChain(storage_directory, GetParam(), 100);
-  ASSERT_EQ(GetWalsList().size(), 6);
+  ASSERT_GE(GetWalsList().size(), 3);
   {
     auto wals = GetWalsList();
     ASSERT_TRUE(std::filesystem::remove(wals.back()));
@@ -1917,7 +1917,7 @@ TEST_P(DurabilityTest, WalMissingPrefixCrashesWhenRecoveryFailureNotAllowed) {
 TEST_P(DurabilityTest, WalSeqNumGapDefunctWhenRecoveryFailureAllowed) {
   CreateMultiWalChain(storage_directory, GetParam(), 100);
   ASSERT_EQ(GetSnapshotsList().size(), 0);
-  ASSERT_EQ(GetWalsList().size(), 6);
+  ASSERT_GE(GetWalsList().size(), 3);
 
   // Remove a middle WAL file to introduce a sequence-number gap while keeping the prefix
   // (seq_num == 0) file present. GetWalsList() is sorted newest-first, so back() is the prefix.


### PR DESCRIPTION
## What

Slice 3 of the defunct-tenants-on-recovery-failure feature (spec: `specs/storage-allow-recovery-failure.md`, issue: `specs/issues/03-full-recovery-failure-coverage.md`).

Slice 1 converted only the "no usable snapshot" recovery point to a flag-gated `throw RecoveryFailure`. This slice extends that conversion to **all remaining data-driven failure points** in the `RecoverData` call tree in `src/storage/v2/durability/durability.cpp`:

- snapshot file-enumeration failure (`GetSnapshotFiles` returned nullopt)
- WAL directory-iterator error
- WAL file-enumeration failure (`GetWalFiles` returned nullopt)
- missing prefix WAL files (no snapshot)
- snapshot with no covering pre-snapshot WAL
- WAL sequence-number gap
- delta-level `LoadWal` failure
- edges-metadata / edge count size mismatch (in `RecoverDerivedState`)

Each point now does `if (config.durability.allow_recovery_failure) throw RecoveryFailure(...); else LOG_FATAL/MG_ASSERT(...)`. The `InMemoryStorage` constructor's existing catch (slice 1) brings the DB up empty + defunct.

The `properties_on_edges`-disabled-with-edge-index invariants are **left always-fatal** (genuine code-logic bugs, not corrupt input), per the spec dividing line.
