### PR TITLE
feat(plan): lower id(n) IN <list> to an indexed scan

### DIFF
--- a/src/query/plan/preprocess.cpp
+++ b/src/query/plan/preprocess.cpp
@@ -273,8 +273,9 @@ PropertyFilter::PropertyFilter(Symbol symbol, PropertyIx property, Type type)
 PropertyFilter::PropertyFilter(Symbol symbol, PropertyIxPath properties, Type type)
     : symbol_(std::move(symbol)), property_ids_(std::move(properties)), type_(type) {}
 
-IdFilter::IdFilter(const SymbolTable &symbol_table, const Symbol &symbol, Expression *value, bool expects_string_id)
-    : symbol_(symbol), value_(value), expects_string_id_(expects_string_id) {
+IdFilter::IdFilter(const SymbolTable &symbol_table, const Symbol &symbol, Expression *value, bool expects_string_id,
+                   Type type)
+    : symbol_(symbol), value_(value), expects_string_id_(expects_string_id), type_(type) {
   MG_ASSERT(value);
   UsedSymbolsCollector collector(symbol_table);
   value->Accept(collector);
@@ -734,24 +735,48 @@ void Filters::AnalyzeAndStoreFilter(Expression *expr, const SymbolTable &symbol_
     all_filters_.emplace_back(filter);
     return;
   };
-  // Check if maybe_id_fun is ID invocation on an indentifier and add it as
-  // IdFilter.
+  // Returns the identifier argument of id(ident)/elementId(ident) with whether
+  // it was elementId (a string id), or a null identifier if expr is neither.
+  auto as_id_function = [](auto *expr) -> std::pair<Identifier *, bool> {
+    auto *id_fun = utils::Downcast<Function>(expr);
+    if (!id_fun) return {nullptr, false};
+    const bool is_element_id = id_fun->function_name_ == kElementId;
+    if (id_fun->function_name_ != kId && !is_element_id) return {nullptr, false};
+    if (id_fun->arguments_.size() != 1U) return {nullptr, false};
+    return {utils::Downcast<Identifier>(id_fun->arguments_.front()), is_element_id};
+  };
+  // Adds `id(n) = val_expr` (or elementId) as an equality IdFilter.
   auto add_id_equal = [&](auto *maybe_id_fun, auto *val_expr) -> bool {
-    auto *id_fun = utils::Downcast<Function>(maybe_id_fun);
-    if (!id_fun) return false;
-    if (id_fun->function_name_ != kId && id_fun->function_name_ != kElementId) return false;
-    if (id_fun->arguments_.size() != 1U) return false;
-    auto *ident = utils::Downcast<Identifier>(id_fun->arguments_.front());
+    auto [ident, is_element_id] = as_id_function(maybe_id_fun);
     if (!ident) return false;
     auto filter = make_filter(FilterInfo::Type::Id);
-    filter.id_filter.emplace(symbol_table, symbol_table.at(*ident), val_expr, id_fun->function_name_ == kElementId);
+    filter.id_filter.emplace(symbol_table, symbol_table.at(*ident), val_expr, is_element_id);
+    all_filters_.emplace_back(filter);
+    return true;
+  };
+  // A statically-known non-list literal (e.g. `IN 'a'`) can never be a
+  // membership list, so leave it to the generic Filter: rewriting it would
+  // throw even on empty input, where the Filter yields no rows. Parameters and
+  // other expressions are admitted; their list-ness is only known at runtime.
+  auto is_non_list_literal = [](Expression *expr) {
+    return utils::Downcast<BaseLiteral>(expr) && !utils::Downcast<ListLiteral>(expr);
+  };
+  // Classifies `id(n) IN val_expr` as an IN-flavoured IdFilter. elementId() is
+  // excluded; string ids are deferred.
+  auto add_id_in_list = [&](auto *maybe_id_fun, auto *val_expr) -> bool {
+    if (is_non_list_literal(val_expr)) return false;
+    auto [ident, is_element_id] = as_id_function(maybe_id_fun);
+    if (!ident || is_element_id) return false;
+    auto filter = make_filter(FilterInfo::Type::Id);
+    filter.id_filter.emplace(
+        symbol_table, symbol_table.at(*ident), val_expr, /*expects_string_id=*/false, IdFilter::Type::IN);
     all_filters_.emplace_back(filter);
     return true;
   };
   // Checks if maybe_lookup is a property lookup, stores it as a
   // PropertyFilter and returns true. If it isn't, returns false.
   auto add_prop_in_list = [&](auto *maybe_lookup, auto *val_expr) -> bool {
-    if (!utils::Downcast<ListLiteral>(val_expr)) return false;
+    if (is_non_list_literal(val_expr)) return false;
     PropertyLookup *prop_lookup = nullptr;
     Identifier *ident = nullptr;
     if (is_nested_property_lookup(maybe_lookup)) {
@@ -956,10 +981,10 @@ void Filters::AnalyzeAndStoreFilter(Expression *expr, const SymbolTable &symbol_
     }
   } else if (auto *in = utils::Downcast<InListOperator>(expr)) {
     // IN isn't equivalent to Equal because IN isn't a symmetric operator. The
-    // IN filter is captured here only if the property lookup occurs on the
-    // left side of the operator. In that case, it's valid to do the IN list
+    // IN filter is captured here only if the property lookup or id() occurs on
+    // the left side of the operator. In that case, it's valid to do the IN list
     // optimization during the index lookup rewrite phase.
-    if (!add_prop_in_list(in->expression1_, in->expression2_)) {
+    if (!add_prop_in_list(in->expression1_, in->expression2_) && !add_id_in_list(in->expression1_, in->expression2_)) {
       all_filters_.emplace_back(make_filter(FilterInfo::Type::Generic));
     }
   } else if (auto *is_not = utils::Downcast<NotOperator>(expr)) {

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -349,17 +349,23 @@ struct PointFilter {
 /// Filtering by ID, for example `MATCH (n) WHERE id(n) = 42 ...`
 class IdFilter {
  public:
+  /// EQUAL is `id(n) = <expr>`; IN is `id(n) IN <list expr>`. The IN form is
+  /// lowered to an Unwind + per-element id scan during the index rewrite.
+  enum class Type : uint8_t { EQUAL, IN };
+
   /// Construct with Expression being the required value for ID.
-  IdFilter(const SymbolTable &, const Symbol &, Expression *, bool expects_string_id = false);
+  IdFilter(const SymbolTable &, const Symbol &, Expression *, bool expects_string_id = false, Type type = Type::EQUAL);
 
   /// Symbol whose id is looked up.
   Symbol symbol_;
   /// Expression which when evaluted produces the value an ID must satisfy.
+  /// For Type::IN this is the list whose elements the id must be one of.
   Expression *value_;
   /// True if the same symbol is used in expressions for value.
   bool is_symbol_in_value_{false};
   /// True if the filter comes from elementId(), which compares against a string id.
   bool expects_string_id_{false};
+  Type type_{Type::EQUAL};
 };
 
 /// Stores additional information for a filter expression.

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1598,20 +1598,36 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       }
     };
 
-    // For any IN filters, we need to unwind
+    // Lower an `x IN list` filter to a per-element index scan: chain
+    // Unwind(toSet(coalesce(list_expr, []))) onto op_input and return the
+    // anonymous identifier bound to each unwound element for the caller's scan.
+    // coalesce turns a null list into zero rows instead of throwing in Unwind
+    // (matching the membership Filter; a non-list scalar still throws), and
+    // toSet dedups so a value repeated in the list drives a single scan. The
+    // dedup collapses whole-number doubles onto their int, safe only because the
+    // downstream scan unifies them too: ScanAllById coerces to an int64 id, and
+    // the label+property index compares numerics cross-type, so a collapsed
+    // value still matches what the raw list would.
+    auto unwind_membership_list = [&](std::shared_ptr<LogicalOperator> &op_input,
+                                      Expression *list_expr) -> Identifier * {
+      auto const &symbol = symbol_table_->CreateAnonymousSymbol();
+      auto *element = ast_storage_->Create<Identifier>(symbol.name());
+      element->MapTo(symbol);
+      auto *empty_list = ast_storage_->Create<ListLiteral>(std::vector<Expression *>{});
+      auto *guarded = ast_storage_->Create<Coalesce>(std::vector<Expression *>{list_expr, empty_list});
+      auto *deduped = ast_storage_->Create<Function>("TOSET", std::vector<Expression *>{guarded});
+      op_input = std::make_shared<Unwind>(op_input, deduped, symbol);
+      return element;
+    };
+
     // TODO(buda): ScanAllByLabelProperty + Filter should be considered
     // here once the operator and the right cardinality estimation exist.
     // TODO: Currently IN uses unwind, this means multiple scans, this could be better
     //  performance if we use single scan
-    // NOTE: make_unwinds has side-effectm changes input to include new unwind stage
     auto make_unwinds = [&](FilterInfo const &filter_info) -> FilterInfo {
       if (filter_info.property_filter->type_ == PropertyFilter::Type::IN) {
-        auto const &symbol = symbol_table_->CreateAnonymousSymbol();
-        auto *expression = ast_storage_->Create<Identifier>(symbol.name());
-        expression->MapTo(symbol);
-        input = std::make_unique<Unwind>(input, filter_info.property_filter->value_, symbol);
         FilterInfo cpy = filter_info;
-        cpy.property_filter->value_ = expression;
+        cpy.property_filter->value_ = unwind_membership_list(input, filter_info.property_filter->value_);
         return cpy;
       }
       return filter_info;
@@ -1627,6 +1643,15 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         auto *value = filter.id_filter->value_;
         metadata.filters_to_erase.push_back(filter);
         metadata.expressions_to_mark_for_removal.push_back(filter.expression);
+        if (filter.id_filter->type_ == IdFilter::Type::IN) {
+          // has_in_filter is set below so order-by elimination is disabled and
+          // an ORDER BY id(n) over the unwound scan is not wrongly elided.
+          auto *element = unwind_membership_list(input, value);
+          return ScanByIndexResult{
+              std::make_shared<ScanAllById>(input, node_symbol, element, view, /*expects_string_id=*/false),
+              std::move(metadata),
+              /*has_in_filter=*/true};
+        }
         return ScanByIndexResult{
             std::make_shared<ScanAllById>(input, node_symbol, value, view, filter.id_filter->expects_string_id_),
             std::move(metadata)};

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -282,6 +282,128 @@ TYPED_TEST(InterpreterTest, Parameters) {
   }
 }
 
+// With a label+property index, n.prop IN <list> unwinds the list into
+// per-element index lookups. This must stay result-identical to the membership
+// Filter: a node matched by a duplicated element is emitted once, a parameter
+// list drives the same lookup, null and empty yield no rows, and a non-list
+// scalar throws.
+TYPED_TEST(InterpreterTest, PropertyInListIndexedEquivalence) {
+  using EPV = memgraph::storage::ExternalPropertyValue;
+
+  this->Interpret("CREATE INDEX ON :L(prop)");
+  this->Interpret("CREATE (:L {prop: 1}), (:L {prop: 2}), (:L {prop: 3})");
+
+  auto count = [&](const std::string &query, EPV::map_t params = {}) {
+    auto stream = this->Interpret(query, params);
+    return static_cast<int64_t>(stream.GetResults().size());
+  };
+  auto list = [](std::vector<EPV> xs) { return EPV(std::move(xs)); };
+
+  // Duplicate list elements must not emit a matched node more than once.
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN [1, 1] RETURN n"), 1);
+  // Whole-number doubles collapse onto their int, and the index matches both.
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN [1, 1.0] RETURN n"), 1);
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN [1, 2] RETURN n"), 2);
+
+  // A parameter list drives the same indexed lookup.
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN $v RETURN n", {{"v", list({EPV(int64_t{1}), EPV(int64_t{2})})}}), 2);
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN $v RETURN n", {{"v", list({EPV(int64_t{1}), EPV(int64_t{1})})}}), 1);
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN $v RETURN n", {{"v", EPV{}}}), 0);                    // null -> 0 rows
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN $v RETURN n", {{"v", list({})}}), 0);                 // empty -> 0 rows
+  EXPECT_EQ(count("MATCH (n:L) WHERE n.prop IN $v RETURN n", {{"v", list({EPV(int64_t{9})})}}), 0);  // no match
+
+  // A non-list scalar parameter throws, matching the membership Filter.
+  EXPECT_ANY_THROW(this->Interpret("MATCH (n:L) WHERE n.prop IN $v RETURN n", {{"v", EPV(int64_t{1})}}));
+}
+
+// `id(n) IN <list>` is lowered to Unwind(toSet(coalesce(value, []))) feeding a
+// per-element ScanAllById. The optimised plan must be result-identical to the
+// ScanAll + membership Filter it replaces for every input shape.
+TYPED_TEST(InterpreterTest, IdInListEquivalence) {
+  using EPV = memgraph::storage::ExternalPropertyValue;
+
+  // Three vertices; capture their ids in creation order.
+  std::vector<int64_t> ids;
+  {
+    auto stream = this->Interpret("UNWIND range(1, 3) AS i CREATE (n) RETURN id(n) AS id");
+    for (const auto &row : stream.GetResults()) ids.push_back(row[0].ValueInt());
+  }
+  ASSERT_EQ(ids.size(), 3U);
+  std::sort(ids.begin(), ids.end());
+  const int64_t present = ids.front();
+  const int64_t missing = ids.back() + 1000;
+
+  auto matched_ids = [&](EPV ids_param) {
+    auto stream = this->Interpret("MATCH (n) WHERE id(n) IN $ids RETURN id(n) AS id", {{"ids", std::move(ids_param)}});
+    std::vector<int64_t> out;
+    for (const auto &row : stream.GetResults()) out.push_back(row[0].ValueInt());
+    std::sort(out.begin(), out.end());
+    return out;
+  };
+  auto list = [](std::vector<EPV> xs) { return EPV(std::move(xs)); };
+  const auto present_dbl = static_cast<double>(present);
+
+  EXPECT_THAT(matched_ids(EPV{}), testing::IsEmpty());          // null parameter -> 0 rows
+  EXPECT_THAT(matched_ids(list({})), testing::IsEmpty());       // empty list -> 0 rows
+  EXPECT_THAT(matched_ids(list({EPV(present), EPV(present)})),  // duplicates -> once
+              testing::ElementsAre(present));
+  EXPECT_THAT(matched_ids(list({EPV(present), EPV(present_dbl)})),  // int/double dup -> once
+              testing::ElementsAre(present));
+  EXPECT_THAT(matched_ids(list({EPV(present), EPV{}})),  // null element dropped
+              testing::ElementsAre(present));
+  EXPECT_THAT(matched_ids(list({EPV(1.5), EPV(std::string("x"))})),  // no coercible id -> none
+              testing::IsEmpty());
+  EXPECT_THAT(matched_ids(list({EPV(present_dbl)})), testing::ElementsAre(present));  // exact-int double matches
+  EXPECT_THAT(matched_ids(list({EPV(missing)})), testing::IsEmpty());                 // missing id -> 0 rows
+
+  // A non-list scalar throws, matching the membership Filter's "IN expected a list".
+  EXPECT_ANY_THROW(this->Interpret("MATCH (n) WHERE id(n) IN $ids RETURN n", {{"ids", EPV(int64_t{5})}}));
+}
+
+// The Unwind feeding the id scan emits nodes in list order, so an ORDER BY
+// id(n) must still sort rather than being elided as already-ordered.
+TYPED_TEST(InterpreterTest, IdInListOrderByNotElided) {
+  using EPV = memgraph::storage::ExternalPropertyValue;
+
+  std::vector<int64_t> ids;
+  {
+    auto stream = this->Interpret("UNWIND range(1, 4) AS i CREATE (n) RETURN id(n) AS id");
+    for (const auto &row : stream.GetResults()) ids.push_back(row[0].ValueInt());
+  }
+  std::sort(ids.begin(), ids.end());
+
+  // Drive the scan with the ids in descending order; ORDER BY must re-sort.
+  EPV::list_t param;
+  for (auto it = ids.rbegin(); it != ids.rend(); ++it) param.emplace_back(EPV(*it));
+  auto stream = this->Interpret("MATCH (n) WHERE id(n) IN $ids RETURN id(n) AS id ORDER BY id(n)",
+                                {{"ids", EPV(std::move(param))}});
+  std::vector<int64_t> out;
+  for (const auto &row : stream.GetResults()) out.push_back(row[0].ValueInt());
+  EXPECT_THAT(out, testing::ElementsAreArray(ids));
+}
+
+// `MATCH (n:L) WHERE id(n) IN $ids` selects the id scan and keeps the label as a
+// residual filter, so only labelled vertices come back.
+TYPED_TEST(InterpreterTest, IdInListLabelResidual) {
+  using EPV = memgraph::storage::ExternalPropertyValue;
+
+  std::vector<int64_t> labelled;
+  std::vector<int64_t> all;
+  {
+    auto stream = this->Interpret("CREATE (a:L), (b) RETURN id(a) AS la, id(b) AS lb");
+    labelled.push_back(stream.GetResults()[0][0].ValueInt());
+    all.push_back(stream.GetResults()[0][0].ValueInt());
+    all.push_back(stream.GetResults()[0][1].ValueInt());
+  }
+
+  EPV::list_t param;
+  for (auto id : all) param.emplace_back(EPV(id));
+  auto stream = this->Interpret("MATCH (n:L) WHERE id(n) IN $ids RETURN id(n) AS id", {{"ids", EPV(std::move(param))}});
+  std::vector<int64_t> out;
+  for (const auto &row : stream.GetResults()) out.push_back(row[0].ValueInt());
+  EXPECT_THAT(out, testing::ElementsAreArray(labelled));
+}
+
 // Run CREATE/MATCH/MERGE queries with property map
 TYPED_TEST(InterpreterTest, ParametersAsPropertyMap) {
   {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2387,6 +2387,46 @@ TYPED_TEST(TestPlanner, ScanAllById) {
   CheckPlan<TypeParam>(query, this->storage, ExpectScanAllById(), ExpectProduce());
 }
 
+TYPED_TEST(TestPlanner, ScanAllByIdInListParameter) {
+  // MATCH (n) WHERE id(n) IN $ids RETURN n lowers the IN-list to an
+  // Unwind feeding a per-element ScanAllById.
+  auto *query = QUERY(
+      SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(IN_LIST(FN("id", IDENT("n")), PARAMETER_LOOKUP(0))), RETURN("n")));
+  CheckPlan<TypeParam>(query, this->storage, ExpectUnwind(), ExpectScanAllById(), ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, ScanAllByIdInListWithLabelResidual) {
+  // The id scan is selected and the label survives as a residual Filter.
+  FakeDbAccessor dba;
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n", "L"))), WHERE(IN_LIST(FN("id", IDENT("n")), PARAMETER_LOOKUP(0))), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  CheckPlan(planner.plan(), symbol_table, ExpectUnwind(), ExpectScanAllById(), ExpectFilter(), ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, ScanAllByIdInListSelfReferentialNotOptimized) {
+  // The RHS list references the scanned node, so it cannot be evaluated before
+  // n is bound; the id scan must not fire and a full ScanAll + Filter remains.
+  FakeDbAccessor dba;
+  auto lst = PROPERTY_PAIR(dba, "lst");
+  auto *prop_rhs = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n"))), WHERE(IN_LIST(FN("id", IDENT("n")), PROPERTY_LOOKUP(dba, "n", lst))), RETURN("n")));
+  {
+    auto symbol_table = memgraph::query::MakeSymbolTable(prop_rhs);
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, prop_rhs);
+    CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectFilter(), ExpectProduce());
+  }
+  auto *list_rhs = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                      WHERE(IN_LIST(FN("id", IDENT("n")), LIST(PROPERTY_LOOKUP(dba, "n", lst)))),
+                                      RETURN("n")));
+  {
+    auto symbol_table = memgraph::query::MakeSymbolTable(list_rhs);
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, list_rhs);
+    CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectFilter(), ExpectProduce());
+  }
+}
+
 TYPED_TEST(TestPlanner, ScanAllByEdgeId) {
   // Test MATCH ()-[r]->() WHERE id(r) = 42 RETURN r
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("anon1"), EDGE("r"), NODE("anon2"))),
@@ -2459,6 +2499,28 @@ TYPED_TEST(TestPlanner, LabelPropertyInListValidOptimization) {
                                              std::vector{ExpressionRange::Equal(fake_identifier)}),
               ExpectProduce());
   }
