### PR TITLE
fix(query): bound AST cache with LRU and fold signed list literals

### DIFF
--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -87,18 +87,14 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
   // caching.
   frontend::StrippedQuery stripped_query{query_string};
 
-  // Get parameters (user + database-scoped then global server parameters when database_uuid provided).
-  // Used for visitor resolution of dynamic labels/edge types and for execution.
-  auto query_parameters = PrepareQueryParameters(stripped_query, user_parameters, server_parameters, database_uuid);
-
-  // Cache the query's AST if it isn't already. The entry is held via a
-  // shared_ptr so we can release the cache lock before the (potentially heavy)
-  // Clone below, and so a concurrent LRU eviction can't free it under us.
-  auto const &cache_key = stripped_query.stripped_query();
-  std::shared_ptr<CachedQuery> cached;
-  cache->WithLock([&](auto &lru) {
-    if (auto entry = lru.get(cache_key)) cached = *entry;
-  });
+  auto lookup = [&](frontend::HashedString const &key) {
+    std::shared_ptr<CachedQuery> entry;
+    cache->WithLock([&](auto &lru) {
+      if (auto hit = lru.get(key)) entry = *hit;
+    });
+    return entry;
+  };
+  auto cached = lookup(stripped_query.stripped_query());
   std::unique_ptr<frontend::opencypher::Parser> parser;
 
   // Return a copy of both the AST storage and the query.
@@ -119,16 +115,40 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
   if (!cached) {
     try {
       parser = std::make_unique<frontend::opencypher::Parser>(stripped_query.stripped_query().str());
-    } catch (const SyntaxException &e) {
-      // There is a syntax exception in the stripped query. Re-run the parser
-      // on the original query to get an appropriate error messsage.
-      parser = std::make_unique<frontend::opencypher::Parser>(query_string);
+    } catch (const SyntaxException &) {
+      // a misfolded sign never parses; retry without folding before reporting
+      // an error
+      auto unfolded = frontend::StrippedQuery{query_string, frontend::SignFolding::kDisabled};
+      if (unfolded.stripped_query() != stripped_query.stripped_query()) {
+        stripped_query = std::move(unfolded);
+        cached = lookup(stripped_query.stripped_query());
+        if (!cached) {
+          try {
+            parser = std::make_unique<frontend::opencypher::Parser>(stripped_query.stripped_query().str());
+          } catch (const SyntaxException &) {
+            // fall through to the original-query parse
+          }
+        }
+      }
+      if (!cached && !parser) {
+        // There is a syntax exception in the stripped query. Re-run the parser
+        // on the original query to get an appropriate error messsage.
+        parser = std::make_unique<frontend::opencypher::Parser>(query_string);
 
-      // If an exception was not thrown here, the stripper messed something
-      // up.
-      LOG_FATAL("The stripped query can't be parsed, but the original can.");
+        // If an exception was not thrown here, the stripper messed something
+        // up.
+        LOG_FATAL("The stripped query can't be parsed, but the original can.");
+      }
     }
+  }
 
