### PR TITLE
experiment: PGO build support (MG_PGO) + daily_benchmark PGO run

### DIFF
--- a/.github/workflows/benchmark_pgo.yaml
+++ b/.github/workflows/benchmark_pgo.yaml
@@ -1,0 +1,139 @@
+name: Benchmark PGO (experiment)
+
+# Quick, on-demand PGO check: instrument -> train on mgbench -> optimize, then run
+# ONLY the pokec-medium mgbench and upload to the bench-graph tagged by branch.
+# Much shorter than the full Daily Benchmark, so it validates the PGO flow and gives
+# a pokec-medium PGO-vs-master signal on Grafana before committing to the long run.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      pgo:
+        type: boolean
+        description: "Build with PGO (instrument -> train on mgbench -> optimize). Off = control run."
+        default: true
+      loop_count:
+        type: number
+        description: "mgbench iterations (keep small for a quick check; each pokec-medium run is ~20 min)."
+        default: 3
+
+jobs:
+  benchmark_pgo:
+    name: "Benchmark PGO (pokec medium mgbench)"
+    runs-on: [self-hosted, Linux, benchmark]
+    timeout-minutes: 240
+    env:
+      ARCH: "amd"
+      OS: "ubuntu-24.04"
+      TOOLCHAIN: "v7"
+      BUILD_TYPE: "RelWithDebInfo"
+      MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
+      MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
+      DEFAULT_MGBENCH_EXPORT_RESULTS_FILE: 'benchmark_result.json'
+      LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+      CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
+      CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
+      CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
+
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
+      - name: Log in to Docker Hub
+        uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Spin up mgbuild container
+        run: |
+          if [[ "$OS" == "ubuntu-24.04" ]]; then
+            USE_CUSTOM_MIRROR=true
+          else
+            USE_CUSTOM_MIRROR=false
+          fi
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN --os $OS --arch $ARCH \
+          run --custom-mirror $USE_CUSTOM_MIRROR
+
+      # Same training as the Daily Benchmark: instrument, train on the full mgbench
+      # pokec query mix (pokec/small, all groups), merge -> build/pgo.profdata.
+      - name: PGO — instrument, train, merge
+        if: ${{ inputs.pgo }}
+        run: |
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN --os $OS --arch $ARCH --build-type $BUILD_TYPE \
+            build-memgraph --pgo generate \
+            --conan-remote $CONAN_REMOTE --conan-username $CONAN_USERNAME --conan-password $CONAN_PASSWORD
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN --os $OS --arch $ARCH \
+            --enterprise-license "$MEMGRAPH_ENTERPRISE_LICENSE" --organization-name "$MEMGRAPH_ORGANIZATION_NAME" \
+            pgo-train --dataset pokec --size small
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH pgo-merge
+
+      - name: Build release binary
+        run: |
+          PGO_ARGS=""
+          if [[ "${{ inputs.pgo }}" == "true" ]]; then
+            PGO_ARGS="--pgo use"   # consumes build/pgo.profdata from the step above
+          fi
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN --os $OS --arch $ARCH --build-type $BUILD_TYPE \
+          build-memgraph \
+          --split-debug \
+          $PGO_ARGS \
+          --conan-remote $CONAN_REMOTE --conan-username $CONAN_USERNAME --conan-password $CONAN_PASSWORD
+
+      - name: Initialize tests
+        run: |
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
+
+      - name: Get branch name
+        shell: bash
+        run: |
+          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
+      - name: Force container into first numa group
+        run: |
+          numagroup="$(./tools/ci/numa-0-cores.sh)"
+          echo "Using numa group: $numagroup"
+          docker update \
+          --cpuset-cpus="$numagroup" \
+          --cpuset-mems="0" \
+          "mgbuild_${TOOLCHAIN}_${OS}"
+
+      - name: Run and upload mgbench (pokec medium)
+        id: mgbench
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            mgbench \
+            mgbench \
+            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Stop mgbuild container
+        if: always()
+        run: |
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH stop --remove
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh

--- a/.github/workflows/benchmark_pgo.yaml
+++ b/.github/workflows/benchmark_pgo.yaml
@@ -89,22 +89,28 @@ jobs:
       - name: PGO — instrument, train, merge
         if: ${{ env.PGO_ENABLED == 'true' }}
         run: |
-          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
+          # 1) instrumented build — this is what copies the repo into the container
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN --os $OS --arch $ARCH --build-type $BUILD_TYPE \
             build-memgraph --pgo generate \
             --conan-remote $CONAN_REMOTE --conan-username $CONAN_USERNAME --conan-password $CONAN_PASSWORD
+          # 2) datasets + test env for training (repo now present in the container)
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
+          # 3) train on the full mgbench pokec query mix
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN --os $OS --arch $ARCH \
             --enterprise-license "$MEMGRAPH_ENTERPRISE_LICENSE" --organization-name "$MEMGRAPH_ORGANIZATION_NAME" \
             pgo-train --dataset pokec --size small