+}
+
+TYPED_TEST(TestPlanner, LabelPropertyInListParameter) {
+  // A parameter on the right of a property IN lowers to the Unwind +
+  // label+property scan, the same shape as a literal list.
+  FakeDbAccessor dba;
+  auto label = dba.Label("label");
+  auto property = PROPERTY_PAIR(dba, "property");
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))),
+                                   WHERE(IN_LIST(PROPERTY_LOOKUP(dba, "n", property), PARAMETER_LOOKUP(0))),
+                                   RETURN("n")));
+  dba.SetIndexCount(label, property.second, 1);
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto fake_identifier = IDENT("fake");
+  CheckPlan(
+      planner.plan(),
+      symbol_table,
+      ExpectUnwind(),
+      ExpectScanAllByLabelProperties(
+          label, std::vector{ms::PropertyPath{property.second}}, std::vector{ExpressionRange::Equal(fake_identifier)}),
+      ExpectProduce());
 }
 
 TYPED_TEST(TestPlanner, LabelPropertyInListWhereLabelPropertyOnLeftNotListOnRight) {


### PR DESCRIPTION
MATCH (n) WHERE id(n) IN <list> now lowers to a per-element ScanAllById (Unwind feeding the id scan) instead of a full ScanAll plus membership Filter. It accepts parameter lists and any list-valued expression, closing the common $ids case that previously fell through to a full scan.

The existing n.prop IN <list> label+property unwind, which only fired for literal lists, is extended the same way: a parameter or other expression now drives the indexed scan too, and a value repeated in the list emits its node once rather than duplicating it.

Both paths wrap the driving list as toSet(coalesce(value, [])) so a null list returns zero rows instead of throwing and duplicates collapse; a statically-known non-list literal and a self-referential list stay on the Filter path. The rewrites stay result-identical to the membership Filter across the full input contract, proven by an end-to-end equivalence suite on in-memory and on-disk storage.
