### PR TITLE
perf(auth): Remove performance regressions caused by property-based access control

### DIFF
--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -588,11 +588,15 @@ State HandleRoute(TSession &session, const Marker marker) {
 
 template <typename TSession>
 State HandleLogOff(TSession &session) {
-  session.LogOff();
-  if (!session.encoder_.MessageSuccess({})) {
-    spdlog::trace("Couldn't send success message!");
-    return State::Close;
+  try {
+    session.LogOff();
+    if (!session.encoder_.MessageSuccess({})) {
+      spdlog::trace("Couldn't send success message!");
+      return State::Close;
+    }
+    return State::Init;
+  } catch (const std::exception &e) {
+    return HandleFailure(session, e);
   }
-  return State::Init;
 }
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -588,8 +588,11 @@ State HandleRoute(TSession &session, const Marker marker) {
 
 template <typename TSession>
 State HandleLogOff(TSession &session) {
-  // No arguments and cannot fail
   session.LogOff();
+  if (!session.encoder_.MessageSuccess({})) {
+    spdlog::trace("Couldn't send success message!");
+    return State::Close;
+  }
   return State::Init;
 }
 }  // namespace memgraph::communication::bolt

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -352,6 +352,7 @@ std::expected<void, communication::bolt::AuthFailure> SessionHL::SSOAuthenticate
 }
 
 void SessionHL::LogOff() {
+  interpreter_.cached_auth_checker_ = nullptr;
   cached_auth_checker_.reset();
 #ifdef MG_ENTERPRISE
   interpreter_.ResetDB();
@@ -361,6 +362,7 @@ void SessionHL::LogOff() {
 }
 
 void SessionHL::Abort() {
+  interpreter_.cached_auth_checker_ = nullptr;
   cached_auth_checker_.reset();
   interpreter_.Abort();
 }
@@ -404,6 +406,7 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
 }
 
 void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, const bolt_map_t &extra) {
+  interpreter_.cached_auth_checker_ = nullptr;
   cached_auth_checker_.reset();
 #ifdef MG_ENTERPRISE
   if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
@@ -455,6 +458,7 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrep
 
 #ifdef MG_ENTERPRISE
     cached_auth_checker_.reset();
+    interpreter_.cached_auth_checker_ = nullptr;
     auto &db = interpreter_.current_db_.db_acc_;
     auto *storage = db ? db->get()->storage() : nullptr;
     if (storage && interpreter_context_->auth_checker && interpreter_.user_or_role_ && *interpreter_.user_or_role_ &&
@@ -466,6 +470,7 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrep
       if (!cached_auth_checker_->NeedsFineGrainedAuthChecker()) {
         cached_auth_checker_.reset();
       }
+      interpreter_.cached_auth_checker_ = cached_auth_checker_.get();
     }
 #endif
 

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -352,7 +352,7 @@ std::expected<void, communication::bolt::AuthFailure> SessionHL::SSOAuthenticate
 }
 
 void SessionHL::LogOff() {
-  interpreter_.cached_fga_.Reset();
+  interpreter_.ResetCachedFga();
 #ifdef MG_ENTERPRISE
   interpreter_.ResetDB();
 #endif
@@ -361,7 +361,7 @@ void SessionHL::LogOff() {
 }
 
 void SessionHL::Abort() {
-  interpreter_.cached_fga_.Reset();
+  interpreter_.ResetCachedFga();
   interpreter_.Abort();
 }
 
@@ -388,7 +388,7 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
         communication::bolt::Encoder<communication::bolt::ChunkedEncoderBuffer<communication::v2::OutputStream>>;
     auto &db = interpreter_.current_db_.db_acc_;
     auto *storage = db ? db->get()->storage() : nullptr;
-    TypedValueResultStream<TEncoder> stream(&encoder_, storage, interpreter_.cached_fga_.get());
+    TypedValueResultStream<TEncoder> stream(&encoder_, storage, interpreter_.GetCachedFga());
     return DecodeSummary(interpreter_.Pull(&stream, n, qid));
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
@@ -619,7 +619,7 @@ void RuntimeConfig::Configure(const bolt_map_t &run_time_info, bool in_explicit_
   // Runtime config is sent at the beginning of the transaction, but is missing during the transaction
   if (in_explicit_tx || (previous_run_time_info_ && run_time_info == *previous_run_time_info_)) return;
 
-  session_->interpreter_.cached_fga_.Reset();
+  session_->interpreter_.ResetCachedFga();
 
   db_explicit_ = false;
   user_explicit_ = false;

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -352,8 +352,7 @@ std::expected<void, communication::bolt::AuthFailure> SessionHL::SSOAuthenticate
 }
 
 void SessionHL::LogOff() {
-  interpreter_.cached_auth_checker_.reset();
-  interpreter_.auth_checker_db_name_.clear();
+  interpreter_.cached_fga_.Reset();
 #ifdef MG_ENTERPRISE
   interpreter_.ResetDB();
 #endif
@@ -362,8 +361,7 @@ void SessionHL::LogOff() {
 }
 
 void SessionHL::Abort() {
-  interpreter_.cached_auth_checker_.reset();
-  interpreter_.auth_checker_db_name_.clear();
+  interpreter_.cached_fga_.Reset();
   interpreter_.Abort();
 }
 
@@ -390,7 +388,7 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
         communication::bolt::Encoder<communication::bolt::ChunkedEncoderBuffer<communication::v2::OutputStream>>;
     auto &db = interpreter_.current_db_.db_acc_;
     auto *storage = db ? db->get()->storage() : nullptr;
-    TypedValueResultStream<TEncoder> stream(&encoder_, storage, interpreter_.cached_auth_checker_.get());
+    TypedValueResultStream<TEncoder> stream(&encoder_, storage, interpreter_.cached_fga_.get());
     return DecodeSummary(interpreter_.Pull(&stream, n, qid));
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
@@ -621,8 +619,7 @@ void RuntimeConfig::Configure(const bolt_map_t &run_time_info, bool in_explicit_
   // Runtime config is sent at the beginning of the transaction, but is missing during the transaction
   if (in_explicit_tx || (previous_run_time_info_ && run_time_info == *previous_run_time_info_)) return;
 
-  session_->interpreter_.cached_auth_checker_.reset();
-  session_->interpreter_.auth_checker_db_name_.clear();
+  session_->interpreter_.cached_fga_.Reset();
 
   db_explicit_ = false;
   user_explicit_ = false;

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -354,6 +354,7 @@ std::expected<void, communication::bolt::AuthFailure> SessionHL::SSOAuthenticate
 void SessionHL::LogOff() {
   interpreter_.cached_auth_checker_ = nullptr;
   cached_auth_checker_.reset();
+  auth_checker_db_name_.clear();
 #ifdef MG_ENTERPRISE
   interpreter_.ResetDB();
 #endif
@@ -364,6 +365,7 @@ void SessionHL::LogOff() {
 void SessionHL::Abort() {
   interpreter_.cached_auth_checker_ = nullptr;
   cached_auth_checker_.reset();
+  auth_checker_db_name_.clear();
   interpreter_.Abort();
 }
 
@@ -406,8 +408,6 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
 }
 
 void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, const bolt_map_t &extra) {
-  interpreter_.cached_auth_checker_ = nullptr;
-  cached_auth_checker_.reset();
 #ifdef MG_ENTERPRISE
   if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
     auto &db = interpreter_.current_db_.db_acc_;
@@ -457,20 +457,28 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrep
     interpreter_.CheckAuthorized(result.privileges, result.db);
 
 #ifdef MG_ENTERPRISE
-    cached_auth_checker_.reset();
     interpreter_.cached_auth_checker_ = nullptr;
     auto &db = interpreter_.current_db_.db_acc_;
     auto *storage = db ? db->get()->storage() : nullptr;
     if (storage && interpreter_context_->auth_checker && interpreter_.user_or_role_ && *interpreter_.user_or_role_ &&
         interpreter_.current_db_.execution_db_accessor_) {
       auto *dba = &*interpreter_.current_db_.execution_db_accessor_;
-      cached_auth_checker_ =
-          interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*interpreter_.user_or_role_, dba);
-      DMG_ASSERT(cached_auth_checker_, "Auth checker should not be null");
-      if (!cached_auth_checker_->NeedsFineGrainedAuthChecker()) {
-        cached_auth_checker_.reset();
+      auto const current_db = dba->DatabaseName();
+      if (cached_auth_checker_ && auth_checker_db_name_ == current_db) {
+        cached_auth_checker_->UpdateDbAccessor(dba);
+      } else {
+        cached_auth_checker_ =
+            interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*interpreter_.user_or_role_, dba);
+        DMG_ASSERT(cached_auth_checker_, "Auth checker should not be null");
+        if (!cached_auth_checker_->NeedsFineGrainedAuthChecker()) {
+          cached_auth_checker_.reset();
+        }
+        auth_checker_db_name_ = current_db;
       }
       interpreter_.cached_auth_checker_ = cached_auth_checker_.get();
+    } else {
+      cached_auth_checker_.reset();
+      auth_checker_db_name_.clear();
     }
 #endif
 
@@ -640,6 +648,10 @@ void RuntimeConfig::Configure(const bolt_map_t &run_time_info, bool in_explicit_
   // NOTE: Once in a transaction, the drivers stop explicitly sending the config and count on using it until commit
   // Runtime config is sent at the beginning of the transaction, but is missing during the transaction
   if (in_explicit_tx || (previous_run_time_info_ && run_time_info == *previous_run_time_info_)) return;
+
+  session_->cached_auth_checker_.reset();
+  session_->auth_checker_db_name_.clear();
+  session_->interpreter_.cached_auth_checker_ = nullptr;
 
   db_explicit_ = false;
   user_explicit_ = false;

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -352,7 +352,7 @@ std::expected<void, communication::bolt::AuthFailure> SessionHL::SSOAuthenticate
 }
 
 void SessionHL::LogOff() {
-  interpreter_.ResetCachedFga();
+  Abort();
 #ifdef MG_ENTERPRISE
   interpreter_.ResetDB();
 #endif

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -352,6 +352,7 @@ std::expected<void, communication::bolt::AuthFailure> SessionHL::SSOAuthenticate
 }
 
 void SessionHL::LogOff() {
+  cached_auth_checker_.reset();
 #ifdef MG_ENTERPRISE
   interpreter_.ResetDB();
 #endif
@@ -359,7 +360,10 @@ void SessionHL::LogOff() {
   session_user_or_role_.reset();
 }
 
-void SessionHL::Abort() { interpreter_.Abort(); }
+void SessionHL::Abort() {
+  cached_auth_checker_.reset();
+  interpreter_.Abort();
+}
 
 bolt_map_t SessionHL::Discard(std::optional<int> n, std::optional<int> qid) {
   try {
@@ -384,20 +388,7 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
         communication::bolt::Encoder<communication::bolt::ChunkedEncoderBuffer<communication::v2::OutputStream>>;
     auto &db = interpreter_.current_db_.db_acc_;
     auto *storage = db ? db->get()->storage() : nullptr;
-
-    std::unique_ptr<memgraph::query::FineGrainedAuthChecker> auth_checker;  // NOLINT(misc-const-correctness)
-#ifdef MG_ENTERPRISE
-    if (storage && interpreter_context_->auth_checker && interpreter_.user_or_role_ && *interpreter_.user_or_role_ &&
-        interpreter_.current_db_.execution_db_accessor_) {
-      auto *dba = &*interpreter_.current_db_.execution_db_accessor_;
-      auth_checker = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*interpreter_.user_or_role_, dba);
-      DMG_ASSERT(auth_checker, "Auth checker should not be null");
-      if (!auth_checker->NeedsFineGrainedAuthChecker()) {
-        auth_checker = nullptr;
-      }
-    }
-#endif
-    TypedValueResultStream<TEncoder> stream(&encoder_, storage, auth_checker.get());
+    TypedValueResultStream<TEncoder> stream(&encoder_, storage, cached_auth_checker_.get());
     return DecodeSummary(interpreter_.Pull(&stream, n, qid));
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
@@ -413,6 +404,7 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
 }
 
 void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, const bolt_map_t &extra) {
+  cached_auth_checker_.reset();
 #ifdef MG_ENTERPRISE
   if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
     auto &db = interpreter_.current_db_.db_acc_;
@@ -460,6 +452,23 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrep
     auto result =
         interpreter_.Prepare(std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
     interpreter_.CheckAuthorized(result.privileges, result.db);
+
+#ifdef MG_ENTERPRISE
+    cached_auth_checker_.reset();
+    auto &db = interpreter_.current_db_.db_acc_;
+    auto *storage = db ? db->get()->storage() : nullptr;
+    if (storage && interpreter_context_->auth_checker && interpreter_.user_or_role_ && *interpreter_.user_or_role_ &&
+        interpreter_.current_db_.execution_db_accessor_) {
+      auto *dba = &*interpreter_.current_db_.execution_db_accessor_;
+      cached_auth_checker_ =
+          interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*interpreter_.user_or_role_, dba);
+      DMG_ASSERT(cached_auth_checker_, "Auth checker should not be null");
+      if (!cached_auth_checker_->NeedsFineGrainedAuthChecker()) {
+        cached_auth_checker_.reset();
+      }
+    }
+#endif
+
     return {std::move(result.headers), result.qid};
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -352,9 +352,8 @@ std::expected<void, communication::bolt::AuthFailure> SessionHL::SSOAuthenticate
 }
 
 void SessionHL::LogOff() {
-  interpreter_.cached_auth_checker_ = nullptr;
-  cached_auth_checker_.reset();
-  auth_checker_db_name_.clear();
+  interpreter_.cached_auth_checker_.reset();
+  interpreter_.auth_checker_db_name_.clear();
 #ifdef MG_ENTERPRISE
   interpreter_.ResetDB();
 #endif
@@ -363,9 +362,8 @@ void SessionHL::LogOff() {
 }
 
 void SessionHL::Abort() {
-  interpreter_.cached_auth_checker_ = nullptr;
-  cached_auth_checker_.reset();
-  auth_checker_db_name_.clear();
+  interpreter_.cached_auth_checker_.reset();
+  interpreter_.auth_checker_db_name_.clear();
   interpreter_.Abort();
 }
 
@@ -392,7 +390,7 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
         communication::bolt::Encoder<communication::bolt::ChunkedEncoderBuffer<communication::v2::OutputStream>>;
     auto &db = interpreter_.current_db_.db_acc_;
     auto *storage = db ? db->get()->storage() : nullptr;
-    TypedValueResultStream<TEncoder> stream(&encoder_, storage, cached_auth_checker_.get());
+    TypedValueResultStream<TEncoder> stream(&encoder_, storage, interpreter_.cached_auth_checker_.get());
     return DecodeSummary(interpreter_.Pull(&stream, n, qid));
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
@@ -455,32 +453,6 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrep
     auto result =
         interpreter_.Prepare(std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
     interpreter_.CheckAuthorized(result.privileges, result.db);
-
-#ifdef MG_ENTERPRISE
-    interpreter_.cached_auth_checker_ = nullptr;
-    auto &db = interpreter_.current_db_.db_acc_;
-    auto *storage = db ? db->get()->storage() : nullptr;
-    if (storage && interpreter_context_->auth_checker && interpreter_.user_or_role_ && *interpreter_.user_or_role_ &&
-        interpreter_.current_db_.execution_db_accessor_) {
-      auto *dba = &*interpreter_.current_db_.execution_db_accessor_;
-      auto const current_db = dba->DatabaseName();
-      if (cached_auth_checker_ && auth_checker_db_name_ == current_db) {
-        cached_auth_checker_->UpdateDbAccessor(dba);
-      } else {
-        cached_auth_checker_ =
-            interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*interpreter_.user_or_role_, dba);
-        DMG_ASSERT(cached_auth_checker_, "Auth checker should not be null");
-        if (!cached_auth_checker_->NeedsFineGrainedAuthChecker()) {
-          cached_auth_checker_.reset();
-        }
-        auth_checker_db_name_ = current_db;
-      }
-      interpreter_.cached_auth_checker_ = cached_auth_checker_.get();
-    } else {
-      cached_auth_checker_.reset();
-      auth_checker_db_name_.clear();
-    }
-#endif
 
     return {std::move(result.headers), result.qid};
   } catch (const memgraph::query::QueryException &e) {
@@ -649,9 +621,8 @@ void RuntimeConfig::Configure(const bolt_map_t &run_time_info, bool in_explicit_
   // Runtime config is sent at the beginning of the transaction, but is missing during the transaction
   if (in_explicit_tx || (previous_run_time_info_ && run_time_info == *previous_run_time_info_)) return;
 
-  session_->cached_auth_checker_.reset();
-  session_->auth_checker_db_name_.clear();
-  session_->interpreter_.cached_auth_checker_ = nullptr;
+  session_->interpreter_.cached_auth_checker_.reset();
+  session_->interpreter_.auth_checker_db_name_.clear();
 
   db_explicit_ = false;
   user_explicit_ = false;

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -18,10 +18,6 @@
 #include "glue/SessionContext.hpp"
 #include "query/interpreter.hpp"
 
-namespace memgraph::query {
-class FineGrainedAuthChecker;
-}
-
 namespace memgraph::glue {
 using bolt_value_t = memgraph::communication::bolt::Value;
 using bolt_map_t = memgraph::communication::bolt::map_t;
@@ -152,8 +148,6 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   memgraph::auth::SynchedAuth *auth_;
   memgraph::communication::v2::ServerEndpoint endpoint_;
   metrics::ScopedGauge bolt_session_gauge_;
-  std::unique_ptr<query::FineGrainedAuthChecker> cached_auth_checker_;
-  std::string auth_checker_db_name_;
   std::optional<ParseRes> parsed_res_;  // SessionHL corresponds to a single connection (we do not support out of order
                                         // execution, so a single query can be prepared/executed)
 };

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -153,6 +153,7 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   memgraph::communication::v2::ServerEndpoint endpoint_;
   metrics::ScopedGauge bolt_session_gauge_;
   std::unique_ptr<query::FineGrainedAuthChecker> cached_auth_checker_;
+  std::string auth_checker_db_name_;
   std::optional<ParseRes> parsed_res_;  // SessionHL corresponds to a single connection (we do not support out of order
                                         // execution, so a single query can be prepared/executed)
 };

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -18,6 +18,10 @@
 #include "glue/SessionContext.hpp"
 #include "query/interpreter.hpp"
 
+namespace memgraph::query {
+class FineGrainedAuthChecker;
+}
+
 namespace memgraph::glue {
 using bolt_value_t = memgraph::communication::bolt::Value;
 using bolt_map_t = memgraph::communication::bolt::map_t;
@@ -148,6 +152,7 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   memgraph::auth::SynchedAuth *auth_;
   memgraph::communication::v2::ServerEndpoint endpoint_;
   metrics::ScopedGauge bolt_session_gauge_;
+  std::unique_ptr<query::FineGrainedAuthChecker> cached_auth_checker_;
   std::optional<ParseRes> parsed_res_;  // SessionHL corresponds to a single connection (we do not support out of order
                                         // execution, so a single query can be prepared/executed)
 };

--- a/src/glue/auth_checker.cpp
+++ b/src/glue/auth_checker.cpp
@@ -212,6 +212,11 @@ bool AuthChecker::CanImpersonate(const memgraph::auth::Roles &roles, const memgr
 FineGrainedAuthChecker::FineGrainedAuthChecker(auth::UserOrRole user_or_role, const memgraph::query::DbAccessor *dba)
     : user_or_role_{std::move(user_or_role)}, dba_(dba), db_name_{dba_->DatabaseName()} {};
 
+void FineGrainedAuthChecker::UpdateDbAccessor(query::DbAccessor const *dba) {
+  DMG_ASSERT(dba->DatabaseName() == db_name_, "UpdateDbAccessor called with mismatched database name");
+  dba_ = dba;
+}
+
 auth::FineGrainedAccessPermissions const &FineGrainedAuthChecker::GetCachedLabelPermissions() const {
   if (!cached_label_permissions_) {
     cached_label_permissions_ = std::visit(memgraph::utils::Overloaded{[this](auto const &user_or_role) {

--- a/src/glue/auth_checker.cpp
+++ b/src/glue/auth_checker.cpp
@@ -411,7 +411,10 @@ bool FineGrainedAuthChecker::HasPropertyPermission(storage::EdgeTypeId const &ed
   return level == auth::PermissionLevel::GRANT;
 }
 
-void FineGrainedAuthChecker::MakeThreadSafe() const { PopulateCachedPermissions(); }
+void FineGrainedAuthChecker::MakeThreadSafe() const {
+  PopulateCachedPermissions();
+  (void)HasPropertyRestrictions();
+}
 
 bool FineGrainedAuthChecker::IsThreadSafe() const { return IsCachedPermissionsPopulated(); }
 

--- a/src/glue/auth_checker.cpp
+++ b/src/glue/auth_checker.cpp
@@ -433,7 +433,8 @@ bool FineGrainedAuthChecker::IsCachedPermissionsPopulated() const {
   return cached_label_permissions_.has_value() && cached_edge_permissions_.has_value() &&
          cached_property_label_permissions_.has_value() && cached_property_edge_type_permissions_.has_value() &&
          unrestricted_vertices_.has_value() && unrestricted_edges_.has_value() &&
-         unrestricted_vertex_properties_.has_value() && unrestricted_edge_properties_.has_value();
+         unrestricted_vertex_properties_.has_value() && unrestricted_edge_properties_.has_value() &&
+         IsPropertyRestrictionsCached();
 }
 #endif
 }  // namespace memgraph::glue

--- a/src/glue/auth_checker.hpp
+++ b/src/glue/auth_checker.hpp
@@ -109,7 +109,7 @@ class FineGrainedAuthChecker : public query::FineGrainedAuthChecker {
 
   // As `FineGrainedAuthChecker` is now cached for the session, we need to
   // ensure it has the latest `DBAccessor`.
-  void UpdateDbAccessor(query::DbAccessor const *dba) override { dba_ = dba; }
+  void UpdateDbAccessor(query::DbAccessor const *dba) override;
 
  private:
   auth::FineGrainedAccessPermissions const &GetCachedLabelPermissions() const;

--- a/src/glue/auth_checker.hpp
+++ b/src/glue/auth_checker.hpp
@@ -108,7 +108,7 @@ class FineGrainedAuthChecker : public query::FineGrainedAuthChecker {
   bool IsCachedPermissionsPopulated() const;
 
   // As `FineGrainedAuthChecker` is now cached for the session, we need to
-  // ensure it has the latest `DBAcessor`.
+  // ensure it has the latest `DBAccessor`.
   void UpdateDbAccessor(query::DbAccessor const *dba) override { dba_ = dba; }
 
  private:

--- a/src/glue/auth_checker.hpp
+++ b/src/glue/auth_checker.hpp
@@ -107,6 +107,8 @@ class FineGrainedAuthChecker : public query::FineGrainedAuthChecker {
   void PopulateCachedPermissions() const;
   bool IsCachedPermissionsPopulated() const;
 
+  void UpdateDbAccessor(query::DbAccessor const *dba) override { dba_ = dba; }
+
  private:
   auth::FineGrainedAccessPermissions const &GetCachedLabelPermissions() const;
   auth::FineGrainedAccessPermissions const &GetCachedEdgePermissions() const;

--- a/src/glue/auth_checker.hpp
+++ b/src/glue/auth_checker.hpp
@@ -107,6 +107,8 @@ class FineGrainedAuthChecker : public query::FineGrainedAuthChecker {
   void PopulateCachedPermissions() const;
   bool IsCachedPermissionsPopulated() const;
 
+  // As `FineGrainedAuthChecker` is now cached for the session, we need to
+  // ensure it has the latest `DBAcessor`.
   void UpdateDbAccessor(query::DbAccessor const *dba) override { dba_ = dba; }
 
  private:

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -226,27 +226,51 @@ class AllowEverythingAuthChecker final : public AuthChecker {
 };
 
 struct CachedFineGrainedAuth {
+  enum class State : uint8_t {
+    EMPTY,            // No auth cached, need to to check licence and FGA
+    NO_LICENSE,       // No enterprise license, so re-evaluate every query
+    NO_RESTRICTIONS,  // Enterprise licensed, no FGA needed, and this is cached
+    ACTIVE,           // Enterprise licensed, FGA active and auth cached
+  };
+
   std::unique_ptr<FineGrainedAuthChecker> checker;
   std::string db_name;
+  State state{State::EMPTY};
 
   FineGrainedAuthChecker const *get() const { return checker.get(); }
 
   void Refresh(AuthChecker const &auth_checker, QueryUserOrRole const &user, DbAccessor const *dba,
                std::string current_db) {
-    if (db_name == current_db) {
+    bool const must_rebuild = state == State::EMPTY || state == State::NO_LICENSE || db_name != current_db;
+
+    if (!must_rebuild) {
       if (checker) checker->UpdateDbAccessor(dba);
       return;
     }
+
     checker = auth_checker.GetFineGrainedAuthChecker(user, dba);
-    if (!checker || !checker->NeedsFineGrainedAuthChecker()) {
-      checker.reset();
+
+    if (!checker) {
+      db_name = std::move(current_db);
+      state = State::NO_LICENSE;
+      return;
     }
+
+    if (!checker->NeedsFineGrainedAuthChecker()) {
+      checker.reset();
+      db_name = std::move(current_db);
+      state = State::NO_RESTRICTIONS;
+      return;
+    }
+
     db_name = std::move(current_db);
+    state = State::ACTIVE;
   }
 
   void Reset() {
     checker.reset();
     db_name.clear();
+    state = State::EMPTY;
   }
 };
 

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -118,7 +118,8 @@ class FineGrainedAuthChecker {
   FineGrainedAuthChecker &operator=(const FineGrainedAuthChecker &) = default;
   FineGrainedAuthChecker &operator=(FineGrainedAuthChecker &&) noexcept = default;
 
- private:
+  bool IsPropertyRestrictionsCached() const { return has_property_restrictions_.has_value(); }
+
   mutable std::optional<bool> has_property_restrictions_;
 };
 

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -96,6 +96,8 @@ class FineGrainedAuthChecker {
                                                    memgraph::storage::PropertyId property,
                                                    AuthQuery::PropertyPermissionType type) const = 0;
 
+  virtual void UpdateDbAccessor(DbAccessor const * /*dba*/) {}
+
   // Used to make the auth checker thread safe
   // throw if not possible
   virtual void MakeThreadSafe() const = 0;

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -235,15 +235,17 @@ struct CachedFineGrainedAuth {
   void Refresh(AuthChecker const &auth_checker, QueryUserOrRole const &user, DbAccessor const *dba,
                std::string_view current_db) {
     if (checked && db_name == current_db) {
-      if (checker) checker->UpdateDbAccessor(dba);
-      return;
+      if (checker) {
+        checker->UpdateDbAccessor(dba);
+        return;
+      }
     }
     checker = auth_checker.GetFineGrainedAuthChecker(user, dba);
     if (!checker || !checker->NeedsFineGrainedAuthChecker()) {
       checker.reset();
     }
     db_name = current_db;
-    checked = checker != nullptr;
+    checked = true;
   }
 
   void Reset() {

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -232,17 +232,17 @@ struct CachedFineGrainedAuth {
   FineGrainedAuthChecker const *get() const { return checker.get(); }
 
   void Refresh(AuthChecker const &auth_checker, QueryUserOrRole const &user, DbAccessor const *dba,
-               std::string current_db) {
+               std::string_view current_db) {
     if (checked && db_name == current_db) {
       if (checker) checker->UpdateDbAccessor(dba);
-    } else {
-      checker = auth_checker.GetFineGrainedAuthChecker(user, dba);
-      if (!checker || !checker->NeedsFineGrainedAuthChecker()) {
-        checker.reset();
-      }
-      db_name = std::move(current_db);
-      checked = true;
+      return;
     }
+    checker = auth_checker.GetFineGrainedAuthChecker(user, dba);
+    if (!checker || !checker->NeedsFineGrainedAuthChecker()) {
+      checker.reset();
+    }
+    db_name = current_db;
+    checked = checker != nullptr;
   }
 
   void Reset() {

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -218,7 +218,7 @@ struct CachedFineGrainedAuth {
   std::string db_name;
   bool checked{false};
 
-  FineGrainedAuthChecker *get() const { return checker.get(); }
+  FineGrainedAuthChecker const *get() const { return checker.get(); }
 
   void Reset() {
     checker.reset();

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -82,6 +82,14 @@ class FineGrainedAuthChecker {
 
   [[nodiscard]] virtual bool HasUnrestrictedAccessToEdgeTypeProperties() const = 0;
 
+  [[nodiscard]] bool HasPropertyRestrictions() const {
+    if (!has_property_restrictions_) {
+      has_property_restrictions_ =
+          !HasUnrestrictedAccessToVertexProperties() || !HasUnrestrictedAccessToEdgeTypeProperties();
+    }
+    return *has_property_restrictions_;
+  }
+
   /// True when a FineGrainedAuthChecker must be attached for correct
   /// authorization, defined by either per-Label/per-Edge rules, or per-Property
   /// rules. When false, the checker is redundant as no restrictions to labels,
@@ -109,6 +117,9 @@ class FineGrainedAuthChecker {
   FineGrainedAuthChecker(FineGrainedAuthChecker &&) noexcept = default;
   FineGrainedAuthChecker &operator=(const FineGrainedAuthChecker &) = default;
   FineGrainedAuthChecker &operator=(FineGrainedAuthChecker &&) noexcept = default;
+
+ private:
+  mutable std::optional<bool> has_property_restrictions_;
 };
 
 class AllowEverythingFineGrainedAuthChecker final : public FineGrainedAuthChecker {

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -228,30 +228,25 @@ class AllowEverythingAuthChecker final : public AuthChecker {
 struct CachedFineGrainedAuth {
   std::unique_ptr<FineGrainedAuthChecker> checker;
   std::string db_name;
-  bool checked{false};
 
   FineGrainedAuthChecker const *get() const { return checker.get(); }
 
   void Refresh(AuthChecker const &auth_checker, QueryUserOrRole const &user, DbAccessor const *dba,
                std::string_view current_db) {
-    if (checked && db_name == current_db) {
-      if (checker) {
-        checker->UpdateDbAccessor(dba);
-        return;
-      }
+    if (db_name == current_db) {
+      if (checker) checker->UpdateDbAccessor(dba);
+      return;
     }
     checker = auth_checker.GetFineGrainedAuthChecker(user, dba);
     if (!checker || !checker->NeedsFineGrainedAuthChecker()) {
       checker.reset();
     }
     db_name = current_db;
-    checked = true;
   }
 
   void Reset() {
     checker.reset();
     db_name.clear();
-    checked = false;
   }
 };
 

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -231,6 +231,20 @@ struct CachedFineGrainedAuth {
 
   FineGrainedAuthChecker const *get() const { return checker.get(); }
 
+  void Refresh(AuthChecker const &auth_checker, QueryUserOrRole const &user, DbAccessor const *dba,
+               std::string current_db) {
+    if (checked && db_name == current_db) {
+      if (checker) checker->UpdateDbAccessor(dba);
+    } else {
+      checker = auth_checker.GetFineGrainedAuthChecker(user, dba);
+      if (!checker || !checker->NeedsFineGrainedAuthChecker()) {
+        checker.reset();
+      }
+      db_name = std::move(current_db);
+      checked = true;
+    }
+  }
+
   void Reset() {
     checker.reset();
     db_name.clear();

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -232,7 +232,7 @@ struct CachedFineGrainedAuth {
   FineGrainedAuthChecker const *get() const { return checker.get(); }
 
   void Refresh(AuthChecker const &auth_checker, QueryUserOrRole const &user, DbAccessor const *dba,
-               std::string_view current_db) {
+               std::string current_db) {
     if (db_name == current_db) {
       if (checker) checker->UpdateDbAccessor(dba);
       return;
@@ -241,7 +241,7 @@ struct CachedFineGrainedAuth {
     if (!checker || !checker->NeedsFineGrainedAuthChecker()) {
       checker.reset();
     }
-    db_name = current_db;
+    db_name = std::move(current_db);
   }
 
   void Reset() {

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -213,4 +213,18 @@ class AllowEverythingAuthChecker final : public AuthChecker {
   }
 };
 
+struct CachedFineGrainedAuth {
+  std::unique_ptr<FineGrainedAuthChecker> checker;
+  std::string db_name;
+  bool checked{false};
+
+  FineGrainedAuthChecker *get() const { return checker.get(); }
+
+  void Reset() {
+    checker.reset();
+    db_name.clear();
+    checked = false;
+  }
+};
+
 }  // namespace memgraph::query

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -130,6 +130,7 @@ struct ExecutionContext {
   HopsLimit hops_limit;
   std::optional<uint64_t> periodic_commit_frequency;
   std::shared_ptr<FineGrainedAuthChecker> auth_checker{nullptr};
+  bool has_property_restrictions{false};
   std::shared_ptr<storage::DatabaseProtector> protector;
   bool is_main{true};
   std::optional<size_t> parallel_execution{std::nullopt};  // if set, number of threads to use for parallel execution

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -129,7 +129,7 @@ struct ExecutionContext {
   int64_t number_of_hops{0};
   HopsLimit hops_limit;
   std::optional<uint64_t> periodic_commit_frequency;
-  std::shared_ptr<FineGrainedAuthChecker> auth_checker{nullptr};
+  FineGrainedAuthChecker const *auth_checker{nullptr};
   bool has_property_restrictions{false};
   std::shared_ptr<storage::DatabaseProtector> protector;
   bool is_main{true};

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -130,7 +130,6 @@ struct ExecutionContext {
   HopsLimit hops_limit;
   std::optional<uint64_t> periodic_commit_frequency;
   FineGrainedAuthChecker const *auth_checker{nullptr};
-  bool has_property_restrictions{false};
   std::shared_ptr<storage::DatabaseProtector> protector;
   bool is_main{true};
   std::optional<size_t> parallel_execution{std::nullopt};  // if set, number of threads to use for parallel execution

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -567,15 +567,13 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
 }
 
 #ifdef MG_ENTERPRISE
-bool ExpressionEvaluator::IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const {
-  if (!auth_checker_) return true;
+bool ExpressionEvaluator::CheckPropertyPermission(VertexAccessor const &accessor, storage::PropertyId prop) const {
   auto maybe_labels = accessor.Labels(view_);
   if (!maybe_labels) return false;
   return auth_checker_->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
 }
 
-bool ExpressionEvaluator::IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const {
-  if (!auth_checker_) return true;
+bool ExpressionEvaluator::CheckPropertyPermission(EdgeAccessor const &accessor, storage::PropertyId prop) const {
   return auth_checker_->HasPropertyPermission(accessor.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
 }
 

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -567,6 +567,16 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
 }
 
 #ifdef MG_ENTERPRISE
+bool ExpressionEvaluator::IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const {
+  if (!auth_checker_ || !auth_checker_->HasPropertyRestrictions()) return true;
+  return CheckPropertyPermission(accessor, prop);
+}
+
+bool ExpressionEvaluator::IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const {
+  if (!auth_checker_ || !auth_checker_->HasPropertyRestrictions()) return true;
+  return CheckPropertyPermission(accessor, prop);
+}
+
 bool ExpressionEvaluator::CheckPropertyPermission(VertexAccessor const &accessor, storage::PropertyId prop) const {
   DMG_ASSERT(auth_checker_);
   auto maybe_labels = accessor.Labels(view_);

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -568,12 +568,14 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
 
 #ifdef MG_ENTERPRISE
 bool ExpressionEvaluator::CheckPropertyPermission(VertexAccessor const &accessor, storage::PropertyId prop) const {
+  DMG_ASSERT(auth_checker_);
   auto maybe_labels = accessor.Labels(view_);
   if (!maybe_labels) return false;
   return auth_checker_->HasPropertyPermission(*maybe_labels, prop, AuthQuery::PropertyPermissionType::READ);
 }
 
 bool ExpressionEvaluator::CheckPropertyPermission(EdgeAccessor const &accessor, storage::PropertyId prop) const {
+  DMG_ASSERT(auth_checker_);
   return auth_checker_->HasPropertyPermission(accessor.EdgeType(), prop, AuthQuery::PropertyPermissionType::READ);
 }
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -257,8 +257,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
         triggering_user_(context.triggering_user.get())
 #ifdef MG_ENTERPRISE
         ,
-        auth_checker_(context.auth_checker),
-        has_property_restrictions_(context.has_property_restrictions)
+        auth_checker_(context.auth_checker)
 #endif
   {
   }
@@ -1077,15 +1076,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   }
 
 #ifdef MG_ENTERPRISE
-  bool IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const {
-    if (!has_property_restrictions_) return true;
-    return CheckPropertyPermission(accessor, prop);
-  }
-
-  bool IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const {
-    if (!has_property_restrictions_) return true;
-    return CheckPropertyPermission(accessor, prop);
-  }
+  bool IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const;
+  bool IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const;
 #else
   template <typename T>
     requires std::same_as<T, VertexAccessor> || std::same_as<T, EdgeAccessor>
@@ -1212,7 +1204,6 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   const QueryUserOrRole *triggering_user_;
 #ifdef MG_ENTERPRISE
   FineGrainedAuthChecker const *auth_checker_{nullptr};
-  bool has_property_restrictions_{false};
 #endif
 };  // namespace memgraph::query
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -257,7 +257,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
         triggering_user_(context.triggering_user.get())
 #ifdef MG_ENTERPRISE
         ,
-        auth_checker_(context.auth_checker.get())
+        auth_checker_(context.auth_checker.get()),
+        has_property_restrictions_(context.has_property_restrictions)
 #endif
   {
   }
@@ -1077,12 +1078,12 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 
 #ifdef MG_ENTERPRISE
   bool IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const {
-    if (!auth_checker_) return true;
+    if (!has_property_restrictions_) return true;
     return CheckPropertyPermission(accessor, prop);
   }
 
   bool IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const {
-    if (!auth_checker_) return true;
+    if (!has_property_restrictions_) return true;
     return CheckPropertyPermission(accessor, prop);
   }
 #else
@@ -1211,6 +1212,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   const QueryUserOrRole *triggering_user_;
 #ifdef MG_ENTERPRISE
   FineGrainedAuthChecker *auth_checker_{nullptr};
+  bool has_property_restrictions_{false};
 #endif
 };  // namespace memgraph::query
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1076,8 +1076,15 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   }
 
 #ifdef MG_ENTERPRISE
-  bool IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const;
-  bool IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const;
+  bool IsPropertyAllowed(VertexAccessor const &accessor, storage::PropertyId prop) const {
+    if (!auth_checker_) return true;
+    return CheckPropertyPermission(accessor, prop);
+  }
+
+  bool IsPropertyAllowed(EdgeAccessor const &accessor, storage::PropertyId prop) const {
+    if (!auth_checker_) return true;
+    return CheckPropertyPermission(accessor, prop);
+  }
 #else
   template <typename T>
     requires std::same_as<T, VertexAccessor> || std::same_as<T, EdgeAccessor>
@@ -1182,6 +1189,11 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   storage::LabelId GetLabel(const LabelIx &label) const { return ctx_->labels[label.ix]; }
 
   storage::EdgeTypeId GetEdgeType(const EdgeTypeIx &edgetype) const { return ctx_->edgetypes[edgetype.ix]; }
+
+#ifdef MG_ENTERPRISE
+  bool CheckPropertyPermission(VertexAccessor const &accessor, storage::PropertyId prop) const;
+  bool CheckPropertyPermission(EdgeAccessor const &accessor, storage::PropertyId prop) const;
+#endif
 
   Frame *frame_;
   const SymbolTable *symbol_table_;

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -257,7 +257,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
         triggering_user_(context.triggering_user.get())
 #ifdef MG_ENTERPRISE
         ,
-        auth_checker_(context.auth_checker.get()),
+        auth_checker_(context.auth_checker),
         has_property_restrictions_(context.has_property_restrictions)
 #endif
   {
@@ -1211,7 +1211,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   const QueryUserOrRole *user_or_role_;
   const QueryUserOrRole *triggering_user_;
 #ifdef MG_ENTERPRISE
-  FineGrainedAuthChecker *auth_checker_{nullptr};
+  FineGrainedAuthChecker const *auth_checker_{nullptr};
   bool has_property_restrictions_{false};
 #endif
 };  // namespace memgraph::query

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3227,8 +3227,6 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
   ctx_.user_or_role = user_or_role;  // Deep copy is not needed here, since it is only used in the current thread
 #ifdef MG_ENTERPRISE
   if (auth_checker) {
-    ctx_.has_property_restrictions = !auth_checker->HasUnrestrictedAccessToVertexProperties() ||
-                                     !auth_checker->HasUnrestrictedAccessToEdgeTypeProperties();
     ctx_.auth_checker = auth_checker;
   }
 #else

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3651,7 +3651,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                               std::move(stopping_context),
                                               dbms::DatabaseProtector{*current_db.db_acc_}.clone(),
                                               *(*current_db.db_acc_)->metric_handles(),
-                                              interpreter.cached_auth_checker_.get(),
+                                              interpreter.cached_fga_.get(),
                                               trigger_context_collector,
                                               memory_limit,
                                               frame_change_collector->AnyCaches() ? frame_change_collector : nullptr,
@@ -3862,7 +3862,7 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                                          db_acc = *current_db.db_acc_,
                                          hops_limit,
                                          db_arena_pool = &current_db.db_acc_->get()->Arena(),
-                                         cached_auth_checker = interpreter.cached_auth_checker_.get()
+                                         cached_auth_checker = interpreter.cached_fga_.get()
 #ifdef MG_ENTERPRISE
                                              ,
                                          parallel_execution,
@@ -9948,19 +9948,19 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
       auto *dba = &*current_db_.execution_db_accessor_;
       auto const current_db = dba->DatabaseName();
-      if (cached_auth_checker_ && auth_checker_db_name_ == current_db) {
-        cached_auth_checker_->UpdateDbAccessor(dba);
+      if (cached_fga_.checked && cached_fga_.db_name == current_db) {
+        if (cached_fga_.checker) cached_fga_.checker->UpdateDbAccessor(dba);
       } else {
-        cached_auth_checker_ = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
-        DMG_ASSERT(cached_auth_checker_, "Auth checker should not be null");
-        if (!cached_auth_checker_->NeedsFineGrainedAuthChecker()) {
-          cached_auth_checker_.reset();
+        cached_fga_.checker = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
+        DMG_ASSERT(cached_fga_.checker, "Auth checker should not be null");
+        if (!cached_fga_.checker->NeedsFineGrainedAuthChecker()) {
+          cached_fga_.checker.reset();
         }
-        auth_checker_db_name_ = current_db;
+        cached_fga_.db_name = current_db;
+        cached_fga_.checked = true;
       }
     } else {
-      cached_auth_checker_.reset();
-      auth_checker_db_name_.clear();
+      cached_fga_.Reset();
     }
 #endif
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3228,6 +3228,8 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
     auto auth_checker = interpreter_context->auth_checker->GetFineGrainedAuthChecker(*user_or_role, dba);
     DMG_ASSERT(auth_checker, "Auth checker should not be null");
     if (auth_checker->NeedsFineGrainedAuthChecker()) {
+      ctx_.has_property_restrictions = !auth_checker->HasUnrestrictedAccessToVertexProperties() ||
+                                       !auth_checker->HasUnrestrictedAccessToEdgeTypeProperties();
       ctx_.auth_checker = std::move(auth_checker);
     }
   }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10872,6 +10872,7 @@ void Interpreter::SetSessionIsolationLevel(const storage::IsolationLevel isolati
 #ifdef MG_ENTERPRISE
 void Interpreter::SetUser(std::shared_ptr<QueryUserOrRole> user_or_role,
                           std::shared_ptr<utils::UserResources> user_resource) {
+  ResetCachedFga();
   user_or_role_ = std::move(user_or_role);
   session_log_ctx_.SetUser((user_or_role_ && user_or_role_->username()) ? user_or_role_->username().value()
                                                                         : std::string{});
@@ -10890,6 +10891,7 @@ void Interpreter::SetUser(std::shared_ptr<QueryUserOrRole> user_or_role,
 }
 #else
 void Interpreter::SetUser(std::shared_ptr<QueryUserOrRole> user_or_role) {
+  ResetCachedFga();
   user_or_role_ = std::move(user_or_role);
   session_log_ctx_.SetUser((user_or_role_ && user_or_role_->username()) ? user_or_role_->username().value()
                                                                         : std::string{});

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3226,9 +3226,7 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
   ctx_.evaluation_context.edgetypes = NamesToEdgeTypes(plan->ast_storage().edge_types_, dba);
   ctx_.user_or_role = user_or_role;  // Deep copy is not needed here, since it is only used in the current thread
 #ifdef MG_ENTERPRISE
-  if (auth_checker) {
-    ctx_.auth_checker = auth_checker;
-  }
+  ctx_.auth_checker = auth_checker;
 #else
   (void)auth_checker;  // [[maybe_unused]] would be better for this community-only
                        // warning, but the PullPlan constructor argument list

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3230,6 +3230,10 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
                                      !auth_checker->HasUnrestrictedAccessToEdgeTypeProperties();
     ctx_.auth_checker = auth_checker;
   }
+#else
+  (void)auth_checker;  // [[maybe_unused]] would be better for this community-only
+                       // warning, but the PullPlan constructor argument list
+                       // is already too dense to read clearly.
 #endif
   ctx_.stopping_context = std::move(stopping_context);
   ctx_.is_profile_query = is_profile_query;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -64,6 +64,7 @@
 #include "memory/query_memory_control.hpp"
 #include "metrics/prometheus_metrics.hpp"
 #include "parameters/parameters.hpp"
+#include "query/auth_checker.hpp"
 #include "query/auth_query_handler.hpp"
 #include "query/common.hpp"
 #include "query/config.hpp"
@@ -3372,15 +3373,24 @@ void AccessorCompliance(PlanWrapper &plan, DbAccessor &dba) {
 
 }  // namespace
 
-Interpreter::Interpreter(InterpreterContext *interpreter_context) : interpreter_context_(interpreter_context) {
+Interpreter::Interpreter(InterpreterContext *interpreter_context)
+    : cached_fga_(std::make_unique<CachedFineGrainedAuth>()), interpreter_context_(interpreter_context) {
   MG_ASSERT(interpreter_context_, "Interpreter context must not be NULL");
 }
 
 Interpreter::Interpreter(InterpreterContext *interpreter_context, memgraph::dbms::DatabaseAccess db)
-    : current_db_{std::move(db)}, interpreter_context_(interpreter_context) {
+    : cached_fga_(std::make_unique<CachedFineGrainedAuth>()),
+      current_db_{std::move(db)},
+      interpreter_context_(interpreter_context) {
   MG_ASSERT(current_db_.db_acc_, "Database accessor needs to be valid");
   MG_ASSERT(interpreter_context_, "Interpreter context must not be NULL");
 }
+
+Interpreter::~Interpreter() { Abort(); }
+
+void Interpreter::ResetCachedFga() { cached_fga_->Reset(); }
+
+FineGrainedAuthChecker const *Interpreter::GetCachedFga() const { return cached_fga_->get(); }
 
 auto DetermineTxTimeout(std::optional<int64_t> tx_timeout_ms, InterpreterConfig const &config) -> TxTimeout {
   using double_seconds = std::chrono::duration<double>;
@@ -3651,7 +3661,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                               std::move(stopping_context),
                                               dbms::DatabaseProtector{*current_db.db_acc_}.clone(),
                                               *(*current_db.db_acc_)->metric_handles(),
-                                              interpreter.cached_fga_.get(),
+                                              interpreter.GetCachedFga(),
                                               trigger_context_collector,
                                               memory_limit,
                                               frame_change_collector->AnyCaches() ? frame_change_collector : nullptr,
@@ -3862,7 +3872,7 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                                          db_acc = *current_db.db_acc_,
                                          hops_limit,
                                          db_arena_pool = &current_db.db_acc_->get()->Arena(),
-                                         cached_auth_checker = interpreter.cached_fga_.get()
+                                         cached_auth_checker = interpreter.GetCachedFga()
 #ifdef MG_ENTERPRISE
                                              ,
                                          parallel_execution,
@@ -9948,19 +9958,19 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
       auto *dba = &*current_db_.execution_db_accessor_;
       auto const current_db = dba->DatabaseName();
-      if (cached_fga_.checked && cached_fga_.db_name == current_db) {
-        if (cached_fga_.checker) cached_fga_.checker->UpdateDbAccessor(dba);
+      if (cached_fga_->checked && cached_fga_->db_name == current_db) {
+        if (cached_fga_->checker) cached_fga_->checker->UpdateDbAccessor(dba);
       } else {
-        cached_fga_.checker = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
-        DMG_ASSERT(cached_fga_.checker, "Auth checker should not be null");
-        if (!cached_fga_.checker->NeedsFineGrainedAuthChecker()) {
-          cached_fga_.checker.reset();
+        cached_fga_->checker = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
+        DMG_ASSERT(cached_fga_->checker, "Auth checker should not be null");
+        if (!cached_fga_->checker->NeedsFineGrainedAuthChecker()) {
+          cached_fga_->checker.reset();
         }
-        cached_fga_.db_name = current_db;
-        cached_fga_.checked = true;
+        cached_fga_->db_name = current_db;
+        cached_fga_->checked = true;
       }
     } else {
-      cached_fga_.Reset();
+      cached_fga_->Reset();
     }
 #endif
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9956,18 +9956,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
 #ifdef MG_ENTERPRISE
     if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
       auto *dba = &*current_db_.execution_db_accessor_;
-      auto current_db = dba->DatabaseName();
-      if (cached_fga_->checked && cached_fga_->db_name == current_db) {
-        if (cached_fga_->checker) cached_fga_->checker->UpdateDbAccessor(dba);
-      } else {
-        cached_fga_->checker = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
-        DMG_ASSERT(cached_fga_->checker, "Auth checker should not be null");
-        if (!cached_fga_->checker->NeedsFineGrainedAuthChecker()) {
-          cached_fga_->checker.reset();
-        }
-        cached_fga_->db_name = std::move(current_db);
-        cached_fga_->checked = true;
-      }
+      cached_fga_->Refresh(*interpreter_context_->auth_checker, *user_or_role_, dba, dba->DatabaseName());
     } else {
       cached_fga_->Reset();
     }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3386,6 +3386,7 @@ Interpreter::Interpreter(InterpreterContext *interpreter_context, memgraph::dbms
 
 Interpreter::~Interpreter() { Abort(); }
 
+// NOLINTNEXTLINE(readability-make-member-function-const)
 void Interpreter::ResetCachedFga() { cached_fga_->Reset(); }
 
 FineGrainedAuthChecker const *Interpreter::GetCachedFga() const { return cached_fga_->get(); }
@@ -9955,7 +9956,8 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
 #ifdef MG_ENTERPRISE
     if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
       auto *dba = &*current_db_.execution_db_accessor_;
-      if (cached_fga_->checked && cached_fga_->db_name == dba->DatabaseNameView()) {
+      auto current_db = dba->DatabaseName();
+      if (cached_fga_->checked && cached_fga_->db_name == current_db) {
         if (cached_fga_->checker) cached_fga_->checker->UpdateDbAccessor(dba);
       } else {
         cached_fga_->checker = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
@@ -9963,7 +9965,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
         if (!cached_fga_->checker->NeedsFineGrainedAuthChecker()) {
           cached_fga_->checker.reset();
         }
-        cached_fga_->db_name = dba->DatabaseName();
+        cached_fga_->db_name = std::move(current_db);
         cached_fga_->checked = true;
       }
     } else {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3136,6 +3136,7 @@ struct PullPlan {
                     DbAccessor *dba, InterpreterContext *interpreter_context, utils::MemoryResource *execution_memory,
                     std::shared_ptr<QueryUserOrRole> user_or_role, StoppingContext stopping_context,
                     storage::DatabaseProtectorPtr protector, metrics::DatabaseMetricHandles &metric_handles,
+                    FineGrainedAuthChecker const *auth_checker = nullptr,
                     TriggerContextCollector *trigger_context_collector = nullptr,
                     std::optional<size_t> memory_limit = {}, FrameChangeCollector *frame_change_collector_ = nullptr,
                     std::optional<int64_t> hops_limit = {}, utils::PriorityThreadPool *worker_pool = nullptr,
@@ -3179,9 +3180,10 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
                    DbAccessor *dba, InterpreterContext *interpreter_context, utils::MemoryResource *execution_memory,
                    std::shared_ptr<QueryUserOrRole> user_or_role, StoppingContext stopping_context,
                    storage::DatabaseProtectorPtr protector, metrics::DatabaseMetricHandles &metric_handles,
-                   TriggerContextCollector *trigger_context_collector, const std::optional<size_t> memory_limit,
-                   FrameChangeCollector *frame_change_collector, const std::optional<int64_t> hops_limit,
-                   utils::PriorityThreadPool *worker_pool, memory::ArenaPool *db_arena_pool
+                   FineGrainedAuthChecker const *auth_checker, TriggerContextCollector *trigger_context_collector,
+                   const std::optional<size_t> memory_limit, FrameChangeCollector *frame_change_collector,
+                   const std::optional<int64_t> hops_limit, utils::PriorityThreadPool *worker_pool,
+                   memory::ArenaPool *db_arena_pool
 #ifdef MG_ENTERPRISE
                    ,
                    std::optional<size_t> parallel_execution, std::shared_ptr<utils::UserResources> user_resource
@@ -3223,15 +3225,10 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
   ctx_.evaluation_context.edgetypes = NamesToEdgeTypes(plan->ast_storage().edge_types_, dba);
   ctx_.user_or_role = user_or_role;  // Deep copy is not needed here, since it is only used in the current thread
 #ifdef MG_ENTERPRISE
-  if (license::global_license_checker.IsEnterpriseValidFast() && user_or_role && *user_or_role && dba) {
-    // Create only if an explicit user is defined
-    auto auth_checker = interpreter_context->auth_checker->GetFineGrainedAuthChecker(*user_or_role, dba);
-    DMG_ASSERT(auth_checker, "Auth checker should not be null");
-    if (auth_checker->NeedsFineGrainedAuthChecker()) {
-      ctx_.has_property_restrictions = !auth_checker->HasUnrestrictedAccessToVertexProperties() ||
-                                       !auth_checker->HasUnrestrictedAccessToEdgeTypeProperties();
-      ctx_.auth_checker = std::move(auth_checker);
-    }
+  if (auth_checker) {
+    ctx_.has_property_restrictions = !auth_checker->HasUnrestrictedAccessToVertexProperties() ||
+                                     !auth_checker->HasUnrestrictedAccessToEdgeTypeProperties();
+    ctx_.auth_checker = auth_checker;
   }
 #endif
   ctx_.stopping_context = std::move(stopping_context);
@@ -3650,6 +3647,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                               std::move(stopping_context),
                                               dbms::DatabaseProtector{*current_db.db_acc_}.clone(),
                                               *(*current_db.db_acc_)->metric_handles(),
+                                              interpreter.cached_auth_checker_,
                                               trigger_context_collector,
                                               memory_limit,
                                               frame_change_collector->AnyCaches() ? frame_change_collector : nullptr,
@@ -3859,9 +3857,10 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                                          stopping_context = std::move(stopping_context),
                                          db_acc = *current_db.db_acc_,
                                          hops_limit,
-                                         db_arena_pool = &current_db.db_acc_->get()->Arena()
+                                         db_arena_pool = &current_db.db_acc_->get()->Arena(),
+                                         cached_auth_checker = interpreter.cached_auth_checker_
 #ifdef MG_ENTERPRISE
-                                             ,
+                                         ,
                                          parallel_execution,
                                          user_resource = std::move(user_resource)
 #endif
@@ -3879,6 +3878,7 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                                         std::move(stopping_context),
                                         dbms::DatabaseProtector{db_acc}.clone(),
                                         *db_acc->metric_handles(),
+                                        cached_auth_checker,
                                         nullptr,
                                         memory_limit,
                                         frame_change_collector->AnyInListCaches() ? frame_change_collector : nullptr,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3651,7 +3651,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                               std::move(stopping_context),
                                               dbms::DatabaseProtector{*current_db.db_acc_}.clone(),
                                               *(*current_db.db_acc_)->metric_handles(),
-                                              interpreter.cached_auth_checker_,
+                                              interpreter.cached_auth_checker_.get(),
                                               trigger_context_collector,
                                               memory_limit,
                                               frame_change_collector->AnyCaches() ? frame_change_collector : nullptr,
@@ -3862,9 +3862,9 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                                          db_acc = *current_db.db_acc_,
                                          hops_limit,
                                          db_arena_pool = &current_db.db_acc_->get()->Arena(),
-                                         cached_auth_checker = interpreter.cached_auth_checker_
+                                         cached_auth_checker = interpreter.cached_auth_checker_.get()
 #ifdef MG_ENTERPRISE
-                                         ,
+                                             ,
                                          parallel_execution,
                                          user_resource = std::move(user_resource)
 #endif
@@ -9943,6 +9943,26 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
           .exception_occurred = parallel_execution ? std::make_shared<std::atomic<uint8_t>>(false) : nullptr,
       };
     };
+
+#ifdef MG_ENTERPRISE
+    if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
+      auto *dba = &*current_db_.execution_db_accessor_;
+      auto const current_db = dba->DatabaseName();
+      if (cached_auth_checker_ && auth_checker_db_name_ == current_db) {
+        cached_auth_checker_->UpdateDbAccessor(dba);
+      } else {
+        cached_auth_checker_ = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
+        DMG_ASSERT(cached_auth_checker_, "Auth checker should not be null");
+        if (!cached_auth_checker_->NeedsFineGrainedAuthChecker()) {
+          cached_auth_checker_.reset();
+        }
+        auth_checker_db_name_ = current_db;
+      }
+    } else {
+      cached_auth_checker_.reset();
+      auth_checker_db_name_.clear();
+    }
+#endif
 
     if (utils::Downcast<CypherQuery>(parsed_query.query)) {
       prepared_query = PrepareCypherQuery(std::move(parsed_query),

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9954,7 +9954,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
 #ifdef MG_ENTERPRISE
     if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
       auto *dba = &*current_db_.execution_db_accessor_;
-      cached_fga_->Refresh(*interpreter_context_->auth_checker, *user_or_role_, dba, *dba->DatabaseNameView());
+      cached_fga_->Refresh(*interpreter_context_->auth_checker, *user_or_role_, dba, dba->DatabaseName());
     } else {
       cached_fga_->Reset();
     }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9955,8 +9955,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
 #ifdef MG_ENTERPRISE
     if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
       auto *dba = &*current_db_.execution_db_accessor_;
-      auto const current_db = dba->DatabaseName();
-      if (cached_fga_->checked && cached_fga_->db_name == current_db) {
+      if (cached_fga_->checked && cached_fga_->db_name == dba->DatabaseNameView()) {
         if (cached_fga_->checker) cached_fga_->checker->UpdateDbAccessor(dba);
       } else {
         cached_fga_->checker = interpreter_context_->auth_checker->GetFineGrainedAuthChecker(*user_or_role_, dba);
@@ -9964,7 +9963,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
         if (!cached_fga_->checker->NeedsFineGrainedAuthChecker()) {
           cached_fga_->checker.reset();
         }
-        cached_fga_->db_name = current_db;
+        cached_fga_->db_name = dba->DatabaseName();
         cached_fga_->checked = true;
       }
     } else {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9954,7 +9954,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
 #ifdef MG_ENTERPRISE
     if (current_db_.execution_db_accessor_ && interpreter_context_->auth_checker && user_or_role_ && *user_or_role_) {
       auto *dba = &*current_db_.execution_db_accessor_;
-      cached_fga_->Refresh(*interpreter_context_->auth_checker, *user_or_role_, dba, dba->DatabaseName());
+      cached_fga_->Refresh(*interpreter_context_->auth_checker, *user_or_role_, dba, *dba->DatabaseNameView());
     } else {
       cached_fga_->Reset();
     }

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -20,6 +20,7 @@
 #include "dbms/database_protector.hpp"
 #include "flags/run_time_configurable.hpp"
 #include "memory/db_arena_fwd.hpp"
+#include "query/auth_checker.hpp"
 #include "query/context.hpp"
 #include "query/db_accessor.hpp"
 #include "query/plan_v2/frontend/query_planner_context.hpp"
@@ -307,7 +308,8 @@ class Interpreter final {
 #ifdef MG_ENTERPRISE
   std::shared_ptr<utils::UserResources> user_resource_;
 #endif
-  FineGrainedAuthChecker const *cached_auth_checker_{nullptr};
+  std::unique_ptr<FineGrainedAuthChecker> cached_auth_checker_;
+  std::string auth_checker_db_name_;
   SessionInfo session_info_;
   bool in_explicit_transaction_{false};
   CurrentDB current_db_;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -308,8 +308,7 @@ class Interpreter final {
 #ifdef MG_ENTERPRISE
   std::shared_ptr<utils::UserResources> user_resource_;
 #endif
-  std::unique_ptr<FineGrainedAuthChecker> cached_auth_checker_;
-  std::string auth_checker_db_name_;
+  CachedFineGrainedAuth cached_fga_;
   SessionInfo session_info_;
   bool in_explicit_transaction_{false};
   CurrentDB current_db_;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -307,6 +307,7 @@ class Interpreter final {
 #ifdef MG_ENTERPRISE
   std::shared_ptr<utils::UserResources> user_resource_;
 #endif
+  FineGrainedAuthChecker const *cached_auth_checker_{nullptr};
   SessionInfo session_info_;
   bool in_explicit_transaction_{false};
   CurrentDB current_db_;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -20,7 +20,6 @@
 #include "dbms/database_protector.hpp"
 #include "flags/run_time_configurable.hpp"
 #include "memory/db_arena_fwd.hpp"
-#include "query/auth_checker.hpp"
 #include "query/context.hpp"
 #include "query/db_accessor.hpp"
 #include "query/plan_v2/frontend/query_planner_context.hpp"
@@ -43,6 +42,9 @@
 #endif
 
 namespace memgraph::query {
+
+class FineGrainedAuthChecker;
+struct CachedFineGrainedAuth;
 
 struct QueryAllocator {
   explicit QueryAllocator(utils::MemoryTracker *db_query_tracker = nullptr)
@@ -280,7 +282,10 @@ class Interpreter final {
   Interpreter(Interpreter &&) = delete;
   Interpreter &operator=(Interpreter &&) = delete;
 
-  ~Interpreter() { Abort(); }
+  ~Interpreter();
+
+  void ResetCachedFga();
+  FineGrainedAuthChecker const *GetCachedFga() const;
 
   struct PrepareResult {
     std::vector<std::string> headers;
@@ -308,7 +313,7 @@ class Interpreter final {
 #ifdef MG_ENTERPRISE
   std::shared_ptr<utils::UserResources> user_resource_;
 #endif
-  CachedFineGrainedAuth cached_fga_;
+  std::unique_ptr<CachedFineGrainedAuth> cached_fga_;
   SessionInfo session_info_;
   bool in_explicit_transaction_{false};
   CurrentDB current_db_;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -6448,7 +6448,7 @@ class AggregateCursor : public Cursor {
 
   bool ProcessAll(Frame *frame, ExecutionContext *context) {
     db_accessor_ = context->db_accessor;
-    auth_checker_ = context->auth_checker.get();
+    auth_checker_ = context->auth_checker;
     MG_ASSERT(db_accessor_, "Aggregation expects a current DB transaction");
     ExpressionEvaluator evaluator =
         ExpressionEvaluator{frame, *context, storage::View::NEW, nullptr, &context->number_of_hops};

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -2890,7 +2890,7 @@ namespace {
 void NextPermittedEdge(mgp_edges_iterator::RealCursor &c, const mgp_vertex &source_vertex) {
   const auto *ctx = source_vertex.graph->ctx;
   if (!ctx || !ctx->auth_checker) return;
-  const auto *auth_checker = ctx->auth_checker.get();
+  const auto *auth_checker = ctx->auth_checker;
   const auto view = source_vertex.graph->view;
   while (c.it != c.edges.end()) {
     auto edgeAcc = *c.it;

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -270,13 +270,13 @@ void Trigger::Execute(DbAccessor *dba, dbms::DatabaseAccess db_acc, utils::Memor
   ctx.triggering_user = triggering_user;
 
 #ifdef MG_ENTERPRISE
+  std::unique_ptr<FineGrainedAuthChecker> fine_grained_checker;
   if (license::global_license_checker.IsEnterpriseValidFast() && auth_checker && ctx.user_or_role &&
       *ctx.user_or_role && dba) {
-    auto fine_grained_checker = auth_checker->GetFineGrainedAuthChecker(*ctx.user_or_role, dba);
+    fine_grained_checker = auth_checker->GetFineGrainedAuthChecker(*ctx.user_or_role, dba);
     DMG_ASSERT(fine_grained_checker, "Auth checker should not be null");
-    // Only assign the auth checker if the user has restricted access (LBAC or PBAC)
     if (fine_grained_checker->NeedsFineGrainedAuthChecker()) {
-      ctx.auth_checker = std::move(fine_grained_checker);
+      ctx.auth_checker = fine_grained_checker.get();
     }
   }
 #endif

--- a/tests/e2e/triggers/privilege_check.cpp
+++ b/tests/e2e/triggers/privilege_check.cpp
@@ -30,6 +30,7 @@ inline constexpr std::string_view kInvokerWithFineGrainedSet{"INVOKER_FG_SET"};
 inline constexpr std::string_view kInvokerWithoutFineGrainedSet{"INVOKER_FG_NO_SET"};
 inline constexpr std::string_view kDefinerWithFineGrainedSet{"DEFINER_FG_SET"};
 inline constexpr std::string_view kDefinerWithoutFineGrainedSet{"DEFINER_FG_NO_SET"};
+inline constexpr std::string_view kPbacUser{"PBAC_USER"};
 inline constexpr std::string_view kTriggerProperty{"triggered"};
 
 void CreateUser(mg::Client &client, std::string_view username) {
@@ -158,6 +159,13 @@ class PrivilegeCheckTest : public ::testing::TestWithParam<std::string> {
       admin_client_->Execute(fmt::format("GRANT READ, SET PROPERTY {{*}} ON NODES CONTAINING LABELS * TO {};", user));
       admin_client_->DiscardAll();
     }
+
+    // PBAC test user: full privileges but READ denied on property "secret"
+    CreateUser(*admin_client_, kPbacUser);
+    GrantAllPrivileges(*admin_client_, kPbacUser);
+    admin_client_->Execute(
+        fmt::format("DENY READ {{secret}} ON NODES CONTAINING LABELS :{} TO {};", kVertexLabel, kPbacUser));
+    admin_client_->DiscardAll();
   }
 
   static void TearDownTestSuite() {
@@ -168,6 +176,7 @@ class PrivilegeCheckTest : public ::testing::TestWithParam<std::string> {
     DropUser(*admin_client_, kInvokerWithFineGrainedSet);
     DropUser(*admin_client_, kInvokerWithoutFineGrainedSet);
     DropUser(*admin_client_, kDefinerWithFineGrainedSet);
+    DropUser(*admin_client_, kPbacUser);
 
     admin_client_.reset();
   }
@@ -412,6 +421,47 @@ TEST_P(PrivilegeCheckTest, DefinerFineGrainedNoSet) {
 
   CleanupVertices(*admin_client_);
   DropTrigger(*admin_client_, "DefinerFGNoSet");
+}
+
+TEST_P(PrivilegeCheckTest, InvokerPropertyDeniedRead) {
+  const std::string &phase = GetParam();
+  const bool is_after = (phase == "AFTER");
+
+  auto pbac_client = ConnectWithUser(kPbacUser);
+
+  // Trigger copies v.secret into v.result. If PBAC is enforced, v.secret is
+  // null.
+  pbac_client->Execute(
+      fmt::format("CREATE TRIGGER PbacReadDeny SECURITY INVOKER ON CREATE "
+                  "{} COMMIT EXECUTE "
+                  "UNWIND createdVertices AS v "
+                  "SET v.result = v.secret",
+                  phase));
+  pbac_client->DiscardAll();
+
+  // Create a vertex with a secret property
+  mg::Map params{{"id", mg::Value{kVertexId}}, {"secret", mg::Value{42}}};
+  pbac_client->Execute(fmt::format("CREATE (n:{} {{id: $id, secret: $secret}})", kVertexLabel),
+                       mg::ConstMap{params.ptr()});
+  pbac_client->DiscardAll();
+
+  mg::Map query_params{{"id", mg::Value{kVertexId}}};
+  auto const check_result = [&]() {
+    pbac_client->Execute(fmt::format("MATCH (n:{} {{id: $id}}) RETURN n.result AS result", kVertexLabel),
+                         mg::ConstMap{query_params.ptr()});
+    auto result = pbac_client->FetchAll();
+    if (!result || result->empty()) return false;
+    return result->at(0)[0].type() == mg::Value::Type::Null;
+  };
+
+  if (is_after) {
+    EXPECT_TRUE(PollUntilTrue(check_result)) << "Trigger should not be able to read denied property";
+  } else {
+    EXPECT_TRUE(check_result()) << "Trigger should not be able to read denied property";
+  }
+
+  CleanupVertices(*admin_client_);
+  DropTrigger(*admin_client_, "PbacReadDeny");
 }
 
 INSTANTIATE_TEST_SUITE_P(TriggerPhases, PrivilegeCheckTest, testing::Values("BEFORE", "AFTER"),

--- a/tests/e2e/triggers/privilege_check.cpp
+++ b/tests/e2e/triggers/privilege_check.cpp
@@ -429,13 +429,14 @@ TEST_P(PrivilegeCheckTest, InvokerPropertyDeniedRead) {
 
   auto pbac_client = ConnectWithUser(kPbacUser);
 
-  // Trigger copies v.secret into v.result. If PBAC is enforced, v.secret is
-  // null.
+  // Trigger copies v.secret (denied) into v.result, and v.id (allowed) into
+  // v.control. If PBAC is enforced, v.result is null; v.control proves the
+  // trigger actually ran.
   pbac_client->Execute(
       fmt::format("CREATE TRIGGER PbacReadDeny SECURITY INVOKER ON CREATE "
                   "{} COMMIT EXECUTE "
                   "UNWIND createdVertices AS v "
-                  "SET v.result = v.secret",
+                  "SET v.result = v.secret, v.control = v.id",
                   phase));
   pbac_client->DiscardAll();
 
@@ -448,11 +449,14 @@ TEST_P(PrivilegeCheckTest, InvokerPropertyDeniedRead) {
   mg::Map query_params{{"id", mg::Value{kVertexId}}};
   auto const check_result = [&]() {
     try {
-      pbac_client->Execute(fmt::format("MATCH (n:{} {{id: $id}}) RETURN n.result AS result", kVertexLabel),
-                           mg::ConstMap{query_params.ptr()});
+      pbac_client->Execute(
+          fmt::format("MATCH (n:{} {{id: $id}}) RETURN n.result AS result, n.control AS control", kVertexLabel),
+          mg::ConstMap{query_params.ptr()});
       auto result = pbac_client->FetchAll();
       if (!result || result->empty()) return false;
-      return result->at(0)[0].type() == mg::Value::Type::Null;
+      auto const &row = result->at(0);
+      // control must be non-null (trigger ran), result must be null (denied read)
+      return row[1].type() != mg::Value::Type::Null && row[0].type() == mg::Value::Type::Null;
     } catch (mg::ClientException const &) {
       return false;
     }

--- a/tests/e2e/triggers/privilege_check.cpp
+++ b/tests/e2e/triggers/privilege_check.cpp
@@ -446,21 +446,18 @@ TEST_P(PrivilegeCheckTest, InvokerPropertyDeniedRead) {
   pbac_client->DiscardAll();
 
   mg::Map query_params{{"id", mg::Value{kVertexId}}};
-  auto const check_result = [&]() -> std::optional<bool> {
+  auto const check_result = [&]() {
     pbac_client->Execute(fmt::format("MATCH (n:{} {{id: $id}}) RETURN n.result AS result", kVertexLabel),
                          mg::ConstMap{query_params.ptr()});
     auto result = pbac_client->FetchAll();
-    if (!result || result->empty()) return std::nullopt;
+    if (!result || result->empty()) return false;
     return result->at(0)[0].type() == mg::Value::Type::Null;
   };
 
   if (is_after) {
-    EXPECT_TRUE(PollUntilTrue([&]() { return check_result().value_or(false); }))
-        << "Trigger should not be able to read denied property";
+    EXPECT_TRUE(PollUntilTrue(check_result)) << "Trigger should not be able to read denied property";
   } else {
-    auto res = check_result();
-    ASSERT_TRUE(res.has_value()) << "Vertex should exist after CREATE";
-    EXPECT_TRUE(*res) << "Trigger should not be able to read denied property";
+    EXPECT_TRUE(check_result()) << "Trigger should not be able to read denied property";
   }
 
   CleanupVertices(*admin_client_);

--- a/tests/e2e/triggers/privilege_check.cpp
+++ b/tests/e2e/triggers/privilege_check.cpp
@@ -446,18 +446,21 @@ TEST_P(PrivilegeCheckTest, InvokerPropertyDeniedRead) {
   pbac_client->DiscardAll();
 
   mg::Map query_params{{"id", mg::Value{kVertexId}}};
-  auto const check_result = [&]() {
+  auto const check_result = [&]() -> std::optional<bool> {
     pbac_client->Execute(fmt::format("MATCH (n:{} {{id: $id}}) RETURN n.result AS result", kVertexLabel),
                          mg::ConstMap{query_params.ptr()});
     auto result = pbac_client->FetchAll();
-    if (!result || result->empty()) return false;
+    if (!result || result->empty()) return std::nullopt;
     return result->at(0)[0].type() == mg::Value::Type::Null;
   };
 
   if (is_after) {
-    EXPECT_TRUE(PollUntilTrue(check_result)) << "Trigger should not be able to read denied property";
+    EXPECT_TRUE(PollUntilTrue([&]() { return check_result().value_or(false); }))
+        << "Trigger should not be able to read denied property";
   } else {
-    EXPECT_TRUE(check_result()) << "Trigger should not be able to read denied property";
+    auto res = check_result();
+    ASSERT_TRUE(res.has_value()) << "Vertex should exist after CREATE";
+    EXPECT_TRUE(*res) << "Trigger should not be able to read denied property";
   }
 
   CleanupVertices(*admin_client_);

--- a/tests/e2e/triggers/privilege_check.cpp
+++ b/tests/e2e/triggers/privilege_check.cpp
@@ -447,11 +447,15 @@ TEST_P(PrivilegeCheckTest, InvokerPropertyDeniedRead) {
 
   mg::Map query_params{{"id", mg::Value{kVertexId}}};
   auto const check_result = [&]() {
-    pbac_client->Execute(fmt::format("MATCH (n:{} {{id: $id}}) RETURN n.result AS result", kVertexLabel),
-                         mg::ConstMap{query_params.ptr()});
-    auto result = pbac_client->FetchAll();
-    if (!result || result->empty()) return false;
-    return result->at(0)[0].type() == mg::Value::Type::Null;
+    try {
+      pbac_client->Execute(fmt::format("MATCH (n:{} {{id: $id}}) RETURN n.result AS result", kVertexLabel),
+                           mg::ConstMap{query_params.ptr()});
+      auto result = pbac_client->FetchAll();
+      if (!result || result->empty()) return false;
+      return result->at(0)[0].type() == mg::Value::Type::Null;
+    } catch (mg::ClientException const &) {
+      return false;
+    }
   };
 
   if (is_after) {

--- a/tests/unit/auth_checker.cpp
+++ b/tests/unit/auth_checker.cpp
@@ -656,4 +656,41 @@ TYPED_TEST(FineGrainedAuthCheckerFixture, PropertyFGAGlobalGrantDeniedOnUnlabele
                                                  name_id,
                                                  memgraph::query::AuthQuery::PropertyPermissionType::READ));
 }
+
+TYPED_TEST(FineGrainedAuthCheckerFixture, CachedCheckerRebuildsOnLicenseActivation) {
+  namespace auth = memgraph::auth;
+  namespace query = memgraph::query;
+
+  std::filesystem::path auth_dir{std::filesystem::temp_directory_path() / "MG_cached_fga_license_test"};
+  memgraph::utils::OnScopeExit clean([&]() {
+    if (std::filesystem::exists(auth_dir)) std::filesystem::remove_all(auth_dir);
+  });
+
+  auth::SynchedAuth synched_auth(auth_dir, auth::Auth::Config{});
+  memgraph::glue::AuthChecker auth_checker(&synched_auth);
+
+  auto user = *synched_auth->AddUser("test_user");
+  user.fine_grained_access_handler().label_permissions().Grant({"l1"}, auth::kAllLabelPermissions);
+  user.fine_grained_access_handler().label_permissions().Deny({"l3"}, auth::kAllLabelPermissions);
+  synched_auth->SaveUser(user);
+
+  auto query_user = auth_checker.GenQueryUser("test_user", {});
+  ASSERT_TRUE(query_user && *query_user);
+
+  memgraph::license::global_license_checker.DisableTesting();
+
+  query::CachedFineGrainedAuth cache;
+  cache.Refresh(auth_checker, *query_user, &this->dba, this->dba.DatabaseName());
+  EXPECT_EQ(cache.get(), nullptr);
+
+  memgraph::license::global_license_checker.EnableTesting();
+
+  // Refresh should detect the license change and rebuild
+  cache.Refresh(auth_checker, *query_user, &this->dba, this->dba.DatabaseName());
+  ASSERT_NE(cache.get(), nullptr);
+
+  EXPECT_TRUE(cache.get()->Has(this->v1, memgraph::storage::View::NEW, query::AuthQuery::FineGrainedPrivilege::READ));
+  EXPECT_FALSE(cache.get()->Has(this->v3, memgraph::storage::View::NEW, query::AuthQuery::FineGrainedPrivilege::READ));
+}
+
 #endif

--- a/tests/unit/bfs_common.hpp
+++ b/tests/unit/bfs_common.hpp
@@ -579,8 +579,6 @@ class Database {
 
     memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
     context.auth_checker = &auth_checker;
-    context.has_property_restrictions = !auth_checker.HasUnrestrictedAccessToVertexProperties() ||
-                                        !auth_checker.HasUnrestrictedAccessToEdgeTypeProperties();
     // We run BFS once from each vertex for each blocked entity.
     input_operator = YieldVertices(&db_accessor, vertices, source_symbol, input_operator);
 

--- a/tests/unit/bfs_common.hpp
+++ b/tests/unit/bfs_common.hpp
@@ -579,6 +579,8 @@ class Database {
 
     memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
     context.auth_checker = &auth_checker;
+    context.has_property_restrictions = !auth_checker.HasUnrestrictedAccessToVertexProperties() ||
+                                        !auth_checker.HasUnrestrictedAccessToEdgeTypeProperties();
     // We run BFS once from each vertex for each blocked entity.
     input_operator = YieldVertices(&db_accessor, vertices, source_symbol, input_operator);
 

--- a/tests/unit/bfs_common.hpp
+++ b/tests/unit/bfs_common.hpp
@@ -578,7 +578,7 @@ class Database {
     }
 
     memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
-    context.auth_checker = std::make_unique<memgraph::glue::FineGrainedAuthChecker>(std::move(auth_checker));
+    context.auth_checker = &auth_checker;
     // We run BFS once from each vertex for each blocked entity.
     input_operator = YieldVertices(&db_accessor, vertices, source_symbol, input_operator);
 

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -543,8 +543,6 @@ class Database {
 
     memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
     context.auth_checker = &auth_checker;
-    context.has_property_restrictions = !auth_checker.HasUnrestrictedAccessToVertexProperties() ||
-                                        !auth_checker.HasUnrestrictedAccessToEdgeTypeProperties();
 
     // We run k-shortest paths for all possible source-sink pairs
     std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -542,7 +542,7 @@ class Database {
     }
 
     memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
-    context.auth_checker = std::make_unique<memgraph::glue::FineGrainedAuthChecker>(std::move(auth_checker));
+    context.auth_checker = &auth_checker;
 
     // We run k-shortest paths for all possible source-sink pairs
     std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -543,6 +543,8 @@ class Database {
 
     memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
     context.auth_checker = &auth_checker;
+    context.has_property_restrictions = !auth_checker.HasUnrestrictedAccessToVertexProperties() ||
+                                        !auth_checker.HasUnrestrictedAccessToEdgeTypeProperties();
 
     // We run k-shortest paths for all possible source-sink pairs
     std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;

--- a/tests/unit/query_plan_common.hpp
+++ b/tests/unit/query_plan_common.hpp
@@ -60,8 +60,6 @@ ExecutionContext MakeContextWithFineGrainedChecker(const AstStorage &storage, co
   context.evaluation_context.labels = NamesToLabels(storage.labels_, dba);
   context.evaluation_context.edgetypes = NamesToEdgeTypes(storage.edge_types_, dba);
   context.auth_checker = auth_checker;
-  context.has_property_restrictions = !auth_checker->HasUnrestrictedAccessToVertexProperties() ||
-                                      !auth_checker->HasUnrestrictedAccessToEdgeTypeProperties();
   context.metric_handles = &TestMetricHandles();
   return context;
 }

--- a/tests/unit/query_plan_common.hpp
+++ b/tests/unit/query_plan_common.hpp
@@ -60,6 +60,8 @@ ExecutionContext MakeContextWithFineGrainedChecker(const AstStorage &storage, co
   context.evaluation_context.labels = NamesToLabels(storage.labels_, dba);
   context.evaluation_context.edgetypes = NamesToEdgeTypes(storage.edge_types_, dba);
   context.auth_checker = auth_checker;
+  context.has_property_restrictions = !auth_checker->HasUnrestrictedAccessToVertexProperties() ||
+                                      !auth_checker->HasUnrestrictedAccessToEdgeTypeProperties();
   context.metric_handles = &TestMetricHandles();
   return context;
 }

--- a/tests/unit/query_plan_common.hpp
+++ b/tests/unit/query_plan_common.hpp
@@ -59,7 +59,7 @@ ExecutionContext MakeContextWithFineGrainedChecker(const AstStorage &storage, co
   context.evaluation_context.properties = NamesToProperties(storage.properties_, dba);
   context.evaluation_context.labels = NamesToLabels(storage.labels_, dba);
   context.evaluation_context.edgetypes = NamesToEdgeTypes(storage.edge_types_, dba);
-  context.auth_checker = std::make_unique<memgraph::glue::FineGrainedAuthChecker>(std::move(*auth_checker));
+  context.auth_checker = auth_checker;
   context.metric_handles = &TestMetricHandles();
   return context;
 }

--- a/tests/unit/query_plan_match_filter_return.cpp
+++ b/tests/unit/query_plan_match_filter_return.cpp
@@ -847,10 +847,13 @@ class QueryPlanExpandVariable : public testing::Test {
     Frame frame(symbol_table.max_position());
     auto cursor = input_op->MakeCursor(memgraph::utils::NewDeleteResource(), TestMetricHandles());
     ExecutionContext context;
+#ifdef MG_ENTERPRISE
+    std::optional<memgraph::glue::FineGrainedAuthChecker> auth_checker;
+#endif
     if (user) {
 #ifdef MG_ENTERPRISE
-      memgraph::glue::FineGrainedAuthChecker auth_checker{*user, &dba};
-      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &auth_checker);
+      auth_checker.emplace(*user, &dba);
+      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &*auth_checker);
 #endif
     } else {
       context = MakeContext(storage, symbol_table, &dba);
@@ -867,10 +870,13 @@ class QueryPlanExpandVariable : public testing::Test {
     Frame frame(symbol_table.max_position());
     auto cursor = input_op->MakeCursor(memgraph::utils::NewDeleteResource(), TestMetricHandles());
     ExecutionContext context;
+#ifdef MG_ENTERPRISE
+    std::optional<memgraph::glue::FineGrainedAuthChecker> auth_checker;
+#endif
     if (user) {
 #ifdef MG_ENTERPRISE
-      memgraph::glue::FineGrainedAuthChecker auth_checker{*user, &dba};
-      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &auth_checker);
+      auth_checker.emplace(*user, &dba);
+      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &*auth_checker);
 #endif
     } else {
       context = MakeContext(storage, symbol_table, &dba);
@@ -2055,10 +2061,13 @@ class QueryPlanExpandWeightedShortestPath : public testing::Test {
     auto cursor = last_op->MakeCursor(memgraph::utils::NewDeleteResource(), TestMetricHandles());
     std::vector<ResultType> results;
     memgraph::query::ExecutionContext context;
+#ifdef MG_ENTERPRISE
+    std::optional<memgraph::glue::FineGrainedAuthChecker> auth_checker;
+#endif
     if (user) {
 #ifdef MG_ENTERPRISE
-      memgraph::glue::FineGrainedAuthChecker auth_checker{*user, &dba};
-      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &auth_checker);
+      auth_checker.emplace(*user, &dba);
+      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &*auth_checker);
 #endif
     } else {
       context = MakeContext(storage, symbol_table, &dba);
@@ -2524,11 +2533,14 @@ class QueryPlanExpandAllShortestPaths : public testing::Test {
     Frame frame(symbol_table.max_position());
     auto cursor = last_op->MakeCursor(memgraph::utils::NewDeleteResource(), TestMetricHandles());
     std::vector<ResultType> results;
+#ifdef MG_ENTERPRISE
+    std::optional<memgraph::glue::FineGrainedAuthChecker> auth_checker;
+#endif
     ExecutionContext context;
     if (user) {
 #ifdef MG_ENTERPRISE
-      memgraph::glue::FineGrainedAuthChecker auth_checker{*user, &dba};
-      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &auth_checker);
+      auth_checker.emplace(*user, &dba);
+      context = MakeContextWithFineGrainedChecker(storage, symbol_table, &dba, &*auth_checker);
 #endif
     } else {
       context = MakeContext(storage, symbol_table, &dba);


### PR DESCRIPTION
Fix performance regressions introduced by property-based access control:

- Cache the `FineGrainedAuthChecker` at the session level during Prepare, avoiding recreation each query. Refresh only the `DbAccessor` pointer on cache hit.                                                                                   
- Add a fast-path in `FineGrainedAuthChecker::HasPropertyRestrictions()` to skip property permission checks when no property-level restrictions exist.                                                                         
- Reduce header coupling by pimpl'ing `CachedFineGrainedAuth` behind a `unique_ptr` in `Interpreter`, removing `auth_checker.hpp` from `interpreter.hpp`.
- Add e2e test for trigger property-based access control.

