### PR TITLE
feat(text_search): fuzzy phrase search 

### DIFF
--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -1010,6 +1010,9 @@ MGP_ENUM_CLASS text_search_mode{
     SPECIFIED_PROPERTIES,
     REGEX,
     ALL_PROPERTIES,
+    // Ordered, adjacent fuzzy term-sequence search over a single `data.<property>`. Appended last to
+    // keep the existing values' numbering stable.
+    SEQUENCE,
 };
 
 /// Search the named text index for the given query. The result is a map with the "search_results" and "error_msg" keys.

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -1010,9 +1010,9 @@ MGP_ENUM_CLASS text_search_mode{
     SPECIFIED_PROPERTIES,
     REGEX,
     ALL_PROPERTIES,
-    // Ordered, adjacent fuzzy term-sequence search over a single `data.<property>`. Appended last to
-    // keep the existing values' numbering stable.
-    SEQUENCE,
+    // Fuzzy phrase search (ordered, adjacent terms; last term a prefix) over a single
+    // `data.<property>`. Appended last to keep the existing values' numbering stable.
+    FUZZY_PHRASE,
 };
 
 /// Search the named text index for the given query. The result is a map with the "search_results" and "error_msg" keys.

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -480,11 +480,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // Adaptive candidate paging: 300 real matches exceed SEQUENCE_BASE_PAGE (256), so returning all of
-    // them forces a second page regardless of score order -- exercising the widening + and_offset
-    // boundary. Returning exactly the 300 (no more, no fewer) proves no boundary drop or duplicate; the
-    // interleaved decoys carry every query term in the wrong order, so they must be rejected across
-    // pages by the order/adjacency post-filter.
+    // Adaptive candidate paging: the 10 real matches sit between 150 decoys on each side, so the first
+    // page (limit 10 * SEQUENCE_OVERFETCH_FACTOR = 80 candidates) holds only decoys whichever way score
+    // ties break -- reaching the matches requires widening past the first page via and_offset. The
+    // decoys carry every query term in the wrong order, so the post-filter must reject them across
+    // pages; returning exactly the 10 proves no boundary drop or duplicate.
     #[test]
     fn search_sequence_pages_past_the_first_candidate_page() {
         let dir = std::env::temp_dir().join(format!("mgcxx_seq_paging_{}", std::process::id()));
@@ -497,14 +497,19 @@ mod tests {
             .to_string();
         let mut ctx = create_index(&path, &ffi::IndexConfig { mappings }).unwrap();
 
-        let real: Vec<u64> = (1u64..=300).collect();
-        for &gid in &real {
-            let data = format!(r#"{{"data":{{"name":"big bad wolf"}},"all":"big bad wolf","gid":{gid}}}"#);
+        let mut add_doc = |gid: u64, name: &str| {
+            let data = format!(r#"{{"data":{{"name":"{name}"}},"all":"{name}","gid":{gid}}}"#);
             add_document(&mut ctx, &ffi::DocumentInput { data }, true).unwrap();
+        };
+        for gid in 1u64..=150 {
+            add_doc(gid, "wolf bad big");
         }
-        for gid in 1000u64..=1049 {
-            let data = format!(r#"{{"data":{{"name":"wolf bad big"}},"all":"wolf bad big","gid":{gid}}}"#);
-            add_document(&mut ctx, &ffi::DocumentInput { data }, true).unwrap();
+        let real: Vec<u64> = (1000..1010).collect();
+        for &gid in &real {
+            add_doc(gid, "big bad wolf");
+        }
+        for gid in 2000u64..=2150 {
+            add_doc(gid, "wolf bad big");
         }
         commit(&mut ctx).unwrap();
 
@@ -514,7 +519,7 @@ mod tests {
             search_query: "data.name:big bad wo".to_string(),
             return_fields: vec![],
             aggregation_query: String::new(),
-            limit: 0, // unlimited -> first page is SEQUENCE_BASE_PAGE, must widen to reach all matches
+            limit: 10,
             fuzzy_distance: 0,
             fuzzy_prefix: true,
             fuzzy_transpositions: false,
@@ -971,12 +976,10 @@ fn search_get_fields(
     Ok(result)
 }
 
-// Adaptive candidate paging for search_sequence. The post-filter discards candidates, so we over-fetch
-// the requested limit, then page wider only when starved. SEQUENCE_BASE_PAGE is the first page for an
-// unlimited query; finite limits start at limit * SEQUENCE_OVERFETCH_FACTOR; pages double each round.
+// Adaptive candidate paging for search_sequence. The post-filter discards candidates, so the first page
+// over-fetches the effective limit by SEQUENCE_OVERFETCH_FACTOR and doubles each round when starved.
 // SEQUENCE_MAX_CANDIDATES caps how many score-ranked candidates one query will ever scan.
 // (Future scalability lever: a str/bytes fast field + columnar collector would filter without the store.)
-const SEQUENCE_BASE_PAGE: usize = 256;
 const SEQUENCE_OVERFETCH_FACTOR: usize = 8;
 const SEQUENCE_MAX_CANDIDATES: usize = 50_000;
 
@@ -1360,13 +1363,10 @@ fn sequence_matched_docs(
     // Page through score-ranked candidates, post-filtering each page, until we've collected
     // `result_limit` matches or the candidate stream runs out. Selective queries fill the first page;
     // we widen only when the post-filter is starved, capped at SEQUENCE_MAX_CANDIDATES.
-    let result_limit = if input.limit == 0 { usize::MAX } else { input.limit };
+    let result_limit = input.effective_limit();
     let mut matched: Vec<(f32, TantivyDocument)> = Vec::new();
     let mut scanned = 0usize;
-    let mut page = match input.limit {
-        0 => SEQUENCE_BASE_PAGE,
-        n => n.saturating_mul(SEQUENCE_OVERFETCH_FACTOR).min(SEQUENCE_MAX_CANDIDATES),
-    };
+    let mut page = result_limit.saturating_mul(SEQUENCE_OVERFETCH_FACTOR).min(SEQUENCE_MAX_CANDIDATES);
     while matched.len() < result_limit && scanned < SEQUENCE_MAX_CANDIDATES {
         let page_limit = page.min(SEQUENCE_MAX_CANDIDATES - scanned);
         let top_docs = searcher_ctx

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -21,6 +21,7 @@ use tantivy::aggregation::AggregationCollector;
 use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
 use tantivy::query::{BooleanQuery, FuzzyTermQuery, Occur, Query, QueryParser, RegexQuery};
+use tantivy::schema::Value as _;
 use tantivy::schema::*;
 use tantivy::tokenizer::{TextAnalyzer, TokenStream};
 use tantivy::{DocSet, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term, TERMINATED};
@@ -1074,13 +1075,10 @@ fn sequence_matches(
 
 // Reads the string value of `property` from a hit's stored `data` JSON object, if present.
 fn extract_property_string(doc: &TantivyDocument, data_field: Field, property: &str) -> Option<String> {
-    match doc.get_first(data_field)?.into() {
-        OwnedValue::Object(entries) => entries.into_iter().find_map(|(k, v)| match v {
-            OwnedValue::Str(s) if k == property => Some(s),
-            _ => None,
-        }),
-        _ => None,
-    }
+    doc.get_first(data_field)?
+        .as_object()?
+        .find(|(key, _)| *key == property)
+        .and_then(|(_, value)| value.as_str().map(str::to_string))
 }
 
 // Reads a stored u64 field (gid / edge gids) from a sequence-search hit's document.
@@ -1090,16 +1088,12 @@ fn extract_u64_field(
     field_name: &str,
     index_path: &std::path::PathBuf,
 ) -> Result<u64, std::io::Error> {
-    let value = doc.get_first(field).ok_or_else(|| {
-        Error::new(ErrorKind::Other, format!("Document missing {} field in {:?}", field_name, index_path))
-    })?;
-    match value.into() {
-        OwnedValue::U64(n) => Ok(n),
-        other => Err(Error::new(
+    doc.get_first(field).and_then(|value| value.as_u64()).ok_or_else(|| {
+        Error::new(
             ErrorKind::Other,
-            format!("{} field has unexpected type {:?} in {:?}", field_name, other, index_path),
-        )),
-    }
+            format!("Document missing u64 {} field in {:?}", field_name, index_path),
+        )
+    })
 }
 
 pub struct SearcherContext {

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -10,7 +10,7 @@
 // licenses/APL.txt.
 
 use log::debug;
-use serde_json::{to_string, Value};
+use serde_json::Value;
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
 use std::num::NonZeroUsize;
@@ -20,9 +20,10 @@ use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::AggregationCollector;
 use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
-use tantivy::query::{QueryParser, RegexQuery};
+use tantivy::query::{BooleanQuery, FuzzyTermQuery, Occur, Query, QueryParser, RegexQuery};
 use tantivy::schema::*;
-use tantivy::{DocSet, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, TERMINATED};
+use tantivy::tokenizer::{TextAnalyzer, TokenStream};
+use tantivy::{DocSet, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term, TERMINATED};
 use tantivy_fst::Regex;
 
 // NOTE: Result<T> == Result<T,std::io::Error>.
@@ -140,6 +141,18 @@ mod ffi {
             searcher: &SearcherContext,
             input: &SearchInput,
         ) -> Result<EdgeGidScoreOutput>;
+        // Ordered, adjacent fuzzy term-sequence search (last term a prefix). search_query is
+        // `data.<property>:<terms>`; fuzzy_distance/transpositions carry the user's exact values.
+        fn search_sequence_gids_pinned(
+            context: &Context,
+            searcher: &SearcherContext,
+            input: &SearchInput,
+        ) -> Result<GidScoreOutput>;
+        fn search_sequence_edge_gids_pinned(
+            context: &Context,
+            searcher: &SearcherContext,
+            input: &SearchInput,
+        ) -> Result<EdgeGidScoreOutput>;
         fn regex_search_edge_gids_pinned(
             context: &Context,
             searcher: &SearcherContext,
@@ -234,6 +247,90 @@ mod tests {
             owned_value_to_json(doc),
             json!({"name": "test", "count": -3, "tags": [true, 42u64], "nested": {"x": 1.5}, "empty": null})
         );
+    }
+
+    fn chars(s: &str) -> Vec<char> {
+        s.chars().collect()
+    }
+    fn toks(words: &[&str]) -> Vec<Vec<char>> {
+        words.iter().map(|w| chars(w)).collect()
+    }
+
+    #[test]
+    fn split_property_and_terms_accepts_single_property_form() {
+        assert_eq!(
+            split_property_and_terms("data.title:big bad wo").unwrap(),
+            ("title".to_string(), "big bad wo".to_string())
+        );
+        assert_eq!(
+            split_property_and_terms("data.a.b:x").unwrap(),
+            ("a.b".to_string(), "x".to_string())
+        );
+        assert_eq!(
+            split_property_and_terms("  data.title :big bad wo").unwrap(),
+            ("title".to_string(), "big bad wo".to_string())
+        );
+    }
+
+    #[test]
+    fn split_property_and_terms_rejects_other_forms() {
+        for q in ["big bad wo", "all:foo", "data.:foo", "data. :foo", "nocolon"] {
+            assert!(split_property_and_terms(q).is_err(), "expected error for {:?}", q);
+        }
+    }
+
+    #[test]
+    fn word_and_prefix_distance() {
+        assert_eq!(word_distance(&chars("bad"), &chars("bad"), true), 0);
+        assert_eq!(word_distance(&chars("bd"), &chars("bad"), true), 1); // one insertion
+        assert_eq!(word_distance(&chars("ba"), &chars("ab"), true), 1); // transposition
+        assert_eq!(word_distance(&chars("ba"), &chars("ab"), false), 2); // without transposition
+        assert_eq!(prefix_distance(&chars("wo"), &chars("wolf"), true), 0); // wo prefixes wolf
+        assert_eq!(prefix_distance(&chars("wolf"), &chars("wolf"), true), 0);
+        assert_eq!(prefix_distance(&chars("wolf"), &chars("world"), true), 2); // wolf is not a prefix
+        assert_eq!(prefix_distance(&chars("xo"), &chars("wolf"), true), 1); // wo within 1 of xo
+    }
+
+    #[test]
+    fn sequence_matches_enforces_order_adjacency_and_prefix() {
+        let value = toks(&["big", "bad", "wolf"]);
+        assert!(sequence_matches(&value, &toks(&["big", "bad", "wo"]), 0, true));
+        assert!(!sequence_matches(&value, &toks(&["bad", "big", "wo"]), 0, true)); // order
+        assert!(!sequence_matches(&value, &toks(&["big", "wolf"]), 0, true)); // adjacency
+        assert!(sequence_matches(&toks(&["the", "big", "bad", "wolf"]), &toks(&["big", "bad", "wo"]), 0, true));
+        let world = toks(&["big", "bad", "world"]);
+        assert!(sequence_matches(&world, &toks(&["big", "bad", "wo"]), 0, true)); // wo prefixes world
+        assert!(!sequence_matches(&world, &toks(&["big", "bad", "wolf"]), 0, true)); // wolf does not
+        assert!(!sequence_matches(&toks(&["big"]), &toks(&["big", "bad"]), 0, true)); // too few tokens
+    }
+
+    #[test]
+    fn sequence_matches_budget_is_per_whole_input_not_per_term() {
+        let value = toks(&["big", "bad", "wolf"]);
+        assert!(sequence_matches(&value, &toks(&["big", "bd", "wo"]), 1, true)); // 1 total edit
+        assert!(!sequence_matches(&value, &toks(&["big", "bd", "wo"]), 0, true));
+        // two single-term typos = 2 total edits: rejected at distance 1 (would pass a per-term budget),
+        // accepted at distance 2.
+        assert!(!sequence_matches(&value, &toks(&["bg", "bd", "wo"]), 1, true));
+        assert!(sequence_matches(&value, &toks(&["bg", "bd", "wo"]), 2, true));
+        // transposition counts as one edit only when enabled.
+        assert!(sequence_matches(&value, &toks(&["big", "abd", "wo"]), 1, true));
+        assert!(!sequence_matches(&value, &toks(&["big", "abd", "wo"]), 1, false));
+        // the shared budget is NOT spent on word boundaries: words stay aligned to tokens, so a query
+        // does not fuzzy-merge across a space. This keeps the post-filter a subset of the candidate net.
+        assert!(!sequence_matches(&toks(&["newyork", "city"]), &toks(&["new", "york"]), 1, true));
+    }
+
+    #[test]
+    fn analyzer_tokenize_matches_default_tokenizer() {
+        let mut analyzer = tantivy::tokenizer::TokenizerManager::default().get("default").unwrap();
+        assert_eq!(analyzer_tokenize(&mut analyzer, "Big Bad Wolf"), toks(&["big", "bad", "wolf"]));
+        // Unicode is segmented and lowercased correctly (the previous ASCII tokenizer would split this).
+        assert_eq!(analyzer_tokenize(&mut analyzer, "Café"), toks(&["café"]));
+        // RemoveLongFilter drops tokens of 40+ bytes.
+        let long = "a".repeat(40);
+        assert!(analyzer_tokenize(&mut analyzer, &long).is_empty());
+        assert_eq!(analyzer_tokenize(&mut analyzer, &"a".repeat(39)).len(), 1);
     }
 
     #[test]
@@ -365,6 +462,58 @@ mod tests {
         let full = canonical("al.*");
         assert_eq!(capped.len(), 2);
         assert!(capped.iter().all(|g| full.contains(g)));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Adaptive candidate paging: 300 real matches exceed SEQUENCE_BASE_PAGE (256), so returning all of
+    // them forces a second page regardless of score order -- exercising the widening + and_offset
+    // boundary. Returning exactly the 300 (no more, no fewer) proves no boundary drop or duplicate; the
+    // interleaved decoys carry every query term in the wrong order, so they must be rejected across
+    // pages by the order/adjacency post-filter.
+    #[test]
+    fn search_sequence_pages_past_the_first_candidate_page() {
+        let dir = std::env::temp_dir().join(format!("mgcxx_seq_paging_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.to_str().unwrap().to_string();
+        let mappings = r#"{"properties":{
+            "data":{"type":"json","fast":true,"stored":true,"text":true},
+            "all":{"type":"text","fast":true,"stored":true,"text":true},
+            "gid":{"type":"u64","fast":true,"stored":true,"indexed":true}}}"#
+            .to_string();
+        let mut ctx = create_index(&path, &ffi::IndexConfig { mappings }).unwrap();
+
+        let real: Vec<u64> = (1u64..=300).collect();
+        for &gid in &real {
+            let data = format!(r#"{{"data":{{"name":"big bad wolf"}},"all":"big bad wolf","gid":{gid}}}"#);
+            add_document(&mut ctx, &ffi::DocumentInput { data }, true).unwrap();
+        }
+        for gid in 1000u64..=1049 {
+            let data = format!(r#"{{"data":{{"name":"wolf bad big"}},"all":"wolf bad big","gid":{gid}}}"#);
+            add_document(&mut ctx, &ffi::DocumentInput { data }, true).unwrap();
+        }
+        commit(&mut ctx).unwrap();
+
+        let searcher = acquire_searcher(&ctx).unwrap();
+        let input = ffi::SearchInput {
+            search_fields: vec![],
+            search_query: "data.name:big bad wo".to_string(),
+            return_fields: vec![],
+            aggregation_query: String::new(),
+            limit: 0, // unlimited -> first page is SEQUENCE_BASE_PAGE, must widen to reach all matches
+            fuzzy_distance: 0,
+            fuzzy_prefix: true,
+            fuzzy_transpositions: false,
+            fuzzy_field: String::new(),
+        };
+        let mut gids: Vec<u64> = search_sequence_gids_pinned(&ctx, &searcher, &input)
+            .unwrap()
+            .docs
+            .iter()
+            .map(|d| d.gid)
+            .collect();
+        gids.sort_unstable();
+        assert_eq!(gids, real);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -808,6 +957,129 @@ fn search_get_fields(
     Ok(result)
 }
 
+// Adaptive candidate paging for search_sequence. The post-filter discards candidates, so we over-fetch
+// the requested limit, then page wider only when starved. SEQUENCE_BASE_PAGE is the first page for an
+// unlimited query; finite limits start at limit * SEQUENCE_OVERFETCH_FACTOR; pages double each round.
+// SEQUENCE_MAX_CANDIDATES caps how many score-ranked candidates one query will ever scan.
+// (Future scalability lever: a str/bytes fast field + columnar collector would filter without the store.)
+const SEQUENCE_BASE_PAGE: usize = 256;
+const SEQUENCE_OVERFETCH_FACTOR: usize = 8;
+const SEQUENCE_MAX_CANDIDATES: usize = 50_000;
+
+// Parses `data.<property>:<terms>` into (property, terms); the field side is trimmed. search_sequence
+// is single-property only, so any other form (no colon, non-`data` prefix, or blank property) is rejected.
+fn split_property_and_terms(query: &str) -> Result<(String, String), std::io::Error> {
+    query
+        .split_once(':')
+        .and_then(|(lhs, terms)| {
+            let property = lhs.trim().strip_prefix("data.")?.trim();
+            (!property.is_empty()).then(|| (property.to_string(), terms.to_string()))
+        })
+        .ok_or_else(|| {
+            Error::new(ErrorKind::Other, format!("search_sequence expects 'data.<property>:<terms>', got: {}", query))
+        })
+}
+
+// Runs the field's own analyzer over `text`, yielding the exact tokens tantivy indexed (Unicode
+// segmentation, RemoveLongFilter, lowercasing -- no approximation).
+fn analyzer_tokenize(analyzer: &mut TextAnalyzer, text: &str) -> Vec<Vec<char>> {
+    let mut tokens = Vec::new();
+    let mut stream = analyzer.token_stream(text);
+    while stream.advance() {
+        tokens.push(stream.token().text.chars().collect());
+    }
+    tokens
+}
+
+// Optimal-string-alignment DP over chars. Returns the final row M[term.len()][*], so the full edit
+// distance is row[token.len()] and the min over prefixes of `token` is min(row).
+fn edit_row(term: &[char], token: &[char], transpositions: bool) -> Vec<usize> {
+    let lk = token.len();
+    let mut transposition_row = vec![0usize; lk + 1];
+    let mut prev_row = (0..=lk).collect::<Vec<_>>();
+    let mut curr_row = vec![0usize; lk + 1];
+    for i in 1..=term.len() {
+        curr_row[0] = i;
+        for j in 1..=lk {
+            let cost = (term[i - 1] != token[j - 1]) as usize;
+            let mut best = (prev_row[j] + 1).min(curr_row[j - 1] + 1).min(prev_row[j - 1] + cost);
+            if transpositions && i > 1 && j > 1 && term[i - 1] == token[j - 2] && term[i - 2] == token[j - 1] {
+                best = best.min(transposition_row[j - 2] + 1);
+            }
+            curr_row[j] = best;
+        }
+        std::mem::swap(&mut transposition_row, &mut prev_row);
+        std::mem::swap(&mut prev_row, &mut curr_row);
+    }
+    prev_row
+}
+
+// Whole-word edit distance between `term` and the full `token` (the final DP cell).
+fn word_distance(term: &[char], token: &[char], transpositions: bool) -> usize {
+    *edit_row(term, token, transpositions).last().expect("row has token.len()+1 cells")
+}
+
+// Smallest edit distance between `term` and any prefix of `token` (min over the DP row).
+fn prefix_distance(term: &[char], token: &[char], transpositions: bool) -> usize {
+    edit_row(term, token, transpositions).into_iter().min().expect("row is non-empty")
+}
+
+// True if `terms` appear as an adjacent, in-order window in `value` (leading terms whole-word, last
+// term a prefix). The per-word distances share one budget: their sum must stay within `distance`.
+fn sequence_matches(value: &[Vec<char>], terms: &[Vec<char>], distance: u8, transpositions: bool) -> bool {
+    let n = terms.len();
+    if n == 0 || value.len() < n {
+        return false;
+    }
+    let last = n - 1;
+    let budget = distance as usize;
+    (0..=value.len() - n).any(|start| {
+        let mut total = 0usize;
+        for (j, term) in terms.iter().enumerate() {
+            let token = &value[start + j];
+            total += if j == last {
+                prefix_distance(term, token, transpositions)
+            } else {
+                word_distance(term, token, transpositions)
+            };
+            if total > budget {
+                return false;
+            }
+        }
+        true
+    })
+}
+
+// Reads the string value of `property` from a hit's stored `data` JSON object, if present.
+fn extract_property_string(doc: &TantivyDocument, data_field: Field, property: &str) -> Option<String> {
+    match doc.get_first(data_field)?.into() {
+        OwnedValue::Object(entries) => entries.into_iter().find_map(|(k, v)| match v {
+            OwnedValue::Str(s) if k == property => Some(s),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+// Reads a stored u64 field (gid / edge gids) from a sequence-search hit's document.
+fn extract_u64_field(
+    doc: &TantivyDocument,
+    field: Field,
+    field_name: &str,
+    index_path: &std::path::PathBuf,
+) -> Result<u64, std::io::Error> {
+    let value = doc.get_first(field).ok_or_else(|| {
+        Error::new(ErrorKind::Other, format!("Document missing {} field in {:?}", field_name, index_path))
+    })?;
+    match value.into() {
+        OwnedValue::U64(n) => Ok(n),
+        other => Err(Error::new(
+            ErrorKind::Other,
+            format!("{} field has unexpected type {:?} in {:?}", field_name, other, index_path),
+        )),
+    }
+}
+
 pub struct SearcherContext {
     searcher: tantivy::Searcher,
 }
@@ -1017,6 +1289,148 @@ fn search_edge_gids_pinned(
         let edge_gid = read_gid(&edge_gid_columns, &doc_address, "edge_gid")?;
         let from_gid = read_gid(&from_gid_columns, &doc_address, "from_vertex_gid")?;
         let to_gid = read_gid(&to_gid_columns, &doc_address, "to_vertex_gid")?;
+        docs.push(ffi::EdgeGidScore { edge_gid, from_gid, to_gid, score });
+    }
+    Ok(ffi::EdgeGidScoreOutput { docs })
+}
+
+// Runs the candidate query for a sequence search and post-filters to the docs whose `data.<property>`
+// value contains the term sequence (adjacent, in order, last term a prefix), up to the result limit.
+fn sequence_matched_docs(
+    context: &ffi::Context,
+    searcher_ctx: &SearcherContext,
+    input: &ffi::SearchInput,
+) -> Result<Vec<(f32, TantivyDocument)>, std::io::Error> {
+    let index_path = &context.tantivyContext.index_path;
+    let index = &context.tantivyContext.index;
+    let schema = &context.tantivyContext.schema;
+
+    let (property, terms_text) = split_property_and_terms(&input.search_query)?;
+    let data_field = schema.get_field("data").map_err(|e| {
+        Error::new(ErrorKind::Other, format!("data field not found in {:?} -> {}", index_path, e))
+    })?;
+    let mut analyzer = index.tokenizer_for_field(data_field).map_err(|e| {
+        Error::new(ErrorKind::Other, format!("no tokenizer for data field in {:?} -> {}", index_path, e))
+    })?;
+    let terms = analyzer_tokenize(&mut analyzer, &terms_text);
+    if terms.is_empty() {
+        return Err(Error::new(
+            ErrorKind::Other,
+            "search_sequence query produced no searchable terms.".to_string(),
+        ));
+    }
+
+    // Candidate net built directly (not via the query parser) so numeric/boolean-looking tokens match
+    // as string terms rather than failing tantivy's JSON fast-value conversion. Every term is required:
+    // last a fuzzy prefix, leading ones whole-word fuzzy. A genuine superset of the post-filter below
+    // (a window whose summed distances are <= d has every term individually <= d).
+    let last = terms.len() - 1;
+    let subqueries: Vec<(Occur, Box<dyn Query>)> = terms
+        .iter()
+        .enumerate()
+        .map(|(i, token)| {
+            let mut term = Term::from_field_json_path(data_field, &property, false);
+            term.append_type_and_str(&token.iter().collect::<String>());
+            let fuzzy = if i == last {
+                FuzzyTermQuery::new_prefix(term, input.fuzzy_distance, input.fuzzy_transpositions)
+            } else {
+                FuzzyTermQuery::new(term, input.fuzzy_distance, input.fuzzy_transpositions)
+            };
+            (Occur::Must, Box::new(fuzzy) as Box<dyn Query>)
+        })
+        .collect();
+    let query = BooleanQuery::new(subqueries);
+
+    // Page through score-ranked candidates, post-filtering each page, until we've collected
+    // `result_limit` matches or the candidate stream runs out. Selective queries fill the first page;
+    // we widen only when the post-filter is starved, capped at SEQUENCE_MAX_CANDIDATES.
+    let result_limit = if input.limit == 0 { usize::MAX } else { input.limit };
+    let mut matched: Vec<(f32, TantivyDocument)> = Vec::new();
+    let mut scanned = 0usize;
+    let mut page = match input.limit {
+        0 => SEQUENCE_BASE_PAGE,
+        n => n.saturating_mul(SEQUENCE_OVERFETCH_FACTOR).min(SEQUENCE_MAX_CANDIDATES),
+    };
+    while matched.len() < result_limit && scanned < SEQUENCE_MAX_CANDIDATES {
+        let page_limit = page.min(SEQUENCE_MAX_CANDIDATES - scanned);
+        let top_docs = searcher_ctx
+            .searcher
+            .search(&query, &TopDocs::with_limit(page_limit).and_offset(scanned))
+            .map_err(|e| {
+                Error::new(ErrorKind::Other, format!("Unable to perform sequence search under {:?} -> {}", index_path, e))
+            })?;
+        let fetched = top_docs.len();
+        for (score, doc_address) in top_docs {
+            let doc: TantivyDocument = searcher_ctx.searcher.doc(doc_address).map_err(|e| {
+                Error::new(ErrorKind::Other, format!("Unable to find document inside {:?} -> {}", index_path, e))
+            })?;
+            let Some(value) = extract_property_string(&doc, data_field, &property) else {
+                continue;
+            };
+            let value_tokens = analyzer_tokenize(&mut analyzer, &value);
+            if sequence_matches(&value_tokens, &terms, input.fuzzy_distance, input.fuzzy_transpositions) {
+                matched.push((score, doc));
+                if matched.len() >= result_limit {
+                    break;
+                }
+            }
+        }
+        scanned += fetched;
+        if fetched < page_limit {
+            break; // candidate stream exhausted -- no more docs to page into
+        }
+        page = page.saturating_mul(2);
+    }
+    if matched.len() < result_limit && scanned >= SEQUENCE_MAX_CANDIDATES {
+        log::warn!(
+            "search_sequence hit the {} candidate scan cap in {:?}; results may be truncated",
+            SEQUENCE_MAX_CANDIDATES,
+            index_path
+        );
+    }
+    Ok(matched)
+}
+
+fn search_sequence_gids_pinned(
+    context: &ffi::Context,
+    searcher_ctx: &SearcherContext,
+    input: &ffi::SearchInput,
+) -> Result<ffi::GidScoreOutput, std::io::Error> {
+    let matched = sequence_matched_docs(context, searcher_ctx, input)?;
+    let index_path = &context.tantivyContext.index_path;
+    let gid_field = context.tantivyContext.schema.get_field("gid").map_err(|e| {
+        Error::new(ErrorKind::Other, format!("gid field not found in {:?} -> {}", index_path, e))
+    })?;
+    let mut docs: Vec<ffi::GidScore> = Vec::with_capacity(matched.len());
+    for (score, doc) in matched {
+        let gid = extract_u64_field(&doc, gid_field, "gid", index_path)?;
+        docs.push(ffi::GidScore { gid, score });
+    }
+    Ok(ffi::GidScoreOutput { docs })
+}
+
+fn search_sequence_edge_gids_pinned(
+    context: &ffi::Context,
+    searcher_ctx: &SearcherContext,
+    input: &ffi::SearchInput,
+) -> Result<ffi::EdgeGidScoreOutput, std::io::Error> {
+    let matched = sequence_matched_docs(context, searcher_ctx, input)?;
+    let index_path = &context.tantivyContext.index_path;
+    let schema = &context.tantivyContext.schema;
+    let edge_gid_field = schema.get_field("edge_gid").map_err(|e| {
+        Error::new(ErrorKind::Other, format!("edge_gid not found in {:?} -> {}", index_path, e))
+    })?;
+    let from_gid_field = schema.get_field("from_vertex_gid").map_err(|e| {
+        Error::new(ErrorKind::Other, format!("from_vertex_gid not found in {:?} -> {}", index_path, e))
+    })?;
+    let to_gid_field = schema.get_field("to_vertex_gid").map_err(|e| {
+        Error::new(ErrorKind::Other, format!("to_vertex_gid not found in {:?} -> {}", index_path, e))
+    })?;
+    let mut docs: Vec<ffi::EdgeGidScore> = Vec::with_capacity(matched.len());
+    for (score, doc) in matched {
+        let edge_gid = extract_u64_field(&doc, edge_gid_field, "edge_gid", index_path)?;
+        let from_gid = extract_u64_field(&doc, from_gid_field, "from_vertex_gid", index_path)?;
+        let to_gid = extract_u64_field(&doc, to_gid_field, "to_vertex_gid", index_path)?;
         docs.push(ffi::EdgeGidScore { edge_gid, from_gid, to_gid, score });
     }
     Ok(ffi::EdgeGidScoreOutput { docs })

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -252,8 +252,8 @@ mod tests {
     fn chars(s: &str) -> Vec<char> {
         s.chars().collect()
     }
-    fn toks(words: &[&str]) -> Vec<Vec<char>> {
-        words.iter().map(|w| chars(w)).collect()
+    fn toks(words: &[&str]) -> Vec<(usize, Vec<char>)> {
+        words.iter().enumerate().map(|(position, w)| (position, chars(w))).collect()
     }
 
     #[test]
@@ -319,6 +319,19 @@ mod tests {
         // the shared budget is NOT spent on word boundaries: words stay aligned to tokens, so a query
         // does not fuzzy-merge across a space. This keeps the post-filter a subset of the candidate net.
         assert!(!sequence_matches(&toks(&["newyork", "city"]), &toks(&["new", "york"]), 1, true));
+    }
+
+    #[test]
+    fn sequence_matches_respects_position_gaps_from_dropped_tokens() {
+        let mut analyzer = tantivy::tokenizer::TokenizerManager::default().get("default").unwrap();
+        let blob = "x".repeat(45);
+        let gapped_value = analyzer_tokenize(&mut analyzer, &format!("big {blob} bad wolf"));
+        let terms = analyzer_tokenize(&mut analyzer, "big bad wo");
+        assert!(!sequence_matches(&gapped_value, &terms, 0, true));
+        assert!(!sequence_matches(&gapped_value, &terms, 2, true));
+        let gapped_terms = analyzer_tokenize(&mut analyzer, &format!("big {blob} bad wo"));
+        assert!(sequence_matches(&gapped_value, &gapped_terms, 0, true));
+        assert!(!sequence_matches(&analyzer_tokenize(&mut analyzer, "big bad wolf"), &gapped_terms, 0, true));
     }
 
     #[test]
@@ -980,13 +993,14 @@ fn split_property_and_terms(query: &str) -> Result<(String, String), std::io::Er
         })
 }
 
-// Runs the field's own analyzer over `text`, yielding the exact tokens tantivy indexed (Unicode
-// segmentation, RemoveLongFilter, lowercasing -- no approximation).
-fn analyzer_tokenize(analyzer: &mut TextAnalyzer, text: &str) -> Vec<Vec<char>> {
+// Runs the field's own analyzer over `text`, yielding the exact (position, token) pairs tantivy
+// indexed (Unicode segmentation, RemoveLongFilter, lowercasing -- no approximation).
+fn analyzer_tokenize(analyzer: &mut TextAnalyzer, text: &str) -> Vec<(usize, Vec<char>)> {
     let mut tokens = Vec::new();
     let mut stream = analyzer.token_stream(text);
     while stream.advance() {
-        tokens.push(stream.token().text.chars().collect());
+        let token = stream.token();
+        tokens.push((token.position, token.text.chars().collect()));
     }
     tokens
 }
@@ -1026,7 +1040,12 @@ fn prefix_distance(term: &[char], token: &[char], transpositions: bool) -> usize
 
 // True if `terms` appear as an adjacent, in-order window in `value` (leading terms whole-word, last
 // term a prefix). The per-word distances share one budget: their sum must stay within `distance`.
-fn sequence_matches(value: &[Vec<char>], terms: &[Vec<char>], distance: u8, transpositions: bool) -> bool {
+fn sequence_matches(
+    value: &[(usize, Vec<char>)],
+    terms: &[(usize, Vec<char>)],
+    distance: u8,
+    transpositions: bool,
+) -> bool {
     let n = terms.len();
     if n == 0 || value.len() < n {
         return false;
@@ -1035,8 +1054,11 @@ fn sequence_matches(value: &[Vec<char>], terms: &[Vec<char>], distance: u8, tran
     let budget = distance as usize;
     (0..=value.len() - n).any(|start| {
         let mut total = 0usize;
-        for (j, term) in terms.iter().enumerate() {
-            let token = &value[start + j];
+        for (j, (term_position, term)) in terms.iter().enumerate() {
+            let (token_position, token) = &value[start + j];
+            if token_position - value[start].0 != term_position - terms[0].0 {
+                return false;
+            }
             total += if j == last {
                 prefix_distance(term, token, transpositions)
             } else {
@@ -1328,7 +1350,7 @@ fn sequence_matched_docs(
     let subqueries: Vec<(Occur, Box<dyn Query>)> = terms
         .iter()
         .enumerate()
-        .map(|(i, token)| {
+        .map(|(i, (_, token))| {
             let mut term = Term::from_field_json_path(data_field, &property, false);
             term.append_type_and_str(&token.iter().collect::<String>());
             let fuzzy = if i == last {

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -142,14 +142,14 @@ mod ffi {
             searcher: &SearcherContext,
             input: &SearchInput,
         ) -> Result<EdgeGidScoreOutput>;
-        // Ordered, adjacent fuzzy term-sequence search (last term a prefix). search_query is
+        // Fuzzy phrase search: ordered, adjacent terms, last term a prefix. search_query is
         // `data.<property>:<terms>`; fuzzy_distance/transpositions carry the user's exact values.
-        fn search_sequence_gids_pinned(
+        fn fuzzy_phrase_search_gids_pinned(
             context: &Context,
             searcher: &SearcherContext,
             input: &SearchInput,
         ) -> Result<GidScoreOutput>;
-        fn search_sequence_edge_gids_pinned(
+        fn fuzzy_phrase_search_edge_gids_pinned(
             context: &Context,
             searcher: &SearcherContext,
             input: &SearchInput,
@@ -293,46 +293,46 @@ mod tests {
     }
 
     #[test]
-    fn sequence_matches_enforces_order_adjacency_and_prefix() {
+    fn fuzzy_phrase_matches_enforces_order_adjacency_and_prefix() {
         let value = toks(&["big", "bad", "wolf"]);
-        assert!(sequence_matches(&value, &toks(&["big", "bad", "wo"]), 0, true));
-        assert!(!sequence_matches(&value, &toks(&["bad", "big", "wo"]), 0, true)); // order
-        assert!(!sequence_matches(&value, &toks(&["big", "wolf"]), 0, true)); // adjacency
-        assert!(sequence_matches(&toks(&["the", "big", "bad", "wolf"]), &toks(&["big", "bad", "wo"]), 0, true));
+        assert!(fuzzy_phrase_matches(&value, &toks(&["big", "bad", "wo"]), 0, true));
+        assert!(!fuzzy_phrase_matches(&value, &toks(&["bad", "big", "wo"]), 0, true)); // order
+        assert!(!fuzzy_phrase_matches(&value, &toks(&["big", "wolf"]), 0, true)); // adjacency
+        assert!(fuzzy_phrase_matches(&toks(&["the", "big", "bad", "wolf"]), &toks(&["big", "bad", "wo"]), 0, true));
         let world = toks(&["big", "bad", "world"]);
-        assert!(sequence_matches(&world, &toks(&["big", "bad", "wo"]), 0, true)); // wo prefixes world
-        assert!(!sequence_matches(&world, &toks(&["big", "bad", "wolf"]), 0, true)); // wolf does not
-        assert!(!sequence_matches(&toks(&["big"]), &toks(&["big", "bad"]), 0, true)); // too few tokens
+        assert!(fuzzy_phrase_matches(&world, &toks(&["big", "bad", "wo"]), 0, true)); // wo prefixes world
+        assert!(!fuzzy_phrase_matches(&world, &toks(&["big", "bad", "wolf"]), 0, true)); // wolf does not
+        assert!(!fuzzy_phrase_matches(&toks(&["big"]), &toks(&["big", "bad"]), 0, true)); // too few tokens
     }
 
     #[test]
-    fn sequence_matches_budget_is_per_whole_input_not_per_term() {
+    fn fuzzy_phrase_matches_budget_is_per_whole_input_not_per_term() {
         let value = toks(&["big", "bad", "wolf"]);
-        assert!(sequence_matches(&value, &toks(&["big", "bd", "wo"]), 1, true)); // 1 total edit
-        assert!(!sequence_matches(&value, &toks(&["big", "bd", "wo"]), 0, true));
+        assert!(fuzzy_phrase_matches(&value, &toks(&["big", "bd", "wo"]), 1, true)); // 1 total edit
+        assert!(!fuzzy_phrase_matches(&value, &toks(&["big", "bd", "wo"]), 0, true));
         // two single-term typos = 2 total edits: rejected at distance 1 (would pass a per-term budget),
         // accepted at distance 2.
-        assert!(!sequence_matches(&value, &toks(&["bg", "bd", "wo"]), 1, true));
-        assert!(sequence_matches(&value, &toks(&["bg", "bd", "wo"]), 2, true));
+        assert!(!fuzzy_phrase_matches(&value, &toks(&["bg", "bd", "wo"]), 1, true));
+        assert!(fuzzy_phrase_matches(&value, &toks(&["bg", "bd", "wo"]), 2, true));
         // transposition counts as one edit only when enabled.
-        assert!(sequence_matches(&value, &toks(&["big", "abd", "wo"]), 1, true));
-        assert!(!sequence_matches(&value, &toks(&["big", "abd", "wo"]), 1, false));
+        assert!(fuzzy_phrase_matches(&value, &toks(&["big", "abd", "wo"]), 1, true));
+        assert!(!fuzzy_phrase_matches(&value, &toks(&["big", "abd", "wo"]), 1, false));
         // the shared budget is NOT spent on word boundaries: words stay aligned to tokens, so a query
         // does not fuzzy-merge across a space. This keeps the post-filter a subset of the candidate net.
-        assert!(!sequence_matches(&toks(&["newyork", "city"]), &toks(&["new", "york"]), 1, true));
+        assert!(!fuzzy_phrase_matches(&toks(&["newyork", "city"]), &toks(&["new", "york"]), 1, true));
     }
 
     #[test]
-    fn sequence_matches_respects_position_gaps_from_dropped_tokens() {
+    fn fuzzy_phrase_matches_respects_position_gaps_from_dropped_tokens() {
         let mut analyzer = tantivy::tokenizer::TokenizerManager::default().get("default").unwrap();
         let blob = "x".repeat(45);
         let gapped_value = analyzer_tokenize(&mut analyzer, &format!("big {blob} bad wolf"));
         let terms = analyzer_tokenize(&mut analyzer, "big bad wo");
-        assert!(!sequence_matches(&gapped_value, &terms, 0, true));
-        assert!(!sequence_matches(&gapped_value, &terms, 2, true));
+        assert!(!fuzzy_phrase_matches(&gapped_value, &terms, 0, true));
+        assert!(!fuzzy_phrase_matches(&gapped_value, &terms, 2, true));
         let gapped_terms = analyzer_tokenize(&mut analyzer, &format!("big {blob} bad wo"));
-        assert!(sequence_matches(&gapped_value, &gapped_terms, 0, true));
-        assert!(!sequence_matches(&analyzer_tokenize(&mut analyzer, "big bad wolf"), &gapped_terms, 0, true));
+        assert!(fuzzy_phrase_matches(&gapped_value, &gapped_terms, 0, true));
+        assert!(!fuzzy_phrase_matches(&analyzer_tokenize(&mut analyzer, "big bad wolf"), &gapped_terms, 0, true));
     }
 
     #[test]
@@ -481,12 +481,12 @@ mod tests {
     }
 
     // Adaptive candidate paging: the 10 real matches sit between 150 decoys on each side, so the first
-    // page (limit 10 * SEQUENCE_OVERFETCH_FACTOR = 80 candidates) holds only decoys whichever way score
+    // page (limit 10 * FUZZY_PHRASE_OVERFETCH_FACTOR = 80 candidates) holds only decoys whichever way score
     // ties break -- reaching the matches requires widening past the first page via and_offset. The
     // decoys carry every query term in the wrong order, so the post-filter must reject them across
     // pages; returning exactly the 10 proves no boundary drop or duplicate.
     #[test]
-    fn search_sequence_pages_past_the_first_candidate_page() {
+    fn fuzzy_phrase_search_pages_past_the_first_candidate_page() {
         let dir = std::env::temp_dir().join(format!("mgcxx_seq_paging_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let path = dir.to_str().unwrap().to_string();
@@ -525,7 +525,7 @@ mod tests {
             fuzzy_transpositions: false,
             fuzzy_field: String::new(),
         };
-        let mut gids: Vec<u64> = search_sequence_gids_pinned(&ctx, &searcher, &input)
+        let mut gids: Vec<u64> = fuzzy_phrase_search_gids_pinned(&ctx, &searcher, &input)
             .unwrap()
             .docs
             .iter()
@@ -976,14 +976,14 @@ fn search_get_fields(
     Ok(result)
 }
 
-// Adaptive candidate paging for search_sequence. The post-filter discards candidates, so the first page
-// over-fetches the effective limit by SEQUENCE_OVERFETCH_FACTOR and doubles each round when starved.
-// SEQUENCE_MAX_CANDIDATES caps how many score-ranked candidates one query will ever scan.
+// Adaptive candidate paging for fuzzy_phrase_search. The post-filter discards candidates, so the first page
+// over-fetches the effective limit by FUZZY_PHRASE_OVERFETCH_FACTOR and doubles each round when starved.
+// FUZZY_PHRASE_MAX_CANDIDATES caps how many score-ranked candidates one query will ever scan.
 // (Future scalability lever: a str/bytes fast field + columnar collector would filter without the store.)
-const SEQUENCE_OVERFETCH_FACTOR: usize = 8;
-const SEQUENCE_MAX_CANDIDATES: usize = 50_000;
+const FUZZY_PHRASE_OVERFETCH_FACTOR: usize = 8;
+const FUZZY_PHRASE_MAX_CANDIDATES: usize = 50_000;
 
-// Parses `data.<property>:<terms>` into (property, terms); the field side is trimmed. search_sequence
+// Parses `data.<property>:<terms>` into (property, terms); the field side is trimmed. fuzzy_phrase_search
 // is single-property only, so any other form (no colon, non-`data` prefix, or blank property) is rejected.
 fn split_property_and_terms(query: &str) -> Result<(String, String), std::io::Error> {
     query
@@ -993,7 +993,7 @@ fn split_property_and_terms(query: &str) -> Result<(String, String), std::io::Er
             (!property.is_empty()).then(|| (property.to_string(), terms.to_string()))
         })
         .ok_or_else(|| {
-            Error::new(ErrorKind::Other, format!("search_sequence expects 'data.<property>:<terms>', got: {}", query))
+            Error::new(ErrorKind::Other, format!("fuzzy_phrase_search expects 'data.<property>:<terms>', got: {}", query))
         })
 }
 
@@ -1044,7 +1044,7 @@ fn prefix_distance(term: &[char], token: &[char], transpositions: bool) -> usize
 
 // True if `terms` appear as an adjacent, in-order window in `value` (leading terms whole-word, last
 // term a prefix). The per-word distances share one budget: their sum must stay within `distance`.
-fn sequence_matches(
+fn fuzzy_phrase_matches(
     value: &[(usize, Vec<char>)],
     terms: &[(usize, Vec<char>)],
     distance: u8,
@@ -1084,7 +1084,7 @@ fn extract_property_string(doc: &TantivyDocument, data_field: Field, property: &
         .and_then(|(_, value)| value.as_str().map(str::to_string))
 }
 
-// Reads a stored u64 field (gid / edge gids) from a sequence-search hit's document.
+// Reads a stored u64 field (gid / edge gids) from a fuzzy-phrase-search hit's document.
 fn extract_u64_field(
     doc: &TantivyDocument,
     field: Field,
@@ -1313,9 +1313,10 @@ fn search_edge_gids_pinned(
     Ok(ffi::EdgeGidScoreOutput { docs })
 }
 
-// Runs the candidate query for a sequence search and post-filters to the docs whose `data.<property>`
-// value contains the term sequence (adjacent, in order, last term a prefix), up to the result limit.
-fn sequence_matched_docs(
+// Runs the candidate query for a fuzzy phrase search and post-filters to the docs whose
+// `data.<property>` value contains the phrase (adjacent, in order, last term a prefix), up to the
+// result limit.
+fn fuzzy_phrase_matched_docs(
     context: &ffi::Context,
     searcher_ctx: &SearcherContext,
     input: &ffi::SearchInput,
@@ -1335,7 +1336,7 @@ fn sequence_matched_docs(
     if terms.is_empty() {
         return Err(Error::new(
             ErrorKind::Other,
-            "search_sequence query produced no searchable terms.".to_string(),
+            "fuzzy_phrase_search query produced no searchable terms.".to_string(),
         ));
     }
 
@@ -1362,18 +1363,18 @@ fn sequence_matched_docs(
 
     // Page through score-ranked candidates, post-filtering each page, until we've collected
     // `result_limit` matches or the candidate stream runs out. Selective queries fill the first page;
-    // we widen only when the post-filter is starved, capped at SEQUENCE_MAX_CANDIDATES.
+    // we widen only when the post-filter is starved, capped at FUZZY_PHRASE_MAX_CANDIDATES.
     let result_limit = input.effective_limit();
     let mut matched: Vec<(f32, TantivyDocument)> = Vec::new();
     let mut scanned = 0usize;
-    let mut page = result_limit.saturating_mul(SEQUENCE_OVERFETCH_FACTOR).min(SEQUENCE_MAX_CANDIDATES);
-    while matched.len() < result_limit && scanned < SEQUENCE_MAX_CANDIDATES {
-        let page_limit = page.min(SEQUENCE_MAX_CANDIDATES - scanned);
+    let mut page = result_limit.saturating_mul(FUZZY_PHRASE_OVERFETCH_FACTOR).min(FUZZY_PHRASE_MAX_CANDIDATES);
+    while matched.len() < result_limit && scanned < FUZZY_PHRASE_MAX_CANDIDATES {
+        let page_limit = page.min(FUZZY_PHRASE_MAX_CANDIDATES - scanned);
         let top_docs = searcher_ctx
             .searcher
             .search(&query, &TopDocs::with_limit(page_limit).and_offset(scanned))
             .map_err(|e| {
-                Error::new(ErrorKind::Other, format!("Unable to perform sequence search under {:?} -> {}", index_path, e))
+                Error::new(ErrorKind::Other, format!("Unable to perform fuzzy phrase search under {:?} -> {}", index_path, e))
             })?;
         let fetched = top_docs.len();
         for (score, doc_address) in top_docs {
@@ -1384,7 +1385,7 @@ fn sequence_matched_docs(
                 continue;
             };
             let value_tokens = analyzer_tokenize(&mut analyzer, &value);
-            if sequence_matches(&value_tokens, &terms, input.fuzzy_distance, input.fuzzy_transpositions) {
+            if fuzzy_phrase_matches(&value_tokens, &terms, input.fuzzy_distance, input.fuzzy_transpositions) {
                 matched.push((score, doc));
                 if matched.len() >= result_limit {
                     break;
@@ -1397,22 +1398,22 @@ fn sequence_matched_docs(
         }
         page = page.saturating_mul(2);
     }
-    if matched.len() < result_limit && scanned >= SEQUENCE_MAX_CANDIDATES {
+    if matched.len() < result_limit && scanned >= FUZZY_PHRASE_MAX_CANDIDATES {
         log::warn!(
-            "search_sequence hit the {} candidate scan cap in {:?}; results may be truncated",
-            SEQUENCE_MAX_CANDIDATES,
+            "fuzzy_phrase_search hit the {} candidate scan cap in {:?}; results may be truncated",
+            FUZZY_PHRASE_MAX_CANDIDATES,
             index_path
         );
     }
     Ok(matched)
 }
 
-fn search_sequence_gids_pinned(
+fn fuzzy_phrase_search_gids_pinned(
     context: &ffi::Context,
     searcher_ctx: &SearcherContext,
     input: &ffi::SearchInput,
 ) -> Result<ffi::GidScoreOutput, std::io::Error> {
-    let matched = sequence_matched_docs(context, searcher_ctx, input)?;
+    let matched = fuzzy_phrase_matched_docs(context, searcher_ctx, input)?;
     let index_path = &context.tantivyContext.index_path;
     let gid_field = context.tantivyContext.schema.get_field("gid").map_err(|e| {
         Error::new(ErrorKind::Other, format!("gid field not found in {:?} -> {}", index_path, e))
@@ -1425,12 +1426,12 @@ fn search_sequence_gids_pinned(
     Ok(ffi::GidScoreOutput { docs })
 }
 
-fn search_sequence_edge_gids_pinned(
+fn fuzzy_phrase_search_edge_gids_pinned(
     context: &ffi::Context,
     searcher_ctx: &SearcherContext,
     input: &ffi::SearchInput,
 ) -> Result<ffi::EdgeGidScoreOutput, std::io::Error> {
-    let matched = sequence_matched_docs(context, searcher_ctx, input)?;
+    let matched = fuzzy_phrase_matched_docs(context, searcher_ctx, input)?;
     let index_path = &context.tantivyContext.index_path;
     let schema = &context.tantivyContext.schema;
     let edge_gid_field = schema.get_field("edge_gid").map_err(|e| {

--- a/query_modules/text_search_module.cpp
+++ b/query_modules/text_search_module.cpp
@@ -12,6 +12,7 @@
 #include <fmt/format.h>
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <iostream>
 #include <mgp.hpp>
 #include <stdexcept>
@@ -20,6 +21,8 @@
 
 namespace TextSearch {
 constexpr std::string_view kProcedureSearch = "search";
+constexpr std::string_view kProcedureSearchSequence = "search_sequence";
+constexpr std::string_view kProcedureSearchSequenceEdges = "search_sequence_edges";
 constexpr std::string_view kProcedureRegexSearch = "regex_search";
 constexpr std::string_view kProcedureSearchAllProperties = "search_all";
 constexpr std::string_view kProcedureAggregate = "aggregate";
@@ -47,6 +50,8 @@ constexpr std::array<std::string_view, 4> kRecognisedConfigKeys{
 mgp::TextSearchConfig ParseConfig(const mgp::Map &config, bool fuzzy_supported);
 
 void Search(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
+void SearchSequence(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
+void SearchSequenceEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void RegexSearch(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void SearchAllProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void SearchEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
@@ -79,6 +84,15 @@ void RejectIfUnsupported(bool fuzzy_supported, bool key_makes_difference, std::s
         fmt::format("text_search config '{}' is not supported on regex_search procedures.", key));
   }
 }
+
+// The last term is always a prefix here, so fuzzy_prefix:false is unsatisfiable -- reject it explicitly.
+void RejectExplicitNonPrefix(const mgp::Map &config) {
+  if (config.KeyExists(TextSearch::kConfigFuzzyPrefix) && !ExtractBool(config, TextSearch::kConfigFuzzyPrefix)) {
+    throw std::invalid_argument(
+        "search_sequence always treats the last term as a prefix; 'fuzzy_prefix:false' is not supported.");
+  }
+}
+
 }  // namespace
 
 mgp::TextSearchConfig TextSearch::ParseConfig(const mgp::Map &config, bool fuzzy_supported) {
@@ -101,6 +115,9 @@ mgp::TextSearchConfig TextSearch::ParseConfig(const mgp::Map &config, bool fuzzy
   if (config.KeyExists(kConfigFuzzyDistance)) {
     const auto raw = ExtractInt(config, kConfigFuzzyDistance);
     RejectIfUnsupported(fuzzy_supported, raw != 0, kConfigFuzzyDistance);
+    if (raw < 0 || raw > 2) {
+      throw std::invalid_argument("text_search config 'fuzzy_distance' must be between 0 and 2.");
+    }
     parsed.fuzzy_distance = static_cast<std::uint8_t>(raw);
   }
 
@@ -133,6 +150,58 @@ void TextSearch::Search(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *r
       auto record = record_factory.NewRecord();
       auto row_list = row.ValueList();
       record.Insert(TextSearch::kReturnNode.data(), row_list[0].ValueNode());
+      record.Insert(TextSearch::kReturnScore.data(), row_list[1].ValueDouble());
+    }
+  } catch (const std::exception &e) {
+    record_factory.SetErrorMessage(e.what());
+  }
+}
+
+// Adjacent, in-order fuzzy term-sequence search (last term a prefix) over a single `data.<property>`.
+// Thin wrapper over text_search_mode::SEQUENCE; all the matching logic runs in mgcxx.
+void TextSearch::SearchSequence(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
+  mgp::MemoryDispatcherGuard guard{memory};
+  const auto record_factory = mgp::RecordFactory(result);
+  auto arguments = mgp::List(args);
+
+  try {
+    const auto index_name = arguments[0].ValueString();
+    const auto search_query = arguments[1].ValueString();
+    const auto config_map = arguments[2].ValueMap();
+    auto config = ParseConfig(config_map, /*fuzzy_supported=*/true);
+    RejectExplicitNonPrefix(config_map);
+    config.fuzzy_prefix = true;
+    for (const auto &row :
+         mgp::SearchTextIndex(memgraph_graph, index_name, search_query, text_search_mode::SEQUENCE, config)) {
+      auto record = record_factory.NewRecord();
+      auto row_list = row.ValueList();
+      record.Insert(TextSearch::kReturnNode.data(), row_list[0].ValueNode());
+      record.Insert(TextSearch::kReturnScore.data(), row_list[1].ValueDouble());
+    }
+  } catch (const std::exception &e) {
+    record_factory.SetErrorMessage(e.what());
+  }
+}
+
+// Edge counterpart of SearchSequence over a relationship text index.
+void TextSearch::SearchSequenceEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result,
+                                     mgp_memory *memory) {
+  mgp::MemoryDispatcherGuard guard{memory};
+  const auto record_factory = mgp::RecordFactory(result);
+  auto arguments = mgp::List(args);
+
+  try {
+    const auto index_name = arguments[0].ValueString();
+    const auto search_query = arguments[1].ValueString();
+    const auto config_map = arguments[2].ValueMap();
+    auto config = ParseConfig(config_map, /*fuzzy_supported=*/true);
+    RejectExplicitNonPrefix(config_map);
+    config.fuzzy_prefix = true;
+    for (const auto &row :
+         mgp::SearchTextEdgeIndex(memgraph_graph, index_name, search_query, text_search_mode::SEQUENCE, config)) {
+      auto record = record_factory.NewRecord();
+      auto row_list = row.ValueList();
+      record.Insert(TextSearch::kReturnEdge.data(), row_list[0].ValueRelationship());
       record.Insert(TextSearch::kReturnScore.data(), row_list[1].ValueDouble());
     }
   } catch (const std::exception &e) {
@@ -302,6 +371,19 @@ extern "C" int mgp_init_module(struct mgp_module *query_module, struct mgp_memor
                  query_module,
                  memory);
 
+    AddProcedure(TextSearch::SearchSequence,
+                 TextSearch::kProcedureSearchSequence,
+                 mgp::ProcedureType::Read,
+                 {
+                     mgp::Parameter(TextSearch::kParameterIndexName, mgp::Type::String),
+                     mgp::Parameter(TextSearch::kParameterSearchQuery, mgp::Type::String),
+                     mgp::Parameter(TextSearch::kParameterConfig, {mgp::Type::Map, mgp::Type::Any}, default_config),
+                 },
+                 {mgp::Return(TextSearch::kReturnNode, mgp::Type::Node),
+                  mgp::Return(TextSearch::kReturnScore, mgp::Type::Double)},
+                 query_module,
+                 memory);
+
     AddProcedure(TextSearch::RegexSearch,
                  TextSearch::kProcedureRegexSearch,
                  mgp::ProcedureType::Read,
@@ -342,6 +424,19 @@ extern "C" int mgp_init_module(struct mgp_module *query_module, struct mgp_memor
 
     AddProcedure(TextSearch::SearchEdges,
                  TextSearch::kProcedureSearchEdges,
+                 mgp::ProcedureType::Read,
+                 {
+                     mgp::Parameter(TextSearch::kParameterIndexName, mgp::Type::String),
+                     mgp::Parameter(TextSearch::kParameterSearchQuery, mgp::Type::String),
+                     mgp::Parameter(TextSearch::kParameterConfig, {mgp::Type::Map, mgp::Type::Any}, default_config),
+                 },
+                 {mgp::Return(TextSearch::kReturnEdge, mgp::Type::Relationship),
+                  mgp::Return(TextSearch::kReturnScore, mgp::Type::Double)},
+                 query_module,
+                 memory);
+
+    AddProcedure(TextSearch::SearchSequenceEdges,
+                 TextSearch::kProcedureSearchSequenceEdges,
                  mgp::ProcedureType::Read,
                  {
                      mgp::Parameter(TextSearch::kParameterIndexName, mgp::Type::String),

--- a/query_modules/text_search_module.cpp
+++ b/query_modules/text_search_module.cpp
@@ -21,8 +21,8 @@
 
 namespace TextSearch {
 constexpr std::string_view kProcedureSearch = "search";
-constexpr std::string_view kProcedureSearchSequence = "search_sequence";
-constexpr std::string_view kProcedureSearchSequenceEdges = "search_sequence_edges";
+constexpr std::string_view kProcedureFuzzyPhraseSearch = "fuzzy_phrase_search";
+constexpr std::string_view kProcedureFuzzyPhraseSearchEdges = "fuzzy_phrase_search_edges";
 constexpr std::string_view kProcedureRegexSearch = "regex_search";
 constexpr std::string_view kProcedureSearchAllProperties = "search_all";
 constexpr std::string_view kProcedureAggregate = "aggregate";
@@ -50,8 +50,8 @@ constexpr std::array<std::string_view, 4> kRecognisedConfigKeys{
 mgp::TextSearchConfig ParseConfig(const mgp::Map &config, bool fuzzy_supported);
 
 void Search(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
-void SearchSequence(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
-void SearchSequenceEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
+void FuzzyPhraseSearch(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
+void FuzzyPhraseSearchEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void RegexSearch(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void SearchAllProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void SearchEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
@@ -89,7 +89,7 @@ void RejectIfUnsupported(bool fuzzy_supported, bool key_makes_difference, std::s
 void RejectExplicitNonPrefix(const mgp::Map &config) {
   if (config.KeyExists(TextSearch::kConfigFuzzyPrefix) && !ExtractBool(config, TextSearch::kConfigFuzzyPrefix)) {
     throw std::invalid_argument(
-        "search_sequence always treats the last term as a prefix; 'fuzzy_prefix:false' is not supported.");
+        "fuzzy_phrase_search always treats the last term as a prefix; 'fuzzy_prefix:false' is not supported.");
   }
 }
 
@@ -157,9 +157,9 @@ void TextSearch::Search(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *r
   }
 }
 
-// Adjacent, in-order fuzzy term-sequence search (last term a prefix) over a single `data.<property>`.
-// Thin wrapper over text_search_mode::SEQUENCE; all the matching logic runs in mgcxx.
-void TextSearch::SearchSequence(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
+// Fuzzy phrase search: adjacent, in-order terms (last term a prefix) over a single `data.<property>`.
+// Thin wrapper over text_search_mode::FUZZY_PHRASE; all the matching logic runs in mgcxx.
+void TextSearch::FuzzyPhraseSearch(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
   mgp::MemoryDispatcherGuard guard{memory};
   const auto record_factory = mgp::RecordFactory(result);
   auto arguments = mgp::List(args);
@@ -172,7 +172,7 @@ void TextSearch::SearchSequence(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
     RejectExplicitNonPrefix(config_map);
     config.fuzzy_prefix = true;
     for (const auto &row :
-         mgp::SearchTextIndex(memgraph_graph, index_name, search_query, text_search_mode::SEQUENCE, config)) {
+         mgp::SearchTextIndex(memgraph_graph, index_name, search_query, text_search_mode::FUZZY_PHRASE, config)) {
       auto record = record_factory.NewRecord();
       auto row_list = row.ValueList();
       record.Insert(TextSearch::kReturnNode.data(), row_list[0].ValueNode());
@@ -183,9 +183,9 @@ void TextSearch::SearchSequence(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
   }
 }
 
-// Edge counterpart of SearchSequence over a relationship text index.
-void TextSearch::SearchSequenceEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result,
-                                     mgp_memory *memory) {
+// Edge counterpart of FuzzyPhraseSearch over a relationship text index.
+void TextSearch::FuzzyPhraseSearchEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result,
+                                        mgp_memory *memory) {
   mgp::MemoryDispatcherGuard guard{memory};
   const auto record_factory = mgp::RecordFactory(result);
   auto arguments = mgp::List(args);
@@ -198,7 +198,7 @@ void TextSearch::SearchSequenceEdges(mgp_list *args, mgp_graph *memgraph_graph, 
     RejectExplicitNonPrefix(config_map);
     config.fuzzy_prefix = true;
     for (const auto &row :
-         mgp::SearchTextEdgeIndex(memgraph_graph, index_name, search_query, text_search_mode::SEQUENCE, config)) {
+         mgp::SearchTextEdgeIndex(memgraph_graph, index_name, search_query, text_search_mode::FUZZY_PHRASE, config)) {
       auto record = record_factory.NewRecord();
       auto row_list = row.ValueList();
       record.Insert(TextSearch::kReturnEdge.data(), row_list[0].ValueRelationship());
@@ -371,8 +371,8 @@ extern "C" int mgp_init_module(struct mgp_module *query_module, struct mgp_memor
                  query_module,
                  memory);
 
-    AddProcedure(TextSearch::SearchSequence,
-                 TextSearch::kProcedureSearchSequence,
+    AddProcedure(TextSearch::FuzzyPhraseSearch,
+                 TextSearch::kProcedureFuzzyPhraseSearch,
                  mgp::ProcedureType::Read,
                  {
                      mgp::Parameter(TextSearch::kParameterIndexName, mgp::Type::String),
@@ -435,8 +435,8 @@ extern "C" int mgp_init_module(struct mgp_module *query_module, struct mgp_memor
                  query_module,
                  memory);
 
-    AddProcedure(TextSearch::SearchSequenceEdges,
-                 TextSearch::kProcedureSearchSequenceEdges,
+    AddProcedure(TextSearch::FuzzyPhraseSearchEdges,
+                 TextSearch::kProcedureFuzzyPhraseSearchEdges,
                  mgp::ProcedureType::Read,
                  {
                      mgp::Parameter(TextSearch::kParameterIndexName, mgp::Type::String),

--- a/src/storage/v2/indices/text_edge_index.cpp
+++ b/src/storage/v2/indices/text_edge_index.cpp
@@ -332,10 +332,21 @@ std::vector<TextEdgeSearchResult> TextEdgeIndex::ActiveIndices::Search(const std
                                             .fuzzy_transpositions = config.fuzzy_transpositions,
                                             .fuzzy_field = kAllField});
         break;
+      case text_search_mode::SEQUENCE:
+        search_results = mgcxx::text_search::search_sequence_edge_gids_pinned(
+            context,
+            searcher,
+            mgcxx::text_search::SearchInput{.search_query = lowered_query,
+                                            .limit = config.limit,
+                                            .fuzzy_distance = config.fuzzy_distance,
+                                            .fuzzy_prefix = config.fuzzy_prefix,
+                                            .fuzzy_transpositions = config.fuzzy_transpositions,
+                                            .fuzzy_field = kDataField});
+        break;
       default:
         throw query::TextSearchException(
-            "Unsupported search mode: please use one of text_search.search_edges, text_search.search_all_edges, or "
-            "text_search.regex_search_edges.");
+            "Unsupported search mode: please use one of text_search.search_edges, text_search.search_all_edges, "
+            "text_search.search_sequence_edges, or text_search.regex_search_edges.");
     }
   } catch (const std::exception &e) {
     throw query::TextSearchException("Tantivy error: {}", e.what());

--- a/src/storage/v2/indices/text_edge_index.cpp
+++ b/src/storage/v2/indices/text_edge_index.cpp
@@ -332,8 +332,8 @@ std::vector<TextEdgeSearchResult> TextEdgeIndex::ActiveIndices::Search(const std
                                             .fuzzy_transpositions = config.fuzzy_transpositions,
                                             .fuzzy_field = kAllField});
         break;
-      case text_search_mode::SEQUENCE:
-        search_results = mgcxx::text_search::search_sequence_edge_gids_pinned(
+      case text_search_mode::FUZZY_PHRASE:
+        search_results = mgcxx::text_search::fuzzy_phrase_search_edge_gids_pinned(
             context,
             searcher,
             mgcxx::text_search::SearchInput{.search_query = lowered_query,
@@ -346,7 +346,7 @@ std::vector<TextEdgeSearchResult> TextEdgeIndex::ActiveIndices::Search(const std
       default:
         throw query::TextSearchException(
             "Unsupported search mode: please use one of text_search.search_edges, text_search.search_all_edges, "
-            "text_search.search_sequence_edges, or text_search.regex_search_edges.");
+            "text_search.fuzzy_phrase_search_edges, or text_search.regex_search_edges.");
     }
   } catch (const std::exception &e) {
     throw query::TextSearchException("Tantivy error: {}", e.what());

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -333,8 +333,8 @@ std::vector<TextSearchResult> TextIndex::ActiveIndices::Search(const std::string
                                             .fuzzy_transpositions = config.fuzzy_transpositions,
                                             .fuzzy_field = kAllField});
         break;
-      case text_search_mode::SEQUENCE:
-        search_results = mgcxx::text_search::search_sequence_gids_pinned(
+      case text_search_mode::FUZZY_PHRASE:
+        search_results = mgcxx::text_search::fuzzy_phrase_search_gids_pinned(
             context,
             searcher,
             mgcxx::text_search::SearchInput{.search_query = lowered_query,
@@ -347,7 +347,7 @@ std::vector<TextSearchResult> TextIndex::ActiveIndices::Search(const std::string
       default:
         throw query::TextSearchException(
             "Unsupported search mode: please use one of text_search.search, text_search.search_all, "
-            "text_search.search_sequence, or text_search.regex_search.");
+            "text_search.fuzzy_phrase_search, or text_search.regex_search.");
     }
   } catch (const std::exception &e) {
     throw query::TextSearchException("Tantivy error: {}", e.what());

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -333,10 +333,21 @@ std::vector<TextSearchResult> TextIndex::ActiveIndices::Search(const std::string
                                             .fuzzy_transpositions = config.fuzzy_transpositions,
                                             .fuzzy_field = kAllField});
         break;
+      case text_search_mode::SEQUENCE:
+        search_results = mgcxx::text_search::search_sequence_gids_pinned(
+            context,
+            searcher,
+            mgcxx::text_search::SearchInput{.search_query = lowered_query,
+                                            .limit = config.limit,
+                                            .fuzzy_distance = config.fuzzy_distance,
+                                            .fuzzy_prefix = config.fuzzy_prefix,
+                                            .fuzzy_transpositions = config.fuzzy_transpositions,
+                                            .fuzzy_field = kDataField});
+        break;
       default:
         throw query::TextSearchException(
-            "Unsupported search mode: please use one of text_search.search, text_search.search_all, or "
-            "text_search.regex_search.");
+            "Unsupported search mode: please use one of text_search.search, text_search.search_all, "
+            "text_search.search_sequence, or text_search.regex_search.");
     }
   } catch (const std::exception &e) {
     throw query::TextSearchException("Tantivy error: {}", e.what());

--- a/tests/gql_behave/tests/memgraph_V1/features/text_edge_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/text_edge_search.feature
@@ -504,3 +504,24 @@ Feature: Text edge search related features
             | title       |
             | 'memgrap'   |
             | 'memgraph'  |
+
+    Scenario: Sequence edge search enforces order with a last-word prefix
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT EDGE INDEX sequenceEdgeIndex ON :LINK
+            """
+        And having executed
+            """
+            CREATE (a:Document)-[:LINK {text: 'big bad wolf'}]->(b:Document)
+            CREATE (c:Document)-[:LINK {text: 'bad big wolf'}]->(d:Document)
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence_edges('sequenceEdgeIndex', 'data.text:big bad wo') YIELD edge
+            RETURN edge.text AS text
+            ORDER BY text ASC
+            """
+        Then the result should be:
+            | text         |
+            | 'big bad wolf' |

--- a/tests/gql_behave/tests/memgraph_V1/features/text_edge_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/text_edge_search.feature
@@ -505,11 +505,11 @@ Feature: Text edge search related features
             | 'memgrap'   |
             | 'memgraph'  |
 
-    Scenario: Sequence edge search enforces order with a last-word prefix
+    Scenario: Fuzzy phrase edge search enforces order with a last-word prefix
         Given an empty graph
         And having executed
             """
-            CREATE TEXT EDGE INDEX sequenceEdgeIndex ON :LINK
+            CREATE TEXT EDGE INDEX fuzzyPhraseEdgeIndex ON :LINK
             """
         And having executed
             """
@@ -518,7 +518,7 @@ Feature: Text edge search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence_edges('sequenceEdgeIndex', 'data.text:big bad wo') YIELD edge
+            CALL text_search.fuzzy_phrase_search_edges('fuzzyPhraseEdgeIndex', 'data.text:big bad wo') YIELD edge
             RETURN edge.text AS text
             ORDER BY text ASC
             """

--- a/tests/gql_behave/tests/memgraph_V1/features/text_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/text_search.feature
@@ -687,11 +687,11 @@ Feature: Text search related features
             """
         Then an error should be raised
 
-    Scenario: Sequence search enforces order and adjacency with a last-word prefix
+    Scenario: Fuzzy phrase search enforces order and adjacency with a last-word prefix
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -703,7 +703,7 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo') YIELD node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:big bad wo') YIELD node
             RETURN node.n AS n
             ORDER BY n ASC
             """
@@ -713,11 +713,11 @@ Feature: Text search related features
             | 2 |
             | 3 |
 
-    Scenario: Sequence search enforces word order
+    Scenario: Fuzzy phrase search enforces word order
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -726,7 +726,7 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:bad big wo') YIELD node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:bad big wo') YIELD node
             RETURN node.n AS n
             ORDER BY n ASC
             """
@@ -734,11 +734,11 @@ Feature: Text search related features
             | n |
             | 4 |
 
-    Scenario: Sequence search tolerates a typo with fuzzy_distance 1
+    Scenario: Fuzzy phrase search tolerates a typo with fuzzy_distance 1
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -747,7 +747,7 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bd wo', {fuzzy_distance: 1}) YIELD node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:big bd wo', {fuzzy_distance: 1}) YIELD node
             RETURN node.n AS n
             ORDER BY n ASC
             """
@@ -755,11 +755,11 @@ Feature: Text search related features
             | n |
             | 1 |
 
-    Scenario: Sequence search rejects fuzzy_prefix false
+    Scenario: Fuzzy phrase search rejects fuzzy_prefix false
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -767,15 +767,15 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo', {fuzzy_prefix: false}) YIELD node RETURN node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:big bad wo', {fuzzy_prefix: false}) YIELD node RETURN node
             """
         Then an error should be raised
 
-    Scenario: Sequence search shares the fuzzy budget across the whole input
+    Scenario: Fuzzy phrase search shares the fuzzy budget across the whole input
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -784,7 +784,7 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo', {fuzzy_distance: 1}) YIELD node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:big bad wo', {fuzzy_distance: 1}) YIELD node
             RETURN node.n AS n
             ORDER BY n ASC
             """
@@ -792,11 +792,11 @@ Feature: Text search related features
             | n |
             | 1 |
 
-    Scenario: Sequence search counts a transposition as one edit
+    Scenario: Fuzzy phrase search counts a transposition as one edit
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -804,18 +804,18 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:big abd wo', {fuzzy_distance: 1}) YIELD node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:big abd wo', {fuzzy_distance: 1}) YIELD node
             RETURN node.n AS n
             """
         Then the result should be:
             | n |
             | 1 |
 
-    Scenario: Sequence search with transpositions disabled needs two edits for a swap
+    Scenario: Fuzzy phrase search with transpositions disabled needs two edits for a swap
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -823,16 +823,16 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:big abd wo', {fuzzy_distance: 1, fuzzy_transpositions: false}) YIELD node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:big abd wo', {fuzzy_distance: 1, fuzzy_transpositions: false}) YIELD node
             RETURN node.n AS n
             """
         Then the result should be empty
 
-    Scenario: Sequence search rejects fuzzy_distance above 2
+    Scenario: Fuzzy phrase search rejects fuzzy_distance above 2
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -840,15 +840,15 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo', {fuzzy_distance: 3}) YIELD node RETURN node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'data.title:big bad wo', {fuzzy_distance: 3}) YIELD node RETURN node
             """
         Then an error should be raised
 
-    Scenario: Sequence search requires a single-property query
+    Scenario: Fuzzy phrase search requires a single-property query
         Given an empty graph
         And having executed
             """
-            CREATE TEXT INDEX sequenceIndex ON :Doc
+            CREATE TEXT INDEX fuzzyPhraseIndex ON :Doc
             """
         And having executed
             """
@@ -856,6 +856,6 @@ Feature: Text search related features
             """
         When executing query:
             """
-            CALL text_search.search_sequence('sequenceIndex', 'big bad wo') YIELD node RETURN node
+            CALL text_search.fuzzy_phrase_search('fuzzyPhraseIndex', 'big bad wo') YIELD node RETURN node
             """
         Then an error should be raised

--- a/tests/gql_behave/tests/memgraph_V1/features/text_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/text_search.feature
@@ -686,3 +686,176 @@ Feature: Text search related features
             CALL text_search.regex_search('regexRejectIndex', 'mem.*', {fuzzy_distance: 1}) YIELD node RETURN node
             """
         Then an error should be raised
+
+    Scenario: Sequence search enforces order and adjacency with a last-word prefix
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            CREATE (:Doc {title: 'big bad world', n: 2})
+            CREATE (:Doc {title: 'the big bad wolf returns', n: 3})
+            CREATE (:Doc {title: 'bad big wolf', n: 4})
+            CREATE (:Doc {title: 'big wolf', n: 5})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo') YIELD node
+            RETURN node.n AS n
+            ORDER BY n ASC
+            """
+        Then the result should be:
+            | n |
+            | 1 |
+            | 2 |
+            | 3 |
+
+    Scenario: Sequence search enforces word order
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            CREATE (:Doc {title: 'bad big wolf', n: 4})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:bad big wo') YIELD node
+            RETURN node.n AS n
+            ORDER BY n ASC
+            """
+        Then the result should be:
+            | n |
+            | 4 |
+
+    Scenario: Sequence search tolerates a typo with fuzzy_distance 1
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            CREATE (:Doc {title: 'coffee shop', n: 2})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bd wo', {fuzzy_distance: 1}) YIELD node
+            RETURN node.n AS n
+            ORDER BY n ASC
+            """
+        Then the result should be:
+            | n |
+            | 1 |
+
+    Scenario: Sequence search rejects fuzzy_prefix false
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo', {fuzzy_prefix: false}) YIELD node RETURN node
+            """
+        Then an error should be raised
+
+    Scenario: Sequence search shares the fuzzy budget across the whole input
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bd wolf', n: 1})
+            CREATE (:Doc {title: 'bg bd wolf', n: 2})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo', {fuzzy_distance: 1}) YIELD node
+            RETURN node.n AS n
+            ORDER BY n ASC
+            """
+        Then the result should be:
+            | n |
+            | 1 |
+
+    Scenario: Sequence search counts a transposition as one edit
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:big abd wo', {fuzzy_distance: 1}) YIELD node
+            RETURN node.n AS n
+            """
+        Then the result should be:
+            | n |
+            | 1 |
+
+    Scenario: Sequence search with transpositions disabled needs two edits for a swap
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:big abd wo', {fuzzy_distance: 1, fuzzy_transpositions: false}) YIELD node
+            RETURN node.n AS n
+            """
+        Then the result should be empty
+
+    Scenario: Sequence search rejects fuzzy_distance above 2
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'data.title:big bad wo', {fuzzy_distance: 3}) YIELD node RETURN node
+            """
+        Then an error should be raised
+
+    Scenario: Sequence search requires a single-property query
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX sequenceIndex ON :Doc
+            """
+        And having executed
+            """
+            CREATE (:Doc {title: 'big bad wolf', n: 1})
+            """
+        When executing query:
+            """
+            CALL text_search.search_sequence('sequenceIndex', 'big bad wo') YIELD node RETURN node
+            """
+        Then an error should be raised


### PR DESCRIPTION
## What

Adds two text-search procedures for **fuzzy phrase** search:

- `text_search.fuzzy_phrase_search(index, 'data.<property>:<terms>', config)`
- `text_search.fuzzy_phrase_search_edges(index, 'data.<property>:<terms>', config)`

They match an **ordered, adjacent** sequence of terms on a single property where the **last term is a prefix**, tolerating up to `fuzzy_distance` typos **across the whole input** (one shared budget, not per word) — e.g. `data.title:big bad wo` matches `big bad wolf` / `big bad world`; `big bd wo` matches at `fuzzy_distance:1` (1 edit total), but two separate typos need `fuzzy_distance:2`; order/adjacency are enforced (`bad big wo` does **not** match `big bad wolf`).

## How

Implemented **natively in mgcxx (Rust)** behind a new `text_search_mode::FUZZY_PHRASE` threaded through the existing search path (`mgp.hpp` → `mg_procedure` → storage `TextIndex::Search` → mgcxx). New `fuzzy_phrase_search_gids_pinned` / `fuzzy_phrase_search_edge_gids_pinned`:

- parse `data.<property>:<terms>` and tokenize the terms with the **field's own analyzer** (`tokenizer_for_field`) — so tokenization matches the index exactly (Unicode segmentation, `RemoveLongFilter`, lowercasing);
- build the candidate query **programmatically** — a `BooleanQuery` of per-term `FuzzyTermQuery` on `Term::from_field_json_path` (leading terms whole-word fuzzy, last term a fuzzy prefix). Building it directly (rather than a `+data.<prop>:t` query string) lets **numeric/boolean tokens match as string terms** (e.g. `report 2024`) instead of failing tantivy's JSON fast-value conversion, and needs no escaping for unusual property names;
- **adaptively page** the candidate pool in score order — the first page is sized to `limit` (with a small over-fetch factor), doubling only when the post-filter is starved, capped at `FUZZY_PHRASE_MAX_CANDIDATES` — reading each hit's stored `data[property]`, tokenizing it with the same analyzer, and keeping docs where the terms appear **adjacent and in order** with the **sum** of their per-word edit distances (optimal-string-alignment; leading whole-word, last a prefix) within `fuzzy_distance` — one budget shared across the phrase, not per term. The summed budget is bounded by the per-term candidate net, so the candidate is a genuine superset (no recall loss).

## Behavior / config

- **Single property only** (`data.<property>:<terms>`); any other query form is rejected.
- `fuzzy_prefix:false` is rejected (the last term is always a prefix); `fuzzy_distance` is validated to `0–2`.

