### PR TITLE
Print output URLs for packages in CI

### DIFF
--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -194,6 +194,7 @@ jobs:
       build_docker_image: ${{ matrix.build_docker_image || 'none' }}
       push_to_github: 'false'
       push_to_s3: 'true'
+      print_output_url: true
       s3_dest_dir: "memgraph${{ inputs.mock && '-mock-rc' || '' }}/${{ needs.PrepareReleaseBranch.outputs.tag_name }}"
       additional_build_args: ${{ matrix.additional_build_args }}
       ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
@@ -296,6 +297,7 @@ jobs:
       cuda: ${{ matrix.cuda }}
       cugraph: ${{ matrix.cugraph }}
       push_to_s3: true
+      print_output_url: true
       malloc: ${{ matrix.malloc }}
       run_smoke_tests: ${{ !matrix.cugraph }}
       upload_debug_symbols: true

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -131,6 +131,7 @@ jobs:
       daily_build: true
       push_to_github: 'false'
       push_to_s3: 'true'
+      print_output_url: true
       s3_dest_dir: "daily-build/memgraph${{ inputs.mock && '_mock' || '' }}/${{ needs.CurrentDateJob.outputs.current_date }}"
       additional_build_args: ${{ matrix.additional_build_args }}
       generate_sbom: ${{ (matrix.os == 'ubuntu-24.04' && matrix.arch == 'amd' && matrix.additional_build_args == '' && matrix.build_docker_image == 'both') && true || false }}
@@ -301,6 +302,7 @@ jobs:
       cuda: ${{ matrix.cuda }}
       cugraph: ${{ matrix.cugraph }}
       push_to_s3: true
+      print_output_url: true
       malloc: ${{ matrix.malloc }}
       run_smoke_tests: ${{ !matrix.cugraph && !inputs.skip_smoke_tests }}
       run_tests: true

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -174,6 +174,7 @@ jobs:
       cuda: ${{ matrix.cuda == 'true' }}
       cugraph: ${{ matrix.cugraph == 'true' }}
       push_to_s3: ${{ matrix.push_to_s3 == 'true' }}
+      print_output_url: true
       upload_debug_symbols: ${{ matrix.push_to_s3 == 'true' }}
       malloc: ${{ matrix.malloc == 'true' }}
       run_smoke_tests: ${{ matrix.run_smoke_tests == 'true' }}

--- a/.github/workflows/package_memgraph.yaml
+++ b/.github/workflows/package_memgraph.yaml
@@ -157,6 +157,7 @@ jobs:
       arch: "amd"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -174,6 +175,7 @@ jobs:
       arch: "amd"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -191,6 +193,7 @@ jobs:
       arch: "amd"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -208,6 +211,7 @@ jobs:
       arch: "arm"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: false
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -225,6 +229,7 @@ jobs:
       arch: "amd"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: false
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -242,6 +247,7 @@ jobs:
       arch: "arm"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -259,6 +265,7 @@ jobs:
       arch: "amd"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -276,6 +283,7 @@ jobs:
       arch: "arm"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: false
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -293,6 +301,7 @@ jobs:
       arch: "amd"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -310,6 +319,7 @@ jobs:
       arch: "amd"
       build_type: RelWithDebInfo
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -328,6 +338,7 @@ jobs:
       build_type: RelWithDebInfo
       build_docker_image: ${{ needs.PackageSetup.outputs.workflow_input_build_docker_image_amd }}
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -346,6 +357,7 @@ jobs:
       build_type: RelWithDebInfo
       build_docker_image: ${{ needs.PackageSetup.outputs.workflow_input_build_docker_image_arm }}
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: ${{ needs.PackageSetup.outputs.workflow_input_malloc == 'true' && '--disable-jemalloc' || '' }}
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
@@ -364,6 +376,7 @@ jobs:
       build_type: RelWithDebInfo
       build_docker_image: ${{ needs.PackageSetup.outputs.workflow_input_build_docker_image_malloc }}
       push_to_s3: ${{ needs.PackageSetup.outputs.workflow_input_push_to_s3 }}
+      print_output_url: true
       push_to_github: ${{ needs.PackageSetup.outputs.workflow_input_push_to_github }}
       additional_build_args: "--disable-jemalloc"
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -35,6 +35,10 @@ on:
         type: string
         description: "Target dir path in S3 bucket."
         default: ''