+          # 4) merge -> /home/mg/pgo.profdata (outside build/, survives the next build)
           ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH pgo-merge
 
       - name: Build release binary
         run: |
           PGO_ARGS=""
           if [[ "$PGO_ENABLED" == "true" ]]; then
-            PGO_ARGS="--pgo use"   # consumes build/pgo.profdata from the step above
+            # --no-copy reuses the source the prelude already copied (so build/pgo.profdata's
+            # sibling profile at /home/mg survives); --pgo use reads that merged profile.
+            PGO_ARGS="--pgo use --no-copy"
           fi
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN --os $OS --arch $ARCH --build-type $BUILD_TYPE \

--- a/.github/workflows/benchmark_pgo.yaml
+++ b/.github/workflows/benchmark_pgo.yaml
@@ -20,10 +20,17 @@ on:
         type: number
         description: "mgbench iterations (keep small for a quick check; each pokec-medium run is ~20 min)."
         default: 3
+  # Runnable from the branch WITHOUT merging to master: add the 'run-pgo-benchmark'
+  # label to the PR. (workflow_dispatch needs the file on the default branch;
+  # pull_request uses the PR branch's own workflow file.)
+  pull_request:
+    types: [labeled]
 
 jobs:
   benchmark_pgo:
     name: "Benchmark PGO (pokec medium mgbench)"
+    # Manual dispatch, or when the 'run-pgo-benchmark' label is added to the PR.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-pgo-benchmark' }}
     runs-on: [self-hosted, Linux, benchmark]
     # PGO adds a 2nd full build + the instrumented training run (~110-140 min fixed)
     # on top of loop_count x ~20 min of pokec-medium mgbench. Generous headroom so a
@@ -38,6 +45,8 @@ jobs:
       MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
       DEFAULT_MGBENCH_EXPORT_RESULTS_FILE: 'benchmark_result.json'
       LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+      # PGO on for label runs (no inputs available); respects the toggle on manual dispatch.
+      PGO_ENABLED: ${{ github.event_name != 'workflow_dispatch' || inputs.pgo }}
       CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
       CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
       CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
@@ -74,7 +83,7 @@ jobs:
       # Same training as the Daily Benchmark: instrument, train on the full mgbench
       # pokec query mix (pokec/small, all groups), merge -> build/pgo.profdata.
       - name: PGO — instrument, train, merge
-        if: ${{ inputs.pgo }}
+        if: ${{ env.PGO_ENABLED == 'true' }}
         run: |
           ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
           ./release/package/mgbuild.sh \
@@ -90,7 +99,7 @@ jobs:
       - name: Build release binary
         run: |
           PGO_ARGS=""
-          if [[ "${{ inputs.pgo }}" == "true" ]]; then
+          if [[ "$PGO_ENABLED" == "true" ]]; then
             PGO_ARGS="--pgo use"   # consumes build/pgo.profdata from the step above
           fi
           ./release/package/mgbuild.sh \
@@ -107,7 +116,11 @@ jobs:
       - name: Get branch name
         shell: bash
         run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+          fi
 
       - name: Force container into first numa group
         run: |

--- a/.github/workflows/benchmark_pgo.yaml
+++ b/.github/workflows/benchmark_pgo.yaml
@@ -25,12 +25,16 @@ on:
   # pull_request uses the PR branch's own workflow file.)
   pull_request:
     types: [labeled]
+  # Direct trigger: every push to the experiment branch runs it. Works while the PR
+  # is a draft and needs no default-branch registration (push != pull_request event).
+  push:
+    branches: [experiment/pgo-benchmark]
 
 jobs:
   benchmark_pgo:
     name: "Benchmark PGO (pokec medium mgbench)"
-    # Manual dispatch, or when the 'run-pgo-benchmark' label is added to the PR.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-pgo-benchmark' }}
+    # Push to the branch, manual dispatch, or the 'run-pgo-benchmark' PR label.
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-pgo-benchmark' }}
     runs-on: [self-hosted, Linux, benchmark]
     # PGO adds a 2nd full build + the instrumented training run (~110-140 min fixed)
     # on top of loop_count x ~20 min of pokec-medium mgbench. Generous headroom so a

--- a/.github/workflows/benchmark_pgo.yaml
+++ b/.github/workflows/benchmark_pgo.yaml
@@ -25,7 +25,10 @@ jobs:
   benchmark_pgo:
     name: "Benchmark PGO (pokec medium mgbench)"
     runs-on: [self-hosted, Linux, benchmark]
