### PR TITLE
fix(plan): correctness fixes for edge IN-list, ORDER BY elimination, and nested edge property filters

### DIFF
--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -743,6 +743,18 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     using ProvidedScan = typename OrderByEliminator<TDbAccessor>::ProvidedScan;
     const auto *target = (op->GetTypeInfo() == Filter::kType) ? op->input().get() : op;
 
+    // A value scan fed by an Unwind is invoked once per unwound element (e.g.
+    // an `x IN list` lowering, or a user UNWIND driving the lookup). When the
+    // lookup value derives from the element the results follow element order,
+    // not property order, so the scan cannot be assumed to provide ordered
+    // iteration and must not eliminate an ORDER BY. Suppressing is conservative:
+    // if the value is element-independent the scan is still ordered, but at
+    // worst we keep an unnecessary sort rather than risk dropping a needed one.
+    if (target->input() && target->input()->GetTypeInfo() == Unwind::kType) {
+      order_by_eliminator_.NotifyScan(std::nullopt);
+      return;
+    }
+
     std::optional<ProvidedScan> scan;
     if (const auto *etr = dynamic_cast<const ScanAllByEdgeTypePropertyRange *>(target)) {
       scan = etr;
@@ -963,6 +975,17 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
       auto *value = filter.id_filter->value_;
       filter_exprs_for_removal_.insert(filter.expression);
       filters_.EraseFilter(filter);
+      if (filter.id_filter->type_ == IdFilter::Type::IN) {
+        auto unwound = UnwindMembershipList(*symbol_table_, ast_storage_, input, value);
+        return std::make_unique<ScanAllByEdgeId>(std::move(unwound.op),
+                                                 common.edge_symbol,
+                                                 common.node1_symbol,
+                                                 common.node2_symbol,
+                                                 common.direction,
+                                                 unwound.element,
+                                                 view,
+                                                 /*expects_string_id=*/false);
+      }
       return std::make_unique<ScanAllByEdgeId>(input,
                                                common.edge_symbol,
                                                common.node1_symbol,
@@ -1033,18 +1056,15 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
       if (prop_filter.type_ == PropertyFilter::Type::IN) {
         // TODO(buda): ScanAllByLabelProperties + Filter should be considered
         // here once the operator and the right cardinality estimation exist.
-        auto const &symbol = symbol_table_->CreateAnonymousSymbol();
-        auto *expression = ast_storage_->Create<Identifier>(symbol.name());
-        expression->MapTo(symbol);
-        auto unwind_operator = std::make_unique<Unwind>(input, prop_filter.value_, symbol);
-        return std::make_unique<ScanAllByEdgeTypePropertyValue>(std::move(unwind_operator),
+        auto unwound = UnwindMembershipList(*symbol_table_, ast_storage_, input, prop_filter.value_);
+        return std::make_unique<ScanAllByEdgeTypePropertyValue>(std::move(unwound.op),
                                                                 common.edge_symbol,
                                                                 common.node1_symbol,
                                                                 common.node2_symbol,
                                                                 common.direction,
                                                                 GetEdgeType(found_index.value()),
                                                                 GetProperty(prop_filter.property_ids_.path[0]),
-                                                                expression,
+                                                                unwound.element,
                                                                 view);
       }
       if (prop_filter.type_ == PropertyFilter::Type::IS_NOT_NULL) {
@@ -1142,17 +1162,14 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
       if (prop_filter.type_ == PropertyFilter::Type::IN) {
         // TODO(buda): ScanAllByLabelProperties + Filter should be considered
         // here once the operator and the right cardinality estimation exist.
-        auto const &symbol = symbol_table_->CreateAnonymousSymbol();
-        auto *expression = ast_storage_->Create<Identifier>(symbol.name());
-        expression->MapTo(symbol);
-        auto unwind_operator = std::make_shared<Unwind>(input, prop_filter.value_, symbol);
-        return std::make_shared<ScanAllByEdgePropertyValue>(std::move(unwind_operator),
+        auto unwound = UnwindMembershipList(*symbol_table_, ast_storage_, input, prop_filter.value_);
+        return std::make_shared<ScanAllByEdgePropertyValue>(std::move(unwound.op),
                                                             common.edge_symbol,
                                                             common.node1_symbol,
                                                             common.node2_symbol,
                                                             common.direction,
                                                             GetProperty(prop_filter.property_ids_.path[0]),
-                                                            expression,
+                                                            unwound.element,
                                                             view);
       }
       if (prop_filter.type_ == PropertyFilter::Type::IS_NOT_NULL) {

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -838,6 +838,12 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
           continue;
         }
 
+        // Edge indexes are single-property; a nested lookup like `e.a.b` has a
+        // multi-element path that no edge index covers, so it must stay a Filter
+        // rather than be misread as a filter on the outer key.
+        if (filter.property_filter->property_ids_.path.size() != 1) {
+          continue;
+        }
         const auto &property = filter.property_filter->property_ids_.path[0];
         if (!db_->EdgeTypePropertyIndexReady(GetEdgeType(edge_type), GetProperty(property))) {
           continue;
@@ -860,6 +866,10 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         continue;
       }
 
+      // Skip nested lookups: a single-property edge index cannot cover a multi-element path.
+      if (filter.property_filter->property_ids_.path.size() != 1) {
+        continue;
+      }
       const auto &property = filter.property_filter->property_ids_.path[0];
       if (!db_->EdgePropertyIndexReady(GetProperty(property))) {
         continue;
@@ -882,6 +892,10 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         continue;
       }
 
+      // Skip nested lookups: a single-property edge index cannot cover a multi-element path.
+      if (filter.property_filter->property_ids_.path.size() != 1) {
+        continue;
+      }
       const auto &property = filter.property_filter->property_ids_.path[0];
       if (!db_->EdgeTypePropertyIndexReady(edge_type_from_relationship.value(), GetProperty(property))) {
         continue;

--- a/src/query/plan/rewrite/general.cpp
+++ b/src/query/plan/rewrite/general.cpp
@@ -12,8 +12,21 @@
 #include "query/plan/rewrite/general.hpp"
 
 #include "query/frontend/ast/ast.hpp"
+#include "query/frontend/semantic/symbol_table.hpp"
+#include "query/plan/operator.hpp"
 
 namespace memgraph::query::plan {
+
+UnwoundMembershipList UnwindMembershipList(SymbolTable &symbol_table, AstStorage *ast_storage,
+                                           std::shared_ptr<LogicalOperator> input, Expression *list_expr) {
+  auto const &symbol = symbol_table.CreateAnonymousSymbol();
+  auto *element = ast_storage->Create<Identifier>(symbol.name());
+  element->MapTo(symbol);
+  auto *empty_list = ast_storage->Create<ListLiteral>(std::vector<Expression *>{});
+  auto *guarded = ast_storage->Create<Coalesce>(std::vector<Expression *>{list_expr, empty_list});
+  auto *deduped = ast_storage->Create<Function>("TOSET", std::vector<Expression *>{guarded});
+  return {.op = std::make_shared<Unwind>(std::move(input), deduped, symbol), .element = element};
+}
 
 ExpressionRemovalResult RemoveExpressions(Expression *expr, const std::unordered_set<Expression *> &exprs_to_remove,
                                           AstStorage *storage) {

--- a/src/query/plan/rewrite/general.hpp
+++ b/src/query/plan/rewrite/general.hpp
@@ -16,20 +16,45 @@
 
 #pragma once
 
+#include <memory>
 #include <unordered_set>
 
 #include "query/frontend/ast/query/expression.hpp"
 
 namespace memgraph::query {
 class AstStorage;
+class Identifier;
+class SymbolTable;
 }  // namespace memgraph::query
 
 namespace memgraph::query::plan {
+
+class LogicalOperator;
 
 struct ExpressionRemovalResult {
   Expression *trimmed_expression;
   bool did_remove{false};
 };
+
+/// A membership list lowered to an Unwind for a per-element index scan.
+struct UnwoundMembershipList {
+  /// Unwind(toSet(coalesce(list, []))) wrapping the caller's input.
+  std::shared_ptr<LogicalOperator> op;
+  /// Identifier bound to each unwound element, to drive the downstream scan.
+  Identifier *element;
+};
+
+/// Lower an `x IN list` filter to the input of a per-element index scan. Wraps
+/// `input` in Unwind(toSet(coalesce(list_expr, []))): coalesce turns a null
+/// list into zero rows instead of throwing in Unwind (matching the membership
+/// Filter; a non-list scalar still throws), and toSet dedups so a value
+/// repeated in the list drives a single scan. The dedup collapses whole-number
+/// doubles onto their int, safe only because the downstream scan unifies them
+/// too: an id scan coerces to an int64 id, and the property index compares
+/// numerics cross-type, so a collapsed value still matches what the raw list
+/// would.
+UnwoundMembershipList UnwindMembershipList(SymbolTable &symbol_table, AstStorage *ast_storage,
+                                           std::shared_ptr<LogicalOperator> input, Expression *list_expr);
 
 // Return the new root expression after removing the given expressions from the
 // given expression tree. This function does NOT modify the original expression tree;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -354,7 +354,17 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     std::optional<ProvidedScan> provided;
     if (indexed_scan && !has_in_filter) {
       if (auto *scan_by_props = dynamic_cast<ScanAllByLabelProperties *>(indexed_scan.get())) {
-        provided = scan_by_props;
+        // A value scan fed by an Unwind is invoked once per unwound element
+        // (e.g. a user UNWIND driving an equality lookup). When the lookup value
+        // derives from the element the results follow element order, not
+        // property order, so the scan cannot be assumed to provide ordered
+        // iteration and must not eliminate an ORDER BY. Suppressing is
+        // conservative: an element-independent value is still ordered, but at
+        // worst we keep an unnecessary sort. The IN-list lowering is already
+        // covered by has_in_filter.
+        if (!(scan_by_props->input() && scan_by_props->input()->GetTypeInfo() == Unwind::kType)) {
+          provided = scan_by_props;
+        }
       }
     }
     order_by_eliminator_.NotifyScan(provided);
@@ -1599,25 +1609,12 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     };
 
     // Lower an `x IN list` filter to a per-element index scan: chain
-    // Unwind(toSet(coalesce(list_expr, []))) onto op_input and return the
+    // Unwind(toSet(coalesce(list_expr, []))) onto `input` and return the
     // anonymous identifier bound to each unwound element for the caller's scan.
-    // coalesce turns a null list into zero rows instead of throwing in Unwind
-    // (matching the membership Filter; a non-list scalar still throws), and
-    // toSet dedups so a value repeated in the list drives a single scan. The
-    // dedup collapses whole-number doubles onto their int, safe only because the
-    // downstream scan unifies them too: ScanAllById coerces to an int64 id, and
-    // the label+property index compares numerics cross-type, so a collapsed
-    // value still matches what the raw list would.
-    auto unwind_membership_list = [&](std::shared_ptr<LogicalOperator> &op_input,
-                                      Expression *list_expr) -> Identifier * {
-      auto const &symbol = symbol_table_->CreateAnonymousSymbol();
-      auto *element = ast_storage_->Create<Identifier>(symbol.name());
-      element->MapTo(symbol);
-      auto *empty_list = ast_storage_->Create<ListLiteral>(std::vector<Expression *>{});
-      auto *guarded = ast_storage_->Create<Coalesce>(std::vector<Expression *>{list_expr, empty_list});
-      auto *deduped = ast_storage_->Create<Function>("TOSET", std::vector<Expression *>{guarded});
-      op_input = std::make_shared<Unwind>(op_input, deduped, symbol);
-      return element;
+    auto unwind_membership_list = [&](Expression *list_expr) -> Identifier * {
+      auto unwound = UnwindMembershipList(*symbol_table_, ast_storage_, input, list_expr);
+      input = std::move(unwound.op);
+      return unwound.element;
     };
 
     // TODO(buda): ScanAllByLabelProperty + Filter should be considered
@@ -1627,7 +1624,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     auto make_unwinds = [&](FilterInfo const &filter_info) -> FilterInfo {
       if (filter_info.property_filter->type_ == PropertyFilter::Type::IN) {
         FilterInfo cpy = filter_info;
-        cpy.property_filter->value_ = unwind_membership_list(input, filter_info.property_filter->value_);
+        cpy.property_filter->value_ = unwind_membership_list(filter_info.property_filter->value_);
         return cpy;
       }
       return filter_info;
@@ -1646,7 +1643,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         if (filter.id_filter->type_ == IdFilter::Type::IN) {
           // has_in_filter is set below so order-by elimination is disabled and
           // an ORDER BY id(n) over the unwound scan is not wrongly elided.
-          auto *element = unwind_membership_list(input, value);
+          auto *element = unwind_membership_list(value);
           return ScanByIndexResult{
               std::make_shared<ScanAllById>(input, node_symbol, element, view, /*expects_string_id=*/false),
               std::move(metadata),

--- a/src/query/plan/rewrite/order_by_elimination.hpp
+++ b/src/query/plan/rewrite/order_by_elimination.hpp
@@ -287,6 +287,13 @@ class OrderByEliminator {
             size_t ob_ptr = 0;
             for (size_t i = 0; i < s->properties_.size() && ob_ptr < group_size; ++i) {
               if (s->properties_[i] == entries[group_start + ob_ptr].resolved) {
+                // A composite index stores a missing property as NULL and sorts
+                // NULL first, but ORDER BY places NULL last, so the index order
+                // only matches ORDER BY when the sort column cannot be NULL. A
+                // column is guaranteed non-null when it carries a filter (every
+                // filter type -- EQUAL/RANGE/REGEX/IN/IS_NOT_NULL -- excludes
+                // NULL); an unconstrained column (no range entry) may be NULL.
+                if (i >= s->expression_ranges_.size()) return false;
                 ++ob_ptr;
               } else if (i < s->expression_ranges_.size() &&
                          s->expression_ranges_[i].type_ == PropertyFilter::Type::EQUAL) {

--- a/tests/e2e/query_planning/query_planning_orderby_index.py
+++ b/tests/e2e/query_planning/query_planning_orderby_index.py
@@ -57,7 +57,9 @@ def test_plan_with_renaming_allows_elimination(memgraph):
 
 
 def test_plan_equality_skip_elimination(memgraph):
-    """WHERE a = 5 ORDER BY b eliminated when index is (a, b) -- equality-pinned skip."""
+    """WHERE a = 5 AND b IS NOT NULL ORDER BY b eliminated when index is (a, b) -- equality-pinned
+    skip; b IS NOT NULL keeps the sort column non-nullable so the index order (NULL first) cannot
+    disagree with ORDER BY (NULL last)."""
     memgraph.execute("CREATE INDEX ON :L(a, b);")
 
     expected = [
@@ -66,8 +68,17 @@ def test_plan_equality_skip_elimination(memgraph):
         " * Once",
     ]
 
-    actual = get_plan(memgraph, "MATCH (n:L) WHERE n.a = 5 RETURN n ORDER BY n.b")
+    actual = get_plan(memgraph, "MATCH (n:L) WHERE n.a = 5 AND n.b IS NOT NULL RETURN n ORDER BY n.b")
     assert expected == actual
+
+
+def test_plan_nullable_suffix_not_eliminated(memgraph):
+    """A nullable suffix column keeps its ORDER BY: a composite index sorts a missing NULL first
+    while ORDER BY places it last, so eliminating the sort would misorder the results."""
+    memgraph.execute("CREATE INDEX ON :L(a, b);")
+
+    plan = get_plan(memgraph, "MATCH (n:L) WHERE n.a = 5 RETURN n ORDER BY n.b")
+    assert any("OrderBy" in step for step in plan), "OrderBy must be kept for an unconstrained (nullable) suffix column"
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +129,17 @@ def test_correctness_composite_order(memgraph):
     results = list(memgraph.execute_and_fetch("MATCH (n:L) WHERE n.a > 0 RETURN n ORDER BY n.a, n.b"))
     pairs = [(r["n"]._properties["a"], r["n"]._properties["b"]) for r in results]
     assert pairs == [(1, 1), (1, 2), (2, 1), (2, 3), (3, 1)]
+
+
+def test_correctness_nullable_suffix_null_last(memgraph):
+    """A missing suffix property sorts last under ORDER BY (NULL last), even though the composite
+    index stores the missing value first. The sort must not be eliminated here."""
+    memgraph.execute("CREATE INDEX ON :L(a, b);")
+    memgraph.execute("CREATE (:L {a: 5, b: 3}), (:L {a: 5, b: 1}), (:L {a: 5}), (:L {a: 5, b: 2})")
+
+    results = list(memgraph.execute_and_fetch("MATCH (n:L) WHERE n.a = 5 RETURN n.b AS b ORDER BY n.b"))
+    values = [r["b"] for r in results]
+    assert values == [1, 2, 3, None]
 
 
 def test_correctness_with_expand(memgraph):
@@ -182,10 +204,13 @@ def test_correctness_in_filter_order_preserved(memgraph):
 
 
 def test_plan_composite_alias_elimination(memgraph):
-    """ORDER BY a, b eliminated when WITH projects both from composite index (a, b)."""
+    """ORDER BY a, b eliminated when WITH projects both from composite index (a, b); b IS NOT NULL
+    keeps the nullable suffix column non-null so elimination stays sound."""
     memgraph.execute("CREATE INDEX ON :L(a, b);")
 
-    plan = get_plan(memgraph, "MATCH (n:L) WHERE n.a > 0 WITH n.a AS a, n.b AS b RETURN a, b ORDER BY a, b")
+    plan = get_plan(
+        memgraph, "MATCH (n:L) WHERE n.a > 0 AND n.b IS NOT NULL WITH n.a AS a, n.b AS b RETURN a, b ORDER BY a, b"
+    )
     assert not any("OrderBy" in step for step in plan), "OrderBy should be eliminated (composite alias resolved)"
 
 

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -316,6 +316,68 @@ TYPED_TEST(InterpreterTest, PropertyInListIndexedEquivalence) {
   EXPECT_ANY_THROW(this->Interpret("MATCH (n:L) WHERE n.prop IN $v RETURN n", {{"v", EPV(int64_t{1})}}));
 }
 
+// With an edge-type+property index, e.prop IN <list> unwinds the list into
+// per-element index lookups. Like the vertex path, this must stay
+// result-identical to the membership Filter: an edge matched by a duplicated
+// element is emitted once, a parameter list drives the same lookup, null and
+// empty yield no rows, and a non-list scalar throws.
+TYPED_TEST(InterpreterTest, EdgePropertyInListIndexedEquivalence) {
+  using EPV = memgraph::storage::ExternalPropertyValue;
+
+  // Edge-type indexes are only supported on in-memory storage.
+  if constexpr (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    return;
+  }
+
+  this->Interpret("CREATE EDGE INDEX ON :R(prop)");
+  this->Interpret("CREATE ()-[:R {prop: 1}]->(), ()-[:R {prop: 2}]->(), ()-[:R {prop: 3}]->()");
+
+  auto count = [&](const std::string &query, EPV::map_t params = {}) {
+    auto stream = this->Interpret(query, params);
+    return static_cast<int64_t>(stream.GetResults().size());
+  };
+  auto list = [](std::vector<EPV> xs) { return EPV(std::move(xs)); };
+
+  // Duplicate list elements must not emit a matched edge more than once.
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN [1, 1] RETURN e"), 1);
+  // Whole-number doubles collapse onto their int, and the index matches both.
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN [1, 1.0] RETURN e"), 1);
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN [1, 2] RETURN e"), 2);
+
+  // A parameter list drives the same indexed lookup.
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN $v RETURN e", {{"v", list({EPV(int64_t{1}), EPV(int64_t{2})})}}),
+            2);
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN $v RETURN e", {{"v", list({EPV(int64_t{1}), EPV(int64_t{1})})}}),
+            1);
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN $v RETURN e", {{"v", EPV{}}}), 0);     // null -> 0 rows
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN $v RETURN e", {{"v", list({})}}), 0);  // empty -> 0 rows
+  EXPECT_EQ(count("MATCH ()-[e:R]->() WHERE e.prop IN $v RETURN e", {{"v", list({EPV(int64_t{9})})}}), 0);  // no match
+
+  // A non-list scalar parameter throws, matching the membership Filter.
+  EXPECT_ANY_THROW(this->Interpret("MATCH ()-[e:R]->() WHERE e.prop IN $v RETURN e", {{"v", EPV(int64_t{1})}}));
+}
+
+// The Unwind feeding an edge property-index scan emits edges in per-element
+// order, so an ORDER BY on the indexed property must still sort rather than
+// being elided as already-ordered.
+TYPED_TEST(InterpreterTest, EdgePropertyInListOrderByNotElided) {
+  using EPV = memgraph::storage::ExternalPropertyValue;
+
+  // Edge-type indexes are only supported on in-memory storage.
+  if constexpr (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    return;
+  }
+
+  this->Interpret("CREATE EDGE INDEX ON :R(prop)");
+  this->Interpret("CREATE ()-[:R {prop: 1}]->(), ()-[:R {prop: 2}]->(), ()-[:R {prop: 3}]->()");
+
+  // Drive the scan with the values out of order; ORDER BY must re-sort.
+  auto stream = this->Interpret("MATCH ()-[e:R]->() WHERE e.prop IN [3, 1, 2] RETURN e.prop AS prop ORDER BY e.prop");
+  std::vector<int64_t> out;
+  for (const auto &row : stream.GetResults()) out.push_back(row[0].ValueInt());
+  EXPECT_THAT(out, testing::ElementsAre(1, 2, 3));
+}
+
 // `id(n) IN <list>` is lowered to Unwind(toSet(coalesce(value, []))) feeding a
 // per-element ScanAllById. The optimised plan must be result-identical to the
 // ScanAll + membership Filter it replaces for every input shape.
@@ -382,6 +444,21 @@ TYPED_TEST(InterpreterTest, IdInListOrderByNotElided) {
   EXPECT_THAT(out, testing::ElementsAreArray(ids));
 }
 
+// A user UNWIND driving a label+property equality lookup feeds the value scan
+// per element, so its output follows list order, not property order. An ORDER
+// BY on the property must still sort rather than being elided as
+// already-ordered.
+TYPED_TEST(InterpreterTest, PropertyEqualityFromUnwindOrderByNotElided) {
+  this->Interpret("CREATE INDEX ON :L(prop)");
+  this->Interpret("CREATE (:L {prop: 1}), (:L {prop: 2}), (:L {prop: 3})");
+
+  auto stream =
+      this->Interpret("UNWIND [3, 1, 2] AS x MATCH (n:L) WHERE n.prop = x RETURN n.prop AS prop ORDER BY n.prop");
+  std::vector<int64_t> out;
+  for (const auto &row : stream.GetResults()) out.push_back(row[0].ValueInt());
+  EXPECT_THAT(out, testing::ElementsAre(1, 2, 3));
+}
+
 // `MATCH (n:L) WHERE id(n) IN $ids` selects the id scan and keeps the label as a
 // residual filter, so only labelled vertices come back.
 TYPED_TEST(InterpreterTest, IdInListLabelResidual) {
@@ -402,6 +479,63 @@ TYPED_TEST(InterpreterTest, IdInListLabelResidual) {
   std::vector<int64_t> out;
   for (const auto &row : stream.GetResults()) out.push_back(row[0].ValueInt());
   EXPECT_THAT(out, testing::ElementsAreArray(labelled));
+}
+
+// `id(e) IN <list>` over an edge is lowered to Unwind(toSet(coalesce(value,
+// []))) feeding a per-element ScanAllByEdgeId, mirroring the vertex id scan. On
+// in-memory storage the optimised plan must be result-identical to the ScanAll
+// + membership Filter it replaces for every input shape. On-disk storage does
+// not implement edge id lookup, so IN stays consistent with `id(e) = x` there
+// and surfaces the same unsupported-operation error rather than silently
+// returning nothing.
+TYPED_TEST(InterpreterTest, EdgeIdInListEquivalence) {
+  using EPV = memgraph::storage::ExternalPropertyValue;
+
+  // Three edges; capture their ids in creation order.
+  std::vector<int64_t> ids;
+  {
+    auto stream = this->Interpret("UNWIND range(1, 3) AS i CREATE ()-[r:R]->() RETURN id(r) AS id");
+    for (const auto &row : stream.GetResults()) ids.push_back(row[0].ValueInt());
+  }
+  ASSERT_EQ(ids.size(), 3U);
+  std::sort(ids.begin(), ids.end());
+  const int64_t present = ids.front();
+  const int64_t missing = ids.back() + 1000;
+  auto list = [](std::vector<EPV> xs) { return EPV(std::move(xs)); };
+
+  if constexpr (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    EXPECT_ANY_THROW(
+        this->Interpret("MATCH ()-[e]->() WHERE id(e) IN $ids RETURN id(e)", {{"ids", list({EPV(present)})}}));
+    return;
+  }
+
+  auto matched_ids = [&](EPV ids_param) {
+    auto stream =
+        this->Interpret("MATCH ()-[e]->() WHERE id(e) IN $ids RETURN id(e) AS id", {{"ids", std::move(ids_param)}});
+    std::vector<int64_t> out;
+    for (const auto &row : stream.GetResults()) out.push_back(row[0].ValueInt());
+    std::sort(out.begin(), out.end());
+    return out;
+  };
+  const auto present_dbl = static_cast<double>(present);
+
+  EXPECT_THAT(matched_ids(list({EPV(ids[0]), EPV(ids[1]), EPV(ids[2])})),  // all present -> all matched
+              testing::ElementsAreArray(ids));
+  EXPECT_THAT(matched_ids(EPV{}), testing::IsEmpty());          // null parameter -> 0 rows
+  EXPECT_THAT(matched_ids(list({})), testing::IsEmpty());       // empty list -> 0 rows
+  EXPECT_THAT(matched_ids(list({EPV(present), EPV(present)})),  // duplicates -> once
+              testing::ElementsAre(present));
+  EXPECT_THAT(matched_ids(list({EPV(present), EPV(present_dbl)})),  // int/double dup -> once
+              testing::ElementsAre(present));
+  EXPECT_THAT(matched_ids(list({EPV(present), EPV{}})),  // null element dropped
+              testing::ElementsAre(present));
+  EXPECT_THAT(matched_ids(list({EPV(1.5), EPV(std::string("x"))})),  // no coercible id -> none
+              testing::IsEmpty());
+  EXPECT_THAT(matched_ids(list({EPV(present_dbl)})), testing::ElementsAre(present));  // exact-int double matches
+  EXPECT_THAT(matched_ids(list({EPV(missing)})), testing::IsEmpty());                 // missing id -> 0 rows
+
+  // A non-list scalar throws, matching the membership Filter's "IN expected a list".
+  EXPECT_ANY_THROW(this->Interpret("MATCH ()-[e]->() WHERE id(e) IN $ids RETURN e", {{"ids", EPV(int64_t{5})}}));
 }
 
 // Run CREATE/MATCH/MERGE queries with property map

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -516,6 +516,36 @@ TYPED_TEST(InterpreterTest, CompositeIndexNullableSuffixOrderByNotElided) {
               testing::ElementsAre(1, 2, 3));
 }
 
+// The DESC counterpart: a DESC composite index sorts NULL last (a full reversal
+// of ASC's NULL-first), but ORDER BY ... DESC places NULL first, so the mismatch
+// is symmetric and the sort must be kept for DESC too. Eliminating it (e.g. by
+// gating the guard on ASC only) would return NULLs last here.
+TYPED_TEST(InterpreterTest, CompositeIndexNullableSuffixDescOrderByNotElided) {
+  // Composite indexes are only supported on in-memory storage.
+  if constexpr (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    return;
+  }
+
+  this->Interpret(R"(CREATE INDEX ON :L(a, b) WITH CONFIG {"order": "DESC"})");
+  // One row leaves b missing (stored as NULL in the index).
+  this->Interpret("CREATE (:L {a: 5, b: 3}), (:L {a: 5, b: 1}), (:L {a: 5}), (:L {a: 5, b: 2})");
+
+  auto values = [&](const std::string &query) {
+    auto stream = this->Interpret(query);
+    std::vector<int64_t> out;
+    for (const auto &row : stream.GetResults()) {
+      out.push_back(row[0].type() == memgraph::communication::bolt::Value::Type::Null ? -1 : row[0].ValueInt());
+    }
+    return out;
+  };
+
+  // Unconstrained suffix, DESC: NULL must sort first, not last.
+  EXPECT_THAT(values("MATCH (n:L) WHERE n.a = 5 RETURN n.b AS b ORDER BY n.b DESC"), testing::ElementsAre(-1, 3, 2, 1));
+  // With LIMIT the misordering would return the wrong rows entirely.
+  EXPECT_THAT(values("MATCH (n:L) WHERE n.a = 5 RETURN n.b AS b ORDER BY n.b DESC LIMIT 2"),
+              testing::ElementsAre(-1, 3));
+}
+
 // `MATCH (n:L) WHERE id(n) IN $ids` selects the id scan and keeps the label as a
 // residual filter, so only labelled vertices come back.
 TYPED_TEST(InterpreterTest, IdInListLabelResidual) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -459,6 +459,40 @@ TYPED_TEST(InterpreterTest, PropertyEqualityFromUnwindOrderByNotElided) {
   EXPECT_THAT(out, testing::ElementsAre(1, 2, 3));
 }
 
+// A composite index stores a missing property as NULL and sorts NULL first,
+// but Cypher ORDER BY places NULL last. When an ORDER BY targets an unconstrained
+// suffix column of the index (only the prefix is pinned), the scan's index order
+// disagrees with ORDER BY on NULL placement, so the sort must not be eliminated.
+// A constrained suffix column (its own filter excludes NULL) is safe to eliminate.
+TYPED_TEST(InterpreterTest, CompositeIndexNullableSuffixOrderByNotElided) {
+  // Composite indexes are only supported on in-memory storage.
+  if constexpr (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    return;
+  }
+
+  this->Interpret("CREATE INDEX ON :L(a, b)");
+  // One row leaves b missing (stored as NULL in the index).
+  this->Interpret("CREATE (:L {a: 5, b: 3}), (:L {a: 5, b: 1}), (:L {a: 5}), (:L {a: 5, b: 2})");
+
+  // Records each row's b as an int, or -1 for NULL, preserving result order.
+  auto values = [&](const std::string &query) {
+    auto stream = this->Interpret(query);
+    std::vector<int64_t> out;
+    for (const auto &row : stream.GetResults()) {
+      out.push_back(row[0].type() == memgraph::communication::bolt::Value::Type::Null ? -1 : row[0].ValueInt());
+    }
+    return out;
+  };
+
+  // Unconstrained suffix: NULL must sort last, not first.
+  EXPECT_THAT(values("MATCH (n:L) WHERE n.a = 5 RETURN n.b AS b ORDER BY n.b"), testing::ElementsAre(1, 2, 3, -1));
+  // With LIMIT the misordering would return the wrong rows entirely.
+  EXPECT_THAT(values("MATCH (n:L) WHERE n.a = 5 RETURN n.b AS b ORDER BY n.b LIMIT 2"), testing::ElementsAre(1, 2));
+  // A constrained suffix stays correct (and remains eligible for elimination).
+  EXPECT_THAT(values("MATCH (n:L) WHERE n.a = 5 AND n.b > 0 RETURN n.b AS b ORDER BY n.b"),
+              testing::ElementsAre(1, 2, 3));
+}
+
 // `MATCH (n:L) WHERE id(n) IN $ids` selects the id scan and keeps the label as a
 // residual filter, so only labelled vertices come back.
 TYPED_TEST(InterpreterTest, IdInListLabelResidual) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -459,6 +459,29 @@ TYPED_TEST(InterpreterTest, PropertyEqualityFromUnwindOrderByNotElided) {
   EXPECT_THAT(out, testing::ElementsAre(1, 2, 3));
 }
 
+// A nested property predicate `e.a.b = x` filters on the path [a, b], which no
+// single-property edge index covers. With an edge index on the outer key `a`,
+// the rewriter must not reinterpret it as `e.a = x` (which would compare the
+// whole map to a scalar and drop the real predicate); it must keep the filter.
+TYPED_TEST(InterpreterTest, EdgeNestedPropertyFilterNotIndexMisread) {
+  // Edge-type indexes are only supported on in-memory storage.
+  if constexpr (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    return;
+  }
+
+  this->Interpret("CREATE EDGE INDEX ON :T(a)");
+  this->Interpret("CREATE ()-[:T {a: {b: 5}}]->(), ()-[:T {a: {b: 99}}]->()");
+
+  auto count = [&](const std::string &query) {
+    auto stream = this->Interpret(query);
+    return static_cast<int64_t>(stream.GetResults().size());
+  };
+
+  EXPECT_EQ(count("MATCH ()-[e:T]->() WHERE e.a.b = 5 RETURN e"), 1);
+  EXPECT_EQ(count("MATCH ()-[e:T]->() WHERE e.a.b = 99 RETURN e"), 1);
+  EXPECT_EQ(count("MATCH ()-[e:T]->() WHERE e.a.b = 7 RETURN e"), 0);
+}
+
 // A composite index stores a missing property as NULL and sorts NULL first,
 // but Cypher ORDER BY places NULL last. When an ORDER BY targets an unconstrained
 // suffix column of the index (only the prefix is pinned), the scan's index order

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2435,6 +2435,15 @@ TYPED_TEST(TestPlanner, ScanAllByEdgeId) {
   CheckPlan<TypeParam>(query, this->storage, ExpectScanAllByEdgeId(), ExpectProduce());
 }
 
+TYPED_TEST(TestPlanner, ScanAllByEdgeIdInList) {
+  // MATCH ()-[r]->() WHERE id(r) IN $ids RETURN r lowers the IN-list to an
+  // Unwind feeding a per-element ScanAllByEdgeId, mirroring the vertex id scan.
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("anon1"), EDGE("r"), NODE("anon2"))),
+                                   WHERE(IN_LIST(FN("id", IDENT("r")), PARAMETER_LOOKUP(0))),
+                                   RETURN("r")));
+  CheckPlan<TypeParam>(query, this->storage, ExpectUnwind(), ExpectScanAllByEdgeId(), ExpectProduce());
+}
+
 TYPED_TEST(TestPlanner, ScanAllByElementId) {
   // Test MATCH (n) WHERE elementId(n) = "42" RETURN n
   auto *query = QUERY(

--- a/tests/unit/query_plan_orderby_index.cpp
+++ b/tests/unit/query_plan_orderby_index.cpp
@@ -173,6 +173,35 @@ TYPED_TEST(OrderByIndexTest, NullableSuffixNotEliminated) {
          "placement";
 }
 
+// The DESC counterpart of NullableSuffixNotEliminated: the NULL-placement
+// mismatch is symmetric across directions, so the guard must not be gated on
+// ASC. A DESC composite index sorts NULL last (a full reversal of ASC's
+// NULL-first), while ORDER BY ... DESC places NULL first, so an unconstrained
+// (nullable) suffix still disagrees on NULL placement and the sort must be kept.
+TYPED_TEST(OrderByIndexTest, NullableSuffixDescNotEliminated) {
+  // MATCH (n:L) WHERE n.a = 5 ORDER BY n.b DESC RETURN n, with a DESC index (a, b)
+  FakeDbAccessor dba;
+  const auto *const label_name = "L";
+  const auto label = dba.Label(label_name);
+  const auto prop_a = PROPERTY_PAIR(dba, "a");
+  const auto prop_b = PROPERTY_PAIR(dba, "b");
+  dba.SetIndexCount(label, 1);
+  std::vector<ms::PropertyPath> composite_props{ms::PropertyPath{prop_a.second}, ms::PropertyPath{prop_b.second}};
+  dba.SetIndexCount(label, std::span{composite_props}, 1, ms::IndexOrder::DESC);
+
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", label_name))),
+                                   WHERE(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5))),
+                                   RETURN("n", ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop_b.second), Ordering::DESC))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
+  EXPECT_TRUE(PlanContainsOp(planner.plan(), OrderBy::kType))
+      << "OrderBy must be kept: b is an unconstrained (nullable) suffix; a DESC index sorts NULL last but ORDER BY "
+         "DESC places NULL first, so the index order disagrees on NULL placement";
+}
+
 // Full composite - WHERE n.a = 5 ORDER BY n.a, n.b with index (a, b)
 TYPED_TEST(OrderByIndexTest, FullCompositeWithEquality) {
   // MATCH (n:L) WHERE n.a = 5 ORDER BY n.a, n.b RETURN n

--- a/tests/unit/query_plan_orderby_index.cpp
+++ b/tests/unit/query_plan_orderby_index.cpp
@@ -122,6 +122,34 @@ TYPED_TEST(OrderByIndexTest, CompositePrefix) {
 
 // Equality on first column, ORDER BY second -- equality-pinned skip allows elimination
 TYPED_TEST(OrderByIndexTest, EqualitySkipEliminated) {
+  // MATCH (n:L) WHERE n.a = 5 AND n.b IS NOT NULL ORDER BY n.b RETURN n
+  // b IS NOT NULL keeps the sort column non-nullable, so the index order (which
+  // sorts a missing/NULL b first) cannot disagree with ORDER BY's NULL-last.
+  FakeDbAccessor dba;
+  const auto *const label_name = "L";
+  const auto label = dba.Label(label_name);
+  const auto prop_a = PROPERTY_PAIR(dba, "a");
+  const auto prop_b = PROPERTY_PAIR(dba, "b");
+  dba.SetIndexCount(label, 1);
+  std::vector<ms::PropertyPath> composite_props{ms::PropertyPath{prop_a.second}, ms::PropertyPath{prop_b.second}};
+  dba.SetIndexCount(label, std::span{composite_props}, 1);
+
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", label_name))),
+                                   WHERE(AND(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5)),
+                                             NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second))))),
+                                   RETURN("n", ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop_b.second)))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
+  EXPECT_FALSE(PlanContainsOp(planner.plan(), OrderBy::kType))
+      << "OrderBy should be eliminated (a equality-pinned, b non-null, ORDER BY b follows in index)";
+}
+
+// A nullable suffix column (only the prefix is pinned) must NOT eliminate the
+// sort: the index sorts a missing NULL first while ORDER BY places it last.
+TYPED_TEST(OrderByIndexTest, NullableSuffixNotEliminated) {
   // MATCH (n:L) WHERE n.a = 5 ORDER BY n.b RETURN n
   FakeDbAccessor dba;
   const auto *const label_name = "L";
@@ -140,8 +168,9 @@ TYPED_TEST(OrderByIndexTest, EqualitySkipEliminated) {
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
   EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
-  EXPECT_FALSE(PlanContainsOp(planner.plan(), OrderBy::kType))
-      << "OrderBy should be eliminated (a is equality-pinned, ORDER BY b follows in index)";
+  EXPECT_TRUE(PlanContainsOp(planner.plan(), OrderBy::kType))
+      << "OrderBy must be kept: b is an unconstrained (nullable) suffix, so the index order disagrees on NULL "
+         "placement";
 }
 
 // Full composite - WHERE n.a = 5 ORDER BY n.a, n.b with index (a, b)
@@ -158,7 +187,8 @@ TYPED_TEST(OrderByIndexTest, FullCompositeWithEquality) {
 
   auto *query = QUERY(SINGLE_QUERY(
       MATCH(PATTERN(NODE("n", label_name))),
-      WHERE(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5))),
+      WHERE(AND(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5)),
+                NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second))))),
       RETURN("n", ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop_a.second), PROPERTY_LOOKUP(dba, "n", prop_b.second)))));
 
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
@@ -166,7 +196,7 @@ TYPED_TEST(OrderByIndexTest, FullCompositeWithEquality) {
 
   EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
   EXPECT_FALSE(PlanContainsOp(planner.plan(), OrderBy::kType))
-      << "OrderBy should be eliminated (full composite with equality)";
+      << "OrderBy should be eliminated (full composite; a pinned, b non-null)";
 }
 
 // With LIMIT - ORDER BY n.prop LIMIT 10
