### PR TITLE
fix(storage): seek to lower bound in edge index scans

### DIFF
--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -116,7 +116,13 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
       EdgeAccessor current_accessor_;
     };
 
-    Iterator begin() { return {this, index_accessor_.begin()}; }
+    Iterator begin() {
+      if (!bounds_valid_) return {this, index_accessor_.end()};
+      if (lower_bound_) {
+        return {this, index_accessor_.find_equal_or_greater(lower_bound_->value())};
+      }
+      return {this, index_accessor_.begin()};
+    }
 
     Iterator end() { return {this, index_accessor_.end()}; }
 

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -90,7 +90,13 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
       EdgeAccessor current_accessor_;
     };
 
-    Iterator begin() { return {this, index_accessor_.begin()}; }
+    Iterator begin() {
+      if (!bounds_valid_) return {this, index_accessor_.end()};
+      if (lower_bound_) {
+        return {this, index_accessor_.find_equal_or_greater(lower_bound_->value())};
+      }
+      return {this, index_accessor_.begin()};
+    }
 
     Iterator end() { return {this, index_accessor_.end()}; }
 

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -77,6 +77,9 @@ target_link_libraries(${test_prefix}storage_v2_property_store mg::storage)
 add_benchmark(storage_v2_enum_store_bench.cpp)
 target_link_libraries(${test_prefix}storage_v2_enum_store_bench mg::storage)
 
+add_benchmark(storage_v2_edge_index_scan.cpp)
+target_link_libraries(${test_prefix}storage_v2_edge_index_scan mg::storage)
+
 add_benchmark(thread_safe_memory.cpp)
 target_link_libraries(${test_prefix}thread_safe_memory mg-utils)
 

--- a/tests/benchmark/storage_v2_edge_index_scan.cpp
+++ b/tests/benchmark/storage_v2_edge_index_scan.cpp
@@ -1,0 +1,100 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Guards that a bounded edge-index lookup stays O(log n) in the index size. The
+// sweep fits per-lookup time against index size, so a regression to a full O(n)
+// scan flips the reported complexity.
+
+#include <benchmark/benchmark.h>
+#include <spdlog/spdlog.h>
+
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/view.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/logging.hpp"
+
+namespace {
+
+using memgraph::storage::Config;
+using memgraph::storage::EdgeTypeId;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::PropertyId;
+using memgraph::storage::PropertyValue;
+using memgraph::storage::View;
+
+// Builds a storage holding n edges of a single type, each with a distinct integer
+// index property 0..n-1, and an edge-type+property index over them.
+std::unique_ptr<InMemoryStorage> MakeIndexedEdges(int64_t n, EdgeTypeId &edge_type, PropertyId &prop) {
+  Config config{};
+  config.salient.items.properties_on_edges = true;
+  auto storage = std::make_unique<InMemoryStorage>(config);
+
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    edge_type = acc->NameToEdgeType("E");
+    prop = acc->NameToProperty("id");
+    for (int64_t i = 0; i < n; ++i) {
+      auto from = acc->CreateVertex();
+      auto to = acc->CreateVertex();
+      auto edge = acc->CreateEdge(&from, &to, edge_type);
+      MG_ASSERT(edge.has_value());
+      MG_ASSERT(edge->SetProperty(prop, PropertyValue(i)).has_value());
+    }
+    MG_ASSERT(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    auto acc = storage->ReadOnlyAccess();
+    MG_ASSERT(acc->CreateIndex(edge_type, prop).has_value());
+    MG_ASSERT(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  return storage;
+}
+
+// NOLINTNEXTLINE(google-runtime-references)
+void EdgeTypePropertyIndexPointLookup(benchmark::State &state) {
+  const int64_t n = state.range(0);
+  EdgeTypeId edge_type;
+  PropertyId prop;
+  auto storage = MakeIndexedEdges(n, edge_type, prop);
+
+  // Look up a value in the middle: reaching it needs the lower-bound seek (a head
+  // scan would walk n/2 entries) and stopping after it needs the upper-bound
+  // early exit (else the scan walks the other n/2). Either regression makes the
+  // per-lookup cost O(n).
+  const auto needle = PropertyValue(n / 2);
+  auto acc = storage->Access(memgraph::storage::READ);
+
+  for (auto _ : state) {
+    int64_t found = 0;
+    for (const auto &edge : acc->Edges(edge_type, prop, needle, View::OLD)) {
+      found += static_cast<int64_t>(edge.Gid().AsUint());
+    }
+    benchmark::DoNotOptimize(found);
+  }
+  state.SetComplexityN(n);
+}
+
+BENCHMARK(EdgeTypePropertyIndexPointLookup)
+    ->RangeMultiplier(2)
+    ->Range(1 << 10, 1 << 18)
+    ->Complexity(benchmark::oLogN)
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  spdlog::set_level(spdlog::level::off);
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -3548,6 +3548,66 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexBasic) {
   EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id2, this->edge_prop_id2, View::NEW), View::NEW), IsEmpty());
 }
 
