### PR TITLE
fix(ha/auth): Migrate users during rolling upgrade between Memgraph instances of different versions

### DIFF
--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -215,6 +215,7 @@ constexpr auto kStoreV2 = "V2";  // Single role links, to JSON arrays for multi-
 constexpr auto kStoreV3 = "V3";  // V2 FGA -> V3 FGA (fine_grained_access_handler to fine_grained_permissions)
 constexpr auto kStoreV4 = "V4";  // V3 FGA -> V4 FGA (global_permission → global_grants/global_denies)
 constexpr auto kStoreV5 = "V5";  // Eagerly migrates entity JSON via MigrateAuthJson over RPC (V3/V4 -> current)
+constexpr auto kCurrentStoreVersion = kStoreV5;
 }  // namespace
 
 /**
@@ -398,7 +399,7 @@ Auth::Auth(std::string storage_directory, Config config
     MigrateVersions(storage_);
   } else {
     // Clean storage; put the version
-    storage_.Put(kStoreVersionKey, kStoreV5);
+    storage_.Put(kStoreVersionKey, kCurrentStoreVersion);
   }
 
 #ifdef MG_ENTERPRISE

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -328,11 +328,15 @@ void MigrateVersions(kvstore::KVStore &store) {
     auto const migrate_entities = [&](auto const &prefix) {
       for (auto it = store.begin(prefix); it != store.end(prefix); ++it) {
         auto const &[key, value] = *it;
-        auto data = nlohmann::json::parse(value);
-        auto const original = data;
-        auth::MigrateAuthJson(data);
-        if (data != original) {
-          puts.emplace(key, data.dump());
+        try {
+          auto data = nlohmann::json::parse(value);
+          auto const original = data;
+          auth::MigrateAuthJson(data);
+          if (data != original) {
+            puts.emplace(key, data.dump());
+          }
+        } catch (nlohmann::json::exception const &e) {
+          throw auth::AuthException("Failed to migrate auth data for '{}': {}", key, e.what());
         }
       }
     };

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -206,11 +206,15 @@ const std::string kMtLinkPrefix = "mtlink:";
 // Profile linking is now handled by UserProfiles class
 const std::string kVersion = "version";
 
-constexpr auto kVersionV1 = "V1";
-constexpr auto kVersionV2 = "V2";
-constexpr auto kVersionV3 = "V3";
-constexpr auto kVersionV4 = "V4";
-constexpr auto kVersionV5 = "V5";
+// Auth KV store versions. These track structural changes to the store layout
+// (key prefixes, link format, etc.). Entity-level schema changes (e.g. FGA
+// format) are handled per-entity via MigrateAuthJson and the entity "version"
+// field: do NOT bump the store version for those (anymore).
+constexpr auto kVersionV1 = "V1";  // Added password hash algorithm field
+constexpr auto kVersionV2 = "V2";  // Single role links, to JSON arrays for multi-role support
+constexpr auto kVersionV3 = "V3";  // V2 FGA -> V3 FGA (fine_grained_access_handler to fine_grained_permissions)
+constexpr auto kVersionV4 = "V4";  // V3 FGA -> V4 FGA (global_permission → global_grants/global_denies)
+constexpr auto kVersionV5 = "V5";  // Eagerly migrates entity JSON via MigrateAuthJson over RPC (V3/V4 -> current)
 }  // namespace
 
 /**

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -310,190 +310,22 @@ void MigrateVersions(kvstore::KVStore &store) {
     spdlog::info("Auth storage migration to V2 completed successfully");
   }
 
-  if (version_str == kVersionV2) {
-    spdlog::info("Migrating auth storage from V2 to V3");
-    spdlog::warn(
-        "IMPORTANT: Review your security policy and explicitly configure finely grained access rules where needed.");
-
-    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV3}};
-
-    auto const convert_v2_to_v3_permissions = [](uint64_t const v2_perm) -> uint64_t {
-      // V2 permissions used bit_0 for read, bit_1 for update, and bit_2 for
-      // create_delete, but note that the trailing bits are also set because the
-      // permission formed a hierarchy.
-      constexpr uint64_t kV2Read = 1;
-      constexpr uint64_t kV2Update = 3;
-      constexpr uint64_t kV2CreateDelete = 7;
-
-      // V3 permission bits: NOTHING=0, READ=1, UPDATE=2, CREATE=8, DELETE=16.
-      // Need to duplicate them here as FineGrainedPermission is enterprise only
-      // and duplication is preferable to leaking the enum into community
-      // builds.
-      constexpr uint64_t kV3Nothing = 0;
-      constexpr uint64_t kV3Read = 1;
-      constexpr uint64_t kV3Update = 2;
-      constexpr uint64_t kV3Create = 8;
-      constexpr uint64_t kV3Delete = 16;
-
-      switch (v2_perm) {
-        case 0:
-          return kV3Nothing;
-        case kV2Read:
-          return kV3Read;
-        case kV2Update:
-          return kV3Update | kV3Read;
-        case kV2CreateDelete:
-          return kV3Create | kV3Delete | kV3Update | kV3Read;
-        default:
-          return kV3Nothing;
-      }
-    };
-
-    auto const migrate_entity = [&](auto const &prefix) {
-      for (auto it = store.begin(prefix); it != store.end(prefix); ++it) {
-        auto const &[key, value] = *it;
-        try {
-          auto data = nlohmann::json::parse(value);
-
-          auto const fg_it = data.find("fine_grained_access_handler");
-          if (fg_it != data.end() && fg_it->is_object()) {
-            for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
-              auto const perm_it = fg_it->find(perm_type);
-              if (perm_it != fg_it->end() && perm_it->is_object()) {
-                auto &perm_data = *perm_it;
-
-                auto const global_perm_it = perm_data.find("global_permission");
-                if (global_perm_it != perm_data.end() && global_perm_it->is_number_integer()) {
-                  auto const v2_perm = global_perm_it->template get<int64_t>();
-                  if (v2_perm >= 0) {
-                    *global_perm_it = convert_v2_to_v3_permissions(static_cast<uint64_t>(v2_perm));
-                  }
-                }
-
-                perm_data["permissions"] = nlohmann::json::array();
-              }
-            }
-
-            data["fine_grained_permissions"] = std::move(*fg_it);
-            data.erase("fine_grained_access_handler");
-            puts.emplace(key, data.dump());
-          }
-        } catch (const nlohmann::json::exception &e) {
-          throw AuthException("Failed to migrate auth data for '{}': {}", key, e.what());
-        }
-      }
-    };
-
-    migrate_entity(kUserPrefix);
-    migrate_entity(kRolePrefix);
-
-    if (!puts.empty()) {
-      store.PutMultiple(puts);
+  if (version_str == kVersionV2 || version_str == kVersionV3) {
+    spdlog::info("Migrating auth storage from {} to V4", *version_str);
+    if (version_str == kVersionV2) {
+      spdlog::warn(
+          "IMPORTANT: Review your security policy and explicitly configure finely grained access rules where needed.");
     }
-
-    version_str = kVersionV3;
-    spdlog::info("Auth storage migration to V3 completed successfully");
-  }
-
-  if (version_str == kVersionV3) {
-    spdlog::info("Migrating auth storage from V3 to V4");
 
     auto puts = std::map<std::string, std::string>{{kVersion, kVersionV4}};
 
-    // V4 changes the fine-grained permissions JSON structure:
-    // - `global_permission` is split into `global_grants`/`global_denies`
-    // - permissions array entries gain a `denied` field
-    // - For labels: UPDATE (bit 1) expands to SET_LABEL | REMOVE_LABEL | SET_PROPERTY | DELETE_EDGE | CREATE_EDGE
-    // - For edge types: UPDATE (bit 1) becomes SET_PROPERTY (bit 1), which is the
-    //   same bit so no migration needed.
-    // - NOTHING becomes a DENY ALL
-
-    // Local copies of FineGrainedPermission values (defined under MG_ENTERPRISE
-    // in models.hpp). Duplicated here so that this migration runs even in
-    // community builds, which is necessary to correctly migrate data if an
-    // installation downgrades from enterprise to community then upgrades again.
-    // Admittedly unlikely, but easily handled!
-    constexpr uint64_t kUpdate = 2;                   // Old UPDATE bit, no longer exists in enum
-    constexpr uint64_t kSetLabel = 32;                // FineGrainedPermission::SET_LABEL
-    constexpr uint64_t kRemoveLabel = 64;             // FineGrainedPermission::REMOVE_LABEL
-    constexpr uint64_t kSetProperty = 2;              // FineGrainedPermission::SET_PROPERTY
-    constexpr uint64_t kDeleteEdge = 128;             // FineGrainedPermission::DELETE_EDGE
-    constexpr uint64_t kCreateEdge = 256;             // FineGrainedPermission::CREATE_EDGE
-    constexpr uint64_t kAllLabelPermissions = 507;    // kAllLabelPermissions
-    constexpr uint64_t kAllEdgeTypePermissions = 27;  // kAllEdgeTypePermissions
-
-    // For labels: UPDATE -> SET_LABEL | REMOVE_LABEL | SET_PROPERTY | DELETE_EDGE | CREATE_EDGE
-    auto const migrate_label_permissions = [&](uint64_t const v3_perm) -> uint64_t {
-      uint64_t result = v3_perm;
-      if (result & kUpdate) {
-        result = (result & ~kUpdate) | kSetLabel | kRemoveLabel | kSetProperty | kDeleteEdge | kCreateEdge;
-      }
-      return result;
-    };
-
     auto const migrate_entity = [&](auto const &prefix) {
       for (auto it = store.begin(prefix); it != store.end(prefix); ++it) {
         auto const &[key, value] = *it;
         try {
           auto data = nlohmann::json::parse(value);
-
-          auto const fg_it = data.find("fine_grained_permissions");
-          if (fg_it != data.end() && fg_it->is_object()) {
-            for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
-              bool const is_label = std::string_view{perm_type} == "label_permissions";
-              auto const perm_it = fg_it->find(perm_type);
-              if (perm_it != fg_it->end() && perm_it->is_object()) {
-                auto &perm_data = *perm_it;
-
-                // Migrate global_permission -> global_grants/global_denies
-                auto const global_perm_it = perm_data.find("global_permission");
-                if (global_perm_it != perm_data.end()) {
-                  auto const old_perm = global_perm_it->template get<int64_t>();
-                  if (old_perm == 0) {
-                    // NOTHING -> deny all
-                    perm_data["global_grants"] = -1;
-                    perm_data["global_denies"] = (is_label ? kAllLabelPermissions : kAllEdgeTypePermissions);
-                  } else if (old_perm == -1) {
-                    // No global permission set
-                    perm_data["global_grants"] = -1;
-                    perm_data["global_denies"] = -1;
-                  } else {
-                    auto new_perm = static_cast<uint64_t>(old_perm);
-                    if (is_label) new_perm = migrate_label_permissions(new_perm);
-                    perm_data["global_grants"] = new_perm;
-                    perm_data["global_denies"] = -1;
-                  }
-                  perm_data.erase("global_permission");
-                }
-
-                // Migrate permissions: add "denied" field, migrate permission values for labels
-                auto const perms_it = perm_data.find("permissions");
-                if (perms_it != perm_data.end() && perms_it->is_array()) {
-                  nlohmann::json new_permissions = nlohmann::json::array();
-                  for (auto const &old_rule : *perms_it) {
-                    nlohmann::json new_rule;
-                    new_rule["symbols"] = old_rule.value("symbols", nlohmann::json::array());
-                    new_rule["matching"] = old_rule.value("matching", "ANY");
-
-                    auto const granted = old_rule.value("granted", int64_t{0});
-                    if (granted == 0) {
-                      // granted=0 (NOTHING) -> deny all
-                      new_rule["granted"] = 0;
-                      new_rule["denied"] = (is_label ? kAllLabelPermissions : kAllEdgeTypePermissions);
-                    } else {
-                      auto new_granted = static_cast<uint64_t>(granted);
-                      if (is_label) new_granted = migrate_label_permissions(new_granted);
-                      new_rule["granted"] = new_granted;
-                      new_rule["denied"] = 0;
-                    }
-                    new_permissions.push_back(std::move(new_rule));
-                  }
-                  perm_data["permissions"] = std::move(new_permissions);
-                }
-              }
-            }
-            puts.emplace(key, data.dump());
-          }
+          auth::MigrateAuthJson(data);
+          puts.emplace(key, data.dump());
         } catch (const nlohmann::json::exception &e) {
           throw AuthException("Failed to migrate auth data for '{}': {}", key, e.what());
         }

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -204,17 +204,17 @@ const std::string kRolePrefix = "role:";
 const std::string kRoleLinkPrefix = "link:";
 const std::string kMtLinkPrefix = "mtlink:";
 // Profile linking is now handled by UserProfiles class
-const std::string kVersion = "version";
+const std::string kStoreVersionKey = "version";
 
 // Auth KV store versions. These track structural changes to the store layout
 // (key prefixes, link format, etc.). Entity-level schema changes (e.g. FGA
 // format) are handled per-entity via MigrateAuthJson and the entity "version"
 // field: do NOT bump the store version for those (anymore).
-constexpr auto kVersionV1 = "V1";  // Added password hash algorithm field
-constexpr auto kVersionV2 = "V2";  // Single role links, to JSON arrays for multi-role support
-constexpr auto kVersionV3 = "V3";  // V2 FGA -> V3 FGA (fine_grained_access_handler to fine_grained_permissions)
-constexpr auto kVersionV4 = "V4";  // V3 FGA -> V4 FGA (global_permission → global_grants/global_denies)
-constexpr auto kVersionV5 = "V5";  // Eagerly migrates entity JSON via MigrateAuthJson over RPC (V3/V4 -> current)
+constexpr auto kStoreV1 = "V1";  // Added password hash algorithm field
+constexpr auto kStoreV2 = "V2";  // Single role links, to JSON arrays for multi-role support
+constexpr auto kStoreV3 = "V3";  // V2 FGA -> V3 FGA (fine_grained_access_handler to fine_grained_permissions)
+constexpr auto kStoreV4 = "V4";  // V3 FGA -> V4 FGA (global_permission → global_grants/global_denies)
+constexpr auto kStoreV5 = "V5";  // Eagerly migrates entity JSON via MigrateAuthJson over RPC (V3/V4 -> current)
 }  // namespace
 
 /**
@@ -237,13 +237,13 @@ constexpr auto kVersionV5 = "V5";  // Eagerly migrates entity JSON via MigrateAu
 namespace {
 void MigrateVersions(kvstore::KVStore &store) {
   static constexpr auto kPasswordHashV0V1 = "password_hash";
-  auto version_str = store.Get(kVersion);
+  auto version_str = store.Get(kStoreVersionKey);
 
   if (!version_str) {
     using namespace std::string_literals;
 
     // pre versioning, add version to the store
-    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV1}};
+    auto puts = std::map<std::string, std::string>{{kStoreVersionKey, kStoreV1}};
 
     // also add hash kind into durability
 
@@ -278,14 +278,14 @@ void MigrateVersions(kvstore::KVStore &store) {
 
     // Perform migration to V1
     store.PutMultiple(puts);
-    version_str = kVersionV1;
+    version_str = kStoreV1;
   }
 
   // Migrate from V1 to V2: convert single role links to JSON arrays
-  if (version_str == kVersionV1) {
+  if (version_str == kStoreV1) {
     spdlog::info("Migrating auth storage from V1 to V2: converting single role links to JSON arrays");
 
-    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV2}};
+    auto puts = std::map<std::string, std::string>{{kStoreVersionKey, kStoreV2}};
     auto deletes = std::vector<std::string>{};
 
     // Migrate all link entries from single role format to JSON array format
@@ -310,20 +310,20 @@ void MigrateVersions(kvstore::KVStore &store) {
     if (!deletes.empty()) {
       store.DeleteMultiple(deletes);
     }
-    version_str = kVersionV2;
+    version_str = kStoreV2;
 
     spdlog::info("Auth storage migration to V2 completed successfully");
   }
 
   // V2/V3/V4 entity-level migrations (FGA schema changes)
-  if (version_str == kVersionV2 || version_str == kVersionV3 || version_str == kVersionV4) {
+  if (version_str == kStoreV2 || version_str == kStoreV3 || version_str == kStoreV4) {
     spdlog::info("Migrating auth storage from {} to V5: migrating entity JSON schemas", *version_str);
-    if (version_str == kVersionV2) {
+    if (version_str == kStoreV2) {
       spdlog::warn(
           "IMPORTANT: Review your security policy and explicitly configure finely grained access rules where needed.");
     }
 
-    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV5}};
+    auto puts = std::map<std::string, std::string>{{kStoreVersionKey, kStoreV5}};
 
     auto const migrate_entities = [&](auto const &prefix) {
       for (auto it = store.begin(prefix); it != store.end(prefix); ++it) {
@@ -345,7 +345,7 @@ void MigrateVersions(kvstore::KVStore &store) {
     migrate_entities(kRolePrefix);
 
     store.PutMultiple(puts);
-    version_str = kVersionV5;
+    version_str = kStoreV5;
 
     spdlog::info("Auth storage migration to V5 completed successfully");
   }
@@ -398,7 +398,7 @@ Auth::Auth(std::string storage_directory, Config config
     MigrateVersions(storage_);
   } else {
     // Clean storage; put the version
-    storage_.Put(kVersion, kVersionV5);
+    storage_.Put(kStoreVersionKey, kStoreV5);
   }
 
 #ifdef MG_ENTERPRISE

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -210,6 +210,7 @@ constexpr auto kVersionV1 = "V1";
 constexpr auto kVersionV2 = "V2";
 constexpr auto kVersionV3 = "V3";
 constexpr auto kVersionV4 = "V4";
+constexpr auto kVersionV5 = "V5";
 }  // namespace
 
 /**
@@ -310,47 +311,11 @@ void MigrateVersions(kvstore::KVStore &store) {
     spdlog::info("Auth storage migration to V2 completed successfully");
   }
 
-  auto const migrate_entities = [&](auto &puts) {
-    for (auto const &prefix : {kUserPrefix, kRolePrefix}) {
-      for (auto it = store.begin(prefix); it != store.end(prefix); ++it) {
-        auto const &[key, value] = *it;
-        try {
-          auto data = nlohmann::json::parse(value);
-          auth::MigrateAuthJson(data);
-          puts.emplace(key, data.dump());
-        } catch (const nlohmann::json::exception &e) {
-          throw AuthException("Failed to migrate auth data for '{}': {}", key, e.what());
-        }
-      }
-    }
-  };
-
-  if (version_str == kVersionV2) {
-    spdlog::info("Migrating auth storage from V2 to V3");
-    spdlog::warn(
-        "IMPORTANT: Review your security policy and explicitly configure finely grained access rules where needed.");
-
-    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV3}};
-    migrate_entities(puts);
-    if (!puts.empty()) {
-      store.PutMultiple(puts);
-    }
-
-    version_str = kVersionV3;
-    spdlog::info("Auth storage migration to V3 completed successfully");
-  }
-
-  if (version_str == kVersionV3) {
-    spdlog::info("Migrating auth storage from V3 to V4");
-
-    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV4}};
-    migrate_entities(puts);
-    if (!puts.empty()) {
-      store.PutMultiple(puts);
-    }
-
-    version_str = kVersionV4;
-    spdlog::info("Auth storage migration to V4 completed successfully");
+  // V3/V4 entity-level migrations (FGA schema changes) are handled lazily by
+  // MigrateAuthJson on each Deserialize. Just bump the store version.
+  if (version_str == kVersionV2 || version_str == kVersionV3 || version_str == kVersionV4) {
+    store.Put(kVersion, kVersionV5);
+    version_str = kVersionV5;
   }
 }
 
@@ -377,6 +342,12 @@ auto ParseJson(std::string_view str) {
   return data;
 }
 
+auto ParseAndMigrateJson(std::string_view str) {
+  auto data = ParseJson(str);
+  auth::MigrateAuthJson(data);
+  return data;
+}
+
 };  // namespace
 
 Auth::Auth(std::string storage_directory, Config config
@@ -395,7 +366,7 @@ Auth::Auth(std::string storage_directory, Config config
     MigrateVersions(storage_);
   } else {
     // Clean storage; put the version
-    storage_.Put(kVersion, kVersionV4);
+    storage_.Put(kVersion, kVersionV5);
   }
 
 #ifdef MG_ENTERPRISE
@@ -683,7 +654,7 @@ std::optional<User> Auth::GetUser(const std::string &username_orig) const {
   auto existing_user = storage_.Get(kUserPrefix + username);
   if (!existing_user) return std::nullopt;
 
-  auto user = User::Deserialize(ParseJson(*existing_user));
+  auto user = User::Deserialize(ParseAndMigrateJson(*existing_user));
   LinkUser(user);
   return user;
 }
@@ -850,7 +821,7 @@ std::vector<auth::User> Auth::AllUsers() const {
     auto username = it->first.substr(kUserPrefix.size());
     if (username != utils::ToLowerCase(username)) continue;
     try {
-      User user = auth::User::Deserialize(ParseJson(it->second));  // Will throw on failure
+      User user = auth::User::Deserialize(ParseAndMigrateJson(it->second));  // Will throw on failure
       LinkUser(user);
       ret.emplace_back(std::move(user));
     } catch (AuthException &) {
@@ -867,7 +838,7 @@ std::vector<std::string> Auth::AllUsernames() const {
     if (username != utils::ToLowerCase(username)) continue;
     try {
       // Check if serialized correctly
-      memgraph::auth::User::Deserialize(ParseJson(it->second));  // Will throw on failure
+      memgraph::auth::User::Deserialize(ParseAndMigrateJson(it->second));  // Will throw on failure
       ret.emplace_back(std::move(username));
     } catch (AuthException &) {
       continue;
@@ -891,7 +862,7 @@ std::optional<Role> Auth::GetRole(const std::string &rolename_orig) const {
   auto existing_role = storage_.Get(kRolePrefix + rolename);
   if (!existing_role) return std::nullopt;
 
-  auto role = Role::Deserialize(ParseJson(*existing_role));
+  auto role = Role::Deserialize(ParseAndMigrateJson(*existing_role));
   LinkRole(role);
   return role;
 }
@@ -1213,7 +1184,7 @@ std::vector<auth::Role> Auth::AllRoles() const {
   for (auto it = storage_.begin(kRolePrefix); it != storage_.end(kRolePrefix); ++it) {
     auto rolename = it->first.substr(kRolePrefix.size());
     if (rolename != utils::ToLowerCase(rolename)) continue;
-    Role role = memgraph::auth::Role::Deserialize(ParseJson(it->second));  // Will throw on failure
+    Role role = memgraph::auth::Role::Deserialize(ParseAndMigrateJson(it->second));  // Will throw on failure
     LinkRole(role);
     ret.emplace_back(std::move(role));
   }
@@ -1227,7 +1198,7 @@ std::vector<std::string> Auth::AllRolenames() const {
     if (rolename != utils::ToLowerCase(rolename)) continue;
     try {
       // Check that the data is serialized correctly
-      memgraph::auth::Role::Deserialize(ParseJson(it->second));
+      memgraph::auth::Role::Deserialize(ParseAndMigrateJson(it->second));
       ret.emplace_back(std::move(rolename));
     } catch (AuthException &) {
       continue;
@@ -1417,7 +1388,7 @@ void Auth::DeleteDatabase(const std::string &db, system::Transaction *system_tx)
   for (auto it = storage_.begin(kUserPrefix); it != storage_.end(kUserPrefix); ++it) {
     auto username = it->first.substr(kUserPrefix.size());
     try {
-      User user = auth::User::Deserialize(ParseJson(it->second));
+      User user = auth::User::Deserialize(ParseAndMigrateJson(it->second));
       LinkUser(user);
       user.db_access().Revoke(db);
       SaveUser(user, system_tx);
@@ -1428,7 +1399,7 @@ void Auth::DeleteDatabase(const std::string &db, system::Transaction *system_tx)
   for (auto it = storage_.begin(kRolePrefix); it != storage_.end(kRolePrefix); ++it) {
     auto rolename = it->first.substr(kRolePrefix.size());
     try {
-      auto role = memgraph::auth::Role::Deserialize(ParseJson(it->second));
+      auto role = memgraph::auth::Role::Deserialize(ParseAndMigrateJson(it->second));
       role.db_access().Revoke(db);
       LinkRole(role);
       SaveRole(role, system_tx);

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -315,7 +315,7 @@ void MigrateVersions(kvstore::KVStore &store) {
     spdlog::info("Auth storage migration to V2 completed successfully");
   }
 
-  // V3/V4 entity-level migrations (FGA schema changes)
+  // V2/V3/V4 entity-level migrations (FGA schema changes)
   if (version_str == kVersionV2 || version_str == kVersionV3 || version_str == kVersionV4) {
     spdlog::info("Migrating auth storage from {} to V5: migrating entity JSON schemas", *version_str);
     if (version_str == kVersionV2) {

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -311,11 +311,31 @@ void MigrateVersions(kvstore::KVStore &store) {
     spdlog::info("Auth storage migration to V2 completed successfully");
   }
 
-  // V3/V4 entity-level migrations (FGA schema changes) are handled lazily by
-  // MigrateAuthJson on each Deserialize. Just bump the store version.
+  // V3/V4 entity-level migrations (FGA schema changes)
   if (version_str == kVersionV2 || version_str == kVersionV3 || version_str == kVersionV4) {
-    store.Put(kVersion, kVersionV5);
+    spdlog::info("Migrating auth storage to V5: migrating entity JSON schemas");
+
+    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV5}};
+
+    auto const migrate_entities = [&](auto const &prefix) {
+      for (auto it = store.begin(prefix); it != store.end(prefix); ++it) {
+        auto const &[key, value] = *it;
+        auto data = nlohmann::json::parse(value);
+        auto const original = data;
+        auth::MigrateAuthJson(data);
+        if (data != original) {
+          puts.emplace(key, data.dump());
+        }
+      }
+    };
+
+    migrate_entities(kUserPrefix);
+    migrate_entities(kRolePrefix);
+
+    store.PutMultiple(puts);
     version_str = kVersionV5;
+
+    spdlog::info("Auth storage migration to V5 completed successfully");
   }
 }
 

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -310,16 +310,8 @@ void MigrateVersions(kvstore::KVStore &store) {
     spdlog::info("Auth storage migration to V2 completed successfully");
   }
 
-  if (version_str == kVersionV2 || version_str == kVersionV3) {
-    spdlog::info("Migrating auth storage from {} to V4", *version_str);
-    if (version_str == kVersionV2) {
-      spdlog::warn(
-          "IMPORTANT: Review your security policy and explicitly configure finely grained access rules where needed.");
-    }
-
-    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV4}};
-
-    auto const migrate_entity = [&](auto const &prefix) {
+  auto const migrate_entities = [&](auto &puts) {
+    for (auto const &prefix : {kUserPrefix, kRolePrefix}) {
       for (auto it = store.begin(prefix); it != store.end(prefix); ++it) {
         auto const &[key, value] = *it;
         try {
@@ -330,11 +322,29 @@ void MigrateVersions(kvstore::KVStore &store) {
           throw AuthException("Failed to migrate auth data for '{}': {}", key, e.what());
         }
       }
-    };
+    }
+  };
 
-    migrate_entity(kUserPrefix);
-    migrate_entity(kRolePrefix);
+  if (version_str == kVersionV2) {
+    spdlog::info("Migrating auth storage from V2 to V3");
+    spdlog::warn(
+        "IMPORTANT: Review your security policy and explicitly configure finely grained access rules where needed.");
 
+    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV3}};
+    migrate_entities(puts);
+    if (!puts.empty()) {
+      store.PutMultiple(puts);
+    }
+
+    version_str = kVersionV3;
+    spdlog::info("Auth storage migration to V3 completed successfully");
+  }
+
+  if (version_str == kVersionV3) {
+    spdlog::info("Migrating auth storage from V3 to V4");
+
+    auto puts = std::map<std::string, std::string>{{kVersion, kVersionV4}};
+    migrate_entities(puts);
     if (!puts.empty()) {
       store.PutMultiple(puts);
     }

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -317,7 +317,11 @@ void MigrateVersions(kvstore::KVStore &store) {
 
   // V3/V4 entity-level migrations (FGA schema changes)
   if (version_str == kVersionV2 || version_str == kVersionV3 || version_str == kVersionV4) {
-    spdlog::info("Migrating auth storage to V5: migrating entity JSON schemas");
+    spdlog::info("Migrating auth storage from {} to V5: migrating entity JSON schemas", *version_str);
+    if (version_str == kVersionV2) {
+      spdlog::warn(
+          "IMPORTANT: Review your security policy and explicitly configure finely grained access rules where needed.");
+    }
 
     auto puts = std::map<std::string, std::string>{{kVersion, kVersionV5}};
 

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1853,7 +1853,11 @@ void MigrateAuthJson(nlohmann::json &data) {
   if (!data.is_object()) return;
 
   auto version = DeduceVersion(data);
-  if (!version.has_value() || version == kCurrentAuthVersion) return;
+  if (!version.has_value()) return;
+  if (version == kCurrentAuthVersion) {
+    if (!data.contains(kVersion)) data[kVersion] = kCurrentAuthVersion;
+    return;
+  }
 
   // V2 to V3: rename fine_grained_access_handler to fine_grained_permissions,
   //           convert global_permission values from V2 enum to V3 bitmask,

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -25,7 +25,6 @@ namespace memgraph::auth {
 namespace {
 
 constexpr auto kVersion = "version";
-constexpr int kCurrentAuthVersion = 4;
 constexpr auto kRoleName = "rolename";
 constexpr auto kBuiltIn = "builtin";
 constexpr auto kPermissions = "permissions";
@@ -1853,8 +1852,7 @@ void MigrateAuthJson(nlohmann::json &data) {
   if (!data.is_object()) return;
 
   auto version = DeduceVersion(data);
-  if (!version.has_value()) return;
-  if (version == kCurrentAuthVersion) {
+  if (!version.has_value() || version == kCurrentAuthVersion) {
     if (!data.contains(kVersion)) data[kVersion] = kCurrentAuthVersion;
     return;
   }

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1871,11 +1871,9 @@ void MigrateAuthJson(nlohmann::json &data) {
   //           convert global_permission values from V2 enum to V3 bitmask,
   //           add empty permissions array per sub-object.
   if (version == 2) {
+    // DeduceVersion returned 2 based on the shape of this key, so it must exist.
     auto fg_it = data.find("fine_grained_access_handler");
-    if (fg_it == data.end() || !fg_it->is_object()) {
-      data[kVersion] = kCurrentEntityVersion;
-      return;
-    }
+    DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
     // V2 permissions used bit_0 for read, bit_1 for update, and bit_2 for
     // create_delete, but note that the trailing bits are also set because the
     // permission formed a hierarchy.
@@ -1933,8 +1931,10 @@ void MigrateAuthJson(nlohmann::json &data) {
       data["fine_grained_permissions"] = std::move(data["fine_grained_access_handler"]);
       data.erase("fine_grained_access_handler");
     }
+    // DeduceVersion returned 3 based on the shape of this key, so it must exist
+    // (after the rename above for the old-key case).
     auto fg_it = data.find("fine_grained_permissions");
-    if (fg_it == data.end() || !fg_it->is_object()) return;
+    DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
 
     // Local copies of FineGrainedPermission values. Duplicated here so that this
     // migration runs even in community builds.

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1908,24 +1908,25 @@ void MigrateAuthJson(nlohmann::json &data) {
     auto &perm_data = *perm_it;
 
     // Migrate global_permission → global_grants / global_denies
-    if (auto global_it = perm_data.find("global_permission"); global_it != perm_data.end()) {
-      auto const old_perm = global_it->template get<int64_t>();
-      if (old_perm == 0) {
-        // NOTHING -> deny all
-        perm_data["global_grants"] = -1;
-        perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
-      } else if (old_perm == -1) {
-        // No global permission set
-        perm_data["global_grants"] = -1;
-        perm_data["global_denies"] = -1;
-      } else {
-        auto new_perm = static_cast<uint64_t>(old_perm);
-        if (is_label) new_perm = migrate_label_permissions(new_perm);
-        perm_data["global_grants"] = new_perm;
-        perm_data["global_denies"] = -1;
-      }
-      perm_data.erase("global_permission");
+    auto global_it = perm_data.find("global_permission");
+    if (global_it == perm_data.end()) continue;  // Already V4
+
+    auto const old_perm = global_it->template get<int64_t>();
+    if (old_perm == 0) {
+      // NOTHING -> deny all
+      perm_data["global_grants"] = -1;
+      perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+    } else if (old_perm == -1) {
+      // No global permission set
+      perm_data["global_grants"] = -1;
+      perm_data["global_denies"] = -1;
+    } else {
+      auto new_perm = static_cast<uint64_t>(old_perm);
+      if (is_label) new_perm = migrate_label_permissions(new_perm);
+      perm_data["global_grants"] = new_perm;
+      perm_data["global_denies"] = -1;
     }
+    perm_data.erase("global_permission");
 
     // Migrate permissions: add "denied" field, migrate permission values for labels
     auto perms_it = perm_data.find("permissions");

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1862,6 +1862,10 @@ void MigrateAuthJson(nlohmann::json &data) {
   //           add empty permissions array per sub-object.
   if (version == 2) {
     auto fg_it = data.find("fine_grained_access_handler");
+    if (fg_it == data.end() || !fg_it->is_object()) {
+      data[kVersion] = kCurrentAuthVersion;
+      return;
+    }
     // V2 permissions used bit_0 for read, bit_1 for update, and bit_2 for
     // create_delete, but note that the trailing bits are also set because the
     // permission formed a hierarchy.

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1867,6 +1867,13 @@ void MigrateAuthJson(nlohmann::json &data) {
     return;
   }
 
+  if (*version > kCurrentEntityVersion) {
+    spdlog::warn("Auth entity has version {} which is newer than the current version {}; leaving unmodified",
+                 *version,
+                 kCurrentEntityVersion);
+    return;
+  }
+
   // V2 to V3: rename fine_grained_access_handler to fine_grained_permissions,
   //           convert global_permission values from V2 enum to V3 bitmask,
   //           add empty permissions array per sub-object.

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1835,13 +1835,23 @@ std::optional<int> DeduceVersion(nlohmann::json const &data) {
   if (auto it = data.find(kVersion); it != data.end() && it->is_number_integer()) {
     return it->get<int>();
   }
-  if (data.contains("fine_grained_access_handler")) return 2;
-  if (auto fg = data.find("fine_grained_permissions"); fg != data.end() && fg->is_object()) {
-    for (auto const &key : {"label_permissions", "edge_type_permissions"}) {
-      if (auto sub = fg->find(key); sub != fg->end() && sub->is_object()) {
-        if (sub->contains("global_permission")) return 3;
-        if (sub->contains("global_grants")) return 4;
+  // Check both old and new key names for the fine-grained permissions block.
+  // 3.9 uses `fine_grained_access_handler` but with V3-style content (V3
+  // bitmasks + permissions array); true V2 (pre-3.8) also uses that key but
+  // with V2-style enum values and no permissions array. We must inspect the
+  // sub-objects to distinguish them.
+  for (auto const &fg_key : {"fine_grained_permissions", "fine_grained_access_handler"}) {
+    if (auto fg = data.find(fg_key); fg != data.end() && fg->is_object()) {
+      for (auto const &key : {"label_permissions", "edge_type_permissions"}) {
+        if (auto sub = fg->find(key); sub != fg->end() && sub->is_object()) {
+          if (sub->contains("global_grants")) return 4;
+          if (sub->contains("global_permission") && sub->contains("permissions") && (*sub)["permissions"].is_array())
+            return 3;
+          if (sub->contains("global_permission")) return 2;
+        }
       }
+      // Has the FGA block but no recognisable sub-objects
+      if (std::string_view{fg_key} == "fine_grained_access_handler") return 2;
     }
   }
   return std::nullopt;
@@ -1902,7 +1912,9 @@ void MigrateAuthJson(nlohmann::json &data) {
             *global_it = convert_v2_to_v3(static_cast<uint64_t>(v2_perm));
           }
         }
-        (*perm_it)["permissions"] = nlohmann::json::array();
+        if (!perm_it->contains("permissions") || !(*perm_it)["permissions"].is_array()) {
+          (*perm_it)["permissions"] = nlohmann::json::array();
+        }
       }
     }
 
@@ -1916,6 +1928,11 @@ void MigrateAuthJson(nlohmann::json &data) {
   //           add denied field to per-entity rules,
   //           expand UPDATE bit for labels.
   if (version == 3) {
+    // Handle V3 content stored under the old key name (pre-3.8 transitional)
+    if (data.contains("fine_grained_access_handler") && !data.contains("fine_grained_permissions")) {
+      data["fine_grained_permissions"] = std::move(data["fine_grained_access_handler"]);
+      data.erase("fine_grained_access_handler");
+    }
     auto fg_it = data.find("fine_grained_permissions");
     if (fg_it == data.end() || !fg_it->is_object()) return;
 

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1824,4 +1824,8 @@ PropertyAccessPermissions Roles::GetPropertyEdgeTypePermissions(std::optional<st
 }
 #endif  // MG_ENTERPRISE
 
+void MigrateAuthJson(nlohmann::json & /*data*/) {
+  // TODO: implement
+}
+
 }  // namespace memgraph::auth

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1861,8 +1861,8 @@ std::optional<int> DeduceVersion(nlohmann::json const &data) {
 //           convert global_permission values from V2 enum to V3 bitmask,
 //           add empty permissions array per sub-object.
 void MigrateV2ToV3(nlohmann::json &data) {
+  // Guaranteed to exist as its presence and type is what identified this as V2
   auto fg_it = data.find(kFineGrainedAccessHandler);
-  DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
 
   constexpr uint64_t kV2Read = 1;
   constexpr uint64_t kV2Update = 3;
@@ -1915,8 +1915,8 @@ void MigrateV3ToV4(nlohmann::json &data) {
     data.erase(kFineGrainedAccessHandler);
   }
 
+  // Guaranteed to exist as its presence and type is what identified this as V3
   auto fg_it = data.find(kFineGrainedPermissions);
-  DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
 
   auto const migrate_label_permissions = [](uint64_t v3_perm) -> uint64_t {
     constexpr auto kUpdate = std::to_underlying(FineGrainedPermission::SET_PROPERTY);  // Old UPDATE bit, same position

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -34,16 +34,20 @@ constexpr auto kUsername = "username";
 constexpr auto kUUID = "uuid";
 constexpr auto kPasswordHash = "password_hash";
 
-#ifdef MG_ENTERPRISE
-
-namespace r = std::ranges;
-
 constexpr auto kGlobalGrants = "global_grants";
 constexpr auto kGlobalDenies = "global_denies";
 constexpr auto kFineGrainedPermissions = "fine_grained_permissions";
 constexpr auto kFineGrainedAccessHandler = "fine_grained_access_handler";
 constexpr auto kLabelPermissions = "label_permissions";
 constexpr auto kEdgeTypePermissions = "edge_type_permissions";
+constexpr auto kSymbols = "symbols";
+constexpr auto kGranted = "granted";
+constexpr auto kDenied = "denied";
+constexpr auto kMatching = "matching";
+
+#ifdef MG_ENTERPRISE
+namespace r = std::ranges;
+
 constexpr auto kAllowAll = "allow_all";
 constexpr auto kDefault = "default";
 constexpr auto kDatabases = "databases";
@@ -52,10 +56,6 @@ constexpr auto kUserImpGranted = "user_imp_granted";
 constexpr auto kUserImpDenied = "user_imp_denied";
 constexpr auto kUserImpId = "user_imp_id";
 constexpr auto kUserImpName = "user_imp_name";
-constexpr auto kSymbols = "symbols";
-constexpr auto kGranted = "granted";
-constexpr auto kDenied = "denied";
-constexpr auto kMatching = "matching";
 constexpr auto kPropertyAccessPermissions = "property_access_permissions";
 constexpr auto kLabelPropertyPermissions = "label_property_permissions";
 constexpr auto kEdgeTypePropertyPermissions = "edge_type_property_permissions";
@@ -1918,21 +1918,14 @@ void MigrateV3ToV4(nlohmann::json &data) {
   auto fg_it = data.find(kFineGrainedPermissions);
   DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
 
-  // Local copies of FineGrainedPermission values. Duplicated here so that this
-  // migration runs even in community builds.
-  constexpr uint64_t kUpdate = 2;             // Old UPDATE bit
-  constexpr uint64_t kSetLabel = 32;          // FineGrainedPermission::SET_LABEL
-  constexpr uint64_t kRemoveLabel = 64;       // FineGrainedPermission::REMOVE_LABEL
-  constexpr uint64_t kSetProperty = 2;        // FineGrainedPermission::SET_PROPERTY
-  constexpr uint64_t kDeleteEdge = 128;       // FineGrainedPermission::DELETE_EDGE
-  constexpr uint64_t kCreateEdge = 256;       // FineGrainedPermission::CREATE_EDGE
-  constexpr uint64_t kAllLabelPerms = 507;    // kAllLabelPermissions
-  constexpr uint64_t kAllEdgeTypePerms = 27;  // kAllEdgeTypePermissions
-
   auto const migrate_label_permissions = [](uint64_t v3_perm) -> uint64_t {
+    constexpr auto kUpdate = std::to_underlying(FineGrainedPermission::SET_PROPERTY);  // Old UPDATE bit, same position
     uint64_t result = v3_perm;
     if (result & kUpdate) {
-      result = (result & ~kUpdate) | kSetLabel | kRemoveLabel | kSetProperty | kDeleteEdge | kCreateEdge;
+      result = (result & ~kUpdate) |
+               std::to_underlying(FineGrainedPermission::SET_LABEL | FineGrainedPermission::REMOVE_LABEL |
+                                  FineGrainedPermission::SET_PROPERTY | FineGrainedPermission::DELETE_EDGE |
+                                  FineGrainedPermission::CREATE_EDGE);
     }
     return result;
   };
@@ -1948,7 +1941,7 @@ void MigrateV3ToV4(nlohmann::json &data) {
       auto const old_perm = global_it->get<int64_t>();
       if (old_perm == 0) {
         perm_data[kGlobalGrants] = -1;
-        perm_data[kGlobalDenies] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+        perm_data[kGlobalDenies] = std::to_underlying(is_label ? kAllLabelPermissions : kAllEdgeTypePermissions);
       } else if (old_perm == -1) {
         perm_data[kGlobalGrants] = -1;
         perm_data[kGlobalDenies] = -1;
@@ -1973,7 +1966,7 @@ void MigrateV3ToV4(nlohmann::json &data) {
       auto const granted = old_rule.value(kGranted, int64_t{0});
       if (granted == 0) {
         new_rule[kGranted] = 0;
-        new_rule[kDenied] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+        new_rule[kDenied] = std::to_underlying(is_label ? kAllLabelPermissions : kAllEdgeTypePermissions);
       } else {
         auto new_granted = static_cast<uint64_t>(granted);
         if (is_label) new_granted = migrate_label_permissions(new_granted);

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1946,22 +1946,22 @@ void MigrateAuthJson(nlohmann::json &data) {
       auto &perm_data = *perm_it;
 
       auto global_it = perm_data.find("global_permission");
-      if (global_it == perm_data.end() || !global_it->is_number_integer()) continue;
-
-      auto const old_perm = global_it->template get<int64_t>();
-      if (old_perm == 0) {
-        perm_data["global_grants"] = -1;
-        perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
-      } else if (old_perm == -1) {
-        perm_data["global_grants"] = -1;
-        perm_data["global_denies"] = -1;
-      } else {
-        auto new_perm = static_cast<uint64_t>(old_perm);
-        if (is_label) new_perm = migrate_label_permissions(new_perm);
-        perm_data["global_grants"] = new_perm;
-        perm_data["global_denies"] = -1;
+      if (global_it != perm_data.end() && global_it->is_number_integer()) {
+        auto const old_perm = global_it->template get<int64_t>();
+        if (old_perm == 0) {
+          perm_data["global_grants"] = -1;
+          perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+        } else if (old_perm == -1) {
+          perm_data["global_grants"] = -1;
+          perm_data["global_denies"] = -1;
+        } else {
+          auto new_perm = static_cast<uint64_t>(old_perm);
+          if (is_label) new_perm = migrate_label_permissions(new_perm);
+          perm_data["global_grants"] = new_perm;
+          perm_data["global_denies"] = -1;
+        }
+        perm_data.erase("global_permission");
       }
-      perm_data.erase("global_permission");
 
       auto perms_it = perm_data.find("permissions");
       if (perms_it == perm_data.end() || !perms_it->is_array()) continue;

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1844,7 +1844,7 @@ void MigrateAuthJson(nlohmann::json &data) {
     constexpr uint64_t kV3Create = 8;
     constexpr uint64_t kV3Delete = 16;
 
-    auto const convert_v2_to_v3 = [&](uint64_t v2_perm) -> uint64_t {
+    auto const convert_v2_to_v3 = [](uint64_t v2_perm) -> uint64_t {
       switch (v2_perm) {
         case kV2Read:
           return kV3Read;
@@ -1910,6 +1910,7 @@ void MigrateAuthJson(nlohmann::json &data) {
     // Migrate global_permission → global_grants / global_denies
     auto global_it = perm_data.find("global_permission");
     if (global_it == perm_data.end()) continue;  // Already V4
+    if (!global_it->is_number_integer()) continue;
 
     auto const old_perm = global_it->template get<int64_t>();
     if (old_perm == 0) {

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1020,7 +1020,7 @@ const FineGrainedAccessPermissions &Role::GetFineGrainedAccessEdgeTypePermission
 
 nlohmann::json Role::Serialize() const {
   nlohmann::json data = nlohmann::json::object();
-  data[kVersion] = kCurrentAuthVersion;
+  data[kVersion] = kCurrentEntityVersion;
   data[kRoleName] = rolename_;
   data[kBuiltIn] = is_builtin_;
   data[kPermissions] = permissions_.Serialize();
@@ -1487,7 +1487,7 @@ PropertyAccessHandler &User::property_access_handler() { return property_access_
 nlohmann::json User::Serialize() const {
   // NOTE: Role and Profile are stored as links to the role and profile lists.
   nlohmann::json data = nlohmann::json::object();
-  data[kVersion] = kCurrentAuthVersion;
+  data[kVersion] = kCurrentEntityVersion;
   data[kUsername] = username_;
   data[kUUID] = uuid_;
   if (password_hash_) {
@@ -1852,8 +1852,8 @@ void MigrateAuthJson(nlohmann::json &data) {
   if (!data.is_object()) return;
 
   auto version = DeduceVersion(data);
-  if (!version.has_value() || version == kCurrentAuthVersion) {
-    if (!data.contains(kVersion)) data[kVersion] = kCurrentAuthVersion;
+  if (!version.has_value() || version == kCurrentEntityVersion) {
+    if (!data.contains(kVersion)) data[kVersion] = kCurrentEntityVersion;
     return;
   }
 
@@ -1863,7 +1863,7 @@ void MigrateAuthJson(nlohmann::json &data) {
   if (version == 2) {
     auto fg_it = data.find("fine_grained_access_handler");
     if (fg_it == data.end() || !fg_it->is_object()) {
-      data[kVersion] = kCurrentAuthVersion;
+      data[kVersion] = kCurrentEntityVersion;
       return;
     }
     // V2 permissions used bit_0 for read, bit_1 for update, and bit_2 for
@@ -1988,7 +1988,7 @@ void MigrateAuthJson(nlohmann::json &data) {
     }
   }
 
-  data[kVersion] = kCurrentAuthVersion;
+  data[kVersion] = kCurrentEntityVersion;
 }
 
 }  // namespace memgraph::auth

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1824,8 +1824,134 @@ PropertyAccessPermissions Roles::GetPropertyEdgeTypePermissions(std::optional<st
 }
 #endif  // MG_ENTERPRISE
 
-void MigrateAuthJson(nlohmann::json & /*data*/) {
-  // TODO: implement
+void MigrateAuthJson(nlohmann::json &data) {
+  if (!data.is_object()) return;
+
+  // --- V2 → V3: rename fine_grained_access_handler → fine_grained_permissions,
+  //              convert global_permission values from V2 enum to V3 bitmask,
+  //              add empty permissions array per sub-object.
+  if (auto fg_it = data.find("fine_grained_access_handler"); fg_it != data.end() && fg_it->is_object()) {
+    // V2 permissions used bit_0 for read, bit_1 for update, and bit_2 for
+    // create_delete, but note that the trailing bits are also set because the
+    // permission formed a hierarchy.
+    constexpr uint64_t kV2Read = 1;
+    constexpr uint64_t kV2Update = 3;
+    constexpr uint64_t kV2CreateDelete = 7;
+
+    // V3 permission bits: NOTHING=0, READ=1, UPDATE=2, CREATE=8, DELETE=16.
+    constexpr uint64_t kV3Read = 1;
+    constexpr uint64_t kV3Update = 2;
+    constexpr uint64_t kV3Create = 8;
+    constexpr uint64_t kV3Delete = 16;
+
+    auto const convert_v2_to_v3 = [&](uint64_t v2_perm) -> uint64_t {
+      switch (v2_perm) {
+        case kV2Read:
+          return kV3Read;
+        case kV2Update:
+          return kV3Update | kV3Read;
+        case kV2CreateDelete:
+          return kV3Create | kV3Delete | kV3Update | kV3Read;
+        default:
+          return 0;
+      }
+    };
+
+    for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
+      auto perm_it = fg_it->find(perm_type);
+      if (perm_it != fg_it->end() && perm_it->is_object()) {
+        auto global_it = perm_it->find("global_permission");
+        if (global_it != perm_it->end() && global_it->is_number_integer()) {
+          auto const v2_perm = global_it->template get<int64_t>();
+          if (v2_perm >= 0) {
+            *global_it = convert_v2_to_v3(static_cast<uint64_t>(v2_perm));
+          }
+        }
+        (*perm_it)["permissions"] = nlohmann::json::array();
+      }
+    }
+
+    data["fine_grained_permissions"] = std::move(*fg_it);
+    data.erase("fine_grained_access_handler");
+  }
+
+  // --- V3 → V4: split global_permission into global_grants/global_denies,
+  //              add denied field to per-entity rules,
+  //              expand UPDATE bit for labels.
+  auto fg_it = data.find("fine_grained_permissions");
+  if (fg_it == data.end() || !fg_it->is_object()) return;
+
+  // Local copies of FineGrainedPermission values. Duplicated here so that this
+  // migration runs even in community builds.
+  constexpr uint64_t kUpdate = 2;             // Old UPDATE bit
+  constexpr uint64_t kSetLabel = 32;          // FineGrainedPermission::SET_LABEL
+  constexpr uint64_t kRemoveLabel = 64;       // FineGrainedPermission::REMOVE_LABEL
+  constexpr uint64_t kSetProperty = 2;        // FineGrainedPermission::SET_PROPERTY
+  constexpr uint64_t kDeleteEdge = 128;       // FineGrainedPermission::DELETE_EDGE
+  constexpr uint64_t kCreateEdge = 256;       // FineGrainedPermission::CREATE_EDGE
+  constexpr uint64_t kAllLabelPerms = 507;    // kAllLabelPermissions
+  constexpr uint64_t kAllEdgeTypePerms = 27;  // kAllEdgeTypePermissions
+
+  // For labels: UPDATE -> SET_LABEL | REMOVE_LABEL | SET_PROPERTY | DELETE_EDGE | CREATE_EDGE
+  auto const migrate_label_permissions = [](uint64_t v3_perm) -> uint64_t {
+    uint64_t result = v3_perm;
+    if (result & kUpdate) {
+      result = (result & ~kUpdate) | kSetLabel | kRemoveLabel | kSetProperty | kDeleteEdge | kCreateEdge;
+    }
+    return result;
+  };
+
+  for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
+    bool const is_label = std::string_view{perm_type} == "label_permissions";
+    auto perm_it = fg_it->find(perm_type);
+    if (perm_it == fg_it->end() || !perm_it->is_object()) continue;
+    auto &perm_data = *perm_it;
+
+    // Migrate global_permission → global_grants / global_denies
+    if (auto global_it = perm_data.find("global_permission"); global_it != perm_data.end()) {
+      auto const old_perm = global_it->template get<int64_t>();
+      if (old_perm == 0) {
+        // NOTHING -> deny all
+        perm_data["global_grants"] = -1;
+        perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+      } else if (old_perm == -1) {
+        // No global permission set
+        perm_data["global_grants"] = -1;
+        perm_data["global_denies"] = -1;
+      } else {
+        auto new_perm = static_cast<uint64_t>(old_perm);
+        if (is_label) new_perm = migrate_label_permissions(new_perm);
+        perm_data["global_grants"] = new_perm;
+        perm_data["global_denies"] = -1;
+      }
+      perm_data.erase("global_permission");
+    }
+
+    // Migrate permissions: add "denied" field, migrate permission values for labels
+    auto perms_it = perm_data.find("permissions");
+    if (perms_it == perm_data.end() || !perms_it->is_array()) continue;
+
+    nlohmann::json new_permissions = nlohmann::json::array();
+    for (auto const &old_rule : *perms_it) {
+      nlohmann::json new_rule;
+      new_rule["symbols"] = old_rule.value("symbols", nlohmann::json::array());
+      new_rule["matching"] = old_rule.value("matching", "ANY");
+
+      auto const granted = old_rule.value("granted", int64_t{0});
+      if (granted == 0) {
+        // granted=0 (NOTHING) -> deny all
+        new_rule["granted"] = 0;
+        new_rule["denied"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+      } else {
+        auto new_granted = static_cast<uint64_t>(granted);
+        if (is_label) new_granted = migrate_label_permissions(new_granted);
+        new_rule["granted"] = new_granted;
+        new_rule["denied"] = 0;
+      }
+      new_permissions.push_back(std::move(new_rule));
+    }
+    perm_data["permissions"] = std::move(new_permissions);
+  }
 }
 
 }  // namespace memgraph::auth

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -41,6 +41,7 @@ namespace r = std::ranges;
 constexpr auto kGlobalGrants = "global_grants";
 constexpr auto kGlobalDenies = "global_denies";
 constexpr auto kFineGrainedPermissions = "fine_grained_permissions";
+constexpr auto kFineGrainedAccessHandler = "fine_grained_access_handler";
 constexpr auto kLabelPermissions = "label_permissions";
 constexpr auto kEdgeTypePermissions = "edge_type_permissions";
 constexpr auto kAllowAll = "allow_all";
@@ -1836,25 +1837,153 @@ std::optional<int> DeduceVersion(nlohmann::json const &data) {
     return it->get<int>();
   }
   // Check both old and new key names for the fine-grained permissions block.
-  // 3.9 uses `fine_grained_access_handler` but with V3-style content (V3
+  // 3.9 uses kFineGrainedAccessHandler but with V3-style content (V3
   // bitmasks + permissions array); true V2 (pre-3.8) also uses that key but
   // with V2-style enum values and no permissions array. We must inspect the
   // sub-objects to distinguish them.
-  for (auto const &fg_key : {"fine_grained_permissions", "fine_grained_access_handler"}) {
+  for (auto const &fg_key : {kFineGrainedPermissions, kFineGrainedAccessHandler}) {
     if (auto fg = data.find(fg_key); fg != data.end() && fg->is_object()) {
-      for (auto const &key : {"label_permissions", "edge_type_permissions"}) {
+      for (auto const &key : {kLabelPermissions, kEdgeTypePermissions}) {
         if (auto sub = fg->find(key); sub != fg->end() && sub->is_object()) {
-          if (sub->contains("global_grants")) return 4;
+          if (sub->contains(kGlobalGrants)) return 4;
           if (sub->contains("global_permission") && sub->contains("permissions") && (*sub)["permissions"].is_array())
             return 3;
           if (sub->contains("global_permission")) return 2;
         }
       }
-      // Has the FGA block but no recognisable sub-objects
-      if (std::string_view{fg_key} == "fine_grained_access_handler") return 2;
+      if (std::string_view{fg_key} == kFineGrainedAccessHandler) return 2;
     }
   }
   return std::nullopt;
+}
+
+// V2 → V3: rename fine_grained_access_handler to fine_grained_permissions,
+//           convert global_permission values from V2 enum to V3 bitmask,
+//           add empty permissions array per sub-object.
+void MigrateV2ToV3(nlohmann::json &data) {
+  auto fg_it = data.find(kFineGrainedAccessHandler);
+  DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
+
+  constexpr uint64_t kV2Read = 1;
+  constexpr uint64_t kV2Update = 3;
+  constexpr uint64_t kV2CreateDelete = 7;
+  constexpr uint64_t kV3Read = 1;
+  constexpr uint64_t kV3Update = 2;
+  constexpr uint64_t kV3Create = 8;
+  constexpr uint64_t kV3Delete = 16;
+
+  auto const convert_v2_to_v3 = [](uint64_t v2_perm) -> uint64_t {
+    switch (v2_perm) {
+      case kV2Read:
+        return kV3Read;
+      case kV2Update:
+        return kV3Update | kV3Read;
+      case kV2CreateDelete:
+        return kV3Create | kV3Delete | kV3Update | kV3Read;
+      default:
+        return 0;
+    }
+  };
+
+  for (auto const &perm_type : {kLabelPermissions, kEdgeTypePermissions}) {
+    auto perm_it = fg_it->find(perm_type);
+    if (perm_it != fg_it->end() && perm_it->is_object()) {
+      auto global_it = perm_it->find("global_permission");
+      if (global_it != perm_it->end() && global_it->is_number_integer()) {
+        auto const v2_perm = global_it->get<int64_t>();
+        if (v2_perm >= 0) {
+          *global_it = convert_v2_to_v3(static_cast<uint64_t>(v2_perm));
+        }
+      }
+      if (!perm_it->contains("permissions") || !(*perm_it)["permissions"].is_array()) {
+        (*perm_it)["permissions"] = nlohmann::json::array();
+      }
+    }
+  }
+
+  data[kFineGrainedPermissions] = std::move(*fg_it);
+  data.erase(kFineGrainedAccessHandler);
+}
+
+// V3 → V4: split global_permission into global_grants/global_denies,
+//           add denied field to per-entity rules,
+//           expand UPDATE bit for labels.
+void MigrateV3ToV4(nlohmann::json &data) {
+  // Handle V3 content stored under the old key name (pre-3.8 transitional)
+  if (data.contains(kFineGrainedAccessHandler) && !data.contains(kFineGrainedPermissions)) {
+    data[kFineGrainedPermissions] = std::move(data[kFineGrainedAccessHandler]);
+    data.erase(kFineGrainedAccessHandler);
+  }
+
+  auto fg_it = data.find(kFineGrainedPermissions);
+  DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
+
+  // Local copies of FineGrainedPermission values. Duplicated here so that this
+  // migration runs even in community builds.
+  constexpr uint64_t kUpdate = 2;             // Old UPDATE bit
+  constexpr uint64_t kSetLabel = 32;          // FineGrainedPermission::SET_LABEL
+  constexpr uint64_t kRemoveLabel = 64;       // FineGrainedPermission::REMOVE_LABEL
+  constexpr uint64_t kSetProperty = 2;        // FineGrainedPermission::SET_PROPERTY
+  constexpr uint64_t kDeleteEdge = 128;       // FineGrainedPermission::DELETE_EDGE
+  constexpr uint64_t kCreateEdge = 256;       // FineGrainedPermission::CREATE_EDGE
+  constexpr uint64_t kAllLabelPerms = 507;    // kAllLabelPermissions
+  constexpr uint64_t kAllEdgeTypePerms = 27;  // kAllEdgeTypePermissions
+
+  auto const migrate_label_permissions = [](uint64_t v3_perm) -> uint64_t {
+    uint64_t result = v3_perm;
+    if (result & kUpdate) {
+      result = (result & ~kUpdate) | kSetLabel | kRemoveLabel | kSetProperty | kDeleteEdge | kCreateEdge;
+    }
+    return result;
+  };
+
+  for (auto const &perm_type : {kLabelPermissions, kEdgeTypePermissions}) {
+    bool const is_label = std::string_view{perm_type} == kLabelPermissions;
+    auto perm_it = fg_it->find(perm_type);
+    if (perm_it == fg_it->end() || !perm_it->is_object()) continue;
+    auto &perm_data = *perm_it;
+
+    auto global_it = perm_data.find("global_permission");
+    if (global_it != perm_data.end() && global_it->is_number_integer()) {
+      auto const old_perm = global_it->get<int64_t>();
+      if (old_perm == 0) {
+        perm_data[kGlobalGrants] = -1;
+        perm_data[kGlobalDenies] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+      } else if (old_perm == -1) {
+        perm_data[kGlobalGrants] = -1;
+        perm_data[kGlobalDenies] = -1;
+      } else {
+        auto new_perm = static_cast<uint64_t>(old_perm);
+        if (is_label) new_perm = migrate_label_permissions(new_perm);
+        perm_data[kGlobalGrants] = new_perm;
+        perm_data[kGlobalDenies] = -1;
+      }
+      perm_data.erase("global_permission");
+    }
+
+    auto perms_it = perm_data.find("permissions");
+    if (perms_it == perm_data.end() || !perms_it->is_array()) continue;
+
+    nlohmann::json new_permissions = nlohmann::json::array();
+    for (auto const &old_rule : *perms_it) {
+      nlohmann::json new_rule;
+      new_rule[kSymbols] = old_rule.value(kSymbols, nlohmann::json::array());
+      new_rule[kMatching] = old_rule.value(kMatching, "ANY");
+
+      auto const granted = old_rule.value(kGranted, int64_t{0});
+      if (granted == 0) {
+        new_rule[kGranted] = 0;
+        new_rule[kDenied] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+      } else {
+        auto new_granted = static_cast<uint64_t>(granted);
+        if (is_label) new_granted = migrate_label_permissions(new_granted);
+        new_rule[kGranted] = new_granted;
+        new_rule[kDenied] = 0;
+      }
+      new_permissions.push_back(std::move(new_rule));
+    }
+    perm_data["permissions"] = std::move(new_permissions);
+  }
 }
 }  // namespace
 
@@ -1874,142 +2003,13 @@ void MigrateAuthJson(nlohmann::json &data) {
     return;
   }
 
-  // V2 to V3: rename fine_grained_access_handler to fine_grained_permissions,
-  //           convert global_permission values from V2 enum to V3 bitmask,
-  //           add empty permissions array per sub-object.
   if (version == 2) {
-    // DeduceVersion returned 2 based on the shape of this key, so it must exist.
-    auto fg_it = data.find("fine_grained_access_handler");
-    DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
-    // V2 permissions used bit_0 for read, bit_1 for update, and bit_2 for
-    // create_delete, but note that the trailing bits are also set because the
-    // permission formed a hierarchy.
-    constexpr uint64_t kV2Read = 1;
-    constexpr uint64_t kV2Update = 3;
-    constexpr uint64_t kV2CreateDelete = 7;
-
-    // V3 permission bits: NOTHING=0, READ=1, UPDATE=2, CREATE=8, DELETE=16.
-    constexpr uint64_t kV3Read = 1;
-    constexpr uint64_t kV3Update = 2;
-    constexpr uint64_t kV3Create = 8;
-    constexpr uint64_t kV3Delete = 16;
-
-    auto const convert_v2_to_v3 = [](uint64_t v2_perm) -> uint64_t {
-      switch (v2_perm) {
-        case kV2Read:
-          return kV3Read;
-        case kV2Update:
-          return kV3Update | kV3Read;
-        case kV2CreateDelete:
-          return kV3Create | kV3Delete | kV3Update | kV3Read;
-        default:
-          return 0;
-      }
-    };
-
-    for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
-      auto perm_it = fg_it->find(perm_type);
-      if (perm_it != fg_it->end() && perm_it->is_object()) {
-        auto global_it = perm_it->find("global_permission");
-        if (global_it != perm_it->end() && global_it->is_number_integer()) {
-          auto const v2_perm = global_it->get<int64_t>();
-          if (v2_perm >= 0) {
-            *global_it = convert_v2_to_v3(static_cast<uint64_t>(v2_perm));
-          }
-        }
-        if (!perm_it->contains("permissions") || !(*perm_it)["permissions"].is_array()) {
-          (*perm_it)["permissions"] = nlohmann::json::array();
-        }
-      }
-    }
-
-    data["fine_grained_permissions"] = std::move(*fg_it);
-    data.erase("fine_grained_access_handler");
-
+    MigrateV2ToV3(data);
     version = 3;
   }
 
-  // V3 to V4: split global_permission into global_grants/global_denies,
-  //           add denied field to per-entity rules,
-  //           expand UPDATE bit for labels.
   if (version == 3) {
-    // Handle V3 content stored under the old key name (pre-3.8 transitional)
-    if (data.contains("fine_grained_access_handler") && !data.contains("fine_grained_permissions")) {
-      data["fine_grained_permissions"] = std::move(data["fine_grained_access_handler"]);
-      data.erase("fine_grained_access_handler");
-    }
-    // DeduceVersion returned 3 based on the shape of this key, so it must exist
-    // (after the rename above for the old-key case).
-    auto fg_it = data.find("fine_grained_permissions");
-    DMG_ASSERT(fg_it != data.end() && fg_it->is_object());
-
-    // Local copies of FineGrainedPermission values. Duplicated here so that this
-    // migration runs even in community builds.
-    constexpr uint64_t kUpdate = 2;             // Old UPDATE bit
-    constexpr uint64_t kSetLabel = 32;          // FineGrainedPermission::SET_LABEL
-    constexpr uint64_t kRemoveLabel = 64;       // FineGrainedPermission::REMOVE_LABEL
-    constexpr uint64_t kSetProperty = 2;        // FineGrainedPermission::SET_PROPERTY
-    constexpr uint64_t kDeleteEdge = 128;       // FineGrainedPermission::DELETE_EDGE
-    constexpr uint64_t kCreateEdge = 256;       // FineGrainedPermission::CREATE_EDGE
-    constexpr uint64_t kAllLabelPerms = 507;    // kAllLabelPermissions
-    constexpr uint64_t kAllEdgeTypePerms = 27;  // kAllEdgeTypePermissions
-
-    // For labels: UPDATE -> SET_LABEL | REMOVE_LABEL | SET_PROPERTY | DELETE_EDGE | CREATE_EDGE
-    auto const migrate_label_permissions = [](uint64_t v3_perm) -> uint64_t {
-      uint64_t result = v3_perm;
-      if (result & kUpdate) {
-        result = (result & ~kUpdate) | kSetLabel | kRemoveLabel | kSetProperty | kDeleteEdge | kCreateEdge;
-      }
-      return result;
-    };
-
-    for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
-      bool const is_label = std::string_view{perm_type} == "label_permissions";
-      auto perm_it = fg_it->find(perm_type);
-      if (perm_it == fg_it->end() || !perm_it->is_object()) continue;
-      auto &perm_data = *perm_it;
-
-      auto global_it = perm_data.find("global_permission");
-      if (global_it != perm_data.end() && global_it->is_number_integer()) {
-        auto const old_perm = global_it->get<int64_t>();
-        if (old_perm == 0) {
-          perm_data["global_grants"] = -1;
-          perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
-        } else if (old_perm == -1) {
-          perm_data["global_grants"] = -1;
-          perm_data["global_denies"] = -1;
-        } else {
-          auto new_perm = static_cast<uint64_t>(old_perm);
-          if (is_label) new_perm = migrate_label_permissions(new_perm);
-          perm_data["global_grants"] = new_perm;
-          perm_data["global_denies"] = -1;
-        }
-        perm_data.erase("global_permission");
-      }
-
-      auto perms_it = perm_data.find("permissions");
-      if (perms_it == perm_data.end() || !perms_it->is_array()) continue;
-
-      nlohmann::json new_permissions = nlohmann::json::array();
-      for (auto const &old_rule : *perms_it) {
-        nlohmann::json new_rule;
-        new_rule["symbols"] = old_rule.value("symbols", nlohmann::json::array());
-        new_rule["matching"] = old_rule.value("matching", "ANY");
-
-        auto const granted = old_rule.value("granted", int64_t{0});
-        if (granted == 0) {
-          new_rule["granted"] = 0;
-          new_rule["denied"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
-        } else {
-          auto new_granted = static_cast<uint64_t>(granted);
-          if (is_label) new_granted = migrate_label_permissions(new_granted);
-          new_rule["granted"] = new_granted;
-          new_rule["denied"] = 0;
-        }
-        new_permissions.push_back(std::move(new_rule));
-      }
-      perm_data["permissions"] = std::move(new_permissions);
-    }
+    MigrateV3ToV4(data);
   }
 
   data[kVersion] = kCurrentEntityVersion;

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -24,6 +24,8 @@
 namespace memgraph::auth {
 namespace {
 
+constexpr auto kVersion = "version";
+constexpr int kCurrentAuthVersion = 4;
 constexpr auto kRoleName = "rolename";
 constexpr auto kBuiltIn = "builtin";
 constexpr auto kPermissions = "permissions";
@@ -1019,6 +1021,7 @@ const FineGrainedAccessPermissions &Role::GetFineGrainedAccessEdgeTypePermission
 
 nlohmann::json Role::Serialize() const {
   nlohmann::json data = nlohmann::json::object();
+  data[kVersion] = kCurrentAuthVersion;
   data[kRoleName] = rolename_;
   data[kBuiltIn] = is_builtin_;
   data[kPermissions] = permissions_.Serialize();
@@ -1485,6 +1488,7 @@ PropertyAccessHandler &User::property_access_handler() { return property_access_
 nlohmann::json User::Serialize() const {
   // NOTE: Role and Profile are stored as links to the role and profile lists.
   nlohmann::json data = nlohmann::json::object();
+  data[kVersion] = kCurrentAuthVersion;
   data[kUsername] = username_;
   data[kUUID] = uuid_;
   if (password_hash_) {
@@ -1824,13 +1828,38 @@ PropertyAccessPermissions Roles::GetPropertyEdgeTypePermissions(std::optional<st
 }
 #endif  // MG_ENTERPRISE
 
+namespace {
+// Deduce the auth version from its shape. Returns nullopt if the format is
+// unrecognised (which will happen for community users without any fine-grained
+// permissions.)
+std::optional<int> DeduceVersion(nlohmann::json const &data) {
+  if (auto it = data.find(kVersion); it != data.end() && it->is_number_integer()) {
+    return it->get<int>();
+  }
+  if (data.contains("fine_grained_access_handler")) return 2;
+  if (auto fg = data.find("fine_grained_permissions"); fg != data.end() && fg->is_object()) {
+    for (auto const &key : {"label_permissions", "edge_type_permissions"}) {
+      if (auto sub = fg->find(key); sub != fg->end() && sub->is_object()) {
+        if (sub->contains("global_permission")) return 3;
+        if (sub->contains("global_grants")) return 4;
+      }
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace
+
 void MigrateAuthJson(nlohmann::json &data) {
   if (!data.is_object()) return;
 
-  // --- V2 → V3: rename fine_grained_access_handler → fine_grained_permissions,
-  //              convert global_permission values from V2 enum to V3 bitmask,
-  //              add empty permissions array per sub-object.
-  if (auto fg_it = data.find("fine_grained_access_handler"); fg_it != data.end() && fg_it->is_object()) {
+  auto version = DeduceVersion(data);
+  if (!version.has_value() || version == kCurrentAuthVersion) return;
+
+  // V2 to V3: rename fine_grained_access_handler to fine_grained_permissions,
+  //           convert global_permission values from V2 enum to V3 bitmask,
+  //           add empty permissions array per sub-object.
+  if (version == 2) {
+    auto fg_it = data.find("fine_grained_access_handler");
     // V2 permissions used bit_0 for read, bit_1 for update, and bit_2 for
     // create_delete, but note that the trailing bits are also set because the
     // permission formed a hierarchy.
@@ -1873,87 +1902,87 @@ void MigrateAuthJson(nlohmann::json &data) {
 
     data["fine_grained_permissions"] = std::move(*fg_it);
     data.erase("fine_grained_access_handler");
+
+    version = 3;
   }
 
-  // --- V3 → V4: split global_permission into global_grants/global_denies,
-  //              add denied field to per-entity rules,
-  //              expand UPDATE bit for labels.
-  auto fg_it = data.find("fine_grained_permissions");
-  if (fg_it == data.end() || !fg_it->is_object()) return;
+  // V3 to V4: split global_permission into global_grants/global_denies,
+  //           add denied field to per-entity rules,
+  //           expand UPDATE bit for labels.
+  if (version == 3) {
+    auto fg_it = data.find("fine_grained_permissions");
+    if (fg_it == data.end() || !fg_it->is_object()) return;
 
-  // Local copies of FineGrainedPermission values. Duplicated here so that this
-  // migration runs even in community builds.
-  constexpr uint64_t kUpdate = 2;             // Old UPDATE bit
-  constexpr uint64_t kSetLabel = 32;          // FineGrainedPermission::SET_LABEL
-  constexpr uint64_t kRemoveLabel = 64;       // FineGrainedPermission::REMOVE_LABEL
-  constexpr uint64_t kSetProperty = 2;        // FineGrainedPermission::SET_PROPERTY
-  constexpr uint64_t kDeleteEdge = 128;       // FineGrainedPermission::DELETE_EDGE
-  constexpr uint64_t kCreateEdge = 256;       // FineGrainedPermission::CREATE_EDGE
-  constexpr uint64_t kAllLabelPerms = 507;    // kAllLabelPermissions
-  constexpr uint64_t kAllEdgeTypePerms = 27;  // kAllEdgeTypePermissions
+    // Local copies of FineGrainedPermission values. Duplicated here so that this
+    // migration runs even in community builds.
+    constexpr uint64_t kUpdate = 2;             // Old UPDATE bit
+    constexpr uint64_t kSetLabel = 32;          // FineGrainedPermission::SET_LABEL
+    constexpr uint64_t kRemoveLabel = 64;       // FineGrainedPermission::REMOVE_LABEL
+    constexpr uint64_t kSetProperty = 2;        // FineGrainedPermission::SET_PROPERTY
+    constexpr uint64_t kDeleteEdge = 128;       // FineGrainedPermission::DELETE_EDGE
+    constexpr uint64_t kCreateEdge = 256;       // FineGrainedPermission::CREATE_EDGE
+    constexpr uint64_t kAllLabelPerms = 507;    // kAllLabelPermissions
+    constexpr uint64_t kAllEdgeTypePerms = 27;  // kAllEdgeTypePermissions
 
-  // For labels: UPDATE -> SET_LABEL | REMOVE_LABEL | SET_PROPERTY | DELETE_EDGE | CREATE_EDGE
-  auto const migrate_label_permissions = [](uint64_t v3_perm) -> uint64_t {
-    uint64_t result = v3_perm;
-    if (result & kUpdate) {
-      result = (result & ~kUpdate) | kSetLabel | kRemoveLabel | kSetProperty | kDeleteEdge | kCreateEdge;
-    }
-    return result;
-  };
-
-  for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
-    bool const is_label = std::string_view{perm_type} == "label_permissions";
-    auto perm_it = fg_it->find(perm_type);
-    if (perm_it == fg_it->end() || !perm_it->is_object()) continue;
-    auto &perm_data = *perm_it;
-
-    // Migrate global_permission → global_grants / global_denies
-    auto global_it = perm_data.find("global_permission");
-    if (global_it == perm_data.end()) continue;  // Already V4
-    if (!global_it->is_number_integer()) continue;
-
-    auto const old_perm = global_it->template get<int64_t>();
-    if (old_perm == 0) {
-      // NOTHING -> deny all
-      perm_data["global_grants"] = -1;
-      perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
-    } else if (old_perm == -1) {
-      // No global permission set
-      perm_data["global_grants"] = -1;
-      perm_data["global_denies"] = -1;
-    } else {
-      auto new_perm = static_cast<uint64_t>(old_perm);
-      if (is_label) new_perm = migrate_label_permissions(new_perm);
-      perm_data["global_grants"] = new_perm;
-      perm_data["global_denies"] = -1;
-    }
-    perm_data.erase("global_permission");
-
-    // Migrate permissions: add "denied" field, migrate permission values for labels
-    auto perms_it = perm_data.find("permissions");
-    if (perms_it == perm_data.end() || !perms_it->is_array()) continue;
-
-    nlohmann::json new_permissions = nlohmann::json::array();
-    for (auto const &old_rule : *perms_it) {
-      nlohmann::json new_rule;
-      new_rule["symbols"] = old_rule.value("symbols", nlohmann::json::array());
-      new_rule["matching"] = old_rule.value("matching", "ANY");
-
-      auto const granted = old_rule.value("granted", int64_t{0});
-      if (granted == 0) {
-        // granted=0 (NOTHING) -> deny all
-        new_rule["granted"] = 0;
-        new_rule["denied"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
-      } else {
-        auto new_granted = static_cast<uint64_t>(granted);
-        if (is_label) new_granted = migrate_label_permissions(new_granted);
-        new_rule["granted"] = new_granted;
-        new_rule["denied"] = 0;
+    // For labels: UPDATE -> SET_LABEL | REMOVE_LABEL | SET_PROPERTY | DELETE_EDGE | CREATE_EDGE
+    auto const migrate_label_permissions = [](uint64_t v3_perm) -> uint64_t {
+      uint64_t result = v3_perm;
+      if (result & kUpdate) {
+        result = (result & ~kUpdate) | kSetLabel | kRemoveLabel | kSetProperty | kDeleteEdge | kCreateEdge;
       }
-      new_permissions.push_back(std::move(new_rule));
+      return result;
+    };
+
+    for (auto const &perm_type : {"label_permissions", "edge_type_permissions"}) {
+      bool const is_label = std::string_view{perm_type} == "label_permissions";
+      auto perm_it = fg_it->find(perm_type);
+      if (perm_it == fg_it->end() || !perm_it->is_object()) continue;
+      auto &perm_data = *perm_it;
+
+      auto global_it = perm_data.find("global_permission");
+      if (global_it == perm_data.end() || !global_it->is_number_integer()) continue;
+
+      auto const old_perm = global_it->template get<int64_t>();
+      if (old_perm == 0) {
+        perm_data["global_grants"] = -1;
+        perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+      } else if (old_perm == -1) {
+        perm_data["global_grants"] = -1;
+        perm_data["global_denies"] = -1;
+      } else {
+        auto new_perm = static_cast<uint64_t>(old_perm);
+        if (is_label) new_perm = migrate_label_permissions(new_perm);
+        perm_data["global_grants"] = new_perm;
+        perm_data["global_denies"] = -1;
+      }
+      perm_data.erase("global_permission");
+
+      auto perms_it = perm_data.find("permissions");
+      if (perms_it == perm_data.end() || !perms_it->is_array()) continue;
+
+      nlohmann::json new_permissions = nlohmann::json::array();
+      for (auto const &old_rule : *perms_it) {
+        nlohmann::json new_rule;
+        new_rule["symbols"] = old_rule.value("symbols", nlohmann::json::array());
+        new_rule["matching"] = old_rule.value("matching", "ANY");
+
+        auto const granted = old_rule.value("granted", int64_t{0});
+        if (granted == 0) {
+          new_rule["granted"] = 0;
+          new_rule["denied"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);
+        } else {
+          auto new_granted = static_cast<uint64_t>(granted);
+          if (is_label) new_granted = migrate_label_permissions(new_granted);
+          new_rule["granted"] = new_granted;
+          new_rule["denied"] = 0;
+        }
+        new_permissions.push_back(std::move(new_rule));
+      }
+      perm_data["permissions"] = std::move(new_permissions);
     }
-    perm_data["permissions"] = std::move(new_permissions);
   }
+
+  data[kVersion] = kCurrentAuthVersion;
 }
 
 }  // namespace memgraph::auth

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1912,7 +1912,7 @@ void MigrateAuthJson(nlohmann::json &data) {
       if (perm_it != fg_it->end() && perm_it->is_object()) {
         auto global_it = perm_it->find("global_permission");
         if (global_it != perm_it->end() && global_it->is_number_integer()) {
-          auto const v2_perm = global_it->template get<int64_t>();
+          auto const v2_perm = global_it->get<int64_t>();
           if (v2_perm >= 0) {
             *global_it = convert_v2_to_v3(static_cast<uint64_t>(v2_perm));
           }
@@ -1971,7 +1971,7 @@ void MigrateAuthJson(nlohmann::json &data) {
 
       auto global_it = perm_data.find("global_permission");
       if (global_it != perm_data.end() && global_it->is_number_integer()) {
-        auto const old_perm = global_it->template get<int64_t>();
+        auto const old_perm = global_it->get<int64_t>();
         if (old_perm == 0) {
           perm_data["global_grants"] = -1;
           perm_data["global_denies"] = static_cast<int64_t>(is_label ? kAllLabelPerms : kAllEdgeTypePerms);

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -1119,6 +1119,8 @@ FineGrainedAccessPermissions Merge(const FineGrainedAccessPermissions &first,
                                    const FineGrainedAccessPermissions &second);
 #endif
 
+constexpr int kCurrentAuthVersion = 4;
+
 /// Migrate a single user or role JSON object to the latest format in-place.
 void MigrateAuthJson(nlohmann::json &data);
 

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -1120,9 +1120,6 @@ FineGrainedAccessPermissions Merge(const FineGrainedAccessPermissions &first,
 #endif
 
 /// Migrate a single user or role JSON object to the latest format in-place.
-/// Detects the version by JSON shape and applies migrations as needed.
-/// Already-current input is a no-op. Handles FGA JSON structure changes only
-/// (V1→V2 role-link/password-hash migration is not relevant here).
 void MigrateAuthJson(nlohmann::json &data);
 
 }  // namespace memgraph::auth

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -1119,4 +1119,10 @@ FineGrainedAccessPermissions Merge(const FineGrainedAccessPermissions &first,
                                    const FineGrainedAccessPermissions &second);
 #endif
 
+/// Migrate a single user or role JSON object to the latest format in-place.
+/// Detects the version by JSON shape and applies migrations as needed.
+/// Already-current input is a no-op. Handles FGA JSON structure changes only
+/// (V1→V2 role-link/password-hash migration is not relevant here).
+void MigrateAuthJson(nlohmann::json &data);
+
 }  // namespace memgraph::auth

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -1119,7 +1119,7 @@ FineGrainedAccessPermissions Merge(const FineGrainedAccessPermissions &first,
                                    const FineGrainedAccessPermissions &second);
 #endif
 
-constexpr int kCurrentAuthVersion = 4;
+constexpr int kCurrentEntityVersion = 4;
 
 /// Migrate a single user or role JSON object to the latest format in-place.
 void MigrateAuthJson(nlohmann::json &data);

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -122,7 +122,6 @@ inline constexpr std::array kPermissionsAll = {
 };
 // clang-format on
 
-#ifdef MG_ENTERPRISE
 // clang-format off
 enum class FineGrainedPermission : uint64_t {
   NONE          = 0,
@@ -160,20 +159,18 @@ constexpr FineGrainedPermission operator~(FineGrainedPermission permission) {
 }
 
 constexpr FineGrainedPermission kAllLabelPermissions =
-    memgraph::auth::FineGrainedPermission::CREATE | memgraph::auth::FineGrainedPermission::DELETE |
-    memgraph::auth::FineGrainedPermission::READ | memgraph::auth::FineGrainedPermission::SET_LABEL |
-    memgraph::auth::FineGrainedPermission::REMOVE_LABEL | memgraph::auth::FineGrainedPermission::SET_PROPERTY |
-    memgraph::auth::FineGrainedPermission::DELETE_EDGE | memgraph::auth::FineGrainedPermission::CREATE_EDGE;
+    FineGrainedPermission::CREATE | FineGrainedPermission::DELETE | FineGrainedPermission::READ |
+    FineGrainedPermission::SET_LABEL | FineGrainedPermission::REMOVE_LABEL | FineGrainedPermission::SET_PROPERTY |
+    FineGrainedPermission::DELETE_EDGE | FineGrainedPermission::CREATE_EDGE;
 
-constexpr FineGrainedPermission kAllEdgeTypePermissions =
-    memgraph::auth::FineGrainedPermission::CREATE | memgraph::auth::FineGrainedPermission::DELETE |
-    memgraph::auth::FineGrainedPermission::READ | memgraph::auth::FineGrainedPermission::SET_PROPERTY;
+constexpr FineGrainedPermission kAllEdgeTypePermissions = FineGrainedPermission::CREATE |
+                                                          FineGrainedPermission::DELETE | FineGrainedPermission::READ |
+                                                          FineGrainedPermission::SET_PROPERTY;
 
 // Cypher UPDATE on node labels expands to these discrete permissions (Memgraph 3.9+).
 constexpr FineGrainedPermission kVertexLabelUpdatePermissions =
     FineGrainedPermission::SET_LABEL | FineGrainedPermission::REMOVE_LABEL | FineGrainedPermission::SET_PROPERTY |
     FineGrainedPermission::DELETE_EDGE | FineGrainedPermission::CREATE_EDGE;
-#endif
 
 // Function that converts a permission to its string representation.
 std::string PermissionToString(Permission permission);

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -166,14 +166,19 @@ void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk:
   memgraph::slk::Save(has_user, builder);
   if (has_user) {
     memgraph::slk::Save(*self.user_json, builder);
-    static std::vector<std::string> const kEmptyRoleJsons;
-    auto const &role_jsons = self.user_role_jsons ? *self.user_role_jsons : kEmptyRoleJsons;
-    memgraph::slk::Save(static_cast<uint64_t>(role_jsons.size()), builder);
-    for (auto const &rj : role_jsons) {
-      memgraph::slk::Save(rj, builder);
+    if (self.user_role_jsons) {
+      memgraph::slk::Save(static_cast<uint64_t>(self.user_role_jsons->size()), builder);
+      for (auto const &rj : *self.user_role_jsons) {
+        memgraph::slk::Save(rj, builder);
+      }
+    } else {
+      memgraph::slk::Save(static_cast<uint64_t>(0), builder);
     }
-    static std::unordered_map<std::string, std::unordered_set<std::string>> const kEmptyMtMap;
-    memgraph::slk::Save(self.user_mt_mappings ? *self.user_mt_mappings : kEmptyMtMap, builder);
+    if (self.user_mt_mappings) {
+      memgraph::slk::Save(*self.user_mt_mappings, builder);
+    } else {
+      memgraph::slk::Save(std::unordered_map<std::string, std::unordered_set<std::string>>{}, builder);
+    }
   }
   bool const has_role = self.role_json.has_value();
   memgraph::slk::Save(has_role, builder);

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -52,9 +52,13 @@ namespace {
 auth::Role LoadAuthRole(memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
-  auto json = nlohmann::json::parse(tmp);
-  memgraph::auth::MigrateAuthJson(json);
-  return memgraph::auth::Role::Deserialize(json);
+  try {
+    auto json = nlohmann::json::parse(tmp);
+    memgraph::auth::MigrateAuthJson(json);
+    return memgraph::auth::Role::Deserialize(json);
+  } catch (nlohmann::json::exception const &e) {
+    throw auth::AuthException("Failed to deserialize role from RPC: {}", e.what());
+  }
 }
 }  // namespace
 
@@ -87,9 +91,13 @@ void Save(const auth::User &self, memgraph::slk::Builder *builder) {
 void Load(auth::User *self, memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
-  auto json = nlohmann::json::parse(tmp);
-  memgraph::auth::MigrateAuthJson(json);
-  *self = memgraph::auth::User::Deserialize(json);
+  try {
+    auto json = nlohmann::json::parse(tmp);
+    memgraph::auth::MigrateAuthJson(json);
+    *self = memgraph::auth::User::Deserialize(json);
+  } catch (nlohmann::json::exception const &e) {
+    throw auth::AuthException("Failed to deserialize user from RPC: {}", e.what());
+  }
   std::vector<auth::Role> roles;
   memgraph::slk::Load(&roles, reader);
 #ifdef MG_ENTERPRISE

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -89,7 +89,7 @@ auth::User LoadAndMigrateUser(memgraph::slk::Reader *reader) {
   return user;
 }
 
-std::string LoadRoleJsonRaw(memgraph::slk::Reader *reader) {
+std::string LoadJsonStringRaw(memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
   return tmp;
@@ -203,7 +203,7 @@ void Load(memgraph::replication::UpdateAuthDataReqV1 *self, memgraph::slk::Reade
     std::vector<std::string> role_jsons;
     role_jsons.reserve(num_roles);
     for (uint64_t i = 0; i < num_roles; ++i) {
-      role_jsons.push_back(LoadRoleJsonRaw(reader));
+      role_jsons.push_back(LoadJsonStringRaw(reader));
     }
     self->user_role_jsons = std::move(role_jsons);
 
@@ -216,7 +216,7 @@ void Load(memgraph::replication::UpdateAuthDataReqV1 *self, memgraph::slk::Reade
   bool has_role = false;
   memgraph::slk::Load(&has_role, reader);
   if (has_role) {
-    self->role_json = LoadRoleJsonRaw(reader);
+    self->role_json = LoadJsonStringRaw(reader);
   }
 
   // Profile (unchanged format)

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -13,6 +13,7 @@
 
 #include <nlohmann/json.hpp>
 #include "auth/auth.hpp"
+#include "auth/models.hpp"
 #include "auth/profiles/user_profiles.hpp"
 #include "slk/serialization.hpp"
 #include "slk/streams.hpp"
@@ -26,9 +27,9 @@ namespace {
 auth::Role LoadAuthRole(memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
-  const auto json = nlohmann::json::parse(tmp);
-  auto role = memgraph::auth::Role::Deserialize(json);
-  return role;
+  auto json = nlohmann::json::parse(tmp);
+  memgraph::auth::MigrateAuthJson(json);
+  return memgraph::auth::Role::Deserialize(json);
 }
 }  // namespace
 
@@ -62,7 +63,8 @@ void Save(const auth::User &self, memgraph::slk::Builder *builder) {
 void Load(auth::User *self, memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
-  const auto json = nlohmann::json::parse(tmp);
+  auto json = nlohmann::json::parse(tmp);
+  memgraph::auth::MigrateAuthJson(json);
   *self = memgraph::auth::User::Deserialize(json);
   std::vector<auth::Role> roles;
   memgraph::slk::Load(&roles, reader);

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -55,12 +55,6 @@ auth::Role LoadAuthRole(memgraph::slk::Reader *reader) {
   memgraph::auth::MigrateAuthJson(json);
   return memgraph::auth::Role::Deserialize(json);
 }
-
-std::string LoadJsonStringRaw(memgraph::slk::Reader *reader) {
-  std::string tmp;
-  memgraph::slk::Load(&tmp, reader);
-  return tmp;
-}
 }  // namespace
 
 // Deserialize code for auth::Role
@@ -126,76 +120,6 @@ void Load(auth::Auth::Config *self, memgraph::slk::Reader *reader) {
   *self = auth::Auth::Config{std::move(name_regex_str), std::move(password_regex_str), password_permit_null};
 }
 
-void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self.main_uuid, builder);
-  memgraph::slk::Save(self.expected_group_timestamp, builder);
-  memgraph::slk::Save(self.new_group_timestamp, builder);
-  bool const has_user = self.user_json.has_value();
-  memgraph::slk::Save(has_user, builder);
-  if (has_user) {
-    memgraph::slk::Save(*self.user_json, builder);
-    if (self.user_role_jsons) {
-      memgraph::slk::Save(static_cast<uint64_t>(self.user_role_jsons->size()), builder);
-      for (auto const &rj : *self.user_role_jsons) {
-        memgraph::slk::Save(rj, builder);
-      }
-    } else {
-      memgraph::slk::Save(static_cast<uint64_t>(0), builder);
-    }
-    if (self.user_mt_mappings) {
-      memgraph::slk::Save(*self.user_mt_mappings, builder);
-    } else {
-      memgraph::slk::Save(std::unordered_map<std::string, std::unordered_set<std::string>>{}, builder);
-    }
-  }
-  bool const has_role = self.role_json.has_value();
-  memgraph::slk::Save(has_role, builder);
-  if (has_role) {
-    memgraph::slk::Save(*self.role_json, builder);
-  }
-  memgraph::slk::Save(self.profile, builder);
-}
-
-void Load(memgraph::replication::UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(&self->main_uuid, reader);
-  memgraph::slk::Load(&self->expected_group_timestamp, reader);
-  memgraph::slk::Load(&self->new_group_timestamp, reader);
-
-  // Read optional<User> in raw form: same wire format as slk::Load<optional<User>>
-  bool has_user = false;
-  memgraph::slk::Load(&has_user, reader);
-  if (has_user) {
-    // User JSON string
-    std::string user_json;
-    memgraph::slk::Load(&user_json, reader);
-    self->user_json = std::move(user_json);
-
-    // Roles vector: slk encodes as uint64_t size followed by each element
-    uint64_t num_roles = 0;
-    memgraph::slk::Load(&num_roles, reader);
-    std::vector<std::string> role_jsons;
-    role_jsons.reserve(num_roles);
-    for (uint64_t i = 0; i < num_roles; ++i) {
-      role_jsons.push_back(LoadJsonStringRaw(reader));
-    }
-    self->user_role_jsons = std::move(role_jsons);
-
-    std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
-    memgraph::slk::Load(&mt_map, reader);
-    self->user_mt_mappings = std::move(mt_map);
-  }
-
-  // Read optional<Role> in raw form
-  bool has_role = false;
-  memgraph::slk::Load(&has_role, reader);
-  if (has_role) {
-    self->role_json = LoadJsonStringRaw(reader);
-  }
-
-  // Profile (unchanged format)
-  memgraph::slk::Load(&self->profile, reader);
-}
-
 void Save(const memgraph::replication::UpdateAuthDataReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.main_uuid, builder);
   memgraph::slk::Save(self.expected_group_timestamp, builder);
@@ -212,14 +136,6 @@ void Load(memgraph::replication::UpdateAuthDataReq *self, memgraph::slk::Reader 
   memgraph::slk::Load(&self->user, reader);
   memgraph::slk::Load(&self->role, reader);
   memgraph::slk::Load(&self->profile, reader);
-}
-
-void Save(const memgraph::replication::UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self.success, builder);
-}
-
-void Load(memgraph::replication::UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(&self->success, reader);
 }
 
 void Save(const memgraph::replication::UpdateAuthDataRes &self, memgraph::slk::Builder *builder) {
@@ -264,62 +180,11 @@ void Load(memgraph::replication::DropAuthDataRes *self, memgraph::slk::Reader *r
 
 namespace memgraph::replication {
 
-UpdateAuthDataReq UpdateAuthDataReq::Upgrade(UpdateAuthDataReqV1 const &v1) {
-  UpdateAuthDataReq req;
-  req.main_uuid = v1.main_uuid;
-  req.expected_group_timestamp = v1.expected_group_timestamp;
-  req.new_group_timestamp = v1.new_group_timestamp;
-
-  if (v1.user_json) {
-    auto user_json = nlohmann::json::parse(*v1.user_json);
-    auth::MigrateAuthJson(user_json);
-    auto user = auth::User::Deserialize(user_json);
-
-    std::vector<auth::Role> roles;
-    if (v1.user_role_jsons) {
-      roles.reserve(v1.user_role_jsons->size());
-      for (auto const &rj : *v1.user_role_jsons) {
-        auto rj_json = nlohmann::json::parse(rj);
-        auth::MigrateAuthJson(rj_json);
-        roles.push_back(auth::Role::Deserialize(rj_json));
-      }
-    }
-
-    AttachRolesToUser(user, roles, v1.user_mt_mappings.value_or({}));
-    req.user = std::move(user);
-  }
-
-  if (v1.role_json) {
-    auto rj = nlohmann::json::parse(*v1.role_json);
-    auth::MigrateAuthJson(rj);
-    req.role = auth::Role::Deserialize(rj);
-  }
-
-  req.profile = v1.profile;
-  return req;
-}
-
-void UpdateAuthDataReqV1::Save(const UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self, builder);
-}
-
-void UpdateAuthDataReqV1::Load(UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(self, reader);
-}
-
 void UpdateAuthDataReq::Save(const UpdateAuthDataReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self, builder);
 }
 
 void UpdateAuthDataReq::Load(UpdateAuthDataReq *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(self, reader);
-}
-
-void UpdateAuthDataResV1::Save(const UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self, builder);
-}
-
-void UpdateAuthDataResV1::Load(UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(self, reader);
 }
 

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -232,6 +232,11 @@ void Save(const memgraph::replication::UpdateAuthDataReq &self, memgraph::slk::B
   memgraph::slk::Save(self.profile, builder);
 }
 
+// Migrating helpers are used instead of slk::Load<User/Role> so that a future
+// entity version (e.g. V5) is automatically migrated on reception without
+// requiring a new RPC version. Currently, as Auth RPC is version 2, we know
+// this corresponds to auth entity version 4 and so the actual upgrade is a
+// no-op.
 void Load(memgraph::replication::UpdateAuthDataReq *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(&self->main_uuid, reader);
   memgraph::slk::Load(&self->expected_group_timestamp, reader);

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -37,6 +37,7 @@ void AttachRolesToUser(
     try {
       user.AddRole(role);
     } catch (memgraph::auth::AuthException const &) {
+      // Role already set as multi-tenant role
       continue;
     }
   }

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -18,6 +18,31 @@
 #include "slk/streams.hpp"
 #include "utils/enum.hpp"
 
+namespace {
+void AttachRolesToUser(
+    memgraph::auth::User &user, std::vector<memgraph::auth::Role> const &roles,
+    [[maybe_unused]] std::unordered_map<std::string, std::unordered_set<std::string>> const &mt_map) {
+  user.ClearAllRoles();
+#ifdef MG_ENTERPRISE
+  for (auto const &[db, role_names] : mt_map) {
+    for (auto const &role_name : role_names) {
+      if (auto it = std::ranges::find_if(roles, [&role_name](auto const &r) { return r.rolename() == role_name; });
+          it != roles.end()) {
+        user.AddMultiTenantRole(*it, db);
+      }
+    }
+  }
+#endif
+  for (auto const &role : roles) {
+    try {
+      user.AddRole(role);
+    } catch (memgraph::auth::AuthException const &) {
+      continue;
+    }
+  }
+}
+}  // namespace
+
 namespace memgraph::slk {
 // Serialize code for auth::Role
 void Save(const auth::Role &self, Builder *builder) { memgraph::slk::Save(self.Serialize().dump(), builder); }
@@ -73,35 +98,11 @@ void Load(auth::User *self, memgraph::slk::Reader *reader) {
   *self = memgraph::auth::User::Deserialize(json);
   std::vector<auth::Role> roles;
   memgraph::slk::Load(&roles, reader);
-  self->ClearAllRoles();
-
+  std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
 #ifdef MG_ENTERPRISE
-  // Handle multi-tenant roles (has to be done before adding all roles)
-  std::unordered_map<std::string, std::unordered_set<std::string>> db_role_map;
-  memgraph::slk::Load(&db_role_map, reader);
-  for (const auto &[db, role_names] : db_role_map) {
-    for (const auto &role : role_names) {
-      if (auto role_it = std::ranges::find_if(roles, [&role](const auto &r) { return r.rolename() == role; });
-          role_it != roles.end()) {
-        self->AddMultiTenantRole(*role_it, db);
-      }
-    }
-  }
+  memgraph::slk::Load(&mt_map, reader);
 #endif
-
-  // Handle global roles
-  for (const auto &role : roles) {
-    try {
-      self->AddRole(role);
-    } catch (const auth::AuthException &e) {
-      // Absorb the exception and continue with the next role (role already set as multi-tenant role)
-      continue;
-    }
-  }
-
-#ifdef MG_ENTERPRISE
-  // Profile management moved to UserProfiles class
-#endif
+  AttachRolesToUser(*self, roles, mt_map);
 }
 
 // Serialize code for auth::Auth::Config
@@ -132,14 +133,15 @@ void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk:
   memgraph::slk::Save(has_user, builder);
   if (has_user) {
     memgraph::slk::Save(*self.user_json, builder);
-    auto const &role_jsons = self.user_role_jsons.value_or(std::vector<std::string>{});
+    static std::vector<std::string> const kEmptyRoleJsons;
+    auto const &role_jsons = self.user_role_jsons ? *self.user_role_jsons : kEmptyRoleJsons;
     memgraph::slk::Save(static_cast<uint64_t>(role_jsons.size()), builder);
     for (auto const &rj : role_jsons) {
       memgraph::slk::Save(rj, builder);
     }
 #ifdef MG_ENTERPRISE
-    memgraph::slk::Save(
-        self.user_mt_mappings.value_or(std::unordered_map<std::string, std::unordered_set<std::string>>{}), builder);
+    static std::unordered_map<std::string, std::unordered_set<std::string>> const kEmptyMtMap;
+    memgraph::slk::Save(self.user_mt_mappings ? *self.user_mt_mappings : kEmptyMtMap, builder);
 #endif
   }
   bool const has_role = self.role_json.has_value();
@@ -271,9 +273,7 @@ UpdateAuthDataReq UpdateAuthDataReq::Upgrade(UpdateAuthDataReqV1 const &v1) {
     auto user_json = nlohmann::json::parse(*v1.user_json);
     auth::MigrateAuthJson(user_json);
     auto user = auth::User::Deserialize(user_json);
-    user.ClearAllRoles();
 
-    // Migrate and reconstruct roles
     std::vector<auth::Role> roles;
     if (v1.user_role_jsons) {
       roles.reserve(v1.user_role_jsons->size());
@@ -284,28 +284,7 @@ UpdateAuthDataReq UpdateAuthDataReq::Upgrade(UpdateAuthDataReqV1 const &v1) {
       }
     }
 
-#ifdef MG_ENTERPRISE
-    // Restore MT role mappings
-    if (v1.user_mt_mappings) {
-      for (auto const &[db, role_names] : *v1.user_mt_mappings) {
-        for (auto const &role_name : role_names) {
-          if (auto it = std::ranges::find_if(roles, [&role_name](auto const &r) { return r.rolename() == role_name; });
-              it != roles.end()) {
-            user.AddMultiTenantRole(*it, db);
-          }
-        }
-      }
-    }
-#endif
-
-    // Add global roles
-    for (auto const &role : roles) {
-      try {
-        user.AddRole(role);
-      } catch (auth::AuthException const &) {
-        continue;
-      }
-    }
+    AttachRolesToUser(user, roles, v1.user_mt_mappings.value_or({}));
     req.user = std::move(user);
   }
 

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -51,42 +51,9 @@ namespace {
 auth::Role LoadAuthRole(memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
-  auto const json = nlohmann::json::parse(tmp);
-  return memgraph::auth::Role::Deserialize(json);
-}
-
-auth::Role LoadAndMigrateRole(memgraph::slk::Reader *reader) {
-  std::string tmp;
-  memgraph::slk::Load(&tmp, reader);
   auto json = nlohmann::json::parse(tmp);
   memgraph::auth::MigrateAuthJson(json);
   return memgraph::auth::Role::Deserialize(json);
-}
-
-auth::User LoadAndMigrateUser(memgraph::slk::Reader *reader) {
-  std::string tmp;
-  memgraph::slk::Load(&tmp, reader);
-  auto json = nlohmann::json::parse(tmp);
-  memgraph::auth::MigrateAuthJson(json);
-  auto user = memgraph::auth::User::Deserialize(json);
-
-  // Load roles vector manually so each role gets migrated
-  uint64_t num_roles = 0;
-  memgraph::slk::Load(&num_roles, reader);
-  std::vector<auth::Role> roles;
-  roles.reserve(num_roles);
-  for (uint64_t i = 0; i < num_roles; ++i) {
-    roles.push_back(LoadAndMigrateRole(reader));
-  }
-
-#ifdef MG_ENTERPRISE
-  std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
-  memgraph::slk::Load(&mt_map, reader);
-  AttachRolesToUser(user, roles, mt_map);
-#else
-  AttachRolesToUser(user, roles, {});
-#endif
-  return user;
 }
 
 std::string LoadJsonStringRaw(memgraph::slk::Reader *reader) {
@@ -125,7 +92,8 @@ void Save(const auth::User &self, memgraph::slk::Builder *builder) {
 void Load(auth::User *self, memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
-  auto const json = nlohmann::json::parse(tmp);
+  auto json = nlohmann::json::parse(tmp);
+  memgraph::auth::MigrateAuthJson(json);
   *self = memgraph::auth::User::Deserialize(json);
   std::vector<auth::Role> roles;
   memgraph::slk::Load(&roles, reader);
@@ -237,30 +205,12 @@ void Save(const memgraph::replication::UpdateAuthDataReq &self, memgraph::slk::B
   memgraph::slk::Save(self.profile, builder);
 }
 
-// Migrating helpers are used instead of slk::Load<User/Role> so that a future
-// entity version (e.g. V5) is automatically migrated on reception without
-// requiring a new RPC version. Currently, as Auth RPC is version 2, we know
-// this corresponds to auth entity version 4 and so the actual upgrade is a
-// no-op.
 void Load(memgraph::replication::UpdateAuthDataReq *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(&self->main_uuid, reader);
   memgraph::slk::Load(&self->expected_group_timestamp, reader);
   memgraph::slk::Load(&self->new_group_timestamp, reader);
-
-  // User: same wire format as optional<User>, but with migration
-  bool has_user = false;
-  memgraph::slk::Load(&has_user, reader);
-  if (has_user) {
-    self->user = LoadAndMigrateUser(reader);
-  }
-
-  // Role: same wire format as optional<Role>, but with migration
-  bool has_role = false;
-  memgraph::slk::Load(&has_role, reader);
-  if (has_role) {
-    self->role = LoadAndMigrateRole(reader);
-  }
-
+  memgraph::slk::Load(&self->user, reader);
+  memgraph::slk::Load(&self->role, reader);
   memgraph::slk::Load(&self->profile, reader);
 }
 

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -51,9 +51,42 @@ namespace {
 auth::Role LoadAuthRole(memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
+  auto const json = nlohmann::json::parse(tmp);
+  return memgraph::auth::Role::Deserialize(json);
+}
+
+auth::Role LoadAndMigrateRole(memgraph::slk::Reader *reader) {
+  std::string tmp;
+  memgraph::slk::Load(&tmp, reader);
   auto json = nlohmann::json::parse(tmp);
   memgraph::auth::MigrateAuthJson(json);
   return memgraph::auth::Role::Deserialize(json);
+}
+
+auth::User LoadAndMigrateUser(memgraph::slk::Reader *reader) {
+  std::string tmp;
+  memgraph::slk::Load(&tmp, reader);
+  auto json = nlohmann::json::parse(tmp);
+  memgraph::auth::MigrateAuthJson(json);
+  auto user = memgraph::auth::User::Deserialize(json);
+
+  // Load roles vector manually so each role gets migrated
+  uint64_t num_roles = 0;
+  memgraph::slk::Load(&num_roles, reader);
+  std::vector<auth::Role> roles;
+  roles.reserve(num_roles);
+  for (uint64_t i = 0; i < num_roles; ++i) {
+    roles.push_back(LoadAndMigrateRole(reader));
+  }
+
+#ifdef MG_ENTERPRISE
+  std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
+  memgraph::slk::Load(&mt_map, reader);
+  AttachRolesToUser(user, roles, mt_map);
+#else
+  AttachRolesToUser(user, roles, {});
+#endif
+  return user;
 }
 
 std::string LoadRoleJsonRaw(memgraph::slk::Reader *reader) {
@@ -92,8 +125,7 @@ void Save(const auth::User &self, memgraph::slk::Builder *builder) {
 void Load(auth::User *self, memgraph::slk::Reader *reader) {
   std::string tmp;
   memgraph::slk::Load(&tmp, reader);
-  auto json = nlohmann::json::parse(tmp);
-  memgraph::auth::MigrateAuthJson(json);
+  auto const json = nlohmann::json::parse(tmp);
   *self = memgraph::auth::User::Deserialize(json);
   std::vector<auth::Role> roles;
   memgraph::slk::Load(&roles, reader);
@@ -204,8 +236,21 @@ void Load(memgraph::replication::UpdateAuthDataReq *self, memgraph::slk::Reader 
   memgraph::slk::Load(&self->main_uuid, reader);
   memgraph::slk::Load(&self->expected_group_timestamp, reader);
   memgraph::slk::Load(&self->new_group_timestamp, reader);
-  memgraph::slk::Load(&self->user, reader);
-  memgraph::slk::Load(&self->role, reader);
+
+  // User: same wire format as optional<User>, but with migration
+  bool has_user = false;
+  memgraph::slk::Load(&has_user, reader);
+  if (has_user) {
+    self->user = LoadAndMigrateUser(reader);
+  }
+
+  // Role: same wire format as optional<Role>, but with migration
+  bool has_role = false;
+  memgraph::slk::Load(&has_role, reader);
+  if (has_role) {
+    self->role = LoadAndMigrateRole(reader);
+  }
+
   memgraph::slk::Load(&self->profile, reader);
 }
 

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -30,6 +30,12 @@ auth::Role LoadAuthRole(memgraph::slk::Reader *reader) {
   memgraph::auth::MigrateAuthJson(json);
   return memgraph::auth::Role::Deserialize(json);
 }
+
+std::string LoadRoleJsonRaw(memgraph::slk::Reader *reader) {
+  std::string tmp;
+  memgraph::slk::Load(&tmp, reader);
+  return tmp;
+}
 }  // namespace
 
 // Deserialize code for auth::Role
@@ -118,7 +124,75 @@ void Load(auth::Auth::Config *self, memgraph::slk::Reader *reader) {
   *self = auth::Auth::Config{std::move(name_regex_str), std::move(password_regex_str), password_permit_null};
 }
 
-// Serialize code for UpdateAuthDataReq
+void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self.main_uuid, builder);
+  memgraph::slk::Save(self.expected_group_timestamp, builder);
+  memgraph::slk::Save(self.new_group_timestamp, builder);
+  bool has_user = self.user_json.has_value();
+  memgraph::slk::Save(has_user, builder);
+  if (has_user) {
+    memgraph::slk::Save(*self.user_json, builder);
+    auto const &role_jsons = self.user_role_jsons.value_or(std::vector<std::string>{});
+    memgraph::slk::Save(static_cast<uint64_t>(role_jsons.size()), builder);
+    for (auto const &rj : role_jsons) {
+      memgraph::slk::Save(rj, builder);
+    }
+#ifdef MG_ENTERPRISE
+    memgraph::slk::Save(
+        self.user_mt_mappings.value_or(std::unordered_map<std::string, std::unordered_set<std::string>>{}), builder);
+#endif
+  }
+  bool has_role = self.role_json.has_value();
+  memgraph::slk::Save(has_role, builder);
+  if (has_role) {
+    memgraph::slk::Save(*self.role_json, builder);
+  }
+  memgraph::slk::Save(self.profile, builder);
+}
+
+void Load(memgraph::replication::UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(&self->main_uuid, reader);
+  memgraph::slk::Load(&self->expected_group_timestamp, reader);
+  memgraph::slk::Load(&self->new_group_timestamp, reader);
+
+  // Read optional<User> in raw form: same wire format as slk::Load<optional<User>>
+  bool has_user = false;
+  memgraph::slk::Load(&has_user, reader);
+  if (has_user) {
+    // User JSON string
+    std::string user_json;
+    memgraph::slk::Load(&user_json, reader);
+    self->user_json = std::move(user_json);
+
+    // Roles vector: slk encodes as uint64_t size followed by each element
+    uint64_t num_roles = 0;
+    memgraph::slk::Load(&num_roles, reader);
+    std::vector<std::string> role_jsons;
+    role_jsons.reserve(num_roles);
+    for (uint64_t i = 0; i < num_roles; ++i) {
+      role_jsons.push_back(LoadRoleJsonRaw(reader));
+    }
+    self->user_role_jsons = std::move(role_jsons);
+
+#ifdef MG_ENTERPRISE
+    // MT role mappings
+    std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
+    memgraph::slk::Load(&mt_map, reader);
+    self->user_mt_mappings = std::move(mt_map);
+#endif
+  }
+
+  // Read optional<Role> in raw form
+  bool has_role = false;
+  memgraph::slk::Load(&has_role, reader);
+  if (has_role) {
+    self->role_json = LoadRoleJsonRaw(reader);
+  }
+
+  // Profile (unchanged format)
+  memgraph::slk::Load(&self->profile, reader);
+}
+
 void Save(const memgraph::replication::UpdateAuthDataReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.main_uuid, builder);
   memgraph::slk::Save(self.expected_group_timestamp, builder);
@@ -137,7 +211,14 @@ void Load(memgraph::replication::UpdateAuthDataReq *self, memgraph::slk::Reader 
   memgraph::slk::Load(&self->profile, reader);
 }
 
-// Serialize code for UpdateAuthDataRes
+void Save(const memgraph::replication::UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self.success, builder);
+}
+
+void Load(memgraph::replication::UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(&self->success, reader);
+}
+
 void Save(const memgraph::replication::UpdateAuthDataRes &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.success, builder);
 }
@@ -180,11 +261,85 @@ void Load(memgraph::replication::DropAuthDataRes *self, memgraph::slk::Reader *r
 
 namespace memgraph::replication {
 
+UpdateAuthDataReq UpdateAuthDataReq::Upgrade(UpdateAuthDataReqV1 const &v1) {
+  UpdateAuthDataReq req;
+  req.main_uuid = v1.main_uuid;
+  req.expected_group_timestamp = v1.expected_group_timestamp;
+  req.new_group_timestamp = v1.new_group_timestamp;
+
+  if (v1.user_json) {
+    auto user_json = nlohmann::json::parse(*v1.user_json);
+    auth::MigrateAuthJson(user_json);
+    auto user = auth::User::Deserialize(user_json);
+    user.ClearAllRoles();
+
+    // Migrate and reconstruct roles
+    std::vector<auth::Role> roles;
+    if (v1.user_role_jsons) {
+      roles.reserve(v1.user_role_jsons->size());
+      for (auto const &rj : *v1.user_role_jsons) {
+        auto rj_json = nlohmann::json::parse(rj);
+        auth::MigrateAuthJson(rj_json);
+        roles.push_back(auth::Role::Deserialize(rj_json));
+      }
+    }
+
+#ifdef MG_ENTERPRISE
+    // Restore MT role mappings
+    if (v1.user_mt_mappings) {
+      for (auto const &[db, role_names] : *v1.user_mt_mappings) {
+        for (auto const &role_name : role_names) {
+          if (auto it = std::ranges::find_if(roles, [&role_name](auto const &r) { return r.rolename() == role_name; });
+              it != roles.end()) {
+            user.AddMultiTenantRole(*it, db);
+          }
+        }
+      }
+    }
+#endif
+
+    // Add global roles
+    for (auto const &role : roles) {
+      try {
+        user.AddRole(role);
+      } catch (auth::AuthException const &) {
+        continue;
+      }
+    }
+    req.user = std::move(user);
+  }
+
+  if (v1.role_json) {
+    auto rj = nlohmann::json::parse(*v1.role_json);
+    auth::MigrateAuthJson(rj);
+    req.role = auth::Role::Deserialize(rj);
+  }
+
+  req.profile = v1.profile;
+  return req;
+}
+
+void UpdateAuthDataReqV1::Save(const UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self, builder);
+}
+
+void UpdateAuthDataReqV1::Load(UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(self, reader);
+}
+
 void UpdateAuthDataReq::Save(const UpdateAuthDataReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self, builder);
 }
 
 void UpdateAuthDataReq::Load(UpdateAuthDataReq *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(self, reader);
+}
+
+void UpdateAuthDataResV1::Save(const UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self, builder);
+}
+
+void UpdateAuthDataResV1::Load(UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(self, reader);
 }
 

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -84,7 +84,6 @@ void Save(const auth::User &self, memgraph::slk::Builder *builder) {
   std::vector<auth::Role> roles{self.roles().cbegin(), self.roles().cend()};
   memgraph::slk::Save(roles, builder);
 #ifdef MG_ENTERPRISE
-  // MT roles
   memgraph::slk::Save(self.GetMultiTenantRoleMappings(), builder);
 #endif
 }
@@ -98,11 +97,13 @@ void Load(auth::User *self, memgraph::slk::Reader *reader) {
   *self = memgraph::auth::User::Deserialize(json);
   std::vector<auth::Role> roles;
   memgraph::slk::Load(&roles, reader);
-  std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
 #ifdef MG_ENTERPRISE
+  std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
   memgraph::slk::Load(&mt_map, reader);
-#endif
   AttachRolesToUser(*self, roles, mt_map);
+#else
+  AttachRolesToUser(*self, roles, {});
+#endif
 }
 
 // Serialize code for auth::Auth::Config
@@ -139,10 +140,8 @@ void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk:
     for (auto const &rj : role_jsons) {
       memgraph::slk::Save(rj, builder);
     }
-#ifdef MG_ENTERPRISE
     static std::unordered_map<std::string, std::unordered_set<std::string>> const kEmptyMtMap;
     memgraph::slk::Save(self.user_mt_mappings ? *self.user_mt_mappings : kEmptyMtMap, builder);
-#endif
   }
   bool const has_role = self.role_json.has_value();
   memgraph::slk::Save(has_role, builder);
@@ -176,12 +175,9 @@ void Load(memgraph::replication::UpdateAuthDataReqV1 *self, memgraph::slk::Reade
     }
     self->user_role_jsons = std::move(role_jsons);
 
-#ifdef MG_ENTERPRISE
-    // MT role mappings
     std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
     memgraph::slk::Load(&mt_map, reader);
     self->user_mt_mappings = std::move(mt_map);
-#endif
   }
 
   // Read optional<Role> in raw form

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -128,7 +128,7 @@ void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk:
   memgraph::slk::Save(self.main_uuid, builder);
   memgraph::slk::Save(self.expected_group_timestamp, builder);
   memgraph::slk::Save(self.new_group_timestamp, builder);
-  bool has_user = self.user_json.has_value();
+  bool const has_user = self.user_json.has_value();
   memgraph::slk::Save(has_user, builder);
   if (has_user) {
     memgraph::slk::Save(*self.user_json, builder);
@@ -142,7 +142,7 @@ void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk:
         self.user_mt_mappings.value_or(std::unordered_map<std::string, std::unordered_set<std::string>>{}), builder);
 #endif
   }
-  bool has_role = self.role_json.has_value();
+  bool const has_role = self.role_json.has_value();
   memgraph::slk::Save(has_role, builder);
   if (has_role) {
     memgraph::slk::Save(*self.role_json, builder);

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -13,7 +13,6 @@
 
 #include <nlohmann/json.hpp>
 #include "auth/auth.hpp"
-#include "auth/models.hpp"
 #include "auth/profiles/user_profiles.hpp"
 #include "slk/serialization.hpp"
 #include "slk/streams.hpp"

--- a/src/auth/rpc.hpp
+++ b/src/auth/rpc.hpp
@@ -88,7 +88,7 @@ struct UpdateAuthDataResV1 {
 
   explicit UpdateAuthDataResV1(bool success) : success{success} {}
 
-  bool success;
+  bool success{};
 };
 
 struct UpdateAuthDataRes {
@@ -103,7 +103,7 @@ struct UpdateAuthDataRes {
 
   UpdateAuthDataResV1 Downgrade() const { return UpdateAuthDataResV1{success}; }
 
-  bool success;
+  bool success{};
 };
 
 using UpdateAuthDataRpc = rpc::RequestResponse<UpdateAuthDataReq, UpdateAuthDataRes>;

--- a/src/auth/rpc.hpp
+++ b/src/auth/rpc.hpp
@@ -20,9 +20,30 @@
 
 namespace memgraph::replication {
 
-struct UpdateAuthDataReq {
+struct UpdateAuthDataReqV1 {
   static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_REQ, .name = "UpdateAuthDataReq"};
   static constexpr uint64_t kVersion{1};
+
+  static void Load(UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader);
+  static void Save(const UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder);
+  UpdateAuthDataReqV1() = default;
+
+  utils::UUID main_uuid;
+  uint64_t expected_group_timestamp{};
+  uint64_t new_group_timestamp{};
+
+  // Raw JSON strings: deserialized without parsing into domain objects so we
+  // can migrate the JSON before constructing User/Role.
+  std::optional<std::string> user_json;
+  std::optional<std::vector<std::string>> user_role_jsons;
+  std::optional<std::unordered_map<std::string, std::unordered_set<std::string>>> user_mt_mappings;
+  std::optional<std::string> role_json;
+  std::optional<auth::UserProfiles::Profile> profile;
+};
+
+struct UpdateAuthDataReq {
+  static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_REQ, .name = "UpdateAuthDataReq"};
+  static constexpr uint64_t kVersion{2};
 
   static void Load(UpdateAuthDataReq *self, memgraph::slk::Reader *reader);
   static void Save(const UpdateAuthDataReq &self, memgraph::slk::Builder *builder);
@@ -47,23 +68,40 @@ struct UpdateAuthDataReq {
         new_group_timestamp{new_ts},
         profile{std::move(profile)} {}
 
+  static UpdateAuthDataReq Upgrade(UpdateAuthDataReqV1 const &v1);
+
   utils::UUID main_uuid;
-  uint64_t expected_group_timestamp;
-  uint64_t new_group_timestamp;
+  uint64_t expected_group_timestamp{};
+  uint64_t new_group_timestamp{};
   std::optional<auth::User> user;
   std::optional<auth::Role> role;
   std::optional<auth::UserProfiles::Profile> profile{};
 };
 
-struct UpdateAuthDataRes {
+struct UpdateAuthDataResV1 {
   static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_RES, .name = "UpdateAuthDataRes"};
   static constexpr uint64_t kVersion{1};
+
+  static void Load(UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader);
+  static void Save(const UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder);
+  UpdateAuthDataResV1() = default;
+
+  explicit UpdateAuthDataResV1(bool success) : success{success} {}
+
+  bool success;
+};
+
+struct UpdateAuthDataRes {
+  static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_RES, .name = "UpdateAuthDataRes"};
+  static constexpr uint64_t kVersion{2};
 
   static void Load(UpdateAuthDataRes *self, memgraph::slk::Reader *reader);
   static void Save(const UpdateAuthDataRes &self, memgraph::slk::Builder *builder);
   UpdateAuthDataRes() = default;
 
   explicit UpdateAuthDataRes(bool success) : success{success} {}
+
+  UpdateAuthDataResV1 Downgrade() const { return UpdateAuthDataResV1{success}; }
 
   bool success;
 };
@@ -123,10 +161,14 @@ void Load(auth::UserProfiles::Profile *self, memgraph::slk::Reader *reader);
 void Save(const auth::Auth::Config &self, memgraph::slk::Builder *builder);
 void Load(auth::Auth::Config *self, memgraph::slk::Reader *reader);
 
+void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder);
+void Load(memgraph::replication::UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader);
+void Save(const memgraph::replication::UpdateAuthDataReq &self, memgraph::slk::Builder *builder);
+void Load(memgraph::replication::UpdateAuthDataReq *self, memgraph::slk::Reader *reader);
+void Save(const memgraph::replication::UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder);
+void Load(memgraph::replication::UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader);
 void Save(const memgraph::replication::UpdateAuthDataRes &self, memgraph::slk::Builder *builder);
 void Load(memgraph::replication::UpdateAuthDataRes *self, memgraph::slk::Reader *reader);
-void Save(const memgraph::replication::UpdateAuthDataReq & /*self*/, memgraph::slk::Builder * /*builder*/);
-void Load(memgraph::replication::UpdateAuthDataReq * /*self*/, memgraph::slk::Reader * /*reader*/);
 void Save(const memgraph::replication::DropAuthDataRes &self, memgraph::slk::Builder *builder);
 void Load(memgraph::replication::DropAuthDataRes *self, memgraph::slk::Reader *reader);
 void Save(const memgraph::replication::DropAuthDataReq & /*self*/, memgraph::slk::Builder * /*builder*/);

--- a/src/auth/rpc.hpp
+++ b/src/auth/rpc.hpp
@@ -20,30 +20,9 @@
 
 namespace memgraph::replication {
 
-struct UpdateAuthDataReqV1 {
-  static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_REQ, .name = "UpdateAuthDataReq"};
-  static constexpr uint64_t kVersion{1};
-
-  static void Load(UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader);
-  static void Save(const UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder);
-  UpdateAuthDataReqV1() = default;
-
-  utils::UUID main_uuid;
-  uint64_t expected_group_timestamp{};
-  uint64_t new_group_timestamp{};
-
-  // Raw JSON strings: deserialized without parsing into domain objects so we
-  // can migrate the JSON before constructing User/Role.
-  std::optional<std::string> user_json;
-  std::optional<std::vector<std::string>> user_role_jsons;
-  std::optional<std::unordered_map<std::string, std::unordered_set<std::string>>> user_mt_mappings;
-  std::optional<std::string> role_json;
-  std::optional<auth::UserProfiles::Profile> profile;
-};
-
 struct UpdateAuthDataReq {
   static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_REQ, .name = "UpdateAuthDataReq"};
-  static constexpr uint64_t kVersion{2};
+  static constexpr uint64_t kVersion{1};
 
   static void Load(UpdateAuthDataReq *self, memgraph::slk::Reader *reader);
   static void Save(const UpdateAuthDataReq &self, memgraph::slk::Builder *builder);
@@ -68,8 +47,6 @@ struct UpdateAuthDataReq {
         new_group_timestamp{new_ts},
         profile{std::move(profile)} {}
 
-  static UpdateAuthDataReq Upgrade(UpdateAuthDataReqV1 const &v1);
-
   utils::UUID main_uuid;
   uint64_t expected_group_timestamp{};
   uint64_t new_group_timestamp{};
@@ -78,30 +55,15 @@ struct UpdateAuthDataReq {
   std::optional<auth::UserProfiles::Profile> profile{};
 };
 
-struct UpdateAuthDataResV1 {
-  static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_RES, .name = "UpdateAuthDataRes"};
-  static constexpr uint64_t kVersion{1};
-
-  static void Load(UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader);
-  static void Save(const UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder);
-  UpdateAuthDataResV1() = default;
-
-  explicit UpdateAuthDataResV1(bool success) : success{success} {}
-
-  bool success{};
-};
-
 struct UpdateAuthDataRes {
   static constexpr utils::TypeInfo kType{.id = utils::TypeId::REP_UPDATE_AUTH_DATA_RES, .name = "UpdateAuthDataRes"};
-  static constexpr uint64_t kVersion{2};
+  static constexpr uint64_t kVersion{1};
 
   static void Load(UpdateAuthDataRes *self, memgraph::slk::Reader *reader);
   static void Save(const UpdateAuthDataRes &self, memgraph::slk::Builder *builder);
   UpdateAuthDataRes() = default;
 
   explicit UpdateAuthDataRes(bool success) : success{success} {}
-
-  UpdateAuthDataResV1 Downgrade() const { return UpdateAuthDataResV1{success}; }
 
   bool success{};
 };
@@ -161,12 +123,8 @@ void Load(auth::UserProfiles::Profile *self, memgraph::slk::Reader *reader);
 void Save(const auth::Auth::Config &self, memgraph::slk::Builder *builder);
 void Load(auth::Auth::Config *self, memgraph::slk::Reader *reader);
 
-void Save(const memgraph::replication::UpdateAuthDataReqV1 &self, memgraph::slk::Builder *builder);
-void Load(memgraph::replication::UpdateAuthDataReqV1 *self, memgraph::slk::Reader *reader);
 void Save(const memgraph::replication::UpdateAuthDataReq &self, memgraph::slk::Builder *builder);
 void Load(memgraph::replication::UpdateAuthDataReq *self, memgraph::slk::Reader *reader);
-void Save(const memgraph::replication::UpdateAuthDataResV1 &self, memgraph::slk::Builder *builder);
-void Load(memgraph::replication::UpdateAuthDataResV1 *self, memgraph::slk::Reader *reader);
 void Save(const memgraph::replication::UpdateAuthDataRes &self, memgraph::slk::Builder *builder);
 void Load(memgraph::replication::UpdateAuthDataRes *self, memgraph::slk::Reader *reader);
 void Save(const memgraph::replication::DropAuthDataRes &self, memgraph::slk::Builder *builder);

--- a/tests/issu/test_upgrade.sh
+++ b/tests/issu/test_upgrade.sh
@@ -863,11 +863,19 @@ wait_memgraph_pods_ready 90s
 echo "Upgrade of pod memgraph-data-1-0 passed successfully"
 
 echo "Waiting for old MAIN to sync auth to upgraded replica..."
-sleep 30
-
-echo "Checking FGA on replica (data-1-0) while old MAIN still running"
 kubectl cp verify_fga_post_upgrade.sh memgraph-data-1-0:/var/lib/memgraph/verify_fga_post_upgrade.sh
-kubectl exec memgraph-data-1-0 -- bash /var/lib/memgraph/verify_fga_post_upgrade.sh --username=system_admin_user --password=admin_password
+for i in $(seq 1 30); do
+  if kubectl exec memgraph-data-1-0 -- bash /var/lib/memgraph/verify_fga_post_upgrade.sh --username=system_admin_user --password=admin_password 2>&1; then
+    echo "FGA synced to replica after ${i} attempt(s)"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "FAIL: FGA did not sync to replica after 30 attempts"
+    exit 1
+  fi
+  echo "Auth not yet synced (attempt $i/30), retrying in 2s..."
+  sleep 2
+done
 
 echo "Deleting pod memgraph-data-0-0 which serves as main"
 kubectl scale statefulset memgraph-data-0 --replicas=0

--- a/tests/issu/test_upgrade.sh
+++ b/tests/issu/test_upgrade.sh
@@ -862,6 +862,13 @@ kubectl delete pod memgraph-data-1-0
 wait_memgraph_pods_ready 90s
 echo "Upgrade of pod memgraph-data-1-0 passed successfully"
 
+echo "Waiting for old MAIN to sync auth to upgraded replica..."
+sleep 30
+
+echo "Checking FGA on replica (data-1-0) while old MAIN still running"
+kubectl cp verify_fga_post_upgrade.sh memgraph-data-1-0:/var/lib/memgraph/verify_fga_post_upgrade.sh
+kubectl exec memgraph-data-1-0 -- bash /var/lib/memgraph/verify_fga_post_upgrade.sh --username=system_admin_user --password=admin_password
+
 echo "Deleting pod memgraph-data-0-0 which serves as main"
 kubectl scale statefulset memgraph-data-0 --replicas=0
 sleep 5

--- a/tests/issu/test_upgrade.sh
+++ b/tests/issu/test_upgrade.sh
@@ -958,6 +958,10 @@ echo "Running auth post-upgrade tests"
 kubectl cp auth_post_upgrade.cypherl "${POST_UPGRADE_TARGET_POD}:/var/lib/memgraph/auth_post_upgrade.cypherl"
 kubectl exec "${POST_UPGRADE_TARGET_POD}" -- bash -c "mgconsole < /var/lib/memgraph/auth_post_upgrade.cypherl --username=system_admin_user --password=admin_password"
 
+echo "Verifying FGA grants survived rolling upgrade"
+kubectl cp verify_fga_post_upgrade.sh "${POST_UPGRADE_TARGET_POD}:/var/lib/memgraph/verify_fga_post_upgrade.sh"
+kubectl exec "${POST_UPGRADE_TARGET_POD}" -- bash /var/lib/memgraph/verify_fga_post_upgrade.sh --username=system_admin_user --password=admin_password
+
 # --- Optional routing tests ---
 if [[ "$TEST_ROUTING" == "true" ]]; then
   kubectl cp routing.py memgraph-coordinator-1-0:/var/lib/memgraph/routing.py

--- a/tests/issu/verify_fga_post_upgrade.sh
+++ b/tests/issu/verify_fga_post_upgrade.sh
@@ -13,7 +13,7 @@ EXPECTED_EDGE="EDGE_TYPE PERMISSION GRANTED"
 FAILED=0
 for role in "${ROLES_TO_CHECK[@]}"; do
   echo "Checking FGA for role: ${role}"
-  OUTPUT=$(echo "SHOW PRIVILEGES FOR ${role};" | mgconsole "$@" -output_format csv 2>&1)
+  OUTPUT=$(echo "SHOW PRIVILEGES FOR ${role};" | mgconsole "$@" --output-format=csv 2>&1)
   echo "Raw output for ${role}:"
   echo "$OUTPUT"
 

--- a/tests/issu/verify_fga_post_upgrade.sh
+++ b/tests/issu/verify_fga_post_upgrade.sh
@@ -13,7 +13,9 @@ EXPECTED_EDGE="EDGE_TYPE PERMISSION GRANTED"
 FAILED=0
 for role in "${ROLES_TO_CHECK[@]}"; do
   echo "Checking FGA for role: ${role}"
-  OUTPUT=$(echo "SHOW PRIVILEGES FOR ${role};" | mgconsole "$@" -output_format csv)
+  OUTPUT=$(echo "SHOW PRIVILEGES FOR ${role};" | mgconsole "$@" -output_format csv 2>&1)
+  echo "Raw output for ${role}:"
+  echo "$OUTPUT"
 
   if ! echo "$OUTPUT" | grep -q "$EXPECTED_LABEL"; then
     echo "FAIL: ${role} is missing label FGA grants"

--- a/tests/issu/verify_fga_post_upgrade.sh
+++ b/tests/issu/verify_fga_post_upgrade.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Verifies that FGA grants survive the rolling upgrade.
+# Runs on the post-upgrade MAIN pod.
+# Usage: verify_fga_post_upgrade.sh <mgconsole_auth_args...>
+#   e.g. verify_fga_post_upgrade.sh --username=system_admin_user --password=admin_password
+
+ROLES_TO_CHECK=("system_admin" "tenant1_admin")
+EXPECTED_LABEL="LABEL PERMISSION GRANTED"
+EXPECTED_EDGE="EDGE_TYPE PERMISSION GRANTED"
+
+FAILED=0
+for role in "${ROLES_TO_CHECK[@]}"; do
+  echo "Checking FGA for role: ${role}"
+  OUTPUT=$(echo "SHOW PRIVILEGES FOR ${role};" | mgconsole "$@" -output_format csv)
+
+  if ! echo "$OUTPUT" | grep -q "$EXPECTED_LABEL"; then
+    echo "FAIL: ${role} is missing label FGA grants"
+    echo "Output was:"
+    echo "$OUTPUT"
+    FAILED=1
+  fi
+
+  if ! echo "$OUTPUT" | grep -q "$EXPECTED_EDGE"; then
+    echo "FAIL: ${role} is missing edge type FGA grants"
+    echo "Output was:"
+    echo "$OUTPUT"
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -eq 1 ]; then
+  echo "FGA verification FAILED"
+  exit 1
+fi
+
+echo "FGA verification PASSED"

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3940,4 +3940,247 @@ TEST_F(AuthWithStorage, GetUsersForProfile) {
 
 // Role-based profile management is no longer supported in the new architecture
 
+// --- MigrateAuthJson unit tests ---
+
+TEST(MigrateAuthJson, V4InputIsNoOp) {
+  auto const original = nlohmann::json::parse(R"({
+    "rolename": "test_role",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_permissions": {
+      "label_permissions": {
+        "global_grants": 1,
+        "global_denies": -1,
+        "permissions": []
+      },
+      "edge_type_permissions": {
+        "global_grants": -1,
+        "global_denies": -1,
+        "permissions": []
+      }
+    }
+  })");
+  auto data = original;
+  MigrateAuthJson(data);
+  EXPECT_EQ(data, original);
+}
+
+TEST(MigrateAuthJson, V3GlobalPermissionReadLabel) {
+  auto data = nlohmann::json::parse(R"({
+    "rolename": "r",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_permissions": {
+      "label_permissions": {
+        "global_permission": 1,
+        "permissions": []
+      },
+      "edge_type_permissions": {
+        "global_permission": -1,
+        "permissions": []
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+
+  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+  ASSERT_FALSE(lp.contains("global_permission"));
+  EXPECT_EQ(lp["global_grants"], 1);   // READ
+  EXPECT_EQ(lp["global_denies"], -1);  // unset
+
+  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+  ASSERT_FALSE(ep.contains("global_permission"));
+  EXPECT_EQ(ep["global_grants"], -1);
+  EXPECT_EQ(ep["global_denies"], -1);
+}
+
+TEST(MigrateAuthJson, V3GlobalPermissionNothing) {
+  auto data = nlohmann::json::parse(R"({
+    "username": "u",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_permissions": {
+      "label_permissions": {
+        "global_permission": 0,
+        "permissions": []
+      },
+      "edge_type_permissions": {
+        "global_permission": 0,
+        "permissions": []
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+
+  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+  ASSERT_FALSE(lp.contains("global_permission"));
+  EXPECT_EQ(lp["global_grants"], -1);
+  EXPECT_EQ(lp["global_denies"], 507);  // kAllLabelPermissions
+
+  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+  ASSERT_FALSE(ep.contains("global_permission"));
+  EXPECT_EQ(ep["global_grants"], -1);
+  EXPECT_EQ(ep["global_denies"], 27);  // kAllEdgeTypePermissions
+}
+
+TEST(MigrateAuthJson, V3LabelUpdateExpands) {
+  // V3 UPDATE bit (2) on labels should expand to SET_LABEL|REMOVE_LABEL|SET_PROPERTY|DELETE_EDGE|CREATE_EDGE
+  auto data = nlohmann::json::parse(R"({
+    "rolename": "r",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_permissions": {
+      "label_permissions": {
+        "global_permission": 3,
+        "permissions": []
+      },
+      "edge_type_permissions": {
+        "global_permission": 3,
+        "permissions": []
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+
+  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+  ASSERT_FALSE(lp.contains("global_permission"));
+  // READ(1) | UPDATE(2) -> READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) |
+  // CREATE_EDGE(256) = 1 | 32 | 64 | 2 | 128 | 256 = 483
+  EXPECT_EQ(lp["global_grants"], 483);
+
+  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+  ASSERT_FALSE(ep.contains("global_permission"));
+  // For edges UPDATE(2) stays as SET_PROPERTY(2), so READ|SET_PROPERTY = 3
+  EXPECT_EQ(ep["global_grants"], 3);
+}
+
+TEST(MigrateAuthJson, V3PerEntityRuleMigration) {
+  auto data = nlohmann::json::parse(R"({
+    "rolename": "r",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_permissions": {
+      "label_permissions": {
+        "global_permission": -1,
+        "permissions": [
+          {"symbols": ["Person"], "granted": 0, "matching": "ANY"},
+          {"symbols": ["Car"], "granted": 3, "matching": "EXACTLY"}
+        ]
+      },
+      "edge_type_permissions": {
+        "global_permission": -1,
+        "permissions": []
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+
+  auto const &rules = data["fine_grained_permissions"]["label_permissions"]["permissions"];
+  ASSERT_EQ(rules.size(), 2);
+  ASSERT_TRUE(rules[0].contains("denied"));
+
+  // granted=0 -> deny all labels
+  EXPECT_EQ(rules[0]["granted"], 0);
+  EXPECT_EQ(rules[0]["denied"], 507);
+  EXPECT_EQ(rules[0]["matching"], "ANY");
+
+  // granted=3 (READ|UPDATE) -> expanded
+  EXPECT_EQ(rules[1]["granted"], 483);
+  EXPECT_EQ(rules[1]["denied"], 0);
+  EXPECT_EQ(rules[1]["matching"], "EXACTLY");
+}
+
+TEST(MigrateAuthJson, V2ToV4) {
+  // V2 format: uses "fine_grained_access_handler" key and V2 permission enum
+  auto data = nlohmann::json::parse(R"({
+    "rolename": "r",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_access_handler": {
+      "label_permissions": {
+        "global_permission": 7
+      },
+      "edge_type_permissions": {
+        "global_permission": 1
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+
+  // Should be fully migrated to V4
+  ASSERT_FALSE(data.contains("fine_grained_access_handler"));
+  ASSERT_TRUE(data.contains("fine_grained_permissions"));
+
+  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+  ASSERT_FALSE(lp.contains("global_permission"));
+  ASSERT_TRUE(lp.contains("global_grants"));
+  ASSERT_TRUE(lp.contains("global_denies"));
+  // V2 CREATE_DELETE (7) -> V3 READ|UPDATE|CREATE|DELETE (1|2|8|16=27) -> V4 label expansion of UPDATE
+  // = READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) | CREATE_EDGE(256) | CREATE(8) |
+  // DELETE(16) = 507
+  EXPECT_EQ(lp["global_grants"], 507);
+  EXPECT_EQ(lp["global_denies"], -1);
+
+  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+  // V2 READ (1) -> V3 READ (1) -> V4 READ (1)
+  EXPECT_EQ(ep["global_grants"], 1);
+  EXPECT_EQ(ep["global_denies"], -1);
+}
+
+TEST(MigrateAuthJson, V3DeserializesToValidRole) {
+  memgraph::license::global_license_checker.EnableTesting();
+  auto data = nlohmann::json::parse(R"({
+    "rolename": "fga_role",
+    "permissions": {"grants": 1, "denies": 0},
+    "fine_grained_permissions": {
+      "label_permissions": {
+        "global_permission": 1,
+        "permissions": []
+      },
+      "edge_type_permissions": {
+        "global_permission": 1,
+        "permissions": []
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+  auto role = Role::Deserialize(data);
+
+  EXPECT_EQ(role.rolename(), "fga_role");
+  auto const &label_perms = role.GetFineGrainedAccessLabelPermissions();
+  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(FineGrainedPermission::READ));
+}
+
+TEST(MigrateAuthJson, V3DeserializesToValidUser) {
+  memgraph::license::global_license_checker.EnableTesting();
+  auto data = nlohmann::json::parse(R"({
+    "username": "fga_user",
+    "password_hash": null,
+    "permissions": {"grants": 1, "denies": 0},
+    "fine_grained_permissions": {
+      "label_permissions": {
+        "global_permission": 1,
+        "permissions": []
+      },
+      "edge_type_permissions": {
+        "global_permission": 1,
+        "permissions": []
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+  auto user = User::Deserialize(data);
+
+  EXPECT_EQ(user.username(), "fga_user");
+  auto const &label_perms = user.GetUserFineGrainedAccessLabelPermissions();
+  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(FineGrainedPermission::READ));
+}
+
+TEST(MigrateAuthJson, NoFgaFieldIsNoOp) {
+  auto const original = nlohmann::json::parse(R"({
+    "username": "basic_user",
+    "password_hash": null,
+    "permissions": {"grants": 0, "denies": 0}
+  })");
+  auto data = original;
+  MigrateAuthJson(data);
+  EXPECT_EQ(data, original);
+}
+
 #endif  // MG_ENTERPRISE

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3971,6 +3971,7 @@ TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
+    ASSERT_EQ(data["version"], kCurrentAuthVersion);
 
     ASSERT_FALSE(data.contains("fine_grained_access_handler"));
     ASSERT_TRUE(data.contains("fine_grained_permissions"));
@@ -4004,6 +4005,7 @@ TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
+    ASSERT_EQ(data["version"], kCurrentAuthVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 label expansion = 483
@@ -4035,6 +4037,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
+    ASSERT_EQ(data["version"], kCurrentAuthVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
@@ -4064,6 +4067,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
+    ASSERT_EQ(data["version"], kCurrentAuthVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
@@ -4093,6 +4097,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
+    ASSERT_EQ(data["version"], kCurrentAuthVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
@@ -4126,6 +4131,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
+    ASSERT_EQ(data["version"], kCurrentAuthVersion);
 
     auto const &rules = data["fine_grained_permissions"]["label_permissions"]["permissions"];
     ASSERT_EQ(rules.size(), 2);
@@ -4144,14 +4150,18 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
 }
 
 TEST(MigrateAuthJson, NoFgaFieldNeedsNoMigration) {
-  auto const original = nlohmann::json::parse(R"({
+  auto data = nlohmann::json::parse(R"({
     "username": "basic_user",
     "password_hash": null,
     "permissions": {"grants": 0, "denies": 0}
   })");
-  auto data = original;
+  auto const original = data;
   MigrateAuthJson(data);
-  EXPECT_EQ(data, original);
+  ASSERT_EQ(data["version"], kCurrentAuthVersion);
+
+  for (auto const &[key, value] : original.items()) {
+    EXPECT_EQ(data[key], value) << "Mismatch for key: " << key;
+  }
 }
 
 #endif  // MG_ENTERPRISE

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3940,9 +3940,7 @@ TEST_F(AuthWithStorage, GetUsersForProfile) {
 
 // Role-based profile management is no longer supported in the new architecture
 
-// --- MigrateAuthJson unit tests ---
-
-TEST(MigrateAuthJson, V4InputIsNoOp) {
+TEST(MigrateAuthJson, CurrentVersionWithoutVersionFieldNeedsNoMigration) {
   auto const original = nlohmann::json::parse(R"({
     "rolename": "test_role",
     "permissions": {"grants": 0, "denies": 0},
@@ -3964,7 +3962,7 @@ TEST(MigrateAuthJson, V4InputIsNoOp) {
   EXPECT_EQ(data, original);
 }
 
-TEST(MigrateAuthJson, V4SerializedRoleIsIdempotent) {
+TEST(MigrateAuthJson, CurrentVersionWithVersionFieldNeedsNoMigration) {
   memgraph::license::global_license_checker.EnableTesting();
 
   Role role{"test_role"};
@@ -3979,7 +3977,7 @@ TEST(MigrateAuthJson, V4SerializedRoleIsIdempotent) {
   EXPECT_EQ(data, original);
 }
 
-TEST(MigrateAuthJson, V3GlobalPermissionReadLabel) {
+TEST(MigrateAuthJson, V3ReadLabelMigratesToGrantsAndDenies) {
   auto data = nlohmann::json::parse(R"({
     "rolename": "r",
     "permissions": {"grants": 0, "denies": 0},
@@ -4007,7 +4005,7 @@ TEST(MigrateAuthJson, V3GlobalPermissionReadLabel) {
   EXPECT_EQ(ep["global_denies"], -1);
 }
 
-TEST(MigrateAuthJson, V3GlobalPermissionNothing) {
+TEST(MigrateAuthJson, V3NothingMigratesToDenyAll) {
   auto data = nlohmann::json::parse(R"({
     "username": "u",
     "permissions": {"grants": 0, "denies": 0},
@@ -4035,7 +4033,7 @@ TEST(MigrateAuthJson, V3GlobalPermissionNothing) {
   EXPECT_EQ(ep["global_denies"], 27);  // kAllEdgeTypePermissions
 }
 
-TEST(MigrateAuthJson, V3LabelUpdateExpands) {
+TEST(MigrateAuthJson, V3LabelUpdateExpandsToFineGrainedBits) {
   // V3 UPDATE bit (2) on labels should expand to SET_LABEL|REMOVE_LABEL|SET_PROPERTY|DELETE_EDGE|CREATE_EDGE
   auto data = nlohmann::json::parse(R"({
     "rolename": "r",
@@ -4065,7 +4063,7 @@ TEST(MigrateAuthJson, V3LabelUpdateExpands) {
   EXPECT_EQ(ep["global_grants"], 3);
 }
 
-TEST(MigrateAuthJson, V3PerEntityRuleMigration) {
+TEST(MigrateAuthJson, V3PerEntityRulesGainDeniedField) {
   auto data = nlohmann::json::parse(R"({
     "rolename": "r",
     "permissions": {"grants": 0, "denies": 0},
@@ -4100,7 +4098,7 @@ TEST(MigrateAuthJson, V3PerEntityRuleMigration) {
   EXPECT_EQ(rules[1]["matching"], "EXACTLY");
 }
 
-TEST(MigrateAuthJson, V2ToV4) {
+TEST(MigrateAuthJson, V2CreateDeleteMigratesToFullLabelGrants) {
   // V2 format: uses "fine_grained_access_handler" key and V2 permission enum
   auto data = nlohmann::json::parse(R"({
     "rolename": "r",
@@ -4136,7 +4134,7 @@ TEST(MigrateAuthJson, V2ToV4) {
   EXPECT_EQ(ep["global_denies"], -1);
 }
 
-TEST(MigrateAuthJson, V2UpdateToV4) {
+TEST(MigrateAuthJson, V2UpdateMigratesWithLabelExpansion) {
   // V2 UPDATE (3) should go through V3 (UPDATE|READ = 2|1 = 3) then V4 label expansion
   auto data = nlohmann::json::parse(R"({
     "rolename": "r",
@@ -4164,7 +4162,7 @@ TEST(MigrateAuthJson, V2UpdateToV4) {
   EXPECT_EQ(ep["global_denies"], -1);
 }
 
-TEST(MigrateAuthJson, V3DeserializesToValidRole) {
+TEST(MigrateAuthJson, V3RoleDeserializesAfterMigration) {
   memgraph::license::global_license_checker.EnableTesting();
   auto data = nlohmann::json::parse(R"({
     "rolename": "fga_role",
@@ -4189,7 +4187,7 @@ TEST(MigrateAuthJson, V3DeserializesToValidRole) {
   EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(FineGrainedPermission::READ));
 }
 
-TEST(MigrateAuthJson, V3DeserializesToValidUser) {
+TEST(MigrateAuthJson, V3UserDeserializesAfterMigration) {
   memgraph::license::global_license_checker.EnableTesting();
   auto data = nlohmann::json::parse(R"({
     "username": "fga_user",
@@ -4215,7 +4213,7 @@ TEST(MigrateAuthJson, V3DeserializesToValidUser) {
   EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(FineGrainedPermission::READ));
 }
 
-TEST(MigrateAuthJson, NoFgaFieldIsNoOp) {
+TEST(MigrateAuthJson, NoFgaFieldNeedsNoMigration) {
   auto const original = nlohmann::json::parse(R"({
     "username": "basic_user",
     "password_hash": null,

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3957,6 +3957,20 @@ TEST(MigrateAuthJson, MigratingCurrentVersionIsIdempotent) {
 
 #endif  // MG_ENTERPRISE
 
+// FineGrainedPermission values for use outside the MG_ENTERPRISE guard.
+// These mirror the enum in models.hpp but are usable in community builds.
+namespace {
+constexpr uint64_t kRead = 1;
+constexpr uint64_t kSetProperty = 2;
+constexpr uint64_t kReadOrSetProperty = kRead | kSetProperty;  // 3
+constexpr uint64_t kAllLabel = 507;
+constexpr uint64_t kAllEdgeType = 27;
+constexpr uint64_t kLabelUpdateExpanded =
+    kRead | kSetProperty | 32 | 64 | 128 |
+    256;  // 483 (READ | SET_PROPERTY | SET_LABEL | REMOVE_LABEL | DELETE_EDGE | CREATE_EDGE)
+constexpr int64_t kUnset = -1;
+}  // namespace
+
 TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
   // CREATE_DELETE (7) -> full label grants
   {
@@ -3982,14 +3996,13 @@ TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
     ASSERT_FALSE(lp.contains("global_permission"));
     ASSERT_TRUE(lp.contains("global_grants"));
     ASSERT_TRUE(lp.contains("global_denies"));
-    // V2 CREATE_DELETE (7) -> V3 READ|UPDATE|CREATE|DELETE (27) -> V4 label expansion = 507
-    EXPECT_EQ(lp["global_grants"], 507);
-    EXPECT_EQ(lp["global_denies"], -1);
+    // V2 CREATE_DELETE (7) -> V3 READ|UPDATE|CREATE|DELETE (27) -> V4 label expansion
+    EXPECT_EQ(lp["global_grants"], kAllLabel);
+    EXPECT_EQ(lp["global_denies"], kUnset);
 
     auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
-    // V2 READ (1) -> V3 READ (1) -> V4 READ (1)
-    EXPECT_EQ(ep["global_grants"], 1);
-    EXPECT_EQ(ep["global_denies"], -1);
+    EXPECT_EQ(ep["global_grants"], kRead);
+    EXPECT_EQ(ep["global_denies"], kUnset);
   }
 
   // UPDATE (3) -> label expansion, edge stays as-is
@@ -4010,14 +4023,14 @@ TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
     ASSERT_EQ(data["version"], kCurrentAuthVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
-    // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 label expansion = 483
-    EXPECT_EQ(lp["global_grants"], 483);
-    EXPECT_EQ(lp["global_denies"], -1);
+    // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 label expansion
+    EXPECT_EQ(lp["global_grants"], kLabelUpdateExpanded);
+    EXPECT_EQ(lp["global_denies"], kUnset);
 
     auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
-    // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 edge: no expansion, stays 3
-    EXPECT_EQ(ep["global_grants"], 3);
-    EXPECT_EQ(ep["global_denies"], -1);
+    // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 edge: no expansion
+    EXPECT_EQ(ep["global_grants"], kReadOrSetProperty);
+    EXPECT_EQ(ep["global_denies"], kUnset);
   }
 }
 
@@ -4043,13 +4056,13 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
-    EXPECT_EQ(lp["global_grants"], 1);   // READ
-    EXPECT_EQ(lp["global_denies"], -1);  // unset
+    EXPECT_EQ(lp["global_grants"], kRead);
+    EXPECT_EQ(lp["global_denies"], kUnset);
 
     auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
     ASSERT_FALSE(ep.contains("global_permission"));
-    EXPECT_EQ(ep["global_grants"], -1);
-    EXPECT_EQ(ep["global_denies"], -1);
+    EXPECT_EQ(ep["global_grants"], kUnset);
+    EXPECT_EQ(ep["global_denies"], kUnset);
   }
 
   // NOTHING -> deny all
@@ -4073,13 +4086,13 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
-    EXPECT_EQ(lp["global_grants"], -1);
-    EXPECT_EQ(lp["global_denies"], 507);  // kAllLabelPermissions
+    EXPECT_EQ(lp["global_grants"], kUnset);
+    EXPECT_EQ(lp["global_denies"], kAllLabel);
 
     auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
     ASSERT_FALSE(ep.contains("global_permission"));
-    EXPECT_EQ(ep["global_grants"], -1);
-    EXPECT_EQ(ep["global_denies"], 27);  // kAllEdgeTypePermissions
+    EXPECT_EQ(ep["global_grants"], kUnset);
+    EXPECT_EQ(ep["global_denies"], kAllEdgeType);
   }
 
   // Label UPDATE expands to fine-grained bits; edge UPDATE stays as SET_PROPERTY
@@ -4103,14 +4116,11 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
-    // READ(1) | UPDATE(2) -> READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) |
-    // CREATE_EDGE(256) = 483
-    EXPECT_EQ(lp["global_grants"], 483);
+    EXPECT_EQ(lp["global_grants"], kLabelUpdateExpanded);
 
     auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
     ASSERT_FALSE(ep.contains("global_permission"));
-    // For edges UPDATE(2) stays as SET_PROPERTY(2), so READ|SET_PROPERTY = 3
-    EXPECT_EQ(ep["global_grants"], 3);
+    EXPECT_EQ(ep["global_grants"], kReadOrSetProperty);
   }
 
   // Per-entity rules gain denied field and label UPDATE is expanded
@@ -4139,13 +4149,11 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
     ASSERT_EQ(rules.size(), 2);
     ASSERT_TRUE(rules[0].contains("denied"));
 
-    // granted=0 -> deny all labels
     EXPECT_EQ(rules[0]["granted"], 0);
-    EXPECT_EQ(rules[0]["denied"], 507);
+    EXPECT_EQ(rules[0]["denied"], kAllLabel);
     EXPECT_EQ(rules[0]["matching"], "ANY");
 
-    // granted=3 (READ|UPDATE) -> expanded
-    EXPECT_EQ(rules[1]["granted"], 483);
+    EXPECT_EQ(rules[1]["granted"], kLabelUpdateExpanded);
     EXPECT_EQ(rules[1]["denied"], 0);
     EXPECT_EQ(rules[1]["matching"], "EXACTLY");
   }

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3965,9 +3965,11 @@ constexpr uint64_t kSetProperty = 2;
 constexpr uint64_t kReadOrSetProperty = kRead | kSetProperty;  // 3
 constexpr uint64_t kAllLabel = 507;
 constexpr uint64_t kAllEdgeType = 27;
-constexpr uint64_t kLabelUpdateExpanded =
-    kRead | kSetProperty | 32 | 64 | 128 |
-    256;  // 483 (READ | SET_PROPERTY | SET_LABEL | REMOVE_LABEL | DELETE_EDGE | CREATE_EDGE)
+constexpr uint64_t kSetLabel = 32;
+constexpr uint64_t kRemoveLabel = 64;
+constexpr uint64_t kDeleteEdge = 128;
+constexpr uint64_t kCreateEdge = 256;
+constexpr uint64_t kLabelUpdateExpanded = kRead | kSetProperty | kSetLabel | kRemoveLabel | kDeleteEdge | kCreateEdge;
 constexpr int64_t kUnset = -1;
 }  // namespace
 

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3964,6 +3964,21 @@ TEST(MigrateAuthJson, V4InputIsNoOp) {
   EXPECT_EQ(data, original);
 }
 
+TEST(MigrateAuthJson, V4SerializedRoleIsIdempotent) {
+  memgraph::license::global_license_checker.EnableTesting();
+
+  Role role{"test_role"};
+  role.permissions().Grant(Permission::MATCH);
+  role.fine_grained_access_handler().label_permissions().Grant({"Person"}, FineGrainedPermission::SET_PROPERTY);
+  role.fine_grained_access_handler().label_permissions().GrantGlobal(FineGrainedPermission::READ);
+  role.fine_grained_access_handler().edge_type_permissions().Grant({"KNOWS"}, FineGrainedPermission::READ);
+
+  auto const original = role.Serialize();
+  auto data = original;
+  MigrateAuthJson(data);
+  EXPECT_EQ(data, original);
+}
+
 TEST(MigrateAuthJson, V3GlobalPermissionReadLabel) {
   auto data = nlohmann::json::parse(R"({
     "rolename": "r",

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3940,29 +3940,7 @@ TEST_F(AuthWithStorage, GetUsersForProfile) {
 
 // Role-based profile management is no longer supported in the new architecture
 
-TEST(MigrateAuthJson, CurrentVersionWithoutVersionFieldNeedsNoMigration) {
-  auto const original = nlohmann::json::parse(R"({
-    "rolename": "test_role",
-    "permissions": {"grants": 0, "denies": 0},
-    "fine_grained_permissions": {
-      "label_permissions": {
-        "global_grants": 1,
-        "global_denies": -1,
-        "permissions": []
-      },
-      "edge_type_permissions": {
-        "global_grants": -1,
-        "global_denies": -1,
-        "permissions": []
-      }
-    }
-  })");
-  auto data = original;
-  MigrateAuthJson(data);
-  EXPECT_EQ(data, original);
-}
-
-TEST(MigrateAuthJson, CurrentVersionWithVersionFieldNeedsNoMigration) {
+TEST(MigrateAuthJson, MigratingCurrentVersionIsIdempotent) {
   memgraph::license::global_license_checker.EnableTesting();
 
   Role role{"test_role"};
@@ -3977,240 +3955,192 @@ TEST(MigrateAuthJson, CurrentVersionWithVersionFieldNeedsNoMigration) {
   EXPECT_EQ(data, original);
 }
 
-TEST(MigrateAuthJson, V3ReadLabelMigratesToGrantsAndDenies) {
-  auto data = nlohmann::json::parse(R"({
-    "rolename": "r",
-    "permissions": {"grants": 0, "denies": 0},
-    "fine_grained_permissions": {
-      "label_permissions": {
-        "global_permission": 1,
-        "permissions": []
-      },
-      "edge_type_permissions": {
-        "global_permission": -1,
-        "permissions": []
+TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
+  // CREATE_DELETE (7) -> full label grants
+  {
+    auto data = nlohmann::json::parse(R"({
+      "rolename": "r",
+      "permissions": {"grants": 0, "denies": 0},
+      "fine_grained_access_handler": {
+        "label_permissions": {
+          "global_permission": 7
+        },
+        "edge_type_permissions": {
+          "global_permission": 1
+        }
       }
-    }
-  })");
-  MigrateAuthJson(data);
+    })");
+    MigrateAuthJson(data);
 
-  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
-  ASSERT_FALSE(lp.contains("global_permission"));
-  EXPECT_EQ(lp["global_grants"], 1);   // READ
-  EXPECT_EQ(lp["global_denies"], -1);  // unset
+    ASSERT_FALSE(data.contains("fine_grained_access_handler"));
+    ASSERT_TRUE(data.contains("fine_grained_permissions"));
 
-  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
-  ASSERT_FALSE(ep.contains("global_permission"));
-  EXPECT_EQ(ep["global_grants"], -1);
-  EXPECT_EQ(ep["global_denies"], -1);
+    auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+    ASSERT_FALSE(lp.contains("global_permission"));
+    ASSERT_TRUE(lp.contains("global_grants"));
+    ASSERT_TRUE(lp.contains("global_denies"));
+    // V2 CREATE_DELETE (7) -> V3 READ|UPDATE|CREATE|DELETE (27) -> V4 label expansion = 507
+    EXPECT_EQ(lp["global_grants"], 507);
+    EXPECT_EQ(lp["global_denies"], -1);
+
+    auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+    // V2 READ (1) -> V3 READ (1) -> V4 READ (1)
+    EXPECT_EQ(ep["global_grants"], 1);
+    EXPECT_EQ(ep["global_denies"], -1);
+  }
+
+  // UPDATE (3) -> label expansion, edge stays as-is
+  {
+    auto data = nlohmann::json::parse(R"({
+      "rolename": "r",
+      "permissions": {"grants": 0, "denies": 0},
+      "fine_grained_access_handler": {
+        "label_permissions": {
+          "global_permission": 3
+        },
+        "edge_type_permissions": {
+          "global_permission": 3
+        }
+      }
+    })");
+    MigrateAuthJson(data);
+
+    auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+    // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 label expansion = 483
+    EXPECT_EQ(lp["global_grants"], 483);
+    EXPECT_EQ(lp["global_denies"], -1);
+
+    auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+    // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 edge: no expansion, stays 3
+    EXPECT_EQ(ep["global_grants"], 3);
+    EXPECT_EQ(ep["global_denies"], -1);
+  }
 }
 
-TEST(MigrateAuthJson, V3NothingMigratesToDenyAll) {
-  auto data = nlohmann::json::parse(R"({
-    "username": "u",
-    "permissions": {"grants": 0, "denies": 0},
-    "fine_grained_permissions": {
-      "label_permissions": {
-        "global_permission": 0,
-        "permissions": []
-      },
-      "edge_type_permissions": {
-        "global_permission": 0,
-        "permissions": []
+TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
+  // READ global permission -> global_grants/global_denies
+  {
+    auto data = nlohmann::json::parse(R"({
+      "rolename": "r",
+      "permissions": {"grants": 0, "denies": 0},
+      "fine_grained_permissions": {
+        "label_permissions": {
+          "global_permission": 1,
+          "permissions": []
+        },
+        "edge_type_permissions": {
+          "global_permission": -1,
+          "permissions": []
+        }
       }
-    }
-  })");
-  MigrateAuthJson(data);
+    })");
+    MigrateAuthJson(data);
 
-  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
-  ASSERT_FALSE(lp.contains("global_permission"));
-  EXPECT_EQ(lp["global_grants"], -1);
-  EXPECT_EQ(lp["global_denies"], 507);  // kAllLabelPermissions
+    auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+    ASSERT_FALSE(lp.contains("global_permission"));
+    EXPECT_EQ(lp["global_grants"], 1);   // READ
+    EXPECT_EQ(lp["global_denies"], -1);  // unset
 
-  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
-  ASSERT_FALSE(ep.contains("global_permission"));
-  EXPECT_EQ(ep["global_grants"], -1);
-  EXPECT_EQ(ep["global_denies"], 27);  // kAllEdgeTypePermissions
-}
+    auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+    ASSERT_FALSE(ep.contains("global_permission"));
+    EXPECT_EQ(ep["global_grants"], -1);
+    EXPECT_EQ(ep["global_denies"], -1);
+  }
 
-TEST(MigrateAuthJson, V3LabelUpdateExpandsToFineGrainedBits) {
-  // V3 UPDATE bit (2) on labels should expand to SET_LABEL|REMOVE_LABEL|SET_PROPERTY|DELETE_EDGE|CREATE_EDGE
-  auto data = nlohmann::json::parse(R"({
-    "rolename": "r",
-    "permissions": {"grants": 0, "denies": 0},
-    "fine_grained_permissions": {
-      "label_permissions": {
-        "global_permission": 3,
-        "permissions": []
-      },
-      "edge_type_permissions": {
-        "global_permission": 3,
-        "permissions": []
+  // NOTHING -> deny all
+  {
+    auto data = nlohmann::json::parse(R"({
+      "username": "u",
+      "permissions": {"grants": 0, "denies": 0},
+      "fine_grained_permissions": {
+        "label_permissions": {
+          "global_permission": 0,
+          "permissions": []
+        },
+        "edge_type_permissions": {
+          "global_permission": 0,
+          "permissions": []
+        }
       }
-    }
-  })");
-  MigrateAuthJson(data);
+    })");
+    MigrateAuthJson(data);
 
-  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
-  ASSERT_FALSE(lp.contains("global_permission"));
-  // READ(1) | UPDATE(2) -> READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) |
-  // CREATE_EDGE(256) = 1 | 32 | 64 | 2 | 128 | 256 = 483
-  EXPECT_EQ(lp["global_grants"], 483);
+    auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+    ASSERT_FALSE(lp.contains("global_permission"));
+    EXPECT_EQ(lp["global_grants"], -1);
+    EXPECT_EQ(lp["global_denies"], 507);  // kAllLabelPermissions
 
-  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
-  ASSERT_FALSE(ep.contains("global_permission"));
-  // For edges UPDATE(2) stays as SET_PROPERTY(2), so READ|SET_PROPERTY = 3
-  EXPECT_EQ(ep["global_grants"], 3);
-}
+    auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+    ASSERT_FALSE(ep.contains("global_permission"));
+    EXPECT_EQ(ep["global_grants"], -1);
+    EXPECT_EQ(ep["global_denies"], 27);  // kAllEdgeTypePermissions
+  }
 
-TEST(MigrateAuthJson, V3PerEntityRulesGainDeniedField) {
-  auto data = nlohmann::json::parse(R"({
-    "rolename": "r",
-    "permissions": {"grants": 0, "denies": 0},
-    "fine_grained_permissions": {
-      "label_permissions": {
-        "global_permission": -1,
-        "permissions": [
-          {"symbols": ["Person"], "granted": 0, "matching": "ANY"},
-          {"symbols": ["Car"], "granted": 3, "matching": "EXACTLY"}
-        ]
-      },
-      "edge_type_permissions": {
-        "global_permission": -1,
-        "permissions": []
+  // Label UPDATE expands to fine-grained bits; edge UPDATE stays as SET_PROPERTY
+  {
+    auto data = nlohmann::json::parse(R"({
+      "rolename": "r",
+      "permissions": {"grants": 0, "denies": 0},
+      "fine_grained_permissions": {
+        "label_permissions": {
+          "global_permission": 3,
+          "permissions": []
+        },
+        "edge_type_permissions": {
+          "global_permission": 3,
+          "permissions": []
+        }
       }
-    }
-  })");
-  MigrateAuthJson(data);
+    })");
+    MigrateAuthJson(data);
 
-  auto const &rules = data["fine_grained_permissions"]["label_permissions"]["permissions"];
-  ASSERT_EQ(rules.size(), 2);
-  ASSERT_TRUE(rules[0].contains("denied"));
+    auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+    ASSERT_FALSE(lp.contains("global_permission"));
+    // READ(1) | UPDATE(2) -> READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) |
+    // CREATE_EDGE(256) = 483
+    EXPECT_EQ(lp["global_grants"], 483);
 
-  // granted=0 -> deny all labels
-  EXPECT_EQ(rules[0]["granted"], 0);
-  EXPECT_EQ(rules[0]["denied"], 507);
-  EXPECT_EQ(rules[0]["matching"], "ANY");
+    auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+    ASSERT_FALSE(ep.contains("global_permission"));
+    // For edges UPDATE(2) stays as SET_PROPERTY(2), so READ|SET_PROPERTY = 3
+    EXPECT_EQ(ep["global_grants"], 3);
+  }
 
-  // granted=3 (READ|UPDATE) -> expanded
-  EXPECT_EQ(rules[1]["granted"], 483);
-  EXPECT_EQ(rules[1]["denied"], 0);
-  EXPECT_EQ(rules[1]["matching"], "EXACTLY");
-}
-
-TEST(MigrateAuthJson, V2CreateDeleteMigratesToFullLabelGrants) {
-  // V2 format: uses "fine_grained_access_handler" key and V2 permission enum
-  auto data = nlohmann::json::parse(R"({
-    "rolename": "r",
-    "permissions": {"grants": 0, "denies": 0},
-    "fine_grained_access_handler": {
-      "label_permissions": {
-        "global_permission": 7
-      },
-      "edge_type_permissions": {
-        "global_permission": 1
+  // Per-entity rules gain denied field and label UPDATE is expanded
+  {
+    auto data = nlohmann::json::parse(R"({
+      "rolename": "r",
+      "permissions": {"grants": 0, "denies": 0},
+      "fine_grained_permissions": {
+        "label_permissions": {
+          "global_permission": -1,
+          "permissions": [
+            {"symbols": ["Person"], "granted": 0, "matching": "ANY"},
+            {"symbols": ["Car"], "granted": 3, "matching": "EXACTLY"}
+          ]
+        },
+        "edge_type_permissions": {
+          "global_permission": -1,
+          "permissions": []
+        }
       }
-    }
-  })");
-  MigrateAuthJson(data);
+    })");
+    MigrateAuthJson(data);
 
-  // Should be fully migrated to V4
-  ASSERT_FALSE(data.contains("fine_grained_access_handler"));
-  ASSERT_TRUE(data.contains("fine_grained_permissions"));
+    auto const &rules = data["fine_grained_permissions"]["label_permissions"]["permissions"];
+    ASSERT_EQ(rules.size(), 2);
+    ASSERT_TRUE(rules[0].contains("denied"));
 
-  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
-  ASSERT_FALSE(lp.contains("global_permission"));
-  ASSERT_TRUE(lp.contains("global_grants"));
-  ASSERT_TRUE(lp.contains("global_denies"));
-  // V2 CREATE_DELETE (7) -> V3 READ|UPDATE|CREATE|DELETE (1|2|8|16=27) -> V4 label expansion of UPDATE
-  // = READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) | CREATE_EDGE(256) | CREATE(8) |
-  // DELETE(16) = 507
-  EXPECT_EQ(lp["global_grants"], 507);
-  EXPECT_EQ(lp["global_denies"], -1);
+    // granted=0 -> deny all labels
+    EXPECT_EQ(rules[0]["granted"], 0);
+    EXPECT_EQ(rules[0]["denied"], 507);
+    EXPECT_EQ(rules[0]["matching"], "ANY");
 
-  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
-  // V2 READ (1) -> V3 READ (1) -> V4 READ (1)
-  EXPECT_EQ(ep["global_grants"], 1);
-  EXPECT_EQ(ep["global_denies"], -1);
-}
-
-TEST(MigrateAuthJson, V2UpdateMigratesWithLabelExpansion) {
-  // V2 UPDATE (3) should go through V3 (UPDATE|READ = 2|1 = 3) then V4 label expansion
-  auto data = nlohmann::json::parse(R"({
-    "rolename": "r",
-    "permissions": {"grants": 0, "denies": 0},
-    "fine_grained_access_handler": {
-      "label_permissions": {
-        "global_permission": 3
-      },
-      "edge_type_permissions": {
-        "global_permission": 3
-      }
-    }
-  })");
-  MigrateAuthJson(data);
-
-  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
-  // V2 UPDATE (3) -> V3 UPDATE|READ (2|1=3) -> V4 label expansion of UPDATE
-  // = READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) | CREATE_EDGE(256) = 483
-  EXPECT_EQ(lp["global_grants"], 483);
-  EXPECT_EQ(lp["global_denies"], -1);
-
-  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
-  // V2 UPDATE (3) -> V3 UPDATE|READ (2|1=3) -> V4 edge: no expansion, stays 3
-  EXPECT_EQ(ep["global_grants"], 3);
-  EXPECT_EQ(ep["global_denies"], -1);
-}
-
-TEST(MigrateAuthJson, V3RoleDeserializesAfterMigration) {
-  memgraph::license::global_license_checker.EnableTesting();
-  auto data = nlohmann::json::parse(R"({
-    "rolename": "fga_role",
-    "permissions": {"grants": 1, "denies": 0},
-    "fine_grained_permissions": {
-      "label_permissions": {
-        "global_permission": 1,
-        "permissions": []
-      },
-      "edge_type_permissions": {
-        "global_permission": 1,
-        "permissions": []
-      }
-    }
-  })");
-  MigrateAuthJson(data);
-  auto role = Role::Deserialize(data);
-
-  EXPECT_EQ(role.rolename(), "fga_role");
-  auto const &label_perms = role.GetFineGrainedAccessLabelPermissions();
-  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(FineGrainedPermission::READ));
-}
-
-TEST(MigrateAuthJson, V3UserDeserializesAfterMigration) {
-  memgraph::license::global_license_checker.EnableTesting();
-  auto data = nlohmann::json::parse(R"({
-    "username": "fga_user",
-    "password_hash": null,
-    "permissions": {"grants": 1, "denies": 0},
-    "fine_grained_permissions": {
-      "label_permissions": {
-        "global_permission": 1,
-        "permissions": []
-      },
-      "edge_type_permissions": {
-        "global_permission": 1,
-        "permissions": []
-      }
-    }
-  })");
-  MigrateAuthJson(data);
-  auto user = User::Deserialize(data);
-
-  EXPECT_EQ(user.username(), "fga_user");
-  auto const &label_perms = user.GetUserFineGrainedAccessLabelPermissions();
-  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(FineGrainedPermission::READ));
+    // granted=3 (READ|UPDATE) -> expanded
+    EXPECT_EQ(rules[1]["granted"], 483);
+    EXPECT_EQ(rules[1]["denied"], 0);
+    EXPECT_EQ(rules[1]["matching"], "EXACTLY");
+  }
 }
 
 TEST(MigrateAuthJson, NoFgaFieldNeedsNoMigration) {

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -4161,6 +4161,59 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
   }
 }
 
+// 3.9 stores V3-style bitmasks and a permissions array under the old
+// `fine_grained_access_handler` key. The migration must not misclassify this
+// as V2 (which would corrupt the bitmasks and wipe the rules array).
+TEST(MigrateAuthJson, V39OldKeyWithV3Content) {
+  auto data = nlohmann::json::parse(R"({
+    "rolename": "system_admin",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_access_handler": {
+      "label_permissions": {
+        "global_permission": 27,
+        "permissions": [
+          {"symbols": ["Person"], "granted": 1, "matching": "ANY"}
+        ]
+      },
+      "edge_type_permissions": {
+        "global_permission": 27,
+        "permissions": [
+          {"symbols": ["KNOWS"], "granted": 27, "matching": "ANY"}
+        ]
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+  ASSERT_EQ(data["version"], kCurrentEntityVersion);
+
+  ASSERT_FALSE(data.contains("fine_grained_access_handler"));
+  ASSERT_TRUE(data.contains("fine_grained_permissions"));
+
+  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+  ASSERT_FALSE(lp.contains("global_permission"));
+  // V3 READ|UPDATE|CREATE|DELETE (27) -> V4 label expansion
+  EXPECT_EQ(lp["global_grants"], kAllLabel);
+  EXPECT_EQ(lp["global_denies"], kUnset);
+
+  // Per-entity rule: READ (1) stays as READ, gains denied=0
+  auto const &lp_rules = lp["permissions"];
+  ASSERT_EQ(lp_rules.size(), 1);
+  EXPECT_EQ(lp_rules[0]["granted"], kRead);
+  EXPECT_EQ(lp_rules[0]["denied"], 0);
+
+  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+  ASSERT_FALSE(ep.contains("global_permission"));
+  // V3 edge 27 -> V4: no expansion for edge types
+  EXPECT_EQ(ep["global_grants"], kAllEdgeType);
+  EXPECT_EQ(ep["global_denies"], kUnset);
+
+  // Per-entity rule preserved
+  auto const &ep_rules = ep["permissions"];
+  ASSERT_EQ(ep_rules.size(), 1);
+  EXPECT_EQ(ep_rules[0]["granted"], kAllEdgeType);
+  EXPECT_EQ(ep_rules[0]["denied"], 0);
+}
+
 TEST(MigrateAuthJson, NoFgaFieldNeedsNoMigration) {
   auto data = nlohmann::json::parse(R"({
     "username": "basic_user",

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -4136,6 +4136,34 @@ TEST(MigrateAuthJson, V2ToV4) {
   EXPECT_EQ(ep["global_denies"], -1);
 }
 
+TEST(MigrateAuthJson, V2UpdateToV4) {
+  // V2 UPDATE (3) should go through V3 (UPDATE|READ = 2|1 = 3) then V4 label expansion
+  auto data = nlohmann::json::parse(R"({
+    "rolename": "r",
+    "permissions": {"grants": 0, "denies": 0},
+    "fine_grained_access_handler": {
+      "label_permissions": {
+        "global_permission": 3
+      },
+      "edge_type_permissions": {
+        "global_permission": 3
+      }
+    }
+  })");
+  MigrateAuthJson(data);
+
+  auto const &lp = data["fine_grained_permissions"]["label_permissions"];
+  // V2 UPDATE (3) -> V3 UPDATE|READ (2|1=3) -> V4 label expansion of UPDATE
+  // = READ(1) | SET_LABEL(32) | REMOVE_LABEL(64) | SET_PROPERTY(2) | DELETE_EDGE(128) | CREATE_EDGE(256) = 483
+  EXPECT_EQ(lp["global_grants"], 483);
+  EXPECT_EQ(lp["global_denies"], -1);
+
+  auto const &ep = data["fine_grained_permissions"]["edge_type_permissions"];
+  // V2 UPDATE (3) -> V3 UPDATE|READ (2|1=3) -> V4 edge: no expansion, stays 3
+  EXPECT_EQ(ep["global_grants"], 3);
+  EXPECT_EQ(ep["global_denies"], -1);
+}
+
 TEST(MigrateAuthJson, V3DeserializesToValidRole) {
   memgraph::license::global_license_checker.EnableTesting();
   auto data = nlohmann::json::parse(R"({

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3989,7 +3989,7 @@ TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
-    ASSERT_EQ(data["version"], kCurrentAuthVersion);
+    ASSERT_EQ(data["version"], kCurrentEntityVersion);
 
     ASSERT_FALSE(data.contains("fine_grained_access_handler"));
     ASSERT_TRUE(data.contains("fine_grained_permissions"));
@@ -4022,7 +4022,7 @@ TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
-    ASSERT_EQ(data["version"], kCurrentAuthVersion);
+    ASSERT_EQ(data["version"], kCurrentEntityVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     // V2 UPDATE (3) -> V3 UPDATE|READ (3) -> V4 label expansion
@@ -4054,7 +4054,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
-    ASSERT_EQ(data["version"], kCurrentAuthVersion);
+    ASSERT_EQ(data["version"], kCurrentEntityVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
@@ -4084,7 +4084,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
-    ASSERT_EQ(data["version"], kCurrentAuthVersion);
+    ASSERT_EQ(data["version"], kCurrentEntityVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
@@ -4114,7 +4114,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
-    ASSERT_EQ(data["version"], kCurrentAuthVersion);
+    ASSERT_EQ(data["version"], kCurrentEntityVersion);
 
     auto const &lp = data["fine_grained_permissions"]["label_permissions"];
     ASSERT_FALSE(lp.contains("global_permission"));
@@ -4145,7 +4145,7 @@ TEST(MigrateAuthJson, V3MigrationToCurrentVersion) {
       }
     })");
     MigrateAuthJson(data);
-    ASSERT_EQ(data["version"], kCurrentAuthVersion);
+    ASSERT_EQ(data["version"], kCurrentEntityVersion);
 
     auto const &rules = data["fine_grained_permissions"]["label_permissions"]["permissions"];
     ASSERT_EQ(rules.size(), 2);
@@ -4169,7 +4169,7 @@ TEST(MigrateAuthJson, NoFgaFieldNeedsNoMigration) {
   })");
   auto const original = data;
   MigrateAuthJson(data);
-  ASSERT_EQ(data["version"], kCurrentAuthVersion);
+  ASSERT_EQ(data["version"], kCurrentEntityVersion);
 
   for (auto const &[key, value] : original.items()) {
     EXPECT_EQ(data[key], value) << "Mismatch for key: " << key;

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3957,19 +3957,18 @@ TEST(MigrateAuthJson, MigratingCurrentVersionIsIdempotent) {
 
 #endif  // MG_ENTERPRISE
 
-// FineGrainedPermission values for use outside the MG_ENTERPRISE guard.
-// These mirror the enum in models.hpp but are usable in community builds.
 namespace {
-constexpr uint64_t kRead = 1;
-constexpr uint64_t kSetProperty = 2;
-constexpr uint64_t kReadOrSetProperty = kRead | kSetProperty;  // 3
-constexpr uint64_t kAllLabel = 507;
-constexpr uint64_t kAllEdgeType = 27;
-constexpr uint64_t kSetLabel = 32;
-constexpr uint64_t kRemoveLabel = 64;
-constexpr uint64_t kDeleteEdge = 128;
-constexpr uint64_t kCreateEdge = 256;
-constexpr uint64_t kLabelUpdateExpanded = kRead | kSetProperty | kSetLabel | kRemoveLabel | kDeleteEdge | kCreateEdge;
+using memgraph::auth::FineGrainedPermission;
+using memgraph::auth::kAllEdgeTypePermissions;
+using memgraph::auth::kAllLabelPermissions;
+
+constexpr auto kAllLabel = std::to_underlying(kAllLabelPermissions);
+constexpr auto kAllEdgeType = std::to_underlying(kAllEdgeTypePermissions);
+constexpr auto kRead = std::to_underlying(FineGrainedPermission::READ);
+constexpr auto kReadOrSetProperty =
+    std::to_underlying(FineGrainedPermission::READ | FineGrainedPermission::SET_PROPERTY);
+constexpr auto kLabelUpdateExpanded =
+    std::to_underlying(memgraph::auth::kVertexLabelUpdatePermissions | FineGrainedPermission::READ);
 constexpr int64_t kUnset = -1;
 }  // namespace
 

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -3955,6 +3955,8 @@ TEST(MigrateAuthJson, MigratingCurrentVersionIsIdempotent) {
   EXPECT_EQ(data, original);
 }
 
+#endif  // MG_ENTERPRISE
+
 TEST(MigrateAuthJson, V2MigrationToCurrentVersion) {
   // CREATE_DELETE (7) -> full label grants
   {
@@ -4163,5 +4165,3 @@ TEST(MigrateAuthJson, NoFgaFieldNeedsNoMigration) {
     EXPECT_EQ(data[key], value) << "Mismatch for key: " << key;
   }
 }
-
-#endif  // MG_ENTERPRISE

--- a/tests/unit/auth_models.cpp
+++ b/tests/unit/auth_models.cpp
@@ -78,7 +78,8 @@ constexpr auto full_json_str = R"({
     ]
   },
   "username":"a",
-  "uuid":[4,91,245,109,241,58,74,21,180,161,26,87,18,208,220,226]
+  "uuid":[4,91,245,109,241,58,74,21,180,161,26,87,18,208,220,226],
+  "version":4
   })";
 
 constexpr auto mg_enterprise_no_license_json_str = R"({
@@ -109,7 +110,8 @@ constexpr auto community_saved_with_license_json_str = R"({
           "property_access_permissions":{"edge_type_property_permissions":{"global":{"*":{"denies":0,"grants":3}}},"label_property_permissions":{"global":{"*":{"denies":0,"grants":3}}}},
           "user_imp":null,
           "username":"a",
-          "uuid":[4,91,245,109,241,58,74,21,180,161,26,87,18,208,220,226]
+          "uuid":[4,91,245,109,241,58,74,21,180,161,26,87,18,208,220,226],
+          "version":4
           })";
 
 const memgraph::utils::UUID::arr_t hash({4, 91, 245, 109, 241, 58, 74, 21, 180, 161, 26, 87, 18, 208, 220, 226});
@@ -992,7 +994,8 @@ TEST(AuthModule, UserSerialization) {
           "property_access_permissions":{"edge_type_property_permissions":{},"label_property_permissions":{}},
           "user_imp":null,
           "username":"",
-          "uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
+          "uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],
+          "version":4
           })");
 
   // Empty user
@@ -1183,7 +1186,8 @@ TEST(AuthModule, RoleSerialization) {
           "property_access_permissions":{"edge_type_property_permissions":{},"label_property_permissions":{}},
           "rolename":"",
           "user_imp":null,
-          "builtin":false
+          "builtin":false,
+          "version":4
           })");
 
   // Empty role

--- a/tests/unit/auth_models_comm.cpp
+++ b/tests/unit/auth_models_comm.cpp
@@ -62,7 +62,8 @@ constexpr auto community_json_str = R"({
       "password_hash":{"hash_algo":0,"password_hash":"$2a$12$pFMD3q0mfCg.lPD3ng0F5uzOCi5n4VZTDklBc2lQyXi19AaUwJXAa"},
       "permissions":{"denies":0,"grants":134217727},
       "username":"a",
-      "uuid":[4,91,245,109,241,58,74,21,180,161,26,87,18,208,220,226]
+      "uuid":[4,91,245,109,241,58,74,21,180,161,26,87,18,208,220,226],
+      "version":4
       })";
 
 constexpr auto community_saved_with_license_json_str = R"({
@@ -236,7 +237,8 @@ TEST(AuthModule, UserSerialization) {
           "password_hash":null,
           "permissions":{"denies":0,"grants":0},
           "username":"",
-          "uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
+          "uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],
+          "version":4
           })");
 
   // Empty user

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -607,11 +607,9 @@ TEST(RpcVersioning, SlkLoadUser_MigratesV3FGA) {
   // Roles vector: size=1, then role JSON string
   memgraph::slk::Save(static_cast<uint64_t>(1), &builder);
   memgraph::slk::Save(role_json_str, &builder);
-#ifdef MG_ENTERPRISE
   // MT mappings: empty map
   std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
   memgraph::slk::Save(mt_map, &builder);
-#endif
   builder.Finalize();
 
   memgraph::slk::Reader reader(buf.data(), buf.size());

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -569,175 +569,70 @@ nlohmann::json MakeV3UserJson(std::string const &username, int64_t label_perm, i
   return data;
 }
 
-// SLK round-trip helper: serialize V1, then LoadWithUpgrade to V2.
-memgraph::replication::UpdateAuthDataReq RoundTripV1ToV2(memgraph::replication::UpdateAuthDataReqV1 const &v1_req) {
+}  // namespace
+
+// slk::Load<Role> migrates V3 FGA (global_permission) to V4 (global_grants/global_denies).
+TEST(RpcVersioning, SlkLoadRole_MigratesV3FGA) {
+  // Inject V3 JSON bytes directly into the SLK stream to simulate an old sender.
   std::vector<uint8_t> buf;
   memgraph::slk::Builder builder(
       [&buf](const uint8_t *data, size_t size, bool) { buf.insert(buf.end(), data, data + size); });
-  memgraph::slk::Save(v1_req, &builder);
+  // slk::Save<Role> calls self.Serialize().dump() — we bypass this to inject V3 JSON.
+  auto const v3_str = MakeV3RoleJson("myrole", /*label_perm=*/1, /*edge_perm=*/1).dump();
+  memgraph::slk::Save(v3_str, &builder);
   builder.Finalize();
 
   memgraph::slk::Reader reader(buf.data(), buf.size());
-  memgraph::replication::UpdateAuthDataReq v2_req;
-  memgraph::rpc::LoadWithUpgrade(v2_req, /*request_version=*/1, &reader);
-  return v2_req;
+  memgraph::auth::Role loaded;
+  memgraph::slk::Load(&loaded, &reader);
+
+  EXPECT_EQ(loaded.rolename(), "myrole");
+  auto const &label_perms = loaded.fine_grained_access_handler().label_permissions();
+  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+  EXPECT_FALSE(label_perms.GetGlobalDenies().has_value());
 }
-}  // namespace
 
-// V1 request with V3-format FGA User JSON → upgraded to V2 with migrated FGA.
-TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithOldFGA_MigratedOnUpgrade) {
-  // V3 global_permission = 1 means READ granted.
-  // After V3→V4 migration: global_grants=1 (READ), global_denies=-1 (unset).
-  auto user_json = MakeV3UserJson("alice", /*label_perm=*/1, /*edge_perm=*/1);
-  auto role_json = MakeV3RoleJson("testrole", /*label_perm=*/1, /*edge_perm=*/1);
+// slk::Load<User> migrates V3 FGA and attached roles.
+TEST(RpcVersioning, SlkLoadUser_MigratesV3FGA) {
+  auto const user_json_str = MakeV3UserJson("alice", /*label_perm=*/1, /*edge_perm=*/1).dump();
+  auto const role_json_str = MakeV3RoleJson("testrole", /*label_perm=*/1, /*edge_perm=*/1).dump();
 
-  memgraph::replication::UpdateAuthDataReqV1 v1;
-  v1.main_uuid = memgraph::utils::UUID{};
-  v1.expected_group_timestamp = 42;
-  v1.new_group_timestamp = 43;
-  v1.user_json = user_json.dump();
-  v1.user_role_jsons = std::vector<std::string>{role_json.dump()};
-  v1.user_mt_mappings = std::unordered_map<std::string, std::unordered_set<std::string>>{};
+  // Build the SLK byte stream manually: user JSON string, then roles vector, then MT mappings.
+  std::vector<uint8_t> buf;
+  memgraph::slk::Builder builder(
+      [&buf](const uint8_t *data, size_t size, bool) { buf.insert(buf.end(), data, data + size); });
+  // User JSON string
+  memgraph::slk::Save(user_json_str, &builder);
+  // Roles vector: size=1, then role JSON string
+  memgraph::slk::Save(static_cast<uint64_t>(1), &builder);
+  memgraph::slk::Save(role_json_str, &builder);
+#ifdef MG_ENTERPRISE
+  // MT mappings: empty map
+  std::unordered_map<std::string, std::unordered_set<std::string>> mt_map;
+  memgraph::slk::Save(mt_map, &builder);
+#endif
+  builder.Finalize();
 
-  auto v2 = RoundTripV1ToV2(v1);
+  memgraph::slk::Reader reader(buf.data(), buf.size());
+  memgraph::auth::User loaded;
+  memgraph::slk::Load(&loaded, &reader);
 
-  ASSERT_TRUE(v2.user.has_value());
-  EXPECT_EQ(v2.user->username(), "alice");
-  EXPECT_FALSE(v2.role.has_value());
-  EXPECT_EQ(v2.expected_group_timestamp, 42);
-  EXPECT_EQ(v2.new_group_timestamp, 43);
+  EXPECT_EQ(loaded.username(), "alice");
 
-  // Verify FGA migrated: global_grants should be set, global_denies unset.
-  auto const &label_perms = v2.user->fine_grained_access_handler().label_permissions();
+  auto const &label_perms = loaded.fine_grained_access_handler().label_permissions();
   ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
   EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
   EXPECT_FALSE(label_perms.GetGlobalDenies().has_value());
 
-  auto const &edge_perms = v2.user->fine_grained_access_handler().edge_type_permissions();
-  ASSERT_TRUE(edge_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(edge_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
-  EXPECT_FALSE(edge_perms.GetGlobalDenies().has_value());
-
-  // Check the embedded role was also migrated
-  auto const &roles = v2.user->roles();
-  ASSERT_EQ(roles.size(), 1);
-  auto const &role = *roles.begin();
+  // Attached role should also be migrated
+  ASSERT_EQ(loaded.roles().size(), 1);
+  auto const &role = *loaded.roles().begin();
   EXPECT_EQ(role.rolename(), "testrole");
   auto const &role_label_perms = role.fine_grained_access_handler().label_permissions();
   ASSERT_TRUE(role_label_perms.GetGlobalGrants().has_value());
   EXPECT_EQ(role_label_perms.GetGlobalGrants().value(),
             static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
-  EXPECT_FALSE(role_label_perms.GetGlobalDenies().has_value());
-
-  auto const &role_edge_perms = role.fine_grained_access_handler().edge_type_permissions();
-  ASSERT_TRUE(role_edge_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(role_edge_perms.GetGlobalGrants().value(),
-            static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
-  EXPECT_FALSE(role_edge_perms.GetGlobalDenies().has_value());
-}
-
-// V1 request with V3-format FGA standalone Role → upgraded with migration.
-TEST(RpcVersioning, UpdateAuthDataRpc_V1RoleWithOldFGA_MigratedOnUpgrade) {
-  auto role_json = MakeV3RoleJson("myrole", /*label_perm=*/1, /*edge_perm=*/1);
-
-  memgraph::replication::UpdateAuthDataReqV1 v1;
-  v1.main_uuid = memgraph::utils::UUID{};
-  v1.expected_group_timestamp = 10;
-  v1.new_group_timestamp = 11;
-  v1.role_json = role_json.dump();
-
-  auto v2 = RoundTripV1ToV2(v1);
-
-  ASSERT_FALSE(v2.user.has_value());
-  ASSERT_TRUE(v2.role.has_value());
-  EXPECT_EQ(v2.role->rolename(), "myrole");
-
-  auto const &label_perms = v2.role->fine_grained_access_handler().label_permissions();
-  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
-}
-
-// V2 request round-trips without migration.
-TEST(RpcVersioning, UpdateAuthDataRpc_V2Request_NoMigrationNeeded) {
-  auto role = memgraph::auth::Role("v2role");
-  role.fine_grained_access_handler().label_permissions().GrantGlobal(memgraph::auth::FineGrainedPermission::READ);
-
-  memgraph::replication::UpdateAuthDataReq orig;
-  orig.main_uuid = memgraph::utils::UUID{};
-  orig.expected_group_timestamp = 5;
-  orig.new_group_timestamp = 6;
-  orig.role = std::move(role);
-
-  // Serialize as V2 and load as V2 (no upgrade needed).
-  std::vector<uint8_t> buf;
-  memgraph::slk::Builder builder(
-      [&buf](const uint8_t *data, size_t size, bool) { buf.insert(buf.end(), data, data + size); });
-  memgraph::slk::Save(orig, &builder);
-  builder.Finalize();
-
-  memgraph::slk::Reader reader(buf.data(), buf.size());
-  memgraph::replication::UpdateAuthDataReq loaded;
-  memgraph::rpc::LoadWithUpgrade(loaded, /*request_version=*/2, &reader);
-
-  ASSERT_TRUE(loaded.role.has_value());
-  EXPECT_EQ(loaded.role->rolename(), "v2role");
-  auto const &label_perms = loaded.role->fine_grained_access_handler().label_permissions();
-  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
-}
-
-// V1 request with user but no roles (user_role_jsons = nullopt).
-TEST(RpcVersioning, UpdateAuthDataRpc_V1UserNoRoles_UpgradesCleanly) {
-  auto user_json = MakeV3UserJson("bob", /*label_perm=*/1, /*edge_perm=*/1);
-
-  memgraph::replication::UpdateAuthDataReqV1 v1;
-  v1.main_uuid = memgraph::utils::UUID{};
-  v1.expected_group_timestamp = 1;
-  v1.new_group_timestamp = 2;
-  v1.user_json = user_json.dump();
-  // user_role_jsons and user_mt_mappings left as nullopt
-
-  auto v2 = RoundTripV1ToV2(v1);
-
-  ASSERT_TRUE(v2.user.has_value());
-  EXPECT_EQ(v2.user->username(), "bob");
-  EXPECT_TRUE(v2.user->roles().empty());
-
-  auto const &label_perms = v2.user->fine_grained_access_handler().label_permissions();
-  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
-}
-
-// V1 request with user and MT role mappings.
-TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithMtMappings_RolesAttachedPerDb) {
-  auto user_json = MakeV3UserJson("carol", /*label_perm=*/-1, /*edge_perm=*/-1);
-  auto role_json = MakeV3RoleJson("dbrole", /*label_perm=*/1, /*edge_perm=*/1);
-
-  memgraph::replication::UpdateAuthDataReqV1 v1;
-  v1.main_uuid = memgraph::utils::UUID{};
-  v1.expected_group_timestamp = 100;
-  v1.new_group_timestamp = 101;
-  v1.user_json = user_json.dump();
-  v1.user_role_jsons = std::vector<std::string>{role_json.dump()};
-  v1.user_mt_mappings = std::unordered_map<std::string, std::unordered_set<std::string>>{{"testdb", {"dbrole"}}};
-
-  auto v2 = RoundTripV1ToV2(v1);
-
-  ASSERT_TRUE(v2.user.has_value());
-  EXPECT_EQ(v2.user->username(), "carol");
-
-  // Carol's own FGA was -1 (unset) → should remain unset after migration
-  auto const &label_perms = v2.user->fine_grained_access_handler().label_permissions();
-  EXPECT_FALSE(label_perms.GetGlobalGrants().has_value());
-  EXPECT_FALSE(label_perms.GetGlobalDenies().has_value());
-
-  // The role should be attached both as a regular role and as an MT mapping
-  EXPECT_EQ(v2.user->roles().size(), 1);
-  EXPECT_EQ(v2.user->roles().begin()->rolename(), "dbrole");
-
-  auto const &mt = v2.user->GetMultiTenantRoleMappings();
-  ASSERT_EQ(mt.count("testdb"), 1);
-  EXPECT_EQ(mt.at("testdb").count("dbrole"), 1);
 }
 
 #endif  // MG_ENTERPRISE

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -11,12 +11,15 @@
 
 #include "gtest/gtest.h"
 
+#include <nlohmann/json.hpp>
+
 #include "coordination/coordinator_rpc.hpp"
 #include "coordination/instance_state.hpp"
 #include "replication_coordination_glue/common.hpp"
 
 #include "rpc_messages.hpp"
 
+#include "auth/rpc.hpp"
 #include "replication_handler/system_rpc.hpp"
 #include "rpc/client.hpp"
 #include "rpc/file_replication_handler.hpp"
@@ -529,3 +532,147 @@ TEST(RpcVersioning, SystemRecoveryRpc_V3Request_CarriesColdSet) {
   EXPECT_TRUE(seen_cold[0].stats.durability_wal_enabled);
   EXPECT_EQ(seen_cold[0].stats.schema_vertex_count, 9U);
 }
+
+#ifdef MG_ENTERPRISE
+
+namespace {
+// Build a V3-format role JSON (uses global_permission instead of global_grants/global_denies).
+nlohmann::json MakeV3RoleJson(std::string const &rolename, int64_t label_perm, int64_t edge_perm) {
+  nlohmann::json data;
+  data["rolename"] = rolename;
+  data["builtin"] = false;
+  data["permissions"] = nlohmann::json{{"grants", 0}, {"denies", 0}};
+  data["fine_grained_permissions"] = {
+      {"label_permissions", {{"global_permission", label_perm}, {"permissions", nlohmann::json::array()}}},
+      {"edge_type_permissions", {{"global_permission", edge_perm}, {"permissions", nlohmann::json::array()}}}};
+  data["databases"] = {{"allow_all", true},
+                       {"grants", nlohmann::json::array()},
+                       {"denies", nlohmann::json::array()},
+                       {"default", "memgraph"}};
+  return data;
+}
+
+// Build a V3-format user JSON.
+nlohmann::json MakeV3UserJson(std::string const &username, int64_t label_perm, int64_t edge_perm) {
+  nlohmann::json data;
+  data["username"] = username;
+  data["uuid"] = memgraph::utils::UUID{};
+  data["password_hash"] = nullptr;
+  data["permissions"] = nlohmann::json{{"grants", 0}, {"denies", 0}};
+  data["fine_grained_permissions"] = {
+      {"label_permissions", {{"global_permission", label_perm}, {"permissions", nlohmann::json::array()}}},
+      {"edge_type_permissions", {{"global_permission", edge_perm}, {"permissions", nlohmann::json::array()}}}};
+  data["databases"] = {{"allow_all", true},
+                       {"grants", nlohmann::json::array()},
+                       {"denies", nlohmann::json::array()},
+                       {"default", "memgraph"}};
+  return data;
+}
+
+// SLK round-trip helper: serialize V1, then LoadWithUpgrade to V2.
+memgraph::replication::UpdateAuthDataReq RoundTripV1ToV2(memgraph::replication::UpdateAuthDataReqV1 const &v1_req) {
+  std::vector<uint8_t> buf;
+  memgraph::slk::Builder builder(
+      [&buf](const uint8_t *data, size_t size, bool) { buf.insert(buf.end(), data, data + size); });
+  memgraph::slk::Save(v1_req, &builder);
+  builder.Finalize();
+
+  memgraph::slk::Reader reader(buf.data(), buf.size());
+  memgraph::replication::UpdateAuthDataReq v2_req;
+  memgraph::rpc::LoadWithUpgrade(v2_req, /*request_version=*/1, &reader);
+  return v2_req;
+}
+}  // namespace
+
+// V1 request with V3-format FGA User JSON → upgraded to V2 with migrated FGA.
+TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithOldFGA_MigratedOnUpgrade) {
+  // V3 global_permission = 1 means READ granted.
+  // After V3→V4 migration: global_grants=1 (READ), global_denies=-1 (unset).
+  auto user_json = MakeV3UserJson("alice", /*label_perm=*/1, /*edge_perm=*/1);
+  auto role_json = MakeV3RoleJson("testrole", /*label_perm=*/1, /*edge_perm=*/1);
+
+  memgraph::replication::UpdateAuthDataReqV1 v1;
+  v1.main_uuid = memgraph::utils::UUID{};
+  v1.expected_group_timestamp = 42;
+  v1.new_group_timestamp = 43;
+  v1.user_json = user_json.dump();
+  v1.user_role_jsons = std::vector<std::string>{role_json.dump()};
+  v1.user_mt_mappings = std::unordered_map<std::string, std::unordered_set<std::string>>{};
+
+  auto v2 = RoundTripV1ToV2(v1);
+
+  ASSERT_TRUE(v2.user.has_value());
+  EXPECT_EQ(v2.user->username(), "alice");
+  EXPECT_FALSE(v2.role.has_value());
+  EXPECT_EQ(v2.expected_group_timestamp, 42);
+  EXPECT_EQ(v2.new_group_timestamp, 43);
+
+  // Verify FGA migrated: global_grants should be set (not nullopt),
+  // and the old global_permission field should be gone.
+  auto const &label_perms = v2.user->fine_grained_access_handler().label_permissions();
+  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
+  // V3 perm=1 (READ) → V4 global_grants=1 (READ bit), but label perms also
+  // expand UPDATE→multiple bits. READ=1 stays as 1.
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), 1);
+
+  // Check the embedded role was also migrated
+  auto const &roles = v2.user->roles();
+  ASSERT_EQ(roles.size(), 1);
+  auto const &role = *roles.begin();
+  EXPECT_EQ(role.rolename(), "testrole");
+  auto const &role_label_perms = role.fine_grained_access_handler().label_permissions();
+  ASSERT_TRUE(role_label_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(role_label_perms.GetGlobalGrants().value(), 1);
+}
+
+// V1 request with V3-format FGA standalone Role → upgraded with migration.
+TEST(RpcVersioning, UpdateAuthDataRpc_V1RoleWithOldFGA_MigratedOnUpgrade) {
+  auto role_json = MakeV3RoleJson("myrole", /*label_perm=*/1, /*edge_perm=*/1);
+
+  memgraph::replication::UpdateAuthDataReqV1 v1;
+  v1.main_uuid = memgraph::utils::UUID{};
+  v1.expected_group_timestamp = 10;
+  v1.new_group_timestamp = 11;
+  v1.role_json = role_json.dump();
+
+  auto v2 = RoundTripV1ToV2(v1);
+
+  ASSERT_FALSE(v2.user.has_value());
+  ASSERT_TRUE(v2.role.has_value());
+  EXPECT_EQ(v2.role->rolename(), "myrole");
+
+  auto const &label_perms = v2.role->fine_grained_access_handler().label_permissions();
+  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), 1);
+}
+
+// V2 request round-trips without migration.
+TEST(RpcVersioning, UpdateAuthDataRpc_V2Request_NoMigrationNeeded) {
+  auto role = memgraph::auth::Role("v2role");
+  role.fine_grained_access_handler().label_permissions().GrantGlobal(memgraph::auth::FineGrainedPermission::READ);
+
+  memgraph::replication::UpdateAuthDataReq orig;
+  orig.main_uuid = memgraph::utils::UUID{};
+  orig.expected_group_timestamp = 5;
+  orig.new_group_timestamp = 6;
+  orig.role = std::move(role);
+
+  // Serialize as V2 and load as V2 (no upgrade needed).
+  std::vector<uint8_t> buf;
+  memgraph::slk::Builder builder(
+      [&buf](const uint8_t *data, size_t size, bool) { buf.insert(buf.end(), data, data + size); });
+  memgraph::slk::Save(orig, &builder);
+  builder.Finalize();
+
+  memgraph::slk::Reader reader(buf.data(), buf.size());
+  memgraph::replication::UpdateAuthDataReq loaded;
+  memgraph::rpc::LoadWithUpgrade(loaded, /*request_version=*/2, &reader);
+
+  ASSERT_TRUE(loaded.role.has_value());
+  EXPECT_EQ(loaded.role->rolename(), "v2role");
+  auto const &label_perms = loaded.role->fine_grained_access_handler().label_permissions();
+  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+}
+
+#endif  // MG_ENTERPRISE

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -675,4 +675,53 @@ TEST(RpcVersioning, UpdateAuthDataRpc_V2Request_NoMigrationNeeded) {
   EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
 }
 
+// V1 request with user but no roles (user_role_jsons = nullopt).
+TEST(RpcVersioning, UpdateAuthDataRpc_V1UserNoRoles_UpgradesCleanly) {
+  auto user_json = MakeV3UserJson("bob", /*label_perm=*/1, /*edge_perm=*/1);
+
+  memgraph::replication::UpdateAuthDataReqV1 v1;
+  v1.main_uuid = memgraph::utils::UUID{};
+  v1.expected_group_timestamp = 1;
+  v1.new_group_timestamp = 2;
+  v1.user_json = user_json.dump();
+  // user_role_jsons and user_mt_mappings left as nullopt
+
+  auto v2 = RoundTripV1ToV2(v1);
+
+  ASSERT_TRUE(v2.user.has_value());
+  EXPECT_EQ(v2.user->username(), "bob");
+  EXPECT_TRUE(v2.user->roles().empty());
+
+  auto const &label_perms = v2.user->fine_grained_access_handler().label_permissions();
+  ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+}
+
+// V1 request with user and MT role mappings.
+TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithMtMappings_RolesAttachedPerDb) {
+  auto user_json = MakeV3UserJson("carol", /*label_perm=*/-1, /*edge_perm=*/-1);
+  auto role_json = MakeV3RoleJson("dbrole", /*label_perm=*/1, /*edge_perm=*/1);
+
+  memgraph::replication::UpdateAuthDataReqV1 v1;
+  v1.main_uuid = memgraph::utils::UUID{};
+  v1.expected_group_timestamp = 100;
+  v1.new_group_timestamp = 101;
+  v1.user_json = user_json.dump();
+  v1.user_role_jsons = std::vector<std::string>{role_json.dump()};
+  v1.user_mt_mappings = std::unordered_map<std::string, std::unordered_set<std::string>>{{"testdb", {"dbrole"}}};
+
+  auto v2 = RoundTripV1ToV2(v1);
+
+  ASSERT_TRUE(v2.user.has_value());
+  EXPECT_EQ(v2.user->username(), "carol");
+
+  // The role should be attached both as a regular role and as an MT mapping
+  EXPECT_EQ(v2.user->roles().size(), 1);
+  EXPECT_EQ(v2.user->roles().begin()->rolename(), "dbrole");
+
+  auto const &mt = v2.user->GetMultiTenantRoleMappings();
+  ASSERT_EQ(mt.count("testdb"), 1);
+  EXPECT_EQ(mt.at("testdb").count("dbrole"), 1);
+}
+
 #endif  // MG_ENTERPRISE

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -613,7 +613,7 @@ TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithOldFGA_MigratedOnUpgrade) {
   ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
   // V3 perm=1 (READ) → V4 global_grants=1 (READ bit), but label perms also
   // expand UPDATE→multiple bits. READ=1 stays as 1.
-  EXPECT_EQ(label_perms.GetGlobalGrants().value(), 1);
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
 
   // Check the embedded role was also migrated
   auto const &roles = v2.user->roles();
@@ -643,7 +643,7 @@ TEST(RpcVersioning, UpdateAuthDataRpc_V1RoleWithOldFGA_MigratedOnUpgrade) {
 
   auto const &label_perms = v2.role->fine_grained_access_handler().label_permissions();
   ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(label_perms.GetGlobalGrants().value(), 1);
+  EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
 }
 
 // V2 request round-trips without migration.

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -607,13 +607,16 @@ TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithOldFGA_MigratedOnUpgrade) {
   EXPECT_EQ(v2.expected_group_timestamp, 42);
   EXPECT_EQ(v2.new_group_timestamp, 43);
 
-  // Verify FGA migrated: global_grants should be set (not nullopt),
-  // and the old global_permission field should be gone.
+  // Verify FGA migrated: global_grants should be set, global_denies unset.
   auto const &label_perms = v2.user->fine_grained_access_handler().label_permissions();
   ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
-  // V3 perm=1 (READ) → V4 global_grants=1 (READ bit), but label perms also
-  // expand UPDATE→multiple bits. READ=1 stays as 1.
   EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+  EXPECT_FALSE(label_perms.GetGlobalDenies().has_value());
+
+  auto const &edge_perms = v2.user->fine_grained_access_handler().edge_type_permissions();
+  ASSERT_TRUE(edge_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(edge_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+  EXPECT_FALSE(edge_perms.GetGlobalDenies().has_value());
 
   // Check the embedded role was also migrated
   auto const &roles = v2.user->roles();
@@ -624,6 +627,13 @@ TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithOldFGA_MigratedOnUpgrade) {
   ASSERT_TRUE(role_label_perms.GetGlobalGrants().has_value());
   EXPECT_EQ(role_label_perms.GetGlobalGrants().value(),
             static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+  EXPECT_FALSE(role_label_perms.GetGlobalDenies().has_value());
+
+  auto const &role_edge_perms = role.fine_grained_access_handler().edge_type_permissions();
+  ASSERT_TRUE(role_edge_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(role_edge_perms.GetGlobalGrants().value(),
+            static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+  EXPECT_FALSE(role_edge_perms.GetGlobalDenies().has_value());
 }
 
 // V1 request with V3-format FGA standalone Role → upgraded with migration.
@@ -715,6 +725,11 @@ TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithMtMappings_RolesAttachedPerDb) {
 
   ASSERT_TRUE(v2.user.has_value());
   EXPECT_EQ(v2.user->username(), "carol");
+
+  // Carol's own FGA was -1 (unset) → should remain unset after migration
+  auto const &label_perms = v2.user->fine_grained_access_handler().label_permissions();
+  EXPECT_FALSE(label_perms.GetGlobalGrants().has_value());
+  EXPECT_FALSE(label_perms.GetGlobalDenies().has_value());
 
   // The role should be attached both as a regular role and as an MT mapping
   EXPECT_EQ(v2.user->roles().size(), 1);

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -591,6 +591,11 @@ TEST(RpcVersioning, SlkLoadRole_MigratesV3FGA) {
   ASSERT_TRUE(label_perms.GetGlobalGrants().has_value());
   EXPECT_EQ(label_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
   EXPECT_FALSE(label_perms.GetGlobalDenies().has_value());
+
+  auto const &edge_perms = loaded.fine_grained_access_handler().edge_type_permissions();
+  ASSERT_TRUE(edge_perms.GetGlobalGrants().has_value());
+  EXPECT_EQ(edge_perms.GetGlobalGrants().value(), static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
+  EXPECT_FALSE(edge_perms.GetGlobalDenies().has_value());
 }
 
 // slk::Load<User> migrates V3 FGA and attached roles.

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -622,7 +622,8 @@ TEST(RpcVersioning, UpdateAuthDataRpc_V1UserWithOldFGA_MigratedOnUpgrade) {
   EXPECT_EQ(role.rolename(), "testrole");
   auto const &role_label_perms = role.fine_grained_access_handler().label_permissions();
   ASSERT_TRUE(role_label_perms.GetGlobalGrants().has_value());
-  EXPECT_EQ(role_label_perms.GetGlobalGrants().value(), 1);
+  EXPECT_EQ(role_label_perms.GetGlobalGrants().value(),
+            static_cast<uint64_t>(memgraph::auth::FineGrainedPermission::READ));
 }
 
 // V1 request with V3-format FGA standalone Role → upgraded with migration.


### PR DESCRIPTION
User/role data sent over the wire was not being migrated.

During a rolling upgrade from `3.9` to `3.10.1`, LBAC grants are lost when a `3.9` MAIN replicates auth data to an upgraded `3.10.1` REPLICA. The old MAIN serializes user/role structs in `V3` format, but the REPLICA's `Deserialize` expects `V4`; the result is that FGA fields are silently dropped. When failover occurs and REPLICA becomes MAIN, it does so with sheared user configurations.

- Per-entity migration on deserialize: Extracted existing `V2` -> `V3` and `V3` -> `V4` migration logic into `MigrateAuthJson()`. Each user or role now carries a `"version"` field.
- Separated auth store-level from entity-level versioning: Auth store versions (`V1` -> `V2` -> `V5`) are now reserved for structural KV store changes such as key prefix migrations. Entity schema changes (such as fine-grained access) are handled per-entity on deserialize.
- ISSU test coverage: Added `verify_fga_post_upgrade.sh` to confirm FGA grants survive mid-upgrade (on REPLICA while old MAIN is still running) and post-upgrade. ISSU test need further enhancement, but that will come in successive PRs.