@@ -394,7 +424,7 @@ TYPED_TEST(OrderByIndexTest, EqualityPlusRangeOnSecondColumnEliminated) {
 
 // ORDER BY matches full composite index (a, b) with range on a -- elimination applies
 TYPED_TEST(OrderByIndexTest, FullCompositeRangeOnFirst) {
-  // MATCH (n:L) WHERE n.a > 5 ORDER BY n.a, n.b RETURN n
+  // MATCH (n:L) WHERE n.a > 5 AND n.b IS NOT NULL ORDER BY n.a, n.b RETURN n
   FakeDbAccessor dba;
   const auto *const label_name = "L";
   const auto label = dba.Label(label_name);
@@ -406,7 +436,8 @@ TYPED_TEST(OrderByIndexTest, FullCompositeRangeOnFirst) {
 
   auto *query = QUERY(SINGLE_QUERY(
       MATCH(PATTERN(NODE("n", label_name))),
-      WHERE(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5))),
+      WHERE(AND(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5)),
+                NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second))))),
       RETURN("n", ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop_a.second), PROPERTY_LOOKUP(dba, "n", prop_b.second)))));
 
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
@@ -414,7 +445,7 @@ TYPED_TEST(OrderByIndexTest, FullCompositeRangeOnFirst) {
 
   EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
   EXPECT_FALSE(PlanContainsOp(planner.plan(), OrderBy::kType))
-      << "OrderBy should be eliminated (ORDER BY n.a, n.b matches index (a, b) with range on a)";
+      << "OrderBy should be eliminated (range on a, b non-null, ORDER BY a, b matches index)";
 }
 
 // Equality on a + range on b, ORDER BY a, b -- equality-pinned column also in ORDER BY
