### PR TITLE
fix(storage): retriable recovery on transient dir-read failure

### DIFF
--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -596,7 +596,13 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
   auto *const epoch_history = &repl_storage_state.history;
 
   auto const maybe_snapshot_files = GetSnapshotFiles(snapshot_directory_);
-  MG_ASSERT(maybe_snapshot_files.has_value(), "Couldn't recover data because of the failure to read snapshot files");
+  // A failed directory read here (e.g. ENOMEM from directory_iterator under memory pressure during a
+  // hot/cold RESUME) is transient and retriable, NOT a programmer-invariant violation. Throw
+  // RecoveryFailure so it propagates out of RecoverData -> the resume path catches it and keeps the tenant
+  // COLD (retriable), instead of MG_ASSERT turning a transient OOM into a whole-process crash.
+  if (!maybe_snapshot_files.has_value()) {
+    throw RecoveryFailure("Couldn't recover data because of the failure to read snapshot files");
+  }
   auto const &snapshot_files = *maybe_snapshot_files;
 
   RecoveryInfo recovery_info;
@@ -682,7 +688,11 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
         spdlog::error("Recovery failure while reading wal file: {}", e.what());
       }
     }
-    MG_ASSERT(!error_code, "Couldn't recover data because an error occurred: {}!", error_code.message());
+    // Transient directory-read failure (see the snapshot-files note above) — throw so a RESUME under
+    // memory pressure stays retriable instead of crashing the process.
+    if (error_code) {
+      throw RecoveryFailure("Couldn't recover data because an error occurred: {}!", error_code.message());
+    }
 
     if (wal_files.empty()) {
       spdlog::warn(utils::MessageWithLink("No snapshot or WAL file found.", "https://memgr.ph/durability"));
@@ -701,7 +711,10 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
                   repl_storage_state.epoch_.id());
   }
   auto const maybe_wal_files = GetWalFiles(wal_directory_, std::string{uuid});
