### PR TITLE
fix: Delay connecting a resumed MAIN to REPLICA until system tx commits

### DIFF
--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -964,7 +964,7 @@ struct SuspendDatabase : memgraph::system::ISystemAction {
 // ResumeDatabaseRpc; the replica rebuilds its own copy (COLD -> HOT) from its on-disk artifacts
 // identified by UUID, in system-timestamp order.
 struct ResumeDatabase : memgraph::system::ISystemAction {
-  explicit ResumeDatabase(utils::UUID uuid) : uuid_{uuid} {}
+  ResumeDatabase(utils::UUID uuid, DatabaseAccess db_acc) : uuid_{uuid}, db_acc_{std::move(db_acc)} {}
 
   void DoDurability() override { /* COLD marker cleared during Resume_ (before this action runs) */ }
 
@@ -980,10 +980,13 @@ struct ResumeDatabase : memgraph::system::ISystemAction {
         check_response, main_uuid, txn.last_committed_system_timestamp(), txn.timestamp(), uuid_);
   }
 
-  void PostReplication(replication::RoleMainData & /*mainData*/) const override {}
+  void PostReplication(replication::RoleMainData &mainData) const override {
+    dbms::DbmsHandler::RecoverStorageReplication(db_acc_, mainData);
+  }
 
  private:
   utils::UUID uuid_;
+  DatabaseAccess db_acc_;
 };
 
 DbmsHandler::SuspendResult DbmsHandler::Suspend_(std::string_view name, system::Transaction *txn, bool for_recovery) {
@@ -1225,8 +1228,7 @@ DbmsHandler::SuspendResult DbmsHandler::Suspend_(std::string_view name, system::
   return {};
 }
 
-DbmsHandler::ResumeResult DbmsHandler::Resume_(std::string_view name, bool rewire_replication, system::Transaction *txn,
-                                               bool *already_hot) {
+DbmsHandler::ResumeResult DbmsHandler::Resume_(std::string_view name, system::Transaction *txn, bool *already_hot) {
   // Outer loop: a loser keeps `continue`-ing only while the winner is demonstrably alive
   // (RESUMING/SUSPENDING), re-initializing gk/salient/rel_dir/won_resume from the map under a fresh
   // shared lock on each pass. All other exits (NON_EXISTENT, already-HOT, timeout, build failure, and
@@ -1477,20 +1479,12 @@ DbmsHandler::ResumeResult DbmsHandler::Resume_(std::string_view name, bool rewir
         }
       });
 
-      // POST-PUBLISH arm (replication). The tenant is ALREADY published HOT and erased from
-      // suspended_; we must NOT abort_resume() here (the gatekeeper is no longer RESUMING). The arm
-      // is independently retriable, so on failure we log and return the live accessor. Skipped when
-      // rewire_replication == false (the replica replication-apply caller holds the repl_state read
-      // lock and on_resume_repl_ would re-take it as a write lock -> self-deadlock). Wired in a later
-      // (replication) commit; on_resume_repl_ is empty by default here, so this is a no-op.
-      best_effort("replication re-wiring (may run un-replicated until re-established)", [&] {
-        if (rewire_replication && on_resume_repl_) on_resume_repl_(acc);
-      });
-
       // Record the system action so the resume is ordered + replicated like CREATE/DROP DATABASE.
-      // Reached only on the winner's successful publish; the replica wire is filled by DoReplication.
+      // DoReplication sends ResumeDatabaseRpc to each replica; PostReplication then re-wires the
+      // MAIN's outbound replication clients for this tenant (RecoverStorageReplication). This order
+      // ensures the replica has resumed its copy BEFORE the MAIN tries to connect to it.
       best_effort("recording the resume system action (may not replicate until the next system sync)", [&] {
-        if (txn) txn->AddAction<ResumeDatabase>(salient.uuid);
+        if (txn) txn->AddAction<ResumeDatabase>(salient.uuid, acc);
         spdlog::info("hot/cold: database '{}' resumed (COLD -> HOT)", name);
       });
       // Winner's own successful publish: a real COLD -> HOT rebuild, so already_hot is false.
@@ -1532,11 +1526,6 @@ DbmsHandler::SuspendResult DbmsHandler::SuspendByUUID(utils::UUID uuid, system::
 }
 
 DbmsHandler::ResumeResult DbmsHandler::ResumeByUUID(utils::UUID uuid, system::Transaction *txn) {
-  // Resolve UUID -> name from the suspended-set, then delegate to Resume_ with rewire_replication
-  // false — the replication-apply caller holds the repl_state read lock, so on_resume_repl_ must
-  // not re-take it as a write lock. The lock is dropped before Resume_ re-acquires it; Resume_
-  // re-validates the COLD shell under its own lock, so the brief TOCTOU is benign (a racing resume
-  // just makes Resume_ observe HOT and share the accessor).
   std::string name;
   {
     auto rd = std::shared_lock{lock_};
@@ -1544,7 +1533,7 @@ DbmsHandler::ResumeResult DbmsHandler::ResumeByUUID(utils::UUID uuid, system::Tr
     if (it == suspended_.end()) return std::unexpected{ResumeError::NON_EXISTENT};
     name = it->first;
   }
-  return Resume_(name, /*rewire_replication=*/false, txn);
+  return Resume_(name, txn);
 }
 
 void DbmsHandler::ApplyColdRecoveryMeta(std::string_view name, const storage::ColdTenantRecovery &meta) {

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -411,12 +411,6 @@ class DbmsHandler {
   void SetRestoreStreams(std::function<void(DatabaseAccess)> cb) { restore_streams_ = std::move(cb); }
 
   /**
-   * @brief Set the post-publish resume arm (runs AFTER the fresh gatekeeper is published).
-   *        Used for replication wiring. Default empty. Wired in a later (replication) commit.
-   */
-  void SetOnResumeRepl(std::function<void(DatabaseAccess)> cb) { on_resume_repl_ = std::move(cb); }
-
-  /**
    * @brief Resume (move COLD -> HOT) the named tenant, recovering its in-memory storage inline.
    *
    * Synchronous: recovery runs on the calling thread. Single-flight via the gatekeeper — concurrent
@@ -440,7 +434,7 @@ class DbmsHandler {
    */
   ResumeOutcomeResult Resume(std::string_view name, system::Transaction *txn = nullptr) {
     bool already_hot = false;
-    auto result = Resume_(name, /*rewire_replication=*/true, txn, &already_hot);
+    auto result = Resume_(name, txn, &already_hot);
     if (!result) return std::unexpected{result.error()};
     return ResumeOutcome{.db = std::move(*result), .already_hot = already_hot};
   }
@@ -459,9 +453,7 @@ class DbmsHandler {
   /**
    * @brief Resume a tenant identified by UUID (replica-apply path for ResumeDatabaseRpc).
    *
-   * Resolves the UUID to a name from the suspended-set, then runs Resume_ with
-   * rewire_replication=false (the caller holds the repl_state read lock; the post-publish
-   * replication arm would re-take it as a write lock -> self-deadlock).
+   * Resolves the UUID to a name from the suspended-set, then delegates to Resume_.
    *
    * @return ResumeResult — the HOT DatabaseAccess on success, NON_EXISTENT if no COLD tenant has
    *         this UUID (e.g. it was never suspended, or was already resumed by a racing caller).
@@ -579,13 +571,12 @@ class DbmsHandler {
   }
 
   /**
-   * @brief Resume a COLD tenant during replica SystemRecovery (rewire_replication=false).
+   * @brief Resume a COLD tenant during replica SystemRecovery.
    *
    * Called during SystemRecovery when MAIN's incoming HOT config names a tenant this replica holds
-   * COLD: Update() would throw on the COLD shell, so it must be resumed first. rewire=false because
-   * recovery runs in the replica apply context (on_resume_repl_ would re-take the repl_state lock).
+   * COLD: Update() would throw on the COLD shell, so it must be resumed first.
    */
-  ResumeResult ResumeForRecovery(std::string_view name) { return Resume_(name, /*rewire_replication=*/false); }
+  ResumeResult ResumeForRecovery(std::string_view name) { return Resume_(name); }
 
   /**
    * @brief Local uuid of a HOT tenant by name; nullopt if absent or COLD.
@@ -889,12 +880,6 @@ class DbmsHandler {
   /**
    * @brief Implementation of Resume. See Resume() for semantics.
    *
-   * rewire_replication: run the post-publish on_resume_repl_ arm (re-wire MAIN-side replication).
-   * MUST be false when called from the replica replication-apply path (added in a later commit):
-   * that caller already holds the repl_state read lock and on_resume_repl_ would re-take it as a
-   * write lock -> self-deadlock on the non-recursive RWSpinLock. Default true keeps the node-local
-   * (test + query-seam) callers unchanged.
-   *
    * txn: originating system transaction; on success records a ResumeDatabase system action (if
    * non-null) for ordered replication. Default nullptr keeps node-local callers unchanged.
    *
@@ -904,8 +889,7 @@ class DbmsHandler {
    * Left untouched on an error return. Default nullptr for callers that don't care (ResumeByUUID,
    * ResumeForRecovery, and Resume_'s own internal restarts).
    */
-  ResumeResult Resume_(std::string_view name, bool rewire_replication = true, system::Transaction *txn = nullptr,
-                       bool *already_hot = nullptr);
+  ResumeResult Resume_(std::string_view name, system::Transaction *txn = nullptr, bool *already_hot = nullptr);
 
   /**
    * @brief return the storage directory of the associated database
@@ -1138,8 +1122,7 @@ class DbmsHandler {
   std::function<void(DatabaseAccess)> on_resume_;    //!< pre-publish resume arm (triggers/streams/TTL); empty default
   std::function<void(DatabaseAccess)> on_suspend_;   //!< pre-teardown suspend arm (stop streams); empty default
   std::function<void(DatabaseAccess)>
-      restore_streams_;  //!< streams-only restore (undo a stopped suspend); empty default
-  std::function<void(DatabaseAccess)> on_resume_repl_;  //!< post-publish resume arm (replication); empty default
+      restore_streams_;                      //!< streams-only restore (undo a stopped suspend); empty default
   ResumeRetryPolicy resume_retry_policy_{};  //!< Resume_ retry/timeout knobs; test-overridable, production defaults
 #endif
 #ifndef MG_ENTERPRISE

--- a/src/dbms/replication_handlers.cpp
+++ b/src/dbms/replication_handlers.cpp
@@ -290,8 +290,6 @@ void ResumeDatabaseHandler(memgraph::system::ReplicaHandlerAccessToState &system
   }
 
   try {
-    // ResumeByUUID -> Resume_(rewire_replication=false). The apply thread holds no repl_state
-    // lock, so the post-publish replication arm (which would take a repl_state write lock) is skipped.
     auto result = dbms_handler.ResumeByUUID(req.uuid);
     if (result) {
       res = ResumeDatabaseRes(ResumeDatabaseRes::Result::SUCCESS);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -950,20 +950,6 @@ int main(int argc, char **argv) {
         return locked_repl_state->IsMainWriteable();
       });
     });
-    // Post-publish arm: re-establish per-replica storage clients for the resumed tenant on MAIN.
-    // lock_ is already released at the call site (dbms_handler.cpp publish block closes at :1394,
-    // durability lock_guard at :1423), so taking repl_state here is not a lock_->repl_state inversion.
-    // RecoverStorageReplication creates AND starts the per-replica clients; the existing FrequentCheck
-    // picks them up — do NOT also call StartReplicaClient (would double-spawn the heartbeat thread).
-    dh->SetOnResumeRepl([&repl_state](memgraph::dbms::DatabaseAccess db_acc) {
-      auto locked = repl_state->Lock();
-      std::visit(memgraph::utils::Overloaded{[&db_acc](memgraph::replication::RoleMainData &mainData) {
-                                               memgraph::dbms::DbmsHandler::RecoverStorageReplication(std::move(db_acc),
-                                                                                                      mainData);
-                                             },
-                                             [](auto &) {}},
-                 locked->ReplicationData());
-    });
   }
 #endif
 

--- a/tests/e2e/system_replication/hot_cold_convergence.py
+++ b/tests/e2e/system_replication/hot_cold_convergence.py
@@ -1661,5 +1661,42 @@ def test_drop_recreate_cold_tenant_uuid_fix_converges(connection, test_name):
     assert tenant_probe(main_cursor, "tenant_x")() == 8, "MAIN must also hold 8 nodes after the marker write"
 
 
+def test_write_after_resume_replicates(connection, test_name):
+    instances = {
+        "replica_1": replica_args(test_name, recovery=False),
+        "main": main_args(test_name),
+    }
+    interactive_mg_runner.start_all(instances, keep_directories=False)
+
+    replica_cursor = connection(BOLT_PORTS["replica_1"], "replica_1").cursor()
+    set_replica_role(replica_cursor)
+
+    main_cursor = connection(BOLT_PORTS["main"], "main").cursor()
+    register_replica(main_cursor, sync=True)
+
+    # Create and populate tenant A on MAIN; wait for replica convergence.
+    create_and_populate(main_cursor, "A", 5)
+    mg_sleep_and_assert(5, tenant_probe(replica_cursor, "A"))
+
+    # SUSPEND -> RESUME round trip.
+    execute_and_fetch_all(main_cursor, "USE DATABASE memgraph;")
+    execute_and_fetch_all(main_cursor, "SUSPEND DATABASE A;")
+    mg_sleep_and_assert("COLD", tenant_probe(replica_cursor, "A"))
+    execute_and_fetch_all(main_cursor, "RESUME DATABASE A;")
+    mg_sleep_and_assert(5, tenant_probe(replica_cursor, "A"))
+
+    execute_and_fetch_all(main_cursor, "USE DATABASE A;")
+    execute_and_fetch_all(main_cursor, "CREATE ();")
+
+    # Replica must converge to 6 nodes: the 5 original plus the new node
+    mg_sleep_and_assert(6, tenant_probe(replica_cursor, "A"))
+
+    # Replica must be "ready", not "invalid".
+    replicas = execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")
+    assert len(replicas) == 1
+    data_info = replicas[0][4]  # data_info column
+    assert data_info["A"]["status"] == "ready", f"Expected replica db A status 'ready', got: {data_info}"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))


### PR DESCRIPTION
`RESUME DATABASE` on MAIN re-wired its outbound replication clients inside `Resume_()`, before the system transaction committed. Because the commit is what sends `ResumeDatabaseRpc` to replicas, MAIN connected to a tenant that was still cold on the REPLICA.

Fixes the bug by moving the re-wiring from the `on_resume_repl_` callback in `Resume_()` into `ResumeDatabase::PostReplication(),` which runs after `DoReplication()`. This mirrors `CreateDatabase::PostReplication()`.                                          