@@ -687,7 +718,7 @@ TYPED_TEST(OrderByIndexTest, ReturnRenameOrderByOutputScope) {
 
 // Equality on a, equality on b, ORDER BY c -- double equality skip with index (a, b, c)
 TYPED_TEST(OrderByIndexTest, DoubleEqualitySkipEliminated) {
-  // MATCH (n:L) WHERE n.a = 1 AND n.b = 2 ORDER BY n.c RETURN n
+  // MATCH (n:L) WHERE n.a = 1 AND n.b = 2 AND n.c IS NOT NULL ORDER BY n.c RETURN n
   FakeDbAccessor dba;
   const auto *const label_name = "L";
   const auto label = dba.Label(label_name);
@@ -700,8 +731,9 @@ TYPED_TEST(OrderByIndexTest, DoubleEqualitySkipEliminated) {
   dba.SetIndexCount(label, std::span{composite_props}, 1);
 
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", label_name))),
-                                   WHERE(AND(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(1)),
-                                             EQ(PROPERTY_LOOKUP(dba, "n", prop_b.second), LITERAL(2)))),
+                                   WHERE(AND(AND(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(1)),
+                                                 EQ(PROPERTY_LOOKUP(dba, "n", prop_b.second), LITERAL(2))),
+                                             NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_c.second))))),
                                    RETURN("n", ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop_c.second)))));
 
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
@@ -709,7 +741,7 @@ TYPED_TEST(OrderByIndexTest, DoubleEqualitySkipEliminated) {
 
   EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
   EXPECT_FALSE(PlanContainsOp(planner.plan(), OrderBy::kType))
-      << "OrderBy should be eliminated (a and b equality-pinned, ORDER BY c follows in index)";
+      << "OrderBy should be eliminated (a and b equality-pinned, c non-null, ORDER BY c follows in index)";
 }
 
 // Equality on a, range on b, ORDER BY c -- range on b creates a gap, should NOT eliminate
