### PR TITLE
fix: show source text in plan_v2 result headers and plan columns

### DIFF
--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -180,7 +180,8 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
 
 auto MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameters &parameters, DbAccessor *db_accessor,
                      const std::vector<Identifier *> &predefined_identifiers,
-                     plan::v2::QueryPlannerContext &planner_context) -> std::unique_ptr<LogicalPlan> {
+                     plan::v2::QueryPlannerContext &planner_context,
+                     const std::unordered_map<int, std::string> &output_names) -> std::unique_ptr<LogicalPlan> {
   // TODO: we need to make sure we decouple symbol position from frame position
   //       symbols are needed for debugging (a semantic name)
   //       during evaluation frame slots are dumping ground for temporary evaluation results
@@ -193,7 +194,7 @@ auto MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameter
     if (flags::AreExperimentsEnabled(flags::Experiments::PLANNER_V2)) {
       // WITH 1 AS tmp RETURN tmp AS result;
       //  SymTbl: tmp result
-      auto [egraph, root] = plan::v2::ConvertToEgraph(*query, symbol_table, parameters);
+      auto [egraph, root] = plan::v2::ConvertToEgraph(*query, symbol_table, parameters, output_names);
 
       // Apply e-graph rewrites (inline identifiers, etc.)
       plan::v2::ApplyAllRewrites(egraph);
@@ -261,8 +262,13 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
     }
   }
 
-  auto logical_plan =
-      MakeLogicalPlan(std::move(ast_storage), query, parameters, db_accessor, predefined_identifiers, planner_context);
+  auto logical_plan = MakeLogicalPlan(std::move(ast_storage),
+                                      query,
+                                      parameters,
+                                      db_accessor,
+                                      predefined_identifiers,
+                                      planner_context,
+                                      stripped_query.named_expressions());
   auto plan = std::make_shared<PlanWrapper>(std::move(logical_plan));
 
   if (use_plan_cache) {

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -230,7 +230,8 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
 
 auto MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameters &parameters, DbAccessor *db_accessor,
                      const std::vector<Identifier *> &predefined_identifiers,
-                     plan::v2::QueryPlannerContext &planner_context) -> LogicalPlanResult {
+                     plan::v2::QueryPlannerContext &planner_context,
+                     const std::unordered_map<int, std::string> &output_names) -> LogicalPlanResult {
   // TODO: we need to make sure we decouple symbol position from frame position
   //       symbols are needed for debugging (a semantic name)
   //       during evaluation frame slots are dumping ground for temporary evaluation results
@@ -244,7 +245,7 @@ auto MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameter
     if (flags::AreExperimentsEnabled(flags::Experiments::PLANNER_V2)) {
       // WITH 1 AS tmp RETURN tmp AS result;
       //  SymTbl: tmp result
-      auto [egraph, root] = plan::v2::ConvertToEgraph(*query, symbol_table, parameters);
+      auto [egraph, root] = plan::v2::ConvertToEgraph(*query, symbol_table, parameters, output_names);
 
       // Apply e-graph rewrites (inline identifiers, etc.)
       plan::v2::ApplyAllRewrites(egraph);
@@ -327,8 +328,13 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
     }
   }
 