-    timeout-minutes: 240
+    # PGO adds a 2nd full build + the instrumented training run (~110-140 min fixed)
+    # on top of loop_count x ~20 min of pokec-medium mgbench. Generous headroom so a
+    # default (loop_count=3, ~200 min) run — or a somewhat larger one — can't time out.
+    timeout-minutes: 330
     env:
       ARCH: "amd"
       OS: "ubuntu-24.04"

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -22,7 +22,9 @@ jobs:
   release_benchmarks:
     name: "Daily benchmarks"
     runs-on: [self-hosted, Linux, benchmark]
-    timeout-minutes: 550
+    # +90 min when pgo=true for the extra instrumented build + training run, so the
+    # PGO prelude doesn't eat the existing ~50 min headroom and time the job out.
+    timeout-minutes: ${{ inputs.pgo && 640 || 550 }}
     #  The timeout above is calculated based on a previous run where the loop count was 100
     #  Rough times per test:
     #  - macro-benchmark: 3 minutes

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -89,22 +89,28 @@ jobs:
       - name: PGO — instrument, train, merge
         if: ${{ inputs.pgo }}
         run: |
-          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
+          # 1) instrumented build — this is what copies the repo into the container
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN --os $OS --arch $ARCH --build-type $BUILD_TYPE \
             build-memgraph --pgo generate \
             --conan-remote $CONAN_REMOTE --conan-username $CONAN_USERNAME --conan-password $CONAN_PASSWORD
+          # 2) datasets + test env for training (repo now present in the container)
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
+          # 3) train on the full mgbench pokec query mix
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN --os $OS --arch $ARCH \
             --enterprise-license "$MEMGRAPH_ENTERPRISE_LICENSE" --organization-name "$MEMGRAPH_ORGANIZATION_NAME" \
             pgo-train --dataset pokec --size small
+          # 4) merge -> /home/mg/pgo.profdata (outside build/, survives the next build)
           ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH pgo-merge
 
       - name: Build release binary
         run: |
           PGO_ARGS=""
           if [[ "${{ inputs.pgo }}" == "true" ]]; then
-            PGO_ARGS="--pgo use"   # consumes build/pgo.profdata from the step above
+            # --no-copy reuses the prelude's copied source so /home/mg/pgo.profdata
+            # survives; --pgo use reads that merged profile.
+            PGO_ARGS="--pgo use --no-copy"
           fi
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -11,6 +11,10 @@ on:
         type: number
         description: "Number of times to run the benchmarks. Default is 10."
         default: 10
+      pgo:
+        type: boolean
+        description: "Build with PGO (instrument -> train on mgbench -> optimize) before benchmarking. Experiment: dispatch on a branch and compare its Grafana series to master."
+        default: false
   schedule:
     - cron: "0 1 * * *"
 
@@ -76,8 +80,30 @@ jobs:
           --arch $ARCH \
           run --custom-mirror $USE_CUSTOM_MIRROR
 
+      # PGO experiment (only when dispatched with pgo=true): build an instrumented
+      # binary, train it on the full mgbench query mix, and merge the profile.
+      # The next step then builds the optimized binary via --pgo use. Datasets are
+      # needed for training, so init-tests runs here too (harmless if repeated later).
+      - name: PGO — instrument, train, merge
+        if: ${{ inputs.pgo }}
+        run: |
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH init-tests
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN --os $OS --arch $ARCH --build-type $BUILD_TYPE \
+            build-memgraph --pgo generate \
+            --conan-remote $CONAN_REMOTE --conan-username $CONAN_USERNAME --conan-password $CONAN_PASSWORD
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN --os $OS --arch $ARCH \
+            --enterprise-license "$MEMGRAPH_ENTERPRISE_LICENSE" --organization-name "$MEMGRAPH_ORGANIZATION_NAME" \
+            pgo-train --dataset pokec --size small
+          ./release/package/mgbuild.sh --toolchain $TOOLCHAIN --os $OS --arch $ARCH pgo-merge
+
       - name: Build release binary
         run: |
+          PGO_ARGS=""
+          if [[ "${{ inputs.pgo }}" == "true" ]]; then
+            PGO_ARGS="--pgo use"   # consumes build/pgo.profdata from the step above
+          fi
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -85,6 +111,7 @@ jobs:
           --build-type $BUILD_TYPE \
           build-memgraph \
           --split-debug \