@@ -899,7 +931,7 @@ TYPED_TEST(OrderByIndexTest, ReturnPropertyAliasEliminated) {
 
 // Composite index WITH n.a AS a, n.b AS b ORDER BY a, b -- both aliases resolved, order matches.
 TYPED_TEST(OrderByIndexTest, CompositeWithPropertyAliasEliminated) {
-  // MATCH (n:L) WHERE n.a > 0 WITH n.a AS a, n.b AS b RETURN a, b ORDER BY a, b
+  // MATCH (n:L) WHERE n.a > 0 AND n.b IS NOT NULL WITH n.a AS a, n.b AS b RETURN a, b ORDER BY a, b
   FakeDbAccessor dba;
   const auto *const label_name = "L";
   const auto label = dba.Label(label_name);
@@ -910,7 +942,8 @@ TYPED_TEST(OrderByIndexTest, CompositeWithPropertyAliasEliminated) {
   dba.SetIndexCount(label, std::span{composite_props}, 1);
 
   auto *match_clause = MATCH(PATTERN(NODE("n", label_name)));
-  match_clause->where_ = WHERE(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(0)));
+  match_clause->where_ = WHERE(AND(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(0)),
+                                   NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second)))));
   auto *with_clause =
       WITH(PROPERTY_LOOKUP(dba, "n", prop_a.second), AS("a"), PROPERTY_LOOKUP(dba, "n", prop_b.second), AS("b"));
   auto *return_clause = RETURN("a", "b", ORDER_BY(IDENT("a"), IDENT("b")));