-  auto [logical_plan, is_cacheable_plan] =
-      MakeLogicalPlan(std::move(ast_storage), query, parameters, db_accessor, predefined_identifiers, planner_context);
+  auto [logical_plan, is_cacheable_plan] = MakeLogicalPlan(std::move(ast_storage),
+                                                           query,
+                                                           parameters,
+                                                           db_accessor,
+                                                           predefined_identifiers,
+                                                           planner_context,
+                                                           stripped_query.named_expressions());
   auto plan = std::make_shared<PlanWrapper>(std::move(logical_plan), module_generation);
 
   if (use_plan_cache && is_cacheable_plan) {

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -157,7 +157,8 @@ using PlanCacheLRU = utils::Synchronized<PlanCache_t, utils::RWSpinLock>;
 
 auto MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameters &parameters, DbAccessor *db_accessor,
                      const std::vector<Identifier *> &predefined_identifiers,
-                     plan::v2::QueryPlannerContext &planner_context) -> std::unique_ptr<LogicalPlan>;
+                     plan::v2::QueryPlannerContext &planner_context,
+                     const std::unordered_map<int, std::string> &output_names = {}) -> std::unique_ptr<LogicalPlan>;
 
 /**
  * Return the parsed *Cypher* query's AST cached logical plan, or create and

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -171,7 +171,8 @@ struct LogicalPlanResult {
 
 auto MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameters &parameters, DbAccessor *db_accessor,
                      const std::vector<Identifier *> &predefined_identifiers,
-                     plan::v2::QueryPlannerContext &planner_context) -> LogicalPlanResult;
+                     plan::v2::QueryPlannerContext &planner_context,
+                     const std::unordered_map<int, std::string> &output_names = {}) -> LogicalPlanResult;
 
 /**
  * Return the parsed *Cypher* query's AST cached logical plan, or create and

--- a/src/query/frontend/semantic/symbol.hpp
+++ b/src/query/frontend/semantic/symbol.hpp
@@ -69,7 +69,7 @@ class Symbol {
   Position_t position_;
   bool user_declared_{true};    /*NOT USED IN PLANNER V2*/
   Type type_{Type::ANY};        /*NOT USED IN PLANNER V2*/
-  int64_t token_position_{-1};  // from ANTLR token stream /*NOT USED IN PLANNER V2*/
+  int64_t token_position_{-1};  // from ANTLR token stream; plan_v2 carries it for result-header naming
 };
 
 }  // namespace memgraph::query

--- a/src/query/plan_v2/egraph/egraph.cpp
+++ b/src/query/plan_v2/egraph/egraph.cpp
@@ -41,8 +41,8 @@ egraph::~egraph() = default;  // required because pimpl
 
 auto egraph::MakeOnce() -> eclass { return from_core(pimpl_->graph.Make<Once>().eclass_id); }
 
