### PR TITLE
fix: pin new transformers version to address vulnerabilities

### DIFF
--- a/mage/python/requirements-gpu.txt
+++ b/mage/python/requirements-gpu.txt
@@ -21,7 +21,7 @@ pyodbc==5.2.0
 python-Levenshtein==0.26.1
 scikit-learn==1.5.2
 scipy==1.13.1
-sentence-transformers==5.1.1
+sentence-transformers==5.6.0
 setuptools==81.0.0  # maximum version that can be used until torchmetrics doesn't rely on pkg_resources any more
 six==1.17.0
 transformers==5.13.0

--- a/mage/python/requirements-gpu.txt
+++ b/mage/python/requirements-gpu.txt
@@ -7,7 +7,7 @@ filelock==3.29.0
 gekko==1.2.1
 gensim==4.3.3
 gqlalchemy==1.8.0
-huggingface-hub==0.35.1
+huggingface-hub==1.22.0
 igraph==0.11.8
 mysql-connector-python==9.1.0
 neo4j==5.28.2

--- a/mage/python/requirements-gpu.txt
+++ b/mage/python/requirements-gpu.txt
@@ -24,6 +24,7 @@ scipy==1.13.1
 sentence-transformers==5.1.1
 setuptools==81.0.0  # maximum version that can be used until torchmetrics doesn't rely on pkg_resources any more
 six==1.17.0
+transformers==5.13.0
 torch==2.9.0
 torchmetrics==0.10.0
 litellm==1.85.0

--- a/mage/python/requirements.txt
+++ b/mage/python/requirements.txt
@@ -7,7 +7,7 @@ filelock==3.29.0
 gekko==1.2.1
 gensim==4.3.3
 gqlalchemy==1.8.0
-huggingface-hub==0.35.1
+huggingface-hub==1.22.0
 igraph==0.11.8
 jaraco-context==6.1.0
 mysql-connector-python==9.1.0

--- a/mage/python/requirements.txt
+++ b/mage/python/requirements.txt
@@ -22,7 +22,7 @@ pyodbc==5.2.0
 python-Levenshtein==0.26.1
 scikit-learn==1.5.2
 scipy==1.13.1
-sentence-transformers==5.1.1
+sentence-transformers==5.6.0
 setuptools==81.0.0  # maximum version that can be used until torchmetrics doesn't rely on pkg_resources any more
 six==1.17.0
 transformers==5.13.0

--- a/mage/python/requirements.txt
+++ b/mage/python/requirements.txt
@@ -25,6 +25,7 @@ scipy==1.13.1
 sentence-transformers==5.1.1
 setuptools==81.0.0  # maximum version that can be used until torchmetrics doesn't rely on pkg_resources any more
 six==1.17.0
+transformers==5.13.0
 torch==2.9.0+cpu; platform_machine != "aarch64"
 torch==2.9.0; platform_machine == "aarch64"
 torchmetrics==0.10.0 # current implementation of node_classification module depends on version <= 0.10.0


### PR DESCRIPTION
Pin a new version of `transformers` (used by `sentence-transformers`) to address these CVEs:
- https://nvd.nist.gov/vuln/detail/CVE-2026-4372
- https://github.com/advisories/GHSA-29pf-2h5f-8g72