@@ -986,7 +1019,7 @@ TYPED_TEST(OrderByIndexTest, WithPropertyDifferentAliasEliminated) {
 
 // Equality-pinned skip with alias -- WHERE a = 5 ORDER BY b, both through WITH.
 TYPED_TEST(OrderByIndexTest, EqualityPinnedWithPropertyAlias) {
-  // MATCH (n:L) WHERE n.a = 5 WITH n.a AS a, n.b AS b RETURN a, b ORDER BY b
+  // MATCH (n:L) WHERE n.a = 5 AND n.b IS NOT NULL WITH n.a AS a, n.b AS b RETURN a, b ORDER BY b
   FakeDbAccessor dba;
   const auto *const label_name = "L";
   const auto label = dba.Label(label_name);
@@ -997,7 +1030,8 @@ TYPED_TEST(OrderByIndexTest, EqualityPinnedWithPropertyAlias) {
   dba.SetIndexCount(label, std::span{composite_props}, 1);
 
   auto *match_clause = MATCH(PATTERN(NODE("n", label_name)));
-  match_clause->where_ = WHERE(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5)));
+  match_clause->where_ = WHERE(AND(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5)),
+                                   NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second)))));
   auto *with_clause =
       WITH(PROPERTY_LOOKUP(dba, "n", prop_a.second), AS("a"), PROPERTY_LOOKUP(dba, "n", prop_b.second), AS("b"));
   auto *return_clause = RETURN("a", "b", ORDER_BY(IDENT("b")));
