### PR TITLE
fix(storage): register committed deltas before MarkFinished

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1875,8 +1875,21 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
 void InMemoryStorage::InMemoryAccessor::FinalizeTransaction() {
   if (commit_timestamp_) {
     auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
-    mem_storage->commit_log_->MarkFinished(*commit_timestamp_);
 
+    // Hand this transaction's deltas over to GC BEFORE marking the commit
+    // timestamp finished. MarkFinished advances commit_log_->OldestActive(),
+    // and another committing transaction's fast-discard precondition
+    // (CheckForFastDiscardOfDeltas: `no_older_transactions`) treats an advanced
+    // OldestActive as "I am the only transaction left, so every delta except my
+    // own is already registered in committed_transactions_/waiting_gc_deltas_
+    // and safe to free". If we marked finished first, there would be a window in
+    // which this transaction is no longer active yet its deltas are still linked
+    // in the version chains and not yet registered, so that fast-discard could
+    // free a delta our still-linked deltas reference via `prev`, leaving a
+    // dangling pointer for a later GC to dereference (use-after-free). The
+    // registration lock release is sequenced-before MarkFinished, so any thread
+    // that observes this txn as finished (through the commit_log SpinLock) also
+    // observes the registration (through the committed_transactions_ SpinLock).
     if (!transaction_.deltas.empty()) {
       if (transaction_.has_non_sequential_deltas) {
         mem_storage->waiting_gc_deltas_.WithLock([&](auto &waiting_list) {
@@ -1890,6 +1903,8 @@ void InMemoryStorage::InMemoryAccessor::FinalizeTransaction() {
         });
       }
     }
+
+    mem_storage->commit_log_->MarkFinished(*commit_timestamp_);
     commit_timestamp_.reset();
   }
 }

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -12,9 +12,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <optional>
 #include <set>
 #include <string_view>
+#include <thread>
+#include <vector>
 
 #include "flags/general.hpp"
 #include "metrics/prometheus_metrics.hpp"
@@ -1755,4 +1758,95 @@ TEST(StorageV2GcLightEdge, AnalyticalModeDeleteGoesToGraveyard) {
     EXPECT_TRUE(acc->FindVertex(v2_gid, ms::View::OLD).has_value());
   }
   // storage destructor runs here — must not crash or report sanitizer errors.
+}
+
+// ASan smoke test for the FastDiscard-vs-GC delta-buffer use-after-free.
+//
+// Background: when a transaction commits it is marked finished (advancing
+// commit_log_->OldestActive()) and only afterwards registers its deltas for GC.
+// A concurrent transaction that commits sole-active in that window can
+// fast-discard and free a delta a just-finished-but-unregistered transaction's
+// chain still references via `prev`, which a later CollectGarbage dereferences.
+//
+// This exercises exactly that shape: several threads delete edges off a single
+// shared vertex (so their commits chain deltas on the same object) while a GC
+// thread hammers FreeMemory(). It is intentionally a NON-deterministic smoke
+// test: the trigger window is a two-statement gap on the committing thread, so
+// reproduction depends on scheduling pressure and the fault is only observable
+// under a sanitizer (the free and the read are serialized by gc_lock_, so this
+// is a use-after-free, not a data race -> ASan catches it, TSan does not). In
+// CI it runs under the ASAN+UBSAN unit-coverage build (ctest -R memgraph__unit).
+// It cannot guarantee a hit on every run; a deterministic reproduction would
+// require a test-only hook in FinalizeTransaction, which we deliberately avoid.
+TEST(StorageV2Gc, ConcurrentDeleteAndGcUAFSmoke) {
+  constexpr int kRounds = 30;
+  constexpr int kEdges = 100;
+  constexpr int kDeleteThreads = 4;
+
+  std::unique_ptr<ms::Storage> store(std::make_unique<ms::InMemoryStorage>(
+      ms::Config{.gc = {.type = ms::Config::Gc::Type::PERIODIC, .interval = std::chrono::milliseconds(1000)}}));
+
+  ms::Gid gid_from{};
+  ms::Gid gid_to{};
+  {
+    auto acc = store->Access(ms::WRITE);
+    gid_from = acc->CreateVertex().Gid();
+    gid_to = acc->CreateVertex().Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  for (int round = 0; round < kRounds; ++round) {
+    {
+      auto acc = store->Access(ms::WRITE);
+      auto vf = acc->FindVertex(gid_from, ms::View::NEW);
+      auto vt = acc->FindVertex(gid_to, ms::View::NEW);
+      auto et = acc->NameToEdgeType("CONC");
+      for (int i = 0; i < kEdges; ++i) {
+        ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    std::atomic<bool> gc_running{true};
+    std::atomic<uint64_t> total_deleted{0};
+    std::thread gc_thread([&]() {
+      while (gc_running.load()) {
+        store->FreeMemory();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      store->FreeMemory();
+      store->FreeMemory();
+    });
+
+    std::vector<std::thread> deleters;
+    deleters.reserve(kDeleteThreads);
+    for (int t = 0; t < kDeleteThreads; ++t) {
+      deleters.emplace_back([&]() {
+        while (true) {
+          auto acc = store->Access(ms::WRITE);
+          auto vf = acc->FindVertex(gid_from, ms::View::NEW);
+          if (!vf) break;
+          auto out = vf->OutEdges(ms::View::NEW);
+          if (!out.has_value() || out->edges.empty()) break;
+          auto edge = out->edges[0];
+          auto del = acc->DeleteEdge(&edge);
+          if (!del.has_value()) continue;  // serialization conflict, retry
+          if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+            total_deleted.fetch_add(1);
+          }
+        }
+      });
+    }
+
+    for (auto &d : deleters) d.join();
+    gc_running.store(false);
+    gc_thread.join();
+
+    // Functional check: every edge was deleted exactly once.
+    EXPECT_EQ(total_deleted.load(), kEdges);
+    auto acc = store->Access(ms::WRITE);
+    auto vf = acc->FindVertex(gid_from, ms::View::OLD);
+    ASSERT_TRUE(vf.has_value());
+    EXPECT_EQ(vf->OutEdges(ms::View::OLD)->edges.size(), 0);
+  }
 }


### PR DESCRIPTION
Fixes a heap-use-after-free between a committing transaction's
fast-discard-of-deltas and concurrent garbage collection.

FinalizeTransaction() marked the commit timestamp finished and only
afterwards registered the transaction's deltas into
committed_transactions_/waiting_gc_deltas_. MarkFinished advances
commit_log_->OldestActive(), which another committer's fast-discard
precondition (CheckForFastDiscardOfDeltas: no_older_transactions) reads to
conclude it is the sole remaining transaction and may free every delta but
its own. Between MarkFinished and the registration there was a window in
which a just-finished transaction's deltas were still linked in the version
chains yet not visible to that sweep; the fast-discard could then free a
delta those still-linked deltas reference via `prev`, leaving a dangling
pointer that a later CollectGarbage dereferences (prev.delta->commit_info).

Reorder so the deltas are handed to GC before MarkFinished. The
registration's lock release is sequenced-before MarkFinished, so any thread
that observes the transaction as finished (through the commit_log SpinLock)
also observes the registration (through the committed_transactions_
SpinLock) and frees the deltas together with its own. GC safety is
unchanged: GCDeltas::unlinkable_timestamp_ (the commit timestamp) still gates
unlinking, so registering early cannot cause a premature unlink.