+          $PGO_ARGS \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
           --conan-password $CONAN_PASSWORD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,39 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RelWithDebInfo TRUE)
 # release flags
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
+# -----------------------------------------------------------------------------
+# Profile-Guided Optimization (PGO).
+# Driven by a single -DMG_PGO=<mode> token so it passes cleanly through
+# mgbuild.sh / build.sh option forwarding (multi-token CMAKE_CXX_FLAGS get
+# word-split by their unquoted expansion; a bare -D token does not).
+#   -DMG_PGO=generate                    instrument; raw profiles -> ${MG_PGO_DIR}
+#   -DMG_PGO=use -DMG_PGO_PROFILE=<file> optimize using the merged .profdata
+# Applies to the in-tree targets defined below (src/, mgcxx, ...); prebuilt
+# Conan deps are unaffected. See tools/pgo/README.md.
+set(MG_PGO "off" CACHE STRING "PGO mode: off | generate | use")
+set(MG_PGO_DIR "${CMAKE_BINARY_DIR}/pgo-raw" CACHE PATH "Directory for -fprofile-generate raw profiles")
+set(MG_PGO_PROFILE "${CMAKE_BINARY_DIR}/pgo.profdata" CACHE FILEPATH
+    "Merged .profdata for -fprofile-use (default: build/pgo.profdata produced by 'mgbuild.sh pgo-merge')")
+string(TOLOWER "${MG_PGO}" _mg_pgo_mode)
+if (_mg_pgo_mode STREQUAL "generate")
+    message(STATUS "MG_PGO=generate: instrumenting (-fprofile-generate=${MG_PGO_DIR})")
+    add_compile_options(-fprofile-generate=${MG_PGO_DIR})
+    add_link_options(-fprofile-generate=${MG_PGO_DIR})
+elseif (_mg_pgo_mode STREQUAL "use")
+    if (NOT EXISTS "${MG_PGO_PROFILE}")
+        message(FATAL_ERROR "MG_PGO=use: profile not found at '${MG_PGO_PROFILE}'. "
+            "Run 'mgbuild.sh build-memgraph --pgo generate', then 'pgo-train' + 'pgo-merge' first, "
+            "or pass -DMG_PGO_PROFILE=<file>.")
+    endif()
+    message(STATUS "MG_PGO=use: optimizing with profile ${MG_PGO_PROFILE}")
+    # Unprofiled/stale functions are expected (partial coverage); keep them warnings, not errors.
+    add_compile_options(-fprofile-use=${MG_PGO_PROFILE}
+        -Wno-error=profile-instr-unprofiled -Wno-error=profile-instr-out-of-date)
+    add_link_options(-fprofile-use=${MG_PGO_PROFILE})
+elseif (NOT _mg_pgo_mode STREQUAL "off")
+    message(FATAL_ERROR "MG_PGO must be one of: off | generate | use (got '${MG_PGO}')")
+endif()
+
 include(SplitDebug)
 
 #debug flags

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -749,6 +749,10 @@ build_memgraph () {
   # PGO: single -D tokens (no spaces) so unquoted forwarding stays intact.
   if [[ -n "$pgo_mode" ]]; then
     additional_options="$additional_options -DMG_PGO=$pgo_mode"
+    # Default 'use' profile to where pgo-merge wrote it (outside build/, survives cleans).
+    if [[ "$pgo_mode" == "use" && -z "$pgo_profile" ]]; then
+      pgo_profile="$MGBUILD_HOME_DIR/pgo.profdata"
+    fi
     if [[ -n "$pgo_profile" ]]; then
       additional_options="$additional_options -DMG_PGO_PROFILE=$pgo_profile"
     fi
@@ -3019,9 +3023,10 @@ case $command in
       docker exec -u mg $build_container bash -c "export MEMGRAPH_ENTERPRISE_LICENSE=$enterprise_license && export MEMGRAPH_ORGANIZATION_NAME=$organization_name && mkdir -p $MGBUILD_ROOT_DIR/build/pgo-raw && export LLVM_PROFILE_FILE=$MGBUILD_ROOT_DIR/build/pgo-raw/mg_%p_%m.profraw && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --installation-type native --num-workers-for-benchmark 6 $PGO_DATASET/$PGO_SIZE/*/*"
     ;;
     pgo-merge)
-      # Merge raw profiles -> build/pgo.profdata for build-memgraph --pgo use.
+      # Merge raw profiles -> $MGBUILD_HOME_DIR/pgo.profdata (OUTSIDE build/ and the repo,
+      # so it survives the 'rm -rf build/*' + repo re-copy the next build-memgraph does).
       shift 1
-      docker exec -u mg $build_container bash -c "source /opt/toolchain-${toolchain_version}/activate && llvm-profdata merge -o $MGBUILD_ROOT_DIR/build/pgo.profdata $MGBUILD_ROOT_DIR/build/pgo-raw/*.profraw && echo 'PGO merged profile:' && ls -la $MGBUILD_ROOT_DIR/build/pgo.profdata"
+      docker exec -u mg $build_container bash -c "source /opt/toolchain-${toolchain_version}/activate && llvm-profdata merge -o $MGBUILD_HOME_DIR/pgo.profdata $MGBUILD_ROOT_DIR/build/pgo-raw/*.profraw && echo 'PGO merged profile:' && ls -la $MGBUILD_HOME_DIR/pgo.profdata"
     ;;
     package-memgraph)
       package_memgraph $@

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -3010,7 +3010,7 @@ case $command in
       # Exercise the instrumented (build-memgraph --pgo generate) binary across the
       # full mgbench query mix so the profile covers reads/writes/aggregates/expansions.
       # %p keeps each server restart's raw profile; pgo-merge combines them.