+  // Get parameters (user + database-scoped then global server parameters when database_uuid provided).
+  // Used for visitor resolution of dynamic labels/edge types and for execution.
+  // token positions differ between folded and unfolded strippings, so this
+  // must run after the final form is chosen.
+  auto query_parameters = PrepareQueryParameters(stripped_query, user_parameters, server_parameters, database_uuid);
+
+  if (!cached) {
     // Convert the ANTLR4 parse tree into an AST.
     AstStorage ast_storage;
     frontend::ParsingContext context{.is_query_cached = true};
@@ -155,7 +175,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
       cached_query->required_privileges = query::GetRequiredPrivileges(visitor.query());
       cached_query->is_cypher_read = read_check();
       cached_query->using_schema_assert = visitor.GetQueryInfo().has_schema_assert;
-      cache->WithLock([&](auto &lru) { lru.put(cache_key, cached_query); });
+      cache->WithLock([&](auto &lru) { lru.put(stripped_query.stripped_query(), cached_query); });
 
       get_information_from_cache(*cached_query);
     } else {

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -40,7 +40,8 @@ DEFINE_bool(query_cost_planner, true, "Use the cost-estimating query planner.");
 DEFINE_VALIDATED_int32(query_plan_cache_max_size, 1000, "Maximum number of query plans to cache.",
                        FLAG_IN_RANGE(0, std::numeric_limits<int32_t>::max()));
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_VALIDATED_int32(query_ast_cache_max_size, 1000, "Maximum number of parsed query ASTs to cache.",
+DEFINE_VALIDATED_int32(query_ast_cache_max_size, 1000,
+                       "Maximum number of parsed query ASTs to cache (0 disables the cache).",
                        FLAG_IN_RANGE(0, std::numeric_limits<int32_t>::max()));
 
 namespace memgraph::query {
@@ -93,7 +94,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
 
   // Cache the query's AST if it isn't already.
   auto const &cache_key = stripped_query.stripped_query();
-  std::shared_ptr<CachedQuery> cached;
+  std::shared_ptr<const CachedQuery> cached;
   cache->WithLock([&](auto &lru) {
     if (auto entry = lru.get(cache_key)) cached = *entry;
   });
@@ -147,13 +148,19 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
     };
 
     if (visitor.GetQueryInfo().is_cacheable) {
-      auto cached_query = std::make_shared<CachedQuery>();
-      cached_query->ast_storage = std::move(ast_storage);
-      cached_query->query = visitor.query();
-      cached_query->required_privileges = query::GetRequiredPrivileges(visitor.query());
-      cached_query->is_cypher_read = read_check();
-      cached_query->using_schema_assert = visitor.GetQueryInfo().has_schema_assert;
-      cache->WithLock([&](auto &lru) { lru.put(cache_key, cached_query); });
+      std::shared_ptr<const CachedQuery> cached_query = std::make_shared<CachedQuery>(
+          CachedQuery{.ast_storage = std::move(ast_storage),
+                      .query = visitor.query(),
+                      .required_privileges = query::GetRequiredPrivileges(visitor.query()),
+                      .is_cypher_read = read_check(),
+                      .using_schema_assert = visitor.GetQueryInfo().has_schema_assert});
+      cache->WithLock([&](auto &lru) {
+        if (auto winner = lru.get(cache_key)) {
+          cached_query = *winner;
+        } else {
+          lru.put(cache_key, cached_query);
+        }
+      });
 
       get_information_from_cache(*cached_query);
     } else {

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -94,10 +94,10 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
   // Cache the query's AST if it isn't already. The entry is held via a
   // shared_ptr so we can release the cache lock before the (potentially heavy)
   // Clone below, and so a concurrent LRU eviction can't free it under us.
-  auto hash = stripped_query.stripped_query().hash();
+  auto const &cache_key = stripped_query.stripped_query();
   std::shared_ptr<CachedQuery> cached;
   cache->WithLock([&](auto &lru) {
-    if (auto entry = lru.get(hash)) cached = *entry;
+    if (auto entry = lru.get(cache_key)) cached = *entry;
   });
   std::unique_ptr<frontend::opencypher::Parser> parser;
 
@@ -155,7 +155,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
       cached_query->required_privileges = query::GetRequiredPrivileges(visitor.query());
       cached_query->is_cypher_read = read_check();
       cached_query->using_schema_assert = visitor.GetQueryInfo().has_schema_assert;
-      cache->WithLock([&](auto &lru) { lru.put(hash, cached_query); });
+      cache->WithLock([&](auto &lru) { lru.put(cache_key, cached_query); });
 
       get_information_from_cache(*cached_query);
     } else {

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -39,6 +39,9 @@ DEFINE_bool(query_cost_planner, true, "Use the cost-estimating query planner.");
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_VALIDATED_int32(query_plan_cache_max_size, 1000, "Maximum number of query plans to cache.",
                        FLAG_IN_RANGE(0, std::numeric_limits<int32_t>::max()));
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_VALIDATED_int32(query_ast_cache_max_size, 1000, "Maximum number of parsed query ASTs to cache.",
+                       FLAG_IN_RANGE(0, std::numeric_limits<int32_t>::max()));
 
 namespace memgraph::query {
 PlanWrapper::PlanWrapper(std::unique_ptr<LogicalPlan> plan) : plan_(std::move(plan)) {}
@@ -71,9 +74,9 @@ auto PrepareQueryParameters(frontend::StrippedQuery const &stripped_query, UserP
   return parameters;
 }
 
-ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const &user_parameters,
-                       utils::SkipList<QueryCacheEntry> *cache, const InterpreterConfig::Query &query_config,
-                       std::string_view database_uuid, parameters::Parameters const *server_parameters) {
+ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const &user_parameters, AstCache *cache,
+                       const InterpreterConfig::Query &query_config, std::string_view database_uuid,
+                       parameters::Parameters const *server_parameters) {
   // Drop leading whitespace so prefix-stripping consumers (EXPLAIN, PROFILE)
   // can rely on the query starting with its first significant character.
   std::string query_string{utils::LTrim(raw_query_string)};
@@ -88,17 +91,21 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
   // Used for visitor resolution of dynamic labels/edge types and for execution.
   auto query_parameters = PrepareQueryParameters(stripped_query, user_parameters, server_parameters, database_uuid);
 
-  // Cache the query's AST if it isn't already.
+  // Cache the query's AST if it isn't already. The entry is held via a
+  // shared_ptr so we can release the cache lock before the (potentially heavy)
+  // Clone below, and so a concurrent LRU eviction can't free it under us.
   auto hash = stripped_query.stripped_query().hash();
-  auto accessor = cache->access();
-  auto it = accessor.find(hash);
+  std::shared_ptr<CachedQuery> cached;
+  cache->WithLock([&](auto &lru) {
+    if (auto entry = lru.get(hash)) cached = *entry;
+  });
   std::unique_ptr<frontend::opencypher::Parser> parser;
 
   // Return a copy of both the AST storage and the query.
   CachedQuery result;
   bool is_cacheable = true;
 
-  auto get_information_from_cache = [&](const auto &cached_query) {
+  auto get_information_from_cache = [&](const CachedQuery &cached_query) {
     result.ast_storage.properties_ = cached_query.ast_storage.properties_;
     result.ast_storage.labels_ = cached_query.ast_storage.labels_;
     result.ast_storage.edge_types_ = cached_query.ast_storage.edge_types_;
@@ -109,7 +116,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
     result.using_schema_assert = cached_query.using_schema_assert;
   };
 
-  if (it == accessor.end()) {
+  if (!cached) {
     try {
       parser = std::make_unique<frontend::opencypher::Parser>(stripped_query.stripped_query().str());
     } catch (const SyntaxException &e) {
@@ -142,14 +149,15 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
     };
 
     if (visitor.GetQueryInfo().is_cacheable) {
-      CachedQuery cached_query{.ast_storage = std::move(ast_storage),
-                               .query = visitor.query(),
-                               .required_privileges = query::GetRequiredPrivileges(visitor.query()),
-                               .is_cypher_read = read_check(),
-                               .using_schema_assert = visitor.GetQueryInfo().has_schema_assert};
-      it = accessor.insert({hash, std::move(cached_query)}).first;
+      auto cached_query = std::make_shared<CachedQuery>();
+      cached_query->ast_storage = std::move(ast_storage);
+      cached_query->query = visitor.query();
+      cached_query->required_privileges = query::GetRequiredPrivileges(visitor.query());
+      cached_query->is_cypher_read = read_check();
+      cached_query->using_schema_assert = visitor.GetQueryInfo().has_schema_assert;
+      cache->WithLock([&](auto &lru) { lru.put(hash, cached_query); });
 
-      get_information_from_cache(it->second);
+      get_information_from_cache(*cached_query);
     } else {
       // Carefully use the query we just built, preserving the ast_storage we used to build it
       result.required_privileges = query::GetRequiredPrivileges(visitor.query());
@@ -161,7 +169,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
       is_cacheable = false;
     }
   } else {
-    get_information_from_cache(it->second);
+    get_information_from_cache(*cached);
   }
 
   return ParsedQuery{

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -87,14 +87,16 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
   // caching.
   frontend::StrippedQuery stripped_query{query_string};
 
-  auto lookup = [&](frontend::HashedString const &key) {
-    std::shared_ptr<CachedQuery> entry;
-    cache->WithLock([&](auto &lru) {
-      if (auto hit = lru.get(key)) entry = *hit;
-    });
-    return entry;
-  };
-  auto cached = lookup(stripped_query.stripped_query());
+  // Get parameters (user + database-scoped then global server parameters when database_uuid provided).
+  // Used for visitor resolution of dynamic labels/edge types and for execution.
+  auto query_parameters = PrepareQueryParameters(stripped_query, user_parameters, server_parameters, database_uuid);
+
+  // Cache the query's AST if it isn't already.
+  auto const &cache_key = stripped_query.stripped_query();
+  std::shared_ptr<CachedQuery> cached;
+  cache->WithLock([&](auto &lru) {
+    if (auto entry = lru.get(cache_key)) cached = *entry;
+  });
   std::unique_ptr<frontend::opencypher::Parser> parser;
 
   // Return a copy of both the AST storage and the query.
@@ -115,40 +117,16 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
   if (!cached) {
     try {
       parser = std::make_unique<frontend::opencypher::Parser>(stripped_query.stripped_query().str());
-    } catch (const SyntaxException &) {
-      // a misfolded sign never parses; retry without folding before reporting
-      // an error
-      auto unfolded = frontend::StrippedQuery{query_string, frontend::SignFolding::kDisabled};
-      if (unfolded.stripped_query() != stripped_query.stripped_query()) {
-        stripped_query = std::move(unfolded);
-        cached = lookup(stripped_query.stripped_query());
-        if (!cached) {
-          try {
-            parser = std::make_unique<frontend::opencypher::Parser>(stripped_query.stripped_query().str());
-          } catch (const SyntaxException &) {
-            // fall through to the original-query parse
-          }
-        }
-      }
-      if (!cached && !parser) {
-        // There is a syntax exception in the stripped query. Re-run the parser
-        // on the original query to get an appropriate error messsage.
-        parser = std::make_unique<frontend::opencypher::Parser>(query_string);
+    } catch (const SyntaxException &e) {
+      // There is a syntax exception in the stripped query. Re-run the parser
+      // on the original query to get an appropriate error messsage.
+      parser = std::make_unique<frontend::opencypher::Parser>(query_string);
 
-        // If an exception was not thrown here, the stripper messed something
-        // up.
-        LOG_FATAL("The stripped query can't be parsed, but the original can.");
-      }
+      // If an exception was not thrown here, the stripper messed something
+      // up.
+      LOG_FATAL("The stripped query can't be parsed, but the original can.");
     }
-  }
 
-  // Get parameters (user + database-scoped then global server parameters when database_uuid provided).
-  // Used for visitor resolution of dynamic labels/edge types and for execution.
-  // token positions differ between folded and unfolded strippings, so this
-  // must run after the final form is chosen.
-  auto query_parameters = PrepareQueryParameters(stripped_query, user_parameters, server_parameters, database_uuid);
-
-  if (!cached) {
     // Convert the ANTLR4 parse tree into an AST.
     AstStorage ast_storage;
     frontend::ParsingContext context{.is_query_cached = true};
@@ -175,7 +153,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
       cached_query->required_privileges = query::GetRequiredPrivileges(visitor.query());
       cached_query->is_cypher_read = read_check();
       cached_query->using_schema_assert = visitor.GetQueryInfo().has_schema_assert;
-      cache->WithLock([&](auto &lru) { lru.put(stripped_query.stripped_query(), cached_query); });
+      cache->WithLock([&](auto &lru) { lru.put(cache_key, cached_query); });
 
       get_information_from_cache(*cached_query);
     } else {

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <memory>
 
 #include "parameters/parameters.hpp"
@@ -103,7 +102,7 @@ struct CachedQuery {
 // keyed by text, not hash, so a hash collision can't return another query's
 // AST. entries are shared_ptr so an LRU eviction can't free an AST mid-clone.
 using AstCache =
-    utils::Synchronized<utils::LRUCache<frontend::HashedString, std::shared_ptr<CachedQuery>>, utils::RWSpinLock>;
+    utils::Synchronized<utils::LRUCache<frontend::HashedString, std::shared_ptr<const CachedQuery>>, utils::RWSpinLock>;
 
 /**
  * A container for data related to the parsing of a query.

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -100,11 +100,8 @@ struct CachedQuery {
   bool using_schema_assert{false};
 };
 
-// Bounded, LRU-evicted cache of parsed ASTs keyed by the stripped query. The
-// key is the HashedString (not the bare hash) so a 64-bit hash collision is
-// resolved by comparing the query text and can never return a different query's
-// AST. Entries are shared_ptr because CachedQuery::query points into its own
-// AstStorage, so the entry must be stored once and shared, never value-copied.
+// keyed by text, not hash, so a hash collision can't return another query's
+// AST. entries are shared_ptr so an LRU eviction can't free an AST mid-clone.
 using AstCache =
     utils::Synchronized<utils::LRUCache<frontend::HashedString, std::shared_ptr<CachedQuery>>, utils::RWSpinLock>;
 

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -100,10 +100,13 @@ struct CachedQuery {
   bool using_schema_assert{false};
 };
 
-// Bounded, LRU-evicted cache of parsed ASTs keyed by the stripped-query hash.
-// Entries are shared_ptr because CachedQuery::query points into its own
+// Bounded, LRU-evicted cache of parsed ASTs keyed by the stripped query. The
+// key is the HashedString (not the bare hash) so a 64-bit hash collision is
+// resolved by comparing the query text and can never return a different query's
+// AST. Entries are shared_ptr because CachedQuery::query points into its own
 // AstStorage, so the entry must be stored once and shared, never value-copied.
-using AstCache = utils::Synchronized<utils::LRUCache<uint64_t, std::shared_ptr<CachedQuery>>, utils::RWSpinLock>;
+using AstCache =
+    utils::Synchronized<utils::LRUCache<frontend::HashedString, std::shared_ptr<CachedQuery>>, utils::RWSpinLock>;
 
 /**
  * A container for data related to the parsing of a query.

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -11,6 +11,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
 #include "parameters/parameters.hpp"
 #include "plan/read_write_type_checker.hpp"
 #include "query/config.hpp"
@@ -20,6 +23,7 @@
 #include "query/parameters.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/lru_cache.hpp"
+#include "utils/rw_spin_lock.hpp"
 #include "utils/synchronized.hpp"
 
 #include "gflags/gflags.h"
@@ -28,6 +32,8 @@
 DECLARE_bool(query_cost_planner);
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_int32(query_plan_cache_max_size);
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_int32(query_ast_cache_max_size);
 
 namespace memgraph::query {
 
@@ -94,20 +100,10 @@ struct CachedQuery {
   bool using_schema_assert{false};
 };
 
-struct QueryCacheEntry {
-  bool operator==(const QueryCacheEntry &other) const { return first == other.first; }
-
-  bool operator<(const QueryCacheEntry &other) const { return first < other.first; }
-
-  bool operator==(const uint64_t &other) const { return first == other; }
-
-  bool operator<(const uint64_t &other) const { return first < other; }
-
-  uint64_t first;
-  // TODO: Maybe store the query string here and use it as a key with the hash
-  // so that we eliminate the risk of hash collisions.
-  CachedQuery second;
-};
+// Bounded, LRU-evicted cache of parsed ASTs keyed by the stripped-query hash.
+// Entries are shared_ptr because CachedQuery::query points into its own
+// AstStorage, so the entry must be stored once and shared, never value-copied.
+using AstCache = utils::Synchronized<utils::LRUCache<uint64_t, std::shared_ptr<CachedQuery>>, utils::RWSpinLock>;
 
 /**
  * A container for data related to the parsing of a query.
@@ -125,9 +121,9 @@ struct ParsedQuery {
   Parameters parameters;
 };
 
-ParsedQuery ParseQuery(const std::string &query_string, UserParameters const &user_parameters,
-                       utils::SkipList<QueryCacheEntry> *cache, const InterpreterConfig::Query &query_config,
-                       std::string_view database_uuid, parameters::Parameters const *server_parameters);
+ParsedQuery ParseQuery(const std::string &query_string, UserParameters const &user_parameters, AstCache *cache,
+                       const InterpreterConfig::Query &query_config, std::string_view database_uuid,
+                       parameters::Parameters const *server_parameters);
 
 class SingleNodeLogicalPlan final : public LogicalPlan {
  public:

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -29,7 +29,7 @@ namespace memgraph::query::frontend {
 
 using namespace lexer_constants;
 
-StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
+StrippedQuery::StrippedQuery(std::string query, SignFolding sign_folding) : original_(std::move(query)) {
   enum class Token {
     UNMATCHED,
     KEYWORD,  // Including true, false and null.
@@ -101,21 +101,12 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
     }
   }
 
-  // Fold a unary +/- that directly precedes a numeric literal into that literal
-  // (the sign is prepended to the number's text and the sign token dropped), so
-  // lists differing only in the sign pattern of their numbers strip to the same
-  // text and share one cache entry. The gate is square-bracket depth, so it
-  // fires anywhere inside `[...]` (list literals, but also indexing, slicing,
-  // comprehensions and variable-length patterns). Folding is value-preserving -
-  // it only rewrites `-<literal>` as a literal of the negated value, which
-  // evaluates identically - so any bracketed context is safe. The bracket gate
-  // exists to stay out of unbracketed clause operands whose sign is validated
-  // from the parse-tree shape, where a folded `-1` would read as a plain
-  // positive literal and slip past the check (e.g. `USING PERIODIC COMMIT -1`).
-  // Fold only when the sign is unambiguously unary: adjacent to the number (no
-  // whitespace) and not preceded by a value, so a subtraction like `[a-1]` or
-  // `[1-1]` is left untouched.
-  {
+  // fold a unary +/- into the adjacent numeric literal so queries differing
+  // only in sign strip to the same text and share an AST cache entry. unary
+  // detection is a lexical heuristic (any keyword can also name a variable, so
+  // `RETURN return-1` misfolds); a misfold never parses, and ParseQuery then
+  // re-strips with SignFolding::kDisabled.
+  if (sign_folding == SignFolding::kEnabled) {
     auto produces_value = [](Token type, const std::string &text) {
       switch (type) {
         case Token::INT:
@@ -126,9 +117,10 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
         case Token::UNESCAPED_NAME:
           return true;
         case Token::KEYWORD:
-          // a keyword can end a value expression (CASE ... END, keyword-named
-          // properties/variables); over-approximating only skips a fold
-          return true;
+          // common value-enders; rarer ones (keyword-named variables and
+          // properties) are rescued by the re-strip
+          return utils::IEquals(text, "true") || utils::IEquals(text, "false") || utils::IEquals(text, "null") ||
+                 utils::IEquals(text, "end");
         case Token::SPECIAL:
           return text == ")" || text == "]" || text == "}";
         default:
@@ -138,27 +130,19 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
     std::vector<std::pair<Token, std::string>> folded;
     folded.reserve(tokens.size());
     bool prev_produces_value = false;  // start of query is a unary context
-    int bracket_depth = 0;
     for (std::size_t i = 0; i < tokens.size(); ++i) {
       const auto &token = tokens[i];
       const bool is_sign = token.first == Token::SPECIAL && (token.second == "-" || token.second == "+");
-      const bool folds = is_sign && bracket_depth > 0 && !prev_produces_value && i + 1 < tokens.size() &&
+      const bool folds = is_sign && !prev_produces_value && i + 1 < tokens.size() &&
                          (tokens[i + 1].first == Token::INT || tokens[i + 1].first == Token::REAL);
       if (folds) {
         const auto &number = tokens[i + 1];
         folded.emplace_back(number.first, token.second + number.second);
         prev_produces_value = true;
-        ++i;  // consume the number token as well
+        ++i;  // also consume the number
         continue;
       }
       if (token.first != Token::SPACE) prev_produces_value = produces_value(token.first, token.second);
-      if (token.first == Token::SPECIAL) {
-        if (token.second == "[") {
-          ++bracket_depth;
-        } else if (token.second == "]" && bracket_depth > 0) {
-          --bracket_depth;
-        }
-      }
       folded.push_back(token);
     }
     tokens = std::move(folded);

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -11,6 +11,7 @@
 
 #include "query/frontend/stripped.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <span>
@@ -29,7 +30,7 @@ namespace memgraph::query::frontend {
 
 using namespace lexer_constants;
 
-StrippedQuery::StrippedQuery(std::string query, SignFolding sign_folding) : original_(std::move(query)) {
+StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
   enum class Token {
     UNMATCHED,
     KEYWORD,  // Including true, false and null.
@@ -101,48 +102,34 @@ StrippedQuery::StrippedQuery(std::string query, SignFolding sign_folding) : orig
     }
   }
 
-  // fold a unary +/- into the adjacent numeric literal so queries differing
-  // only in sign strip to the same text and share an AST cache entry. unary
-  // detection is a lexical heuristic (any keyword can also name a variable, so
-  // `RETURN return-1` misfolds); a misfold never parses, and ParseQuery then
-  // re-strips with SignFolding::kDisabled.
-  if (sign_folding == SignFolding::kEnabled) {
-    auto produces_value = [](Token type, const std::string &text) {
-      switch (type) {
-        case Token::INT:
-        case Token::REAL:
-        case Token::STRING:
-        case Token::PARAMETER:
-        case Token::ESCAPED_NAME:
-        case Token::UNESCAPED_NAME:
-          return true;
-        case Token::KEYWORD:
-          // common value-enders; rarer ones (keyword-named variables and
-          // properties) are rescued by the re-strip
-          return utils::IEquals(text, "true") || utils::IEquals(text, "false") || utils::IEquals(text, "null") ||
-                 utils::IEquals(text, "end");
-        case Token::SPECIAL:
-          return text == ")" || text == "]" || text == "}";
-        default:
-          return false;
-      }
+  // a +/- between a `[`, `(` or `,` and a numeric literal can only be a unary
+  // sign, so fold it into the literal; sign variants of a query then strip to
+  // the same text and share one AST cache entry
+  {
+    auto const is_space = [](auto const &t) { return t.first == Token::SPACE; };
+    auto const is_number = [](auto const &t) { return t.first == Token::INT || t.first == Token::REAL; };
+    auto const is_sign = [](auto const &t) {
+      return t.first == Token::SPECIAL && (t.second == "-" || t.second == "+");
     };
+    auto const is_opener = [](auto const &t) {
+      return t.first == Token::SPECIAL && (t.second == "[" || t.second == "(" || t.second == ",");
+    };
+
     std::vector<std::pair<Token, std::string>> folded;
     folded.reserve(tokens.size());
-    bool prev_produces_value = false;  // start of query is a unary context
+    bool prev_is_opener = false;
     for (std::size_t i = 0; i < tokens.size(); ++i) {
-      const auto &token = tokens[i];
-      const bool is_sign = token.first == Token::SPECIAL && (token.second == "-" || token.second == "+");
-      const bool folds = is_sign && !prev_produces_value && i + 1 < tokens.size() &&
-                         (tokens[i + 1].first == Token::INT || tokens[i + 1].first == Token::REAL);
-      if (folds) {
-        const auto &number = tokens[i + 1];
-        folded.emplace_back(number.first, token.second + number.second);
-        prev_produces_value = true;
-        ++i;  // also consume the number
-        continue;
+      auto const &token = tokens[i];
+      if (prev_is_opener && is_sign(token)) {
+        auto const number = std::ranges::find_if_not(tokens.begin() + i + 1, tokens.end(), is_space);
+        if (number != tokens.end() && is_number(*number)) {
+          folded.emplace_back(number->first, token.second + number->second);
+          i = static_cast<std::size_t>(number - tokens.begin());
+          prev_is_opener = false;
+          continue;
+        }
       }
-      if (token.first != Token::SPACE) prev_produces_value = produces_value(token.first, token.second);
+      if (!is_space(token)) prev_is_opener = is_opener(token);
       folded.push_back(token);
     }
     tokens = std::move(folded);

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -126,7 +126,9 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
         case Token::UNESCAPED_NAME:
           return true;
         case Token::KEYWORD:
-          return utils::IEquals(text, "true") || utils::IEquals(text, "false") || utils::IEquals(text, "null");
+          // a keyword can end a value expression (CASE ... END, keyword-named
+          // properties/variables); over-approximating only skips a fold
+          return true;
         case Token::SPECIAL:
           return text == ")" || text == "]" || text == "}";
         default:

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -104,10 +104,14 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
   // Fold a unary +/- that directly precedes a numeric literal into that literal
   // (the sign is prepended to the number's text and the sign token dropped), so
   // lists differing only in the sign pattern of their numbers strip to the same
-  // text and share one cache entry. This is confined to list literals `[...]`:
-  // that covers the motivating case (embedding vectors) while avoiding clause
-  // operands whose sign is validated from the parse-tree shape (a folded `-1`
-  // would look like a plain positive literal), e.g. `USING PERIODIC COMMIT -1`.
+  // text and share one cache entry. The gate is square-bracket depth, so it
+  // fires anywhere inside `[...]` (list literals, but also indexing, slicing,
+  // comprehensions and variable-length patterns). Folding is value-preserving -
+  // it only rewrites `-<literal>` as a literal of the negated value, which
+  // evaluates identically - so any bracketed context is safe. The bracket gate
+  // exists to stay out of unbracketed clause operands whose sign is validated
+  // from the parse-tree shape, where a folded `-1` would read as a plain
+  // positive literal and slip past the check (e.g. `USING PERIODIC COMMIT -1`).
   // Fold only when the sign is unambiguously unary: adjacent to the number (no
   // whitespace) and not preceded by a value, so a subtraction like `[a-1]` or
   // `[1-1]` is left untouched.
@@ -132,11 +136,11 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
     std::vector<std::pair<Token, std::string>> folded;
     folded.reserve(tokens.size());
     bool prev_produces_value = false;  // start of query is a unary context
-    int list_depth = 0;
+    int bracket_depth = 0;
     for (std::size_t i = 0; i < tokens.size(); ++i) {
       const auto &token = tokens[i];
       const bool is_sign = token.first == Token::SPECIAL && (token.second == "-" || token.second == "+");
-      const bool folds = is_sign && list_depth > 0 && !prev_produces_value && i + 1 < tokens.size() &&
+      const bool folds = is_sign && bracket_depth > 0 && !prev_produces_value && i + 1 < tokens.size() &&
                          (tokens[i + 1].first == Token::INT || tokens[i + 1].first == Token::REAL);
       if (folds) {
         const auto &number = tokens[i + 1];
@@ -148,9 +152,9 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
       if (token.first != Token::SPACE) prev_produces_value = produces_value(token.first, token.second);
       if (token.first == Token::SPECIAL) {
         if (token.second == "[") {
-          ++list_depth;
-        } else if (token.second == "]" && list_depth > 0) {
-          --list_depth;
+          ++bracket_depth;
+        } else if (token.second == "]" && bracket_depth > 0) {
+          --bracket_depth;
         }
       }
       folded.push_back(token);

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <cstdint>
 #include <span>
 #include <string>
@@ -119,7 +120,8 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
     for (std::size_t i = 0; i < tokens.size(); ++i) {
       auto const &token = tokens[i];
       if (at_list_element_start && is_sign(token)) {
-        auto const number = std::ranges::find_if_not(tokens.begin() + i + 1, tokens.end(), is_space);
+        auto const number =
+            std::ranges::find_if_not(tokens.begin() + static_cast<std::ptrdiff_t>(i + 1), tokens.end(), is_space);
         if (number != tokens.end() && is_number(*number)) {
           folded.emplace_back(number->first, token.second + number->second);
           i = static_cast<std::size_t>(number - tokens.begin());

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -11,7 +11,6 @@
 
 #include "query/frontend/stripped.hpp"
 
-#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <span>
@@ -100,39 +99,6 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
         break;
       }
     }
-  }
-
-  // a +/- between a `[`, `(` or `,` and a numeric literal can only be a unary
-  // sign, so fold it into the literal; sign variants of a query then strip to
-  // the same text and share one AST cache entry
-  {
-    auto const is_space = [](auto const &t) { return t.first == Token::SPACE; };
-    auto const is_number = [](auto const &t) { return t.first == Token::INT || t.first == Token::REAL; };
-    auto const is_sign = [](auto const &t) {
-      return t.first == Token::SPECIAL && (t.second == "-" || t.second == "+");
-    };
-    auto const is_opener = [](auto const &t) {
-      return t.first == Token::SPECIAL && (t.second == "[" || t.second == "(" || t.second == ",");
-    };
-
-    std::vector<std::pair<Token, std::string>> folded;
-    folded.reserve(tokens.size());
-    bool prev_is_opener = false;
-    for (std::size_t i = 0; i < tokens.size(); ++i) {
-      auto const &token = tokens[i];
-      if (prev_is_opener && is_sign(token)) {
-        auto const number = std::ranges::find_if_not(tokens.begin() + i + 1, tokens.end(), is_space);
-        if (number != tokens.end() && is_number(*number)) {
-          folded.emplace_back(number->first, token.second + number->second);
-          i = static_cast<std::size_t>(number - tokens.begin());
-          prev_is_opener = false;
-          continue;
-        }
-      }
-      if (!is_space(token)) prev_is_opener = is_opener(token);
-      folded.push_back(token);
-    }
-    tokens = std::move(folded);
   }
 
   std::vector<std::string> token_strings;

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -101,6 +101,63 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
     }
   }
 
+  // Fold a unary +/- that directly precedes a numeric literal into that literal
+  // (the sign is prepended to the number's text and the sign token dropped), so
+  // lists differing only in the sign pattern of their numbers strip to the same
+  // text and share one cache entry. This is confined to list literals `[...]`:
+  // that covers the motivating case (embedding vectors) while avoiding clause
+  // operands whose sign is validated from the parse-tree shape (a folded `-1`
+  // would look like a plain positive literal), e.g. `USING PERIODIC COMMIT -1`.
+  // Fold only when the sign is unambiguously unary: adjacent to the number (no
+  // whitespace) and not preceded by a value, so a subtraction like `[a-1]` or
+  // `[1-1]` is left untouched.
+  {
+    auto produces_value = [](Token type, const std::string &text) {
+      switch (type) {
+        case Token::INT:
+        case Token::REAL:
+        case Token::STRING:
+        case Token::PARAMETER:
+        case Token::ESCAPED_NAME:
+        case Token::UNESCAPED_NAME:
+          return true;
+        case Token::KEYWORD:
+          return utils::IEquals(text, "true") || utils::IEquals(text, "false") || utils::IEquals(text, "null");
+        case Token::SPECIAL:
+          return text == ")" || text == "]" || text == "}";
+        default:
+          return false;
+      }
+    };
+    std::vector<std::pair<Token, std::string>> folded;
+    folded.reserve(tokens.size());
+    bool prev_produces_value = false;  // start of query is a unary context
+    int list_depth = 0;
+    for (std::size_t i = 0; i < tokens.size(); ++i) {
+      const auto &token = tokens[i];
+      const bool is_sign = token.first == Token::SPECIAL && (token.second == "-" || token.second == "+");
+      const bool folds = is_sign && list_depth > 0 && !prev_produces_value && i + 1 < tokens.size() &&
+                         (tokens[i + 1].first == Token::INT || tokens[i + 1].first == Token::REAL);
+      if (folds) {
+        const auto &number = tokens[i + 1];
+        folded.emplace_back(number.first, token.second + number.second);
+        prev_produces_value = true;
+        ++i;  // consume the number token as well
+        continue;
+      }
+      if (token.first != Token::SPACE) prev_produces_value = produces_value(token.first, token.second);
+      if (token.first == Token::SPECIAL) {
+        if (token.second == "[") {
+          ++list_depth;
+        } else if (token.second == "]" && list_depth > 0) {
+          --list_depth;
+        }
+      }
+      folded.push_back(token);
+    }
+    tokens = std::move(folded);
+  }
+
   std::vector<std::string> token_strings;
   // A helper function that stores literal and its token position in a
   // literals_. In stripped query text literal is replaced with a new_value.

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -11,6 +11,7 @@
 
 #include "query/frontend/stripped.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <span>
@@ -99,6 +100,47 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
         break;
       }
     }
+  }
+
+  // a +/- after `[`, or after `,` inside brackets, can only be a unary sign:
+  // fold it into the number so sign variants of a list strip to the same text
+  // and share one AST cache entry
+  {
+    auto const is_space = [](auto const &token) { return token.first == Token::SPACE; };
+    auto const is_number = [](auto const &token) { return token.first == Token::INT || token.first == Token::REAL; };
+    auto const is_sign = [](auto const &token) {
+      return token.first == Token::SPECIAL && (token.second == "-" || token.second == "+");
+    };
+
+    std::vector<std::pair<Token, std::string>> folded;
+    folded.reserve(tokens.size());
+    int bracket_depth = 0;
+    bool at_list_element_start = false;
+    for (std::size_t i = 0; i < tokens.size(); ++i) {
+      auto const &token = tokens[i];
+      if (at_list_element_start && is_sign(token)) {
+        auto const number = std::ranges::find_if_not(tokens.begin() + i + 1, tokens.end(), is_space);
+        if (number != tokens.end() && is_number(*number)) {
+          folded.emplace_back(number->first, token.second + number->second);
+          i = static_cast<std::size_t>(number - tokens.begin());
+          at_list_element_start = false;
+          continue;
+        }
+      }
+      if (token.first == Token::SPECIAL) {
+        if (token.second == "[") {
+          ++bracket_depth;
+        } else if (token.second == "]" && bracket_depth > 0) {
+          --bracket_depth;
+        }
+      }
+      if (!is_space(token)) {
+        at_list_element_start =
+            token.first == Token::SPECIAL && (token.second == "[" || (token.second == "," && bracket_depth > 0));
+      }
+      folded.push_back(token);
+    }
+    tokens = std::move(folded);
   }
 
   std::vector<std::string> token_strings;

--- a/src/query/frontend/stripped.hpp
+++ b/src/query/frontend/stripped.hpp
@@ -114,9 +114,6 @@ class StrippedQuery {
   HashedString stripped_query_;
 
   // Token positions of stripped out literals mapped to their values.
-  // TODO: Parameters class really doesn't provide anything interesting. This
-  // could be changed to std::unordered_map, but first we need to rewrite (or
-  // get rid of) hardcoded queries which expect Parameters.
   Parameters literals_;
 
   // Token positions of query parameters mapped to their names.

--- a/src/query/frontend/stripped.hpp
+++ b/src/query/frontend/stripped.hpp
@@ -53,6 +53,10 @@ struct HashedString {
   size_t hash_{utils::Fnv(str_)};
 };
 
+// folding is heuristic - a misfolded subtraction never parses, so ParseQuery
+// retries with kDisabled
+enum class SignFolding : uint8_t { kEnabled, kDisabled };
+
 /**
  * StrippedQuery contains:
  *     * stripped query
@@ -67,7 +71,7 @@ class StrippedQuery {
    *
    * @param query Input query.
    */
-  explicit StrippedQuery(std::string query);
+  explicit StrippedQuery(std::string query, SignFolding sign_folding = SignFolding::kEnabled);
 
   /**
    * Copy constructor is deleted because we don't want to make unnecessary

--- a/src/query/frontend/stripped.hpp
+++ b/src/query/frontend/stripped.hpp
@@ -53,10 +53,6 @@ struct HashedString {
   size_t hash_{utils::Fnv(str_)};
 };
 
-// folding is heuristic - a misfolded subtraction never parses, so ParseQuery
-// retries with kDisabled
-enum class SignFolding : uint8_t { kEnabled, kDisabled };
-
 /**
  * StrippedQuery contains:
  *     * stripped query
@@ -71,7 +67,7 @@ class StrippedQuery {
    *
    * @param query Input query.
    */
-  explicit StrippedQuery(std::string query, SignFolding sign_folding = SignFolding::kEnabled);
+  explicit StrippedQuery(std::string query);
 
   /**
    * Copy constructor is deleted because we don't want to make unnecessary

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2124,12 +2124,12 @@ Callback HandleReplicationInfoQuery(ReplicationInfoQuery *repl_query,
 
 #ifdef MG_ENTERPRISE
 
-int64_t EvaluateCoordinatorId(Expression *coordinator_id, ExpressionVisitor<TypedValue> &eval) {
-  const auto value = coordinator_id->Accept(eval);
-  if (!value.IsInt() || value.ValueInt() < 0) {
-    throw QueryRuntimeException("Coordinator id must be a non-negative integer.");
+int32_t EvaluateCoordinatorId(ExpressionVisitor<TypedValue> &eval, Expression *coordinator_id) {
+  const auto value = *EvaluateUint(eval, coordinator_id, "Coordinator id");
+  if (value > std::numeric_limits<int32_t>::max()) {
+    throw QueryRuntimeException("Coordinator id must fit into 32 bits.");
   }
-  return value.ValueInt();
+  return static_cast<int32_t>(value);
 }
 
 Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Parameters &parameters,
@@ -2152,10 +2152,10 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
       EvaluationContext const evaluation_context{.timestamp = QueryTimestamp(), .parameters = parameters};
       auto evaluator = PrimitiveLiteralExpressionEvaluator{evaluation_context};
 
-      auto coord_server_id = EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator);
+      const auto coord_server_id = EvaluateCoordinatorId(evaluator, coordinator_query->coordinator_id_);
 
       callback.fn = [handler = CoordQueryHandler{*coordinator_state}, coord_server_id]() mutable {
-        handler.RemoveCoordinatorInstance(static_cast<int>(coord_server_id));
+        handler.RemoveCoordinatorInstance(coord_server_id);
         return std::vector<std::vector<TypedValue>>();
       };
 
@@ -2202,15 +2202,14 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         throw QueryRuntimeException("Config map must contain {} entry!", kManagementServer);
       }
 
-      auto coord_server_id = EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator);
+      const auto coord_server_id = EvaluateCoordinatorId(evaluator, coordinator_query->coordinator_id_);
 
       callback.fn = [handler = CoordQueryHandler{*coordinator_state},
                      coord_server_id,
                      bolt_server = bolt_server_it->second,
                      coordinator_server = coordinator_server_it->second,
                      management_server = management_server_it->second]() mutable {
-        handler.AddCoordinatorInstance(
-            static_cast<int32_t>(coord_server_id), bolt_server, coordinator_server, management_server);
+        handler.AddCoordinatorInstance(coord_server_id, bolt_server, coordinator_server, management_server);
         return std::vector<std::vector<TypedValue>>();
       };
 
@@ -2249,7 +2248,7 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         if (!coordinator_query->instance_name_.empty()) {
           return coordinator_query->instance_name_;
         }
-        return static_cast<int32_t>(EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator));
+        return EvaluateCoordinatorId(evaluator, coordinator_query->coordinator_id_);
       });
 
       callback.fn =
@@ -2267,7 +2266,7 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         if (!coordinator_query->instance_name_.empty()) {
           return fmt::format("for instance {}", coordinator_query->instance_name_);
         }
-        auto coord_server_id = EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator);
+        const auto coord_server_id = EvaluateCoordinatorId(evaluator, coordinator_query->coordinator_id_);
         return fmt::format("for coordinator {}", coord_server_id);
       });
       notifications->emplace_back(

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2124,6 +2124,14 @@ Callback HandleReplicationInfoQuery(ReplicationInfoQuery *repl_query,
 
 #ifdef MG_ENTERPRISE
 
+int64_t EvaluateCoordinatorId(Expression *coordinator_id, ExpressionVisitor<TypedValue> &eval) {
+  const auto value = coordinator_id->Accept(eval);
+  if (!value.IsInt() || value.ValueInt() < 0) {
+    throw QueryRuntimeException("Coordinator id must be a non-negative integer.");
+  }
+  return value.ValueInt();
+}
+
 Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Parameters &parameters,
                                 coordination::CoordinatorState *coordinator_state,
                                 std::vector<Notification> *notifications) {
@@ -2144,7 +2152,7 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
       EvaluationContext const evaluation_context{.timestamp = QueryTimestamp(), .parameters = parameters};
       auto evaluator = PrimitiveLiteralExpressionEvaluator{evaluation_context};
 
-      auto coord_server_id = coordinator_query->coordinator_id_->Accept(evaluator).ValueInt();
+      auto coord_server_id = EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator);
 
       callback.fn = [handler = CoordQueryHandler{*coordinator_state}, coord_server_id]() mutable {
         handler.RemoveCoordinatorInstance(static_cast<int>(coord_server_id));
@@ -2194,7 +2202,7 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         throw QueryRuntimeException("Config map must contain {} entry!", kManagementServer);
       }
 
-      auto coord_server_id = coordinator_query->coordinator_id_->Accept(evaluator).ValueInt();
+      auto coord_server_id = EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator);
 
       callback.fn = [handler = CoordQueryHandler{*coordinator_state},
                      coord_server_id,
@@ -2241,7 +2249,7 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         if (!coordinator_query->instance_name_.empty()) {
           return coordinator_query->instance_name_;
         }
-        return static_cast<int32_t>(coordinator_query->coordinator_id_->Accept(evaluator).ValueInt());
+        return static_cast<int32_t>(EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator));
       });
 
       callback.fn =
@@ -2259,7 +2267,7 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         if (!coordinator_query->instance_name_.empty()) {
           return fmt::format("for instance {}", coordinator_query->instance_name_);
         }
-        auto coord_server_id = coordinator_query->coordinator_id_->Accept(evaluator).ValueInt();
+        auto coord_server_id = EvaluateCoordinatorId(coordinator_query->coordinator_id_, evaluator);
         return fmt::format("for coordinator {}", coord_server_id);
       });
       notifications->emplace_back(

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -42,6 +42,7 @@ InterpreterContext::InterpreterContext(InterpreterConfig interpreter_config, mem
       parameters(parameters),
       dbms_handler(dbms_handler),
       config(std::move(interpreter_config)),
+      ast_cache{static_cast<std::size_t>(FLAGS_query_ast_cache_max_size)},
       repl_state(rs),
 #ifdef MG_ENTERPRISE
       coordinator_state_(coordinator_state),

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -34,7 +34,6 @@
 #include "utils/priority_thread_pool.hpp"
 #include "utils/resource_monitoring.hpp"
 #include "utils/settings.hpp"
-#include "utils/skip_list.hpp"
 #include "utils/spin_lock.hpp"
 #include "utils/synchronized.hpp"
 #ifdef MG_ENTERPRISE
@@ -69,7 +68,7 @@ struct InterpreterContext {
   // Internal
   const InterpreterConfig config;
   std::atomic<bool> is_shutting_down{false};  // TODO: Do we even need this, since there is a global one also
-  AstCache ast_cache{static_cast<std::size_t>(FLAGS_query_ast_cache_max_size)};
+  AstCache ast_cache;
 
   // GLOBAL
   utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> *repl_state;

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -21,6 +21,7 @@
 
 #include "parameters/parameters.hpp"
 #include "query/config.hpp"
+#include "query/cypher_query_interpreter.hpp"
 #include "query/replication_query_handler.hpp"
 #include "query/typed_value.hpp"
 #include "replication/state.hpp"
@@ -48,8 +49,6 @@ class DbmsHandler;
 
 namespace memgraph::query {
 
-struct QueryCacheEntry;
-
 constexpr uint64_t kInterpreterTransactionInitialId = 1ULL << 63U;
 
 class AuthQueryHandler;
@@ -70,7 +69,7 @@ struct InterpreterContext {
   // Internal
   const InterpreterConfig config;
   std::atomic<bool> is_shutting_down{false};  // TODO: Do we even need this, since there is a global one also
-  utils::SkipList<QueryCacheEntry> ast_cache;
+  AstCache ast_cache{static_cast<std::size_t>(FLAGS_query_ast_cache_max_size)};
 
   // GLOBAL
   utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> *repl_state;

--- a/src/query/parameters.hpp
+++ b/src/query/parameters.hpp
@@ -12,8 +12,6 @@
 #pragma once
 
 #include <unordered_map>
-#include <utility>
-#include <vector>
 
 #include "storage/v2/property_value.hpp"
 #include "utils/logging.hpp"
@@ -32,10 +30,7 @@ struct Parameters {
    * @param position Token position in query of value.
    * @param value
    */
-  void Add(int position, const storage::ExternalPropertyValue &value) {
-    position_index_.emplace(position, storage_.size());
-    storage_.emplace_back(position, value);
-  }
+  void Add(int position, const storage::ExternalPropertyValue &value) { storage_.emplace(position, value); }
 
   /**
    *  Returns the value found for the given token position.
@@ -44,24 +39,11 @@ struct Parameters {
    *  @return Value for the given token position.
    */
   const storage::ExternalPropertyValue &AtTokenPosition(int position) const {
-    const auto found = position_index_.find(position);
-    MG_ASSERT(found != position_index_.end(), "Token position must be present in container");
-    return storage_[found->second].second;
+    const auto found = storage_.find(position);
+    MG_ASSERT(found != storage_.end(), "Token position must be present in container");
+    return found->second;
   }
 
-  /**
-   * Returns the position-th stripped value. Asserts that this
-   * container has at least (position + 1) elements.
-   *
-   * @param position Which stripped param is sought.
-   * @return Token position and value for sought param.
-   */
-  const std::pair<int, storage::ExternalPropertyValue> &At(int position) const {
-    MG_ASSERT(position < static_cast<int>(storage_.size()), "Invalid position");
-    return storage_[position];
-  }
-
-  /** Returns the number of arguments in this container */
   auto size() const { return storage_.size(); }
 
   auto begin() const { return storage_.begin(); }
@@ -69,8 +51,7 @@ struct Parameters {
   auto end() const { return storage_.end(); }
 
  private:
-  std::vector<std::pair<int, storage::ExternalPropertyValue>> storage_;
-  std::unordered_map<int, std::size_t> position_index_;
+  std::unordered_map<int, storage::ExternalPropertyValue> storage_;
 };
 
 }  // namespace memgraph::query

--- a/src/query/parameters.hpp
+++ b/src/query/parameters.hpp
@@ -33,8 +33,8 @@ struct Parameters {
    * @param value
    */
   void Add(int position, const storage::ExternalPropertyValue &value) {
-    // Index the token position to keep AtTokenPosition O(1); emplace preserves
-    // the first entry for a position, matching a linear first-match scan.
+    // emplace keeps the first entry for a duplicate position, matching the
+    // first-match linear scan this index replaced
     position_index_.emplace(position, storage_.size());
     storage_.emplace_back(position, value);
   }
@@ -72,7 +72,7 @@ struct Parameters {
 
  private:
   std::vector<std::pair<int, storage::ExternalPropertyValue>> storage_;
-  // Token position -> index into storage_, so AtTokenPosition is O(1).
+  // position -> storage_ index for O(1) AtTokenPosition
   std::unordered_map<int, std::size_t> position_index_;
 };
 

--- a/src/query/parameters.hpp
+++ b/src/query/parameters.hpp
@@ -33,8 +33,6 @@ struct Parameters {
    * @param value
    */
   void Add(int position, const storage::ExternalPropertyValue &value) {
-    // emplace keeps the first entry for a duplicate position, matching the
-    // first-match linear scan this index replaced
     position_index_.emplace(position, storage_.size());
     storage_.emplace_back(position, value);
   }
@@ -46,7 +44,7 @@ struct Parameters {
    *  @return Value for the given token position.
    */
   const storage::ExternalPropertyValue &AtTokenPosition(int position) const {
-    auto found = position_index_.find(position);
+    const auto found = position_index_.find(position);
     MG_ASSERT(found != position_index_.end(), "Token position must be present in container");
     return storage_[found->second].second;
   }
@@ -72,7 +70,6 @@ struct Parameters {
 
  private:
   std::vector<std::pair<int, storage::ExternalPropertyValue>> storage_;
-  // position -> storage_ index for O(1) AtTokenPosition
   std::unordered_map<int, std::size_t> position_index_;
 };
 

--- a/src/query/parameters.hpp
+++ b/src/query/parameters.hpp
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <algorithm>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -32,7 +32,12 @@ struct Parameters {
    * @param position Token position in query of value.
    * @param value
    */
-  void Add(int position, const storage::ExternalPropertyValue &value) { storage_.emplace_back(position, value); }
+  void Add(int position, const storage::ExternalPropertyValue &value) {
+    // Index the token position to keep AtTokenPosition O(1); emplace preserves
+    // the first entry for a position, matching a linear first-match scan.
+    position_index_.emplace(position, storage_.size());
+    storage_.emplace_back(position, value);
+  }
 
   /**
    *  Returns the value found for the given token position.
@@ -41,10 +46,9 @@ struct Parameters {
    *  @return Value for the given token position.
    */
   const storage::ExternalPropertyValue &AtTokenPosition(int position) const {
-    // TODO: make it not a linear scan
-    auto found = std::ranges::find_if(storage_, [&](const auto &a) { return a.first == position; });
-    MG_ASSERT(found != storage_.end(), "Token position must be present in container");
-    return found->second;
+    auto found = position_index_.find(position);
+    MG_ASSERT(found != position_index_.end(), "Token position must be present in container");
+    return storage_[found->second].second;
   }
 
   /**
@@ -68,6 +72,8 @@ struct Parameters {
 
  private:
   std::vector<std::pair<int, storage::ExternalPropertyValue>> storage_;
+  // Token position -> index into storage_, so AtTokenPosition is O(1).
+  std::unordered_map<int, std::size_t> position_index_;
 };
 
 }  // namespace memgraph::query

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -167,7 +167,7 @@ std::vector<std::pair<Identifier, TriggerIdentifierTag>> GetPredefinedIdentifier
 }  // namespace
 
 Trigger::Trigger(std::string name, const std::string &query, const UserParameters &user_parameters,
-                 TriggerEventType event_type, utils::SkipList<QueryCacheEntry> *query_cache, DbAccessor *db_accessor,
+                 TriggerEventType event_type, AstCache *query_cache, DbAccessor *db_accessor,
                  const InterpreterConfig::Query &query_config, std::shared_ptr<QueryUserOrRole> creator,
                  std::string_view db_name, TriggerPrivilegeContext privilege_context,
                  parameters::Parameters const *server_parameters)
@@ -340,7 +340,7 @@ bool MigrateTriggerData(nlohmann::json &json_data, uint64_t version) {
 TriggerStore::TriggerStore(std::filesystem::path directory)
     : storage_{std::move(directory)}, before_commit_triggers_{}, after_commit_triggers_{} {}
 
-void TriggerStore::RestoreTrigger(utils::SkipList<QueryCacheEntry> *query_cache, DbAccessor *db_accessor,
+void TriggerStore::RestoreTrigger(AstCache *query_cache, DbAccessor *db_accessor,
                                   const InterpreterConfig::Query &query_config, const query::AuthChecker *auth_checker,
                                   std::string_view trigger_name, std::string_view trigger_data,
                                   std::string_view db_name, parameters::Parameters const *server_parameters) {
@@ -459,7 +459,7 @@ void TriggerStore::RestoreTrigger(utils::SkipList<QueryCacheEntry> *query_cache,
   spdlog::debug("Trigger loaded successfully!");
 }
 
-void TriggerStore::RestoreTriggers(utils::SkipList<QueryCacheEntry> *query_cache, DbAccessor *db_accessor,
+void TriggerStore::RestoreTriggers(AstCache *query_cache, DbAccessor *db_accessor,
                                    const InterpreterConfig::Query &query_config, const query::AuthChecker *auth_checker,
                                    std::string_view db_name, parameters::Parameters const *server_parameters) {
   MG_ASSERT(before_commit_triggers_.size() == 0 && after_commit_triggers_.size() == 0,
@@ -473,10 +473,10 @@ void TriggerStore::RestoreTriggers(utils::SkipList<QueryCacheEntry> *query_cache
 }
 
 void TriggerStore::AddTrigger(std::string name, const std::string &query, const UserParameters &user_parameters,
-                              TriggerEventType event_type, TriggerPhase phase,
-                              utils::SkipList<QueryCacheEntry> *query_cache, DbAccessor *db_accessor,
-                              const InterpreterConfig::Query &query_config, std::shared_ptr<QueryUserOrRole> creator,
-                              std::string_view db_name, TriggerPrivilegeContext privilege_context,
+                              TriggerEventType event_type, TriggerPhase phase, AstCache *query_cache,
+                              DbAccessor *db_accessor, const InterpreterConfig::Query &query_config,
+                              std::shared_ptr<QueryUserOrRole> creator, std::string_view db_name,
+                              TriggerPrivilegeContext privilege_context,
                               parameters::Parameters const *server_parameters) {
   std::unique_lock store_guard{store_lock_};
   if (storage_.Get(name)) {

--- a/src/query/trigger.hpp
+++ b/src/query/trigger.hpp
@@ -31,13 +31,11 @@
 
 namespace memgraph::query {
 
-struct QueryCacheEntry;
-
 enum class TransactionStatus;
 
 struct Trigger {
   explicit Trigger(std::string name, const std::string &query, const UserParameters &user_parameters,
-                   TriggerEventType event_type, utils::SkipList<QueryCacheEntry> *query_cache, DbAccessor *db_accessor,
+                   TriggerEventType event_type, AstCache *query_cache, DbAccessor *db_accessor,
                    const InterpreterConfig::Query &query_config, std::shared_ptr<QueryUserOrRole> creator,
                    std::string_view db_name,
                    TriggerPrivilegeContext privilege_context = TriggerPrivilegeContext::DEFINER,
@@ -97,15 +95,15 @@ enum class TriggerPhase : uint8_t { BEFORE_COMMIT, AFTER_COMMIT };
 struct TriggerStore {
   explicit TriggerStore(std::filesystem::path directory);
 
-  void RestoreTriggers(utils::SkipList<QueryCacheEntry> *query_cache, DbAccessor *db_accessor,
-                       const InterpreterConfig::Query &query_config, const query::AuthChecker *auth_checker,
-                       std::string_view db_name, parameters::Parameters const *server_parameters);
+  void RestoreTriggers(AstCache *query_cache, DbAccessor *db_accessor, const InterpreterConfig::Query &query_config,
+                       const query::AuthChecker *auth_checker, std::string_view db_name,
+                       parameters::Parameters const *server_parameters);
 
   void AddTrigger(std::string name, const std::string &query, const UserParameters &user_parameters,
-                  TriggerEventType event_type, TriggerPhase phase, utils::SkipList<QueryCacheEntry> *query_cache,
-                  DbAccessor *db_accessor, const InterpreterConfig::Query &query_config,
-                  std::shared_ptr<QueryUserOrRole> creator, std::string_view db_name,
-                  TriggerPrivilegeContext privilege_context, parameters::Parameters const *server_parameters);
+                  TriggerEventType event_type, TriggerPhase phase, AstCache *query_cache, DbAccessor *db_accessor,
+                  const InterpreterConfig::Query &query_config, std::shared_ptr<QueryUserOrRole> creator,
+                  std::string_view db_name, TriggerPrivilegeContext privilege_context,
+                  parameters::Parameters const *server_parameters);
 
   void DropTrigger(const std::string &name);
   void DropAll();
@@ -130,9 +128,9 @@ struct TriggerStore {
   std::unordered_set<TriggerEventType> GetEventTypes() const;
 
  private:
-  void RestoreTrigger(utils::SkipList<QueryCacheEntry> *query_cache, DbAccessor *db_accessor,
-                      const InterpreterConfig::Query &query_config, const query::AuthChecker *auth_checker,
-                      std::string_view trigger_name, std::string_view trigger_data, std::string_view db_name,
+  void RestoreTrigger(AstCache *query_cache, DbAccessor *db_accessor, const InterpreterConfig::Query &query_config,
+                      const query::AuthChecker *auth_checker, std::string_view trigger_name,
+                      std::string_view trigger_data, std::string_view db_name,
                       parameters::Parameters const *server_parameters);
 
   utils::SpinLock store_lock_;

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -289,6 +289,11 @@ startup_config_dict = {
     ),
     "query_cost_planner": ("true", "true", "Use the cost-estimating query planner."),
     "query_plan_cache_max_size": ("1000", "1000", "Maximum number of query plans to cache."),
+    "query_ast_cache_max_size": (
+        "1000",
+        "1000",
+        "Maximum number of parsed query ASTs to cache (0 disables the cache).",
+    ),
     "query_vertex_count_to_expand_existing": (
         "10",
         "10",

--- a/tests/manual/query_hash.cpp
+++ b/tests/manual/query_hash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -36,8 +36,8 @@ int main(int argc, char **argv) {
   std::cout << fmt::format("Stripped query: {}\n", preprocessed.stripped_query().str());
   std::cout << fmt::format("Query hash: {}\n", preprocessed.stripped_query().hash());
   std::cout << fmt::format("Property values:\n");
-  for (int i = 0; i < preprocessed.literals().size(); ++i) {
-    std::cout << " " << preprocessed.literals().At(1).second;
+  for (const auto &[position, value] : preprocessed.literals()) {
+    std::cout << " " << value;
   }
   std::cout << std::endl;
 

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1016,7 +1016,8 @@ TEST_P(CypherMainVisitorTest, NotOperator) {
 
 TEST_P(CypherMainVisitorTest, UnaryMinusPlusOperators) {
   auto &ast_generator = *GetParam();
-  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN -+5"));
+  // spaced signs: adjacent ones would fold into the literal during stripping
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN - + 5"));
   ASSERT_TRUE(query);
   ASSERT_TRUE(query->single_query_);
   auto *single_query = query->single_query_;
@@ -8211,7 +8212,12 @@ TEST_P(CypherMainVisitorTest, TopLevelPeriodicCommitQuery) {
   }
 
   {
-    ASSERT_THROW(ast_generator.ParseQuery("USING PERIODIC COMMIT -1 CREATE (n);"), SyntaxException);
+    // sign folding defers the sign check to runtime on the cached (stripped) path
+    if (ast_generator.context_.is_query_cached) {
+      EXPECT_NO_THROW(ast_generator.ParseQuery("USING PERIODIC COMMIT -1 CREATE (n);"));
+    } else {
+      ASSERT_THROW(ast_generator.ParseQuery("USING PERIODIC COMMIT -1 CREATE (n);"), SyntaxException);
+    }
   }
 
   {
@@ -8252,6 +8258,8 @@ TEST_P(CypherMainVisitorTest, NestedPeriodicCommitQuery) {
   }
 
   {
+    // `of` is not a stripper keyword, so the sign never folds here and the
+    // rejection stays at parse time on every path
     ASSERT_THROW(ast_generator.ParseQuery("UNWIND range(1, 100) as x CALL { CREATE () } IN TRANSACTIONS OF -1 ROWS;"),
                  SyntaxException);
   }
@@ -8349,7 +8357,12 @@ TEST_P(CypherMainVisitorTest, ParallelExecutionValidation) {
   }
 
   {
-    ASSERT_THROW(ast_generator.ParseQuery("USING PARALLEL EXECUTION -1 CREATE (n);"), SyntaxException);
+    // sign folding defers the sign check to runtime on the cached (stripped) path
+    if (ast_generator.context_.is_query_cached) {
+      EXPECT_NO_THROW(ast_generator.ParseQuery("USING PARALLEL EXECUTION -1 CREATE (n);"));
+    } else {
+      ASSERT_THROW(ast_generator.ParseQuery("USING PARALLEL EXECUTION -1 CREATE (n);"), SyntaxException);
+    }
   }
 
   {

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1016,8 +1016,7 @@ TEST_P(CypherMainVisitorTest, NotOperator) {
 
 TEST_P(CypherMainVisitorTest, UnaryMinusPlusOperators) {
   auto &ast_generator = *GetParam();
-  // spaced signs: adjacent ones would fold into the literal during stripping
-  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN - + 5"));
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN -+5"));
   ASSERT_TRUE(query);
   ASSERT_TRUE(query->single_query_);
   auto *single_query = query->single_query_;
@@ -8212,12 +8211,7 @@ TEST_P(CypherMainVisitorTest, TopLevelPeriodicCommitQuery) {
   }
 
   {
-    // sign folding defers the sign check to runtime on the cached (stripped) path
-    if (ast_generator.context_.is_query_cached) {
-      EXPECT_NO_THROW(ast_generator.ParseQuery("USING PERIODIC COMMIT -1 CREATE (n);"));
-    } else {
-      ASSERT_THROW(ast_generator.ParseQuery("USING PERIODIC COMMIT -1 CREATE (n);"), SyntaxException);
-    }
+    ASSERT_THROW(ast_generator.ParseQuery("USING PERIODIC COMMIT -1 CREATE (n);"), SyntaxException);
   }
 
   {
@@ -8258,8 +8252,6 @@ TEST_P(CypherMainVisitorTest, NestedPeriodicCommitQuery) {
   }
 
   {
-    // `of` is not a stripper keyword, so the sign never folds here and the
-    // rejection stays at parse time on every path
     ASSERT_THROW(ast_generator.ParseQuery("UNWIND range(1, 100) as x CALL { CREATE () } IN TRANSACTIONS OF -1 ROWS;"),
                  SyntaxException);
   }
@@ -8357,12 +8349,7 @@ TEST_P(CypherMainVisitorTest, ParallelExecutionValidation) {
   }
 
   {
-    // sign folding defers the sign check to runtime on the cached (stripped) path
-    if (ast_generator.context_.is_query_cached) {
-      EXPECT_NO_THROW(ast_generator.ParseQuery("USING PARALLEL EXECUTION -1 CREATE (n);"));
-    } else {
-      ASSERT_THROW(ast_generator.ParseQuery("USING PARALLEL EXECUTION -1 CREATE (n);"), SyntaxException);
-    }
+    ASSERT_THROW(ast_generator.ParseQuery("USING PARALLEL EXECUTION -1 CREATE (n);"), SyntaxException);
   }
 
   {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1882,6 +1882,27 @@ TYPED_TEST(InterpreterTest, AnalyzeGraphDeduplicatesAscDescIndexes) {
   EXPECT_EQ(deleted_labels, (std::set<std::string>{"LabelA", "LabelB"}));
 }
 
+TYPED_TEST(InterpreterTest, MixedSignListSharesCacheEntryAndKeepsValues) {
+  auto values = [](const auto &stream) {
+    std::vector<int64_t> out;
+    for (const auto &v : stream.GetResults()[0][0].ValueList()) out.push_back(v.ValueInt());
+    return out;
+  };
+  EXPECT_EQ(this->AstCacheSize(), 0U);
+  auto s1 = this->Interpret("RETURN [-1, 2, -3] AS x");
+  auto s2 = this->Interpret("RETURN [4, -5, 6] AS x");
+  EXPECT_EQ(values(s1), (std::vector<int64_t>{-1, 2, -3}));
+  EXPECT_EQ(values(s2), (std::vector<int64_t>{4, -5, 6}));
+  EXPECT_EQ(this->AstCacheSize(), 1U);
+}
+
+TYPED_TEST(InterpreterTest, ListWithSubtractionKeepsBinaryMinus) {
+  auto stream = this->Interpret("RETURN [1-2, 3] AS x");
+  const auto &list = stream.GetResults()[0][0].ValueList();
+  EXPECT_EQ(list[0].ValueInt(), -1);
+  EXPECT_EQ(list[1].ValueInt(), 3);
+}
+
 TEST(AstCacheBounded, EvictsBeyondMaxSize) {
   constexpr std::size_t kMaxSize = 2;
   memgraph::query::AstCache cache{kMaxSize};

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -10,10 +10,12 @@
 // licenses/APL.txt.
 
 #include <algorithm>
+#include <atomic>
 #include <cstdlib>
 #include <filesystem>
 #include <map>
 #include <set>
+#include <thread>
 
 #include "communication/bolt/v1/value.hpp"
 #include "communication/result_stream_faker.hpp"
@@ -1876,6 +1878,28 @@ TYPED_TEST(InterpreterTest, AnalyzeGraphDeduplicatesAscDescIndexes) {
   EXPECT_EQ(deleted_labels, (std::set<std::string>{"LabelA", "LabelB"}));
 }
 
+// Sign folding collapses same-length lists that differ only in sign/value onto
+// one cache entry, and each query still returns its own values (the shared AST
+// holds ParameterLookups; the values come from the per-call parameters).
+TYPED_TEST(InterpreterTest, MixedSignListSharesCacheEntryAndKeepsValues) {
+  auto ast_size = [this] {
+    return this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); });
+  };
+  auto values = [](const auto &stream) {
+    std::vector<int64_t> out;
+    for (const auto &v : stream.GetResults()[0][0].ValueList()) out.push_back(v.ValueInt());
+    return out;
+  };
+
+  EXPECT_EQ(ast_size(), 0U);
+  auto s1 = this->Interpret("RETURN [-1, 2, -3] AS x");
+  auto s2 = this->Interpret("RETURN [4, -5, 6] AS x");
+  EXPECT_EQ(values(s1), (std::vector<int64_t>{-1, 2, -3}));
+  EXPECT_EQ(values(s2), (std::vector<int64_t>{4, -5, 6}));
+  // Both queries share a single AST cache entry despite different sign patterns.
+  EXPECT_EQ(ast_size(), 1U);
+}
+
 // The AST cache is LRU-bounded. Queries whose stripped form varies each take a
 // distinct entry (here via distinct aliases; the same happens for the verbatim
 // unary-minus tokens of mixed-sign numeric lists), so an unbounded cache would
@@ -1893,4 +1917,35 @@ TEST(AstCacheBounded, EvictsBeyondMaxSize) {
   }
   // Caching is still active (the bound did not disable it).
   EXPECT_EQ(cache_size(), kMaxSize);
+}
+
+// Correctness under eviction and contention: with a size-1 cache every distinct
+// query evicts the previous entry, so concurrent parsers continuously insert and
+// evict. Each ParseQuery must still return a well-formed AST whose stripped
+// literal round-trips to that call's own value, proving entries are not shared
+// or freed out from under an in-flight clone.
+TEST(AstCacheConcurrency, CorrectUnderEvictionContention) {
+  memgraph::query::AstCache cache{1};
+  memgraph::query::InterpreterConfig::Query const query_config{};
+  constexpr int kThreads = 8;
+  constexpr int kIters = 3000;
+  std::atomic<int> failures{0};
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t] {
+      for (int i = 0; i < kIters; ++i) {
+        int const value = t * kIters + i;  // disjoint per thread -> all distinct -> constant eviction
+        auto parsed =
+            memgraph::query::ParseQuery("RETURN " + std::to_string(value), {}, &cache, query_config, "uuid", nullptr);
+        // "RETURN <value>" strips to "RETURN 0" with the literal at token position 1.
+        if (parsed.query == nullptr || parsed.parameters.AtTokenPosition(1).ValueInt() != value) {
+          failures.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+  for (auto &th : threads) th.join();
+  EXPECT_EQ(failures.load(), 0);
+  EXPECT_LE(cache.WithLock([](auto &c) { return c.size(); }), 1U);
 }

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -140,6 +140,10 @@ class InterpreterTest : public ::testing::Test {
   auto Interpret(const std::string &query, const memgraph::storage::ExternalPropertyValue::map_t &params = {}) {
     return default_interpreter.Interpret(query, params);
   }
+
+  auto AstCacheSize() {
+    return interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); });
+  }
 };
 
 using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage>;
@@ -846,7 +850,7 @@ TYPED_TEST(InterpreterTest, UniqueConstraintTest) {
 
 TYPED_TEST(InterpreterTest, ExplainQuery) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   auto stream = this->Interpret("EXPLAIN MATCH (n) RETURN *;");
   ASSERT_EQ(stream.GetHeader().size(), 1U);
   EXPECT_EQ(stream.GetHeader().front(), "QUERY PLAN");
@@ -861,15 +865,15 @@ TYPED_TEST(InterpreterTest, ExplainQuery) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ExplainQueryMultiplePulls) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   auto [stream, qid] = this->Prepare("EXPLAIN MATCH (n) RETURN *;");
   ASSERT_EQ(stream.GetHeader().size(), 1U);
   EXPECT_EQ(stream.GetHeader().front(), "QUERY PLAN");
@@ -894,15 +898,15 @@ TYPED_TEST(InterpreterTest, ExplainQueryMultiplePulls) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ExplainQueryInMulticommandTransaction) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   this->Interpret("BEGIN");
   auto stream = this->Interpret("EXPLAIN MATCH (n) RETURN *;");
   this->Interpret("COMMIT");
@@ -919,15 +923,15 @@ TYPED_TEST(InterpreterTest, ExplainQueryInMulticommandTransaction) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ExplainQueryWithParams) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   auto stream = this->Interpret("EXPLAIN MATCH (n) WHERE n.id = $id RETURN *;",
                                 {{"id", memgraph::storage::ExternalPropertyValue(42)}});
   ASSERT_EQ(stream.GetHeader().size(), 1U);
@@ -943,16 +947,16 @@ TYPED_TEST(InterpreterTest, ExplainQueryWithParams) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("MATCH (n) WHERE n.id = $id RETURN *;",
                   {{"id", memgraph::storage::ExternalPropertyValue("something else")}});
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQuery) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   auto stream = this->Interpret("PROFILE MATCH (n) RETURN *;");
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
   EXPECT_EQ(stream.GetHeader(), expected_header);
@@ -967,15 +971,15 @@ TYPED_TEST(InterpreterTest, ProfileQuery) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQueryMultiplePulls) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   auto [stream, qid] = this->Prepare("PROFILE MATCH (n) RETURN *;");
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
   EXPECT_EQ(stream.GetHeader(), expected_header);
@@ -1003,10 +1007,10 @@ TYPED_TEST(InterpreterTest, ProfileQueryMultiplePulls) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQueryInMulticommandTransaction) {
@@ -1017,7 +1021,7 @@ TYPED_TEST(InterpreterTest, ProfileQueryInMulticommandTransaction) {
 
 TYPED_TEST(InterpreterTest, ProfileQueryWithParams) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   auto stream = this->Interpret("PROFILE MATCH (n) WHERE n.id = $id RETURN *;",
                                 {{"id", memgraph::storage::ExternalPropertyValue(42)}});
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
@@ -1033,16 +1037,16 @@ TYPED_TEST(InterpreterTest, ProfileQueryWithParams) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("MATCH (n) WHERE n.id = $id RETURN *;",
                   {{"id", memgraph::storage::ExternalPropertyValue("something else")}});
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQueryWithLiterals) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
+  EXPECT_EQ(this->AstCacheSize(), 0U);
   auto stream = this->Interpret("PROFILE UNWIND range(1, 1000) AS x CREATE (:Node {id: x});", {});
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
   EXPECT_EQ(stream.GetHeader(), expected_header);
@@ -1057,10 +1061,10 @@ TYPED_TEST(InterpreterTest, ProfileQueryWithLiterals) {
   // We should have a plan cache for UNWIND ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner UNWIND ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
   this->Interpret("UNWIND range(42, 4242) AS x CREATE (:Node {id: x});", {});
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
+  EXPECT_EQ(this->AstCacheSize(), 2U);
 }
 
 TYPED_TEST(InterpreterTest, Transactions) {
@@ -1285,7 +1289,7 @@ TYPED_TEST(InterpreterTest, CacheableQueries) {
   {
     SCOPED_TRACE("Cacheable query");
     this->Interpret("RETURN 1");
-    EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 1U);
+    EXPECT_EQ(this->AstCacheSize(), 1U);
     EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   }
 
@@ -1294,7 +1298,7 @@ TYPED_TEST(InterpreterTest, CacheableQueries) {
     // Queries which are calling procedure should not be cached because the
     // result signature could be changed
     this->Interpret("CALL mg.load_all()");
-    EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 1U);
+    EXPECT_EQ(this->AstCacheSize(), 1U);
     EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   }
 }

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -844,7 +844,7 @@ TYPED_TEST(InterpreterTest, UniqueConstraintTest) {
 
 TYPED_TEST(InterpreterTest, ExplainQuery) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   auto stream = this->Interpret("EXPLAIN MATCH (n) RETURN *;");
   ASSERT_EQ(stream.GetHeader().size(), 1U);
   EXPECT_EQ(stream.GetHeader().front(), "QUERY PLAN");
@@ -859,15 +859,15 @@ TYPED_TEST(InterpreterTest, ExplainQuery) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ExplainQueryMultiplePulls) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   auto [stream, qid] = this->Prepare("EXPLAIN MATCH (n) RETURN *;");
   ASSERT_EQ(stream.GetHeader().size(), 1U);
   EXPECT_EQ(stream.GetHeader().front(), "QUERY PLAN");
@@ -892,15 +892,15 @@ TYPED_TEST(InterpreterTest, ExplainQueryMultiplePulls) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ExplainQueryInMulticommandTransaction) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   this->Interpret("BEGIN");
   auto stream = this->Interpret("EXPLAIN MATCH (n) RETURN *;");
   this->Interpret("COMMIT");
@@ -917,15 +917,15 @@ TYPED_TEST(InterpreterTest, ExplainQueryInMulticommandTransaction) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ExplainQueryWithParams) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   auto stream = this->Interpret("EXPLAIN MATCH (n) WHERE n.id = $id RETURN *;",
                                 {{"id", memgraph::storage::ExternalPropertyValue(42)}});
   ASSERT_EQ(stream.GetHeader().size(), 1U);
@@ -941,16 +941,16 @@ TYPED_TEST(InterpreterTest, ExplainQueryWithParams) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for EXPLAIN ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("MATCH (n) WHERE n.id = $id RETURN *;",
                   {{"id", memgraph::storage::ExternalPropertyValue("something else")}});
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQuery) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   auto stream = this->Interpret("PROFILE MATCH (n) RETURN *;");
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
   EXPECT_EQ(stream.GetHeader(), expected_header);
@@ -965,15 +965,15 @@ TYPED_TEST(InterpreterTest, ProfileQuery) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQueryMultiplePulls) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   auto [stream, qid] = this->Prepare("PROFILE MATCH (n) RETURN *;");
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
   EXPECT_EQ(stream.GetHeader(), expected_header);
@@ -1001,10 +1001,10 @@ TYPED_TEST(InterpreterTest, ProfileQueryMultiplePulls) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("MATCH (n) RETURN *;");
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQueryInMulticommandTransaction) {
@@ -1015,7 +1015,7 @@ TYPED_TEST(InterpreterTest, ProfileQueryInMulticommandTransaction) {
 
 TYPED_TEST(InterpreterTest, ProfileQueryWithParams) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   auto stream = this->Interpret("PROFILE MATCH (n) WHERE n.id = $id RETURN *;",
                                 {{"id", memgraph::storage::ExternalPropertyValue(42)}});
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
@@ -1031,16 +1031,16 @@ TYPED_TEST(InterpreterTest, ProfileQueryWithParams) {
   // We should have a plan cache for MATCH ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner MATCH ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("MATCH (n) WHERE n.id = $id RETURN *;",
                   {{"id", memgraph::storage::ExternalPropertyValue("something else")}});
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, ProfileQueryWithLiterals) {
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 0U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 0U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 0U);
   auto stream = this->Interpret("PROFILE UNWIND range(1, 1000) AS x CREATE (:Node {id: x});", {});
   std::vector<std::string> expected_header{"OPERATOR", "ACTUAL HITS", "RELATIVE TIME", "ABSOLUTE TIME"};
   EXPECT_EQ(stream.GetHeader(), expected_header);
@@ -1055,10 +1055,10 @@ TYPED_TEST(InterpreterTest, ProfileQueryWithLiterals) {
   // We should have a plan cache for UNWIND ...
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   // We should have AST cache for PROFILE ... and for inner UNWIND ...
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
   this->Interpret("UNWIND range(42, 4242) AS x CREATE (:Node {id: x});", {});
   EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
-  EXPECT_EQ(this->interpreter_context.ast_cache.size(), 2U);
+  EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 2U);
 }
 
 TYPED_TEST(InterpreterTest, Transactions) {
@@ -1283,7 +1283,7 @@ TYPED_TEST(InterpreterTest, CacheableQueries) {
   {
     SCOPED_TRACE("Cacheable query");
     this->Interpret("RETURN 1");
-    EXPECT_EQ(this->interpreter_context.ast_cache.size(), 1U);
+    EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 1U);
     EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   }
 
@@ -1292,7 +1292,7 @@ TYPED_TEST(InterpreterTest, CacheableQueries) {
     // Queries which are calling procedure should not be cached because the
     // result signature could be changed
     this->Interpret("CALL mg.load_all()");
-    EXPECT_EQ(this->interpreter_context.ast_cache.size(), 1U);
+    EXPECT_EQ(this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); }), 1U);
     EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
   }
 }
@@ -1874,4 +1874,23 @@ TYPED_TEST(InterpreterTest, AnalyzeGraphDeduplicatesAscDescIndexes) {
     deleted_labels.insert(row[kLabelCol].ValueString());
   }
   EXPECT_EQ(deleted_labels, (std::set<std::string>{"LabelA", "LabelB"}));
+}
+
+// The AST cache is LRU-bounded. Queries whose stripped form varies each take a
+// distinct entry (here via distinct aliases; the same happens for the verbatim
+// unary-minus tokens of mixed-sign numeric lists), so an unbounded cache would
+// grow one entry per distinct query without limit.
+TEST(AstCacheBounded, EvictsBeyondMaxSize) {
+  constexpr std::size_t kMaxSize = 2;
+  memgraph::query::AstCache cache{kMaxSize};
+  memgraph::query::InterpreterConfig::Query const query_config{};
+  auto const cache_size = [&] { return cache.WithLock([](auto &c) { return c.size(); }); };
+
+  for (int i = 0; i < 10; ++i) {
+    auto const query = "RETURN 1 AS a" + std::to_string(i);
+    memgraph::query::ParseQuery(query, {}, &cache, query_config, "uuid", nullptr);
+    EXPECT_LE(cache_size(), kMaxSize) << "cache grew past its bound at iteration " << i;
+  }
+  // Caching is still active (the bound did not disable it).
+  EXPECT_EQ(cache_size(), kMaxSize);
 }

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1878,29 +1878,6 @@ TYPED_TEST(InterpreterTest, AnalyzeGraphDeduplicatesAscDescIndexes) {
   EXPECT_EQ(deleted_labels, (std::set<std::string>{"LabelA", "LabelB"}));
 }
 
-TYPED_TEST(InterpreterTest, MixedSignListSharesCacheEntryAndKeepsValues) {
-  auto ast_size = [this] {
-    return this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); });
-  };
-  auto values = [](const auto &stream) {
-    std::vector<int64_t> out;
-    for (const auto &v : stream.GetResults()[0][0].ValueList()) out.push_back(v.ValueInt());
-    return out;
-  };
-
-  EXPECT_EQ(ast_size(), 0U);
-  auto s1 = this->Interpret("RETURN [-1, 2, -3] AS x");
-  auto s2 = this->Interpret("RETURN [4, -5, 6] AS x");
-  EXPECT_EQ(values(s1), (std::vector<int64_t>{-1, 2, -3}));
-  EXPECT_EQ(values(s2), (std::vector<int64_t>{4, -5, 6}));
-  EXPECT_EQ(ast_size(), 1U);
-}
-
-TYPED_TEST(InterpreterTest, KeywordNamedVariableSubtraction) {
-  auto stream = this->Interpret("WITH 5 AS filter RETURN filter-1 AS x");
-  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 4);
-}
-
 TEST(AstCacheBounded, EvictsBeyondMaxSize) {
   constexpr std::size_t kMaxSize = 2;
   memgraph::query::AstCache cache{kMaxSize};
@@ -1912,12 +1889,9 @@ TEST(AstCacheBounded, EvictsBeyondMaxSize) {
     memgraph::query::ParseQuery(query, {}, &cache, query_config, "uuid", nullptr);
     EXPECT_LE(cache_size(), kMaxSize) << "cache grew past its bound at iteration " << i;
   }
-  // the bound caps the cache, it does not disable it
   EXPECT_EQ(cache_size(), kMaxSize);
 }
 
-// size-1 cache: concurrent distinct queries evict constantly, so an entry must
-// never be freed out from under an in-flight clone
 TEST(AstCacheConcurrency, CorrectUnderEvictionContention) {
   memgraph::query::AstCache cache{1};
   memgraph::query::InterpreterConfig::Query const query_config{};
@@ -1925,21 +1899,22 @@ TEST(AstCacheConcurrency, CorrectUnderEvictionContention) {
   constexpr int kIters = 3000;
   std::atomic<int> failures{0};
 
-  std::vector<std::thread> threads;
-  for (int t = 0; t < kThreads; ++t) {
-    threads.emplace_back([&, t] {
-      for (int i = 0; i < kIters; ++i) {
-        int const value = t * kIters + i;  // disjoint per thread -> all distinct -> constant eviction
-        auto parsed =
-            memgraph::query::ParseQuery("RETURN " + std::to_string(value), {}, &cache, query_config, "uuid", nullptr);
-        // "RETURN <value>" strips to "RETURN 0" with the literal at token position 1.
-        if (parsed.query == nullptr || parsed.parameters.AtTokenPosition(1).ValueInt() != value) {
-          failures.fetch_add(1, std::memory_order_relaxed);
+  {
+    std::vector<std::jthread> threads;
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([&, t] {
+        for (int i = 0; i < kIters; ++i) {
+          int const value = t * kIters + i;  // disjoint per thread -> all distinct -> constant eviction
+          auto parsed =
+              memgraph::query::ParseQuery("RETURN " + std::to_string(value), {}, &cache, query_config, "uuid", nullptr);
+          // "RETURN <value>" strips to "RETURN 0" with the literal at token position 1.
+          if (parsed.query == nullptr || parsed.parameters.AtTokenPosition(1).ValueInt() != value) {
+            failures.fetch_add(1, std::memory_order_relaxed);
+          }
         }
-      }
-    });
+      });
+    }
   }
-  for (auto &th : threads) th.join();
   EXPECT_EQ(failures.load(), 0);
   EXPECT_LE(cache.WithLock([](auto &c) { return c.size(); }), 1U);
 }

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1878,9 +1878,6 @@ TYPED_TEST(InterpreterTest, AnalyzeGraphDeduplicatesAscDescIndexes) {
   EXPECT_EQ(deleted_labels, (std::set<std::string>{"LabelA", "LabelB"}));
 }
 
-// Sign folding collapses same-length lists that differ only in sign/value onto
-// one cache entry, and each query still returns its own values (the shared AST
-// holds ParameterLookups; the values come from the per-call parameters).
 TYPED_TEST(InterpreterTest, MixedSignListSharesCacheEntryAndKeepsValues) {
   auto ast_size = [this] {
     return this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); });
@@ -1896,14 +1893,48 @@ TYPED_TEST(InterpreterTest, MixedSignListSharesCacheEntryAndKeepsValues) {
   auto s2 = this->Interpret("RETURN [4, -5, 6] AS x");
   EXPECT_EQ(values(s1), (std::vector<int64_t>{-1, 2, -3}));
   EXPECT_EQ(values(s2), (std::vector<int64_t>{4, -5, 6}));
-  // Both queries share a single AST cache entry despite different sign patterns.
   EXPECT_EQ(ast_size(), 1U);
 }
 
-// The AST cache is LRU-bounded. Queries whose stripped form varies each take a
-// distinct entry (here via distinct aliases; the same happens for the verbatim
-// unary-minus tokens of mixed-sign numeric lists), so an unbounded cache would
-// grow one entry per distinct query without limit.
+TYPED_TEST(InterpreterTest, ScalarSignSharesCacheEntryAndKeepsValues) {
+  auto ast_size = [this] {
+    return this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); });
+  };
+  EXPECT_EQ(ast_size(), 0U);
+  auto s1 = this->Interpret("RETURN -1 AS x");
+  auto s2 = this->Interpret("RETURN 1 AS x");
+  EXPECT_EQ(s1.GetResults()[0][0].ValueInt(), -1);
+  EXPECT_EQ(s2.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(ast_size(), 1U);
+}
+
+// `filter` lexes as a keyword, so the adjacent -1 misfolds and ParseQuery
+// must re-strip without folding
+TYPED_TEST(InterpreterTest, KeywordNamedVariableSubtraction) {
+  auto stream = this->Interpret("WITH 5 AS filter RETURN filter-1 AS x");
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 4);
+}
+
+// the folded literal passes the integer-literal shape check; the value is
+// rejected at runtime by EvaluateUint
+TYPED_TEST(InterpreterTest, PeriodicCommitNegativeFrequencyRejectedAtRuntime) {
+  EXPECT_THROW(this->Interpret("USING PERIODIC COMMIT -1 UNWIND range(1, 3) AS x CREATE ();"),
+               memgraph::query::QueryRuntimeException);
+}
+
+TEST(AstCacheSignFold, MisfoldRestripsWithoutFolding) {
+  memgraph::query::AstCache cache{10};
+  memgraph::query::InterpreterConfig::Query const query_config{};
+  auto parsed =
+      memgraph::query::ParseQuery("WITH 5 AS filter RETURN filter-1", {}, &cache, query_config, "uuid", nullptr);
+  ASSERT_NE(parsed.query, nullptr);
+  EXPECT_EQ(parsed.stripped_query.stripped_query().str(), "WITH 0 AS filter RETURN filter - 0");
+  EXPECT_EQ(cache.WithLock([](auto &c) { return c.size(); }), 1U);
+  // a repeat is served from the unfolded entry, not cached under the folded key
+  memgraph::query::ParseQuery("WITH 5 AS filter RETURN filter-1", {}, &cache, query_config, "uuid", nullptr);
+  EXPECT_EQ(cache.WithLock([](auto &c) { return c.size(); }), 1U);
+}
+
 TEST(AstCacheBounded, EvictsBeyondMaxSize) {
   constexpr std::size_t kMaxSize = 2;
   memgraph::query::AstCache cache{kMaxSize};
@@ -1915,15 +1946,12 @@ TEST(AstCacheBounded, EvictsBeyondMaxSize) {
     memgraph::query::ParseQuery(query, {}, &cache, query_config, "uuid", nullptr);
     EXPECT_LE(cache_size(), kMaxSize) << "cache grew past its bound at iteration " << i;
   }
-  // Caching is still active (the bound did not disable it).
+  // the bound caps the cache, it does not disable it
   EXPECT_EQ(cache_size(), kMaxSize);
 }
 
-// Correctness under eviction and contention: with a size-1 cache every distinct
-// query evicts the previous entry, so concurrent parsers continuously insert and
-// evict. Each ParseQuery must still return a well-formed AST whose stripped
-// literal round-trips to that call's own value, proving entries are not shared
-// or freed out from under an in-flight clone.
+// size-1 cache: concurrent distinct queries evict constantly, so an entry must
+// never be freed out from under an in-flight clone
 TEST(AstCacheConcurrency, CorrectUnderEvictionContention) {
   memgraph::query::AstCache cache{1};
   memgraph::query::InterpreterConfig::Query const query_config{};

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1896,43 +1896,9 @@ TYPED_TEST(InterpreterTest, MixedSignListSharesCacheEntryAndKeepsValues) {
   EXPECT_EQ(ast_size(), 1U);
 }
 
-TYPED_TEST(InterpreterTest, ScalarSignSharesCacheEntryAndKeepsValues) {
-  auto ast_size = [this] {
-    return this->interpreter_context.ast_cache.WithLock([](auto &cache) { return cache.size(); });
-  };
-  EXPECT_EQ(ast_size(), 0U);
-  auto s1 = this->Interpret("RETURN -1 AS x");
-  auto s2 = this->Interpret("RETURN 1 AS x");
-  EXPECT_EQ(s1.GetResults()[0][0].ValueInt(), -1);
-  EXPECT_EQ(s2.GetResults()[0][0].ValueInt(), 1);
-  EXPECT_EQ(ast_size(), 1U);
-}
-
-// `filter` lexes as a keyword, so the adjacent -1 misfolds and ParseQuery
-// must re-strip without folding
 TYPED_TEST(InterpreterTest, KeywordNamedVariableSubtraction) {
   auto stream = this->Interpret("WITH 5 AS filter RETURN filter-1 AS x");
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 4);
-}
-
-// the folded literal passes the integer-literal shape check; the value is
-// rejected at runtime by EvaluateUint
-TYPED_TEST(InterpreterTest, PeriodicCommitNegativeFrequencyRejectedAtRuntime) {
-  EXPECT_THROW(this->Interpret("USING PERIODIC COMMIT -1 UNWIND range(1, 3) AS x CREATE ();"),
-               memgraph::query::QueryRuntimeException);
-}
-
-TEST(AstCacheSignFold, MisfoldRestripsWithoutFolding) {
-  memgraph::query::AstCache cache{10};
-  memgraph::query::InterpreterConfig::Query const query_config{};
-  auto parsed =
-      memgraph::query::ParseQuery("WITH 5 AS filter RETURN filter-1", {}, &cache, query_config, "uuid", nullptr);
-  ASSERT_NE(parsed.query, nullptr);
-  EXPECT_EQ(parsed.stripped_query.stripped_query().str(), "WITH 0 AS filter RETURN filter - 0");
-  EXPECT_EQ(cache.WithLock([](auto &c) { return c.size(); }), 1U);
-  // a repeat is served from the unfolded entry, not cached under the folded key
-  memgraph::query::ParseQuery("WITH 5 AS filter RETURN filter-1", {}, &cache, query_config, "uuid", nullptr);
-  EXPECT_EQ(cache.WithLock([](auto &c) { return c.size(); }), 1U);
 }
 
 TEST(AstCacheBounded, EvictsBeyondMaxSize) {

--- a/tests/unit/query_dump.cpp
+++ b/tests/unit/query_dump.cpp
@@ -1825,7 +1825,7 @@ TYPED_TEST(DumpTest, MultiplePartialPulls) {
 TYPED_TEST(DumpTest, DumpDatabaseWithTriggers) {
   auto acc = this->db->storage()->Access(memgraph::storage::WRITE);
   memgraph::query::DbAccessor dba(acc.get());
-  memgraph::utils::SkipList<memgraph::query::QueryCacheEntry> ast_cache;
+  memgraph::query::AstCache ast_cache{1000};
   memgraph::query::AllowEverythingAuthChecker auth_checker;
   memgraph::query::InterpreterConfig::Query query_config;
   memgraph::storage::ExternalPropertyValue::map_t props;

--- a/tests/unit/query_trigger.cpp
+++ b/tests/unit/query_trigger.cpp
@@ -1029,7 +1029,7 @@ class TriggerStoreTest : public ::testing::Test {
 
   std::optional<memgraph::query::DbAccessor> dba;
 
-  memgraph::utils::SkipList<memgraph::query::QueryCacheEntry> ast_cache;
+  memgraph::query::AstCache ast_cache{1000};
   memgraph::query::AllowEverythingAuthChecker auth_checker;
 
  private:

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -532,6 +532,7 @@ TEST(QueryStripper, SignFoldInList) {
   {
     StrippedQuery stripped("RETURN [-1e-3]");
     EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), -1e-3);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedDoubleToken + " ]");
   }
   {
     StrippedQuery stripped("RETURN [+42]");

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -593,4 +593,37 @@ TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
   }
 }
 
+TEST(Parameters, LookupByTokenPosition) {
+  Parameters params;
+  params.Add(3, memgraph::storage::ExternalPropertyValue(int64_t{30}));
+  params.Add(7, memgraph::storage::ExternalPropertyValue(int64_t{70}));
+  params.Add(5, memgraph::storage::ExternalPropertyValue(int64_t{50}));
+
+  EXPECT_EQ(params.size(), 3);
+  // Lookup is by token position, independent of insertion order.
+  EXPECT_EQ(params.AtTokenPosition(3).ValueInt(), 30);
+  EXPECT_EQ(params.AtTokenPosition(5).ValueInt(), 50);
+  EXPECT_EQ(params.AtTokenPosition(7).ValueInt(), 70);
+  // At() still addresses storage in insertion order.
+  EXPECT_EQ(params.At(0).first, 3);
+  EXPECT_EQ(params.At(1).first, 7);
+  EXPECT_EQ(params.At(2).first, 5);
+}
+
+TEST(Parameters, DuplicateTokenPositionKeepsFirst) {
+  Parameters params;
+  params.Add(1, memgraph::storage::ExternalPropertyValue(int64_t{100}));
+  params.Add(1, memgraph::storage::ExternalPropertyValue(int64_t{200}));
+  EXPECT_EQ(params.AtTokenPosition(1).ValueInt(), 100);
+}
+
+TEST(Parameters, CopyPreservesLookup) {
+  Parameters params;
+  params.Add(2, memgraph::storage::ExternalPropertyValue(int64_t{20}));
+  params.Add(9, memgraph::storage::ExternalPropertyValue(int64_t{90}));
+  Parameters copy = params;  // PrepareQueryParameters copies the stripped literals
+  EXPECT_EQ(copy.AtTokenPosition(2).ValueInt(), 20);
+  EXPECT_EQ(copy.AtTokenPosition(9).ValueInt(), 90);
+}
+
 }  // namespace

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -15,7 +15,6 @@
 //
 
 #include <cstdint>
-#include <limits>
 #include <unordered_map>
 
 #include "gmock/gmock.h"
@@ -514,177 +513,6 @@ TEST(QueryStripper, KeywordsCanBeUsedInStrippedQueries) {
   }
 }
 
-TEST(QueryStripper, NegativeIntegerInList) {
-  StrippedQuery stripped("RETURN [-42]");
-  EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -42);
-  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
-}
-
-TEST(QueryStripper, NegativeRealInList) {
-  StrippedQuery stripped("RETURN [-0.5]");
-  EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), -0.5);
-  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedDoubleToken + " ]");
-}
-
-TEST(QueryStripper, UnaryPlusInList) {
-  StrippedQuery stripped("RETURN [+42]");
-  EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
-  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
-}
-
-TEST(QueryStripper, NegativeExponentRealInList) {
-  StrippedQuery stripped("RETURN [-1e-3]");
-  EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), -1e-3);
-  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedDoubleToken + " ]");
-}
-
-TEST(QueryStripper, MixedSignListFoldsToPositiveShape) {
-  StrippedQuery stripped("RETURN [-1, 2, -3]");
-  EXPECT_EQ(stripped.literals().size(), 3);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
-  EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 2);
-  EXPECT_EQ(stripped.literals().At(2).second.ValueInt(), -3);
-  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ 0 , 0 , 0 ]");
-}
-
-TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
-  auto a = StrippedQuery("RETURN [-1, 2, -3]");
-  auto b = StrippedQuery("RETURN [4, -5, 6]");
-  auto c = StrippedQuery("RETURN [1, 2, 3]");
-  EXPECT_EQ(a.stripped_query().str(), b.stripped_query().str());
-  EXPECT_EQ(a.stripped_query().str(), c.stripped_query().str());
-  EXPECT_EQ(a.stripped_query().hash(), b.stripped_query().hash());
-  EXPECT_EQ(a.stripped_query().hash(), c.stripped_query().hash());
-  EXPECT_EQ(StrippedQuery("RETURN [-1]").stripped_query().str(), StrippedQuery("RETURN [- 1]").stripped_query().str());
-}
-
-TEST(QueryStripper, SignFoldOnlyAfterOpeners) {
-  {
-    StrippedQuery stripped("RETURN -42");
-    EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
-  }
-  {
-    StrippedQuery stripped("RETURN {k: -1}");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN { k : - " + kStrippedIntToken + " }");
-  }
-  {
-    StrippedQuery stripped("RETURN (-1)");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN ( " + kStrippedIntToken + " )");
-  }
-  {
-    StrippedQuery stripped("RETURN abs(-1.5)");
-    EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), -1.5);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN abs ( " + kStrippedDoubleToken + " )");
-  }
-}
-
-TEST(QueryStripper, SignFoldAcrossWhitespace) {
-  {
-    StrippedQuery stripped("RETURN [-   1]");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
-  }
-  {
-    StrippedQuery stripped("RETURN [ - 1, +  2 ]");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
-    EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 2);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " , " + kStrippedIntToken + " ]");
-  }
-}
-
-TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
-  {
-    StrippedQuery stripped("RETURN [a - 1]");  // spaced: number is not adjacent to the sign
-    EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
-  }
-  {
-    StrippedQuery stripped("RETURN [1-1]");  // adjacent, but preceded by a value
-    EXPECT_EQ(stripped.literals().size(), 2);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " - " + kStrippedIntToken + " ]");
-  }
-  {
-    StrippedQuery stripped("RETURN [a-1]");  // adjacent, preceded by an identifier
-    EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
-  }
-}
-
-TEST(QueryStripper, BinaryMinusAfterValueEndingKeywordIsNotFolded) {
-  {
-    StrippedQuery stripped("RETURN [CASE WHEN true THEN 2 END-1]");
-    EXPECT_EQ(stripped.literals().At(2).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(),
-              "RETURN [ CASE WHEN " + kStrippedBooleanToken + " THEN " + kStrippedIntToken + " END - " +
-                  kStrippedIntToken + " ]");
-  }
-  {
-    StrippedQuery stripped("RETURN [a.end-1]");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a . end - " + kStrippedIntToken + " ]");
-  }
-}
-
-TEST(QueryStripper, SignFoldStackedSignsDoNotFold) {
-  {
-    StrippedQuery stripped("RETURN [--1]");
-    EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - - " + kStrippedIntToken + " ]");
-  }
-  {
-    StrippedQuery stripped("RETURN [-+1]");
-    EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - + " + kStrippedIntToken + " ]");
-  }
-}
-
-TEST(QueryStripper, SignFoldIntMinHexOctal) {
-  {
-    StrippedQuery stripped("RETURN [-9223372036854775808]");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), std::numeric_limits<int64_t>::min());
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
-  }
-  {
-    StrippedQuery stripped("RETURN [-0x1F]");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -31);
-  }
-  {
-    StrippedQuery stripped("RETURN [-010]");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -8);
-  }
-}
-
-TEST(QueryStripper, SignFoldNestedAndBracketedContexts) {
-  {
-    StrippedQuery stripped("RETURN [[1, -2], -3]");  // nested list
-    EXPECT_EQ(stripped.literals().size(), 3);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), -2);
-    EXPECT_EQ(stripped.literals().At(2).second.ValueInt(), -3);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ [ 0 , 0 ] , 0 ]");
-  }
-  {
-    StrippedQuery stripped("RETURN a[-1]");  // indexing: bracket, sign folds into the index
-    EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN a [ " + kStrippedIntToken + " ]");
-  }
-}
-
 TEST(Parameters, LookupByTokenPosition) {
   Parameters params;
   params.Add(3, memgraph::storage::ExternalPropertyValue(int64_t{30}));
@@ -692,30 +520,12 @@ TEST(Parameters, LookupByTokenPosition) {
   params.Add(5, memgraph::storage::ExternalPropertyValue(int64_t{50}));
 
   EXPECT_EQ(params.size(), 3);
-  // Lookup is by token position, independent of insertion order.
   EXPECT_EQ(params.AtTokenPosition(3).ValueInt(), 30);
   EXPECT_EQ(params.AtTokenPosition(5).ValueInt(), 50);
   EXPECT_EQ(params.AtTokenPosition(7).ValueInt(), 70);
-  // At() still addresses storage in insertion order.
   EXPECT_EQ(params.At(0).first, 3);
   EXPECT_EQ(params.At(1).first, 7);
   EXPECT_EQ(params.At(2).first, 5);
-}
-
-TEST(Parameters, DuplicateTokenPositionKeepsFirst) {
-  Parameters params;
-  params.Add(1, memgraph::storage::ExternalPropertyValue(int64_t{100}));
-  params.Add(1, memgraph::storage::ExternalPropertyValue(int64_t{200}));
-  EXPECT_EQ(params.AtTokenPosition(1).ValueInt(), 100);
-}
-
-TEST(Parameters, CopyPreservesLookup) {
-  Parameters params;
-  params.Add(2, memgraph::storage::ExternalPropertyValue(int64_t{20}));
-  params.Add(9, memgraph::storage::ExternalPropertyValue(int64_t{90}));
-  Parameters copy = params;  // PrepareQueryParameters copies the stripped literals
-  EXPECT_EQ(copy.AtTokenPosition(2).ValueInt(), 20);
-  EXPECT_EQ(copy.AtTokenPosition(9).ValueInt(), 90);
 }
 
 // force every key into one bucket so equality must disambiguate by text

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -597,6 +597,21 @@ TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
   }
 }
 
+TEST(QueryStripper, BinaryMinusAfterValueEndingKeywordIsNotFolded) {
+  {
+    StrippedQuery stripped("RETURN [CASE WHEN true THEN 2 END-1]");
+    EXPECT_EQ(stripped.literals().At(2).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(),
+              "RETURN [ CASE WHEN " + kStrippedBooleanToken + " THEN " + kStrippedIntToken + " END - " +
+                  kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [a.end-1]");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a . end - " + kStrippedIntToken + " ]");
+  }
+}
+
 TEST(QueryStripper, SignFoldStackedSigns) {
   // Only the sign adjacent to the number folds; the outer sign stays a token.
   {

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -507,6 +507,89 @@ TEST(QueryStripper, KeywordsCanBeUsedInStrippedQueries) {
   {
     StrippedQuery stripped("MATCH (n:Constraints), (m:Indexes) RETURN n, m");
     EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n : Constraints ) , ( m : Indexes ) RETURN n , m");
+  }
+}
+
+TEST(QueryStripper, NegativeIntegerInList) {
+  StrippedQuery stripped("RETURN [-42]");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -42);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
+}
+
+TEST(QueryStripper, NegativeRealInList) {
+  StrippedQuery stripped("RETURN [-0.5]");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), -0.5);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedDoubleToken + " ]");
+}
+
+TEST(QueryStripper, UnaryPlusInList) {
+  StrippedQuery stripped("RETURN [+42]");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
+}
+
+TEST(QueryStripper, NegativeExponentRealInList) {
+  StrippedQuery stripped("RETURN [-1e-3]");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), -1e-3);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedDoubleToken + " ]");
+}
+
+TEST(QueryStripper, MixedSignListFoldsToPositiveShape) {
+  StrippedQuery stripped("RETURN [-1, 2, -3]");
+  EXPECT_EQ(stripped.literals().size(), 3);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
+  EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 2);
+  EXPECT_EQ(stripped.literals().At(2).second.ValueInt(), -3);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ 0 , 0 , 0 ]");
+}
+
+TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
+  // The point of the fold: lists differing only in per-element sign and value
+  // now strip to the same query, so they share a single cache entry.
+  auto a = StrippedQuery("RETURN [-1, 2, -3]");
+  auto b = StrippedQuery("RETURN [4, -5, 6]");
+  auto c = StrippedQuery("RETURN [1, 2, 3]");
+  EXPECT_EQ(a.stripped_query().str(), b.stripped_query().str());
+  EXPECT_EQ(a.stripped_query().str(), c.stripped_query().str());
+  EXPECT_EQ(a.stripped_query().hash(), b.stripped_query().hash());
+  EXPECT_EQ(a.stripped_query().hash(), c.stripped_query().hash());
+}
+
+TEST(QueryStripper, SignFoldOnlyInsideListLiterals) {
+  // Folding is confined to list literals, so a top-level signed number keeps
+  // its unary-minus token (its sign is not moved into the literal value). This
+  // preserves parse-tree-shape validation of clause operands elsewhere.
+  StrippedQuery stripped("RETURN -42");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
+}
+
+TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
+  // Inside a list, a `-` whose left side produces a value is still a
+  // subtraction operator; the literal keeps its own positive sign.
+  {
+    StrippedQuery stripped("RETURN [a - 1]");  // spaced: number is not adjacent to the sign
+    EXPECT_EQ(stripped.literals().size(), 1);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [1-1]");  // adjacent, but preceded by a value
+    EXPECT_EQ(stripped.literals().size(), 2);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [a-1]");  // adjacent, preceded by an identifier
+    EXPECT_EQ(stripped.literals().size(), 1);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
   }
 }
 

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -552,8 +552,6 @@ TEST(QueryStripper, MixedSignListFoldsToPositiveShape) {
 }
 
 TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
-  // The point of the fold: lists differing only in per-element sign and value
-  // now strip to the same query, so they share a single cache entry.
   auto a = StrippedQuery("RETURN [-1, 2, -3]");
   auto b = StrippedQuery("RETURN [4, -5, 6]");
   auto c = StrippedQuery("RETURN [1, 2, 3]");
@@ -561,21 +559,35 @@ TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
   EXPECT_EQ(a.stripped_query().str(), c.stripped_query().str());
   EXPECT_EQ(a.stripped_query().hash(), b.stripped_query().hash());
   EXPECT_EQ(a.stripped_query().hash(), c.stripped_query().hash());
+  EXPECT_EQ(StrippedQuery("RETURN -1").stripped_query().str(), StrippedQuery("RETURN 1").stripped_query().str());
 }
 
-TEST(QueryStripper, SignFoldOnlyInsideListLiterals) {
-  // Folding is confined to list literals, so a top-level signed number keeps
-  // its unary-minus token (its sign is not moved into the literal value). This
-  // preserves parse-tree-shape validation of clause operands elsewhere.
-  StrippedQuery stripped("RETURN -42");
+TEST(QueryStripper, SignFoldOutsideBrackets) {
+  {
+    StrippedQuery stripped("RETURN -42");
+    EXPECT_EQ(stripped.literals().size(), 1);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -42);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
+  }
+  {
+    StrippedQuery stripped("RETURN {k: -1}");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN { k : " + kStrippedIntToken + " }");
+  }
+  {
+    StrippedQuery stripped("MATCH (n) WHERE n.x > -1.5 RETURN n");
+    EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), -1.5);
+  }
+}
+
+TEST(QueryStripper, SignFoldingDisabled) {
+  StrippedQuery stripped("RETURN -42", SignFolding::kDisabled);
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
-  // Inside a list, a `-` whose left side produces a value is still a
-  // subtraction operator; the literal keeps its own positive sign.
   {
     StrippedQuery stripped("RETURN [a - 1]");  // spaced: number is not adjacent to the sign
     EXPECT_EQ(stripped.literals().size(), 1);
@@ -613,7 +625,6 @@ TEST(QueryStripper, BinaryMinusAfterValueEndingKeywordIsNotFolded) {
 }
 
 TEST(QueryStripper, SignFoldStackedSigns) {
-  // Only the sign adjacent to the number folds; the outer sign stays a token.
   {
     StrippedQuery stripped("RETURN [--1]");
     EXPECT_EQ(stripped.literals().size(), 1);
@@ -694,11 +705,7 @@ TEST(Parameters, CopyPreservesLookup) {
   EXPECT_EQ(copy.AtTokenPosition(9).ValueInt(), 90);
 }
 
-// The AST cache keys on HashedString, so a 64-bit hash collision must resolve by
-// query text and never return a different query's entry. HashedString equality
-// compares hash and string, and the cache's unordered_map disambiguates a
-// bucket collision via that operator==. Force every key into one bucket to
-// exercise the collision path directly.
+// force every key into one bucket so equality must disambiguate by text
 TEST(HashedString, DisambiguatesOnHashCollision) {
   struct AlwaysCollide {
     std::size_t operator()(const HashedString & /*unused*/) const { return 0; }
@@ -708,12 +715,10 @@ TEST(HashedString, DisambiguatesOnHashCollision) {
   map.emplace(HashedString{"RETURN 0"}, 1);
   map.emplace(HashedString{"RETURN 1"}, 2);
 
-  // Distinct query text with a forced hash collision stays two separate entries.
   ASSERT_EQ(map.size(), 2U);
   EXPECT_EQ(map.at(HashedString{"RETURN 0"}), 1);
   EXPECT_EQ(map.at(HashedString{"RETURN 1"}), 2);
 
-  // Same content compares equal (and would share an entry); different content does not.
   EXPECT_EQ(HashedString{"RETURN 0"}, HashedString{"RETURN 0"});
   EXPECT_NE(HashedString{"RETURN 0"}, HashedString{"RETURN 1"});
 }

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -14,6 +14,9 @@
 // Created by Florijan Stamenkovic on 07.03.17.
 //
 
+#include <cstdint>
+#include <limits>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -590,6 +593,55 @@ TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
     EXPECT_EQ(stripped.literals().size(), 1);
     EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
+  }
+}
+
+TEST(QueryStripper, SignFoldStackedSigns) {
+  // Only the sign adjacent to the number folds; the outer sign stays a token.
+  {
+    StrippedQuery stripped("RETURN [--1]");
+    EXPECT_EQ(stripped.literals().size(), 1);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [-+1]");
+    EXPECT_EQ(stripped.literals().size(), 1);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - " + kStrippedIntToken + " ]");
+  }
+}
+
+TEST(QueryStripper, SignFoldIntMinHexOctal) {
+  {
+    StrippedQuery stripped("RETURN [-9223372036854775808]");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [-0x1F]");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -31);
+  }
+  {
+    StrippedQuery stripped("RETURN [-010]");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -8);
+  }
+}
+
+TEST(QueryStripper, SignFoldNestedAndBracketedContexts) {
+  {
+    StrippedQuery stripped("RETURN [[1, -2], -3]");  // nested list
+    EXPECT_EQ(stripped.literals().size(), 3);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), -2);
+    EXPECT_EQ(stripped.literals().At(2).second.ValueInt(), -3);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ [ 0 , 0 ] , 0 ]");
+  }
+  {
+    StrippedQuery stripped("RETURN a[-1]");  // indexing: bracket, sign folds into the index
+    EXPECT_EQ(stripped.literals().size(), 1);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN a [ " + kStrippedIntToken + " ]");
   }
 }
 

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -534,20 +534,16 @@ TEST(QueryStripper, SignFoldInList) {
   }
 }
 
-TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
+TEST(QueryStripper, SignPatternDoesNotAffectCacheKeyAndKeepsValues) {
   auto a = StrippedQuery("RETURN [-1, 2, -3]");
   auto b = StrippedQuery("RETURN [4, -5, 6]");
   auto c = StrippedQuery("RETURN [1, 2, 3]");
   EXPECT_EQ(a.stripped_query().str(), "RETURN [ 0 , 0 , 0 ]");
   EXPECT_EQ(a.stripped_query().str(), b.stripped_query().str());
   EXPECT_EQ(a.stripped_query().str(), c.stripped_query().str());
-}
-
-TEST(QueryStripper, MixedSignListKeepsValues) {
-  StrippedQuery stripped("RETURN [-1, 2, -3]");
-  EXPECT_EQ(stripped.literals().AtTokenPosition(2).ValueInt(), -1);
-  EXPECT_EQ(stripped.literals().AtTokenPosition(4).ValueInt(), 2);
-  EXPECT_EQ(stripped.literals().AtTokenPosition(6).ValueInt(), -3);
+  EXPECT_EQ(a.literals().AtTokenPosition(2).ValueInt(), -1);
+  EXPECT_EQ(a.literals().AtTokenPosition(4).ValueInt(), 2);
+  EXPECT_EQ(a.literals().AtTokenPosition(6).ValueInt(), -3);
 }
 
 TEST(QueryStripper, SignFoldAcrossWhitespace) {
@@ -558,15 +554,6 @@ TEST(QueryStripper, SignFoldAcrossWhitespace) {
 }
 
 TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
-  {
-    StrippedQuery stripped("RETURN [a - 1]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
-  }
-  {
-    StrippedQuery stripped("RETURN [1-1]");
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " - " + kStrippedIntToken + " ]");
-  }
   {
     StrippedQuery stripped("RETURN [1-2, 3]");
     EXPECT_EQ(stripped.stripped_query().str(),
@@ -640,11 +627,6 @@ TEST(QueryStripper, NoFoldOutsideBrackets) {
     StrippedQuery stripped("RETURN -42");
     EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 42);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
-  }
-  {
-    StrippedQuery stripped("RETURN {k: -1}");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN { k : - " + kStrippedIntToken + " }");
   }
   {
     StrippedQuery stripped("RETURN abs(-1.5)");

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -42,6 +42,12 @@ void EXPECT_PROP_EQ(const memgraph::storage::ExternalPropertyValue &a, const Typ
   EXPECT_PROP_EQ(TypedValue(a), b);
 }
 
+memgraph::storage::ExternalPropertyValue SingleLiteral(const StrippedQuery &stripped) {
+  EXPECT_EQ(stripped.literals().size(), 1);
+  if (stripped.literals().size() != 1) return {};
+  return stripped.literals().begin()->second;
+}
+
 TEST(QueryStripper, NoLiterals) {
   StrippedQuery stripped("CREATE (n)");
   EXPECT_EQ(stripped.literals().size(), 0);
@@ -65,49 +71,49 @@ TEST(QueryStripper, DecimalInteger) {
 TEST(QueryStripper, OctalInteger) {
   StrippedQuery stripped("RETURN 010");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 8);
+  EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 8);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, HexInteger) {
   StrippedQuery stripped("RETURN 0xa");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 10);
+  EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 10);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, RegularDecimal) {
   StrippedQuery stripped("RETURN 42.3");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 42.3);
+  EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), 42.3);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal) {
   StrippedQuery stripped("RETURN 4e2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 4e2);
+  EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), 4e2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal2) {
   StrippedQuery stripped("RETURN 4e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 4e-2);
+  EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), 4e-2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal3) {
   StrippedQuery stripped("RETURN 0.1e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 0.1e-2);
+  EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), 0.1e-2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal4) {
   StrippedQuery stripped("RETURN .1e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), .1e-2);
+  EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), .1e-2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
@@ -120,28 +126,28 @@ TEST(QueryStripper, SymbolicNameStartingWithE) {
 TEST(QueryStripper, StringLiteral) {
   StrippedQuery stripped("RETURN 'something'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "something");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "something");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral2) {
   StrippedQuery stripped("RETURN 'so\\'me'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "so'me");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "so'me");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral3) {
   StrippedQuery stripped("RETURN \"so\\\"me'\"");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "so\"me'");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "so\"me'");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral4) {
   StrippedQuery stripped("RETURN '\\u1Aa4'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(),
             "\xE1\xAA\xA4");  // "u8"\u1Aa4
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -153,7 +159,7 @@ TEST(QueryStripper, LowSurrogateAlone) { ASSERT_THROW(StrippedQuery("RETURN '\\u
 TEST(QueryStripper, Surrogates) {
   StrippedQuery stripped("RETURN '\\ud83d\\udeeb'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(),
             "\xF0\x9F\x9B\xAB");  // u8"\U0001f6eb"
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -161,14 +167,14 @@ TEST(QueryStripper, Surrogates) {
 TEST(QueryStripper, Utf32BasicLatin) {
   StrippedQuery stripped("RETURN '\\U00000041'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "A");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "A");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, Utf32Emoji) {
   StrippedQuery stripped("RETURN '\\U0001F600'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(),
             "\xF0\x9F\x98\x80");  // u8"\U0001F600" 😀
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -176,7 +182,7 @@ TEST(QueryStripper, Utf32Emoji) {
 TEST(QueryStripper, Utf32MaxValid) {
   StrippedQuery stripped("RETURN '\\U0010FFFF'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(),
             "\xF4\x8F\xBF\xBF");  // Maximum valid Unicode codepoint
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -190,20 +196,20 @@ TEST(QueryStripper, Utf32WrongLength) {
   // Exactly 8 hex digits followed by a non-hex character is valid
   // The parser reads exactly 8 digits, so "\\U00000058X" parses as U+00000058 ('X') followed by 'X'
   StrippedQuery stripped("RETURN '\\U00000058X'");  // 'X' followed by 'X'
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "XX");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "XX");
 }
 
 TEST(QueryStripper, UnicodeNull) {
   StrippedQuery stripped("RETURN '\\u0000'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), std::string("\0", 1));
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), std::string("\0", 1));
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, UnicodeBmpMax) {
   StrippedQuery stripped("RETURN '\\uffff'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(),
             "\xEF\xBF\xBF");  // U+FFFF (not a character but valid codepoint)
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -211,21 +217,21 @@ TEST(QueryStripper, UnicodeBmpMax) {
 TEST(QueryStripper, UnicodeUppercaseHex) {
   StrippedQuery stripped("RETURN '\\uABCD'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "\xEA\xAF\x8D");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "\xEA\xAF\x8D");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, UnicodeLowercaseHex) {
   StrippedQuery stripped("RETURN '\\uabcd'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "\xEA\xAF\x8D");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "\xEA\xAF\x8D");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, UnicodeMixedCase) {
   StrippedQuery stripped("RETURN '\\uAbCd'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "\xEA\xAF\x8D");
+  EXPECT_EQ(SingleLiteral(stripped).ValueString(), "\xEA\xAF\x8D");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
@@ -237,14 +243,14 @@ TEST(QueryStripper, StringLiteralIllegalEscapedSequence) {
 TEST(QueryStripper, TrueLiteral) {
   StrippedQuery stripped("RETURN trUE");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_PROP_EQ(stripped.literals().begin()->second, TypedValue(true));
+  EXPECT_PROP_EQ(SingleLiteral(stripped), TypedValue(true));
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedBooleanToken);
 }
 
 TEST(QueryStripper, FalseLiteral) {
   StrippedQuery stripped("RETURN fAlse");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_PROP_EQ(stripped.literals().begin()->second, TypedValue(false));
+  EXPECT_PROP_EQ(SingleLiteral(stripped), TypedValue(false));
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedBooleanToken);
 }
 
@@ -515,21 +521,21 @@ TEST(QueryStripper, KeywordsCanBeUsedInStrippedQueries) {
 TEST(QueryStripper, SignFoldInList) {
   {
     StrippedQuery stripped("RETURN [-42]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -42);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), -42);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
   }
   {
     StrippedQuery stripped("RETURN [+0.5]");
-    EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 0.5);
+    EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), 0.5);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedDoubleToken + " ]");
   }
   {
     StrippedQuery stripped("RETURN [-1e-3]");
-    EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), -1e-3);
+    EXPECT_FLOAT_EQ(SingleLiteral(stripped).ValueDouble(), -1e-3);
   }
   {
     StrippedQuery stripped("RETURN [+42]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 42);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 42);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
   }
 }
@@ -561,7 +567,7 @@ TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
   }
   {
     StrippedQuery stripped("RETURN [a-1]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 1);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
   }
   {
@@ -575,12 +581,12 @@ TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
 TEST(QueryStripper, StackedSignsAreNotFolded) {
   {
     StrippedQuery stripped("RETURN [--1]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 1);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - - " + kStrippedIntToken + " ]");
   }
   {
     StrippedQuery stripped("RETURN [-+1]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 1);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - + " + kStrippedIntToken + " ]");
   }
 }
@@ -588,15 +594,15 @@ TEST(QueryStripper, StackedSignsAreNotFolded) {
 TEST(QueryStripper, SignFoldIntMinHexOctal) {
   {
     StrippedQuery stripped("RETURN [-9223372036854775808]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), std::numeric_limits<int64_t>::min());
   }
   {
     StrippedQuery stripped("RETURN [-0x1F]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -31);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), -31);
   }
   {
     StrippedQuery stripped("RETURN [-010]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -8);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), -8);
   }
 }
 
@@ -608,7 +614,7 @@ TEST(QueryStripper, SignFoldInBracketContexts) {
   }
   {
     StrippedQuery stripped("RETURN a[-1]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -1);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), -1);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN a [ " + kStrippedIntToken + " ]");
   }
   {
@@ -625,7 +631,7 @@ TEST(QueryStripper, SignFoldInBracketContexts) {
 TEST(QueryStripper, NoFoldOutsideBrackets) {
   {
     StrippedQuery stripped("RETURN -42");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 42);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 42);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
   }
   {
@@ -642,7 +648,7 @@ TEST(QueryStripper, NoFoldOutsideBrackets) {
   }
   {
     StrippedQuery stripped("RETURN [{k: -1}]");
-    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 1);
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ { k : - " + kStrippedIntToken + " } ]");
   }
 }

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -536,9 +536,6 @@ TEST(HashedString, DisambiguatesOnHashCollision) {
   ASSERT_EQ(map.size(), 2U);
   EXPECT_EQ(map.at(HashedString{"RETURN 0"}), 1);
   EXPECT_EQ(map.at(HashedString{"RETURN 1"}), 2);
-
-  EXPECT_EQ(HashedString{"RETURN 0"}, HashedString{"RETURN 0"});
-  EXPECT_NE(HashedString{"RETURN 0"}, HashedString{"RETURN 1"});
 }
 
 }  // namespace

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -49,8 +50,6 @@ TEST(QueryStripper, NoLiterals) {
 TEST(QueryStripper, ZeroInteger) {
   StrippedQuery stripped("RETURN 0");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).first, 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 0);
   EXPECT_EQ(stripped.literals().AtTokenPosition(1).ValueInt(), 0);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
@@ -58,8 +57,6 @@ TEST(QueryStripper, ZeroInteger) {
 TEST(QueryStripper, DecimalInteger) {
   StrippedQuery stripped("RETURN 42");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).first, 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
   EXPECT_EQ(stripped.literals().AtTokenPosition(1).ValueInt(), 42);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
@@ -67,49 +64,49 @@ TEST(QueryStripper, DecimalInteger) {
 TEST(QueryStripper, OctalInteger) {
   StrippedQuery stripped("RETURN 010");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 8);
+  EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 8);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, HexInteger) {
   StrippedQuery stripped("RETURN 0xa");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 10);
+  EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 10);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, RegularDecimal) {
   StrippedQuery stripped("RETURN 42.3");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 42.3);
+  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 42.3);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal) {
   StrippedQuery stripped("RETURN 4e2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 4e2);
+  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 4e2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal2) {
   StrippedQuery stripped("RETURN 4e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 4e-2);
+  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 4e-2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal3) {
   StrippedQuery stripped("RETURN 0.1e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 0.1e-2);
+  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 0.1e-2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal4) {
   StrippedQuery stripped("RETURN .1e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), .1e-2);
+  EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), .1e-2);
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
@@ -122,28 +119,28 @@ TEST(QueryStripper, SymbolicNameStartingWithE) {
 TEST(QueryStripper, StringLiteral) {
   StrippedQuery stripped("RETURN 'something'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "something");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "something");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral2) {
   StrippedQuery stripped("RETURN 'so\\'me'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "so'me");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "so'me");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral3) {
   StrippedQuery stripped("RETURN \"so\\\"me'\"");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "so\"me'");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "so\"me'");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral4) {
   StrippedQuery stripped("RETURN '\\u1Aa4'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(),
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
             "\xE1\xAA\xA4");  // "u8"\u1Aa4
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -155,7 +152,7 @@ TEST(QueryStripper, LowSurrogateAlone) { ASSERT_THROW(StrippedQuery("RETURN '\\u
 TEST(QueryStripper, Surrogates) {
   StrippedQuery stripped("RETURN '\\ud83d\\udeeb'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(),
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
             "\xF0\x9F\x9B\xAB");  // u8"\U0001f6eb"
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -163,14 +160,14 @@ TEST(QueryStripper, Surrogates) {
 TEST(QueryStripper, Utf32BasicLatin) {
   StrippedQuery stripped("RETURN '\\U00000041'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "A");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "A");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, Utf32Emoji) {
   StrippedQuery stripped("RETURN '\\U0001F600'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(),
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
             "\xF0\x9F\x98\x80");  // u8"\U0001F600" 😀
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -178,7 +175,7 @@ TEST(QueryStripper, Utf32Emoji) {
 TEST(QueryStripper, Utf32MaxValid) {
   StrippedQuery stripped("RETURN '\\U0010FFFF'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(),
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
             "\xF4\x8F\xBF\xBF");  // Maximum valid Unicode codepoint
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -192,20 +189,20 @@ TEST(QueryStripper, Utf32WrongLength) {
   // Exactly 8 hex digits followed by a non-hex character is valid
   // The parser reads exactly 8 digits, so "\\U00000058X" parses as U+00000058 ('X') followed by 'X'
   StrippedQuery stripped("RETURN '\\U00000058X'");  // 'X' followed by 'X'
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "XX");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "XX");
 }
 
 TEST(QueryStripper, UnicodeNull) {
   StrippedQuery stripped("RETURN '\\u0000'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), std::string("\0", 1));
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), std::string("\0", 1));
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, UnicodeBmpMax) {
   StrippedQuery stripped("RETURN '\\uffff'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(),
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(),
             "\xEF\xBF\xBF");  // U+FFFF (not a character but valid codepoint)
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
@@ -213,21 +210,21 @@ TEST(QueryStripper, UnicodeBmpMax) {
 TEST(QueryStripper, UnicodeUppercaseHex) {
   StrippedQuery stripped("RETURN '\\uABCD'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "\xEA\xAF\x8D");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "\xEA\xAF\x8D");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, UnicodeLowercaseHex) {
   StrippedQuery stripped("RETURN '\\uabcd'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "\xEA\xAF\x8D");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "\xEA\xAF\x8D");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, UnicodeMixedCase) {
   StrippedQuery stripped("RETURN '\\uAbCd'");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "\xEA\xAF\x8D");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueString(), "\xEA\xAF\x8D");
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
@@ -239,14 +236,14 @@ TEST(QueryStripper, StringLiteralIllegalEscapedSequence) {
 TEST(QueryStripper, TrueLiteral) {
   StrippedQuery stripped("RETURN trUE");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_PROP_EQ(stripped.literals().At(0).second, TypedValue(true));
+  EXPECT_PROP_EQ(stripped.literals().begin()->second, TypedValue(true));
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedBooleanToken);
 }
 
 TEST(QueryStripper, FalseLiteral) {
   StrippedQuery stripped("RETURN fAlse");
   EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_PROP_EQ(stripped.literals().At(0).second, TypedValue(false));
+  EXPECT_PROP_EQ(stripped.literals().begin()->second, TypedValue(false));
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedBooleanToken);
 }
 
@@ -277,8 +274,9 @@ TEST(QueryStripper, MapProjectionLiteral) {
 TEST(QueryStripper, RangeLiteral) {
   StrippedQuery stripped("MATCH (n)-[*2..3]-() RETURN n");
   EXPECT_EQ(stripped.literals().size(), 2);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 2);
-  EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 3);
+  std::vector<int64_t> values;
+  for (const auto &[position, value] : stripped.literals()) values.push_back(value.ValueInt());
+  EXPECT_THAT(values, UnorderedElementsAre(2, 3));
   EXPECT_EQ(stripped.stripped_query().str(),
             "MATCH ( n ) - [ * " + kStrippedIntToken + " .. " + kStrippedIntToken + " ] - ( ) RETURN n");
 }
@@ -523,9 +521,6 @@ TEST(Parameters, LookupByTokenPosition) {
   EXPECT_EQ(params.AtTokenPosition(3).ValueInt(), 30);
   EXPECT_EQ(params.AtTokenPosition(5).ValueInt(), 50);
   EXPECT_EQ(params.AtTokenPosition(7).ValueInt(), 70);
-  EXPECT_EQ(params.At(0).first, 3);
-  EXPECT_EQ(params.At(1).first, 7);
-  EXPECT_EQ(params.At(2).first, 5);
 }
 
 // force every key into one bucket so equality must disambiguate by text

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <unordered_map>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -676,6 +677,30 @@ TEST(Parameters, CopyPreservesLookup) {
   Parameters copy = params;  // PrepareQueryParameters copies the stripped literals
   EXPECT_EQ(copy.AtTokenPosition(2).ValueInt(), 20);
   EXPECT_EQ(copy.AtTokenPosition(9).ValueInt(), 90);
+}
+
+// The AST cache keys on HashedString, so a 64-bit hash collision must resolve by
+// query text and never return a different query's entry. HashedString equality
+// compares hash and string, and the cache's unordered_map disambiguates a
+// bucket collision via that operator==. Force every key into one bucket to
+// exercise the collision path directly.
+TEST(HashedString, DisambiguatesOnHashCollision) {
+  struct AlwaysCollide {
+    std::size_t operator()(const HashedString & /*unused*/) const { return 0; }
+  };
+
+  std::unordered_map<HashedString, int, AlwaysCollide> map;
+  map.emplace(HashedString{"RETURN 0"}, 1);
+  map.emplace(HashedString{"RETURN 1"}, 2);
+
+  // Distinct query text with a forced hash collision stays two separate entries.
+  ASSERT_EQ(map.size(), 2U);
+  EXPECT_EQ(map.at(HashedString{"RETURN 0"}), 1);
+  EXPECT_EQ(map.at(HashedString{"RETURN 1"}), 2);
+
+  // Same content compares equal (and would share an entry); different content does not.
+  EXPECT_EQ(HashedString{"RETURN 0"}, HashedString{"RETURN 0"});
+  EXPECT_NE(HashedString{"RETURN 0"}, HashedString{"RETURN 1"});
 }
 
 }  // namespace

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -15,6 +15,7 @@
 //
 
 #include <cstdint>
+#include <limits>
 #include <unordered_map>
 #include <vector>
 
@@ -508,6 +509,138 @@ TEST(QueryStripper, KeywordsCanBeUsedInStrippedQueries) {
   {
     StrippedQuery stripped("MATCH (n:Constraints), (m:Indexes) RETURN n, m");
     EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n : Constraints ) , ( m : Indexes ) RETURN n , m");
+  }
+}
+
+TEST(QueryStripper, SignFoldInList) {
+  {
+    StrippedQuery stripped("RETURN [-42]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -42);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [+0.5]");
+    EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), 0.5);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedDoubleToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [-1e-3]");
+    EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), -1e-3);
+  }
+}
+
+TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
+  auto a = StrippedQuery("RETURN [-1, 2, -3]");
+  auto b = StrippedQuery("RETURN [4, -5, 6]");
+  auto c = StrippedQuery("RETURN [1, 2, 3]");
+  EXPECT_EQ(a.stripped_query().str(), "RETURN [ 0 , 0 , 0 ]");
+  EXPECT_EQ(a.stripped_query().str(), b.stripped_query().str());
+  EXPECT_EQ(a.stripped_query().str(), c.stripped_query().str());
+}
+
+TEST(QueryStripper, MixedSignListKeepsValues) {
+  StrippedQuery stripped("RETURN [-1, 2, -3]");
+  EXPECT_EQ(stripped.literals().AtTokenPosition(2).ValueInt(), -1);
+  EXPECT_EQ(stripped.literals().AtTokenPosition(4).ValueInt(), 2);
+  EXPECT_EQ(stripped.literals().AtTokenPosition(6).ValueInt(), -3);
+}
+
+TEST(QueryStripper, SignFoldAcrossWhitespace) {
+  StrippedQuery stripped("RETURN [ -   1, +  2 ]");
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " , " + kStrippedIntToken + " ]");
+  EXPECT_EQ(stripped.literals().AtTokenPosition(2).ValueInt(), -1);
+  EXPECT_EQ(stripped.literals().AtTokenPosition(4).ValueInt(), 2);
+}
+
+TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
+  {
+    StrippedQuery stripped("RETURN [a - 1]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [1-1]");
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [1-2, 3]");
+    EXPECT_EQ(stripped.stripped_query().str(),
+              "RETURN [ " + kStrippedIntToken + " - " + kStrippedIntToken + " , " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [a-1]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ a - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [CASE WHEN true THEN 2 END-1]");
+    EXPECT_EQ(stripped.stripped_query().str(),
+              "RETURN [ CASE WHEN " + kStrippedBooleanToken + " THEN " + kStrippedIntToken + " END - " +
+                  kStrippedIntToken + " ]");
+  }
+}
+
+TEST(QueryStripper, StackedSignsAreNotFolded) {
+  StrippedQuery stripped("RETURN [--1]");
+  EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - - " + kStrippedIntToken + " ]");
+}
+
+TEST(QueryStripper, SignFoldIntMinHexOctal) {
+  {
+    StrippedQuery stripped("RETURN [-9223372036854775808]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), std::numeric_limits<int64_t>::min());
+  }
+  {
+    StrippedQuery stripped("RETURN [-0x1F]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -31);
+  }
+  {
+    StrippedQuery stripped("RETURN [-010]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -8);
+  }
+}
+
+TEST(QueryStripper, SignFoldInBracketContexts) {
+  {
+    StrippedQuery stripped("RETURN [[1, -2], -3]");
+    EXPECT_EQ(stripped.stripped_query().str(),
+              "RETURN [ [ " + kStrippedIntToken + " , " + kStrippedIntToken + " ] , " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN a[-1]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), -1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN a [ " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN a[-2..-1]");
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN a [ " + kStrippedIntToken + " .. - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [max(1, -2)]");
+    EXPECT_EQ(stripped.stripped_query().str(),
+              "RETURN [ max ( " + kStrippedIntToken + " , " + kStrippedIntToken + " ) ]");
+  }
+}
+
+TEST(QueryStripper, NoFoldOutsideBrackets) {
+  {
+    StrippedQuery stripped("RETURN -42");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 42);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
+  }
+  {
+    StrippedQuery stripped("RETURN {k: -1}");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN { k : - " + kStrippedIntToken + " }");
+  }
+  {
+    StrippedQuery stripped("RETURN abs(-1.5)");
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN abs ( - " + kStrippedDoubleToken + " )");
+  }
+  {
+    StrippedQuery stripped("RETURN 1, -2");
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken + " , - " + kStrippedIntToken);
   }
 }
 

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -559,32 +559,45 @@ TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
   EXPECT_EQ(a.stripped_query().str(), c.stripped_query().str());
   EXPECT_EQ(a.stripped_query().hash(), b.stripped_query().hash());
   EXPECT_EQ(a.stripped_query().hash(), c.stripped_query().hash());
-  EXPECT_EQ(StrippedQuery("RETURN -1").stripped_query().str(), StrippedQuery("RETURN 1").stripped_query().str());
+  EXPECT_EQ(StrippedQuery("RETURN [-1]").stripped_query().str(), StrippedQuery("RETURN [- 1]").stripped_query().str());
 }
 
-TEST(QueryStripper, SignFoldOutsideBrackets) {
+TEST(QueryStripper, SignFoldOnlyAfterOpeners) {
   {
     StrippedQuery stripped("RETURN -42");
     EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -42);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
   }
   {
     StrippedQuery stripped("RETURN {k: -1}");
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN { k : " + kStrippedIntToken + " }");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN { k : - " + kStrippedIntToken + " }");
   }
   {
-    StrippedQuery stripped("MATCH (n) WHERE n.x > -1.5 RETURN n");
+    StrippedQuery stripped("RETURN (-1)");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN ( " + kStrippedIntToken + " )");
+  }
+  {
+    StrippedQuery stripped("RETURN abs(-1.5)");
     EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), -1.5);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN abs ( " + kStrippedDoubleToken + " )");
   }
 }
 
-TEST(QueryStripper, SignFoldingDisabled) {
-  StrippedQuery stripped("RETURN -42", SignFolding::kDisabled);
-  EXPECT_EQ(stripped.literals().size(), 1);
-  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
-  EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
+TEST(QueryStripper, SignFoldAcrossWhitespace) {
+  {
+    StrippedQuery stripped("RETURN [-   1]");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [ - 1, +  2 ]");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
+    EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 2);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " , " + kStrippedIntToken + " ]");
+  }
 }
 
 TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
@@ -624,18 +637,18 @@ TEST(QueryStripper, BinaryMinusAfterValueEndingKeywordIsNotFolded) {
   }
 }
 
-TEST(QueryStripper, SignFoldStackedSigns) {
+TEST(QueryStripper, SignFoldStackedSignsDoNotFold) {
   {
     StrippedQuery stripped("RETURN [--1]");
     EXPECT_EQ(stripped.literals().size(), 1);
-    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), -1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - " + kStrippedIntToken + " ]");
+    EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - - " + kStrippedIntToken + " ]");
   }
   {
     StrippedQuery stripped("RETURN [-+1]");
     EXPECT_EQ(stripped.literals().size(), 1);
     EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 1);
-    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - " + kStrippedIntToken + " ]");
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - + " + kStrippedIntToken + " ]");
   }
 }
 

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -527,6 +527,11 @@ TEST(QueryStripper, SignFoldInList) {
     StrippedQuery stripped("RETURN [-1e-3]");
     EXPECT_FLOAT_EQ(stripped.literals().begin()->second.ValueDouble(), -1e-3);
   }
+  {
+    StrippedQuery stripped("RETURN [+42]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 42);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ]");
+  }
 }
 
 TEST(QueryStripper, SignPatternDoesNotAffectCacheKey) {
@@ -581,9 +586,16 @@ TEST(QueryStripper, BinaryMinusInListIsNotFolded) {
 }
 
 TEST(QueryStripper, StackedSignsAreNotFolded) {
-  StrippedQuery stripped("RETURN [--1]");
-  EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
-  EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - - " + kStrippedIntToken + " ]");
+  {
+    StrippedQuery stripped("RETURN [--1]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - - " + kStrippedIntToken + " ]");
+  }
+  {
+    StrippedQuery stripped("RETURN [-+1]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ - + " + kStrippedIntToken + " ]");
+  }
 }
 
 TEST(QueryStripper, SignFoldIntMinHexOctal) {
@@ -641,6 +653,15 @@ TEST(QueryStripper, NoFoldOutsideBrackets) {
   {
     StrippedQuery stripped("RETURN 1, -2");
     EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken + " , - " + kStrippedIntToken);
+  }
+  {
+    StrippedQuery stripped("RETURN [1], -2");
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ " + kStrippedIntToken + " ] , - " + kStrippedIntToken);
+  }
+  {
+    StrippedQuery stripped("RETURN [{k: -1}]");
+    EXPECT_EQ(stripped.literals().begin()->second.ValueInt(), 1);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN [ { k : - " + kStrippedIntToken + " } ]");
   }
 }
 


### PR DESCRIPTION
## Why

`InterpreterContext::ast_cache` was an unbounded skip list keyed on a bare 64-bit hash. Query stripping replaces literal values with placeholders, but every *distinct stripped text* permanently retained its own `AstStorage` — a stream of structurally-varying queries (e.g. inlined embedding vectors, whose sign patterns alone produce a distinct stripped text per query) grew process memory without limit. The reported leak.

## How

- Replace the unbounded skip list with an LRU sized by `--query-ast-cache-max-size` (default 1000, 0 disables the cache). Entries are `shared_ptr<const CachedQuery>`: the lock is released before the (potentially heavy) AST clone, a concurrent eviction can't free an entry mid-clone, and shared entries are compiler-enforced immutable. A parse race on the same uncached query converges on one entry (the loser adopts the winner's).
- Key the cache on `HashedString` instead of the raw 64-bit hash: a bucket collision is resolved by comparing text, so a colliding query is a real hit or a fresh parse, never a wrong AST.
- Fold a unary sign into the numeric literal it precedes when the previous non-space token is `[`, or `,` at bracket depth > 0. In those positions a `-`/`+` cannot be a subtraction — nothing it could subtract from precedes it — so folding needs no heuristics and cannot misfire. Sign variants of a list (`[-1, 2]`, `[1, -2]`, `[1, 2]`) then strip to the same text and hit both the AST and plan caches. Binary minus is untouched (`[1-2, 3]`, `[a-1]`), as are scalars, maps, and parens (`RETURN -1`, `{k: -1}`, `abs(-1)`).
- Make `Parameters::AtTokenPosition` O(1) by keying parameters on their token position — list-literal evaluation looked up one parameter per element per row, so an N-element list literal did O(N²) work per row.
- Validate coordinator ids where they are evaluated: `EvaluateCoordinatorId` goes through `EvaluateUint` and rejects values above `INT32_MAX` instead of silently truncating at the `static_cast` call sites.

## Known trade-offs

Sign variants of scalars/maps (`RETURN -1` vs `RETURN 1`) still take separate entries — 2 entries per shape, LRU-bounded, unlike the 2^N list case this PR targets.