@@ -1073,7 +1107,7 @@ TYPED_TEST(OrderByIndexTest, RenameChainBeforeProjectionEliminated) {
 
 // Composite rename chain -- WITH n AS m WITH m.a AS a, m.b AS b ORDER BY a, b.
 TYPED_TEST(OrderByIndexTest, CompositeRenameChainEliminated) {
-  // MATCH (n:L) WHERE n.a > 0 WITH n AS m WITH m.a AS a, m.b AS b RETURN a, b ORDER BY a, b
+  // MATCH (n:L) WHERE n.a > 0 AND n.b IS NOT NULL WITH n AS m WITH m.a AS a, m.b AS b RETURN a, b ORDER BY a, b
   FakeDbAccessor dba;
   const auto *const label_name = "L";
   const auto label = dba.Label(label_name);
@@ -1085,7 +1119,8 @@ TYPED_TEST(OrderByIndexTest, CompositeRenameChainEliminated) {
 
   auto *ident_n = IDENT("n");
   auto *match_clause = MATCH(PATTERN(NODE("n", label_name)));
-  match_clause->where_ = WHERE(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(0)));
+  match_clause->where_ = WHERE(AND(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(0)),
+                                   NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second)))));
   auto *with1_clause = WITH(ident_n, AS("m"));
   auto *with2_clause =
       WITH(PROPERTY_LOOKUP(dba, "m", prop_a.second), AS("a"), PROPERTY_LOOKUP(dba, "m", prop_b.second), AS("b"));
