### PR TITLE
Feature proposal: Add vector search prefiltering

### DIFF
--- a/include/_mgp.hpp
+++ b/include/_mgp.hpp
@@ -421,14 +421,15 @@ inline size_t graph_approximate_edge_count(mgp_graph *g) {
 // vector index
 
 inline mgp_map *graph_search_vector_index(mgp_graph *graph, const char *index_name, mgp_list *search_vector,
-                                          size_t result_size, mgp_memory *memory) {
-  return MgInvoke<mgp_map *>(mgp_graph_search_vector_index, graph, index_name, search_vector, result_size, memory);
+                                          size_t result_size, mgp_list *search_filter, mgp_memory *memory) {
+  return MgInvoke<mgp_map *>(
+      mgp_graph_search_vector_index, graph, index_name, search_vector, result_size, search_filter, memory);
 }
 
 inline mgp_map *graph_search_vector_index_on_edges(mgp_graph *graph, const char *index_name, mgp_list *search_vector,
-                                                   size_t result_size, mgp_memory *memory) {
+                                                   size_t result_size, mgp_list *search_filter, mgp_memory *memory) {
   return MgInvoke<mgp_map *>(
-      mgp_graph_search_vector_index_on_edges, graph, index_name, search_vector, result_size, memory);
+      mgp_graph_search_vector_index_on_edges, graph, index_name, search_vector, result_size, search_filter, memory);
 }
 
 inline mgp_map *graph_show_index_info(mgp_graph *graph, mgp_memory *memory) {

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -1042,12 +1042,16 @@ enum mgp_error mgp_graph_search_text_edge_index(struct mgp_graph *graph, const c
                                                 int fuzzy_transpositions, struct mgp_memory *memory,
                                                 struct mgp_map **result);
 
+/// The optional `search_filter` list, when non-null and non-empty, restricts the search to the given entity ids
+/// (vertex ids for the node index, edge ids for the edge index); pass a null or empty list to search the whole index.
 enum mgp_error mgp_graph_search_vector_index(struct mgp_graph *graph, const char *index_name, struct mgp_list *query,
-                                             int result_size, struct mgp_memory *memory, struct mgp_map **result);
+                                             int result_size, struct mgp_list *search_filter, struct mgp_memory *memory,
+                                             struct mgp_map **result);
 
 enum mgp_error mgp_graph_search_vector_index_on_edges(struct mgp_graph *graph, const char *index_name,
                                                       struct mgp_list *query, int result_size,
-                                                      struct mgp_memory *memory, struct mgp_map **result);
+                                                      struct mgp_list *search_filter, struct mgp_memory *memory,
+                                                      struct mgp_map **result);
 
 enum mgp_error mgp_graph_show_index_info(struct mgp_graph *graph, struct mgp_memory *memory, struct mgp_map **result);
 

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -5524,11 +5524,14 @@ inline std::string AggregateOverTextEdgeIndex(mgp_graph *memgraph_graph, std::st
 }
 
 inline List SearchVectorIndex(mgp_graph *memgraph_graph, std::string_view index_name, List &query_vector,
-                              size_t result_size) {
-  auto results_or_error =
-      Map(mgp::MemHandlerCallback(
-              graph_search_vector_index, memgraph_graph, index_name.data(), query_vector.GetPtr(), result_size),
-          StealType{});
+                              size_t result_size, List &search_filter) {
+  auto results_or_error = Map(mgp::MemHandlerCallback(graph_search_vector_index,
+                                                      memgraph_graph,
+                                                      index_name.data(),
+                                                      query_vector.GetPtr(),
+                                                      result_size,
+                                                      search_filter.GetPtr()),
+                              StealType{});
   if (results_or_error.KeyExists(kErrorMsgKey)) {
     if (!results_or_error.At(kErrorMsgKey).IsString()) {
       throw VectorSearchException{"The error message is not a string!"};
@@ -5539,11 +5542,14 @@ inline List SearchVectorIndex(mgp_graph *memgraph_graph, std::string_view index_
 }
 
 inline List SearchVectorIndexOnEdges(mgp_graph *memgraph_graph, std::string_view index_name, List &query_vector,
-                                     size_t result_size) {
-  auto results_or_error = Map(
-      mgp::MemHandlerCallback(
-          graph_search_vector_index_on_edges, memgraph_graph, index_name.data(), query_vector.GetPtr(), result_size),
-      StealType{});
+                                     size_t result_size, List &search_filter) {
+  auto results_or_error = Map(mgp::MemHandlerCallback(graph_search_vector_index_on_edges,
+                                                      memgraph_graph,
+                                                      index_name.data(),
+                                                      query_vector.GetPtr(),
+                                                      result_size,
+                                                      search_filter.GetPtr()),
+                              StealType{});
   if (results_or_error.KeyExists(kErrorMsgKey)) {
     if (!results_or_error.At(kErrorMsgKey).IsString()) {
       throw VectorSearchException{"The error message is not a string!"};
@@ -5551,6 +5557,19 @@ inline List SearchVectorIndexOnEdges(mgp_graph *memgraph_graph, std::string_view
     throw VectorSearchException(results_or_error.At(kErrorMsgKey).ValueString().data());
   }
   return results_or_error.At(kSearchResultsKey).ValueList();
+}
+
+// Backward-compatible overloads that search the whole index without a prefilter.
+inline List SearchVectorIndex(mgp_graph *memgraph_graph, std::string_view index_name, List &query_vector,
+                              size_t result_size) {
+  List empty_filter{};
+  return SearchVectorIndex(memgraph_graph, index_name, query_vector, result_size, empty_filter);
+}
+
+inline List SearchVectorIndexOnEdges(mgp_graph *memgraph_graph, std::string_view index_name, List &query_vector,
+                                     size_t result_size) {
+  List empty_filter{};
+  return SearchVectorIndexOnEdges(memgraph_graph, index_name, query_vector, result_size, empty_filter);
 }
 
 inline List GetVectorIndexInfo(mgp_graph *memgraph_graph) {

--- a/query_modules/vector_search_module.cpp
+++ b/query_modules/vector_search_module.cpp
@@ -12,6 +12,8 @@
 #include <cmath>
 #include <iostream>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include <mgp.hpp>
 
@@ -21,6 +23,8 @@ static constexpr std::string_view kProcedureSearchEdges = "search_edges";
 static constexpr std::string_view kParameterIndexName = "index_name";
 static constexpr std::string_view kParameterResultSetSize = "result_set_size";
 static constexpr std::string_view kParameterQueryVector = "query_vector";
+static constexpr std::string_view kParameterPrefilteredNodes = "prefiltered_nodes";
+static constexpr std::string_view kParameterPrefilteredEdges = "prefiltered_edges";
 static constexpr std::string_view kReturnNode = "node";
 static constexpr std::string_view kReturnEdge = "edge";
 static constexpr std::string_view kReturnDistance = "distance";
@@ -38,14 +42,45 @@ static constexpr std::string_view kReturnScalarKind = "scalar_kind";
 static constexpr std::string_view kReturnIndexType = "index_type";
 
 static constexpr std::string_view kProcedureCosineSimilarity = "cosine_similarity";
+static constexpr std::string_view kProcedureInnerProduct = "ip";
+static constexpr std::string_view kProcedureL2Squared = "l2sq";
+static constexpr std::string_view kProcedureHaversine = "haversine";
 static constexpr std::string_view kParameterVector1 = "vector1";
 static constexpr std::string_view kParameterVector2 = "vector2";
+
+// Builds a list of entity ids from the optional prefilter argument at `index` in `arguments`. The argument is a list
+// of nodes, relationships, or integer ids; the returned list of ids is passed to the vector index to restrict the
+// search. Returns an empty list (no filtering) when the argument is absent or empty.
+mgp::List BuildElementFilter(const mgp::List &arguments, size_t index);
 
 void Search(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void SearchEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void ShowIndexInfo(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void CosineSimilarityFunction(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_memory *memory);
+void InnerProductFunction(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_memory *memory);
+void L2SquaredFunction(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_memory *memory);
+void HaversineFunction(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_memory *memory);
 }  // namespace VectorSearch
+
+mgp::List VectorSearch::BuildElementFilter(const mgp::List &arguments, size_t index) {
+  mgp::List filter{};
+  if (arguments.Size() <= index) {
+    return filter;
+  }
+  const auto filter_arg = arguments[index].ValueList();
+  for (const auto &val : filter_arg) {
+    if (val.IsNode()) {
+      filter.AppendExtend(mgp::Value(val.ValueNode().Id().AsInt()));
+    } else if (val.IsRelationship()) {
+      filter.AppendExtend(mgp::Value(val.ValueRelationship().Id().AsInt()));
+    } else if (val.IsInt()) {
+      filter.AppendExtend(mgp::Value(val.ValueInt()));
+    } else {
+      throw std::invalid_argument("The vector search filter must contain nodes, relationships, or their integer ids.");
+    }
+  }
+  return filter;
+}
 
 void VectorSearch::Search(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
   mgp::MemoryDispatcherGuard guard{memory};
@@ -56,8 +91,9 @@ void VectorSearch::Search(mgp_list *args, mgp_graph *memgraph_graph, mgp_result 
     const auto index_name = arguments[0].ValueString();
     const auto result_set_size = arguments[1].ValueInt();
     auto query_vector = arguments[2].ValueList();
+    auto search_filter = VectorSearch::BuildElementFilter(arguments, 3);
 
-    auto results = mgp::SearchVectorIndex(memgraph_graph, index_name, query_vector, result_set_size);
+    auto results = mgp::SearchVectorIndex(memgraph_graph, index_name, query_vector, result_set_size, search_filter);
 
     for (const auto &result : results) {
       auto record = record_factory.NewRecord();
@@ -82,8 +118,10 @@ void VectorSearch::SearchEdges(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
     const auto index_name = arguments[0].ValueString();
     const auto result_set_size = arguments[1].ValueInt();
     auto query_vector = arguments[2].ValueList();
+    auto search_filter = VectorSearch::BuildElementFilter(arguments, 3);
 
-    auto results = mgp::SearchVectorIndexOnEdges(memgraph_graph, index_name, query_vector, result_set_size);
+    auto results =
+        mgp::SearchVectorIndexOnEdges(memgraph_graph, index_name, query_vector, result_set_size, search_filter);
 
     for (const auto &result : results) {
       auto record = record_factory.NewRecord();
@@ -125,37 +163,53 @@ void VectorSearch::ShowIndexInfo(mgp_list *args, mgp_graph *memgraph_graph, mgp_
   }
 }
 
+namespace {
+// Extracts two equal-length numeric vectors from the function arguments. Must be called with an active
+// MemoryDispatcherGuard, as it constructs mgp values.
+std::pair<std::vector<double>, std::vector<double>> ExtractVectorPair(mgp_list *args) {
+  const auto vector1 = mgp::Value(mgp::ref_type, mgp::list_at(args, 0)).ValueList();
+  const auto vector2 = mgp::Value(mgp::ref_type, mgp::list_at(args, 1)).ValueList();
+
+  if (vector1.Size() == 0 || vector1.Size() != vector2.Size()) {
+    throw std::invalid_argument("Vectors must be non-empty and have the same dimension");
+  }
+
+  auto get_numeric_value = [](const mgp::Value &val) {
+    if (val.IsDouble()) {
+      return val.ValueDouble();
+    }
+    if (val.IsInt()) {
+      return static_cast<double>(val.ValueInt());
+    }
+    throw std::invalid_argument("Vector elements must be numeric (int or double)");
+  };
+
+  std::vector<double> v1;
+  std::vector<double> v2;
+  v1.reserve(vector1.Size());
+  v2.reserve(vector2.Size());
+  for (size_t i = 0; i < vector1.Size(); ++i) {
+    v1.push_back(get_numeric_value(vector1[i]));
+    v2.push_back(get_numeric_value(vector2[i]));
+  }
+  return {std::move(v1), std::move(v2)};
+}
+}  // namespace
+
 void VectorSearch::CosineSimilarityFunction(mgp_list *args, mgp_func_context * /*ctx*/, mgp_func_result *res,
                                             mgp_memory *memory) {
   try {
     mgp::MemoryDispatcherGuard guard{memory};
 
-    const auto vector1 = mgp::Value(mgp::ref_type, mgp::list_at(args, 0)).ValueList();
-    const auto vector2 = mgp::Value(mgp::ref_type, mgp::list_at(args, 1)).ValueList();
-
-    if (vector1.Size() == 0 || vector1.Size() != vector2.Size()) {
-      throw std::invalid_argument("Vectors must be non-empty and have the same dimension");
-    }
+    const auto [v1, v2] = ExtractVectorPair(args);
 
     auto dot_product = 0.0;
     auto magnitude1 = 0.0;
     auto magnitude2 = 0.0;
-    for (auto i = 0; i < vector1.Size(); ++i) {
-      auto get_numeric_value = [&](const mgp::Value &val) {
-        if (val.IsDouble()) {
-          return val.ValueDouble();
-        }
-        if (val.IsInt()) {
-          return static_cast<double>(val.ValueInt());
-        }
-        throw std::invalid_argument("Vector elements must be numeric (int or double)");
-      };
-      const auto val1 = get_numeric_value(vector1[i]);
-      const auto val2 = get_numeric_value(vector2[i]);
-
-      dot_product += val1 * val2;
-      magnitude1 += val1 * val1;
-      magnitude2 += val2 * val2;
+    for (size_t i = 0; i < v1.size(); ++i) {
+      dot_product += v1[i] * v2[i];
+      magnitude1 += v1[i] * v1[i];
+      magnitude2 += v2[i] * v2[i];
     }
     magnitude1 = std::sqrt(magnitude1);
     magnitude2 = std::sqrt(magnitude2);
@@ -171,24 +225,100 @@ void VectorSearch::CosineSimilarityFunction(mgp_list *args, mgp_func_context * /
   }
 }
 
+// Inner-product distance, matching uSearch's `ip` metric: 1 - dot(v1, v2).
+void VectorSearch::InnerProductFunction(mgp_list *args, mgp_func_context * /*ctx*/, mgp_func_result *res,
+                                        mgp_memory *memory) {
+  try {
+    mgp::MemoryDispatcherGuard guard{memory};
+
+    const auto [v1, v2] = ExtractVectorPair(args);
+
+    auto dot_product = 0.0;
+    for (size_t i = 0; i < v1.size(); ++i) {
+      dot_product += v1[i] * v2[i];
+    }
+
+    auto result = mgp::Result(res);
+    result.SetValue(1.0 - dot_product);
+  } catch (const std::exception &e) {
+    mgp::func_result_set_error_msg(res, e.what(), memory);
+  }
+}
+
+// Squared Euclidean distance, matching uSearch's `l2sq` metric (the default index metric): sum((a - b)^2).
+void VectorSearch::L2SquaredFunction(mgp_list *args, mgp_func_context * /*ctx*/, mgp_func_result *res,
+                                     mgp_memory *memory) {
+  try {
+    mgp::MemoryDispatcherGuard guard{memory};
+
+    const auto [v1, v2] = ExtractVectorPair(args);
+
+    auto squared_distance = 0.0;
+    for (size_t i = 0; i < v1.size(); ++i) {
+      const auto diff = v1[i] - v2[i];
+      squared_distance += diff * diff;
+    }
+
+    auto result = mgp::Result(res);
+    result.SetValue(squared_distance);
+  } catch (const std::exception &e) {
+    mgp::func_result_set_error_msg(res, e.what(), memory);
+  }
+}
+
+// Haversine (great-circle) distance on the unit sphere, matching uSearch's `haversine` metric. Both inputs must be
+// 2-element [latitude, longitude] vectors in degrees; the result is the central angle in radians.
+void VectorSearch::HaversineFunction(mgp_list *args, mgp_func_context * /*ctx*/, mgp_func_result *res,
+                                     mgp_memory *memory) {
+  try {
+    mgp::MemoryDispatcherGuard guard{memory};
+
+    const auto [v1, v2] = ExtractVectorPair(args);
+    if (v1.size() != 2) {
+      throw std::invalid_argument("Haversine distance requires 2-element [latitude, longitude] vectors (in degrees)");
+    }
+
+    auto to_radians = [](double degrees) { return degrees * M_PI / 180.0; };
+    const auto lat_a = v1[0];
+    const auto lon_a = v1[1];
+    const auto lat_b = v2[0];
+    const auto lon_b = v2[1];
+
+    const auto lat_delta = to_radians(lat_b - lat_a) / 2.0;
+    const auto lon_delta = to_radians(lon_b - lon_a) / 2.0;
+
+    const auto x = std::sin(lat_delta) * std::sin(lat_delta) + std::cos(to_radians(lat_a)) *
+                                                                   std::cos(to_radians(lat_b)) * std::sin(lon_delta) *
+                                                                   std::sin(lon_delta);
+
+    auto result = mgp::Result(res);
+    result.SetValue(2.0 * std::asin(std::sqrt(x)));
+  } catch (const std::exception &e) {
+    mgp::func_result_set_error_msg(res, e.what(), memory);
+  }
+}
+
 extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *memory) {
   try {
     mgp::MemoryDispatcherGuard guard{memory};
-    AddProcedure(VectorSearch::Search,
-                 VectorSearch::kProcedureSearch,
-                 mgp::ProcedureType::Read,
-                 {
-                     mgp::Parameter(VectorSearch::kParameterIndexName, mgp::Type::String),
-                     mgp::Parameter(VectorSearch::kParameterResultSetSize, mgp::Type::Int),
-                     mgp::Parameter(VectorSearch::kParameterQueryVector, {mgp::Type::List, mgp::Type::Any}),
-                 },
-                 {
-                     mgp::Return(VectorSearch::kReturnNode, mgp::Type::Node),
-                     mgp::Return(VectorSearch::kReturnDistance, mgp::Type::Double),
-                     mgp::Return(VectorSearch::kReturnSimilarity, mgp::Type::Double),
-                 },
-                 module,
-                 memory);
+    const auto empty_filter = mgp::Value(mgp::List{});
+    AddProcedure(
+        VectorSearch::Search,
+        VectorSearch::kProcedureSearch,
+        mgp::ProcedureType::Read,
+        {
+            mgp::Parameter(VectorSearch::kParameterIndexName, mgp::Type::String),
+            mgp::Parameter(VectorSearch::kParameterResultSetSize, mgp::Type::Int),
+            mgp::Parameter(VectorSearch::kParameterQueryVector, {mgp::Type::List, mgp::Type::Any}),
+            mgp::Parameter(VectorSearch::kParameterPrefilteredNodes, {mgp::Type::List, mgp::Type::Any}, empty_filter),
+        },
+        {
+            mgp::Return(VectorSearch::kReturnNode, mgp::Type::Node),
+            mgp::Return(VectorSearch::kReturnDistance, mgp::Type::Double),
+            mgp::Return(VectorSearch::kReturnSimilarity, mgp::Type::Double),
+        },
+        module,
+        memory);
 
     AddProcedure(VectorSearch::ShowIndexInfo,
                  VectorSearch::kProcedureShowIndexInfo,
@@ -208,24 +338,53 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
                  module,
                  memory);
 
-    AddProcedure(VectorSearch::SearchEdges,
-                 VectorSearch::kProcedureSearchEdges,
-                 mgp::ProcedureType::Read,
-                 {
-                     mgp::Parameter(VectorSearch::kParameterIndexName, mgp::Type::String),
-                     mgp::Parameter(VectorSearch::kParameterResultSetSize, mgp::Type::Int),
-                     mgp::Parameter(VectorSearch::kParameterQueryVector, {mgp::Type::List, mgp::Type::Any}),
-                 },
-                 {
-                     mgp::Return(VectorSearch::kReturnEdge, mgp::Type::Relationship),
-                     mgp::Return(VectorSearch::kReturnDistance, mgp::Type::Double),
-                     mgp::Return(VectorSearch::kReturnSimilarity, mgp::Type::Double),
-                 },
-                 module,
-                 memory);
+    AddProcedure(
+        VectorSearch::SearchEdges,
+        VectorSearch::kProcedureSearchEdges,
+        mgp::ProcedureType::Read,
+        {
+            mgp::Parameter(VectorSearch::kParameterIndexName, mgp::Type::String),
+            mgp::Parameter(VectorSearch::kParameterResultSetSize, mgp::Type::Int),
+            mgp::Parameter(VectorSearch::kParameterQueryVector, {mgp::Type::List, mgp::Type::Any}),
+            mgp::Parameter(VectorSearch::kParameterPrefilteredEdges, {mgp::Type::List, mgp::Type::Any}, empty_filter),
+        },
+        {
+            mgp::Return(VectorSearch::kReturnEdge, mgp::Type::Relationship),
+            mgp::Return(VectorSearch::kReturnDistance, mgp::Type::Double),
+            mgp::Return(VectorSearch::kReturnSimilarity, mgp::Type::Double),
+        },
+        module,
+        memory);
 
     mgp::AddFunction(VectorSearch::CosineSimilarityFunction,
                      VectorSearch::kProcedureCosineSimilarity,
+                     {
+                         mgp::Parameter(VectorSearch::kParameterVector1, {mgp::Type::List, mgp::Type::Any}),
+                         mgp::Parameter(VectorSearch::kParameterVector2, {mgp::Type::List, mgp::Type::Any}),
+                     },
+                     module,
+                     memory);
+
+    mgp::AddFunction(VectorSearch::InnerProductFunction,
+                     VectorSearch::kProcedureInnerProduct,
+                     {
+                         mgp::Parameter(VectorSearch::kParameterVector1, {mgp::Type::List, mgp::Type::Any}),
+                         mgp::Parameter(VectorSearch::kParameterVector2, {mgp::Type::List, mgp::Type::Any}),
+                     },
+                     module,
+                     memory);
+
+    mgp::AddFunction(VectorSearch::L2SquaredFunction,
+                     VectorSearch::kProcedureL2Squared,
+                     {
+                         mgp::Parameter(VectorSearch::kParameterVector1, {mgp::Type::List, mgp::Type::Any}),
+                         mgp::Parameter(VectorSearch::kParameterVector2, {mgp::Type::List, mgp::Type::Any}),
+                     },
+                     module,
+                     memory);
+
+    mgp::AddFunction(VectorSearch::HaversineFunction,
+                     VectorSearch::kProcedureHaversine,
                      {
                          mgp::Parameter(VectorSearch::kParameterVector1, {mgp::Type::List, mgp::Type::Any}),
                          mgp::Parameter(VectorSearch::kParameterVector2, {mgp::Type::List, mgp::Type::Any}),

--- a/src/query/db_accessor.cpp
+++ b/src/query/db_accessor.cpp
@@ -256,13 +256,15 @@ bool DbAccessor::PointIndexExists(storage::LabelId label, storage::PropertyId pr
 }
 
 std::vector<std::tuple<storage::VertexAccessor, double, double>> DbAccessor::VectorIndexSearchOnNodes(
-    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
-  return accessor_->VectorIndexSearchOnNodes(index_name, number_of_results, vector);
+    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+    const std::unordered_set<storage::Gid> &vertex_filter) {
+  return accessor_->VectorIndexSearchOnNodes(index_name, number_of_results, vector, vertex_filter);
 }
 
 std::vector<std::tuple<storage::EdgeAccessor, double, double>> DbAccessor::VectorIndexSearchOnEdges(
-    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
-  return accessor_->VectorIndexSearchOnEdges(index_name, number_of_results, vector);
+    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+    const std::unordered_set<storage::Gid> &edge_filter) {
+  return accessor_->VectorIndexSearchOnEdges(index_name, number_of_results, vector, edge_filter);
 }
 
 std::vector<storage::VectorIndexInfo> DbAccessor::ListAllVectorIndices() const {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -53,6 +53,7 @@ enum class text_search_mode;
 #include <optional>
 #include <ranges>
 #include <span>
+#include <unordered_set>
 
 #include <cppitertools/filter.hpp>
 #include <cppitertools/imap.hpp>
@@ -720,10 +721,12 @@ class DbAccessor final {
   bool PointIndexExists(storage::LabelId label, storage::PropertyId prop) const;
 
   std::vector<std::tuple<storage::VertexAccessor, double, double>> VectorIndexSearchOnNodes(
-      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector);
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+      const std::unordered_set<storage::Gid> &vertex_filter = {});
 
   std::vector<std::tuple<storage::EdgeAccessor, double, double>> VectorIndexSearchOnEdges(
-      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector);
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+      const std::unordered_set<storage::Gid> &edge_filter = {});
 
   std::vector<storage::VectorIndexInfo> ListAllVectorIndices() const;
 

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -21,6 +21,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 
@@ -4653,9 +4654,33 @@ mgp_error mgp_graph_search_text_edge_index(struct mgp_graph *graph, const char *
   });
 }
 
+namespace {
+// Builds a gid allowlist from an mgp list of entity ids (as returned by id(node)/id(rel)). A null or empty list means
+// "no filter". Used to prefilter vector index search.
+std::unordered_set<memgraph::storage::Gid> BuildVectorSearchFilter(mgp_list *search_filter) {
+  std::unordered_set<memgraph::storage::Gid> filter;
+  if (search_filter == nullptr) {
+    return filter;
+  }
+  filter.reserve(search_filter->elems.size());
+  for (auto &elem : search_filter->elems) {
+    if (MgpValueGetType(elem) != mgp_value_type::MGP_VALUE_TYPE_INT) {
+      throw std::logic_error("The vector search filter must be a list of entity ids (integers)!");
+    }
+    int64_t value = 0;
+    if (auto err = mgp_value_get_int(&elem, &value); err != mgp_error::MGP_ERROR_NO_ERROR) {
+      throw std::logic_error("Failed extracting an id from the vector search filter argument!");
+    }
+    filter.insert(memgraph::storage::Gid::FromInt(value));
+  }
+  return filter;
+}
+}  // namespace
+
 mgp_error mgp_graph_search_vector_index(mgp_graph *graph, const char *index_name, mgp_list *search_query,
-                                        int result_size, mgp_memory *memory, mgp_map **result) {
-  return WrapExceptions([graph, memory, index_name, search_query, result, result_size]() {
+                                        int result_size, mgp_list *search_filter, mgp_memory *memory,
+                                        mgp_map **result) {
+  return WrapExceptions([graph, memory, index_name, search_query, search_filter, result, result_size]() {
     std::vector<std::tuple<memgraph::storage::VertexAccessor, double, double>> found_vertices;
     std::optional<std::string> error_msg = std::nullopt;
     try {
@@ -4682,7 +4707,9 @@ mgp_error mgp_graph_search_vector_index(mgp_graph *graph, const char *index_name
         throw std::logic_error(
             "Unrecognized argument type when performing vector search, expected values are Double or Int!");
       }
-      found_vertices = graph->getImpl()->VectorIndexSearchOnNodes(index_name, result_size, search_query_vector);
+      const auto vertex_filter = BuildVectorSearchFilter(search_filter);
+      found_vertices =
+          graph->getImpl()->VectorIndexSearchOnNodes(index_name, result_size, search_query_vector, vertex_filter);
     } catch (memgraph::query::QueryException &e) {
       error_msg = e.what();
     }
@@ -4691,8 +4718,9 @@ mgp_error mgp_graph_search_vector_index(mgp_graph *graph, const char *index_name
 }
 
 mgp_error mgp_graph_search_vector_index_on_edges(mgp_graph *graph, const char *index_name, mgp_list *search_query,
-                                                 int result_size, mgp_memory *memory, mgp_map **result) {
-  return WrapExceptions([graph, memory, index_name, search_query, result, result_size]() {
+                                                 int result_size, mgp_list *search_filter, mgp_memory *memory,
+                                                 mgp_map **result) {
+  return WrapExceptions([graph, memory, index_name, search_query, search_filter, result, result_size]() {
     std::vector<std::tuple<memgraph::storage::EdgeAccessor, double, double>> found_edges;
     std::optional<std::string> error_msg = std::nullopt;
     try {
@@ -4719,7 +4747,9 @@ mgp_error mgp_graph_search_vector_index_on_edges(mgp_graph *graph, const char *i
         throw std::logic_error(
             "Unrecognized argument type when performing vector search, expected values are Double or Int!");
       }
-      found_edges = graph->getImpl()->VectorIndexSearchOnEdges(index_name, result_size, search_query_vector);
+      const auto edge_filter = BuildVectorSearchFilter(search_filter);
+      found_edges =
+          graph->getImpl()->VectorIndexSearchOnEdges(index_name, result_size, search_query_vector, edge_filter);
     } catch (memgraph::query::QueryException &e) {
       error_msg = e.what();
     }

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2448,12 +2448,14 @@ auto DiskStorage::DiskAccessor::PointVertices(LabelId /*label*/, PropertyId /*pr
 }
 
 std::vector<std::tuple<VertexAccessor, double, double>> DiskStorage::DiskAccessor::VectorIndexSearchOnNodes(
-    const std::string & /*index_name*/, uint64_t /*number_of_results*/, const std::vector<float> & /*vector*/) {
+    const std::string & /*index_name*/, uint64_t /*number_of_results*/, const std::vector<float> & /*vector*/,
+    const std::unordered_set<Gid> & /*vertex_filter*/) {
   throw utils::NotYetImplemented("Vector index is not yet implemented for on-disk storage. {}", kErrorMessage);
 }
 
 std::vector<std::tuple<EdgeAccessor, double, double>> DiskStorage::DiskAccessor::VectorIndexSearchOnEdges(
-    const std::string & /*index_name*/, uint64_t /*number_of_results*/, const std::vector<float> & /*vector*/) {
+    const std::string & /*index_name*/, uint64_t /*number_of_results*/, const std::vector<float> & /*vector*/,
+    const std::unordered_set<Gid> & /*edge_filter*/) {
   throw utils::NotYetImplemented("Vector index is not yet implemented for on-disk storage. {}", kErrorMessage);
 }
 

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -371,10 +371,12 @@ class DiskStorage final : public Storage {
         -> PointIterable override;
 
     std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearchOnNodes(
-        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;
+        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+        const std::unordered_set<Gid> &vertex_filter = {}) override;
 
     std::vector<std::tuple<EdgeAccessor, double, double>> VectorIndexSearchOnEdges(
-        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;
+        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+        const std::unordered_set<Gid> &edge_filter = {}) override;
 
     std::vector<VectorIndexInfo> ListAllVectorIndices() const override;
 

--- a/src/storage/v2/indices/vector_edge_index.cpp
+++ b/src/storage/v2/indices/vector_edge_index.cpp
@@ -370,9 +370,9 @@ std::optional<uint64_t> VectorEdgeIndex::ApproximateEdgesVectorCount(std::string
   return std::nullopt;
 }
 
-VectorEdgeIndex::VectorSearchEdgeResults VectorEdgeIndex::SearchEdges(std::string_view index_name,
-                                                                      uint64_t result_set_size,
-                                                                      const std::vector<float> &query_vector) const {
+VectorEdgeIndex::VectorSearchEdgeResults VectorEdgeIndex::SearchEdges(
+    std::string_view index_name, uint64_t result_set_size, const std::vector<float> &query_vector,
+    const std::unordered_set<Gid> &edge_filter) const {
   auto maybe_id = std::invoke([&]() -> std::optional<uint64_t> {
     for (const auto &[id, item_ptr] : *index_) {
       if (item_ptr->spec.index_name == index_name) return id;
@@ -390,8 +390,11 @@ VectorEdgeIndex::VectorSearchEdgeResults VectorEdgeIndex::SearchEdges(std::strin
 
   auto guard = utils::SharedResourceLockGuard(mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
   auto ep_lock = std::shared_lock{edge_endpoints_mutex_};
-  const auto result_keys = mg_index.index.filtered_search(
-      query_vector.data(), result_set_size, [this](Edge *edge) { return edge_endpoints_.contains(edge); });
+  // Reading Edge::gid is safe here: gid is immutable and the storage layer holds an edges accessor for the search.
+  const auto result_keys =
+      mg_index.index.filtered_search(query_vector.data(), result_set_size, [this, &edge_filter](Edge *edge) {
+        return edge_endpoints_.contains(edge) && (edge_filter.empty() || edge_filter.contains(edge->gid));
+      });
   for (std::size_t i = 0; i < result_keys.size(); ++i) {
     auto *edge = static_cast<Edge *>(result_keys[i].member.key);
     auto [from_vertex, to_vertex, edge_type] = edge_endpoints_.at(edge);

--- a/src/storage/v2/indices/vector_edge_index.hpp
+++ b/src/storage/v2/indices/vector_edge_index.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <shared_mutex>
 #include <span>
+#include <unordered_set>
 
 #include "storage/v2/durability/serialization.hpp"
 #include "storage/v2/edge.hpp"
@@ -244,8 +245,11 @@ class VectorEdgeIndex {
   std::optional<uint64_t> ApproximateEdgesVectorCount(std::string_view index_name) const;
 
   /// @brief Searches for edges in the specified index using a query vector.
+  /// @param edge_filter Optional allowlist of edge gids to restrict the search to. When empty, no filtering is applied;
+  /// when non-empty, only edges whose gid is present are considered (prefiltering during traversal).
   VectorSearchEdgeResults SearchEdges(std::string_view index_name, uint64_t result_set_size,
-                                      const std::vector<float> &query_vector) const;
+                                      const std::vector<float> &query_vector,
+                                      const std::unordered_set<Gid> &edge_filter = {}) const;
 
   /// @brief Aborts the entries in the vector edge index.
   void AbortEntries(AbortProcessor::AbortableInfo &cleanup_collection);

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -431,7 +431,8 @@ std::optional<uint64_t> VectorIndex::ApproximateNodesVectorCount(std::string_vie
 
 VectorIndex::VectorSearchNodeResults VectorIndex::SearchNodes(std::string_view index_name, uint64_t result_set_size,
                                                               const std::vector<float> &query_vector,
-                                                              NameIdMapper *name_id_mapper) const {
+                                                              NameIdMapper *name_id_mapper,
+                                                              const std::unordered_set<Gid> &vertex_filter) const {
   auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
   if (!maybe_id.has_value()) {
     throw query::VectorSearchException(fmt::format("Vector index {} does not exist.", index_name));
@@ -446,7 +447,14 @@ VectorIndex::VectorSearchNodeResults VectorIndex::SearchNodes(std::string_view i
   result.reserve(result_set_size);
 
   auto guard = utils::SharedResourceLockGuard(item_ptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
-  const auto result_keys = item_ptr->mg_index.index.search(query_vector.data(), result_set_size);
+  // Reading Vertex::gid is safe under the shared index lock: gid is immutable and the storage layer holds a vertices
+  // accessor that keeps the pointers alive for the duration of the search.
+  const auto result_keys = vertex_filter.empty()
+                               ? item_ptr->mg_index.index.search(query_vector.data(), result_set_size)
+                               : item_ptr->mg_index.index.filtered_search(
+                                     query_vector.data(), result_set_size, [&vertex_filter](Vertex *vertex) {
+                                       return vertex_filter.contains(vertex->gid);
+                                     });
   for (std::size_t i = 0; i < result_keys.size(); ++i) {
     const auto &vertex = static_cast<Vertex *>(result_keys[i].member.key);
     result.emplace_back(

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <span>
 #include <string_view>
+#include <unordered_set>
 
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/join.hpp>
@@ -366,9 +367,12 @@ class VectorIndex {
   /// @param result_set_size The number of results to return.
   /// @param query_vector The vector to be used for the search query.
   /// @param name_id_mapper Mapper for name/ID conversions.
+  /// @param vertex_filter Optional allowlist of vertex gids to restrict the search to. When empty, no filtering is
+  /// applied; when non-empty, only vertices whose gid is present are considered (prefiltering during traversal).
   /// @return A vector of tuples containing the vertex, distance, and similarity of the search results.
   VectorSearchNodeResults SearchNodes(std::string_view index_name, uint64_t result_set_size,
-                                      const std::vector<float> &query_vector, NameIdMapper *name_id_mapper) const;
+                                      const std::vector<float> &query_vector, NameIdMapper *name_id_mapper,
+                                      const std::unordered_set<Gid> &vertex_filter = {}) const;
 
   /// @brief Removes vertices from all vector indices.
   /// Called by GC before skip list removal, while the vertex pointer is still valid.

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -5136,14 +5136,15 @@ auto InMemoryStorage::InMemoryAccessor::PointVertices(LabelId label, PropertyId 
 }
 
 std::vector<std::tuple<VertexAccessor, double, double>> InMemoryStorage::InMemoryAccessor::VectorIndexSearchOnNodes(
-    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
+    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+    const std::unordered_set<Gid> &vertex_filter) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
   std::vector<std::tuple<VertexAccessor, double, double>> result;
 
   // we have to take vertices accessor to be sure no vertex is deleted while we are searching
   auto acc = mem_storage->vertices_.access();
   const auto search_results = storage_->indices_.vector_index_.SearchNodes(
-      index_name, number_of_results, vector, mem_storage->name_id_mapper_.get());
+      index_name, number_of_results, vector, mem_storage->name_id_mapper_.get(), vertex_filter);
   std::transform(search_results.begin(), search_results.end(), std::back_inserter(result), [&](const auto &item) {
     auto &[vertex, distance, score] = item;
     return std::make_tuple(VertexAccessor{vertex, storage_, &transaction_}, distance, score);
@@ -5153,13 +5154,15 @@ std::vector<std::tuple<VertexAccessor, double, double>> InMemoryStorage::InMemor
 }
 
 std::vector<std::tuple<EdgeAccessor, double, double>> InMemoryStorage::InMemoryAccessor::VectorIndexSearchOnEdges(
-    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
+    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+    const std::unordered_set<Gid> &edge_filter) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
   std::vector<std::tuple<EdgeAccessor, double, double>> result;
 
   // we have to take edges accessor to be sure no edge is deleted while we are searching
   auto acc = mem_storage->edges_.access();
-  const auto search_results = storage_->indices_.vector_edge_index_.SearchEdges(index_name, number_of_results, vector);
+  const auto search_results =
+      storage_->indices_.vector_edge_index_.SearchEdges(index_name, number_of_results, vector, edge_filter);
   std::transform(search_results.begin(), search_results.end(), std::back_inserter(result), [&](const auto &item) {
     const auto &[entry, distance, score] = item;
     return std::make_tuple(

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -620,10 +620,12 @@ class InMemoryStorage final : public Storage {
         -> PointIterable override;
 
     std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearchOnNodes(
-        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;
+        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+        const std::unordered_set<Gid> &vertex_filter = {}) override;
 
     std::vector<std::tuple<EdgeAccessor, double, double>> VectorIndexSearchOnEdges(
-        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;
+        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+        const std::unordered_set<Gid> &edge_filter = {}) override;
 
     std::vector<VectorIndexInfo> ListAllVectorIndices() const override;
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -1122,10 +1122,12 @@ class Accessor {
                              WithinBBoxCondition condition) -> PointIterable = 0;
 
   virtual std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearchOnNodes(
-      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) = 0;
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+      const std::unordered_set<Gid> &vertex_filter = {}) = 0;
 
   virtual std::vector<std::tuple<EdgeAccessor, double, double>> VectorIndexSearchOnEdges(
-      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) = 0;
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector,
+      const std::unordered_set<Gid> &edge_filter = {}) = 0;
 
   virtual std::vector<VectorIndexInfo> ListAllVectorIndices() const = 0;
 


### PR DESCRIPTION
# Vector search: prefiltering + additional distance metrics

## Summary

This branch adds two capabilities to the built-in `vector_search` module:

1. **Prefiltering** — restrict a vector index search to a candidate set of nodes/relationships, evaluated *during* the HNSW graph traversal (true prefiltering, not post-filtering).
2. **New distance functions** — `ip`, `l2sq`, and `haversine` standalone functions alongside the existing `cosine_similarity`, mirroring uSearch's metric formulas so the same distance the index uses can be computed over arbitrary vector pairs.

## 1. Prefiltering

`vector_search.search` and `vector_search.search_edges` gain an **optional** trailing parameter — `prefiltered_nodes` / `prefiltered_edges` — a list of nodes/relationships (or their integer ids) that the search is restricted to. When omitted (default empty list) the search runs over the whole index with zero added overhead (plain `.search()` path); when provided, the index uses uSearch's `filtered_search` with a predicate that keeps only entities whose `gid` is in the allowlist.

The candidate ids are threaded from the query module down through the whole stack:

`query module → mgp.hpp → _mgp.hpp → mgp C API → DbAccessor → Storage::Accessor → VectorIndex::SearchNodes / VectorEdgeIndex::SearchEdges → uSearch filtered_search`

The predicate reads only the immutable `Vertex::gid` / `Edge::gid` under the existing shared index lock and entity accessor, so it is safe inside uSearch's `noexcept` traversal (no MVCC or throwing hazards). For the edge index, the user filter is ANDed with the pre-existing `edge_endpoints_` check.

### Usage

```cypher
-- Unfiltered (unchanged behavior)
CALL vector_search.search('doc_idx', 10, $query) YIELD node, distance, similarity;

-- Prefiltered to a candidate set computed with arbitrary Cypher
MATCH (n:Document) WHERE n.year > 2020 AND n.public
WITH collect(n) AS candidates
CALL vector_search.search('doc_idx', 10, $query, candidates)
YIELD node, distance, similarity
RETURN node, distance, similarity;

-- Edges work the same way
MATCH ()-[r:SIMILAR_TO]->() WHERE r.weight > 0.5
WITH collect(r) AS candidates
CALL vector_search.search_edges('rel_idx', 10, $query, candidates)
YIELD edge, distance, similarity
RETURN edge, distance, similarity;
```

The filter list also accepts raw integer ids (`id(n)`) in addition to node/relationship values.

## 2. Distance functions

New functions matching uSearch's metric definitions:

| Function | Formula |
|---|---|
| `vector_search.ip(v1, v2)` | `1 − Σ(aᵢ·bᵢ)` (inner-product distance) |
| `vector_search.l2sq(v1, v2)` | `Σ(aᵢ−bᵢ)²` (squared Euclidean — the default index metric) |
| `vector_search.haversine(v1, v2)` | central angle in radians over 2-element `[lat, lon]` inputs in degrees |

```cypher
RETURN vector_search.l2sq([1.0, 2.0, 3.0], [1.5, 2.5, 2.0]) AS distance;
RETURN vector_search.ip([0.1, 0.2], [0.3, 0.4]) AS ip_distance;
RETURN vector_search.haversine([45.81, 15.98], [40.71, -74.01]) AS angular_distance;
```

## Notes

- **API compatibility:** the C++ `mgp::SearchVectorIndex` / `SearchVectorIndexOnEdges` wrappers keep backward-compatible overloads without the filter, so existing modules compile unchanged. The underlying C-API functions (`mgp_graph_search_vector_index*`) gained a `search_filter` argument.
- **Recall tradeoff:** with a highly selective allowlist, HNSW `filtered_search` may return fewer than `result_set_size` results even when more matches exist, since traversal may not reach isolated matching nodes. uSearch's `exact` fallback could be exposed later if this becomes an issue.