+      print_output_url:
+        type: boolean
+        description: "Print the S3 URLs of all uploaded artifacts (package, debuginfo sidecar, prod/debug docker images) at the end of the workflow."
+        default: false
       ref:
         type: string
         description: "Git ref to checkout. Default value is the current ref."
@@ -666,6 +670,30 @@ jobs:
           AWS_REGION: ${{ env.S3_REGION }}
           SOURCE_DIR: ${{ env.DOCKER_DEBUG_ARTIFACT_DIR }}
           DEST_DIR: "${{ inputs.s3_dest_dir }}/${{ env.DOCKER_DEBUG_ARTIFACT_NAME }}/"
+
+      - name: "Print artifact S3 URLs"
+        if: ${{ inputs.print_output_url && inputs.push_to_s3 == 'true' }}
+        run: |
+          base="https://s3.${S3_REGION}.amazonaws.com/${S3_BUCKET}/${S3_DEST_DIR}"
+          shopt -s nullglob
+          print_dir() {
+            local dir="$1" subdir="$2"
+            [[ -d "$dir" ]] || return 0
+            for f in "$dir"/*; do
+              [[ -f "$f" ]] || continue
+              enc=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$(basename "$f")")
+              echo "::notice::Artifact URL: ${base}/${subdir}/${enc}"
+            done
+          }
+          # The package dir (deb/rpm + debuginfo sidecar) is always uploaded when
+          # push_to_s3 is set; the image dirs only when the matching image built.
+          print_dir "$PACKAGE_ARTIFACT_DIR" "$PKG_ARTIFACT_NAME"
+          if [[ "$BUILD_DOCKER_IMAGE" == "prod" || "$BUILD_DOCKER_IMAGE" == "both" ]]; then
+            print_dir "$DOCKER_PROD_ARTIFACT_DIR" "$DOCKER_PROD_ARTIFACT_NAME"
+          fi
+          if [[ "$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both" ]]; then
+            print_dir "$DOCKER_DEBUG_ARTIFACT_DIR" "$DOCKER_DEBUG_ARTIFACT_NAME"
+          fi
 
       - name: Clean up heaptrack
         if: ${{ inputs.build_docker_image == 'debug' || inputs.build_docker_image == 'both' }}

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -1139,16 +1139,20 @@ jobs:
 
       - name: Print Output URL
         if: ${{ inputs.print_output_url && inputs.push_to_s3 }}
+        env:
+          DEST_DIR: "${{ inputs.s3_dest_dir }}"
         run: |
-          # ::notice:: lines surface in the GA UI summary. Print each
-          # variant that actually exists so callers and humans can grab
-          # the link without re-deriving it from the matrix dims.
-          if [[ -n "${{ steps.output-url.outputs.s3_url_prod }}" ]]; then
-            echo "::notice::Prod image URL: ${{ steps.output-url.outputs.s3_url_prod }}"
+          base="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/${DEST_DIR}"
+          shopt -s nullglob
+          artifacts=(output/*)
+          if [[ ${#artifacts[@]} -eq 0 ]]; then
+            echo "No artifacts in output/ to report."
+            exit 0
           fi
-          if [[ -n "${{ steps.output-url.outputs.s3_url_debug }}" ]]; then
-            echo "::notice::Debug image URL: ${{ steps.output-url.outputs.s3_url_debug }}"
-          fi
+          for f in "${artifacts[@]}"; do
+            [[ -f "$f" ]] || continue
+            echo "::notice::Artifact URL: ${base}/$(basename "$f")"
+          done
 
       - name: Memgraph Docker Cleanup
         if: always()

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -1151,7 +1151,10 @@ jobs:
           fi
           for f in "${artifacts[@]}"; do
             [[ -f "$f" ]] || continue
-            echo "::notice::Artifact URL: ${base}/$(basename "$f")"
+            # URL-encode the filename so unsafe chars (+, ~, etc. in daily-build
+            # versions like 3.12.0+5~<commit>) resolve correctly over HTTP.
+            enc=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$(basename "$f")")
+            echo "::notice::Artifact URL: ${base}/${enc}"
           done
 
       - name: Memgraph Docker Cleanup


### PR DESCRIPTION
Update workflows to print out the full URLs to all packages produced for Memgraph and MAGE in the daily/RC builds and the packaging workflows. URLs will be visible as annotations in the parent workflow.