-auto egraph::MakeSymbol(int32_t position, std::string_view name) -> eclass {
-  return from_core(pimpl_->graph.Make<Symbol>(position, name).eclass_id);
+auto egraph::MakeSymbol(int32_t position, std::string_view name, int64_t token_position) -> eclass {
+  return from_core(pimpl_->graph.Make<Symbol>(position, name, token_position).eclass_id);
 }
 
 auto egraph::MakeLiteral(storage::ExternalPropertyValue const &value) -> eclass {

--- a/src/query/plan_v2/egraph/egraph.hpp
+++ b/src/query/plan_v2/egraph/egraph.hpp
@@ -38,7 +38,7 @@ struct egraph {
 
   // Public API for creating egraph nodes
   auto MakeOnce() -> eclass;
-  auto MakeSymbol(int32_t position, std::string_view name) -> eclass;
+  auto MakeSymbol(int32_t position, std::string_view name, int64_t token_position = -1) -> eclass;
   auto MakeLiteral(storage::ExternalPropertyValue const &value) -> eclass;
   auto MakeParameterLookup(int32_t position) -> eclass;
   auto MakeBind(eclass input, eclass sym, eclass expr) -> eclass;

--- a/src/query/plan_v2/egraph/symbol.hpp
+++ b/src/query/plan_v2/egraph/symbol.hpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <utility>
 
 #include "query/plan_v2/egraph/symbol_lists.hpp"
@@ -21,6 +22,14 @@
 import memgraph.planner.core.typed_egraph;
 
 namespace memgraph::query::plan::v2 {
+
+/// Side-data for a Symbol e-node: the variable's name and its source
+/// `token_position` (-1 when absent). The token position lets the result-header
+/// path recover an unaliased column's source text from the stripped query.
+struct SymbolInfo {
+  std::string name;
+  int64_t token_position{-1};
+};
 
 /// The `symbol` enum: one entry per X-list row in symbol_lists.hpp.
 /// Adding a symbol = adding an X-list entry; arity, descriptor, and

--- a/src/query/plan_v2/egraph/symbol_make_traits.cpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.cpp
@@ -19,8 +19,9 @@ auto symbol_make_traits<Once>::make(storage_type &s) -> seeded_node {
   return {.lowered = {.children = {}, .disambiguator = s.counter++}, .seed = default_analysis_seed<Once>()};
 }
 
-auto symbol_make_traits<Symbol>::make(storage_type &s, int32_t pos, std::string_view name) -> seeded_node {
-  s.store.try_emplace(pos, std::string{name});
+auto symbol_make_traits<Symbol>::make(storage_type &s, int32_t pos, std::string_view name, int64_t token_position)
+    -> seeded_node {
+  s.store.try_emplace(pos, SymbolInfo{.name = std::string{name}, .token_position = token_position});
   return {.lowered = {.children = {}, .disambiguator = static_cast<uint64_t>(pos)},
           .seed = default_analysis_seed<Symbol>()};
 }

--- a/src/query/plan_v2/egraph/symbol_make_traits.hpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.hpp
@@ -84,10 +84,10 @@ struct symbol_make_traits<symbol::Once> {
 template <>
 struct symbol_make_traits<symbol::Symbol> {
   struct storage_type {
-    std::map<int32_t, std::string> store;
+    std::map<int32_t, SymbolInfo> store;
   };
 
-  static auto make(storage_type &s, int32_t pos, std::string_view name) -> seeded_node;
+  static auto make(storage_type &s, int32_t pos, std::string_view name, int64_t token_position = -1) -> seeded_node;
 };
 
 /// Literal: value <-> id mapping.  `store` (value -> id) is the hash-consing

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -76,9 +76,10 @@ class LoweringCtx {
   egraph &g;
   SymbolTable const &symbol_table;
   Parameters const &parameters;
+  plan::v2::OutputColumnNames const &output_names;
 
-  LoweringCtx(egraph &eg, SymbolTable const &st, Parameters const &params)
-      : g(eg), symbol_table(st), parameters(params) {}
+  LoweringCtx(egraph &eg, SymbolTable const &st, Parameters const &params, plan::v2::OutputColumnNames const &names)
+      : g(eg), symbol_table(st), parameters(params), output_names(names) {}
 
   auto OpenScratch() -> ScratchFrame { return ScratchFrame{*this}; }
 
@@ -336,6 +337,17 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
   return pipe;
 }
 
+// The display name for a RETURN column: the alias if present, else the source
+// text recovered from `output_names` (stripping replaced the expression with a
+// placeholder), falling back to the AST name when neither applies (raw parse).
+auto OutputDisplayName(LoweringCtx &ctx, NamedExpression const &ne) -> std::string {
+  if (ne.is_aliased_) return ne.name_;
+  if (auto const it = ctx.output_names.find(static_cast<int>(ne.token_position_)); it != ctx.output_names.end()) {
+    return it->second;
+  }
+  return ne.name_;
+}
+
 auto LowerReturn(query::Return &ret, eclass pipe, LoweringCtx &ctx) -> eclass {
   // See LowerWith: `*` symbols bypass named_expressions, so refuse them rather
   // than drop columns or let referenced_syms miss a `*`-referenced binding.
@@ -343,7 +355,7 @@ auto LowerReturn(query::Return &ret, eclass pipe, LoweringCtx &ctx) -> eclass {
   auto frame = ctx.OpenScratch();
   for (auto *ne : ret.body_.named_expressions) {
     auto expr = Lower(ctx, *ne->expression_);
-    frame.push(ctx.g.MakeNamedOutput(ne->name_, SymEclassFor(ctx, *ne), expr));
+    frame.push(ctx.g.MakeNamedOutput(OutputDisplayName(ctx, *ne), SymEclassFor(ctx, *ne), expr));
   }
   auto output = ctx.g.MakeOutput(pipe, frame.as_span());
   HashConsTailExpressions(ret.body_, ctx);
@@ -404,10 +416,10 @@ auto LowerCypherQuery(CypherQuery &cq, LoweringCtx &ctx) -> eclass {
 
 namespace memgraph::query::plan::v2 {
 
-auto ConvertToEgraph(CypherQuery const &query, SymbolTable const &symbol_table, Parameters const &parameters)
-    -> std::tuple<egraph, eclass> {
+auto ConvertToEgraph(CypherQuery const &query, SymbolTable const &symbol_table, Parameters const &parameters,
+                     OutputColumnNames const &output_names) -> std::tuple<egraph, eclass> {
   auto eg = egraph{};
-  auto ctx = LoweringCtx{eg, symbol_table, parameters};
+  auto ctx = LoweringCtx{eg, symbol_table, parameters, output_names};
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   auto root = LowerCypherQuery(const_cast<CypherQuery &>(query), ctx);
   return {std::move(eg), root};

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -337,15 +337,10 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
   return pipe;
 }
 
-// The display name for a RETURN column: the alias if present, else the source
-// text recovered from `output_names` (stripping replaced the expression with a
-// placeholder), falling back to the AST name when neither applies (raw parse).
-// This names the EXPLAIN `Produce {...}` column. The result-set header is
-// derived independently in interpreter.cpp from the reconstructed symbol's
-// token_position against the same named_expressions() map; both must apply this
-// same alias-else-source-else-name rule so header and EXPLAIN stay in agreement.
-// Naming the unaliased column by its source text is intentional and stronger
-// than the v1 planner, which shows the stripped placeholder here.
+// Display name for a RETURN column: the alias, else the source text
+// (`output_names` holds it, since stripping replaced the expression with a
+// placeholder), else the AST name. The result-set header applies the same rule
+// in interpreter.cpp, so both must stay in sync.
 auto OutputDisplayName(LoweringCtx &ctx, NamedExpression const &ne) -> std::string {
   if (ne.is_aliased_) return ne.name_;
   if (auto const it = ctx.output_names.find(static_cast<int>(ne.token_position_)); it != ctx.output_names.end()) {

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -340,6 +340,12 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
 // The display name for a RETURN column: the alias if present, else the source
 // text recovered from `output_names` (stripping replaced the expression with a
 // placeholder), falling back to the AST name when neither applies (raw parse).
+// This names the EXPLAIN `Produce {...}` column. The result-set header is
+// derived independently in interpreter.cpp from the reconstructed symbol's
+// token_position against the same named_expressions() map; both must apply this
+// same alias-else-source-else-name rule so header and EXPLAIN stay in agreement.
+// Naming the unaliased column by its source text is intentional and stronger
+// than the v1 planner, which shows the stripped placeholder here.
 auto OutputDisplayName(LoweringCtx &ctx, NamedExpression const &ne) -> std::string {
   if (ne.is_aliased_) return ne.name_;
   if (auto const it = ctx.output_names.find(static_cast<int>(ne.token_position_)); it != ctx.output_names.end()) {

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -120,7 +120,7 @@ template <typename AstNode>
 auto SymEclassFor(LoweringCtx &ctx, AstNode &node) -> eclass {
   DMG_ASSERT(node.symbol_pos_ != -1, "AST symbol should have already been mapped into the frame");
   auto const &sym = ctx.symbol_table.at(node);
-  return ctx.g.MakeSymbol(node.symbol_pos_, sym.name());
+  return ctx.g.MakeSymbol(node.symbol_pos_, sym.name(), sym.token_position());
 }
 
 // Expression AST nodes not yet lowered. Each entry expands to a

--- a/src/query/plan_v2/frontend/ast_converter.hpp
+++ b/src/query/plan_v2/frontend/ast_converter.hpp
@@ -11,7 +11,9 @@
 
 #pragma once
 
+#include <string>
 #include <tuple>
+#include <unordered_map>
 
 #include "query/plan_v2/egraph/egraph.hpp"
 
@@ -23,11 +25,17 @@ struct Parameters;
 
 namespace memgraph::query::plan::v2 {
 
+/// Source text of each unaliased RETURN column, by token position. Stripping
+/// replaces a column's expression with a placeholder, so this restores its
+/// display name (e.g. `RETURN 1 + 2` -> "1 + 2") in the extracted plan.
+using OutputColumnNames = std::unordered_map<int, std::string>;
+
 /// Lower a parsed Cypher query to an e-graph. `parameters` carries the values of
 /// stripped literals and user parameters by token position; plan_v2 does not
 /// cache plans, so a ParameterLookup whose value is known is folded to a
 /// constant, letting the analysis see the actual value (e.g. a list length).
-auto ConvertToEgraph(CypherQuery const &query, SymbolTable const &symbol_table, Parameters const &parameters)
-    -> std::tuple<egraph, eclass>;
+/// `output_names` restores unaliased column display names lost to stripping.
+auto ConvertToEgraph(CypherQuery const &query, SymbolTable const &symbol_table, Parameters const &parameters,
+                     OutputColumnNames const &output_names = {}) -> std::tuple<egraph, eclass>;
 
 }  // namespace memgraph::query::plan::v2

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -160,8 +160,10 @@ struct symbol_build_traits<symbol::Symbol> {
     if (it == state.symbol_store.end()) [[unlikely]] {
       ThrowPlannerBug("symbol not found in store");
     }
-    // Diagnostics-only loss: rebuilt Symbol carries no user_declared_/type_.
-    auto const &symbol = state.symbol_table.CreateSymbol(it->second, false /*TODO*/);
+    // token_position is carried so result-header naming can recover an unaliased
+    // column's source text. Diagnostics-only loss: no user_declared_/type_.
+    auto const &symbol = state.symbol_table.CreateSymbol(
+        it->second.name, false /*TODO*/, Symbol::Type::ANY, static_cast<int32_t>(it->second.token_position));
     return state.symbol_cache.emplace(sym_pos, symbol).first->second;
   }
 };

--- a/src/query/plan_v2/frontend/builder.hpp
+++ b/src/query/plan_v2/frontend/builder.hpp
@@ -48,7 +48,7 @@ struct BuildState {
   // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   std::vector<storage::ExternalPropertyValue const *> const &literal_info;
   std::vector<std::string_view> const &named_output_info;
-  std::map<std::int32_t, std::string> const &symbol_store;
+  std::map<std::int32_t, SymbolInfo> const &symbol_store;
   std::vector<FunctionInfo> const &function_info;
   /// The e-graph, so a build body can read an e-class's analysis facts (e.g.
   /// dead Unwind reading its list's statically known length).

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -208,7 +208,8 @@ std::shared_ptr<Trigger::TriggerPlan> Trigger::GetPlan(DbAccessor *db_accessor, 
                                         parsed_statements_.parameters,
                                         db_accessor,
                                         predefined_identifiers,
-                                        planner_context);
+                                        planner_context,
+                                        parsed_statements_.stripped_query.named_expressions());
 
     trigger_plan_ = std::make_shared<TriggerPlan>(std::move(logical_plan), std::move(identifiers));
   }

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -214,7 +214,8 @@ std::shared_ptr<Trigger::TriggerPlan> Trigger::GetPlan(DbAccessor *db_accessor, 
                                         parsed_statements_.parameters,
                                         db_accessor,
                                         predefined_identifiers,
-                                        planner_context)
+                                        planner_context,
+                                        parsed_statements_.stripped_query.named_expressions())
                             .plan;
 
     trigger_plan_ = std::make_shared<TriggerPlan>(std::move(logical_plan), std::move(identifiers));

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -231,6 +231,44 @@ TEST_F(PlannerV2InterpreterTest, ElidedUnwindExecutesToScaledRows) {
   }
 }
 
+TEST_F(PlannerV2InterpreterTest, ReturningBoundVariableYieldsItsValues) {
+  // The bound variable is reachable both as the Unwind binder and as the RETURN
+  // reference; it must reconstruct to one symbol (one frame slot) so the rows
+  // carry x's values rather than reading an unpopulated slot.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, ExplainProduceShowsUnaliasedColumnSourceText) {
+  // The EXPLAIN plan dump names an unaliased column by its source text, not the
+  // stripped placeholder.
+  auto stream = Interpret("EXPLAIN RETURN 1 + 2;");
+  auto const plan = PlanText(stream);
+  EXPECT_NE(plan.find("Produce {1 + 2}"), std::string::npos) << plan;
+}
+
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceText) {
+  // An unaliased column's header is its source text, recovered via the symbol's
+  // token_position; without it the header falls back to the stripped placeholder.
+  auto stream = Interpret("RETURN 42;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "42");
+}
+
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue) {
+  // The header is the column's source text - carried on the symbol's
+  // token_position - independent of expression folding. `1 + 1` folds to the
+  // value 2, but the column is still named "1 + 1".
+  auto stream = Interpret("RETURN 1 + 1;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
 TEST_F(PlannerV2InterpreterTest, ConcatenatedKnownListsHaveKnownLength) {
   // List concatenation of two known-length lists has a known length
   // (3 + 100 = 103), so an unused binding over it still elides to a
@@ -271,36 +309,6 @@ TEST_F(PlannerV2InterpreterTest, SizeOfKnownLengthListFoldsToItsLength) {
   auto const plan = PlanText(stream);
   EXPECT_NE(plan.find("CardinalityScale {n=3}"), std::string::npos) << plan;
   EXPECT_EQ(plan.find("Unwind"), std::string::npos) << plan;
-}
-
-TEST_F(PlannerV2InterpreterTest, ReturningBoundVariableYieldsItsValues) {
-  // The bound variable is reachable both as the Unwind binder and as the RETURN
-  // reference; it must reconstruct to one symbol (one frame slot) so the rows
-  // carry x's values rather than reading an unpopulated slot.
-  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x;");
-  ASSERT_EQ(stream.GetResults().size(), 3U);
-  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
-  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
-  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
-}
-
-TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceText) {
-  // An unaliased column's header is its source text, recovered via the symbol's
-  // token_position; without it the header falls back to the stripped placeholder.
-  auto stream = Interpret("RETURN 42;");
-  ASSERT_EQ(stream.GetHeader().size(), 1U);
-  EXPECT_EQ(stream.GetHeader()[0], "42");
-}
-
-TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue) {
-  // The header is the column's source text - carried on the symbol's
-  // token_position - independent of expression folding. `1 + 1` folds to the
-  // value 2, but the column is still named "1 + 1".
-  auto stream = Interpret("RETURN 1 + 1;");
-  ASSERT_EQ(stream.GetHeader().size(), 1U);
-  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
-  ASSERT_EQ(stream.GetResults().size(), 1U);
-  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
 TEST_F(PlannerV2InterpreterTest, UserParameterRangeLengthEnablesElision) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -269,6 +269,34 @@ TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
+TEST_F(PlannerV2InterpreterTest, AliasedColumnHeaderIsAliasNotSourceText) {
+  // An aliased column takes its alias as both the header and the EXPLAIN column
+  // name, never the source text; this exercises OutputDisplayName's is_aliased_
+  // branch, which short-circuits the token_position lookup.
+  auto stream = Interpret("RETURN 1 + 2 AS foo;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "foo");
+
+  auto explained = Interpret("EXPLAIN RETURN 1 + 2 AS foo;");
+  auto const plan = PlanText(explained);
+  EXPECT_NE(plan.find("Produce {foo}"), std::string::npos) << plan;
+}
+
+TEST_F(PlannerV2InterpreterTest, MixedColumnHeadersAreResolvedPerColumn) {
+  // Each column's header is resolved from its own token_position, so an
+  // unaliased expression, an unaliased variable reference, and an aliased
+  // expression in one RETURN don't cross-contaminate.
+  auto stream = Interpret("UNWIND [1] AS x RETURN 1 + 1, x, 2 + 2 AS y;");
+  ASSERT_EQ(stream.GetHeader().size(), 3U);
+  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
+  EXPECT_EQ(stream.GetHeader()[1], "x");
+  EXPECT_EQ(stream.GetHeader()[2], "y");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][2].ValueInt(), 4);
+}
+
 TEST_F(PlannerV2InterpreterTest, ConcatenatedKnownListsHaveKnownLength) {
   // List concatenation of two known-length lists has a known length
   // (3 + 100 = 103), so an unused binding over it still elides to a

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -284,6 +284,25 @@ TEST_F(PlannerV2InterpreterTest, ReturningBoundVariableYieldsItsValues) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
 }
 
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceText) {
+  // An unaliased column's header is its source text, recovered via the symbol's
+  // token_position; without it the header falls back to the stripped placeholder.
+  auto stream = Interpret("RETURN 42;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "42");
+}
+
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue) {
+  // The header is the column's source text - carried on the symbol's
+  // token_position - independent of expression folding. `1 + 1` folds to the
+  // value 2, but the column is still named "1 + 1".
+  auto stream = Interpret("RETURN 1 + 1;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
 TEST_F(PlannerV2InterpreterTest, UserParameterRangeLengthEnablesElision) {
   // A user parameter's value is known for this execution and plan_v2 is
   // uncached, so range($lo, $hi) folds to a provable length: the unused binding

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -887,6 +887,25 @@ TEST_F(PlannerV2InterpreterTest, ReturningBoundVariableYieldsItsValues) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
 }
 
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceText) {
+  // An unaliased column's header is its source text, recovered via the symbol's
+  // token_position; without it the header falls back to the stripped placeholder.
+  auto stream = Interpret("RETURN 42;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "42");
+}
+
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue) {
+  // The header is the column's source text - carried on the symbol's
+  // token_position - independent of expression folding. `1 + 1` folds to the
+  // value 2, but the column is still named "1 + 1".
+  auto stream = Interpret("RETURN 1 + 1;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
 TEST_F(PlannerV2InterpreterTest, UserParameterRangeLengthEnablesElision) {
   // A user parameter's value is known for this execution and plan_v2 is
   // uncached, so range($lo, $hi) folds to a provable length: the unused binding

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -872,6 +872,34 @@ TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
+TEST_F(PlannerV2InterpreterTest, AliasedColumnHeaderIsAliasNotSourceText) {
+  // An aliased column takes its alias as both the header and the EXPLAIN column
+  // name, never the source text; this exercises OutputDisplayName's is_aliased_
+  // branch, which short-circuits the token_position lookup.
+  auto stream = Interpret("RETURN 1 + 2 AS foo;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "foo");
+
+  auto explained = Interpret("EXPLAIN RETURN 1 + 2 AS foo;");
+  auto const plan = PlanText(explained);
+  EXPECT_NE(plan.find("Produce {foo}"), std::string::npos) << plan;
+}
+
+TEST_F(PlannerV2InterpreterTest, MixedColumnHeadersAreResolvedPerColumn) {
+  // Each column's header is resolved from its own token_position, so an
+  // unaliased expression, an unaliased variable reference, and an aliased
+  // expression in one RETURN don't cross-contaminate.
+  auto stream = Interpret("UNWIND [1] AS x RETURN 1 + 1, x, 2 + 2 AS y;");
+  ASSERT_EQ(stream.GetHeader().size(), 3U);
+  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
+  EXPECT_EQ(stream.GetHeader()[1], "x");
+  EXPECT_EQ(stream.GetHeader()[2], "y");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[0][1].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[0][2].ValueInt(), 4);
+}
+
 TEST_F(PlannerV2InterpreterTest, ConcatenatedKnownListsHaveKnownLength) {
   // List concatenation of two known-length lists has a known length
   // (3 + 100 = 103), so an unused binding over it still elides to a

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -834,6 +834,44 @@ TEST_F(PlannerV2InterpreterTest, ElidedUnwindExecutesToScaledRows) {
   }
 }
 
+TEST_F(PlannerV2InterpreterTest, ReturningBoundVariableYieldsItsValues) {
+  // The bound variable is reachable both as the Unwind binder and as the RETURN
+  // reference; it must reconstruct to one symbol (one frame slot) so the rows
+  // carry x's values rather than reading an unpopulated slot.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, ExplainProduceShowsUnaliasedColumnSourceText) {
+  // The EXPLAIN plan dump names an unaliased column by its source text, not the
+  // stripped placeholder.
+  auto stream = Interpret("EXPLAIN RETURN 1 + 2;");
+  auto const plan = PlanText(stream);
+  EXPECT_NE(plan.find("Produce {1 + 2}"), std::string::npos) << plan;
+}
+
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceText) {
+  // An unaliased column's header is its source text, recovered via the symbol's
+  // token_position; without it the header falls back to the stripped placeholder.
+  auto stream = Interpret("RETURN 42;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "42");
+}
+
+TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue) {
+  // The header is the column's source text - carried on the symbol's
+  // token_position - independent of expression folding. `1 + 1` folds to the
+  // value 2, but the column is still named "1 + 1".
+  auto stream = Interpret("RETURN 1 + 1;");
+  ASSERT_EQ(stream.GetHeader().size(), 1U);
+  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
 TEST_F(PlannerV2InterpreterTest, ConcatenatedKnownListsHaveKnownLength) {
   // List concatenation of two known-length lists has a known length
   // (3 + 100 = 103), so an unused binding over it still elides to a
@@ -874,36 +912,6 @@ TEST_F(PlannerV2InterpreterTest, SizeOfKnownLengthListFoldsToItsLength) {
   auto const plan = PlanText(stream);
   EXPECT_NE(plan.find("CardinalityScale {n=3}"), std::string::npos) << plan;
   EXPECT_EQ(plan.find("Unwind"), std::string::npos) << plan;
-}
-
-TEST_F(PlannerV2InterpreterTest, ReturningBoundVariableYieldsItsValues) {
-  // The bound variable is reachable both as the Unwind binder and as the RETURN
-  // reference; it must reconstruct to one symbol (one frame slot) so the rows
-  // carry x's values rather than reading an unpopulated slot.
-  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x;");
-  ASSERT_EQ(stream.GetResults().size(), 3U);
-  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
-  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
-  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
-}
-
-TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceText) {
-  // An unaliased column's header is its source text, recovered via the symbol's
-  // token_position; without it the header falls back to the stripped placeholder.
-  auto stream = Interpret("RETURN 42;");
-  ASSERT_EQ(stream.GetHeader().size(), 1U);
-  EXPECT_EQ(stream.GetHeader()[0], "42");
-}
-
-TEST_F(PlannerV2InterpreterTest, UnaliasedColumnHeaderIsSourceTextNotFoldedValue) {
-  // The header is the column's source text - carried on the symbol's
-  // token_position - independent of expression folding. `1 + 1` folds to the
-  // value 2, but the column is still named "1 + 1".
-  auto stream = Interpret("RETURN 1 + 1;");
-  ASSERT_EQ(stream.GetHeader().size(), 1U);
-  EXPECT_EQ(stream.GetHeader()[0], "1 + 1");
-  ASSERT_EQ(stream.GetResults().size(), 1U);
-  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
 TEST_F(PlannerV2InterpreterTest, UserParameterRangeLengthEnablesElision) {


### PR DESCRIPTION
Two fixes so plan_v2 shows an unaliased column by its **source text** instead of a stripping placeholder. planner_v2 stays experimental and off by default, so there is no effect on the production planner; these are display-name fixes, not result-value fixes.

**What / how**
- **Result header** (`symbol.hpp`, `ast_converter`, `builder`): an unaliased column's header is its source text (`RETURN 1 + 1` → `1 + 1`), recovered from the stripped query by the symbol's `token_position`. plan_v2 dropped `token_position` on reconstructed symbols, so the header fell back to the stripped placeholder (`RETURN 42` showed header `0`). `token_position` now rides on the reconstructed symbol, independent of expression folding, so a folded column keeps its source text as its name.
- **Plan display name** (`cypher_query_interpreter`, `ast_converter`): stripping replaces an unaliased column's expression with a placeholder, so `EXPLAIN` showed `Produce {0+0}` for `RETURN 1 + 2`. The stripped per-column source text is threaded into the converter and used as the display name for unaliased, unfolded columns; aliased columns keep their alias, and a raw (unstripped) parse falls back to the AST name.

**Why**: without these, plan_v2 mislabels result-column headers and plan output for unaliased expression columns.

Stacked PR — **base branch is `feat/plan-v2-cardinality-scale`, not `master`.**