-      shift 1
+      # NOTE: the main parser already shifted off the command name, so $@ starts at the flags.
       PGO_DATASET='pokec'
       PGO_SIZE='small'
       while [[ $# -gt 0 ]]; do
@@ -3025,7 +3025,6 @@ case $command in
     pgo-merge)
       # Merge raw profiles -> $MGBUILD_HOME_DIR/pgo.profdata (OUTSIDE build/ and the repo,
       # so it survives the 'rm -rf build/*' + repo re-copy the next build-memgraph does).
-      shift 1
       docker exec -u mg $build_container bash -c "source /opt/toolchain-${toolchain_version}/activate && llvm-profdata merge -o $MGBUILD_HOME_DIR/pgo.profdata $MGBUILD_ROOT_DIR/build/pgo-raw/*.profraw && echo 'PGO merged profile:' && ls -la $MGBUILD_HOME_DIR/pgo.profdata"
     ;;
     package-memgraph)

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -3020,12 +3020,16 @@ case $command in
           *) echo "Error: Unknown flag '$1' for pgo-train"; exit 1 ;;
         esac
       done
-      docker exec -u mg $build_container bash -c "export MEMGRAPH_ENTERPRISE_LICENSE=$enterprise_license && export MEMGRAPH_ORGANIZATION_NAME=$organization_name && mkdir -p $MGBUILD_ROOT_DIR/build/pgo-raw && export LLVM_PROFILE_FILE=$MGBUILD_ROOT_DIR/build/pgo-raw/mg_%p_%m.profraw && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --installation-type native --num-workers-for-benchmark 6 $PGO_DATASET/$PGO_SIZE/*/*"
+      # Mirrors the working 'mgbench' invocation (incl. required --export-results; the
+      # results file is throwaway for training). LLVM_PROFILE_FILE names each memgraph
+      # restart's profile uniquely; the instrumented binary also bakes -fprofile-generate
+      # to the same dir, so raw profiles land in build/pgo-raw either way.
+      docker exec -u mg $build_container bash -c "export MEMGRAPH_ENTERPRISE_LICENSE=$enterprise_license && export MEMGRAPH_ORGANIZATION_NAME=$organization_name && mkdir -p $MGBUILD_ROOT_DIR/build/pgo-raw && export LLVM_PROFILE_FILE=$MGBUILD_ROOT_DIR/build/pgo-raw/mg_%p_%m.profraw && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --installation-type native --num-workers-for-benchmark 6 --export-results pgo_train_result.json $PGO_DATASET/$PGO_SIZE/*/*"
     ;;
     pgo-merge)
       # Merge raw profiles -> $MGBUILD_HOME_DIR/pgo.profdata (OUTSIDE build/ and the repo,
       # so it survives the 'rm -rf build/*' + repo re-copy the next build-memgraph does).
-      docker exec -u mg $build_container bash -c "source /opt/toolchain-${toolchain_version}/activate && llvm-profdata merge -o $MGBUILD_HOME_DIR/pgo.profdata $MGBUILD_ROOT_DIR/build/pgo-raw/*.profraw && echo 'PGO merged profile:' && ls -la $MGBUILD_HOME_DIR/pgo.profdata"
+      docker exec -u mg $build_container bash -c "source /opt/toolchain-${toolchain_version}/activate && echo 'raw profiles:' && ls -la $MGBUILD_ROOT_DIR/build/pgo-raw/ && llvm-profdata merge -o $MGBUILD_HOME_DIR/pgo.profdata $MGBUILD_ROOT_DIR/build/pgo-raw/*.profraw && echo 'PGO merged profile:' && ls -la $MGBUILD_HOME_DIR/pgo.profdata"
     ;;
     package-memgraph)
       package_memgraph $@

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -88,6 +88,8 @@ print_help () {
   echo -e "  build [OPTIONS]                    Build mgbuild image"
   echo -e "  build-memgraph [OPTIONS]           Build memgraph binary inside mgbuild container"
   echo -e "  init-tests                         Initialize tests inside mgbuild container"
+  echo -e "  pgo-train [--dataset D --size S]   Train instrumented binary on mgbench (for PGO); default pokec/small"
+  echo -e "  pgo-merge                          Merge raw PGO profiles into build/pgo.profdata"
   echo -e "  copy [OPTIONS]                     Copy an artifact from mgbuild container to host"
   echo -e "  copy-debug-symbols [OPTIONS]       Copy all .debug sidecars from build tree to host (requires split-debug build)"
   echo -e "  package-memgraph                   Create memgraph package from built binary inside mgbuild container"
@@ -139,6 +141,8 @@ print_help () {
   echo -e "\nbuild-memgraph options:"
   echo -e "  --asan                        Build with ASAN"
   echo -e "  --cmake-only                  Only run cmake configure command"
+  echo -e "  --pgo generate|use            PGO mode: instrument, or optimize with a merged profile"
+  echo -e "  --pgo-profile PATH            Merged .profdata for --pgo use (e.g. build/pgo.profdata)"
   echo -e "  --community                   Build community version"
   echo -e "  --coverage                    Build with code coverage"
   echo -e "  --init-only                   Only run init script"
@@ -486,8 +490,18 @@ build_memgraph () {
   local build_dependency=""
   local link_threads=0
   local split_debug=false
+  local pgo_mode=""
+  local pgo_profile=""
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
+      --pgo)
+        pgo_mode="$2"
+        shift 2
+      ;;
+      --pgo-profile)
+        pgo_profile="$2"
+        shift 2
+      ;;
       --community)
         community_flag="-DMG_ENTERPRISE=OFF"
         shift 1
