### PR TITLE
Feature (Defunct Recovery / 4) - feat(storage): clear defunct on successful RECOVER SNAPSHOT

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -4531,6 +4531,11 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
     throw utils::BasicException("Couldn't recover from the snapshot because of: {}", e.what());
   }
 
+  // A successful recovery cures a defunct tenant: the durability directory is now
+  // restart-clean (prior/corrupt files moved to .old or deleted), so background
+  // durability can resume.
+  SetDefunct(false);
+
   return {};
 }
 

--- a/tests/e2e/durability/CMakeLists.txt
+++ b/tests/e2e/durability/CMakeLists.txt
@@ -18,6 +18,7 @@ copy_e2e_python_files(durability parameters_durability.py)
 copy_e2e_python_files(durability tenant_profile_durability.py)
 copy_e2e_python_files(durability recovery_failure_defunct.py)
 copy_e2e_python_files(durability recovery_failure_status.py)
+copy_e2e_python_files(durability recovery_failure_recover_snapshot.py)
 
 
 

--- a/tests/e2e/durability/recovery_failure_recover_snapshot.py
+++ b/tests/e2e/durability/recovery_failure_recover_snapshot.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import os
+import shutil
+import sys
+
+import interactive_mg_runner
+import pytest
+from common import connect, corrupt_snapshots, execute_and_fetch_all, get_data_path
+
+interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+interactive_mg_runner.PROJECT_DIR = os.path.normpath(
+    os.path.join(interactive_mg_runner.SCRIPT_DIR, "..", "..", "..", "..")
+)
+interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
+interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
+
+
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
+@pytest.fixture(autouse=True)
+def cleanup_instances():
+    interactive_mg_runner.kill_all()
+    yield
+    interactive_mg_runner.kill_all()
+
+
+def storage_info(cursor):
+    rows = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
+    return {row[0]: row[1] for row in rows}
+
+
+def test_recover_snapshot_cures_defunct(test_name):
+    """A defunct default database is cured in place by RECOVER SNAPSHOT: after loading a
+    known-good snapshot the data comes back, status flips to ready, and the tenant recovers
+    healthy across a restart (it does not re-enter defunct)."""
+    data_directory = get_data_path("recovery_failure_recover_snapshot", test_name)
+    full_data_directory = os.path.join(interactive_mg_runner.BUILD_DIR, "e2e", "data", data_directory)
+    shutil.rmtree(full_data_directory, ignore_errors=True)
+
+    instances = {
+        "default": {
+            # WAL disabled so the snapshot is the only durability: corrupting it makes
+            # recovery fail deterministically (no WAL fallback that would recover healthy).
+            "args": ["--log-level=TRACE", "--data-recovery-on-startup=true", "--storage-wal-enabled=false"],
+            "log_file": "recovery_failure_recover_snapshot.log",
+            "data_directory": data_directory,
+        }
+    }
+
+    # Healthy instance: create data and a snapshot.
+    interactive_mg_runner.start(instances, "default")
+    cursor = connect(host="localhost", port=7687).cursor()
+    execute_and_fetch_all(cursor, "UNWIND range(1, 5000) AS i CREATE (:Node {id: i})")
+    execute_and_fetch_all(cursor, "CREATE SNAPSHOT")
+    assert storage_info(cursor)["status"] == "ready"
+    interactive_mg_runner.kill_all()
+
+    # Stash a known-good copy of the snapshot outside the data directory before corrupting it.
+    snapshot_dir = os.path.join(full_data_directory, "snapshots")
+    snapshot_files = [
+        os.path.join(snapshot_dir, f) for f in os.listdir(snapshot_dir) if os.path.isfile(os.path.join(snapshot_dir, f))
+    ]
+    assert len(snapshot_files) == 1, f"Expected exactly one snapshot, got {snapshot_files}"
+    good_snapshot_copy = os.path.join(interactive_mg_runner.BUILD_DIR, "e2e", "data", "recover_snapshot_good_copy")
+    shutil.copyfile(snapshot_files[0], good_snapshot_copy)
+
+    # Corrupt the in-place snapshot and restart with the recovery-failure flag -> defunct.
+    corrupt_snapshots(full_data_directory)
+    instances["default"]["args"].append("--storage-allow-recovery-failure=true")
+    interactive_mg_runner.start(instances, "default")
+
+    cursor = connect(host="localhost", port=7687).cursor()
+    assert storage_info(cursor)["status"] == "defunct"
+
+    # Cure the defunct database in place with the known-good snapshot copy.
+    execute_and_fetch_all(cursor, f"RECOVER SNAPSHOT '{good_snapshot_copy}'")
+
+    # The data is back and the tenant reports ready.
+    count = execute_and_fetch_all(cursor, "MATCH (n:Node) RETURN count(n)")[0][0]
+    assert count == 5000
+    assert storage_info(cursor)["status"] == "ready"
+    interactive_mg_runner.kill_all()
+
+    # Restart: the cure left the durability directory restart-clean, so the tenant recovers
+    # healthy with the data intact and does not re-enter the defunct state.
+    interactive_mg_runner.start(instances, "default")
+    cursor = connect(host="localhost", port=7687).cursor()
+    assert storage_info(cursor)["status"] == "ready"
+    count = execute_and_fetch_all(cursor, "MATCH (n:Node) RETURN count(n)")[0][0]
+    assert count == 5000
+    interactive_mg_runner.stop_all()
+
+    os.remove(good_snapshot_copy)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/durability/workloads.yaml
+++ b/tests/e2e/durability/workloads.yaml
@@ -11,6 +11,9 @@ workloads:
   - name: "Recovery failure status reporting"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/recovery_failure_status.py"]
