### PR TITLE
fix: Package MAGE setup

### DIFF
--- a/.github/workflows/external_package_mage.yaml
+++ b/.github/workflows/external_package_mage.yaml
@@ -67,7 +67,7 @@ jobs:
     needs: CallCreateStagingBranch
     uses: ./.github/workflows/package_mage.yaml
     with:
-      arch: ${{ inputs.build_arch }}
+      build_arch: ${{ inputs.build_arch }}
       memgraph_download_link: ${{ inputs.memgraph_download_link }}
       cuda: ${{ inputs.cuda }}
       push_to_s3: ${{ inputs.push_to_s3 }}

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -72,7 +72,7 @@ on:
 
   workflow_call:
     inputs:
-      arch:
+      build_arch:
         type: string
         description: "Architecture to build the image for"
         required: true

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -43,6 +43,10 @@ on:
         type: boolean
         description: "Run smoke tests on images after building (tests against previous tagged image)"
         default: false
+      run_tests:
+        type: boolean
+        description: "Run MAGE tests (unit/e2e) after building"
+        default: false
       build_offline_installer:
         type: boolean
         description: "Build offline installer (.run) for Ubuntu 24.04"
@@ -103,6 +107,10 @@ on:
       run_smoke_tests:
         type: boolean
         description: "Run smoke tests on images after building (tests against previous tagged image)"
+        default: false
+      run_tests:
+        type: boolean
+        description: "Run MAGE tests (unit/e2e) after building"
         default: false
       build_offline_installer:
         type: boolean

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -138,14 +138,32 @@ class PackageMageSetup:
         return None
 
     def _check_workflow_input(self) -> list:
-        if self.workflow_inputs.get("matrix_build") == "true":
-            return [
-                {**build, "build_docker_image": _build_docker_image(build["os"], build["cugraph"])}
-                for build in MATRIX_BUILDS
-            ]
+        # Inputs that apply uniformly to every build in the suite (i.e. not the
+        # per-build arch/os/flavour that define a matrix entry).
         # GitHub passes workflow_dispatch/workflow_call inputs as strings
         # ("true"/"false"); keep the fallbacks as strings too so the matrix
         # always serialises booleans consistently — see MATRIX_BUILDS comment.
+        common = {
+            "memgraph_download_link": self.workflow_inputs.get("memgraph_download_link", ""),
+            "push_to_s3": self.workflow_inputs.get("push_to_s3", "false"),
+            "s3_dest_dir": self.workflow_inputs.get("s3_dest_dir", "mage-unofficial"),
+            "run_smoke_tests": self.workflow_inputs.get("run_smoke_tests", "false"),
+            "run_tests": self.workflow_inputs.get("run_tests", "false"),
+            "package_mage": self.workflow_inputs.get("package_mage", "default"),
+            "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
+            "ref": self.workflow_inputs.get("ref", ""),
+        }
+        if self.workflow_inputs.get("matrix_build") == "true":
+            # arch/os/cuda/cugraph/malloc come from each MATRIX_BUILDS entry; the
+            # remaining inputs above are applied uniformly across the matrix.
+            return [
+                {
+                    **build,
+                    **common,
+                    "build_docker_image": _build_docker_image(build["os"], build["cugraph"]),
+                }
+                for build in MATRIX_BUILDS
+            ]
         os = self.workflow_inputs.get("os", "ubuntu-24.04")
         cugraph = self.workflow_inputs.get("cugraph", "false")
         return [
@@ -154,16 +172,9 @@ class PackageMageSetup:
                 "cuda": self.workflow_inputs.get("cuda", "false"),
                 "cugraph": cugraph,
                 "malloc": self.workflow_inputs.get("malloc", "false"),
-                "memgraph_download_link": self.workflow_inputs.get("memgraph_download_link", ""),
-                "push_to_s3": self.workflow_inputs.get("push_to_s3", "false"),
-                "s3_dest_dir": self.workflow_inputs.get("s3_dest_dir", "mage-unofficial"),
-                "run_smoke_tests": self.workflow_inputs.get("run_smoke_tests", "false"),
-                "run_tests": self.workflow_inputs.get("run_tests", "false"),
-                "package_mage": self.workflow_inputs.get("package_mage", "default"),
-                "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
-                "ref": self.workflow_inputs.get("ref", ""),
                 "os": os,
                 "build_docker_image": _build_docker_image(os, cugraph),
+                **common,
             }
         ]
 

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -57,6 +57,14 @@ MATRIX_BUILDS = [
 ]
 
 
+def _build_docker_image(os: str, cugraph: str) -> str:
+    # Builds produce a debug MAGE image so the docker smoke + e2e tests have
+    # something to run against. Only ubuntu-24.04 publishes a MAGE image; rpm
+    # distros build none (smoke-tested via the rpm smoke image) and cugraph can't
+    # be smoke/e2e-tested in CI (GPU), so it gets no image either.
+    return "debug" if (os == "ubuntu-24.04" and cugraph != "true") else "none"
+
+
 class PackageMageSetup:
     def __init__(self, gh_context_path: str):
         self._gh_context_path = gh_context_path
@@ -111,15 +119,7 @@ class PackageMageSetup:
                 "cugraph": build["cugraph"],
                 "malloc": build["malloc"],
                 "os": build["os"],