@@ -1318,7 +1353,8 @@ TYPED_TEST(OrderByIndexTest, DescCompositeDescOrderEliminated) {
   dba.SetIndexCount(label, std::span{composite_props}, 1, ms::IndexOrder::DESC);
 
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", label_name))),
-                                   WHERE(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5))),
+                                   WHERE(AND(GREATER(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5)),
+                                             NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second))))),
                                    RETURN("n",
                                           ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop_a.second),
                                                    Ordering::DESC,
@@ -1330,7 +1366,7 @@ TYPED_TEST(OrderByIndexTest, DescCompositeDescOrderEliminated) {
 
   EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
   EXPECT_FALSE(PlanContainsOp(planner.plan(), OrderBy::kType))
-      << "OrderBy DESC, DESC should be eliminated with DESC composite index";
+      << "OrderBy DESC, DESC should be eliminated with DESC composite index (b non-null)";
 }
 
 // DESC index with equality-pinned column + ORDER BY second column DESC → eliminated
@@ -1346,7 +1382,8 @@ TYPED_TEST(OrderByIndexTest, DescIndexEqualityPinnedEliminated) {
   dba.SetIndexCount(label, std::span{composite_props}, 1, ms::IndexOrder::DESC);
 
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", label_name))),
-                                   WHERE(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5))),
+                                   WHERE(AND(EQ(PROPERTY_LOOKUP(dba, "n", prop_a.second), LITERAL(5)),
+                                             NOT(IS_NULL(PROPERTY_LOOKUP(dba, "n", prop_b.second))))),
                                    RETURN("n", ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop_b.second), Ordering::DESC))));
 
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
@@ -1354,7 +1391,7 @@ TYPED_TEST(OrderByIndexTest, DescIndexEqualityPinnedEliminated) {
 
   EXPECT_TRUE(PlanContainsOp(planner.plan(), ScanAllByLabelProperties::kType));
   EXPECT_FALSE(PlanContainsOp(planner.plan(), OrderBy::kType))
-      << "OrderBy DESC on second column should be eliminated with DESC index and equality-pinned first column";
+      << "OrderBy DESC on second column should be eliminated with DESC index, a pinned and b non-null";
 }
 
 // Both ASC and DESC indices exist — ASC ORDER BY uses ASC, DESC ORDER BY uses DESC


### PR DESCRIPTION
Six silent wrong-results bugs in the planner's index-lookup and
ORDER BY-elimination rewrites, each a case the vertex path got right but the
edge or composite-index path did not. Fixed test-first (in-memory + on-disk).

- `id(e) IN [...]` on edges returned **zero rows**, now lowered to
  `Unwind -> ScanAllByEdgeId`.
  `MATCH ()-[e]->() WHERE id(e) IN [0,1,2] RETURN e`
- Edge `e.prop IN [...]` **duplicated rows** for repeated values, now deduped.
  `MATCH ()-[e:R]->() WHERE e.prop IN [1,1] RETURN e`
- `ORDER BY` **silently dropped** over an Unwind-fed value scan (edge + vertex).
  `... WHERE e.prop IN [3,1,2] RETURN e.prop ORDER BY e.prop`
- Composite-index nullable suffix **misordered NULL** (wrong rows under LIMIT).
  `MATCH (n:L) WHERE n.a = 5 RETURN n.b ORDER BY n.b LIMIT 2`
- Nested edge property `e.a.b = 5` **misread as `e.a = 5`**, wrong rows.
  `MATCH ()-[e:T]->() WHERE e.a.b = 5 RETURN e`