+// A bounded scan returns exactly the entries inside the requested range, with the
+// boundary entries included or excluded per the bound.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(IndexTest, EdgeTypePropertyIndexBoundedScan) {
+  if constexpr (!(std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
+    return;
+  }
+  {
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(!acc->CreateIndex(this->edge_type_id1, this->prop_id).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  auto acc = this->storage->Access(memgraph::storage::WRITE);
+  for (int i = 0; i < 20; ++i) {
+    auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
+    auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
+    auto edge = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id1, acc.get());
+    ASSERT_NO_ERROR(edge.SetProperty(this->prop_id, memgraph::storage::PropertyValue(i)));
+  }
+  acc->AdvanceCommand();
+
+  // Equality: only the exact value.
+  EXPECT_THAT(
+      this->GetIds(acc->Edges(this->edge_type_id1, this->prop_id, memgraph::storage::PropertyValue(12), View::OLD)),
+      UnorderedElementsAre(12));
+
+  // Inclusive bounds keep the boundary entries 5 and 10.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1,
+                                      this->prop_id,
+                                      memgraph::utils::MakeBoundInclusive(memgraph::storage::PropertyValue(5)),
+                                      memgraph::utils::MakeBoundInclusive(memgraph::storage::PropertyValue(10)),
+                                      View::OLD)),
+              UnorderedElementsAre(5, 6, 7, 8, 9, 10));
+
+  // Exclusive bounds drop the boundary entries 5 and 10.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1,
+                                      this->prop_id,
+                                      memgraph::utils::MakeBoundExclusive(memgraph::storage::PropertyValue(5)),
+                                      memgraph::utils::MakeBoundExclusive(memgraph::storage::PropertyValue(10)),
+                                      View::OLD)),
+              UnorderedElementsAre(6, 7, 8, 9));
+
+  // Lower bound only.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1,
+                                      this->prop_id,
+                                      memgraph::utils::MakeBoundInclusive(memgraph::storage::PropertyValue(17)),
+                                      std::nullopt,
+                                      View::OLD)),
+              UnorderedElementsAre(17, 18, 19));
+
+  // Upper bound only.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1,
+                                      this->prop_id,
+                                      std::nullopt,
+                                      memgraph::utils::MakeBoundExclusive(memgraph::storage::PropertyValue(3)),
+                                      View::OLD)),
+              UnorderedElementsAre(0, 1, 2));
+}
+
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, EdgeTypePropertyIndexTransactionalIsolation) {
   if constexpr (!(std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
@@ -4002,6 +4062,61 @@ TYPED_TEST(IndexTest, EdgePropertyIndexBasic) {
   EXPECT_THAT(this->GetIds(acc->Edges(this->edge_prop_id2, View::OLD), View::OLD), IsEmpty());
   EXPECT_THAT(this->GetIds(acc->Edges(this->edge_prop_id1, View::NEW), View::NEW), UnorderedElementsAre(1, 3, 5, 7, 9));
   EXPECT_THAT(this->GetIds(acc->Edges(this->edge_prop_id2, View::NEW), View::NEW), IsEmpty());
+}
+
+// A bounded scan returns exactly the entries inside the requested range, with the
+// boundary entries included or excluded per the bound.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(IndexTest, EdgePropertyIndexBoundedScan) {
+  if constexpr (!(std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
+    return;
+  }
+  {
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(!acc->CreateGlobalEdgeIndex(this->prop_id).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  auto acc = this->storage->Access(memgraph::storage::WRITE);
+  for (int i = 0; i < 20; ++i) {
+    auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
+    auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
+    auto edge = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id1, acc.get());
+    ASSERT_NO_ERROR(edge.SetProperty(this->prop_id, memgraph::storage::PropertyValue(i)));
+  }
+  acc->AdvanceCommand();
+
+  // Equality: only the exact value.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->prop_id, memgraph::storage::PropertyValue(12), View::OLD)),
+              UnorderedElementsAre(12));
+
+  // Inclusive bounds keep the boundary entries 5 and 10.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->prop_id,
+                                      memgraph::utils::MakeBoundInclusive(memgraph::storage::PropertyValue(5)),
+                                      memgraph::utils::MakeBoundInclusive(memgraph::storage::PropertyValue(10)),
+                                      View::OLD)),
+              UnorderedElementsAre(5, 6, 7, 8, 9, 10));
+
+  // Exclusive bounds drop the boundary entries 5 and 10.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->prop_id,
+                                      memgraph::utils::MakeBoundExclusive(memgraph::storage::PropertyValue(5)),
+                                      memgraph::utils::MakeBoundExclusive(memgraph::storage::PropertyValue(10)),
+                                      View::OLD)),
+              UnorderedElementsAre(6, 7, 8, 9));
+
+  // Lower bound only.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->prop_id,
+                                      memgraph::utils::MakeBoundInclusive(memgraph::storage::PropertyValue(17)),
+                                      std::nullopt,
+                                      View::OLD)),
+              UnorderedElementsAre(17, 18, 19));
+
+  // Upper bound only.
+  EXPECT_THAT(this->GetIds(acc->Edges(this->prop_id,
+                                      std::nullopt,
+                                      memgraph::utils::MakeBoundExclusive(memgraph::storage::PropertyValue(3)),
+                                      View::OLD)),
+              UnorderedElementsAre(0, 1, 2));
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)


### PR DESCRIPTION
Previously, edge-type-property and edge-property index scans started at the head of the skiplist and walked forward to the requested range, so each bounded lookup was O(n) in the index size and ScanAllByEdgeTypePropertyValue slowed down as the index grew.

Iterable::begin() now seeks directly to the lower bound, so a lookup is O(log n) plus the number of matches.