-                # PR builds produce a debug MAGE image so the docker smoke + e2e
-                # tests have something to run against. Only ubuntu-24.04 publishes
-                # a MAGE image; rpm distros build none (smoke-tested via the rpm
-                # smoke image) and cugraph can't be smoke/e2e-tested in CI (GPU),
-                # so it gets no image either — run_smoke_tests stays true but is a
-                # no-op without an image.
-                "build_docker_image": (
-                    "debug" if (build["os"] == "ubuntu-24.04" and build["cugraph"] != "true") else "none"
-                ),
+                "build_docker_image": _build_docker_image(build["os"], build["cugraph"]),
             }
             out.update(default_args)
             return out
@@ -139,15 +139,20 @@ class PackageMageSetup:
 
     def _check_workflow_input(self) -> list:
         if self.workflow_inputs.get("matrix_build") == "true":
-            return MATRIX_BUILDS
+            return [
+                {**build, "build_docker_image": _build_docker_image(build["os"], build["cugraph"])}
+                for build in MATRIX_BUILDS
+            ]
         # GitHub passes workflow_dispatch/workflow_call inputs as strings
         # ("true"/"false"); keep the fallbacks as strings too so the matrix
         # always serialises booleans consistently — see MATRIX_BUILDS comment.
+        os = self.workflow_inputs.get("os", "ubuntu-24.04")
+        cugraph = self.workflow_inputs.get("cugraph", "false")
         return [
             {
                 "arch": self.workflow_inputs.get("build_arch", "amd"),
                 "cuda": self.workflow_inputs.get("cuda", "false"),
-                "cugraph": self.workflow_inputs.get("cugraph", "false"),
+                "cugraph": cugraph,
                 "malloc": self.workflow_inputs.get("malloc", "false"),
                 "memgraph_download_link": self.workflow_inputs.get("memgraph_download_link", ""),
                 "push_to_s3": self.workflow_inputs.get("push_to_s3", "false"),
@@ -157,7 +162,8 @@ class PackageMageSetup:
                 "package_mage": self.workflow_inputs.get("package_mage", "default"),
                 "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
                 "ref": self.workflow_inputs.get("ref", ""),
-                "os": self.workflow_inputs.get("os", "ubuntu-24.04"),
+                "os": os,
+                "build_docker_image": _build_docker_image(os, cugraph),
             }
         ]
 

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -57,12 +57,12 @@ MATRIX_BUILDS = [
 ]
 
 
-def _build_docker_image(os: str, cugraph: str) -> str:
+def _build_docker_image(distro: str, cugraph: str) -> str:
     # Builds produce a debug MAGE image so the docker smoke + e2e tests have
     # something to run against. Only ubuntu-24.04 publishes a MAGE image; rpm
     # distros build none (smoke-tested via the rpm smoke image) and cugraph can't
     # be smoke/e2e-tested in CI (GPU), so it gets no image either.
-    return "debug" if (os == "ubuntu-24.04" and cugraph != "true") else "none"
+    return "debug" if (distro == "ubuntu-24.04" and cugraph != "true") else "none"
 
 
 class PackageMageSetup:
@@ -162,7 +162,7 @@ class PackageMageSetup:
                 }
                 for build in MATRIX_BUILDS
             ]
-        os = self.workflow_inputs.get("os", "ubuntu-24.04")
+        distro = self.workflow_inputs.get("os", "ubuntu-24.04")
         cugraph = self.workflow_inputs.get("cugraph", "false")
         return [
             {
@@ -170,8 +170,8 @@ class PackageMageSetup:
                 "cuda": self.workflow_inputs.get("cuda", "false"),
                 "cugraph": cugraph,
                 "malloc": self.workflow_inputs.get("malloc", "false"),
-                "os": os,
-                "build_docker_image": _build_docker_image(os, cugraph),
+                "os": distro,
+                "build_docker_image": _build_docker_image(distro, cugraph),
                 "memgraph_download_link": self.workflow_inputs.get("memgraph_download_link", ""),
                 "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
                 **common,

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -144,13 +144,11 @@ class PackageMageSetup:
         # ("true"/"false"); keep the fallbacks as strings too so the matrix
         # always serialises booleans consistently — see MATRIX_BUILDS comment.
         common = {
-            "memgraph_download_link": self.workflow_inputs.get("memgraph_download_link", ""),
             "push_to_s3": self.workflow_inputs.get("push_to_s3", "false"),
             "s3_dest_dir": self.workflow_inputs.get("s3_dest_dir", "mage-unofficial"),
             "run_smoke_tests": self.workflow_inputs.get("run_smoke_tests", "false"),
             "run_tests": self.workflow_inputs.get("run_tests", "false"),
             "package_mage": self.workflow_inputs.get("package_mage", "default"),
-            "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
             "ref": self.workflow_inputs.get("ref", ""),
         }
         if self.workflow_inputs.get("matrix_build") == "true":
@@ -174,6 +172,8 @@ class PackageMageSetup:
                 "malloc": self.workflow_inputs.get("malloc", "false"),
                 "os": os,
                 "build_docker_image": _build_docker_image(os, cugraph),
+                "memgraph_download_link": self.workflow_inputs.get("memgraph_download_link", ""),
+                "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
                 **common,
             }
         ]


### PR DESCRIPTION
- Fixes the missing docker image build when running `package_mage.yaml`.
- Adds option to run tests while packaging MAGE.
- Small refactoring of input handling in `package_mage_setup.py`  so that matrix builds are also affected by workflow inputs such as `push_to_s3` and `run_smoke_tests` etc.
- Normalised mismatched workflow inputs for the build architecture.

