### PR TITLE
fix: Sending final response msg failure handling

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -388,7 +388,7 @@ void InMemoryReplicationHandlers::HeartbeatHandler(dbms::DbmsHandler *dbms_handl
 
   const storage::replication::HeartbeatRes res{
       true, commit_info.ldt_, last_epoch_with_commit, commit_info.num_committed_txns_};
-  rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
+  rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
 }
 
 void InMemoryReplicationHandlers::PrepareCommitHandler(
@@ -475,7 +475,7 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
     }
 
     const storage::replication::PrepareCommitRes res{false};
-    rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
+    rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
     return;
   }
 
@@ -493,7 +493,7 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
     two_pc_cache_.durability_commit_timestamp_ = req.durability_commit_timestamp;
     res.success = true;
   }
-  rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
+  rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
 }
 
 void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_handler,
@@ -640,10 +640,8 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
 
   if (!utils::RenamePath(src_snapshot_file, dst_snapshot_file)) {
     spdlog::error("Couldn't copy file from {} to {}", src_snapshot_file, dst_snapshot_file);
-    rpc::SendFinalResponse(storage::replication::SnapshotRes{std::nullopt, 0},
-                           request_version,
-                           res_builder,
-                           fmt::format("db: {}", storage->name()));
+    rpc::SendFinalResponse(
+        storage::replication::SnapshotRes{std::nullopt, 0}, request_version, res_builder, storage->name());
     return;
   }
 
@@ -652,10 +650,8 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
     auto storage_guard = std::unique_lock{storage->main_lock_, std::defer_lock};
     if (!storage_guard.try_lock_for(kWaitForMainLockTimeout)) {
       spdlog::error("Failed to acquire main lock in {}s", kWaitForMainLockTimeout.count());
-      rpc::SendFinalResponse(storage::replication::SnapshotRes{std::nullopt, 0},
-                             request_version,
-                             res_builder,
-                             fmt::format("db: {}", storage->name()));
+      rpc::SendFinalResponse(
+          storage::replication::SnapshotRes{std::nullopt, 0}, request_version, res_builder, storage->name());
       return;
     }
 
@@ -719,7 +715,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
           e.what());
       storage->Clear();
       const storage::replication::SnapshotRes res{std::nullopt, 0};
-      rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
+      rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
       return;
     }
   }
@@ -762,7 +758,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
   }};
 
   const storage::replication::SnapshotRes res{ldt, num_committed_txns};
-  rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
+  rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
 }
 
 // Commit timestamp on main's side shouldn't be updated if:
@@ -863,6 +859,22 @@ void InMemoryReplicationHandlers::WalFilesHandler(
 
   auto const &active_files = file_replication_handler.GetActiveFileNames();
 
+  // On a force reset the storage was cleared above, so the old durability files must be removed regardless of
+  // whether sending the response succeeds; otherwise a SendFinalResponse throw would orphan a stale WAL chain
+  // next to the reset seq_num 0 WAL and corrupt the next recovery. ProcessOldDurableFiles is a no-op when the
+  // reset wasn't requested. The guard body must never throw because it can run during stack unwinding.
+  utils::OnScopeExit const cleanup_old_durability_files{[&] {
+    try {
+      ProcessOldDurableFiles(req.reset_needed,
+                             storage->recovery_.snapshot_directory_,
+                             current_wal_directory,
+                             old_wal_files,
+                             &storage->file_retainer_);
+    } catch (const std::exception &e) {
+      spdlog::error("Failed to clean up old durability files after WAL files recovery: {}", e.what());
+    }
+  }};
+
   uint32_t local_batch_counter{0};
   uint64_t num_committed_txns{0};
   for (auto i = 0UL; i < wal_file_number; ++i) {
@@ -884,23 +896,7 @@ void InMemoryReplicationHandlers::WalFilesHandler(
   const storage::replication::WalFilesRes res{
       storage->repl_storage_state_.commit_ts_info_.load(std::memory_order_acquire).ldt_, num_committed_txns};
 
-  // On a force reset the storage was cleared above, so the old durability files must be removed regardless of
-  // whether sending the response succeeds; otherwise a SendFinalResponse throw would orphan a stale WAL chain
-  // next to the reset seq_num 0 WAL and corrupt the next recovery. ProcessOldDurableFiles is a no-op when the
-  // reset wasn't requested. The guard body must never throw because it can run during stack unwinding.
-  utils::OnScopeExit const cleanup_old_durability_files{[&] {
-    try {
-      ProcessOldDurableFiles(req.reset_needed,
-                             storage->recovery_.snapshot_directory_,
-                             current_wal_directory,
-                             old_wal_files,
-                             &storage->file_retainer_);
-    } catch (const std::exception &e) {
-      spdlog::error("Failed to clean up old durability files after WAL files recovery: {}", e.what());
-    }
-  }};
-
-  rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
+  rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
 }
 
 // Commit timestamp on MAIN's side shouldn't be updated if:
@@ -1024,7 +1020,7 @@ void InMemoryReplicationHandlers::CurrentWalHandler(
     }
   }};
 