@@ -730,6 +744,14 @@ build_memgraph () {
       exit 1
     fi
     additional_options="$additional_options -DMG_SPLIT_DEBUG=ON"
+  fi
+
+  # PGO: single -D tokens (no spaces) so unquoted forwarding stays intact.
+  if [[ -n "$pgo_mode" ]]; then
+    additional_options="$additional_options -DMG_PGO=$pgo_mode"
+    if [[ -n "$pgo_profile" ]]; then
+      additional_options="$additional_options -DMG_PGO_PROFILE=$pgo_profile"
+    fi
   fi
 
   if [[ -n "$additional_options" ]]; then
@@ -2979,6 +3001,27 @@ case $command in
     ;;
     build-memgraph)
       build_memgraph $@
+    ;;
+    pgo-train)
+      # Exercise the instrumented (build-memgraph --pgo generate) binary across the
+      # full mgbench query mix so the profile covers reads/writes/aggregates/expansions.
+      # %p keeps each server restart's raw profile; pgo-merge combines them.
+      shift 1
+      PGO_DATASET='pokec'
+      PGO_SIZE='small'
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --dataset) PGO_DATASET="$2"; shift 2 ;;
+          --size) PGO_SIZE="$2"; shift 2 ;;
+          *) echo "Error: Unknown flag '$1' for pgo-train"; exit 1 ;;
+        esac
+      done
+      docker exec -u mg $build_container bash -c "export MEMGRAPH_ENTERPRISE_LICENSE=$enterprise_license && export MEMGRAPH_ORGANIZATION_NAME=$organization_name && mkdir -p $MGBUILD_ROOT_DIR/build/pgo-raw && export LLVM_PROFILE_FILE=$MGBUILD_ROOT_DIR/build/pgo-raw/mg_%p_%m.profraw && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --installation-type native --num-workers-for-benchmark 6 $PGO_DATASET/$PGO_SIZE/*/*"
+    ;;
+    pgo-merge)
+      # Merge raw profiles -> build/pgo.profdata for build-memgraph --pgo use.
+      shift 1
+      docker exec -u mg $build_container bash -c "source /opt/toolchain-${toolchain_version}/activate && llvm-profdata merge -o $MGBUILD_ROOT_DIR/build/pgo.profdata $MGBUILD_ROOT_DIR/build/pgo-raw/*.profraw && echo 'PGO merged profile:' && ls -la $MGBUILD_ROOT_DIR/build/pgo.profdata"
     ;;
     package-memgraph)
       package_memgraph $@