-  MG_ASSERT(maybe_wal_files.has_value(), "Couldn't recover data because of the failure to read wal files");
+  // Transient directory-read failure (see the snapshot-files note above) — throw so RESUME stays retriable.
+  if (!maybe_wal_files.has_value()) {
+    throw RecoveryFailure("Couldn't recover data because of the failure to read wal files");
+  }
 
   if (auto const &wal_files = *maybe_wal_files; !wal_files.empty()) {
     spdlog::info("Checking WAL files.");

--- a/tests/unit/hot_cold_resume.cpp
+++ b/tests/unit/hot_cold_resume.cpp
@@ -46,6 +46,7 @@
 #ifdef MG_ENTERPRISE
 
 #include <sys/resource.h>
+#include <unistd.h>  // geteuid — the transient-read-failure tests induce EACCES via chmod, which root bypasses
 
 #include <algorithm>
 #include <atomic>
@@ -77,9 +78,26 @@ static fs::path g_storage_root{fs::temp_directory_path() / "MG_test_unit_hot_col
 
 class HotColdResume : public ::testing::Test {
  protected:
+  // Delete `path` even if a prior test left an unreadable (chmod-000) directory behind — the transient
+  // read-failure tests chmod a durability dir to induce EACCES, and a regression that aborts the process
+  // before restoring perms (exactly the crash this suite guards against) would otherwise leave a dir that
+  // plain fs::remove_all cannot descend into, poisoning every subsequent run. Restore owner rwx pre-order
+  // (a dir is made traversable before we reach its children), then remove.
+  static void RemoveAllResilient(const fs::path &path) {
+    std::error_code ec;
+    if (!fs::exists(path, ec)) return;
+    fs::permissions(path, fs::perms::owner_all, fs::perm_options::add, ec);
+    for (auto it = fs::recursive_directory_iterator(path, fs::directory_options::skip_permission_denied, ec);
+         !ec && it != fs::recursive_directory_iterator();
+         it.increment(ec)) {
+      fs::permissions(it->path(), fs::perms::owner_all, fs::perm_options::add, ec);
+    }
+    fs::remove_all(path, ec);
+  }
+
   void SetUp() override {
     test_dir_ = g_storage_root / ::testing::UnitTest::GetInstance()->current_test_info()->name();
-    fs::remove_all(test_dir_);
+    RemoveAllResilient(test_dir_);
     fs::create_directories(test_dir_);
 
     memgraph::storage::UpdatePaths(conf_, test_dir_);
@@ -91,7 +109,7 @@ class HotColdResume : public ::testing::Test {
 
   void TearDown() override {
     handler_.reset();
-    fs::remove_all(test_dir_);
+    RemoveAllResilient(test_dir_);
   }
 
   // Simulate a process restart: tear down the handler (closes durability + storage) and reconstruct
@@ -1025,6 +1043,91 @@ TEST_F(HotColdResume, CorruptDurableEntrySkippedAndDataPreserved) {
   // CRUCIAL: the victim's data dir must NOT have been deleted — cleanup is skipped when the durable view
   // is incomplete, so a parse glitch never escalates to data loss.
   EXPECT_TRUE(fs::exists(victim_dir)) << "a corrupt entry's data dir must be preserved, not reaped by cleanup";
+}
+
+// Regression (hot_cold_oom stress crash @durability.cpp GetSnapshotFiles): a TRANSIENT directory-read
+// failure during a RESUME's recovery must surface as a clean, retriable RECOVERY_FAILED (tenant stays
+// COLD), NEVER a whole-process MG_ASSERT crash. In CI the memory-hog workload drove the snapshot
+// directory_iterator to ENOMEM under the 1 GiB ceiling; GetSnapshotFiles returned std::nullopt and
+// MG_ASSERT(maybe_snapshot_files.has_value()) fired -> LOG_FATAL -> the whole server aborted mid-stress
+// (the "Failed to read from defunct connection" cascade). The fix makes RecoverData throw RecoveryFailure
+// at that nullopt site, which Resume_ catches and maps to RECOVERY_FAILED.
+//
+// This reproduces the exact GetSnapshotFiles-returns-nullopt precondition DETERMINISTICALLY as EACCES
+// (chmod 000 on the snapshot dir) instead of the flaky ENOMEM — both set directory_iterator's error_code
+// and drive the identical `if (error_code) return std::nullopt` branch.
+//
+// Root note: chmod 000 does not deny root (root bypasses permission bits), so the induced EACCES only
+// occurs for a non-root euid — skip under root rather than silently pass a no-op.
+TEST_F(HotColdResume, ResumeTransientSnapshotDirReadFailureStaysColdRetriable) {
+  if (geteuid() == 0) GTEST_SKIP() << "chmod 000 does not induce EACCES for root";
+  constexpr int kNodes = 6;
+  auto name = CreateAndPopulate("snap_dir_eacces", kNodes);
+
+  // Capture the uuid BEFORE suspend — Get() trips the cold seam once the tenant is COLD.
+  std::string uuid_str;
+  {
+    auto acc = handler_->Get(name);
+    uuid_str = static_cast<std::string>(acc->storage()->uuid());
+  }
+  ASSERT_TRUE(handler_->Suspend(name).has_value());
+
+  const auto snap_dir = test_dir_ / std::string(memgraph::dbms::kMultiTenantDir) / uuid_str / "snapshots";
+  // The snapshots dir must EXIST (so DirExists passes) but be unreadable (so directory_iterator sets
+  // error_code -> GetSnapshotFiles -> std::nullopt) — the exact CI crash precondition. An empty dir is
+  // enough: opendir() fails with EACCES on a chmod-000 dir regardless of its contents.
+  fs::create_directories(snap_dir);
+  fs::permissions(snap_dir, fs::perms::none);
+
+  auto failed = handler_->Resume(name);
+  // Restore perms right away so the dir is readable again for the retry below and TearDown's remove_all.
+  fs::permissions(snap_dir, fs::perms::owner_all);
+
+  ASSERT_FALSE(failed.has_value()) << "a transient snapshot-dir read failure must FAIL the resume, not crash";
+  EXPECT_EQ(failed.error(), DbmsHandler::ResumeError::RECOVERY_FAILED);
+  EXPECT_FALSE(InAll(name)) << "the tenant must stay COLD after the failed resume";
+  EXPECT_TRUE(handler_->IsSuspended(name)) << "the tenant must remain suspended/retriable, not stuck";
+
+  // Retriable + no data loss: with the dir readable again, the resume recovers all data (WAL replay).
+  auto ok = handler_->Resume(name);
+  ASSERT_TRUE(ok.has_value()) << "the resume must succeed once the transient read failure clears";
+  EXPECT_TRUE(InAll(name));
+  EXPECT_EQ(CountNodes(ok.value().db), kNodes) << "no data may be lost across the transient failure";
+}
+
+// Companion to the snapshot-dir case above, covering the WAL-directory read-failure site in RecoverData
+// (the no-snapshot branch's inline directory_iterator over wal_directory_). With snapshot_on_exit=false a
+// suspended tenant's durability lives entirely in the WAL, so on resume RecoverData skips straight to the
+// WAL scan; an unreadable WAL dir (EACCES, deterministic stand-in for the CI ENOMEM) must likewise fail
+// the resume as retriable RECOVERY_FAILED, not crash the process.
+TEST_F(HotColdResume, ResumeTransientWalDirReadFailureStaysColdRetriable) {
+  if (geteuid() == 0) GTEST_SKIP() << "chmod 000 does not induce EACCES for root";
+  constexpr int kNodes = 5;
+  auto name = CreateAndPopulate("wal_dir_eacces", kNodes);
+
+  std::string uuid_str;
+  {
+    auto acc = handler_->Get(name);
+    uuid_str = static_cast<std::string>(acc->storage()->uuid());
+  }
+  ASSERT_TRUE(handler_->Suspend(name).has_value());
+
+  const auto wal_dir = test_dir_ / std::string(memgraph::dbms::kMultiTenantDir) / uuid_str / "wal";
+  ASSERT_TRUE(fs::exists(wal_dir)) << "suspend must have left a WAL dir to recover from";
+  fs::permissions(wal_dir, fs::perms::none);
+
+  auto failed = handler_->Resume(name);
+  fs::permissions(wal_dir, fs::perms::owner_all);
+
+  ASSERT_FALSE(failed.has_value()) << "a transient WAL-dir read failure must FAIL the resume, not crash";
+  EXPECT_EQ(failed.error(), DbmsHandler::ResumeError::RECOVERY_FAILED);
+  EXPECT_FALSE(InAll(name)) << "the tenant must stay COLD after the failed resume";
+  EXPECT_TRUE(handler_->IsSuspended(name)) << "the tenant must remain suspended/retriable, not stuck";
+
+  auto ok = handler_->Resume(name);
+  ASSERT_TRUE(ok.has_value()) << "the resume must succeed once the transient read failure clears";
+  EXPECT_TRUE(InAll(name));
+  EXPECT_EQ(CountNodes(ok.value().db), kNodes) << "no data may be lost across the transient failure";
 }
 
 #else


### PR DESCRIPTION
Under memory pressure a hot/cold RESUME's recovery could hit ENOMEM from std::filesystem::directory_iterator; GetSnapshotFiles/GetWalFiles then returned nullopt and the MG_ASSERTs in RecoverData turned that transient, retriable failure into a whole-process LOG_FATAL crash (the hot_cold_oom stress flake: "Assertion failed ... durability.cpp 'maybe_snapshot_files.has_value()'" -> defunct-connection cascade).

Replace the three MG_ASSERTs on the transient dir-read path (snapshot files, inline WAL scan, WAL files) with `throw RecoveryFailure`. The exception propagates cleanly out of RecoverData and is handled per call site:
  - boot recovery loop (DbmsHandler ctor) still catches it and LOG_FATALs, so startup remains fail-loud/fatal exactly as before;
  - Resume_ maps it to ResumeError::RECOVERY_FAILED, so the tenant stays COLD and the RESUME is retriable ("failed to recover while resuming").

Bug introduced in version 3.12 and fixed in 3.12.