### PR TITLE
fix: Abort replication on shutdown

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -14,6 +14,7 @@
 #include "dbms/dbms_handler.hpp"
 #include "memory/db_arena_fwd.hpp"
 #include "rpc/file_replication_handler.hpp"
+#include "rpc/protocol.hpp"
 #include "rpc/utils.hpp"  // Include after all SLK definitions are present
 #include "storage/v2/constraints/type_constraints_kind.hpp"
 #include "storage/v2/durability/snapshot.hpp"
@@ -58,7 +59,14 @@ class SnapshotObserver final : public utils::Observer<void> {
 
   void Update() override {
     auto guard = std::lock_guard{mtx_};
-    rpc::SendInProgressMsg(res_builder_);
+    try {
+      rpc::SendInProgressMsg(res_builder_);
+    } catch (const rpc::SessionException &e) {
+      // Progress heartbeats are advisory. If the peer is (temporarily) gone the send fails, but recovery must neither
+      // crash nor abort: the loaded state stands and main reconciles it via a later heartbeat RPC once reconnected.
+      // No latch: the next Update() retries on a now-clean builder (see slk::Builder::FlushInternal).
+      spdlog::trace("Failed to send recovery progress heartbeat: {}", e.what());
+    }
   }
 
  private:

--- a/src/replication/replication_client.cpp
+++ b/src/replication/replication_client.cpp
@@ -21,10 +21,12 @@ ReplicationClient::ReplicationClient(const ReplicationClientConfig &config)
       mode_{config.mode} {}
 
 void ReplicationClient::Shutdown() const {
-  replica_checker_.Stop();
-  // Abort is needed to break possible ongoing task. Doesn't destroy underlying object, just invokes
-  // socket shutdown operation
+  // Abort must run first. It marks the client as aborted (so no task can open or reconnect a stream) and shuts down the
+  // socket to break any in-flight RPC, releasing the rpc client lock. If we stopped the replica checker first, its
+  // heartbeat callback could be blocked on that lock (held by an in-flight recovery RPC waiting on InProgressRes), and
+  // Scheduler::Stop() would join a thread stuck mid-callback, deadlocking before we ever reach Abort.
   rpc_client_.Abort();
+  replica_checker_.Stop();
   thread_pool_.ShutDown();
   rpc_client_.Shutdown();
 }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -22,9 +22,10 @@ Client::Client(io::network::Endpoint endpoint, communication::ClientContext *con
       connect_timeout_ms_(connect_timeout_ms) {}
 
 void Client::Abort() {
-  // Shut down the socket to abort any pending read, write, or connect
-  // operations on another thread. Does NOT destroy the client object,
-  // so it is safe to call concurrently with an in-flight RPC.
+  // Latch the aborted flag first so any thread that subsequently tries to open a stream fails fast instead of
+  // reconnecting. Then shut down the socket to abort any pending read, write, or connect operations on another thread.
+  // Does NOT destroy the client object, so it is safe to call concurrently with an in-flight RPC.
+  aborted_.store(true, std::memory_order_release);
   if (!client_) return;
   client_->Shutdown();
 }

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <storage/v2/replication/rpc.hpp>
@@ -414,6 +415,12 @@ class Client {
       return local_guard;  // RVO
     });
 
+    // The client has been aborted as part of shutdown. Refuse to open (or reconnect) a stream so a queued recovery
+    // task, heartbeat, or commit can't revive the connection after Abort() already tore it down.
+    if (aborted_.load(std::memory_order_acquire)) {
+      throw GenericRpcFailedException();
+    }
+
     // Check if the connection is broken (if we haven't used the client for a
     // long time the server could have died).
     if (client_ && client_->ErrorStatus()) {
@@ -494,6 +501,9 @@ class Client {
   std::chrono::milliseconds connect_timeout_ms_;
 
   mutable utils::ResourceLock mutex_;
+  // Set once by Abort() during shutdown. Latches permanently: an aborted client never opens another stream, so no
+  // in-flight or queued task can reconnect after teardown begins.
+  std::atomic<bool> aborted_{false};
 };
 
 }  // namespace memgraph::rpc

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -179,10 +179,8 @@ void RpcMessageDeliverer::Execute() {
   // NOLINTNEXTLINE
   catch (const slk::SlkReaderLeftoverDataException &) {
     // Skip, it may fail because not all data has been read, that's fine.
-  } catch (const std::exception &e) {
-    spdlog::error("Error occurred in the callback: {}", e.what());
-    throw SlkRpcFailedException();
   }
+  // other exceptions will be caught in session.hpp and its HandleException function
 }
 
 }  // namespace memgraph::rpc

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -134,7 +134,9 @@ void RpcMessageDeliverer::Execute() {
 
   slk::Reader req_reader = GetReqReader();
   slk::Builder res_builder([&](const uint8_t *data, size_t const size, bool const have_more) {
-    output_stream_->Write(data, size, have_more);
+    if (!output_stream_->Write(data, size, have_more)) {
+      throw SessionException("Failed to write RPC response; peer connection is broken");
+    }
   });
 
   auto const maybe_message_header = std::invoke([&req_reader]() -> std::optional<ProtocolMessageHeader> {

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -180,7 +180,7 @@ void RpcMessageDeliverer::Execute() {
   catch (const slk::SlkReaderLeftoverDataException &) {
     // Skip, it may fail because not all data has been read, that's fine.
   }
-  // other exceptions will be caught in session.hpp and its HandleException function
+  // other exceptions will be caught in session.hpp
 }
 
 }  // namespace memgraph::rpc

--- a/src/slk/streams.cpp
+++ b/src/slk/streams.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include "utils/logging.hpp"
+#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::slk {
 
@@ -65,8 +66,11 @@ void Builder::PrepareForFileSending() {
 void Builder::Finalize() { FlushSegment(true); }
 
 void Builder::FlushInternal(size_t const size, bool const has_more) {
+  // Reset the write position even if write_func_ throws, so a failed flush leaves the builder empty and reusable.
+  // Callers that retry (e.g. recovery progress heartbeats) then start from a clean segment instead of tripping the
+  // "buffer must be empty" guard.
+  utils::OnScopeExit const reset_pos{[this] { pos_ = 0; }};
   write_func_(segment_.data(), size, has_more);
-  pos_ = 0;
 }
 
 // Flushes data and resets position

--- a/tests/unit/rpc_in_progress.cpp
+++ b/tests/unit/rpc_in_progress.cpp
@@ -11,6 +11,10 @@
 
 #include <storage/v2/replication/replication_client.hpp>
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -209,4 +213,106 @@ TEST(RpcInProgress, NoTimeout) {
 
   auto stream = client.Stream<SumV1>(2, 3);
   EXPECT_NO_THROW(stream.SendAndWaitProgress());
+}
+
+// Regression for the shutdown deadlock where ReplicationClient::Shutdown() could never break an in-flight recovery RPC.
+// A replica that keeps streaming InProgressRes keeps the main's SendAndWaitProgress read alive indefinitely (well below
+// the per-message timeout). Abort() must interrupt that wait promptly by shutting down the socket, regardless of the
+// long configured RPC timeout.
+TEST(RpcInProgress, AbortInterruptsInProgressWait) {
+  Endpoint const endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    ASSERT_TRUE(rpc_server.Shutdown());
+    rpc_server.AwaitShutdown();
+  }};
+
+  // Handler emulates a replica stuck loading a snapshot: it never sends the final response, only InProgressRes
+  // heartbeats, until the client tears the connection down (at which point the write fails and we stop).
+  rpc_server.Register<Sum>([](std::optional<memgraph::rpc::FileReplicationHandler> const & /*file_replication_handler*/,
+                              uint64_t const request_version,
+                              auto *req_reader,
+                              auto *res_builder) {
+    SumReq req;
+    memgraph::rpc::LoadWithUpgrade(req, request_version, req_reader);
+    try {
+      for (int i = 0; i < 600; ++i) {  // bounded so the worker can't run forever even if the client never aborts
+        std::this_thread::sleep_for(50ms);
+        memgraph::rpc::SendInProgressMsg(res_builder);
+      }
+    } catch (...) {
+      // Client shut the socket down mid-stream; nothing left to do.
+    }
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  // Generous per-message timeout: only Abort() can end the wait within the test window, not the timeout.
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("SumReq"sv, 60'000)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  std::atomic<bool> threw{false};
+  std::thread worker{[&] {
+    try {
+      auto stream = client.Stream<SumV1>(2, 3);
+      stream.SendAndWaitProgress();
+    } catch (const GenericRpcFailedException &) {
+      threw.store(true);
+    } catch (...) {
+      // Any other failure leaves threw=false and fails the expectation below.
+    }
+  }};
+
+  // Let the RPC get in-flight and receive a few InProgressRes heartbeats.
+  std::this_thread::sleep_for(300ms);
+
+  auto const before = std::chrono::steady_clock::now();
+  client.Abort();
+  worker.join();
+  auto const elapsed = std::chrono::steady_clock::now() - before;
+
+  EXPECT_TRUE(threw.load());
+  // The wait must end because of Abort, not because the 60s timeout elapsed.
+  EXPECT_LT(elapsed, 5s);
+}
+
+// Regression for the reconnect race: once Abort() has torn the client down during shutdown, no later Stream() (a queued
+// recovery task, a heartbeat, or a commit) may revive the connection. The stream attempt must fail fast instead.
+TEST(RpcInProgress, AbortPreventsReconnect) {
+  Endpoint const endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    ASSERT_TRUE(rpc_server.Shutdown());
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<Sum>([](std::optional<memgraph::rpc::FileReplicationHandler> const & /*file_replication_handler*/,
+                              uint64_t const request_version,
+                              auto *req_reader,
+                              auto *res_builder) {
+    SumReq req;
+    memgraph::rpc::LoadWithUpgrade(req, request_version, req_reader);
+    SumRes const res{5};
+    memgraph::rpc::SendFinalResponse(res, request_version, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  ClientContext client_context;
+  Client client{endpoint, &client_context};
+
+  // A healthy call works before abort.
+  EXPECT_NO_THROW(client.Stream<SumV1>(2, 3).SendAndWaitProgress());
+
+  client.Abort();
+
+  // After abort the server is still up, but the client must refuse to open a new stream rather than reconnect.
+  EXPECT_THROW(client.Stream<SumV1>(2, 3), GenericRpcFailedException);
 }


### PR DESCRIPTION
Shutdown main instance even in the case of long ongoing snapshot/wal replication by aborting the replication client.
Throw SessionException if replica cannot send response to main.
If `InProgressMsg` cannot be delivered to main, we catch and process the exception. The next such message can be sent normally on the clean state.

