### PR TITLE
feat: Remove deprecated HA flags

### DIFF
--- a/src/flags/coordination.cpp
+++ b/src/flags/coordination.cpp
@@ -27,23 +27,6 @@ DEFINE_VALIDATED_int32(coordinator_port, 0, "Port on which raft servers will be 
 // NOLINTEND(performance-avoid-endl)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_int32(coordinator_id, 0, "Unique ID of the raft server.");
-// NOLINTNEXTLINE
-DEFINE_VALIDATED_HIDDEN_uint32(
-    instance_down_timeout_sec, 5, "Time duration after which an instance is considered down.", {
-      spdlog::warn(
-          "The instance_down_timeout_sec flag is deprecated and its value is ignored. Please set this setting by "
-          "running \"SET COORDINATOR SETTING 'instance_down_timeout_sec' TO <YOUR-VALUE>\" query on any coordinator.");
-      return true;
-    });
-// NOLINTNEXTLINE
-DEFINE_VALIDATED_HIDDEN_uint32(
-    instance_health_check_frequency_sec, 1, "The time duration between two health checks/pings.", {
-      spdlog::warn(
-          "The instance_health_check_frequency_sec is deprecated and its value is ignored. Please set this setting by "
-          "running \"SET COORDINATOR SETTING 'instance_health_check_frequency_sec' TO <YOUR-VALUE>\" query on any "
-          "coordinator.");
-      return true;
-    });
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_string(nuraft_log_file, "", "Path to the file where NuRaft logs are saved.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/src/flags/coordination.hpp
+++ b/src/flags/coordination.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -20,10 +20,6 @@ DECLARE_int32(management_port);
 DECLARE_int32(coordinator_port);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_int32(coordinator_id);
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DECLARE_uint32(instance_down_timeout_sec);
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DECLARE_uint32(instance_health_check_frequency_sec);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_string(nuraft_log_file);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -639,13 +639,6 @@ int main(int argc, char **argv) {
               "flag.");
   }
 
-  if (std::chrono::seconds(FLAGS_instance_down_timeout_sec) <
-      std::chrono::seconds(FLAGS_instance_health_check_frequency_sec)) {
-    LOG_FATAL(
-        "Instance down timeout config option must be greater than or equal to instance health check frequency config "
-        "option!");
-  }
-
 #endif
 
   // Default interpreter configuration

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -15,13 +15,7 @@ from functools import partial
 
 import interactive_mg_runner
 import pytest
-from common import (
-    connect,
-    execute_and_fetch_all,
-    get_data_path,
-    get_logs_path,
-    show_instances,
-)
+from common import connect, execute_and_fetch_all, get_data_path, get_logs_path, show_instances
 from mg_utils import mg_sleep_and_assert
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -45,10 +39,6 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--management-port",
             "10011",
             "--also-log-to-stderr",
-            "--instance-health-check-frequency-sec",
-            "1",
-            "--instance-down-timeout-sec",
-            "5",
         ],
         "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
         "data_directory": f"{get_data_path(file, test_name)}/instance_1",
@@ -63,10 +53,6 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--management-port",
             "10012",
             "--also-log-to-stderr",
-            "--instance-health-check-frequency-sec",
-            "1",
-            "--instance-down-timeout-sec",
-            "5",
         ],
         "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
         "data_directory": f"{get_data_path(file, test_name)}/instance_2",
@@ -81,10 +67,6 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--management-port",
             "10013",
             "--also-log-to-stderr",
-            "--instance-health-check-frequency-sec",
-            "5",
-            "--instance-down-timeout-sec",
-            "10",
         ],
         "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
         "data_directory": f"{get_data_path(file, test_name)}/instance_3",

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -1878,11 +1878,6 @@ def test_coordinator_user_action_demote_instance_to_replica(test_name):
     # 1
     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
 
-    FAILOVER_PERIOD = 2
-    inner_instances_description["instance_1"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-    inner_instances_description["instance_2"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-    inner_instances_description["instance_3"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -1963,7 +1958,7 @@ def test_coordinator_user_action_demote_instance_to_replica(test_name):
         execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
     assert str(e.value) == "Show replicas query should only be run on the main instance."
 
-    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3), FAILOVER_PERIOD + 1)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
     mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
     mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 


### PR DESCRIPTION
Removes deprecated HA flags from 3.10: `--instance-down-timeout-sec`, `--instance-health-check-frequency-sec`.