--- a/tools/pgo/README.md
+++ b/tools/pgo/README.md
@@ -46,6 +46,16 @@ tracked series un-PGO'd for clean history.
 gh workflow run daily_benchmark.yaml --ref experiment/pgo-benchmark -f pgo=true -f loop_count=10
 ```
 
+For a **quick check** (the full daily suite is long), `benchmark_pgo.yaml` runs the same
+PGO train/build but only the pokec-**medium** mgbench, and uploads it tagged by branch:
+
+```
+gh workflow run benchmark_pgo.yaml --ref experiment/pgo-benchmark -f pgo=true -f loop_count=3
+```
+
+Trained the same way (pokec/small, all groups). Run once with `pgo=false` if you want a
+same-machine control alongside master's series.
+
 ## What to train on (the important part)
 
 **Recommendation: train on the full mgbench pokec query mix — `pokec/small/*/*` (all groups).**

--- a/tools/pgo/README.md
+++ b/tools/pgo/README.md
@@ -47,13 +47,25 @@ gh workflow run daily_benchmark.yaml --ref experiment/pgo-benchmark -f pgo=true 
 ```
 
 For a **quick check** (the full daily suite is long), `benchmark_pgo.yaml` runs the same
-PGO train/build but only the pokec-**medium** mgbench, and uploads it tagged by branch:
+PGO train/build but only the pokec-**medium** mgbench, uploaded tagged by branch. Trained the
+same way (pokec/small, all groups).
+
+**Run it without merging to master** — `workflow_dispatch` needs the file on the default
+branch, so before the PR merges use the **label trigger**: add the `run-pgo-benchmark` label to
+the PR (it runs the PR branch's workflow via `pull_request`). Re-add the label to re-run.
+
+```
+gh label create run-pgo-benchmark --color ededed        # once
+gh api repos/memgraph/memgraph/issues/<PR>/labels -X POST -f "labels[]=run-pgo-benchmark"
+```
+
+After the PR is on master, the manual dispatch also works and takes inputs:
 
 ```
 gh workflow run benchmark_pgo.yaml --ref experiment/pgo-benchmark -f pgo=true -f loop_count=3
 ```
 
-Trained the same way (pokec/small, all groups). Run once with `pgo=false` if you want a
+On a label run PGO is on and `loop_count=3`; dispatch a `pgo=false` run if you want a
 same-machine control alongside master's series.
 
 ## What to train on (the important part)

--- a/tools/pgo/README.md
+++ b/tools/pgo/README.md
@@ -1,0 +1,90 @@
+# Profile-Guided Optimization (PGO) for Memgraph
+
+PGO builds Memgraph twice: an **instrumented** binary that records which code runs
+hottest while executing a representative workload, and a final binary the compiler
+re-optimizes (inlining, block layout, hot/cold splitting) using that profile.
+
+On forge (AMD Zen 4), instrumented PGO trained on pokec expansions gave, control-validated:
+**~+25% throughput on short queries** and double-digit gains on traversals, and it
+**generalized** to held-out query types (a never-trained `MATCH (n {id}) RETURN n` gained +31%).
+It needs no PMU/LBR (unlike AutoFDO/BOLT), so it works anywhere the toolchain runs.
+
+## Build knobs
+
+Single `-D` token so it forwards cleanly through `build.sh` / `mgbuild.sh`:
+
+| CMake | Meaning |
+|---|---|
+| `-DMG_PGO=generate` | instrument; raw profiles → `build/pgo-raw/` |
+| `-DMG_PGO=use` | optimize using `build/pgo.profdata` (override with `-DMG_PGO_PROFILE=<file>`) |
+
+Via `mgbuild.sh`:
+
+```bash
+# 1. instrumented build
+mgbuild.sh ... build-memgraph --pgo generate
+# 2. train (exercises the instrumented binary across the full mgbench query mix)
+mgbuild.sh ... --enterprise-license "$L" --organization-name "$O" pgo-train --dataset pokec --size small
+# 3. merge raw profiles -> build/pgo.profdata
+mgbuild.sh ... pgo-merge
+# 4. optimized build
+mgbuild.sh ... build-memgraph --pgo use --split-debug
+```
+
+## The CI / Grafana experiment
+
+`daily_benchmark.yaml` gained a `pgo` **workflow_dispatch** input. Trigger the job on a
+branch (this one) with `pgo=true`; results upload to the bench-graph tagged by branch, so
+its series overlays master's (un-PGO'd) series across the **whole** suite.
+
+Keep the branch = master + this PGO build change **only**, so the branch-vs-master delta on
+Grafana is *pure PGO effect* (isolates it — this is the correct use of PGO-in-benchmark, not a
+code-regression gate). Do **not** enable `pgo` on the scheduled master run — keep master's
+tracked series un-PGO'd for clean history.
+
+```
+gh workflow run daily_benchmark.yaml --ref experiment/pgo-benchmark -f pgo=true -f loop_count=10
+```
+
+## What to train on (the important part)
+
+**Recommendation: train on the full mgbench pokec query mix — `pokec/small/*/*` (all groups).**
+`pgo-train` does this by default. It's the "super general" set because it exercises the two
+things PGO optimizes:
+
+1. **Shared per-query machinery** — parse / query-strip / plan-cache lookup / operator `Pull`
+   framework / Bolt encode / thread-pool dispatch. *Every* query runs this, so profiling it
+   lifts essentially all queries (why a never-trained point-read still gained +31%).
+2. **Common hot operators** — `ScanAll`, indexed lookup, `Expand`, `Filter`, `Produce`,
+   `Distinct`, `Aggregate`. pokec's groups cover reads, writes, 1–4-hop expansions (+filters),
+   and aggregations (count/min/max/avg) — the OLTP graph core.
+
+**Coverage is what matters, not data size or query count.** Measured caveat: a hot loop *not*
+exercised during training gets almost no benefit — expansion-only training left a full-scan
+aggregate at +2%. So:
+
+- Train on **all query groups** (`*/*`), not one family. ✅ (default)
+- Use **pokec small** — the instrumented binary is 2–4× slower, and PGO cares about *code paths*
+  (query shapes), not cache footprint. Small is fast and covers every shape. Bump to `medium`
+  only if you specifically want more realistic memory behavior in the profile.
+- If production runs query types pokec lacks (vector/text search, shortest-path, `load_parquet`,
+  heavy analytics), add them to training so those hot loops get profiled. The most future-proof
+  policy: **train on whatever the daily benchmark measures** — then the profile always matches
+  what's tracked. `pgo-train` can be extended, or run extra `benchmark.py` globs into
+  `build/pgo-raw/` before `pgo-merge`.
+
+Don't over-engineer coverage — the broad pokec mix is the 80/20; expansions + aggregations +
+reads/writes already generalize well.
+
+## Caveats
+
+- **Train/test overlap:** training on mgbench and then benchmarking mgbench is optimistic
+  ("train on test"). It's the realistic case when production traffic ≈ benchmark traffic, and
+  the shared-machinery win generalizes regardless — but read the absolute numbers with that in mind.
+- **First CI run is a shakeout.** The profile plumbing (instrumented binary writing to
+  `build/pgo-raw/` via `LLVM_PROFILE_FILE=...%p_%m.profraw`, then `llvm-profdata merge`) is
+  wired but has not run in this CI; watch the "PGO — instrument, train, merge" step logs.
+- **Not BOLT/AutoFDO.** Those need branch-record (LBR) sampling, unavailable on VMs; instrumented
+  PGO is deliberate here and needs no PMU.
+- **~2× build time** on the PGO path (two full builds + a training run). Fine for the nightly
+  window; for production, generate the profile on a cadence and cache it rather than every build.

--- a/tools/pgo/README.md
+++ b/tools/pgo/README.md
@@ -21,15 +21,21 @@ Single `-D` token so it forwards cleanly through `build.sh` / `mgbuild.sh`:
 Via `mgbuild.sh`:
 
 ```bash
-# 1. instrumented build
+# 1. instrumented build (this is what copies the repo into the container)
 mgbuild.sh ... build-memgraph --pgo generate
-# 2. train (exercises the instrumented binary across the full mgbench query mix)
+# 2. datasets + test env for the training workload
+mgbuild.sh ... init-tests
+# 3. train (exercises the instrumented binary across the full mgbench query mix)
 mgbuild.sh ... --enterprise-license "$L" --organization-name "$O" pgo-train --dataset pokec --size small
-# 3. merge raw profiles -> build/pgo.profdata
+# 4. merge raw profiles -> /home/mg/pgo.profdata (OUTSIDE build/, so it survives step 5's clean)
 mgbuild.sh ... pgo-merge
-# 4. optimized build
-mgbuild.sh ... build-memgraph --pgo use --split-debug
+# 5. optimized build; --no-copy reuses the source from step 1, --pgo use reads the merged profile
+mgbuild.sh ... build-memgraph --pgo use --no-copy --split-debug
 ```
+
+Order matters: `build-memgraph` wipes `build/*` (and re-copies the repo unless `--no-copy`),
+so the instrumented build must come first, the profile is stored outside `build/`, and the
+optimized build uses `--no-copy` to keep the source + profile from the earlier steps.
 
 ## The CI / Grafana experiment
 


### PR DESCRIPTION
Adds opt-in Profile-Guided Optimization (PGO) for the `memgraph` binary and an experiment path to measure it on the bench-graph.

**What.** A `MG_PGO=generate|use` CMake option, `mgbuild.sh` support (`build-memgraph --pgo`, plus `pgo-train` / `pgo-merge`), and a `pgo` `workflow_dispatch` input on the Daily Benchmark workflow that builds a PGO'd binary (instrument → train on mgbench → optimize) before benchmarking.

**How.** `MG_PGO` is a single `-D` token that `CMakeLists.txt` expands into `-fprofile-generate` / `-fprofile-use` (a single token avoids the word-splitting that mangles multi-token `CMAKE_CXX_FLAGS` through `mgbuild.sh`/`build.sh`). `pgo-train` exercises the full mgbench pokec query mix (`pokec/small/*/*`, all groups) against the instrumented binary with a per-restart `LLVM_PROFILE_FILE`; `pgo-merge` combines the raw profiles into `build/pgo.profdata`. Dispatching `daily_benchmark` with `pgo=true` runs instrument → train → merge → `--pgo use`, then benchmarks and uploads tagged by branch, so the branch series overlays master's on the bench-graph.

**Why.** Top-down microarchitecture profiling showed query execution is frontend-bound; instrumented PGO measured ~+25% short-query throughput (control- and generalization-validated). This lets us confirm the effect across the whole benchmark suite before productionizing PGO. Design and training-data rationale in `tools/pgo/README.md`.

Experiment: dispatch this branch with `pgo=true`; master's scheduled run is unaffected (input defaults `false`).