-  rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
+  rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
 }
 
 // The method will return false and hence signal the failure of completely loading the WAL file if:

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -25,6 +25,7 @@
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/file.hpp"
 #include "utils/observer.hpp"
+#include "utils/on_scope_exit.hpp"
 
 #include <spdlog/spdlog.h>
 #include <optional>
@@ -726,37 +727,42 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
 
   auto const [ldt, num_committed_txns] = storage->repl_storage_state_.commit_ts_info_.load(std::memory_order_acquire);
 
+  // The old durability files (WALs and snapshots that predate this recovery snapshot) must be removed
+  // regardless of whether sending the response below succeeds. If SendFinalResponse throws (e.g. the
+  // connection to main drops mid-flush), leaving them behind orphans a stale WAL chain next to the
+  // freshly reset seq_num 0 WAL, which corrupts the next recovery. The guard body must never throw
+  // because it can run during stack unwinding.
+  utils::OnScopeExit const cleanup_old_durability_files{[&] {
+    try {
+      auto const current_wal_directory = storage->recovery_.wal_directory_;
+      auto const curr_snapshot_files = utils::GetFilesFromDir(current_snapshot_dir);
+      auto const curr_wal_files = utils::GetFilesFromDir(current_wal_directory);
+      auto const not_recovery_snapshot = [&dst_snapshot_file](auto const &snapshot_path) {
+        return snapshot_path != dst_snapshot_file;
+      };
+      auto snapshots_to_process = curr_snapshot_files | rv::filter(not_recovery_snapshot) | r::to_vector;
+
+      if (FLAGS_storage_backup_dir_enabled) {
+        auto const maybe_backup_dirs = CreateBackupDirectories(current_snapshot_dir, current_wal_directory);
+        if (!maybe_backup_dirs) {
+          spdlog::error("Couldn't create backup directories. Old durable files won't be moved to .old directory.");
+          return;
+        }
+        auto const &[backup_snapshot_dir, backup_wal_dir] = *maybe_backup_dirs;
+        MoveDurabilityFiles(
+            snapshots_to_process, backup_snapshot_dir, curr_wal_files, backup_wal_dir, &(storage->file_retainer_));
+      } else {
+        DeleteFiles(snapshots_to_process, &storage->file_retainer_);
+        DeleteFiles(curr_wal_files, &storage->file_retainer_);
+      }
+      spdlog::debug("Replication recovery from snapshot finished!");
+    } catch (const std::exception &e) {
+      spdlog::error("Failed to clean up old durability files after snapshot recovery: {}", e.what());
+    }
+  }};
+
   const storage::replication::SnapshotRes res{ldt, num_committed_txns};
   rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
-
-  auto const curr_snapshot_files = utils::GetFilesFromDir(current_snapshot_dir);
-  auto const current_wal_directory = storage->recovery_.wal_directory_;
-  auto const curr_wal_files = utils::GetFilesFromDir(current_wal_directory);
-  auto const not_recovery_snapshot = [&dst_snapshot_file](auto const &snapshot_path) {
-    return snapshot_path != dst_snapshot_file;
-  };
-
-  auto snapshots_to_process = curr_snapshot_files | rv::filter(not_recovery_snapshot) | r::to_vector;
-
-  if (FLAGS_storage_backup_dir_enabled) {
-    // Read durability files
-
-    auto const maybe_backup_dirs = CreateBackupDirectories(current_snapshot_dir, current_wal_directory);
-    if (!maybe_backup_dirs) {
-      spdlog::error("Couldn't create backup directories. Replica won't be recovered.");
-      const storage::replication::SnapshotRes res{std::nullopt, 0};
-      rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
-      return;
-    }
-    auto const &[backup_snapshot_dir, backup_wal_dir] = *maybe_backup_dirs;
-    MoveDurabilityFiles(
-        snapshots_to_process, backup_snapshot_dir, curr_wal_files, backup_wal_dir, &(storage->file_retainer_));
-  } else {
-    DeleteFiles(snapshots_to_process, &storage->file_retainer_);
-    DeleteFiles(curr_wal_files, &storage->file_retainer_);
-  }
-
-  spdlog::debug("Replication recovery from snapshot finished!");
 }
 
 // Commit timestamp on main's side shouldn't be updated if:
