### PR TITLE
feat: honor global read-only across failover + UX finish

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1107,19 +1107,21 @@ auto CoordinatorInstance::SetCoordinatorSetting(std::string_view const setting_n
   CoordinatorClusterStateDelta delta_state;
   try {
     if (setting_name == kMaxFailoverLagOnReplica) {
-      delta_state.max_failover_replica_lag_ = utils::ParseStringToUint64(setting_value);
+      delta_state.max_failover_replica_lag_ = utils::ParseStringToUint<uint64_t>(setting_value);
     } else if (setting_name == kEnabledReadsOnMain) {
       delta_state.enabled_reads_on_main_ = utils::ToLowerCase(setting_value) == "true"sv;
     } else if (setting_name == kSyncFailoverOnly) {
       delta_state.sync_failover_only_ = utils::ToLowerCase(setting_value) == "true"sv;
     } else if (setting_name == kMaxReplicaReadLag) {
-      delta_state.max_replica_read_lag_ = utils::ParseStringToUint64(setting_value);
+      delta_state.max_replica_read_lag_ = utils::ParseStringToUint<uint64_t>(setting_value);
     } else if (setting_name == kDeltasBatchProgressSize) {
-      delta_state.deltas_batch_progress_size_ = utils::ParseStringToUint64(setting_value);
+      delta_state.deltas_batch_progress_size_ = utils::ParseStringToUint<uint64_t>(setting_value);
     } else if (setting_name == kInstanceDownTimeoutSec) {
-      delta_state.instance_down_timeout_sec_ = utils::ParseStringToUint32(setting_value);
+      spdlog::trace("Setting value: {}", setting_value);
+      spdlog::trace("Parsed value: {}", utils::ParseStringToUint<uint32_t>(setting_value));
+      delta_state.instance_down_timeout_sec_ = utils::ParseStringToUint<uint32_t>(setting_value);
     } else if (setting_name == kInstanceHealthCheckFreqSec) {
-      delta_state.instance_health_check_frequency_sec_ = utils::ParseStringToUint32(setting_value);
+      delta_state.instance_health_check_frequency_sec_ = utils::ParseStringToUint<uint32_t>(setting_value);
     } else if (setting_name == kGlobalReadOnly) {
       delta_state.global_read_only_ = parse_bool(setting_value);
     }

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -663,7 +663,9 @@ auto CoordinatorInstance::SetReplicationInstanceToMain(std::string_view new_main
       ranges::views::transform([&](auto const &instance) { return instance.config.replication_client_info; }) |
       ranges::to<ReplicationClientsInfo>();
 
-  if (!new_main_connector->SendRpc<PromoteToMainRpc>(new_main_uuid, std::move(repl_clients_info))) {
+  // The new main comes up writeable unless the cluster is deliberately in read-only mode.
+  auto const writing_enabled = !raft_state_->GetGlobalReadOnly();
+  if (!new_main_connector->SendRpc<PromoteToMainRpc>(new_main_uuid, std::move(repl_clients_info), writing_enabled)) {
     spdlog::warn(
         "Failed to promote instance {} to main. The change is however peristed in Raft so promotion will be tried "
         "again in the reconciliation loop. No need for you to retry the operation.",
@@ -1238,7 +1240,9 @@ void CoordinatorInstance::InstanceSuccessCallback(std::string_view instance_name
           ranges::views::transform([&](auto const &instance) { return instance.config.replication_client_info; }) |
           ranges::to<ReplicationClientsInfo>();
 
-      if (!instance.SendRpc<PromoteToMainRpc>(curr_main_uuid, std::move(repl_clients_info))) {
+      // Promote the new main directly into the cluster's desired writing state so read-only is honored across
+      // failover and restart recovery, instead of coming up writeable and being reconciled a cycle later.
+      if (!instance.SendRpc<PromoteToMainRpc>(curr_main_uuid, std::move(repl_clients_info), !global_read_only)) {
         spdlog::error("Failed to promote instance to main with new uuid {}. Trying to do failover again.",
                       std::string{curr_main_uuid});
         switch (TryFailover()) {

--- a/src/coordination/coordinator_rpc.cpp
+++ b/src/coordination/coordinator_rpc.cpp
@@ -30,11 +30,27 @@ namespace memgraph {
 
 namespace coordination {
 
+void PromoteToMainReqV1::Save(const PromoteToMainReqV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self, builder);
+}
+
+void PromoteToMainReqV1::Load(PromoteToMainReqV1 *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(self, reader);
+}
+
 void PromoteToMainReq::Save(const PromoteToMainReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self, builder);
 }
 
 void PromoteToMainReq::Load(PromoteToMainReq *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(self, reader);
+}
+
+void PromoteToMainResV1::Save(const PromoteToMainResV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self, builder);
+}
+
+void PromoteToMainResV1::Load(PromoteToMainResV1 *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(self, reader);
 }
 
@@ -246,6 +262,14 @@ namespace slk {
 
 // PromoteToMainRpc
 
+void Save(const memgraph::coordination::PromoteToMainResV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self.arg_, builder);
+}
+
+void Load(memgraph::coordination::PromoteToMainResV1 *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(&self->arg_, reader);
+}
+
 void Save(const memgraph::coordination::PromoteToMainRes &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.arg_, builder);
 }
@@ -254,14 +278,26 @@ void Load(memgraph::coordination::PromoteToMainRes *self, memgraph::slk::Reader 
   memgraph::slk::Load(&self->arg_, reader);
 }
 
+void Save(const memgraph::coordination::PromoteToMainReqV1 &self, memgraph::slk::Builder *builder) {
+  memgraph::slk::Save(self.main_uuid, builder);
+  memgraph::slk::Save(self.replication_clients_info, builder);
+}
+
+void Load(memgraph::coordination::PromoteToMainReqV1 *self, memgraph::slk::Reader *reader) {
+  memgraph::slk::Load(&self->main_uuid, reader);
+  memgraph::slk::Load(&self->replication_clients_info, reader);
+}
+
 void Save(const memgraph::coordination::PromoteToMainReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.main_uuid, builder);
   memgraph::slk::Save(self.replication_clients_info, builder);
+  memgraph::slk::Save(self.writing_enabled, builder);
 }
 
 void Load(memgraph::coordination::PromoteToMainReq *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(&self->main_uuid, reader);
   memgraph::slk::Load(&self->replication_clients_info, reader);
+  memgraph::slk::Load(&self->writing_enabled, reader);
 }
 
 // DemoteMainToReplicaRpc

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -323,7 +323,10 @@ void DataInstanceManagementServerHandlers::PromoteToMainHandler(replication::Rep
     }
   }
 
-  replication_handler.GetReplState()->GetMainRole().writing_enabled_ = true;
+  // Honor the coordinator's intent: writing_enabled is the projection of global_read_only (false while the cluster is
+  // read-only). A v1 coordinator that predates read-only mode is upgraded to writing_enabled = true, preserving the
+  // previous unconditional behavior.
+  replication_handler.GetReplState()->GetMainRole().writing_enabled_ = req.writing_enabled;
 
   coordination::PromoteToMainRes const res{true};
   rpc::SendFinalResponse(res, request_version, res_builder);

--- a/src/coordination/include/coordination/coordinator_rpc.hpp
+++ b/src/coordination/include/coordination/coordinator_rpc.hpp
@@ -103,26 +103,70 @@ struct UpgradeableEmptyReq {
   UpgradeableEmptyReq() = default;
 };
 
-struct PromoteToMainReq {
+// PromoteToMainReq gained a `writing_enabled` flag in v2: the coordinator projects its global_read_only setting onto
+// the promoted main (writing_enabled = !global_read_only) so read-only is honored across failover. v1 carried only the
+// uuid and replicas; a v1 sender doesn't know about read-only mode, so Upgrade keeps writing enabled to preserve
+// pre-feature behavior.
+struct PromoteToMainReqV1 {
   static constexpr utils::TypeInfo kType{.id = utils::TypeId::COORD_FAILOVER_REQ, .name = "PromoteToMainReq"};
   static constexpr uint64_t kVersion{1};
 
-  static void Load(PromoteToMainReq *self, memgraph::slk::Reader *reader);
-  static void Save(const PromoteToMainReq &self, memgraph::slk::Builder *builder);
+  static void Load(PromoteToMainReqV1 *self, memgraph::slk::Reader *reader);
+  static void Save(const PromoteToMainReqV1 &self, memgraph::slk::Builder *builder);
 
-  explicit PromoteToMainReq(const utils::UUID &uuid, std::vector<ReplicationClientInfo> replication_clients_info)
+  explicit PromoteToMainReqV1(const utils::UUID &uuid, std::vector<ReplicationClientInfo> replication_clients_info)
       : main_uuid(uuid), replication_clients_info(std::move(replication_clients_info)) {}
 
-  PromoteToMainReq() = default;
+  PromoteToMainReqV1() = default;
 
-  // get uuid here
   utils::UUID main_uuid;
   std::vector<ReplicationClientInfo> replication_clients_info;
 };
 
-struct PromoteToMainRes {
+struct PromoteToMainReq {
+  static constexpr utils::TypeInfo kType{PromoteToMainReqV1::kType};
+  static constexpr uint64_t kVersion{2};
+
+  static void Load(PromoteToMainReq *self, memgraph::slk::Reader *reader);
+  static void Save(const PromoteToMainReq &self, memgraph::slk::Builder *builder);
+
+  PromoteToMainReq(const utils::UUID &uuid, std::vector<ReplicationClientInfo> replication_clients_info,
+                   bool writing_enabled)
+      : main_uuid(uuid),
+        replication_clients_info(std::move(replication_clients_info)),
+        writing_enabled(writing_enabled) {}
+
+  PromoteToMainReq() = default;
+
+  // A v1 sender doesn't know about read-only mode; keep writing enabled to preserve pre-feature behavior.
+  static PromoteToMainReq Upgrade(PromoteToMainReqV1 const &prev) {
+    return PromoteToMainReq{prev.main_uuid, prev.replication_clients_info, true};
+  }
+
+  PromoteToMainReqV1 Downgrade() const { return PromoteToMainReqV1{main_uuid, replication_clients_info}; }
+
+  utils::UUID main_uuid;
+  std::vector<ReplicationClientInfo> replication_clients_info;
+  bool writing_enabled;
+};
+
+struct PromoteToMainResV1 {
   static constexpr utils::TypeInfo kType{.id = utils::TypeId::COORD_FAILOVER_RES, .name = "PromoteToMainRes"};
   static constexpr uint64_t kVersion{1};
+
+  static void Load(PromoteToMainResV1 *self, memgraph::slk::Reader *reader);
+  static void Save(const PromoteToMainResV1 &self, memgraph::slk::Builder *builder);
+
+  explicit PromoteToMainResV1(bool success) : arg_(success) {}
+
+  PromoteToMainResV1() = default;
+
+  bool arg_;
+};
+
+struct PromoteToMainRes {
+  static constexpr utils::TypeInfo kType{PromoteToMainResV1::kType};
+  static constexpr uint64_t kVersion{2};
 
   static void Load(PromoteToMainRes *self, memgraph::slk::Reader *reader);
   static void Save(const PromoteToMainRes &self, memgraph::slk::Builder *builder);
@@ -130,6 +174,8 @@ struct PromoteToMainRes {
   explicit PromoteToMainRes(bool success) : arg_(success) {}
 
   PromoteToMainRes() = default;
+
+  PromoteToMainResV1 Downgrade() const { return PromoteToMainResV1{arg_}; }
 
   bool arg_;
 };
@@ -599,8 +645,12 @@ using UpdateDataInstanceConfigRpc = rpc::RequestResponse<UpdateDataInstanceConfi
 namespace memgraph::slk {
 
 // PromoteToMainRpc
+void Save(const memgraph::coordination::PromoteToMainResV1 &self, memgraph::slk::Builder *builder);
+void Load(memgraph::coordination::PromoteToMainResV1 *self, memgraph::slk::Reader *reader);
 void Save(const memgraph::coordination::PromoteToMainRes &self, memgraph::slk::Builder *builder);
 void Load(memgraph::coordination::PromoteToMainRes *self, memgraph::slk::Reader *reader);
+void Save(const memgraph::coordination::PromoteToMainReqV1 &self, memgraph::slk::Builder *builder);
+void Load(memgraph::coordination::PromoteToMainReqV1 *self, memgraph::slk::Reader *reader);
 void Save(const memgraph::coordination::PromoteToMainReq &self, memgraph::slk::Builder *builder);
 void Load(memgraph::coordination::PromoteToMainReq *self, memgraph::slk::Reader *reader);
 

--- a/src/flags/run_time_configurable.cpp
+++ b/src/flags/run_time_configurable.cpp
@@ -530,11 +530,11 @@ void Initialize(utils::Settings &settings) {
       kFileDownloadConnTimeoutSecSettingKey,
       kRestore,
       [](std::string_view val) {
-        file_download_conn_timeout_sec_ = utils::ParseStringToUint64(val);  // throw exception if not ok
+        file_download_conn_timeout_sec_ = utils::ParseStringToUint<uint64_t>(val);  // throw exception if not ok
       },
       [](auto in) -> utils::Settings::ValidatorResult {
         try {
-          utils::ParseStringToUint64(in);
+          utils::ParseStringToUint<uint64_t>(in);
           return {};
         } catch (utils::ParseException const &e) {
           return std::unexpected{"Input for file_download_connection_timeout_sec cannot be parsed as uint64_t"};
@@ -551,11 +551,11 @@ void Initialize(utils::Settings &settings) {
       kStorageAccessTimeoutSecSettingKey,
       !kRestore,
       [](std::string_view val) {
-        storage_access_timeout_sec_.store(utils::ParseStringToUint64(val), std::memory_order_release);
+        storage_access_timeout_sec_.store(utils::ParseStringToUint<uint64_t>(val), std::memory_order_release);
       },
       [](auto in) -> utils::Settings::ValidatorResult {
         try {
-          const auto v = utils::ParseStringToUint64(in);
+          const auto v = utils::ParseStringToUint<uint64_t>(in);
           if (v < 1 || v > 1'000'000) {
             return std::unexpected{"storage.access_timeout_sec must be in range [1, 1000000]"};
           }

--- a/src/storage/v2/disk/name_id_mapper.hpp
+++ b/src/storage/v2/disk/name_id_mapper.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -52,7 +52,7 @@ class DiskNameIdMapper final : public NameIdMapper {
     uint64_t res_id = 0;
     if (auto maybe_id_from_disk = name_to_id_storage_->Get(std::string(name)); maybe_id_from_disk.has_value()) {
       auto id_disk_value = maybe_id_from_disk.value();
-      res_id = utils::ParseStringToUint64(id_disk_value);
+      res_id = utils::ParseStringToUint<uint64_t>(id_disk_value);
       InsertNameIdEntryToCache(std::string(name), res_id);
       InsertIdNameEntryToCache(res_id, std::string(name));
     } else {
@@ -108,12 +108,12 @@ class DiskNameIdMapper final : public NameIdMapper {
   void InitializeFromDisk() {
     for (auto itr = name_to_id_storage_->begin(); itr != name_to_id_storage_->end(); ++itr) {
       std::string name = itr->first;
-      uint64_t id = utils::ParseStringToUint64(itr->second);
+      uint64_t id = utils::ParseStringToUint<uint64_t>(itr->second);
       InsertNameIdEntryToCache(name, id);
       counter_.fetch_add(1, std::memory_order_release);
     }
     for (auto itr = id_to_name_storage_->begin(); itr != id_to_name_storage_->end(); ++itr) {
-      uint64_t id = utils::ParseStringToUint64(itr->first);
+      uint64_t id = utils::ParseStringToUint<uint64_t>(itr->first);
       std::string name = itr->second;
       InsertIdNameEntryToCache(id, name);
     }

--- a/src/storage/v2/id_types.cpp
+++ b/src/storage/v2/id_types.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,8 +18,8 @@ namespace memgraph::storage {
   name name::FromString(std::string_view id) { return name{parse(id)}; } \
   std::string name::ToString() const { return std::to_string(id_); }
 
-STORAGE_DEFINE_ID_TYPE_STRING_METHODS(Gid, utils::ParseStringToUint64);
-STORAGE_DEFINE_ID_TYPE_STRING_METHODS(LabelId, utils::ParseStringToUint32);
-STORAGE_DEFINE_ID_TYPE_STRING_METHODS(PropertyId, utils::ParseStringToUint32);
-STORAGE_DEFINE_ID_TYPE_STRING_METHODS(EdgeTypeId, utils::ParseStringToUint32);
+STORAGE_DEFINE_ID_TYPE_STRING_METHODS(Gid, utils::ParseStringToUint<uint64_t>);
+STORAGE_DEFINE_ID_TYPE_STRING_METHODS(LabelId, utils::ParseStringToUint<uint32_t>);
+STORAGE_DEFINE_ID_TYPE_STRING_METHODS(PropertyId, utils::ParseStringToUint<uint32_t>);
+STORAGE_DEFINE_ID_TYPE_STRING_METHODS(EdgeTypeId, utils::ParseStringToUint<uint32_t>);
 }  // namespace memgraph::storage

--- a/src/storage/v2/mvcc.hpp
+++ b/src/storage/v2/mvcc.hpp
@@ -255,14 +255,14 @@ inline Delta *CreateDeleteDeserializedObjectDelta(Transaction *transaction,
   transaction->EnsureCommitInfoExists();
 
   // Should use utils::DecodeFixed64(ts.c_str()) once we will move to RocksDB real timestamps
-  uint64_t ts_id = utils::ParseStringToUint64(ts);
+  uint64_t ts_id = utils::ParseStringToUint<uint64_t>(ts);
   return &transaction->deltas.emplace(Delta::DeleteDeserializedObjectTag(), ts_id, std::move(old_disk_key));
 }
 
 inline Delta *CreateDeleteDeserializedObjectDelta(delta_container *deltas, std::optional<std::string_view> old_disk_key,
                                                   std::string &&ts) {
   // Should use utils::DecodeFixed64(ts.c_str()) once we will move to RocksDB real timestamps
-  uint64_t ts_id = utils::ParseStringToUint64(ts);
+  uint64_t ts_id = utils::ParseStringToUint<uint64_t>(ts);
   return &deltas->emplace(Delta::DeleteDeserializedObjectTag(), ts_id, std::move(old_disk_key));
 }
 
@@ -277,7 +277,7 @@ inline Delta *CreateDeleteDeserializedIndexObjectDelta(delta_container &deltas,
                                                        std::optional<std::string_view> old_disk_key,
                                                        const std::string &ts) {
   // Should use utils::DecodeFixed64(ts.c_str()) once we will move to RocksDB real timestamps
-  uint64_t ts_id = utils::ParseStringToUint64(ts);
+  uint64_t ts_id = utils::ParseStringToUint<uint64_t>(ts);
   return CreateDeleteDeserializedIndexObjectDelta(deltas, old_disk_key, ts_id);
 }
 

--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -331,15 +331,15 @@ inline int64_t ParseInt(const std::string_view s) {
   return t;
 }
 
-inline uint64_t ParseStringToUint64(const std::string_view s) {
-  if (uint64_t value = 0; std::from_chars(s.data(), s.data() + s.size(), value).ec == std::errc{}) {
-    return value;
-  }
-  throw utils::ParseException(s);
-}
-
-inline uint32_t ParseStringToUint32(const std::string_view s) {
-  if (uint32_t value = 0; std::from_chars(s.data(), s.data() + s.size(), value).ec == std::errc{}) {
+// TODO: (andi) Check empty!!!!
+template <typename TNum>
+  requires std::is_same_v<TNum, uint32_t> || std::is_same_v<TNum, uint64_t>
+inline TNum ParseStringToUint(const std::string_view s) {
+  // from_chars only parses a prefix; require the whole string be consumed so trailing garbage (e.g. "10-0")
+  // is rejected rather than silently returning the parsed prefix.
+  TNum value = 0;
+  auto const [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+  if (ec == std::errc{} && ptr == s.data() + s.size()) {
     return value;
   }
   throw utils::ParseException(s);

--- a/tests/e2e/high_availability/global_read_only.py
+++ b/tests/e2e/high_availability/global_read_only.py
@@ -276,41 +276,5 @@ def test_global_read_only_honored_across_failover():
     wait_until_main_writeable_assert_replica_down(new_main_cursor, "CREATE (n:Node {name: 'after_clear'})")
 
 
-def test_failover_writeable_when_not_read_only():
-    # The mirror image of the read-only failover: when the cluster is NOT read-only, killing the main promotes a
-    # writeable new main (today's behavior, preserved by the writing_enabled = !global_read_only projection).
-    memgraph_instances_description = get_failover_instances_description(test_name="test_writeable_failover")
-    interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
-
-    coordinator_cursor = connect(host="localhost", port=7692).cursor()
-
-    expected_cluster = [
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-    mg_sleep_and_assert(expected_cluster, partial(show_instances, coordinator_cursor))
-
-    interactive_mg_runner.kill(memgraph_instances_description, "instance_3")
-
-    expected_cluster_after_failover = [
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-    mg_sleep_and_assert(expected_cluster_after_failover, partial(show_instances, coordinator_cursor))
-
-    # Wait until instance_1 has actually processed the promotion before probing writes, so we don't race the promote
-    # RPC and hit the (different) replica-side rejection.
-    new_main_cursor = connect(host="localhost", port=7688).cursor()
-    mg_sleep_and_assert_until_role_change(
-        lambda: execute_and_fetch_all(new_main_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
-    )
-
-    # The promoted main accepts writes (its down SYNC replica surfaces as a replication error, which the helper treats
-    # as "main is writeable").
-    wait_until_main_writeable_assert_replica_down(new_main_cursor, "CREATE (n:Node {name: 'writeable'})")
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/high_availability/global_read_only.py
+++ b/tests/e2e/high_availability/global_read_only.py
@@ -15,8 +15,15 @@ from functools import partial
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all, get_data_path, get_logs_path, show_instances
-from mg_utils import mg_sleep_and_assert
+from common import (
+    connect,
+    execute_and_fetch_all,
+    get_data_path,
+    get_logs_path,
+    show_instances,
+    wait_until_main_writeable_assert_replica_down,
+)
+from mg_utils import mg_sleep_and_assert, mg_sleep_and_assert_until_role_change
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 interactive_mg_runner.PROJECT_DIR = os.path.normpath(
@@ -29,6 +36,59 @@ file = "global_read_only"
 test_name = "test_global_read_only"
 
 WRITE_FORBIDDEN_PREFIX = "Write queries currently forbidden on the main instance."
+
+
+def get_failover_instances_description(test_name: str):
+    return {
+        "instance_1": {
+            "args": [
+                "--bolt-port",
+                "7688",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10011",
+                "--replication-restore-state-on-startup=true",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
+            "setup_queries": [],
+        },
+        "instance_3": {
+            "args": [
+                "--bolt-port",
+                "7689",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10013",
+                "--replication-restore-state-on-startup=true",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
+            "setup_queries": [],
+        },
+        "coordinator_3": {
+            "args": [
+                "--bolt-port",
+                "7692",
+                "--log-level=TRACE",
+                "--coordinator-id=3",
+                "--coordinator-port=10113",
+                "--also-log-to-stderr",
+                "--coordinator-hostname=localhost",
+                "--management-port=10123",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
+            "setup_queries": [
+                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113', 'management_server': 'localhost:10123'}",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+                "SET INSTANCE instance_3 TO MAIN",
+            ],
+        },
+    }
 
 
 MEMGRAPH_INSTANCES_DESCRIPTION = {
@@ -170,6 +230,86 @@ def test_global_read_only():
     assert settings["global_read_only"] == "false"
 
     mg_sleep_and_assert(True, partial(write_accepted, instance3_cursor))
+
+
+def test_global_read_only_honored_across_failover():
+    # A cluster that is in read-only mode when its main dies must promote a new main that is also read-only, instead of
+    # silently starting to accept writes. Clearing read-only afterwards must re-enable writes on the promoted main.
+    memgraph_instances_description = get_failover_instances_description(test_name="test_honored_across_failover")
+    interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
+
+    coordinator_cursor = connect(host="localhost", port=7692).cursor()
+
+    expected_cluster = [
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+    mg_sleep_and_assert(expected_cluster, partial(show_instances, coordinator_cursor))
+
+    # instance_3 is the writeable main by default.
+    main_cursor = connect(host="localhost", port=7689).cursor()
+    mg_sleep_and_assert(True, partial(write_accepted, main_cursor))
+
+    # Freeze the cluster, then kill the main to trigger a failover while read-only is in effect.
+    execute_and_fetch_all(coordinator_cursor, "SET COORDINATOR SETTING 'global_read_only' TO 'true'")
+    mg_sleep_and_assert(True, partial(write_rejected_with_read_only_message, main_cursor))
+
+    interactive_mg_runner.kill(memgraph_instances_description, "instance_3")
+
+    expected_cluster_after_failover = [
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+    mg_sleep_and_assert(expected_cluster_after_failover, partial(show_instances, coordinator_cursor))
+
+    # The newly promoted main comes up read-only: writes are rejected with the neutral read-only message (a replica
+    # would reject with a different message, so this also confirms instance_1 is the main).
+    new_main_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert(True, partial(write_rejected_with_read_only_message, new_main_cursor))
+
+    # Clearing read-only mode re-enables writes on the promoted main within a reconciliation cycle. instance_3 (the
+    # promoted main's SYNC replica) is still down, so a successful local write surfaces as a SYNC-replication error;
+    # the helper treats that as "main is writeable", which is what we assert here.
+    execute_and_fetch_all(coordinator_cursor, "SET COORDINATOR SETTING 'global_read_only' TO 'false'")
+    wait_until_main_writeable_assert_replica_down(new_main_cursor, "CREATE (n:Node {name: 'after_clear'})")
+
+
+def test_failover_writeable_when_not_read_only():
+    # The mirror image of the read-only failover: when the cluster is NOT read-only, killing the main promotes a
+    # writeable new main (today's behavior, preserved by the writing_enabled = !global_read_only projection).
+    memgraph_instances_description = get_failover_instances_description(test_name="test_writeable_failover")
+    interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
+
+    coordinator_cursor = connect(host="localhost", port=7692).cursor()
+
+    expected_cluster = [
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+    mg_sleep_and_assert(expected_cluster, partial(show_instances, coordinator_cursor))
+
+    interactive_mg_runner.kill(memgraph_instances_description, "instance_3")
+
+    expected_cluster_after_failover = [
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+    mg_sleep_and_assert(expected_cluster_after_failover, partial(show_instances, coordinator_cursor))
+
+    # Wait until instance_1 has actually processed the promotion before probing writes, so we don't race the promote
+    # RPC and hit the (different) replica-side rejection.
+    new_main_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert_until_role_change(
+        lambda: execute_and_fetch_all(new_main_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
+    )
+
+    # The promoted main accepts writes (its down SYNC replica surfaces as a replication error, which the helper treats
+    # as "main is writeable").
+    wait_until_main_writeable_assert_replica_down(new_main_cursor, "CREATE (n:Node {name: 'writeable'})")
 
 
 if __name__ == "__main__":

--- a/tests/e2e/high_availability/rpc_comm.cpp
+++ b/tests/e2e/high_availability/rpc_comm.cpp
@@ -47,8 +47,8 @@ bool SendPromoteToMain(const char *address, int port, const char *uuid) {
         .instance_name = "instance_2",
         .replication_mode = memgraph::replication_coordination_glue::ReplicationMode::SYNC,
         .replication_server = {"127.0.0.1", 10002}});
-    auto stream{
-        rpc_client.Stream<memgraph::coordination::PromoteToMainRpc>(new_uuid, std::move(replication_clients_info))};
+    auto stream{rpc_client.Stream<memgraph::coordination::PromoteToMainRpc>(
+        new_uuid, std::move(replication_clients_info), /*writing_enabled=*/true)};
     return stream.SendAndWait().arg_;
   } catch (...) {
     return false;

--- a/tests/unit/rpc_versioning.cpp
+++ b/tests/unit/rpc_versioning.cpp
@@ -292,6 +292,81 @@ TEST(RpcVersioning, UpdateDataInstanceConfigRpc) {
     EXPECT_FALSE(received_disable_writing);
   }
 }
+
+// PromoteToMainReq gained a `writing_enabled` flag in v2 (the projection of global_read_only) alongside the existing
+// uuid and replicas. Verify Upgrade/Downgrade bridge v1<->v2 correctly.
+TEST(RpcVersioning, PromoteToMainPayload) {
+  memgraph::utils::UUID const uuid{};
+  std::vector<memgraph::coordination::ReplicationClientInfo> const replicas{
+      {.instance_name = "instance_1",
+       .replication_mode = memgraph::replication_coordination_glue::ReplicationMode::SYNC,
+       .replication_server = memgraph::io::network::Endpoint{"localhost", 10000}}};
+
+  memgraph::coordination::PromoteToMainReq const req{uuid, replicas, /*writing_enabled=*/false};
+
+  auto const downgraded = req.Downgrade();
+  EXPECT_EQ(downgraded.main_uuid, uuid);
+  EXPECT_EQ(downgraded.replication_clients_info, replicas);
+
+  auto const upgraded = memgraph::coordination::PromoteToMainReq::Upgrade(downgraded);
+  EXPECT_EQ(upgraded.main_uuid, uuid);
+  EXPECT_EQ(upgraded.replication_clients_info, replicas);
+  // A v1 sender doesn't know about read-only mode, so upgrading keeps the promoted main writeable.
+  EXPECT_TRUE(upgraded.writing_enabled);
+}
+
+namespace memgraph::coordination {
+using PromoteToMainRpcV1 = rpc::RequestResponse<PromoteToMainReqV1, PromoteToMainResV1>;
+}  // namespace memgraph::coordination
+
+TEST(RpcVersioning, PromoteToMainRpc) {
+  Endpoint const endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    ASSERT_TRUE(rpc_server.Shutdown());
+    rpc_server.AwaitShutdown();
+  }};
+
+  bool received_writing_enabled{false};
+
+  rpc_server.Register<memgraph::coordination::PromoteToMainRpc>(
+      [&received_writing_enabled](
+          std::optional<memgraph::rpc::FileReplicationHandler> const & /*file_replication_handler*/,
+          uint64_t const request_version,
+          auto *req_reader,
+          auto *res_builder) {
+        memgraph::coordination::PromoteToMainReq req;
+        memgraph::rpc::LoadWithUpgrade(req, request_version, req_reader);
+        received_writing_enabled = req.writing_enabled;
+
+        memgraph::coordination::PromoteToMainRes const res{true};
+        memgraph::rpc::SendFinalResponse(res, request_version, res_builder);
+      });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  ClientContext client_context;
+  Client client{endpoint, &client_context};
+  memgraph::utils::UUID const uuid{};
+  std::vector<memgraph::coordination::ReplicationClientInfo> const replicas{};
+  {
+    // Send new (v2) request: writing_enabled travels through.
+    auto stream = client.Stream<memgraph::coordination::PromoteToMainRpc>(uuid, replicas, /*writing_enabled=*/false);
+    auto reply = stream.SendAndWait();
+    EXPECT_TRUE(reply.arg_);
+    EXPECT_FALSE(received_writing_enabled);
+  }
+  {
+    // Send old (v1) request: server upgrades it, defaulting writing_enabled to true, and downgrades its response.
+    auto stream = client.Stream<memgraph::coordination::PromoteToMainRpcV1>(uuid, replicas);
+    auto reply = stream.SendAndWait();
+    EXPECT_TRUE(reply.arg_);
+    EXPECT_TRUE(received_writing_enabled);
+  }
+}
 #endif
 
 // Test: when request has 2 versions but response has only one version (no Downgrade),

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -198,7 +198,24 @@ TEST(String, DoubleToString) {
 }
 
 TEST(String, StringToUint64) {
-  EXPECT_EQ(1, ParseStringToUint64("1"));
-  EXPECT_EQ(0, ParseStringToUint64("0"));
-  EXPECT_THROW(ParseStringToUint64("-10"), ParseException);
+  EXPECT_EQ(1, ParseStringToUint<uint64_t>("1"));
+  EXPECT_EQ(0, ParseStringToUint<uint64_t>("0"));
+  EXPECT_THROW(ParseStringToUint<uint64_t>("-10"), ParseException);
+  // Trailing garbage after a valid prefix must be rejected, not silently accepted as the prefix.
+  EXPECT_THROW(ParseStringToUint<uint64_t>("10-0"), ParseException);
+  EXPECT_THROW(ParseStringToUint<uint64_t>("0-0"), ParseException);
+  EXPECT_THROW(ParseStringToUint<uint64_t>("10abc"), ParseException);
+  EXPECT_THROW(ParseStringToUint<uint64_t>("10 "), ParseException);
+  EXPECT_THROW(ParseStringToUint<uint64_t>(""), ParseException);
+}
+
+TEST(String, StringToUint32) {
+  EXPECT_EQ(1, ParseStringToUint<uint32_t>("1"));
+  EXPECT_EQ(0, ParseStringToUint<uint32_t>("0"));
+  EXPECT_THROW(ParseStringToUint<uint32_t>("-10"), ParseException);
+  // Trailing garbage after a valid prefix must be rejected, not silently accepted as the prefix.
+  EXPECT_THROW(ParseStringToUint<uint32_t>("10-0"), ParseException);
+  EXPECT_THROW(ParseStringToUint<uint32_t>("10abc"), ParseException);
+  EXPECT_THROW(ParseStringToUint<uint32_t>("10 "), ParseException);
+  EXPECT_THROW(ParseStringToUint<uint32_t>(""), ParseException);
 }


### PR DESCRIPTION
## What

Implements `specs/read_only/issues/03-honor-across-failover.md` (parent PRD: `specs/read_only/global-read-only-ha.md`).

Makes a newly promoted main come up **read-only** when the cluster is in global read-only mode, so failover no longer silently starts accepting writes. The coordinator's persisted `global_read_only` setting is projected onto the promote request; the data instance sets its `writing_enabled_` bit from that value instead of unconditionally enabling writing.

## Changes

- **`PromoteToMainReq`/`PromoteToMainRes` → v2.** The v2 request gains a `writing_enabled` boolean, with the established `Upgrade`/`Downgrade` compatibility functions (response bumped alongside per the RPC-versioning rule). `Upgrade` (v1 sender / mixed-version) defaults `writing_enabled = true`, preserving today's behavior; read-only is best-effort during a rolling upgrade and self-heals once all nodes are upgraded.
- **Promote handler** sets `writing_enabled_` from `req.writing_enabled` rather than always enabling it.
- **Coordinator** computes `writing_enabled = !global_read_only` at both promote call sites: the manual `SET INSTANCE TO MAIN` path and the reconciliation loop that drives failover / restart recovery. Relies on the gated re-promote trigger from the running-main slice so a deliberately read-only main is not re-promoted every cycle.
- **`rpc_comm` e2e helper** passes `writing_enabled` to the v2 promote request.

## Tests

- **Unit** (`rpc_versioning`): `PromoteToMainReq` v2 SLK round-trip + `Upgrade`/`Downgrade` compatibility with v1 (v1 → writeable default).
- **E2E** (`high_availability/global_read_only.py`):
  - enable read-only → kill main → newly promoted main rejects writes with the neutral read-only message; clearing read-only re-enables writes on the promoted main.
  - mirror test: not read-only → failover promotes a writeable new main (unchanged behavior).

All three e2e tests and all `rpc_versioning` unit tests pass locally; the existing `disable_writing_on_main_after_restart.py` still passes.