### PR TITLE
feat(storage): arity-specialize label-property index entry storage

### DIFF
--- a/src/storage/v2/disk/edge_import_mode_cache.cpp
+++ b/src/storage/v2/disk/edge_import_mode_cache.cpp
@@ -29,19 +29,20 @@ InMemoryLabelIndex::Iterable EdgeImportModeCache::Vertices(LabelId label, View v
       ->Vertices(label, vertices_.access(), view, storage, transaction);
 }
 
-InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry> EdgeImportModeCache::Vertices(
+InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry<1>> EdgeImportModeCache::Vertices(
     LabelId label, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) const {
   auto index = in_memory_indices_.label_property_index_->GetActiveIndices();
   return static_cast<InMemoryLabelPropertyIndex::ActiveIndices *>(index.get())
-      ->Vertices<InMemoryLabelPropertyIndex::Entry>(label,
-                                                    std::array{PropertyPath{property}},
-                                                    std::array{PropertyValueRange::Bounded(lower_bound, upper_bound)},
-                                                    vertices_.access(),
-                                                    view,
-                                                    storage,
-                                                    transaction);
+      ->Vertices<InMemoryLabelPropertyIndex::Entry<1>>(
+          label,
+          std::array{PropertyPath{property}},
+          std::array{PropertyValueRange::Bounded(lower_bound, upper_bound)},
+          vertices_.access(),
+          view,
+          storage,
+          transaction);
 }
 
 bool EdgeImportModeCache::CreateIndex(

--- a/src/storage/v2/disk/edge_import_mode_cache.hpp
+++ b/src/storage/v2/disk/edge_import_mode_cache.hpp
@@ -36,7 +36,7 @@ class EdgeImportModeCache final {
 
   InMemoryLabelIndex::Iterable Vertices(LabelId label, View view, Storage *storage, Transaction *transaction) const;
 
-  InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry> Vertices(
+  InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry<1>> Vertices(
       LabelId label, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
       const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
       Transaction *transaction) const;

--- a/src/storage/v2/indices/label_property_index.cpp
+++ b/src/storage/v2/indices/label_property_index.cpp
@@ -71,6 +71,10 @@ auto PropertiesPermutationHelper::Extract(PropertyStore const &properties) const
   return properties.ExtractPropertyValuesMissingAsNull(sorted_properties_);
 }
 
+void PropertiesPermutationHelper::ExtractInto(PropertyStore const &properties, std::span<PropertyValue> out) const {
+  properties.ExtractPropertyValuesMissingAsNull(sorted_properties_, out);
+}
+
 void PropertiesPermutationHelper::Update(PropertyId outer_prop_id, PropertyValue const &value,
                                          std::vector<PropertyValue> &extracted_values) const {
   auto it = grouped_by_outer_prop_id_.find(outer_prop_id);
@@ -82,21 +86,24 @@ void PropertiesPermutationHelper::Update(PropertyId outer_prop_id, PropertyValue
   }
 }
 
-auto PropertiesPermutationHelper::ApplyPermutation(std::vector<PropertyValue> values) const
-    -> IndexOrderedPropertyValues {
+void PropertiesPermutationHelper::ApplyPermutationInPlace(std::span<PropertyValue> values) const {
   for (const auto &cycle : cycles_) {
     auto tmp = std::move(values[cycle.front()]);
     for (auto pos : std::span{cycle}.subspan<1>()) {
-      tmp = std::exchange(values[pos], tmp);
+      tmp = std::exchange(values[pos], std::move(tmp));
     }
     values[cycle.front()] = std::move(tmp);
   }
+}
 
+auto PropertiesPermutationHelper::ApplyPermutation(std::vector<PropertyValue> values) const
+    -> IndexOrderedValuesVector {
+  ApplyPermutationInPlace(std::span{values});
   return {std::move(values)};
 }
 
 auto PropertiesPermutationHelper::MatchesValue(PropertyId outer_prop_id, PropertyValue const &value,
-                                               IndexOrderedPropertyValues const &cmp_values) const
+                                               IndexOrderedValuesView cmp_values) const
     -> std::vector<std::pair<std::ptrdiff_t, bool>> {
   auto enum_properties = rv::enumerate(sorted_properties_);
   auto relevant_paths =
@@ -104,7 +111,7 @@ auto PropertiesPermutationHelper::MatchesValue(PropertyId outer_prop_id, Propert
 
   auto is_match = [&](auto &&el) -> std::pair<std::ptrdiff_t, bool> {
     auto &&[index, path] = el;
-    auto const &cmp_value = cmp_values.values_[position_lookup_[index]];
+    auto const &cmp_value = cmp_values[position_lookup_[index]];
     // Outer property was already read to get `value`, strip that off of the path
     DMG_ASSERT(!path.empty(), "PropertyPath should be at least 1");
     auto const *nested_value = ReadNestedPropertyValue(value, path | rv::drop(1));
@@ -113,9 +120,9 @@ auto PropertiesPermutationHelper::MatchesValue(PropertyId outer_prop_id, Propert
   return relevant_paths | rv::transform(is_match) | r::to_vector;
 }
 
-auto PropertiesPermutationHelper::MatchesValues(PropertyStore const &properties,
-                                                IndexOrderedPropertyValues const &values) const -> std::vector<bool> {
-  return properties.ArePropertiesEqual(sorted_properties_, values.values_, position_lookup_);
+auto PropertiesPermutationHelper::MatchesValues(PropertyStore const &properties, IndexOrderedValuesView values) const
+    -> std::vector<bool> {
+  return properties.ArePropertiesEqual(sorted_properties_, values, position_lookup_);
 }
 
 size_t PropertyValueRange::hash() const noexcept {

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -20,10 +20,15 @@
 #include "storage/v2/vertex_accessor.hpp"
 #include "utils/bound.hpp"
 
+#include <array>
+#include <concepts>
 #include <cstdint>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 #include <ranges>
+#include <span>
+#include <type_traits>
+#include <utility>
 
 namespace memgraph::storage {
 
@@ -90,13 +95,110 @@ struct PropertyValueRange {
       : type_{type}, lower_{std::move(lower)}, upper_{std::move(upper)} {}
 };
 
-struct IndexOrderedPropertyValues {
-  IndexOrderedPropertyValues(std::vector<PropertyValue> value) : values_{std::move(value)} {}
+/** A non-owning view over property values known to be in *index* order (the
+ * order dictated by the index definition), as opposed to the monotonic
+ * `PropertyId` order in which they are laid out in a `PropertyStore`. The match
+ * and comparison helpers accept only this type, so storage-ordered values
+ * cannot be passed where index-ordered values are required. Only the owning
+ * index value types (which hold their values in index order by construction)
+ * can produce one. */
+class IndexOrderedValuesView {
+ public:
+  auto operator[](std::size_t pos) const -> PropertyValue const & { return values_[pos]; }
 
-  friend auto operator<=>(IndexOrderedPropertyValues const &, IndexOrderedPropertyValues const &) = default;
+  auto size() const -> std::size_t { return values_.size(); }
+
+  auto begin() const { return values_.begin(); }
+
+  auto end() const { return values_.end(); }
+
+  friend bool operator==(IndexOrderedValuesView lhs, IndexOrderedValuesView rhs) {
+    return std::ranges::equal(lhs.values_, rhs.values_);
+  }
+
+ private:
+  friend struct IndexOrderedValuesVector;
+  template <std::size_t>
+  friend struct IndexOrderedValuesArray;
+
+  explicit IndexOrderedValuesView(std::span<PropertyValue const> values) : values_{values} {}
+
+  std::span<PropertyValue const> values_;
+};
+
+struct IndexOrderedValuesVector {
+  IndexOrderedValuesVector(std::vector<PropertyValue> value) : values_{std::move(value)} {}
+
+  friend auto operator<=>(IndexOrderedValuesVector const &, IndexOrderedValuesVector const &) = default;
+
+  auto as_view() const -> IndexOrderedValuesView { return IndexOrderedValuesView{values_}; }
+
+  // NOLINTNEXTLINE(google-explicit-constructor): widening an owner to its own view is safe.
+  operator IndexOrderedValuesView() const { return as_view(); }
+
+  auto begin() const { return values_.begin(); }
+
+  auto end() const { return values_.end(); }
+
+  auto size() const { return values_.size(); }
+
+  auto operator[](std::size_t pos) const -> PropertyValue const & { return values_[pos]; }
 
   std::vector<PropertyValue> values_;
 };
+
+/** Array-backed index value storage for a fixed composite arity `N`. Inlines
+ * the values directly into the skiplist node (no heap indirection), unlike the
+ * dynamic `IndexOrderedValuesVector`. Constructed from the index-ordered
+ * values produced by `PropertiesPermutationHelper::ApplyPermutation`. */
+template <std::size_t N>
+struct IndexOrderedValuesArray {
+  IndexOrderedValuesArray() = default;
+
+  // Take ownership of an already index-ordered buffer (the producing path fills
+  // and permutes a stack array, then moves it in).
+  explicit IndexOrderedValuesArray(std::array<PropertyValue, N> vals) : values_{std::move(vals)} {}
+
+  // Construct from the index-ordered values produced by ApplyPermutation.
+  // Forwards each value's value category: a producing rvalue moves its
+  // PropertyValues into the array (no deep copy on the insert path), a const
+  // lvalue (the abort path) copies. Entries are never reordered once stored, so
+  // this is the only point at which values enter the array.
+  template <typename Src>
+    requires std::same_as<std::remove_cvref_t<Src>, IndexOrderedValuesVector>
+  // NOLINTNEXTLINE(google-explicit-constructor): same value, denser storage.
+  IndexOrderedValuesArray(Src &&src) {
+    for (std::size_t i = 0; i != N; ++i) {
+      values_[i] = std::forward_like<Src>(src.values_[i]);
+    }
+  }
+
+  friend auto operator<=>(IndexOrderedValuesArray const &, IndexOrderedValuesArray const &) = default;
+
+  auto as_view() const -> IndexOrderedValuesView {
+    return IndexOrderedValuesView{std::span<PropertyValue const>{values_}};
+  }
+
+  // NOLINTNEXTLINE(google-explicit-constructor): widening an owner to its own view is safe.
+  operator IndexOrderedValuesView() const { return as_view(); }
+
+  auto begin() const { return values_.begin(); }
+
+  auto end() const { return values_.end(); }
+
+  auto size() const { return values_.size(); }
+
+  auto operator[](std::size_t pos) const -> PropertyValue const & { return values_[pos]; }
+
+  std::array<PropertyValue, N> values_;
+};
+
+/** Entry value storage chosen by composite arity: a fixed `std::array` for
+ * small arities (inlined), the dynamic `IndexOrderedValuesVector` (vector)
+ * for `dynamic_extent`. */
+template <std::size_t N>
+using IndexOrderedValues =
+    std::conditional_t<N == std::dynamic_extent, IndexOrderedValuesVector, IndexOrderedValuesArray<N>>;
 
 /**
  * Due to the monotonic ordering of properties within the `PropertyStore`, we
@@ -116,10 +218,15 @@ struct PropertiesPermutationHelper {
    */
   explicit PropertiesPermutationHelper(std::span<PropertyPath const> properties);
 
-  /** Rearranges a vector of monotonically ordered properties (as returned
-   * by `Extract`) into the index order.
+  /** Rearranges monotonically ordered properties (as returned by `Extract` /
+   * written by `ExtractInto`) into the index order, in place.
    */
-  auto ApplyPermutation(std::vector<PropertyValue> values) const -> IndexOrderedPropertyValues;
+  void ApplyPermutationInPlace(std::span<PropertyValue> values) const;
+
+  /** Permutes the given vector into the index order and wraps it as the
+   * index-ordered values for the dynamic (vector-backed) storage.
+   */
+  auto ApplyPermutation(std::vector<PropertyValue> values) const -> IndexOrderedValuesVector;
 
   /* Extract one or more values from the given property store, returned in
    * increasing `PropertyId` order. Use `ApplyPermutation` to arrange the
@@ -127,6 +234,13 @@ struct PropertiesPermutationHelper {
    * @sa ApplyPermutation
    */
   auto Extract(PropertyStore const &properties) const -> std::vector<PropertyValue>;
+
+  /** As `Extract`, but writes into the caller-provided `out` (one slot per
+   * index property, monotonic `PropertyId` order) without allocating, so a
+   * fixed-arity entry can be built into a stack buffer. `out.size()` must equal
+   * the index arity.
+   */
+  void ExtractInto(PropertyStore const &properties, std::span<PropertyValue> out) const;
 
   /**
    * Inplace update the `extracted_values` with the current value if relevant
@@ -142,22 +256,21 @@ struct PropertiesPermutationHelper {
    * (in monotonic property id order), and a boolean indicating whether the
    * property matches.
    */
-  auto MatchesValue(PropertyId outer_prop_id, PropertyValue const &value,
-                    IndexOrderedPropertyValues const &cmp_values) const -> std::vector<std::pair<std::ptrdiff_t, bool>>;
+  auto MatchesValue(PropertyId outer_prop_id, PropertyValue const &value, IndexOrderedValuesView cmp_values) const
+      -> std::vector<std::pair<std::ptrdiff_t, bool>>;
 
   /** Efficiently compares multiple values in the property store with the given
    * values. This returns a vector of boolean flags indicating per-element
    * equality (in monotonic property id order.)
    */
-  auto MatchesValues(PropertyStore const &properties, IndexOrderedPropertyValues const &values) const
-      -> std::vector<bool>;
+  auto MatchesValues(PropertyStore const &properties, IndexOrderedValuesView values) const -> std::vector<bool>;
 
   /** Returns an augmented view over the values in the given vector, where each
    * element is a tuple comprising: (position, [property id path], and value).
    */
-  auto WithPropertyId(IndexOrderedPropertyValues const &values) const {
-    return ranges::views::enumerate(sorted_properties_) | ranges::views::transform([&](auto &&p) {
-             return std::tuple{p.first, std::cref(p.second), std::cref(values.values_[position_lookup_[p.first]])};
+  auto WithPropertyId(IndexOrderedValuesView values) const {
+    return ranges::views::enumerate(sorted_properties_) | ranges::views::transform([&, values](auto &&p) {
+             return std::tuple{p.first, std::cref(p.second), std::cref(values[position_lookup_[p.first]])};
            });
   }
 
@@ -169,7 +282,7 @@ struct PropertiesPermutationHelper {
 };
 
 using LabelPropertyIndexAbortableInfo =
-    std::map<LabelId, std::map<PropertiesPaths const *, std::vector<std::pair<IndexOrderedPropertyValues, Vertex *>>>>;
+    std::map<LabelId, std::map<PropertiesPaths const *, std::vector<std::pair<IndexOrderedValuesVector, Vertex *>>>>;
 
 class LabelPropertyIndex {
  public:

--- a/src/storage/v2/indices/vector_edge_index.cpp
+++ b/src/storage/v2/indices/vector_edge_index.cpp
@@ -289,6 +289,8 @@ void VectorEdgeIndex::Clear() {
 
 void VectorEdgeIndex::UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
                                           PropertyId property, const PropertyValue &value) {
+  // No vector edge indexes: a value can only be a vector-index id when one exists, so there is nothing to do.
+  if (index_->empty()) return;
   // Property should already be updated to the vector index id if it has vector index defined on it.
   if (value.IsVectorIndexId()) {
     const auto &vector_property = value.ValueVectorIndexList();

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -296,6 +296,8 @@ void VectorIndex::UpdateOnRemoveLabel(LabelId label, Vertex *vertex, const Index
 }
 
 void VectorIndex::UpdateOnSetProperty(PropertyId property, const PropertyValue &value, Vertex *vertex) {
+  // No vector indexes: a value can only be a vector-index id when one exists, so there is nothing to do.
+  if (index_->empty()) return;
   // Property should already be updated to the vector index id if it has vector index defined on it.
   if (value.IsVectorIndexId()) {
     const auto &vector_property = value.ValueVectorIndexList();

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -9,10 +9,14 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <array>
 #include <concepts>
 #include <cstdint>
 #include <optional>
 #include <range/v3/all.hpp>
+#include <span>
+#include <tuple>
+#include <variant>
 
 #include "metrics/prometheus_metrics.hpp"
 #include "storage/v2/id_types.hpp"
@@ -24,6 +28,8 @@
 #include "storage/v2/property_constants.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/property_value_utils.hpp"
+#include "storage/v2/vertices_chunked_iterable.hpp"
+#include "storage/v2/vertices_iterable.hpp"
 #include "utils/bound.hpp"
 #include "utils/counter.hpp"
 #include "utils/logging.hpp"
@@ -36,9 +42,9 @@ namespace memgraph::storage {
 namespace {
 
 auto PropertyValueMatch_ActionMethod(std::vector<bool> &match, PropertiesPermutationHelper const &helper,
-                                     IndexOrderedPropertyValues const &cmp_values) {
+                                     IndexOrderedValuesView cmp_values) {
   using enum Delta::Action;
-  return ActionMethod<SET_PROPERTY>([&](Delta const &delta) {
+  return ActionMethod<SET_PROPERTY>([&match, &helper, cmp_values](Delta const &delta) {
     for (auto &&[pos, matches] : helper.MatchesValue(delta.property.key, *delta.property.value, cmp_values)) {
       match[pos] = matches;
     }
@@ -68,15 +74,36 @@ bool AnyNonNull(auto const &values) {
   return r::any_of(values, [](auto &&v) { return !v.IsNull(); });
 }
 
+// Produces the index-ordered values for a new entry of type EntryT directly
+// from the property store, or nullopt when all-null (a vertex with none of the
+// indexed properties set takes no entry). A fixed-arity entry fills and
+// permutes a stack array - no heap traffic on the value path; the dynamic entry
+// uses the vector. The all-null check runs before permutation (order-agnostic).
+template <typename EntryT>
+auto BuildEntryValues(PropertiesPermutationHelper const &helper, PropertyStore const &store)
+    -> std::optional<typename EntryT::ValuesType> {
+  if constexpr (EntryT::kArity == std::dynamic_extent) {
+    auto values = helper.Extract(store);
+    if (!AnyNonNull(values)) return std::nullopt;
+    return helper.ApplyPermutation(std::move(values));
+  } else {
+    std::array<PropertyValue, EntryT::kArity> values{};
+    helper.ExtractInto(store, values);
+    if (!AnyNonNull(values)) return std::nullopt;
+    helper.ApplyPermutationInPlace(std::span{values});
+    return typename EntryT::ValuesType{std::move(values)};
+  }
+}
+
 // Erase the contiguous run of skiplist entries for `vertex` at the given key.
 // Entries are sorted by (values, vertex, timestamp), so all entries with this
 // (values, vertex) pair are adjacent regardless of ASC/DESC ordering (the
 // reversal only affects the values comparison, not equal-key neighbours).
 template <typename Acc>
-void EraseEntriesAtKey(Acc &acc, IndexOrderedPropertyValues const &values, Vertex *vertex) {
+void EraseEntriesAtKey(Acc &acc, IndexOrderedValuesVector const &values, Vertex *vertex) {
   using EntryT = typename Acc::value_type;
   for (auto it = acc.find_equal_or_greater(EntryT{values, vertex, 0});
-       it != acc.end() && it->vertex == vertex && it->values == values;) {
+       it != acc.end() && it->vertex == vertex && std::ranges::equal(it->values, values);) {
     auto const next_it = std::next(it);
     acc.remove(*it);
     it = next_it;
@@ -87,7 +114,7 @@ void EraseEntriesAtKey(Acc &acc, IndexOrderedPropertyValues const &values, Verte
 // this transaction can see the given vertex, and the visible version has the
 // given label and properties.
 bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, PropertiesPermutationHelper const &helper,
-                                      IndexOrderedPropertyValues const &values, Transaction *transaction, View view,
+                                      IndexOrderedValuesView values, Transaction *transaction, View view,
                                       bool use_cache = true) {
   bool exists = true;
   bool deleted = false;
@@ -183,8 +210,8 @@ bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, Prope
 /// there is a reachable version of the vertex that has the given label and
 /// properties values.
 inline bool AnyVersionHasLabelProperties(const Vertex &vertex, LabelId label, std::span<PropertyPath const> key,
-                                         PropertiesPermutationHelper const &helper,
-                                         IndexOrderedPropertyValues const &values, uint64_t timestamp) {
+                                         PropertiesPermutationHelper const &helper, IndexOrderedValuesView values,
+                                         uint64_t timestamp) {
   Delta const *delta;
   bool exists = true;
   bool deleted;
@@ -240,7 +267,7 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
 
     // Check the prefix has at least one non-null value
     if (!lower_bound.empty()) {
-      auto const prefix_values_only = index_iterator->values.values_ | ranges::views::take(lower_bound.size());
+      auto const prefix_values_only = index_iterator->values | ranges::views::take(lower_bound.size());
       auto const all_null = ranges::all_of(prefix_values_only, [](PropertyValue const &pv) { return pv.IsNull(); });
       if (all_null) continue;
     }
@@ -284,7 +311,7 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
     auto bounds_checker = [&]() {
       auto at_boundary_counter = 0;
       for (auto level = 0U; level < lower_bound.size(); ++level) {
-        switch (value_within_bounds(lower_bound[level], upper_bound[level], index_iterator->values.values_[level])) {
+        switch (value_within_bounds(lower_bound[level], upper_bound[level], index_iterator->values[level])) {
           case InBoundResult::UNDER: {
             // At level 0, out_of_range_below is direction-dependent: ASC→Skip, DESC→NoMoreValidEntries.
             // At level >= 1, a secondary property below range doesn't mean all remaining entries are invalid
@@ -331,7 +358,7 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
     if (CurrentVersionHasLabelProperties(*index_iterator->vertex,
                                          label,
                                          *permutation_helper,
-                                         index_iterator->values,
+                                         index_iterator->values.as_view(),
                                          transaction,
                                          view,
                                          use_cache)) {
@@ -344,24 +371,24 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
 
 }  // namespace
 
-template <bool Reverse>
-bool InMemoryLabelPropertyIndex::BasicEntry<Reverse>::operator<(std::vector<PropertyValue> const &rhs) const {
-  auto span = std::span{values.values_.begin(), std::min(rhs.size(), values.values_.size())};
+template <IndexOrder Order, std::size_t N>
+bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<(std::vector<PropertyValue> const &rhs) const {
+  auto const prefix = values | std::views::take(std::min(rhs.size(), values.size()));
   // In DESC, "less than" in skip-list terms means "greater than" in value terms.
-  if constexpr (Reverse) {
-    return std::ranges::lexicographical_compare(rhs, span);
+  if constexpr (Order == IndexOrder::DESC) {
+    return std::ranges::lexicographical_compare(rhs, prefix);
   } else {
-    return std::ranges::lexicographical_compare(span, rhs);
+    return std::ranges::lexicographical_compare(prefix, rhs);
   }
 }
 
-template <bool Reverse>
-bool InMemoryLabelPropertyIndex::BasicEntry<Reverse>::operator==(std::vector<PropertyValue> const &rhs) const {
-  return std::ranges::equal(std::span{values.values_.begin(), std::min(rhs.size(), values.values_.size())}, rhs);
+template <IndexOrder Order, std::size_t N>
+bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator==(std::vector<PropertyValue> const &rhs) const {
+  return std::ranges::equal(values | std::views::take(std::min(rhs.size(), values.size())), rhs);
 }
 
-template <bool Reverse>
-bool InMemoryLabelPropertyIndex::BasicEntry<Reverse>::operator<=(std::vector<PropertyValue> const &rhs) const {
+template <IndexOrder Order, std::size_t N>
+bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<=(std::vector<PropertyValue> const &rhs) const {
   return *this < rhs || *this == rhs;
 }
 
@@ -377,14 +404,13 @@ inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, Propert
     return;
   }
 
-  auto values = props.Extract(vertex.properties);
-  if (r::all_of(values, [](auto const &each) { return each.IsNull(); })) {
-    return;
-  }
+  using EntryT = typename std::remove_cvref_t<decltype(index_accessor)>::value_type;
+  auto values = BuildEntryValues<EntryT>(props, vertex.properties);
+  if (!values) return;
 
   // Using 0 as a timestamp is fine because the index is created at timestamp x
   // and any query using the index will be > x.
-  index_accessor.insert({props.ApplyPermutation(std::move(values)), &vertex, 0});
+  index_accessor.insert({std::move(*values), &vertex, 0});
 }
 
 inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, PropertiesPermutationHelper const &props,
@@ -453,10 +479,48 @@ bool InMemoryLabelPropertyIndex::CreateIndexOnePass(
 }
 
 namespace {
+// Applies f to the IndividualIndex inside an index-pointer variant, hiding the
+// visit-and-dereference repeated at each deref site.
+template <typename Variant, typename F>
+decltype(auto) WithIndex(Variant &&variant, F &&f) {
+  return std::visit([&](auto &&ptr) -> decltype(auto) { return f(*ptr); }, std::forward<Variant>(variant));
+}
+
+// Single source of truth for the arity -> entry-type policy: arity 1 and 2 are
+// array-backed, anything else the dynamic vector-backed alternative. Adding an
+// arity is a one-line change here.
+template <IndexOrder Order, typename F>
+decltype(auto) DispatchByArity(std::size_t arity, F &&f) {
+  if (arity == 1) return f.template operator()<InMemoryLabelPropertyIndex::BasicEntry<Order, 1>>();
+  if (arity == 2) return f.template operator()<InMemoryLabelPropertyIndex::BasicEntry<Order, 2>>();
+  return f.template operator()<InMemoryLabelPropertyIndex::BasicEntry<Order, std::dynamic_extent>>();
+}
+
+// Lifts a runtime sort order to the same value as a compile-time template argument.
+template <typename F>
+decltype(auto) DispatchByOrder(IndexOrder order, F &&f) {
+  if (order == IndexOrder::ASC) return std::forward<F>(f).template operator()<IndexOrder::ASC>();
+  return std::forward<F>(f).template operator()<IndexOrder::DESC>();
+}
+
+// Lifts the sort order and arity together to the concrete entry type.
+template <typename F>
+decltype(auto) DispatchByEntry(IndexOrder order, std::size_t arity, F &&f) {
+  return DispatchByOrder(order, [&]<IndexOrder Order>() -> decltype(auto) { return DispatchByArity<Order>(arity, f); });
+}
+
+template <IndexOrder Order>
+auto MakeIndexVariant(std::size_t arity, PropertiesPermutationHelper helper)
+    -> InMemoryLabelPropertyIndex::IndexPtrVariant<Order> {
+  return DispatchByArity<Order>(arity, [&]<typename E>() -> InMemoryLabelPropertyIndex::IndexPtrVariant<Order> {
+    return std::make_shared<InMemoryLabelPropertyIndex::IndividualIndex<E>>(std::move(helper));
+  });
+}
+
 // Inserts a new index into indices_map, updates the all_indices tracking list,
 // and populates the reverse lookup. Returns false if the index already exists.
 // Caller must hold the all_indices_ lock when passing all_indexes.
-template <typename IndicesMap, typename AllIndicesVec, typename ReverseLookup>
+template <IndexOrder Order, typename IndicesMap, typename AllIndicesVec, typename ReverseLookup>
 bool RegisterIntoIndicesMap(IndicesMap &indices_map, AllIndicesVec &all_indexes, ReverseLookup &reverse_lookup,
                             LabelId label, PropertiesPaths const &properties) {
   auto [it1, _] = indices_map.try_emplace(label);
@@ -465,15 +529,13 @@ bool RegisterIntoIndicesMap(IndicesMap &indices_map, AllIndicesVec &all_indexes,
     return false;
   }
   auto helper = PropertiesPermutationHelper{properties};
-  using IndexPtr = typename std::decay_t<decltype(properties_map)>::mapped_type;
-  using IndexT = typename IndexPtr::element_type;
-  auto [it3, _2] = properties_map.emplace(properties, std::make_shared<IndexT>(std::move(helper)));
+  auto [it3, _2] = properties_map.emplace(properties, MakeIndexVariant<Order>(properties.size(), std::move(helper)));
   auto new_all_indexes = *all_indexes;
   new_all_indexes.emplace_back(it3->second, label, properties);
   using Vec = std::decay_t<decltype(*all_indexes)>;
   all_indexes = std::make_shared<Vec>(std::move(new_all_indexes));
-  using EntryDetail = std::tuple<PropertiesPaths const *, IndexT *>;
-  auto de = EntryDetail{&it3->first, it3->second.get()};
+  using EntryDetailT = typename ReverseLookup::mapped_type::mapped_type;
+  auto const de = EntryDetailT{&it3->first, &it3->second};
   for (auto &&property_path : properties) {
     reverse_lookup[property_path[0]].insert({label, de});
   }
@@ -487,11 +549,10 @@ bool InMemoryLabelPropertyIndex::RegisterIndex(LabelId label, PropertiesPaths co
     auto new_index = std::make_shared<IndexContainer>(*index);
 
     const bool registered = all_indices_.WithLock([&](AllIndicesData &data) {
-      if (order == IndexOrder::ASC)
-        return RegisterIntoIndicesMap(
-            new_index->asc_indices_, data.asc, new_index->asc_reverse_lookup_, label, properties);
-      return RegisterIntoIndicesMap(
-          new_index->desc_indices_, data.desc, new_index->desc_reverse_lookup_, label, properties);
+      return DispatchByOrder(order, [&]<IndexOrder Order>() {
+        return RegisterIntoIndicesMap<Order>(
+            new_index->Indices<Order>(), data.Entries<Order>(), new_index->ReverseLookup<Order>(), label, properties);
+      });
     });
     if (!registered) return false;
 
@@ -528,9 +589,9 @@ auto InMemoryLabelPropertyIndex::PopulateIndex(
     }
   };
 
+  auto const populate_for = [&]<typename E>() { populate(GetIndividualIndex<E>(label, properties)); };
   try {
-    (order == IndexOrder::ASC) ? populate(GetIndividualIndex<Entry>(label, properties))
-                               : populate(GetIndividualIndex<DescEntry>(label, properties));
+    DispatchByEntry(order, properties.size(), populate_for);
   } catch (const PopulateCancel &) {
     std::ignore = DropIndex(label, properties, updater, order);
     return std::unexpected{IndexPopulateError::Cancellation};
@@ -549,8 +610,8 @@ bool InMemoryLabelPropertyIndex::PublishIndex(LabelId label, PropertiesPaths con
     index->Publish(commit_timestamp, gauge_);
     return true;
   };
-  return (order == IndexOrder::ASC) ? publish(GetIndividualIndex<Entry>(label, properties))
-                                    : publish(GetIndividualIndex<DescEntry>(label, properties));
+  auto const publish_for = [&]<typename E>() { return publish(GetIndividualIndex<E>(label, properties)); };
+  return DispatchByEntry(order, properties.size(), publish_for);
 }
 
 template <typename EntryT>
@@ -566,7 +627,7 @@ auto InMemoryLabelPropertyIndex::GetIndividualIndex(LabelId const &label, Proper
   return index_.WithReadLock(
       [&](std::shared_ptr<IndexContainer const> const &index) -> std::shared_ptr<IndividualIndex<EntryT>> {
         auto const &indices_map = [&]() -> auto const & {
-          if constexpr (std::same_as<EntryT, DescEntry>) {
+          if constexpr (EntryT::kOrder == IndexOrder::DESC) {
             return index->desc_indices_;
           } else {
             return index->asc_indices_;
@@ -579,7 +640,10 @@ auto InMemoryLabelPropertyIndex::GetIndividualIndex(LabelId const &label, Proper
         auto it2 = properties_map.find(properties);
         if (it2 == properties_map.cend()) [[unlikely]]
           return {};
-        return it2->second;
+        if (auto const *ptr = std::get_if<std::shared_ptr<IndividualIndex<EntryT>>>(&it2->second)) {
+          return *ptr;
+        }
+        return {};
       });
 }
 
@@ -596,13 +660,14 @@ void InMemoryLabelPropertyIndex::ActiveIndices::UpdateOnAddLabel(LabelId added_l
   auto const insert_into = [&](auto &indices_map) {
     auto const it = indices_map.find(added_label);
     if (it == indices_map.cend()) return;
-    for (auto &[props, index] : it->second | rv::filter(relevant_index)) {
-      auto &[permutations_helper, skiplist, status, _] = *index;
-      auto values = permutations_helper.Extract(vertex_after_update->properties);
-      if (AnyNonNull(values)) {
-        auto acc = skiplist.access();
-        acc.insert({permutations_helper.ApplyPermutation(std::move(values)), vertex_after_update, tx.start_timestamp});
-      }
+    for (auto &[props, index_variant] : it->second | rv::filter(relevant_index)) {
+      WithIndex(index_variant, [&](auto &index) {
+        using EntryT = typename std::decay_t<decltype(index)>::EntryType;
+        auto values = BuildEntryValues<EntryT>(index.permutations_helper, vertex_after_update->properties);
+        if (!values) return;
+        auto acc = index.skiplist.access();
+        acc.insert({std::move(*values), vertex_after_update, tx.start_timestamp});
+      });
     }
   };
 
@@ -628,11 +693,13 @@ void InMemoryLabelPropertyIndex::ActiveIndices::UpdateOnRemoveLabel(LabelId remo
   auto const remove_from = [&](auto &indices_map) {
     auto const it = indices_map.find(removed_label);
     if (it == indices_map.cend()) return;
-    for (auto &[props, index] : it->second | rv::filter(relevant_index)) {
-      auto values = index->permutations_helper.Extract(vertex_before_update->properties);
-      if (!AnyNonNull(values)) continue;
-      auto acc = index->skiplist.access();
-      EraseEntriesAtKey(acc, index->permutations_helper.ApplyPermutation(std::move(values)), vertex_before_update);
+    for (auto &[props, index_variant] : it->second | rv::filter(relevant_index)) {
+      WithIndex(index_variant, [&](auto &index) {
+        auto values = index.permutations_helper.Extract(vertex_before_update->properties);
+        if (!AnyNonNull(values)) return;
+        auto acc = index.skiplist.access();
+        EraseEntriesAtKey(acc, index.permutations_helper.ApplyPermutation(std::move(values)), vertex_before_update);
+      });
     }
   };
 
@@ -660,29 +727,34 @@ void InMemoryLabelPropertyIndex::ActiveIndices::UpdateOnSetProperty(PropertyId p
     auto const relevant_index = [&](auto &&each) { return has_label(each) && has_property(each); };
 
     for (auto &lookup : it->second | rv::filter(relevant_index)) {
-      auto &[property_ids, index] = lookup.second;
-      auto values = index->permutations_helper.Extract(vertex->properties);
+      auto &[property_ids, index_variant] = lookup.second;
+      WithIndex(*index_variant, [&](auto &index) {
+        using EntryT = typename std::decay_t<decltype(index)>::EntryType;
+        auto const &helper = index.permutations_helper;
 
-      // Defer accessor construction (an AllocateId / ReleaseId pair) until we
-      // know we'll touch the skiplist. The all-null overwrite path skips it.
-      using AccT = decltype(index->skiplist.access());
-      std::optional<AccT> acc;
-      auto with_acc = [&]() -> AccT & {
-        if (!acc) acc.emplace(index->skiplist.access());
-        return *acc;
-      };
+        // Defer accessor construction (an AllocateId / ReleaseId pair) until we
+        // know we'll touch the skiplist. The all-null overwrite path skips it.
+        using AccT = decltype(index.skiplist.access());
+        std::optional<AccT> acc;
+        auto with_acc = [&]() -> AccT & {
+          if (!acc) acc.emplace(index.skiplist.access());
+          return *acc;
+        };
 
-      if (analytical) [[unlikely]] {
-        auto old_values = values;
-        index->permutations_helper.Update(property, old_value, old_values);
-        if (AnyNonNull(old_values)) {
-          EraseEntriesAtKey(with_acc(), index->permutations_helper.ApplyPermutation(std::move(old_values)), vertex);
+        if (analytical) [[unlikely]] {
+          // Erase the pre-update entry. This rebuilds the old key as a vector
+          // (the key-from-value path), kept separate from the hot insert below.
+          auto old_values = helper.Extract(vertex->properties);
+          helper.Update(property, old_value, old_values);
+          if (AnyNonNull(old_values)) {
+            EraseEntriesAtKey(with_acc(), helper.ApplyPermutation(std::move(old_values)), vertex);
+          }
         }
-      }
 
-      if (AnyNonNull(values)) {
-        with_acc().insert({index->permutations_helper.ApplyPermutation(std::move(values)), vertex, tx.start_timestamp});
-      }
+        if (auto values = BuildEntryValues<EntryT>(helper, vertex->properties); values) {
+          with_acc().insert({std::move(*values), vertex, tx.start_timestamp});
+        }
+      });
     }
   };
 
@@ -781,8 +853,8 @@ void InMemoryLabelPropertyIndex::CleanupStatsForDrop(IndexContainer const &new_i
 auto InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
                                            ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order)
     -> DropCapture {
-  std::shared_ptr<IndividualIndex<Entry>> asc_evicted;
-  std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted;
+  std::optional<AscIndexPtrVariant> asc_evicted;
+  std::optional<DescIndexPtrVariant> desc_evicted;
   std::optional<PropertiesIndicesStats> stats_evicted;
   auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) -> DropResult {
     bool const try_asc = !order || *order == IndexOrder::ASC;
@@ -836,8 +908,8 @@ auto InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPa
 }
 
 void InMemoryLabelPropertyIndex::RestoreIndex(LabelId label, std::vector<PropertyPath> properties,
-                                              std::shared_ptr<IndividualIndex<Entry>> asc_evicted,
-                                              std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted,
+                                              std::optional<AscIndexPtrVariant> asc_evicted,
+                                              std::optional<DescIndexPtrVariant> desc_evicted,
                                               std::optional<PropertiesIndicesStats> stats_evicted,
                                               ActiveIndicesUpdater const &updater) {
   if (!asc_evicted && !desc_evicted) return;
@@ -853,8 +925,8 @@ void InMemoryLabelPropertyIndex::RestoreIndex(LabelId label, std::vector<Propert
     // Two copies: first to mutate the per-order maps, second to rebuild the
     // reverse_lookup (the IndexContainer copy ctor calls BuildReverseLookup).
     IndexContainer mutated{*index};
-    if (!skip_asc) mutated.asc_indices_[label].emplace(properties, std::move(asc_evicted));
-    if (!skip_desc) mutated.desc_indices_[label].emplace(properties, std::move(desc_evicted));
+    if (!skip_asc) mutated.asc_indices_[label].emplace(properties, std::move(*asc_evicted));
+    if (!skip_desc) mutated.desc_indices_[label].emplace(properties, std::move(*desc_evicted));
     auto new_index = std::make_shared<IndexContainer>(std::move(mutated));
     index = std::move(new_index);
     updater(std::make_shared<ActiveIndices>(index));
@@ -891,7 +963,7 @@ bool InMemoryLabelPropertyIndex::ActiveIndices::IndexReady(LabelId label,
     if (it != indices_map.end()) {
       auto it2 = it->second.find(properties);
       if (it2 != it->second.end()) {
-        return it2->second->status.IsReady();
+        return WithIndex(it2->second, [](auto const &index) { return index.status.IsReady(); });
       }
     }
     return false;
@@ -938,8 +1010,8 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesIn
       auto it = indices_map.find(label);
       if (it == indices_map.end()) continue;
 
-      for (const auto &[nested_props, index] : it->second) {
-        if (!index->status.IsReady()) continue;
+      for (const auto &[nested_props, index_variant] : it->second) {
+        if (!WithIndex(index_variant, [](auto const &index) { return index.status.IsReady(); })) continue;
 
         bool has_matching_property = false;
         auto positions = std::vector<int64_t>();
@@ -977,8 +1049,8 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::ListIndicesImpl(uint64_t start_t
   };
   auto const collect_from = [&](auto const &indices_map, IndexOrder o) {
     for (auto const &[label, indices] : indices_map) {
-      for (auto const &[props, index] : indices) {
-        if (index->status.IsVisible(start_timestamp)) {
+      for (auto const &[props, index_variant] : indices) {
+        if (WithIndex(index_variant, [&](auto const &index) { return index.status.IsVisible(start_timestamp); })) {
           ret.emplace_back(label, props, o);
         }
       }
@@ -999,35 +1071,41 @@ void InMemoryLabelPropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_st
   CleanupAllIndices();
 
   auto const remove_from = [&](auto const &all_indexes) {
-    for (auto &[index, label_id, property_paths] : *all_indexes) {
+    for (auto &all_entry : *all_indexes) {
       if (token.stop_requested()) return;
+      auto const &label_id = all_entry.label_;
+      auto const &property_paths = all_entry.properties_;
 
-      auto const &permutationHelper = index->permutations_helper;
-      auto index_acc = index->skiplist.access();
-      auto it = index_acc.begin();
-      auto end_it = index_acc.end();
-      if (it == end_it) continue;
-      while (true) {
-        if (maybe_stop() && token.stop_requested()) return;
+      bool const stop = WithIndex(all_entry.index_, [&](auto &index) -> bool {
+        auto const &permutationHelper = index.permutations_helper;
+        auto index_acc = index.skiplist.access();
+        auto it = index_acc.begin();
+        auto end_it = index_acc.end();
+        if (it == end_it) return false;
+        while (true) {
+          if (maybe_stop() && token.stop_requested()) return true;
 
-        auto next_it = it;
-        ++next_it;
+          auto next_it = it;
+          ++next_it;
 
-        const bool has_next = next_it != end_it;
-        if (it->timestamp < oldest_active_start_timestamp) {
-          const bool redundant_duplicate = has_next && it->vertex == next_it->vertex && it->values == next_it->values;
-          if (redundant_duplicate || !AnyVersionHasLabelProperties(*it->vertex,
-                                                                   label_id,
-                                                                   property_paths,
-                                                                   permutationHelper,
-                                                                   it->values,
-                                                                   oldest_active_start_timestamp)) {
-            index_acc.remove(*it);
+          const bool has_next = next_it != end_it;
+          if (it->timestamp < oldest_active_start_timestamp) {
+            const bool redundant_duplicate = has_next && it->vertex == next_it->vertex && it->values == next_it->values;
+            if (redundant_duplicate || !AnyVersionHasLabelProperties(*it->vertex,
+                                                                     label_id,
+                                                                     property_paths,
+                                                                     permutationHelper,
+                                                                     it->values.as_view(),
+                                                                     oldest_active_start_timestamp)) {
+              index_acc.remove(*it);
+            }
           }
+          if (!has_next) break;
+          it = next_it;
         }
-        if (!has_next) break;
-        it = next_it;
-      }
+        return false;
+      });
+      if (stop) return;
     }
   };
 
@@ -1055,7 +1133,7 @@ InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::operator++() {
 
 template <typename EntryT>
 void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid() {
-  constexpr bool is_desc = std::same_as<EntryT, DescEntry>;
+  constexpr bool is_desc = EntryT::kOrder == IndexOrder::DESC;
   AdvanceUntilValid_(index_iterator_,
                      self_->index_accessor_.end(),
                      current_vertex_,
@@ -1095,7 +1173,7 @@ template <typename EntryT>
 typename InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator InMemoryLabelPropertyIndex::Iterable<EntryT>::begin() {
   if (!bounds_valid_) return {this, index_accessor_.end()};
   auto index_iterator = index_accessor_.begin();
-  if constexpr (std::same_as<EntryT, DescEntry>) {
+  if constexpr (EntryT::kOrder == IndexOrder::DESC) {
     // For DESC index, we seek to the upper bound (highest value), because forward
     // iteration in DESC goes from high to low values.
     if (const auto upper_bound = GenerateBounds(upper_bound_, kLargestProperty); upper_bound) {
@@ -1154,7 +1232,7 @@ uint64_t InMemoryLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(
         return bounds.IsValueInRange(value);
       };
       auto value_within_bounds = [&](auto &&p) { return std::apply(within_bounds, p); };
-      return std::ranges::all_of(std::ranges::views::zip(entry.values.values_, bounds), value_within_bounds);
+      return std::ranges::all_of(std::ranges::views::zip(entry.values, bounds), value_within_bounds);
     };
     return std::ranges::count_if(acc.sampling_range(), in_bounds_for_all_prefix);
   });
@@ -1231,8 +1309,8 @@ void InMemoryLabelPropertyIndex::RunGC() {
   CleanupAllIndices();
 
   auto const run_gc = [](auto const &all_indexes) {
-    for (auto &[index, _1, _2] : *all_indexes) {
-      index->skiplist.run_gc();
+    for (auto &all_entry : *all_indexes) {
+      WithIndex(all_entry.index_, [](auto &index) { index.skiplist.run_gc(); });
     }
   };
   auto data = all_indices_.ReadCopy();
@@ -1274,12 +1352,13 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices(LabelId label, std::spa
                                                          View view, Storage *storage, Transaction *transaction)
     -> Iterable<EntryT> {
   auto it = FindIndexOrDie(IndicesMap<EntryT>(), label, properties);
+  auto const &index_ptr = std::get<std::shared_ptr<IndividualIndex<EntryT>>>(it->second);
   const auto max_gid = Gid::FromUint(storage->vertex_id_.load(std::memory_order_acquire));
-  return {it->second->skiplist.access(),
+  return {index_ptr->skiplist.access(),
           std::move(vertices_acc),
           label,
           &it->first,
-          &it->second->permutations_helper,
+          &index_ptr->permutations_helper,
           range,
           view,
           storage,
@@ -1293,18 +1372,42 @@ InMemoryLabelPropertyIndex::ChunkedIterable<EntryT> InMemoryLabelPropertyIndex::
     utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view, Storage *storage, Transaction *transaction,
     size_t num_chunks) {
   auto it = FindIndexOrDie(IndicesMap<EntryT>(), label, properties);
+  auto const &index_ptr = std::get<std::shared_ptr<IndividualIndex<EntryT>>>(it->second);
   const auto max_gid = Gid::FromUint(storage->vertex_id_.load(std::memory_order_acquire));
-  return {it->second->skiplist.access(),
+  return {index_ptr->skiplist.access(),
           std::move(vertices_acc),
           label,
           &it->first,
-          &it->second->permutations_helper,
+          &index_ptr->permutations_helper,
           range,
           view,
           storage,
           transaction,
           num_chunks,
           max_gid};
+}
+
+auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices(LabelId label, std::span<PropertyPath const> properties,
+                                                         std::span<PropertyValueRange const> range, View view,
+                                                         Storage *storage, Transaction *transaction, IndexOrder order)
+    -> VerticesIterable {
+  auto build = [&]<typename E>() -> VerticesIterable {
+    return VerticesIterable(Vertices<E>(label, properties, range, view, storage, transaction));
+  };
+  return DispatchByEntry(order, properties.size(), build);
+}
+
+auto InMemoryLabelPropertyIndex::ActiveIndices::ChunkedVertices(LabelId label, std::span<PropertyPath const> properties,
+                                                                std::span<PropertyValueRange const> range,
+                                                                utils::SkipListDb<Vertex>::ConstAccessor vertices_acc,
+                                                                View view, Storage *storage, Transaction *transaction,
+                                                                size_t num_chunks, IndexOrder order)
+    -> VerticesChunkedIterable {
+  auto build = [&]<typename E>() -> VerticesChunkedIterable {
+    return VerticesChunkedIterable(
+        ChunkedVertices<E>(label, properties, range, std::move(vertices_acc), view, storage, transaction, num_chunks));
+  };
+  return DispatchByEntry(order, properties.size(), build);
 }
 
 void InMemoryLabelPropertyIndex::DropGraphClearIndices() {
@@ -1323,7 +1426,10 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::GetAbortProcessor() const -> Lab
 
   auto const collect_from = [&](auto &indices_map) {
     for (const auto &[label, per_properties] : indices_map) {
-      for (auto const &[props, index] : per_properties) {
+      for (auto const &[props, index_variant] : per_properties) {
+        auto const *helper = WithIndex(index_variant, [](auto const &index) -> PropertiesPermutationHelper const * {
+          return &index.permutations_helper;
+        });
         auto const unique_props = std::invoke(
             [](auto props) {
               auto root_props = props | rv::transform([](auto &&el) { return el[0]; }) | r::to<std::vector>();
@@ -1333,8 +1439,8 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::GetAbortProcessor() const -> Lab
             props);
 
         for (auto const &root_prop : unique_props) {
-          res.l2p[label][root_prop].emplace_back(&props, &index->permutations_helper);
-          res.p2l[root_prop][label].emplace_back(&props, &index->permutations_helper);
+          res.l2p[label][root_prop].emplace_back(&props, helper);
+          res.p2l[root_prop][label].emplace_back(&props, helper);
         }
       }
     }
@@ -1353,17 +1459,19 @@ void InMemoryLabelPropertyIndex::ActiveIndices::AbortEntries(AbortableInfo const
   // An entry to abort may only exist in ASC, DESC, or both — soft lookup is intentional.
   // `info` is const, so entries are always copied into EntryT.
   auto const abort_from = [&](auto const &indices_map) {
-    using EntryT = typename std::decay_t<decltype(indices_map)>::mapped_type::mapped_type::element_type::EntryType;
     for (auto const &[label, by_properties] : info) {
       auto it = indices_map.find(label);
       if (it == indices_map.end()) continue;
       for (auto const &[prop, to_remove] : by_properties) {
         auto it2 = it->second.find(*prop);
         if (it2 == it->second.end()) continue;
-        auto acc = it2->second->skiplist.access();
-        for (auto const &[values, vertex] : to_remove) {
-          acc.remove(EntryT{values, vertex, start_timestamp});
-        }
+        WithIndex(it2->second, [&](auto &index) {
+          using EntryT = typename std::decay_t<decltype(index)>::EntryType;
+          auto acc = index.skiplist.access();
+          for (auto const &[values, vertex] : to_remove) {
+            acc.remove(EntryT{values, vertex, start_timestamp});
+          }
+        });
       }
     }
   };
@@ -1373,7 +1481,9 @@ void InMemoryLabelPropertyIndex::ActiveIndices::AbortEntries(AbortableInfo const
 
 void InMemoryLabelPropertyIndex::CleanupAllIndices() {
   auto const cleanup = [](auto &indices) {
-    auto keep_condition = [](auto const &entry) { return entry.index_.use_count() != 1; };
+    auto keep_condition = [](auto const &entry) {
+      return std::visit([](auto const &index_ptr) { return index_ptr.use_count(); }, entry.index_) != 1;
+    };
     if (!r::all_of(*indices, keep_condition)) {
       using Vec = std::decay_t<decltype(*indices)>;
       indices = std::make_shared<Vec>(*indices | rv::filter(keep_condition) | r::to<std::vector>());
@@ -1384,7 +1494,7 @@ void InMemoryLabelPropertyIndex::CleanupAllIndices() {
 
 template <typename EntryT>
 void InMemoryLabelPropertyIndex::ChunkedIterable<EntryT>::Iterator::AdvanceUntilValid() {
-  constexpr bool is_desc = std::same_as<EntryT, DescEntry>;
+  constexpr bool is_desc = EntryT::kOrder == IndexOrder::DESC;
   AdvanceUntilValid_(index_iterator_,
                      typename utils::SkipListDb<EntryT>::ChunkedIterator{},
                      current_vertex_,
@@ -1419,7 +1529,7 @@ InMemoryLabelPropertyIndex::ChunkedIterable<EntryT>::ChunkedIterable(
   bounds_valid_ = ValidateBounds(ranges, lower_bound_, upper_bound_);  // NOLINT
   if (!bounds_valid_) return;
 
-  if constexpr (std::same_as<EntryT, DescEntry>) {
+  if constexpr (EntryT::kOrder == IndexOrder::DESC) {
     chunks_ = index_accessor_.create_chunks(
         num_chunks, GenerateBounds(upper_bound_, kLargestProperty), GenerateBounds(lower_bound_, kSmallestProperty));
   } else {
@@ -1430,40 +1540,70 @@ InMemoryLabelPropertyIndex::ChunkedIterable<EntryT>::ChunkedIterable(
       chunks_, [](const auto &a, const auto &b) { return a.vertex == b.vertex && a.values == b.values; });
 }
 
-// Explicit template instantiations
-template struct InMemoryLabelPropertyIndex::BasicEntry<false>;
-template struct InMemoryLabelPropertyIndex::BasicEntry<true>;
-template struct InMemoryLabelPropertyIndex::IndividualIndex<InMemoryLabelPropertyIndex::Entry>;
-template struct InMemoryLabelPropertyIndex::IndividualIndex<InMemoryLabelPropertyIndex::DescEntry>;
-template class InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry>;
-template class InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::DescEntry>;
-template class InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::Entry>;
-template class InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::DescEntry>;
-template auto InMemoryLabelPropertyIndex::GetIndividualIndex<InMemoryLabelPropertyIndex::Entry>(
-    LabelId const &, PropertiesPaths const &) const -> std::shared_ptr<IndividualIndex<Entry>>;
-template auto InMemoryLabelPropertyIndex::GetIndividualIndex<InMemoryLabelPropertyIndex::DescEntry>(
-    LabelId const &, PropertiesPaths const &) const -> std::shared_ptr<IndividualIndex<DescEntry>>;
-template auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices<InMemoryLabelPropertyIndex::Entry>(
-    LabelId, std::span<PropertyPath const>, std::span<PropertyValueRange const>, View, Storage *, Transaction *)
-    -> Iterable<Entry>;
-template auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices<InMemoryLabelPropertyIndex::DescEntry>(
-    LabelId, std::span<PropertyPath const>, std::span<PropertyValueRange const>, View, Storage *, Transaction *)
-    -> Iterable<DescEntry>;
-template auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices<InMemoryLabelPropertyIndex::Entry>(
-    LabelId, std::span<PropertyPath const>, std::span<PropertyValueRange const>,
-    memgraph::utils::SkipListDb<memgraph::storage::Vertex>::ConstAccessor, View, Storage *, Transaction *)
-    -> Iterable<Entry>;
-template auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices<InMemoryLabelPropertyIndex::DescEntry>(
-    LabelId, std::span<PropertyPath const>, std::span<PropertyValueRange const>,
-    memgraph::utils::SkipListDb<memgraph::storage::Vertex>::ConstAccessor, View, Storage *, Transaction *)
-    -> Iterable<DescEntry>;
-template InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::Entry>
-InMemoryLabelPropertyIndex::ActiveIndices::ChunkedVertices<InMemoryLabelPropertyIndex::Entry>(
-    LabelId, std::span<PropertyPath const>, std::span<PropertyValueRange const>,
-    memgraph::utils::SkipListDb<memgraph::storage::Vertex>::ConstAccessor, View, Storage *, Transaction *, size_t);
-template InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::DescEntry>
-InMemoryLabelPropertyIndex::ActiveIndices::ChunkedVertices<InMemoryLabelPropertyIndex::DescEntry>(
-    LabelId, std::span<PropertyPath const>, std::span<PropertyValueRange const>,
-    memgraph::utils::SkipListDb<memgraph::storage::Vertex>::ConstAccessor, View, Storage *, Transaction *, size_t);
+// Explicit template instantiations.
 
+// Entry storage structs. The alias templates Entry<>/DescEntry<> cannot name an
+// explicit instantiation, so the underlying BasicEntry is spelled out here.
+template struct InMemoryLabelPropertyIndex::BasicEntry<IndexOrder::ASC>;
+template struct InMemoryLabelPropertyIndex::BasicEntry<IndexOrder::DESC>;
+template struct InMemoryLabelPropertyIndex::BasicEntry<IndexOrder::ASC, 1>;
+template struct InMemoryLabelPropertyIndex::BasicEntry<IndexOrder::DESC, 1>;
+template struct InMemoryLabelPropertyIndex::BasicEntry<IndexOrder::ASC, 2>;
+template struct InMemoryLabelPropertyIndex::BasicEntry<IndexOrder::DESC, 2>;
+
+using AscEntry1 = InMemoryLabelPropertyIndex::Entry<1>;
+using DescEntry1 = InMemoryLabelPropertyIndex::DescEntry<1>;
+using AscEntry2 = InMemoryLabelPropertyIndex::Entry<2>;
+using DescEntry2 = InMemoryLabelPropertyIndex::DescEntry<2>;
+
+// The array-backed entry must stay free of indirection: a vertex pointer, a
+// timestamp, and N values inlined directly (no vector header, no heap block).
+// Regression guard - if an entry regrows a vector, the size breaks.
+template <std::size_t N>
+consteval std::size_t ExpectedInlineEntrySize() {
+  return sizeof(Vertex *) + sizeof(std::uint64_t) + sizeof(std::array<PropertyValue, N>);
+}
+
+static_assert(sizeof(AscEntry1) == ExpectedInlineEntrySize<1>());
+static_assert(sizeof(DescEntry1) == ExpectedInlineEntrySize<1>());
+static_assert(sizeof(AscEntry2) == ExpectedInlineEntrySize<2>());
+static_assert(sizeof(DescEntry2) == ExpectedInlineEntrySize<2>());
+
+// The query surface instantiated for every concrete entry type.
+#define MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(EntryT)                                                              \
+  template struct InMemoryLabelPropertyIndex::IndividualIndex<EntryT>;                                                 \
+  template class InMemoryLabelPropertyIndex::Iterable<EntryT>;                                                         \
+  template class InMemoryLabelPropertyIndex::ChunkedIterable<EntryT>;                                                  \
+  template auto InMemoryLabelPropertyIndex::GetIndividualIndex<EntryT>(LabelId const &, PropertiesPaths const &) const \
+      -> std::shared_ptr<IndividualIndex<EntryT>>;                                                                     \
+  template auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices<EntryT>(                                           \
+      LabelId, std::span<PropertyPath const>, std::span<PropertyValueRange const>, View, Storage *, Transaction *)     \
+      -> Iterable<EntryT>;                                                                                             \
+  template auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices<EntryT>(                                           \
+      LabelId,                                                                                                         \
+      std::span<PropertyPath const>,                                                                                   \
+      std::span<PropertyValueRange const>,                                                                             \
+      memgraph::utils::SkipListDb<memgraph::storage::Vertex>::ConstAccessor,                                           \
+      View,                                                                                                            \
+      Storage *,                                                                                                       \
+      Transaction *) -> Iterable<EntryT>;                                                                              \
+  template InMemoryLabelPropertyIndex::ChunkedIterable<EntryT>                                                         \
+  InMemoryLabelPropertyIndex::ActiveIndices::ChunkedVertices<EntryT>(                                                  \
+      LabelId,                                                                                                         \
+      std::span<PropertyPath const>,                                                                                   \
+      std::span<PropertyValueRange const>,                                                                             \
+      memgraph::utils::SkipListDb<memgraph::storage::Vertex>::ConstAccessor,                                           \
+      View,                                                                                                            \
+      Storage *,                                                                                                       \
+      Transaction *,                                                                                                   \
+      size_t);
+
+MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(InMemoryLabelPropertyIndex::Entry<>)
+MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(InMemoryLabelPropertyIndex::DescEntry<>)
+MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(AscEntry1)
+MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(DescEntry1)
+MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(AscEntry2)
+MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(DescEntry2)
+
+#undef MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1387,6 +1387,7 @@ InMemoryLabelPropertyIndex::ChunkedIterable<EntryT> InMemoryLabelPropertyIndex::
           max_gid};
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static): `this` used via Vertices<E> in `build`.
 auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices(LabelId label, std::span<PropertyPath const> properties,
                                                          std::span<PropertyValueRange const> range, View view,
                                                          Storage *storage, Transaction *transaction, IndexOrder order)
@@ -1397,6 +1398,7 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::Vertices(LabelId label, std::spa
   return DispatchByEntry(order, properties.size(), build);
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static): `this` used via ChunkedVertices<E> in `build`.
 auto InMemoryLabelPropertyIndex::ActiveIndices::ChunkedVertices(LabelId label, std::span<PropertyPath const> properties,
                                                                 std::span<PropertyValueRange const> range,
                                                                 utils::SkipListDb<Vertex>::ConstAccessor vertices_acc,
@@ -1468,6 +1470,7 @@ void InMemoryLabelPropertyIndex::ActiveIndices::AbortEntries(AbortableInfo const
         WithIndex(it2->second, [&](auto &index) {
           using EntryT = typename std::decay_t<decltype(index)>::EntryType;
           auto acc = index.skiplist.access();
+          // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Assign): to_remove holds fully-constructed pairs.
           for (auto const &[values, vertex] : to_remove) {
             acc.remove(EntryT{values, vertex, start_timestamp});
           }
@@ -1570,6 +1573,7 @@ static_assert(sizeof(AscEntry2) == ExpectedInlineEntrySize<2>());
 static_assert(sizeof(DescEntry2) == ExpectedInlineEntrySize<2>());
 
 // The query surface instantiated for every concrete entry type.
+// NOLINTBEGIN(bugprone-macro-parentheses): EntryT is a template type argument, parenthesising it is not valid syntax.
 #define MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(EntryT)                                                              \
   template struct InMemoryLabelPropertyIndex::IndividualIndex<EntryT>;                                                 \
   template class InMemoryLabelPropertyIndex::Iterable<EntryT>;                                                         \
@@ -1597,6 +1601,7 @@ static_assert(sizeof(DescEntry2) == ExpectedInlineEntrySize<2>());
       Storage *,                                                                                                       \
       Transaction *,                                                                                                   \
       size_t);
+// NOLINTEND(bugprone-macro-parentheses)
 
 MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(InMemoryLabelPropertyIndex::Entry<>)
 MG_INSTANTIATE_LABEL_PROPERTY_INDEX_QUERY(InMemoryLabelPropertyIndex::DescEntry<>)

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -11,7 +11,12 @@
 
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <memory>
 #include <span>
+#include <tuple>
+#include <variant>
 
 #include "memory/db_arena_fwd.hpp"
 #include "metrics/prometheus_metrics.hpp"
@@ -31,19 +36,32 @@
 
 namespace memgraph::storage {
 
+// Type-erased iterable wrappers the query executor consumes. Forward-declared
+// to keep the seam: vertices_iterable.hpp includes this header, so the erased
+// query methods take these by value in their declarations (incomplete type is
+// fine for a by-value return declaration) and are defined in the .cpp.
+class VerticesIterable;
+class VerticesChunkedIterable;
+
 class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
  public:
-  /// Index entry stored in the SkipList. Parameterized on sort direction:
-  /// Reverse=false gives ASC ordering, Reverse=true gives DESC (reversed values comparison).
-  template <bool Reverse = false>
+  /// Index entry stored in the SkipList. Parameterized on sort direction and
+  /// composite arity: Order=IndexOrder::ASC sorts ascending, IndexOrder::DESC
+  /// descending (the values comparison flips); N is the fixed composite arity
+  /// (array-backed) or dynamic_extent for the vector-backed dynamic storage.
+  template <IndexOrder Order = IndexOrder::ASC, std::size_t N = std::dynamic_extent>
   struct BasicEntry {
-    IndexOrderedPropertyValues values;
+    static constexpr IndexOrder kOrder = Order;
+    static constexpr std::size_t kArity = N;
+    using ValuesType = IndexOrderedValues<N>;
+
+    IndexOrderedValues<N> values;
     Vertex *vertex;
     uint64_t timestamp;
 
     friend std::weak_ordering operator<=>(BasicEntry const &lhs, BasicEntry const &rhs) {
-      // Reverse ONLY the values comparison; vertex+timestamp stay same for MVCC correctness
-      if constexpr (Reverse) {
+      // Flip ONLY the values comparison for DESC; vertex+timestamp stay same for MVCC correctness
+      if constexpr (Order == IndexOrder::DESC) {
         if (auto cmp = (rhs.values <=> lhs.values); cmp != 0) return cmp;
       } else {
         if (auto cmp = (lhs.values <=> rhs.values); cmp != 0) return cmp;
@@ -59,12 +77,14 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     bool operator<=(std::vector<PropertyValue> const &rhs) const;
   };
 
-  using Entry = BasicEntry<false>;
-  using DescEntry = BasicEntry<true>;
+  template <std::size_t N = std::dynamic_extent>
+  using Entry = BasicEntry<IndexOrder::ASC, N>;
+  template <std::size_t N = std::dynamic_extent>
+  using DescEntry = BasicEntry<IndexOrder::DESC, N>;
 
   explicit InMemoryLabelPropertyIndex(metrics::GaugeHandle gauge = {}) : gauge_{gauge} {}
 
-  template <typename EntryT = Entry>
+  template <typename EntryT = Entry<>>
   struct IndividualIndex {
     using EntryType = EntryT;
 
@@ -80,6 +100,19 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     metrics::ScopedGauge gauge_{};
   };
 
+  // An index of any supported composite arity, for a fixed sort direction. The
+  // array-backed fixed arities (1, 2) inline their values into the skiplist
+  // node; the dynamic_extent alternative is the vector-backed fallback for any
+  // other arity. The arity is fixed at index creation, so a given map entry
+  // holds exactly one alternative.
+  template <IndexOrder Order>
+  using IndexPtrVariant = std::variant<std::shared_ptr<IndividualIndex<BasicEntry<Order, 1>>>,
+                                       std::shared_ptr<IndividualIndex<BasicEntry<Order, 2>>>,
+                                       std::shared_ptr<IndividualIndex<BasicEntry<Order, std::dynamic_extent>>>>;
+
+  using AscIndexPtrVariant = IndexPtrVariant<IndexOrder::ASC>;
+  using DescIndexPtrVariant = IndexPtrVariant<IndexOrder::DESC>;
+
   struct Compare {
     template <std::ranges::forward_range T, std::ranges::forward_range U>
     bool operator()(T const &lhs, U const &rhs) const {
@@ -90,32 +123,33 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   };
 
   // ASC index types
-  using AscPropertiesIndices =
-      std::map<PropertiesPaths, std::shared_ptr<IndividualIndex<Entry>>, Compare,
-               memory::DbAwareAllocator<std::pair<const PropertiesPaths, std::shared_ptr<IndividualIndex<Entry>>>>>;
+  using AscPropertiesIndices = std::map<PropertiesPaths, AscIndexPtrVariant, Compare,
+                                        memory::DbAwareAllocator<std::pair<const PropertiesPaths, AscIndexPtrVariant>>>;
   using AscLabelPropertiesIndices = std::map<LabelId, AscPropertiesIndices, std::less<>,
                                              memory::DbAwareAllocator<std::pair<const LabelId, AscPropertiesIndices>>>;
-  using AscEntryDetail = std::tuple<PropertiesPaths const *, IndividualIndex<Entry> *>;
+  // Non-owning back-reference into the index map: the paths key and the owning
+  // index variant, both pointing into the same map node.
+  using AscEntryDetail = std::tuple<PropertiesPaths const *, AscIndexPtrVariant const *>;
   using AscReverseLookup = std::unordered_map<PropertyId, std::multimap<LabelId, AscEntryDetail>>;
 
   // DESC index types
   using DescPropertiesIndices =
-      std::map<PropertiesPaths, std::shared_ptr<IndividualIndex<DescEntry>>, Compare,
-               memory::DbAwareAllocator<std::pair<const PropertiesPaths, std::shared_ptr<IndividualIndex<DescEntry>>>>>;
+      std::map<PropertiesPaths, DescIndexPtrVariant, Compare,
+               memory::DbAwareAllocator<std::pair<const PropertiesPaths, DescIndexPtrVariant>>>;
   using DescLabelPropertiesIndices =
       std::map<LabelId, DescPropertiesIndices, std::less<>,
                memory::DbAwareAllocator<std::pair<const LabelId, DescPropertiesIndices>>>;
-  using DescEntryDetail = std::tuple<PropertiesPaths const *, IndividualIndex<DescEntry> *>;
+  using DescEntryDetail = std::tuple<PropertiesPaths const *, DescIndexPtrVariant const *>;
   using DescReverseLookup = std::unordered_map<PropertyId, std::multimap<LabelId, DescEntryDetail>>;
 
   struct IndexContainer {
    private:
     template <typename IndicesMap, typename ReverseLookup>
     static void BuildReverseLookup(IndicesMap const &indices, ReverseLookup &reverse_lookup) {
+      using EntryDetailT = typename ReverseLookup::mapped_type::mapped_type;
       for (auto const &[label, by_label] : indices) {
         for (auto const &[propertyPaths, entry] : by_label) {
-          using EntryDetailT = std::tuple<PropertiesPaths const *, typename std::decay_t<decltype(*entry)> *>;
-          auto const ed = EntryDetailT{&propertyPaths, entry.get()};
+          auto const ed = EntryDetailT{&propertyPaths, &entry};
           for (auto const &prop : propertyPaths) {
             reverse_lookup[prop[0]].emplace(label, ed);
           }
@@ -160,17 +194,37 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
       fn(asc_reverse_lookup_);
       fn(desc_reverse_lookup_);
     }
+
+    // Select the asc or desc member by sort direction, so direction-generic
+    // code names it once.
+    template <IndexOrder Order>
+    auto &Indices(this auto &self) {
+      if constexpr (Order == IndexOrder::DESC) {
+        return self.desc_indices_;
+      } else {
+        return self.asc_indices_;
+      }
+    }
+
+    template <IndexOrder Order>
+    auto &ReverseLookup() {
+      if constexpr (Order == IndexOrder::DESC) {
+        return desc_reverse_lookup_;
+      } else {
+        return asc_reverse_lookup_;
+      }
+    }
   };
 
-  template <typename EntryT>
+  template <IndexOrder Order>
   struct BasicAllIndicesEntry {
-    std::shared_ptr<IndividualIndex<EntryT>> index_;
+    IndexPtrVariant<Order> index_;
     LabelId label_;
     PropertiesPaths properties_;
   };
 
-  using AscAllIndicesEntry = BasicAllIndicesEntry<Entry>;
-  using DescAllIndicesEntry = BasicAllIndicesEntry<DescEntry>;
+  using AscAllIndicesEntry = BasicAllIndicesEntry<IndexOrder::ASC>;
+  using DescAllIndicesEntry = BasicAllIndicesEntry<IndexOrder::DESC>;
 
   struct AllIndicesData {
     std::shared_ptr<std::vector<AscAllIndicesEntry> const> asc{
@@ -188,6 +242,16 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     void ForEach(Fn &&fn) const {
       fn(asc);
       fn(desc);
+    }
+
+    // Select the asc or desc tracking list by sort direction.
+    template <IndexOrder Order>
+    auto &Entries() {
+      if constexpr (Order == IndexOrder::DESC) {
+        return desc;
+      } else {
+        return asc;
+      }
     }
   };
 
@@ -215,7 +279,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   bool PublishIndex(LabelId label, PropertiesPaths const &properties, uint64_t commit_timestamp,
                     IndexOrder order = IndexOrder::ASC);
 
-  template <typename EntryT = Entry>
+  template <typename EntryT = Entry<>>
   class Iterable {
    public:
     Iterable(typename utils::SkipListDb<EntryT>::Accessor index_accessor,
@@ -266,7 +330,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     Gid max_gid_;
   };
 
-  template <typename EntryT = Entry>
+  template <typename EntryT = Entry<>>
   class ChunkedIterable {
    public:
     ChunkedIterable(typename utils::SkipListDb<EntryT>::Accessor index_accessor,
@@ -379,6 +443,17 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
                                 std::span<PropertyValueRange const> bounds) const -> uint64_t override;
 
+    // Type-erased query entry points. They pick the entry type from the index's
+    // composite arity and sort direction internally and hand back the variant
+    // wrapper the executor consumes, so callers never name a per-arity type.
+    auto Vertices(LabelId label, std::span<PropertyPath const> properties, std::span<PropertyValueRange const> range,
+                  View view, Storage *storage, Transaction *transaction, IndexOrder order) -> VerticesIterable;
+
+    auto ChunkedVertices(LabelId label, std::span<PropertyPath const> properties,
+                         std::span<PropertyValueRange const> range,
+                         utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view, Storage *storage,
+                         Transaction *transaction, size_t num_chunks, IndexOrder order) -> VerticesChunkedIterable;
+
     template <typename EntryT>
     auto Vertices(LabelId label, std::span<PropertyPath const> properties, std::span<PropertyValueRange const> range,
                   View view, Storage *storage, Transaction *transaction) -> Iterable<EntryT>;
@@ -388,7 +463,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
                   utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view, Storage *storage,
                   Transaction *transaction) -> Iterable<EntryT>;
 
-    template <typename EntryT = Entry>
+    template <typename EntryT = Entry<>>
     ChunkedIterable<EntryT> ChunkedVertices(LabelId label, std::span<PropertyPath const> properties,
                                             std::span<PropertyValueRange const> range,
                                             utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view,
@@ -408,7 +483,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
         if (it == indices_map.end()) return std::nullopt;
         auto it2 = it->second.find(properties);
         if (it2 == it->second.end()) return std::nullopt;
-        return fn(*it2->second);
+        return std::visit([&](auto const &index_ptr) { return fn(*index_ptr); }, it2->second);
       };
       if (auto r = try_find(index_container_->asc_indices_)) return r;
       if (auto r = try_find(index_container_->desc_indices_)) return r;
@@ -418,11 +493,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     // Returns the indices map (asc or desc) based on EntryT.
     template <typename EntryT>
     auto const &IndicesMap() const {
-      if constexpr (std::same_as<EntryT, DescEntry>) {
-        return index_container_->desc_indices_;
-      } else {
-        return index_container_->asc_indices_;
-      }
+      return index_container_->Indices<EntryT::kOrder>();
     }
 
     std::shared_ptr<IndexContainer const> index_container_;
@@ -438,8 +509,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   // RestoreIndex must NOT re-insert there.
   struct DropCapture {
     DropResult result;
-    std::shared_ptr<IndividualIndex<Entry>> asc_evicted;       // null if asc not dropped
-    std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted;  // null if desc not dropped
+    std::optional<AscIndexPtrVariant> asc_evicted;    // nullopt if asc not dropped
+    std::optional<DescIndexPtrVariant> desc_evicted;  // nullopt if desc not dropped
     // Per-label stats slice captured before CleanupStatsForDrop erased entries.
     // nullopt if the label had no stats at drop time.
     std::optional<PropertiesIndicesStats> stats_evicted;
@@ -449,9 +520,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   [[nodiscard]] auto DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
                                ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order = std::nullopt)
       -> DropCapture;
-  void RestoreIndex(LabelId label, std::vector<PropertyPath> properties,
-                    std::shared_ptr<IndividualIndex<Entry>> asc_evicted,
-                    std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted,
+  void RestoreIndex(LabelId label, std::vector<PropertyPath> properties, std::optional<AscIndexPtrVariant> asc_evicted,
+                    std::optional<DescIndexPtrVariant> desc_evicted,
                     std::optional<PropertiesIndicesStats> stats_evicted, ActiveIndicesUpdater const &updater);
 
   std::vector<std::pair<LabelId, std::vector<PropertyPath>>> ClearIndexStats();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2150,8 +2150,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto updater = storage_->indices_.MakeUpdater();
 
   LabelPropertyIndex::DropResult drop_result;
-  std::shared_ptr<InMemoryLabelPropertyIndex::IndividualIndex<InMemoryLabelPropertyIndex::Entry>> asc_evicted;
-  std::shared_ptr<InMemoryLabelPropertyIndex::IndividualIndex<InMemoryLabelPropertyIndex::DescEntry>> desc_evicted;
+  std::optional<InMemoryLabelPropertyIndex::AscIndexPtrVariant> asc_evicted;
+  std::optional<InMemoryLabelPropertyIndex::DescIndexPtrVariant> desc_evicted;
   std::optional<InMemoryLabelPropertyIndex::PropertiesIndicesStats> stats_evicted;
   storage_->invalidator_->invalidate_now([&] {
     auto captured = mem_label_property_index->DropIndex(label, properties, updater, order);
@@ -2605,12 +2605,7 @@ VerticesIterable InMemoryStorage::InMemoryAccessor::Vertices(
     std::span<storage::PropertyValueRange const> property_ranges, View view, IndexOrder order) {
   auto *active_indices =
       static_cast<InMemoryLabelPropertyIndex::ActiveIndices *>(transaction_.active_indices_->label_properties_.get());
-  if (order == IndexOrder::DESC) {
-    return VerticesIterable(active_indices->Vertices<InMemoryLabelPropertyIndex::DescEntry>(
-        label, properties, property_ranges, view, storage_, &transaction_));
-  }
-  return VerticesIterable(active_indices->Vertices<InMemoryLabelPropertyIndex::Entry>(
-      label, properties, property_ranges, view, storage_, &transaction_));
+  return active_indices->Vertices(label, properties, property_ranges, view, storage_, &transaction_, order);
 }
 
 VerticesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedVertices(View view, size_t num_chunks) {
@@ -2634,12 +2629,8 @@ VerticesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedVertices(
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
   auto *active_indices =
       static_cast<InMemoryLabelPropertyIndex::ActiveIndices *>(transaction_.active_indices_->label_properties_.get());
-  if (order == IndexOrder::DESC) {
-    return VerticesChunkedIterable(active_indices->ChunkedVertices<InMemoryLabelPropertyIndex::DescEntry>(
-        label, properties, property_ranges, std::move(vertices_acc), view, storage_, &transaction_, num_chunks));
-  }
-  return VerticesChunkedIterable(active_indices->ChunkedVertices<InMemoryLabelPropertyIndex::Entry>(
-      label, properties, property_ranges, std::move(vertices_acc), view, storage_, &transaction_, num_chunks));
+  return active_indices->ChunkedVertices(
+      label, properties, property_ranges, std::move(vertices_acc), view, storage_, &transaction_, num_chunks, order);
 }
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(EdgeTypeId edge_type, View view) {

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -2660,42 +2660,52 @@ class ReaderPropPositionHistory {
   std::vector<History> history_;
 };
 
+namespace {
+// Single forward pass over `reader`, exploiting the PropertyId-sorted order of
+// `ordered_properties`, handing each extracted value (or nullopt for missing)
+// to `sink`. Shared by the vector-returning and into-buffer overloads.
+template <typename Sink>
+void ForEachExtractedValueMissingAsNull(Reader &reader, std::span<PropertyPath const> ordered_properties, Sink sink) {
+  auto max_history_depth = r::max_element(ordered_properties, {}, std::mem_fn(&PropertyPath::size))->size() - 1;
+  ReaderPropPositionHistory history{max_history_depth};
+
+  auto const get_value =
+      [&](Reader &reader, PropertyPath const &path) -> std::pair<ExpectedPropertyStatus, std::optional<PropertyValue>> {
+    auto result = history.ScanToPropertyPathParent(reader, path);
+    if (result != ExpectedPropertyStatus::EQUAL) {
+      return {result, std::nullopt};
+    }
+    return MatchSpecificProperty(&reader, path.back());
+  };
+
+  auto safe_reader = SafeReader{reader, get_value, std::move(sink), std::nullopt};
+  for (auto &&path : ordered_properties) {
+    safe_reader(std::forward_as_tuple(path), std::tuple{});
+  }
+}
+}  // namespace
+
 std::vector<PropertyValue> PropertyStore::ExtractPropertyValuesMissingAsNull(
     std::span<PropertyPath const> ordered_properties) const {
-  auto get_properties = [&](Reader &reader) -> std::vector<PropertyValue> {
+  return WithReader([&](Reader &reader) -> std::vector<PropertyValue> {
     auto values = std::vector<PropertyValue>{};
     values.reserve(ordered_properties.size());
-
-    auto max_history_depth = r::max_element(ordered_properties, {}, std::mem_fn(&PropertyPath::size))->size() - 1;
-    ReaderPropPositionHistory history{max_history_depth};
-
-    auto const get_value =
-        [&](Reader &reader,
-            PropertyPath const &path) -> std::pair<ExpectedPropertyStatus, std::optional<PropertyValue>> {
-      auto result = history.ScanToPropertyPathParent(reader, path);
-      if (result != ExpectedPropertyStatus::EQUAL) {
-        return {result, std::nullopt};
-      }
-
-      auto leaf_property_id = path.back();
-      return MatchSpecificProperty(&reader, leaf_property_id);
-    };
-
-    auto const insert_value = [&](std::optional<PropertyValue> value) {
-      if (value) {
-        values.emplace_back(*std::move(value));
-      } else {
-        values.emplace_back();
-      }
-    };
-
-    auto safe_reader = SafeReader{reader, get_value, insert_value, std::nullopt};
-    for (auto &&path : ordered_properties) {
-      safe_reader(std::forward_as_tuple(path), std::tuple{});
-    }
+    ForEachExtractedValueMissingAsNull(reader, ordered_properties, [&](std::optional<PropertyValue> value) {
+      values.emplace_back(value ? *std::move(value) : PropertyValue{});
+    });
     return values;
-  };
-  return WithReader(get_properties);
+  });
+}
+
+void PropertyStore::ExtractPropertyValuesMissingAsNull(std::span<PropertyPath const> ordered_properties,
+                                                       std::span<PropertyValue> out) const {
+  DMG_ASSERT(out.size() == ordered_properties.size(), "Output buffer size must match the number of properties");
+  WithReader([&](Reader &reader) {
+    auto it = out.begin();
+    ForEachExtractedValueMissingAsNull(reader, ordered_properties, [&](std::optional<PropertyValue> value) {
+      *it++ = value ? *std::move(value) : PropertyValue{};
+    });
+  });
 }
 
 bool PropertyStore::IsPropertyEqual(PropertyId property, const PropertyValue &value) const {

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -98,6 +98,11 @@ class PropertyStore {
   /// @param ordered_properties: a pre-sorted collection of `PropertyPath`
   std::vector<PropertyValue> ExtractPropertyValuesMissingAsNull(std::span<PropertyPath const> ordered_properties) const;
 
+  /// As above, but writes into the caller-provided `out` (one slot per ordered property, same single pass), so a
+  /// fixed-size buffer can be filled without a heap allocation. `out.size()` must equal `ordered_properties.size()`.
+  void ExtractPropertyValuesMissingAsNull(std::span<PropertyPath const> ordered_properties,
+                                          std::span<PropertyValue> out) const;
+
   /// Checks whether the property `property` is equal to the specified value
   /// `value`. This function doesn't perform any memory allocations while
   /// performing the equality check. The time complexity of this function is

--- a/src/storage/v2/vertices_chunked_iterable.hpp
+++ b/src/storage/v2/vertices_chunked_iterable.hpp
@@ -20,10 +20,15 @@
 namespace memgraph::storage {
 
 class VerticesChunkedIterable final {
-  using AscChunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::Entry>;
-  using DescChunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::DescEntry>;
+  using AscChunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::Entry<>>;
+  using DescChunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::DescEntry<>>;
+  using Asc1Chunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::Entry<1>>;
+  using Desc1Chunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::DescEntry<1>>;
+  using Asc2Chunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::Entry<2>>;
+  using Desc2Chunked = InMemoryLabelPropertyIndex::ChunkedIterable<InMemoryLabelPropertyIndex::DescEntry<2>>;
 
-  using Data = std::variant<AllVerticesChunkedIterable, InMemoryLabelIndex::ChunkedIterable, AscChunked, DescChunked>;
+  using Data = std::variant<AllVerticesChunkedIterable, InMemoryLabelIndex::ChunkedIterable, AscChunked, DescChunked,
+                            Asc1Chunked, Desc1Chunked, Asc2Chunked, Desc2Chunked>;
 
   Data data_;
 
@@ -36,6 +41,14 @@ class VerticesChunkedIterable final {
 
   explicit VerticesChunkedIterable(DescChunked v) : data_(std::move(v)) {}
 
+  explicit VerticesChunkedIterable(Asc1Chunked v) : data_(std::move(v)) {}
+
+  explicit VerticesChunkedIterable(Desc1Chunked v) : data_(std::move(v)) {}
+
+  explicit VerticesChunkedIterable(Asc2Chunked v) : data_(std::move(v)) {}
+
+  explicit VerticesChunkedIterable(Desc2Chunked v) : data_(std::move(v)) {}
+
   VerticesChunkedIterable(const VerticesChunkedIterable &) = delete;
   VerticesChunkedIterable &operator=(const VerticesChunkedIterable &) = delete;
 
@@ -46,7 +59,8 @@ class VerticesChunkedIterable final {
 
   class Iterator final {
     using Data = std::variant<AllVerticesChunkedIterable::Iterator, InMemoryLabelIndex::ChunkedIterable::Iterator,
-                              AscChunked::Iterator, DescChunked::Iterator>;
+                              AscChunked::Iterator, DescChunked::Iterator, Asc1Chunked::Iterator,
+                              Desc1Chunked::Iterator, Asc2Chunked::Iterator, Desc2Chunked::Iterator>;
 
     Data data_;
 
@@ -58,6 +72,14 @@ class VerticesChunkedIterable final {
     explicit Iterator(AscChunked::Iterator it) : data_(std::move(it)) {}
 
     explicit Iterator(DescChunked::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Asc1Chunked::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Desc1Chunked::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Asc2Chunked::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Desc2Chunked::Iterator it) : data_(std::move(it)) {}
 
     Iterator(const Iterator &) = default;
     Iterator &operator=(const Iterator &) = default;

--- a/src/storage/v2/vertices_iterable.hpp
+++ b/src/storage/v2/vertices_iterable.hpp
@@ -20,10 +20,15 @@
 namespace memgraph::storage {
 
 class VerticesIterable final {
-  using AscIterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry>;
-  using DescIterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::DescEntry>;
+  using AscIterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry<>>;
+  using DescIterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::DescEntry<>>;
+  using Asc1Iterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry<1>>;
+  using Desc1Iterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::DescEntry<1>>;
+  using Asc2Iterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::Entry<2>>;
+  using Desc2Iterable = InMemoryLabelPropertyIndex::Iterable<InMemoryLabelPropertyIndex::DescEntry<2>>;
 
-  using Data = std::variant<AllVerticesIterable, InMemoryLabelIndex::Iterable, AscIterable, DescIterable>;
+  using Data = std::variant<AllVerticesIterable, InMemoryLabelIndex::Iterable, AscIterable, DescIterable, Asc1Iterable,
+                            Desc1Iterable, Asc2Iterable, Desc2Iterable>;
 
   Data data_;
 
@@ -36,6 +41,14 @@ class VerticesIterable final {
 
   explicit VerticesIterable(DescIterable v) : data_(std::move(v)) {}
 
+  explicit VerticesIterable(Asc1Iterable v) : data_(std::move(v)) {}
+
+  explicit VerticesIterable(Desc1Iterable v) : data_(std::move(v)) {}
+
+  explicit VerticesIterable(Asc2Iterable v) : data_(std::move(v)) {}
+
+  explicit VerticesIterable(Desc2Iterable v) : data_(std::move(v)) {}
+
   VerticesIterable(const VerticesIterable &) = delete;
   VerticesIterable &operator=(const VerticesIterable &) = delete;
 
@@ -46,7 +59,8 @@ class VerticesIterable final {
 
   class Iterator final {
     using Data = std::variant<AllVerticesIterable::Iterator, InMemoryLabelIndex::Iterable::Iterator,
-                              AscIterable::Iterator, DescIterable::Iterator>;
+                              AscIterable::Iterator, DescIterable::Iterator, Asc1Iterable::Iterator,
+                              Desc1Iterable::Iterator, Asc2Iterable::Iterator, Desc2Iterable::Iterator>;
 
     Data data_;
 
@@ -61,6 +75,14 @@ class VerticesIterable final {
     explicit Iterator(AscIterable::Iterator it) : data_(std::move(it)) {}
 
     explicit Iterator(DescIterable::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Asc1Iterable::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Desc1Iterable::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Asc2Iterable::Iterator it) : data_(std::move(it)) {}
+
+    explicit Iterator(Desc2Iterable::Iterator it) : data_(std::move(it)) {}
 
     Iterator(const Iterator &) = default;
     Iterator &operator=(const Iterator &) = default;

--- a/tests/unit/storage_v2_property_store.cpp
+++ b/tests/unit/storage_v2_property_store.cpp
@@ -1733,7 +1733,7 @@ TEST(PropertiesPermutationHelper, MatchesValue_ProducesVectorOfPositionsAndCompa
   PropertiesPermutationHelper prop_reader{std::array{
       PropertyPath{p1, p2}, PropertyPath{p1, p3}, PropertyPath{p1, p4}, PropertyPath{p5, p6}, PropertyPath{p7}}};
 
-  IndexOrderedPropertyValues const baseline{{
+  IndexOrderedValuesVector const baseline{{
       PropertyValue("apple"),
       PropertyValue("banana"),
       PropertyValue("cherry"),
@@ -1816,7 +1816,7 @@ TEST(PropertiesPermutationHelper, MatchesValue_ComparesOutOfOrderProperties) {
       PropertyPath{p1, p2},
   }};
 
-  IndexOrderedPropertyValues const baseline{{
+  IndexOrderedValuesVector const baseline{{
       PropertyValue("apple"),   // corresponds to p3.p4; ordered-index[1]
       PropertyValue("banana"),  // corresponds to p1.p2; ordered-index[0]
   }};
@@ -1850,7 +1850,7 @@ TEST(PropertiesPermutationHelper, MatchesValue_ComparesOutOfOrderPropertiesWhenR
   PropertiesPermutationHelper prop_reader{
       std::array{PropertyPath{p3, p4}, PropertyPath{p1, p6}, PropertyPath{p3, p5}, PropertyPath{p1, p2}}};
 
-  IndexOrderedPropertyValues const baseline{{
+  IndexOrderedValuesVector const baseline{{
       PropertyValue("apple"),   // corresponds to p3.p4; ordered-index[2]
       PropertyValue("banana"),  // corresponds to p1.p6; ordered-index[1]
       PropertyValue("cherry"),  // corresponds to p3.p5; ordered-index[3]
@@ -1958,24 +1958,25 @@ TEST(PropertiesPermutationHelper, MatchesValues_ReturnsABooleanMaskOfMatches) {
   PropertyStore store;
   store.InitProperties(data);
 
-  EXPECT_EQ(
-      prop_reader.MatchesValues(
-          store,
-          std::vector{PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"date"}}),
-      (std::vector{true, true, true, true}));
-
-  EXPECT_EQ(
-      prop_reader.MatchesValues(
-          store,
-          std::vector{
-              PropertyValue{"applex"}, PropertyValue{"bananax"}, PropertyValue{"cherryx"}, PropertyValue{"datex"}}),
-      (std::vector{false, false, false, false}));
-
   EXPECT_EQ(prop_reader.MatchesValues(
                 store,
-                std::vector{
-                    PropertyValue{"apple"}, PropertyValue{"bananax"}, PropertyValue{"cherry"}, PropertyValue{"datex"}}),
-            (std::vector{true, false, true, false}));
+                IndexOrderedValuesVector{
+                    {PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"date"}}}),
+            (std::vector{true, true, true, true}));
+
+  EXPECT_EQ(
+      prop_reader.MatchesValues(
+          store,
+          IndexOrderedValuesVector{
+              {PropertyValue{"applex"}, PropertyValue{"bananax"}, PropertyValue{"cherryx"}, PropertyValue{"datex"}}}),
+      (std::vector{false, false, false, false}));
+
+  EXPECT_EQ(
+      prop_reader.MatchesValues(
+          store,
+          IndexOrderedValuesVector{
+              {PropertyValue{"apple"}, PropertyValue{"bananax"}, PropertyValue{"cherry"}, PropertyValue{"datex"}}}),
+      (std::vector{true, false, true, false}));
 }
 
 TEST(PropertiesPermutationHelper, MatchesValues_WorksWithOutOfOrderProperties) {
@@ -1995,17 +1996,17 @@ TEST(PropertiesPermutationHelper, MatchesValues_WorksWithOutOfOrderProperties) {
   PropertyStore store;
   store.InitProperties(data);
 
-  EXPECT_EQ(
-      prop_reader.MatchesValues(
-          store,
-          std::vector{PropertyValue{"cherry"}, PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"date"}}),
-      (std::vector{true, true, true, true}));
+  EXPECT_EQ(prop_reader.MatchesValues(
+                store,
+                IndexOrderedValuesVector{
+                    {PropertyValue{"cherry"}, PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"date"}}}),
+            (std::vector{true, true, true, true}));
 
-  EXPECT_EQ(
-      prop_reader.MatchesValues(
-          store,
-          std::vector{PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"date"}}),
-      (std::vector{false, false, false, true}));
+  EXPECT_EQ(prop_reader.MatchesValues(
+                store,
+                IndexOrderedValuesVector{
+                    {PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"date"}}}),
+            (std::vector{false, false, false, true}));
 }
 
 TEST(PropertiesPermutationHelper, MatchesValues_WorksWithNestedProperties) {
@@ -2026,17 +2027,17 @@ TEST(PropertiesPermutationHelper, MatchesValues_WorksWithNestedProperties) {
   PropertyStore store;
   store.InitProperties(data);
 
-  EXPECT_EQ(
-      prop_reader.MatchesValues(
-          store,
-          std::vector{PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"apple"}, PropertyValue{"date"}}),
-      (std::vector{true, true, true, true}));
+  EXPECT_EQ(prop_reader.MatchesValues(
+                store,
+                IndexOrderedValuesVector{
+                    {PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"apple"}, PropertyValue{"date"}}}),
+            (std::vector{true, true, true, true}));
 
-  EXPECT_EQ(
-      prop_reader.MatchesValues(
-          store,
-          std::vector{PropertyValue{"apple"}, PropertyValue{"cherry"}, PropertyValue{"banana"}, PropertyValue{"date"}}),
-      (std::vector{false, false, true, true}));
+  EXPECT_EQ(prop_reader.MatchesValues(
+                store,
+                IndexOrderedValuesVector{
+                    {PropertyValue{"apple"}, PropertyValue{"cherry"}, PropertyValue{"banana"}, PropertyValue{"date"}}}),
+            (std::vector{false, false, true, true}));
 }
 
 //==============================================================================


### PR DESCRIPTION
Single- and two-property label-property index entries store their values in a fixed std::array inlined into the skiplist node, instead of a std::vector (a header plus a separate heap allocation) per entry; higher composite arities keep the vector. This removes the per-entry heap indirection that composite index support introduced for the common fixed-arity cases and restores the single-property entry footprint.

Entry storage is parameterized on composite arity and sort direction, with the per-arity index objects behind a variant chosen once at index creation. The query entry points are type-erased: they pick the entry type from the index's arity and direction and return the wrapper the executor consumes, so callers never name a per-arity type. A single dispatch layer holds the arity-and-order-to-entry-type policy that creation, population, publication, and the query paths share, so supporting another fixed arity is one edit. A strong IndexOrderedValuesView keeps index-ordered values distinct from storage order across the match and comparison helpers, and a static_assert pins each array-backed entry to its no-indirection size.

The ingestion path builds a fixed-arity entry straight into a stack array and moves it into the node, with no transient heap vector: PropertyStore and PropertiesPermutationHelper gain into-buffer extract and in-place permutation overloads, and the permutation carry moves rather than copies each value.

VectorIndex and VectorEdgeIndex return early from UpdateOnSetProperty when no vector index is defined, removing per-write overhead on databases without one.