@@ -878,12 +884,23 @@ void InMemoryReplicationHandlers::WalFilesHandler(
   const storage::replication::WalFilesRes res{
       storage->repl_storage_state_.commit_ts_info_.load(std::memory_order_acquire).ldt_, num_committed_txns};
 
+  // On a force reset the storage was cleared above, so the old durability files must be removed regardless of
+  // whether sending the response succeeds; otherwise a SendFinalResponse throw would orphan a stale WAL chain
+  // next to the reset seq_num 0 WAL and corrupt the next recovery. ProcessOldDurableFiles is a no-op when the
+  // reset wasn't requested. The guard body must never throw because it can run during stack unwinding.
+  utils::OnScopeExit const cleanup_old_durability_files{[&] {
+    try {
+      ProcessOldDurableFiles(req.reset_needed,
+                             storage->recovery_.snapshot_directory_,
+                             current_wal_directory,
+                             old_wal_files,
+                             &storage->file_retainer_);
+    } catch (const std::exception &e) {
+      spdlog::error("Failed to clean up old durability files after WAL files recovery: {}", e.what());
+    }
+  }};
+
   rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
-  ProcessOldDurableFiles(req.reset_needed,
-                         storage->recovery_.snapshot_directory_,
-                         current_wal_directory,
-                         old_wal_files,
-                         &storage->file_retainer_);
 }
 
 // Commit timestamp on MAIN's side shouldn't be updated if:
@@ -991,12 +1008,23 @@ void InMemoryReplicationHandlers::CurrentWalHandler(
       storage->repl_storage_state_.commit_ts_info_.load(std::memory_order_acquire).ldt_,
       load_wal_res.num_txns_committed};
 
+  // On a force reset the storage was cleared above, so the old durability files must be removed regardless of
+  // whether sending the response succeeds; otherwise a SendFinalResponse throw would orphan a stale WAL chain
+  // next to the reset seq_num 0 WAL and corrupt the next recovery. ProcessOldDurableFiles is a no-op when the
+  // reset wasn't requested. The guard body must never throw because it can run during stack unwinding.
+  utils::OnScopeExit const cleanup_old_durability_files{[&] {
+    try {
+      ProcessOldDurableFiles(req.reset_needed,
+                             storage->recovery_.snapshot_directory_,
+                             current_wal_directory,
+                             old_wal_files,
+                             &storage->file_retainer_);
+    } catch (const std::exception &e) {
+      spdlog::error("Failed to clean up old durability files after current WAL recovery: {}", e.what());
+    }
+  }};
+
   rpc::SendFinalResponse(res, request_version, res_builder, fmt::format("db: {}", storage->name()));
-  ProcessOldDurableFiles(req.reset_needed,
-                         storage->recovery_.snapshot_directory_,
-                         current_wal_directory,
-                         old_wal_files,
-                         &storage->file_retainer_);
 }
 
 // The method will return false and hence signal the failure of completely loading the WAL file if:

--- a/src/rpc/utils.hpp
+++ b/src/rpc/utils.hpp
@@ -43,14 +43,18 @@ void SaveWithDowngrade(TResponse const &res, uint64_t const response_version, sl
 
 template <RpcMessage TResponse>
 void SendFinalResponse(TResponse const &res, uint64_t const response_version, slk::Builder *builder,
-                       std::string description = "") {
+                       std::string_view db_name = {}) {
   ProtocolMessageHeader const message_header{.protocol_version = current_protocol_version,
                                              .message_id = TResponse::kType.id,
                                              .message_version = response_version};
   SaveMessageHeader(message_header, builder);
   SaveWithDowngrade(res, response_version, builder);
   builder->Finalize();
-  spdlog::trace("[RpcServer] sent {}, version {}. {}", TResponse::kType.name, response_version, description);
+  if (db_name.empty()) {
+    spdlog::trace("[RpcServer] sent {}, version {}.", TResponse::kType.name, response_version);
+  } else {
+    spdlog::trace("[RpcServer] sent {}, version {}. db: {}", TResponse::kType.name, response_version, db_name);
+  }
 }
 
 inline void SendInProgressMsg(slk::Builder *builder) {


### PR DESCRIPTION
Regardless of whether the response is successfully sent for SnapshotRpc, WalFilesRpc and CurrentWalRpc, files should be moved to .old directory. The issue exists since a long time but wasn't seen until changes in https://github.com/memgraph/memgraph/pull/4314.