+  - name: "Recovery failure cure via RECOVER SNAPSHOT"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["durability/recovery_failure_recover_snapshot.py"]
   - name: "Periodic snapshot"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/periodic_snapshot.py"]

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -1812,6 +1812,61 @@ TEST_P(DurabilityTest, SnapshotCorruptDefunctWhenRecoveryFailureAllowed) {
   }
 }
 
+// RECOVER SNAPSHOT cures a defunct tenant: loading a known-good snapshot into the empty
+// defunct placeholder clears the defunct flag and brings the data back.
+TEST_P(DurabilityTest, RecoverSnapshotCuresDefunct) {
+  CreateSimpleSnapshot(storage_directory, GetParam(), 1000);
+  ASSERT_EQ(GetSnapshotsList().size(), 1);
+
+  // Stash a known-good copy of the snapshot outside the storage directory before corrupting
+  // the in-place file, so we can RECOVER from it later.
+  auto const good_snapshot_copy =
+      std::filesystem::temp_directory_path() / "MG_test_unit_storage_v2_durability_good_snapshot";
+  std::filesystem::remove(good_snapshot_copy);
+  {
+    auto const snapshots = GetSnapshotsList();
+    ASSERT_EQ(snapshots.size(), 1);
+    std::filesystem::copy_file(
+        snapshots.front(), good_snapshot_copy, std::filesystem::copy_options::overwrite_existing);
+  }
+
+  for (const auto &snapshot : GetSnapshotsList()) {
+    CorruptSnapshot(snapshot);
+  }
+
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory,
+                     .recover_on_startup = true,
+                     .allow_recovery_failure = true},
+      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+
+  ASSERT_TRUE(db.storage()->IsDefunct());
+  ASSERT_EQ(db.storage()->GetBaseInfo().vertex_count, 0);
+
+  auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+  auto const res = storage->RecoverSnapshot(
+      good_snapshot_copy, true, memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  ASSERT_TRUE(res.has_value());
+
+  // The cure clears defunct and the recovered data is present.
+  EXPECT_FALSE(db.storage()->IsDefunct());
+  EXPECT_EQ(db.storage()->GetBaseInfo().vertex_count, 1000);
+
+  // The durability directory is restart-clean: a single recovered snapshot file remains
+  // (the prior corrupt snapshot was moved into the .old backup directory).
+  auto const remaining_snapshots = GetSnapshotsList();
+  size_t snapshot_file_count = 0;
+  for (auto const &p : remaining_snapshots) {
+    if (std::filesystem::is_regular_file(p)) ++snapshot_file_count;
+  }
+  EXPECT_EQ(snapshot_file_count, 1);
+
+  std::filesystem::remove(good_snapshot_copy);
+}
+
 // With the flag off (default), the same corruption still aborts startup.
 TEST_P(DurabilityTest, SnapshotCorruptCrashesWhenRecoveryFailureNotAllowed) {
   CreateSimpleSnapshot(storage_directory, GetParam(), 1000);


### PR DESCRIPTION
## Slice 4 — Cure via RECOVER SNAPSHOT

Part of the *defunct tenants on recovery failure* feature (`specs/storage-allow-recovery-failure.md`, `specs/issues/04-cure-recover-snapshot.md`). Builds on slice 1.

### What changed
- `InMemoryStorage::RecoverSnapshot` now calls `SetDefunct(false)` on the success path. Loading a known-good snapshot into the empty defunct placeholder cures the tenant in place.
- The existing `RecoverSnapshot` behavior already moves prior/corrupt snapshots and WAL files to `.old` (or deletes them when `--storage-backup-dir-enabled=false`), leaving a restart-clean single-snapshot directory — so background durability resumes and the tenant recovers healthy on the next restart rather than re-entering defunct.
- No defunct-only restriction: `RECOVER SNAPSHOT` remains usable on ordinary empty databases (a defunct placeholder is empty, satisfying the existing non-empty-storage precondition).

### Acceptance criteria
- [x] `RECOVER SNAPSHOT` against a defunct tenant clears defunct; subsequent queries return the recovered data.
- [x] After the cure, the durability directory contains only the recovered snapshot (prior/corrupt files moved to `.old`).
- [x] A restart after the cure recovers the tenant healthy (does not re-enter defunct).
