### PR TITLE
feat: run WITH ... WHERE queries in the plan_v2 planner

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4392,9 +4392,8 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
-  // Carry all_filters_ (EXPLAIN label) and re-clone the top-level expression.
-  // TODO: nested property/id/point value exprs stay aliased to the source storage; cosmetic-only, re-home if a
-  // cross-storage clone is added.
+  // Carry all_filters_ (EXPLAIN label); re-clone each top-level expression.
+  // TODO: nested property/id/point exprs stay aliased to source storage (cosmetic today).
   object->all_filters_ = all_filters_;
   for (auto &filter : object->all_filters_) {
     if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4396,7 +4396,7 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
   // TODO: nested property/id/point exprs stay aliased to source storage (cosmetic today).
   object->all_filters_ = all_filters_;
   for (auto &filter : object->all_filters_) {
-    if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);
+    if (filter.expression) filter.expression = filter.expression->Clone(storage);
   }
   return object;
 }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4392,9 +4392,9 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
-  // Carry all_filters_ so EXPLAIN's label survives cloning. ToString reads only
-  // expression/used_symbols, so re-clone the expression into storage; the rest
-  // copies by value.
+  // Carry all_filters_ (EXPLAIN label) and re-clone the top-level expression.
+  // TODO: nested property/id/point value exprs stay aliased to the source storage; cosmetic-only, re-home if a
+  // cross-storage clone is added.
   object->all_filters_ = all_filters_;
   for (auto &filter : object->all_filters_) {
     if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4392,12 +4392,9 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
-  // Carry all_filters_ (EXPLAIN label); re-clone each top-level expression.
-  // TODO: nested property/id/point exprs stay aliased to source storage (cosmetic today).
+  // Shallow copy suffices: only Filter::ToString reads all_filters_, and the source
+  // AstStorage outlives the clone, so its aliased expressions need no re-homing.
   object->all_filters_ = all_filters_;
-  for (auto &filter : object->all_filters_) {
-    if (filter.expression) filter.expression = filter.expression->Clone(storage);
-  }
   return object;
 }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4392,6 +4392,13 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
+  // Carry all_filters_ so EXPLAIN's label survives cloning. ToString reads only
+  // expression/used_symbols, so re-clone the expression into storage; the rest
+  // copies by value.
+  object->all_filters_ = all_filters_;
+  for (auto &filter : object->all_filters_) {
+    if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);
+  }
   return object;
 }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5054,9 +5054,9 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
-  // Carry all_filters_ so EXPLAIN's label survives cloning. ToString reads only
-  // expression/used_symbols, so re-clone the expression into storage; the rest
-  // copies by value.
+  // Carry all_filters_ (EXPLAIN label) and re-clone the top-level expression.
+  // TODO: nested property/id/point value exprs stay aliased to the source storage; cosmetic-only, re-home if a
+  // cross-storage clone is added.
   object->all_filters_ = all_filters_;
   for (auto &filter : object->all_filters_) {
     if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5054,9 +5054,8 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
-  // Carry all_filters_ (EXPLAIN label) and re-clone the top-level expression.
-  // TODO: nested property/id/point value exprs stay aliased to the source storage; cosmetic-only, re-home if a
-  // cross-storage clone is added.
+  // Carry all_filters_ (EXPLAIN label); re-clone each top-level expression.
+  // TODO: nested property/id/point exprs stay aliased to source storage (cosmetic today).
   object->all_filters_ = all_filters_;
   for (auto &filter : object->all_filters_) {
     if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5054,6 +5054,13 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
+  // Carry all_filters_ so EXPLAIN's label survives cloning. ToString reads only
+  // expression/used_symbols, so re-clone the expression into storage; the rest
+  // copies by value.
+  object->all_filters_ = all_filters_;
+  for (auto &filter : object->all_filters_) {
+    if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);
+  }
   return object;
 }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5058,7 +5058,7 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
   // TODO: nested property/id/point exprs stay aliased to source storage (cosmetic today).
   object->all_filters_ = all_filters_;
   for (auto &filter : object->all_filters_) {
-    if (filter.expression != nullptr) filter.expression = filter.expression->Clone(storage);
+    if (filter.expression) filter.expression = filter.expression->Clone(storage);
   }
   return object;
 }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5054,12 +5054,9 @@ std::unique_ptr<LogicalOperator> Filter::Clone(AstStorage *storage) const {
     object->pattern_filters_[i1] = pattern_filters_[i1] ? pattern_filters_[i1]->Clone(storage) : nullptr;
   }
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
-  // Carry all_filters_ (EXPLAIN label); re-clone each top-level expression.
-  // TODO: nested property/id/point exprs stay aliased to source storage (cosmetic today).
+  // Shallow copy suffices: only Filter::ToString reads all_filters_, and the source
+  // AstStorage outlives the clone, so its aliased expressions need no re-homing.
   object->all_filters_ = all_filters_;
-  for (auto &filter : object->all_filters_) {
-    if (filter.expression) filter.expression = filter.expression->Clone(storage);
-  }
   return object;
 }
 

--- a/src/query/plan_v2/cost/cost_model.cpp
+++ b/src/query/plan_v2/cost/cost_model.cpp
@@ -53,9 +53,9 @@ inline constexpr double kUnwindPerRowOverhead = 1.0;
 /// Structural placeholder until measured data justifies a value.
 inline constexpr double kFilterPerRowOverhead = 1.0;
 
-/// Fraction of input rows a filter is assumed to pass.  A coarse placeholder
-/// (execution-only; real selectivity estimation is a later optimisation).  It
-/// biases nothing here since a filtered query has a single valid extraction.
+/// Fraction of input rows a filter is assumed to pass. Coarse placeholder. Doesn't
+/// affect plan choice today (one extraction per query) but flows into ancestor cost,
+/// so it will matter once Filter rewrites add alternative plan shapes.
 inline constexpr double kFilterSelectivity = 0.5;
 
 // Per-alternative leaf costs.  Structural placeholders, 1.0 until measured
@@ -252,13 +252,10 @@ auto UnwindFlatMap(CostFrontier const &input, CostFrontier const &list, planner:
   });
 }
 
-/// Filter flat-map: row-reducing pass-through.  For each input alt and each
-/// predicate alt the input can satisfy, emit one alt whose cardinality is scaled
-/// by the placeholder selectivity, whose predicate is evaluated once per input
-/// row, and which introduces exactly what the input introduces (Filter binds
-/// nothing).  (input, predicate) pairs whose predicate demand isn't met by the
-/// input are skipped (see BindFlatMap header for rationale): the alive-Bind
-/// variant of the row pipe supplies the satisfiable pairing.
+/// Filter flat-map: row-reducing pass-through. Per input alt, emit one alt per
+/// satisfiable predicate alt: cardinality scaled by selectivity, predicate cost
+/// paid per input row, introduces = input's (Filter binds nothing). Pairs whose
+/// predicate demand the input can't meet are skipped (see BindFlatMap).
 auto FilterFlatMap(CostFrontier const &input, CostFrontier const &predicate, planner::core::ENodeId enode_id)
     -> CostFrontier {
   return CostFrontier::flat_map(input, [&predicate, enode_id](Alternative const &input_alt, auto emit) {
@@ -423,11 +420,7 @@ struct symbol_cost_traits<Unwind> {
 
 template <>
 struct symbol_cost_traits<Filter> {
-  // Row-reducing pass-through.  Children layout is [input, predicate].  The
-  // predicate is evaluated once per input row; cardinality is scaled by a
-  // placeholder selectivity.  Filter introduces nothing, so the emitted alt
-  // carries the input's introduces (the resolver's downward demand then forces
-  // the input to actually provide the predicate's symbols).
+  // Children [input, predicate]; see FilterFlatMap.
   static auto cost(ENodeT const &, ENodeId id, CostChildren children, CostCtx const &) -> CostFrontier {
     using namespace child::filter;
     return FilterFlatMap(*children[input], *children[predicate], id);

--- a/src/query/plan_v2/cost/cost_model.cpp
+++ b/src/query/plan_v2/cost/cost_model.cpp
@@ -49,6 +49,15 @@ inline constexpr double kIdentifier = 1.0;
 /// deliberately small (1.0) so it doesn't dominate other per-row terms.
 inline constexpr double kUnwindPerRowOverhead = 1.0;
 
+/// Per-input-row overhead for the WHERE filter, on top of predicate evaluation.
+/// Structural placeholder until measured data justifies a value.
+inline constexpr double kFilterPerRowOverhead = 1.0;
+
+/// Fraction of input rows a filter is assumed to pass.  A coarse placeholder
+/// (execution-only; real selectivity estimation is a later optimisation).  It
+/// biases nothing here since a filtered query has a single valid extraction.
+inline constexpr double kFilterSelectivity = 0.5;
+
 // Per-alternative leaf costs.  Structural placeholders, 1.0 until measured
 // data justifies divergent values.
 inline constexpr double kOnceLeaf = 1.0;
@@ -243,6 +252,28 @@ auto UnwindFlatMap(CostFrontier const &input, CostFrontier const &list, planner:
   });
 }
 
+/// Filter flat-map: row-reducing pass-through.  For each input alt and each
+/// predicate alt the input can satisfy, emit one alt whose cardinality is scaled
+/// by the placeholder selectivity, whose predicate is evaluated once per input
+/// row, and which introduces exactly what the input introduces (Filter binds
+/// nothing).  (input, predicate) pairs whose predicate demand isn't met by the
+/// input are skipped (see BindFlatMap header for rationale): the alive-Bind
+/// variant of the row pipe supplies the satisfiable pairing.
+auto FilterFlatMap(CostFrontier const &input, CostFrontier const &predicate, planner::core::ENodeId enode_id)
+    -> CostFrontier {
+  return CostFrontier::flat_map(input, [&predicate, enode_id](Alternative const &input_alt, auto emit) {
+    DMG_ASSERT(input_alt.required.empty(), "operator Alt must have empty required");
+    for (Alternative const &pred_alt : predicate.alts()) {
+      if (!DemandMet(input_alt, pred_alt)) continue;  // predicate reads a symbol this input can't provide
+      emit({.cost = input_alt.cost + (input_alt.cardinality * (pred_alt.cost + kFilterPerRowOverhead)),
+            .cardinality = input_alt.cardinality * kFilterSelectivity,
+            .required = {},
+            .introduces = input_alt.introduces,
+            .enode_id = enode_id});
+    }
+  });
+}
+
 /// Subquery flat-map: scope-barrier row-pipe.  Non-importing CALL only - an
 /// importing inner is pruned to an empty frontier by its Output and rejected by
 /// the Subquery cost guard, so every inner alt reaching here is self-contained
@@ -387,6 +418,19 @@ struct symbol_cost_traits<Unwind> {
                          ctx.syms.referenced_syms,
                          ctx.syms.variable_index,
                          id);
+  }
+};
+
+template <>
+struct symbol_cost_traits<Filter> {
+  // Row-reducing pass-through.  Children layout is [input, predicate].  The
+  // predicate is evaluated once per input row; cardinality is scaled by a
+  // placeholder selectivity.  Filter introduces nothing, so the emitted alt
+  // carries the input's introduces (the resolver's downward demand then forces
+  // the input to actually provide the predicate's symbols).
+  static auto cost(ENodeT const &, ENodeId id, CostChildren children, CostCtx const &) -> CostFrontier {
+    using namespace child::filter;
+    return FilterFlatMap(*children[input], *children[predicate], id);
   }
 };
 

--- a/src/query/plan_v2/egraph/child_layout.hpp
+++ b/src/query/plan_v2/egraph/child_layout.hpp
@@ -35,6 +35,11 @@ namespace unwind_dead {
 inline constexpr std::size_t input = 0, list = 1;
 }
 
+// WHERE filter: [input row pipe, predicate expression]. Introduces no binding.
+namespace filter {
+inline constexpr std::size_t input = 0, predicate = 1;
+}
+
 namespace identifier {
 inline constexpr std::size_t sym = 0;
 }

--- a/src/query/plan_v2/egraph/egraph.cpp
+++ b/src/query/plan_v2/egraph/egraph.cpp
@@ -143,6 +143,10 @@ auto egraph::MakeUnwind(eclass input, eclass sym, eclass list_expr) -> eclass {
   return from_core(pimpl_->graph.Make<Unwind>(to_core(input), to_core(sym), to_core(list_expr)).eclass_id);
 }
 
+auto egraph::MakeFilter(eclass input, eclass predicate) -> eclass {
+  return from_core(pimpl_->graph.Make<Filter>(to_core(input), to_core(predicate)).eclass_id);
+}
+
 auto egraph::MakeSubquery(eclass outer_input, eclass inner_root, std::span<eclass const> exposed_syms) -> eclass {
   auto children = utils::small_vector<planner::core::EClassId>{};
   children.reserve(2 + exposed_syms.size());

--- a/src/query/plan_v2/egraph/egraph.hpp
+++ b/src/query/plan_v2/egraph/egraph.hpp
@@ -60,6 +60,7 @@ struct egraph {
   }
 
   auto MakeUnwind(eclass input, eclass sym, eclass list_expr) -> eclass;
+  auto MakeFilter(eclass input, eclass predicate) -> eclass;
   auto MakeSubquery(eclass outer_input, eclass inner_root, std::span<eclass const> exposed_syms) -> eclass;
 
   auto MakeSubquery(eclass outer_input, eclass inner_root, std::initializer_list<eclass> exposed_syms) -> eclass {

--- a/src/query/plan_v2/egraph/symbol_lists.hpp
+++ b/src/query/plan_v2/egraph/symbol_lists.hpp
@@ -55,7 +55,9 @@
   /* CALL { ... } subquery: variadic [outer_input, inner_root, exposed_sym_1, ...]. */ \
   /* Acts as a scope barrier: inner's introduces are stripped at the boundary; */      \
   /* only the explicit exposed_sym children become visible to the outer scope. */      \
-  X(Subquery)
+  X(Subquery)                                                                          \
+  /* WHERE filter: 2 children [input, predicate_expr]; introduces no binding. */       \
+  X(Filter)
 
 #define EGRAPH_ALL_SYMBOLS(X) \
   EGRAPH_LEAF_SYMBOLS(X)      \
@@ -74,7 +76,8 @@
   X(Bind)                          \
   X(Output)                        \
   X(Unwind)                        \
-  X(Subquery)
+  X(Subquery)                      \
+  X(Filter)
 
 // Symbol: e-class denotes a binding. Singleton by invariant.
 #define EGRAPH_SYMBOL_KIND_SYMBOLS(X) X(Symbol)

--- a/src/query/plan_v2/egraph/symbol_make_traits.cpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.cpp
@@ -88,6 +88,12 @@ auto symbol_make_traits<Unwind>::make(storage_type & /*s*/, planner::core::EClas
           .seed = default_analysis_seed<Unwind>()};
 }
 
+auto symbol_make_traits<Filter>::make(storage_type & /*s*/, planner::core::EClassId input,
+                                      planner::core::EClassId predicate) -> seeded_node {
+  return {.lowered = {.children = utils::small_vector{input, predicate}, .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Filter>()};
+}
+
 auto symbol_make_traits<Subquery>::make(storage_type & /*s*/, utils::small_vector<planner::core::EClassId> children)
     -> seeded_node {
   return {.lowered = {.children = std::move(children), .disambiguator = std::nullopt},

--- a/src/query/plan_v2/egraph/symbol_make_traits.cpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.cpp
@@ -87,6 +87,12 @@ auto symbol_make_traits<Unwind>::make(storage_type & /*s*/, planner::core::EClas
           .seed = default_analysis_seed<Unwind>()};
 }
 
+auto symbol_make_traits<Filter>::make(storage_type & /*s*/, planner::core::EClassId input,
+                                      planner::core::EClassId predicate) -> seeded_node {
+  return {.lowered = {.children = utils::small_vector{input, predicate}, .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Filter>()};
+}
+
 auto symbol_make_traits<Subquery>::make(storage_type & /*s*/, utils::small_vector<planner::core::EClassId> children)
     -> seeded_node {
   return {.lowered = {.children = std::move(children), .disambiguator = std::nullopt},

--- a/src/query/plan_v2/egraph/symbol_make_traits.hpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.hpp
@@ -196,8 +196,7 @@ struct symbol_make_traits<symbol::Unwind> {
                    planner::core::EClassId list_expr) -> seeded_node;
 };
 
-/// Filter: no storage; children are [input, predicate_expr]. Introduces no
-/// binding, so unlike Unwind there is no sym child.
+/// Filter: no storage; children [input, predicate_expr]. Binds nothing (no sym child).
 template <>
 struct symbol_make_traits<symbol::Filter> {
   struct storage_type {};

--- a/src/query/plan_v2/egraph/symbol_make_traits.hpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.hpp
@@ -196,6 +196,15 @@ struct symbol_make_traits<symbol::Unwind> {
                    planner::core::EClassId list_expr) -> seeded_node;
 };
 
+/// Filter: no storage; children are [input, predicate_expr]. Introduces no
+/// binding, so unlike Unwind there is no sym child.
+template <>
+struct symbol_make_traits<symbol::Filter> {
+  struct storage_type {};
+
+  static auto make(storage_type &, planner::core::EClassId input, planner::core::EClassId predicate) -> seeded_node;
+};
+
 /// Subquery: no storage; children are [outer_input, inner_root, exposed_syms...].
 /// Variadic to encode the projection set of the inner block as direct e-graph
 /// children, so the cost case and resolver don't have to peek into inner_root's

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -294,15 +294,14 @@ auto Lower(LoweringCtx &ctx, Expression &expr) -> eclass {
 
 auto LowerSingleQuery(SingleQuery &sq, LoweringCtx &ctx) -> eclass;
 
-// ORDER BY / SKIP / LIMIT expressions are lowered for their e-graph
-// presence only; their result e-classes are not chained into the row-pipe
-// in the minimum scope. Hashconsing dedupes shared expressions across
-// clauses; when Sort/Skip/Limit operators land, the resolver will recover
-// these e-classes by hashconsing again.
-void HashConsTailExpressions(ReturnBody const &body, LoweringCtx &ctx) {
-  for (auto const &ob : body.order_by) (void)Lower(ctx, *ob.expression);
-  if (body.skip) (void)Lower(ctx, *body.skip);
-  if (body.limit) (void)Lower(ctx, *body.limit);
+// ORDER BY / SKIP / LIMIT are not yet lowered into operators. Rather than
+// silently drop them (which would return wrong results), refuse a body that
+// carries any of them. When the Sort/Skip/Limit operators land they replace
+// this guard.
+void GuardUnsupportedTailClauses(ReturnBody const &body) {
+  if (!body.order_by.empty() || body.skip != nullptr || body.limit != nullptr) {
+    ThrowNotImplementedYet("ORDER BY / SKIP / LIMIT");
+  }
 }
 
 // exposed_syms come from the inner cypher_query_'s last RETURN clause.
@@ -332,8 +331,14 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
     auto expr = Lower(ctx, *ne->expression_);
     pipe = ctx.g.MakeBind(pipe, SymEclassFor(ctx, *ne), expr);
   }
-  HashConsTailExpressions(with.body_, ctx);
-  if (with.where_ != nullptr) ThrowNotImplementedYet(*with.where_);
+  GuardUnsupportedTailClauses(with.body_);
+  // WHERE filters the projected rows, so the Filter sits above the projection
+  // Binds. The predicate reuses expression lowering (unsupported sub-nodes throw
+  // NotYetImplemented there).
+  if (with.where_ != nullptr) {
+    auto predicate = Lower(ctx, *with.where_->expression_);
+    pipe = ctx.g.MakeFilter(pipe, predicate);
+  }
   return pipe;
 }
 
@@ -359,7 +364,7 @@ auto LowerReturn(query::Return &ret, eclass pipe, LoweringCtx &ctx) -> eclass {
     frame.push(ctx.g.MakeNamedOutput(OutputDisplayName(ctx, *ne), SymEclassFor(ctx, *ne), expr));
   }
   auto output = ctx.g.MakeOutput(pipe, frame.as_span());
-  HashConsTailExpressions(ret.body_, ctx);
+  GuardUnsupportedTailClauses(ret.body_);
   return output;
 }
 

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -294,13 +294,11 @@ auto Lower(LoweringCtx &ctx, Expression &expr) -> eclass {
 
 auto LowerSingleQuery(SingleQuery &sq, LoweringCtx &ctx) -> eclass;
 
-// ORDER BY / SKIP / LIMIT are not yet lowered into operators. Rather than
-// silently drop them (which would return wrong results), refuse a body that
-// carries any of them. When the Sort/Skip/Limit operators land they replace
-// this guard.
+// ORDER BY / SKIP / LIMIT / DISTINCT aren't lowered yet; refuse them rather than
+// silently drop them (wrong results). Replaced when those operators land.
 void GuardUnsupportedTailClauses(ReturnBody const &body) {
-  if (!body.order_by.empty() || body.skip != nullptr || body.limit != nullptr) {
-    ThrowNotImplementedYet("ORDER BY / SKIP / LIMIT");
+  if (!body.order_by.empty() || body.skip != nullptr || body.limit != nullptr || body.distinct) {
+    ThrowNotImplementedYet("ORDER BY / SKIP / LIMIT / DISTINCT");
   }
 }
 
@@ -332,9 +330,7 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
     pipe = ctx.g.MakeBind(pipe, SymEclassFor(ctx, *ne), expr);
   }
   GuardUnsupportedTailClauses(with.body_);
-  // WHERE filters the projected rows, so the Filter sits above the projection
-  // Binds. The predicate reuses expression lowering (unsupported sub-nodes throw
-  // NotYetImplemented there).
+  // WHERE filters the projected rows, so Filter sits above the projection Binds.
   if (with.where_ != nullptr) {
     auto predicate = Lower(ctx, *with.where_->expression_);
     pipe = ctx.g.MakeFilter(pipe, predicate);

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -297,7 +297,7 @@ auto LowerSingleQuery(SingleQuery &sq, LoweringCtx &ctx) -> eclass;
 // ORDER BY / SKIP / LIMIT / DISTINCT aren't lowered yet; refuse them rather than
 // silently drop them (wrong results). Replaced when those operators land.
 void GuardUnsupportedTailClauses(ReturnBody const &body) {
-  if (!body.order_by.empty() || body.skip != nullptr || body.limit != nullptr || body.distinct) {
+  if (!body.order_by.empty() || body.skip || body.limit || body.distinct) {
     ThrowNotImplementedYet("ORDER BY / SKIP / LIMIT / DISTINCT");
   }
 }
@@ -331,7 +331,7 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
   }
   GuardUnsupportedTailClauses(with.body_);
   // WHERE filters the projected rows, so Filter sits above the projection Binds.
-  if (with.where_ != nullptr) {
+  if (with.where_) {
     auto predicate = Lower(ctx, *with.where_->expression_);
     pipe = ctx.g.MakeFilter(pipe, predicate);
   }

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -309,13 +309,10 @@ struct symbol_build_traits<symbol::Filter> {
     using predicate = ChildSlot<child::filter::predicate, Expression *>;
   };
 
-  // all_filters_ is the source of Filter::ToString's EXPLAIN label; runtime
-  // filtering uses expression_. We reuse v1's CollectFilterExpression on purpose:
-  // its classification matches v1 and is what the index rewrites plan_v2 will grow
-  // (Property/Id/Point/Label) consume. Build is bottom-up, so the predicate's
-  // Identifiers are already in state.symbol_table. Today it yields Generic and Id
-  // filters; Property/Point/Label/EdgeType need AST nodes still refused at lowering.
-  // pattern_filters stays empty (MATCH territory).
+  // all_filters_ feeds the EXPLAIN label (Filter::ToString); runtime filtering uses
+  // expression_. CollectFilterExpression classifies exactly as v1 does (today only
+  // Generic/Id). Build is bottom-up, so the predicate's Identifiers are already in
+  // state.symbol_table.
   static auto build(BuildState &state, ENodeRef /*node*/, Children children) -> result_type {
     auto const &input = children.get<slots::input>();
     auto *predicate = children.get<slots::predicate>();

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -309,12 +309,13 @@ struct symbol_build_traits<symbol::Filter> {
     using predicate = ChildSlot<child::filter::predicate, Expression *>;
   };
 
-  // Built exactly as the v1 planner does in GenFilters: populate `all_filters_`
-  // via CollectFilterExpression so EXPLAIN renders the predicate (Filter::ToString
-  // derives its label solely from all_filters_).  Build is bottom-up, so the
-  // predicate's Identifier -> Symbol nodes are already registered in
-  // `state.symbol_table` by the time this runs.  pattern_filters is empty (that
-  // is MATCH pattern-predicate territory, N/A without MATCH).
+  // all_filters_ populated as v1's GenFilters does (source of Filter::ToString's
+  // EXPLAIN label). Build is bottom-up, so the predicate's Identifiers are already
+  // in state.symbol_table. pattern_filters is empty (MATCH territory); only the
+  // Generic path is reachable today.
+  // NOTE: the EXPLAIN label is empty for now - the converter clones the plan and
+  // Filter::Clone drops all_filters_ (fixed in a stacked commit); runtime is
+  // unaffected (it uses expression_, which is cloned).
   static auto build(BuildState &state, ENodeRef /*node*/, Children children) -> result_type {
     auto const &input = children.get<slots::input>();
     auto *predicate = children.get<slots::predicate>();

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -313,9 +313,6 @@ struct symbol_build_traits<symbol::Filter> {
   // EXPLAIN label). Build is bottom-up, so the predicate's Identifiers are already
   // in state.symbol_table. pattern_filters is empty (MATCH territory); only the
   // Generic path is reachable today.
-  // NOTE: the EXPLAIN label is empty for now - the converter clones the plan and
-  // Filter::Clone drops all_filters_ (fixed in a stacked commit); runtime is
-  // unaffected (it uses expression_, which is cloned).
   static auto build(BuildState &state, ENodeRef /*node*/, Children children) -> result_type {
     auto const &input = children.get<slots::input>();
     auto *predicate = children.get<slots::predicate>();

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -309,15 +309,19 @@ struct symbol_build_traits<symbol::Filter> {
     using predicate = ChildSlot<child::filter::predicate, Expression *>;
   };
 
-  // all_filters_ feeds the EXPLAIN label (Filter::ToString); runtime filtering uses
-  // expression_. CollectFilterExpression classifies exactly as v1 does (today only
-  // Generic/Id). Build is bottom-up, so the predicate's Identifiers are already in
-  // state.symbol_table.
+  // Runtime filtering uses expression_. all_filters_ is display-only (feeds
+  // Filter::ToString's EXPLAIN label). We record the whole predicate as one Generic
+  // filter rather than classifying it (v1's CollectFilterExpression): index selection
+  // in plan_v2 will be an e-graph rewrite that offers indexed scans as a costed
+  // option, not a classification baked in at build time.
   static auto build(BuildState &state, ENodeRef /*node*/, Children children) -> result_type {
     auto const &input = children.get<slots::input>();
     auto *predicate = children.get<slots::predicate>();
+    query::plan::UsedSymbolsCollector collector(state.symbol_table);
+    predicate->Accept(collector);
     query::plan::Filters all_filters;
-    all_filters.CollectFilterExpression(predicate, state.symbol_table);
+    all_filters.SetFilters(
+        {query::plan::FilterInfo{query::plan::FilterInfo::Type::Generic, predicate, std::move(collector.symbols_)}});
     return std::static_pointer_cast<LogicalOperator>(std::make_shared<query::plan::Filter>(
         input, std::vector<std::shared_ptr<LogicalOperator>>{}, predicate, std::move(all_filters)));
   }

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -16,6 +16,7 @@
 
 #include <range/v3/range/conversion.hpp>
 
+#include "query/plan/preprocess.hpp"
 #include "query/plan_v2/egraph/child_layout.hpp"
 #include "query/plan_v2/egraph/op_ast_lists.hpp"
 #include "query/plan_v2/egraph/symbol_dispatch.hpp"
@@ -296,6 +297,31 @@ struct symbol_build_traits<symbol::Unwind> {
     // n=0 scales every input row to zero rows: the result is empty.
     if (scale == 0) return std::static_pointer_cast<LogicalOperator>(std::make_shared<query::plan::EmptyResult>(input));
     return std::static_pointer_cast<LogicalOperator>(std::make_shared<query::plan::CardinalityScale>(input, scale));
+  }
+};
+
+template <>
+struct symbol_build_traits<symbol::Filter> {
+  using result_type = LogicalOperatorPtr;
+
+  struct slots {
+    using input = ChildSlot<child::filter::input, LogicalOperatorPtr>;
+    using predicate = ChildSlot<child::filter::predicate, Expression *>;
+  };
+
+  // Built exactly as the v1 planner does in GenFilters: populate `all_filters_`
+  // via CollectFilterExpression so EXPLAIN renders the predicate (Filter::ToString
+  // derives its label solely from all_filters_).  Build is bottom-up, so the
+  // predicate's Identifier -> Symbol nodes are already registered in
+  // `state.symbol_table` by the time this runs.  pattern_filters is empty (that
+  // is MATCH pattern-predicate territory, N/A without MATCH).
+  static auto build(BuildState &state, ENodeRef /*node*/, Children children) -> result_type {
+    auto const &input = children.get<slots::input>();
+    auto *predicate = children.get<slots::predicate>();
+    query::plan::Filters all_filters;
+    all_filters.CollectFilterExpression(predicate, state.symbol_table);
+    return std::static_pointer_cast<LogicalOperator>(std::make_shared<query::plan::Filter>(
+        input, std::vector<std::shared_ptr<LogicalOperator>>{}, predicate, std::move(all_filters)));
   }
 };
 

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -309,10 +309,13 @@ struct symbol_build_traits<symbol::Filter> {
     using predicate = ChildSlot<child::filter::predicate, Expression *>;
   };
 
-  // all_filters_ populated as v1's GenFilters does (source of Filter::ToString's
-  // EXPLAIN label). Build is bottom-up, so the predicate's Identifiers are already
-  // in state.symbol_table. pattern_filters is empty (MATCH territory); only the
-  // Generic path is reachable today.
+  // all_filters_ is the source of Filter::ToString's EXPLAIN label; runtime
+  // filtering uses expression_. We reuse v1's CollectFilterExpression on purpose:
+  // its classification matches v1 and is what the index rewrites plan_v2 will grow
+  // (Property/Id/Point/Label) consume. Build is bottom-up, so the predicate's
+  // Identifiers are already in state.symbol_table. Today it yields Generic and Id
+  // filters; Property/Point/Label/EdgeType need AST nodes still refused at lowering.
+  // pattern_filters stays empty (MATCH territory).
   static auto build(BuildState &state, ENodeRef /*node*/, Children children) -> result_type {
     auto const &input = children.get<slots::input>();
     auto *predicate = children.get<slots::predicate>();

--- a/src/query/plan_v2/resolve/resolver.hpp
+++ b/src/query/plan_v2/resolve/resolver.hpp
@@ -200,9 +200,8 @@ struct symbol_resolve_traits<symbol::Output> {
 template <>
 struct symbol_resolve_traits<symbol::Filter> {
   // Output with own_syms = ∅: the pipe must introduce the chosen alt's full set
-  // (which ⊇ predicate.required via FilterFlatMap's pruning), and the predicate
-  // reads in parent.in_scope ∪ that set. Uniform threading wouldn't force the
-  // pipe to provide the predicate's symbols nor let the predicate see them.
+  // (⊇ predicate.required via FilterFlatMap's pruning), and the predicate reads
+  // parent.in_scope ∪ that set.
   static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,
                                VariableSet const &chosen_introduces, SymbolContext const & /*syms*/,
                                planner::core::extract::ChildSink<ResolverKey> auto visit) {

--- a/src/query/plan_v2/resolve/resolver.hpp
+++ b/src/query/plan_v2/resolve/resolver.hpp
@@ -186,6 +186,25 @@ struct symbol_resolve_traits<symbol::Output> {
   }
 };
 
+template <>
+struct symbol_resolve_traits<symbol::Filter> {
+  // Structurally Output with own_syms = ∅: Filter binds nothing, so the pipe
+  // carries the chosen alt's full introduces (⊇ parent demand AND ⊇
+  // predicate.required, by FilterFlatMap's pruning), and the predicate is an
+  // expression read in parent.in_scope ∪ that set.  Uniform threading would be
+  // wrong here - it would neither force the pipe to introduce the predicate's
+  // symbols nor let the predicate see pipe-introduced bindings.
+  static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,
+                               VariableSet const &chosen_introduces, SymbolContext const & /*syms*/,
+                               planner::core::extract::ChildSink<ResolverKey> auto visit) {
+    using namespace child::filter;
+    auto const &children = enode.children();
+    auto pred_in_scope = parent_key.in_scope.set_union(chosen_introduces);
+    visit(ResolverKey{children[input], parent_key.in_scope, chosen_introduces});
+    visit(ResolverKey{children[predicate], std::move(pred_in_scope), {}});
+  }
+};
+
 // Expression ops and structural leaves: uniform threading.
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define MG_UNIFORM_RESOLVE(SYM) \

--- a/src/query/plan_v2/resolve/resolver.hpp
+++ b/src/query/plan_v2/resolve/resolver.hpp
@@ -188,12 +188,10 @@ struct symbol_resolve_traits<symbol::Output> {
 
 template <>
 struct symbol_resolve_traits<symbol::Filter> {
-  // Structurally Output with own_syms = ∅: Filter binds nothing, so the pipe
-  // carries the chosen alt's full introduces (⊇ parent demand AND ⊇
-  // predicate.required, by FilterFlatMap's pruning), and the predicate is an
-  // expression read in parent.in_scope ∪ that set.  Uniform threading would be
-  // wrong here - it would neither force the pipe to introduce the predicate's
-  // symbols nor let the predicate see pipe-introduced bindings.
+  // Output with own_syms = ∅: the pipe must introduce the chosen alt's full set
+  // (which ⊇ predicate.required via FilterFlatMap's pruning), and the predicate
+  // reads in parent.in_scope ∪ that set. Uniform threading wouldn't force the
+  // pipe to provide the predicate's symbols nor let the predicate see them.
   static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,
                                VariableSet const &chosen_introduces, SymbolContext const & /*syms*/,
                                planner::core::extract::ChildSink<ResolverKey> auto visit) {

--- a/src/query/plan_v2/resolve/resolver.hpp
+++ b/src/query/plan_v2/resolve/resolver.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <span>
 #include <utility>
 
 #include <boost/container_hash/hash.hpp>
@@ -162,6 +163,20 @@ struct symbol_resolve_traits<symbol::Subquery> {
   }
 };
 
+// Threads a "pipe + non-introducing reader children" operator. The pipe must
+// introduce `pipe_must_introduce`; each reader child reads
+// parent.in_scope ∪ pipe_must_introduce and introduces nothing. Shared by
+// Output (readers = NamedOutput children) and Filter (reader = predicate).
+void ResolvePipeThenReaders(planner::core::EClassId pipe, std::span<planner::core::EClassId const> reader_children,
+                            ResolverKey const &parent_key, VariableSet const &pipe_must_introduce,
+                            planner::core::extract::ChildSink<ResolverKey> auto visit) {
+  auto const reader_in_scope = parent_key.in_scope.set_union(pipe_must_introduce);
+  visit(ResolverKey{pipe, parent_key.in_scope, pipe_must_introduce});
+  for (auto reader : reader_children) {
+    visit(ResolverKey{reader, reader_in_scope, {}});
+  }
+}
+
 template <>
 struct symbol_resolve_traits<symbol::Output> {
   // own_syms = {each NamedOutput child's sym}. Pipe gets:
@@ -178,11 +193,7 @@ struct symbol_resolve_traits<symbol::Output> {
     DMG_ASSERT(!children.empty(), "Output enode must have at least a pipe child");
     auto const own_syms = ExtractOutputOwnSyms(enode, syms.egraph, syms.variable_index);
     auto const pipe_must_introduce = chosen_introduces.difference(own_syms);
-    auto const named_out_in_scope = parent_key.in_scope.set_union(pipe_must_introduce);
-    visit(ResolverKey{children[pipe], parent_key.in_scope, pipe_must_introduce});
-    for (auto named_out : children.subspan(first_named)) {
-      visit(ResolverKey{named_out, named_out_in_scope, {}});
-    }
+    ResolvePipeThenReaders(children[pipe], children.subspan(first_named), parent_key, pipe_must_introduce, visit);
   }
 };
 
@@ -197,9 +208,7 @@ struct symbol_resolve_traits<symbol::Filter> {
                                planner::core::extract::ChildSink<ResolverKey> auto visit) {
     using namespace child::filter;
     auto const &children = enode.children();
-    auto pred_in_scope = parent_key.in_scope.set_union(chosen_introduces);
-    visit(ResolverKey{children[input], parent_key.in_scope, chosen_introduces});
-    visit(ResolverKey{children[predicate], std::move(pred_in_scope), {}});
+    ResolvePipeThenReaders(children[input], children.subspan(predicate, 1), parent_key, chosen_introduces, visit);
   }
 };
 

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -355,6 +355,53 @@ TEST_F(PlannerV2InterpreterTest, UserParameterRangeLengthEnablesElision) {
   for (auto const &row : exec.GetResults()) EXPECT_EQ(row[0].ValueInt(), 42);
 }
 
+TEST_F(PlannerV2InterpreterTest, WithWhereFiltersRows) {
+  // The WHERE predicate filters the projected rows: only 2 and 3 satisfy x > 1.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereThatMatchesNothingYieldsEmptyResult) {
+  // A predicate no row satisfies executes to an empty result, not an error.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 100 RETURN x;");
+  EXPECT_EQ(stream.GetResults().size(), 0U);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereThatMatchesEverythingPassesAllRows) {
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 0 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
+  // A conjunction is a single boolean predicate expression; only 2 lies in (1, 3).
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 AND x < 3 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
+TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
+  // The WHERE lowers to a Filter operator above the projection.
+  auto stream = Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;");
+  EXPECT_NE(PlanText(stream).find("Filter"), std::string::npos) << PlanText(stream);
+}
+
+TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
+  // An IN-list predicate is an unsupported expression node; it must surface a
+  // clear query error rather than crash or silently drop rows.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
+  // SKIP/LIMIT/ORDER BY are not built into operators yet. Rather than silently
+  // ignore the SKIP (wrong results), the query is refused.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);
+}
+
 TYPED_TEST(InterpreterTest, MultiplePulls) {
   {
     auto [stream, qid] = this->Prepare("UNWIND [1,2,3,4,5] as n RETURN n");

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -444,6 +444,15 @@ TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);
 }
 
+TEST_F(PlannerV2InterpreterTest, WherePatternPredicateReportsNotImplemented) {
+  // A graph-pattern sub-expression in a WHERE is what v1 compiles into a Filter's
+  // pattern_filters_. plan_v2 doesn't lower pattern expressions, so it refuses the
+  // predicate during expression lowering rather than building a Filter with pattern
+  // sub-plans - pattern_filters_ is always empty in plan_v2.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE size([(a)-[]->(b) | b]) > 0 RETURN x;"),
+               memgraph::query::QueryException);
+}
+
 TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
   // ORDER BY / SKIP / LIMIT aren't built yet; refused rather than silently dropped.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -394,14 +394,10 @@ TEST_F(PlannerV2InterpreterTest, WithWhereKeepsAliveASymbolUsedOnlyInThePredicat
 }
 
 TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
-  // Filter sits above the Unwind. The predicate text isn't asserted: Filter::Clone
-  // drops all_filters_ so the label renders empty (strengthened in the stacked fix).
+  // The predicate renders as a Generic filter over x. Asserting the text (not just
+  // "Filter") proves all_filters_ was captured and survived the plan clone.
   auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;"));
-  auto const filter_pos = plan.find("Filter");
-  auto const unwind_pos = plan.find("Unwind");
-  ASSERT_NE(filter_pos, std::string::npos) << plan;
-  ASSERT_NE(unwind_pos, std::string::npos) << plan;
-  EXPECT_LT(filter_pos, unwind_pos) << plan;  // Filter above Unwind
+  EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
 }
 
 TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -385,12 +385,9 @@ TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
 }
 
 TEST_F(PlannerV2InterpreterTest, WithWherePredicateOverAliasInlinesTheAliasAndDropsItsBind) {
-  // y is referenced only in the WHERE, never in the RETURN. The inline rewrite
-  // merges Identifier(y) with its definition (x * 2), so the predicate is
-  // extracted as x * 2 > 2: the filter reads {x}, and y's Bind is eliminated
-  // rather than kept. (Demand threading that keeps a predicate-only symbol alive
-  // is exercised instead by a non-inlinable Unwind symbol; see the pipeline
-  // suite's PredicateDemandKeepsUnwindBinding.) Only x in {2, 3} survives.
+  // y is used only in the WHERE. The inline rewrite merges Identifier(y) with its
+  // definition, so the predicate extracts as x * 2 > 2 (filter reads {x}) and y's Bind
+  // is dropped, not kept. Demand-based keep-alive: see PredicateDemandKeepsUnwindBinding.
   auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;"));
   EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
   auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;");

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -430,6 +430,15 @@ TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
   EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
 }
 
+TEST_F(PlannerV2InterpreterTest, WhereFilterIsAlwaysGenericNeverIndexClassified) {
+  // plan_v2 records every predicate as one Generic filter and never runs v1's index
+  // classification. id(x) classifies as an Id filter in v1 (labelled "id(x)"); here
+  // it must stay Generic - index selection is deferred to a future e-graph rewrite.
+  auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE id(x) = 5 RETURN x;"));
+  EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
+  EXPECT_EQ(plan.find("id(x)"), std::string::npos) << plan;
+}
+
 TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
   // IN-list is an unsupported expression node; it must error, not silently drop rows.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -384,22 +384,46 @@ TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
+TEST_F(PlannerV2InterpreterTest, WithWhereKeepsAliveASymbolUsedOnlyInThePredicate) {
+  // y is referenced only in the WHERE, never in the RETURN, so the resolver's
+  // demand threading must keep y's Bind alive. Only x*2 > 2 (x in {2, 3}) survives.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
 TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
-  // The WHERE lowers to a Filter operator above the projection.
-  auto stream = Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;");
-  EXPECT_NE(PlanText(stream).find("Filter"), std::string::npos) << PlanText(stream);
+  // Filter sits above the Unwind. The predicate text isn't asserted: Filter::Clone
+  // drops all_filters_ so the label renders empty (strengthened in the stacked fix).
+  auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;"));
+  auto const filter_pos = plan.find("Filter");
+  auto const unwind_pos = plan.find("Unwind");
+  ASSERT_NE(filter_pos, std::string::npos) << plan;
+  ASSERT_NE(unwind_pos, std::string::npos) << plan;
+  EXPECT_LT(filter_pos, unwind_pos) << plan;  // Filter above Unwind
 }
 
 TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
-  // An IN-list predicate is an unsupported expression node; it must surface a
-  // clear query error rather than crash or silently drop rows.
+  // IN-list is an unsupported expression node; it must error, not silently drop rows.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);
 }
 
 TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
-  // SKIP/LIMIT/ORDER BY are not built into operators yet. Rather than silently
-  // ignore the SKIP (wrong results), the query is refused.
+  // ORDER BY / SKIP / LIMIT aren't built yet; refused rather than silently dropped.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, TailClauseOnReturnReportsNotImplemented) {
+  // Same guard on the final RETURN body.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x LIMIT 2;"), memgraph::query::QueryException);
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY x;"), memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, DistinctReportsNotImplemented) {
+  // DISTINCT isn't lowered yet; dropping it would silently return duplicates.
+  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;"), memgraph::query::QueryException);
+  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x WITH DISTINCT x RETURN x;"), memgraph::query::QueryException);
 }
 
 TYPED_TEST(InterpreterTest, MultiplePulls) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -384,13 +384,46 @@ TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
-TEST_F(PlannerV2InterpreterTest, WithWhereKeepsAliveASymbolUsedOnlyInThePredicate) {
-  // y is referenced only in the WHERE, never in the RETURN, so the resolver's
-  // demand threading must keep y's Bind alive. Only x*2 > 2 (x in {2, 3}) survives.
+TEST_F(PlannerV2InterpreterTest, WithWherePredicateOverAliasInlinesTheAliasAndDropsItsBind) {
+  // y is referenced only in the WHERE, never in the RETURN. The inline rewrite
+  // merges Identifier(y) with its definition (x * 2), so the predicate is
+  // extracted as x * 2 > 2: the filter reads {x}, and y's Bind is eliminated
+  // rather than kept. (Demand threading that keeps a predicate-only symbol alive
+  // is exercised instead by a non-inlinable Unwind symbol; see the pipeline
+  // suite's PredicateDemandKeepsUnwindBinding.) Only x in {2, 3} survives.
+  auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;"));
+  EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
   auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;");
   ASSERT_EQ(stream.GetResults().size(), 2U);
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
   EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereDisjunctionFiltersRows) {
+  // A single OR predicate: x < 2 (x = 1) OR x = 4 keeps the endpoints, drops 2 and 3.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4] AS x WITH x WHERE x < 2 OR x = 4 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 4);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereNegationFiltersRows) {
+  // NOT over an equality: everything except 3 survives.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4] AS x WITH x WHERE NOT x = 3 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 4);
+}
+
+TEST_F(PlannerV2InterpreterTest, ChainedWithWhereAppliesEveryFilter) {
+  // Two WITH ... WHERE clauses stack into two Filters; the resolver threads scope
+  // through the lower Filter into the upper one. x > 1 then x < 5 leaves {2, 3, 4}.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4, 5] AS x WITH x WHERE x > 1 WITH x WHERE x < 5 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 4);
 }
 
 TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -958,6 +958,53 @@ TEST_F(PlannerV2InterpreterTest, UserParameterRangeLengthEnablesElision) {
   for (auto const &row : exec.GetResults()) EXPECT_EQ(row[0].ValueInt(), 42);
 }
 
+TEST_F(PlannerV2InterpreterTest, WithWhereFiltersRows) {
+  // The WHERE predicate filters the projected rows: only 2 and 3 satisfy x > 1.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereThatMatchesNothingYieldsEmptyResult) {
+  // A predicate no row satisfies executes to an empty result, not an error.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 100 RETURN x;");
+  EXPECT_EQ(stream.GetResults().size(), 0U);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereThatMatchesEverythingPassesAllRows) {
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 0 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
+  // A conjunction is a single boolean predicate expression; only 2 lies in (1, 3).
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 AND x < 3 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
+TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
+  // The WHERE lowers to a Filter operator above the projection.
+  auto stream = Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;");
+  EXPECT_NE(PlanText(stream).find("Filter"), std::string::npos) << PlanText(stream);
+}
+
+TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
+  // An IN-list predicate is an unsupported expression node; it must surface a
+  // clear query error rather than crash or silently drop rows.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
+  // SKIP/LIMIT/ORDER BY are not built into operators yet. Rather than silently
+  // ignore the SKIP (wrong results), the query is refused.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);
+}
+
 TYPED_TEST(InterpreterTest, MultiplePulls) {
   {
     auto [stream, qid] = this->Prepare("UNWIND [1,2,3,4,5] as n RETURN n");

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -997,14 +997,10 @@ TEST_F(PlannerV2InterpreterTest, WithWhereKeepsAliveASymbolUsedOnlyInThePredicat
 }
 
 TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
-  // Filter sits above the Unwind. The predicate text isn't asserted: Filter::Clone
-  // drops all_filters_ so the label renders empty (strengthened in the stacked fix).
+  // The predicate renders as a Generic filter over x. Asserting the text (not just
+  // "Filter") proves all_filters_ was captured and survived the plan clone.
   auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;"));
-  auto const filter_pos = plan.find("Filter");
-  auto const unwind_pos = plan.find("Unwind");
-  ASSERT_NE(filter_pos, std::string::npos) << plan;
-  ASSERT_NE(unwind_pos, std::string::npos) << plan;
-  EXPECT_LT(filter_pos, unwind_pos) << plan;  // Filter above Unwind
+  EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
 }
 
 TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -987,13 +987,46 @@ TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
-TEST_F(PlannerV2InterpreterTest, WithWhereKeepsAliveASymbolUsedOnlyInThePredicate) {
-  // y is referenced only in the WHERE, never in the RETURN, so the resolver's
-  // demand threading must keep y's Bind alive. Only x*2 > 2 (x in {2, 3}) survives.
+TEST_F(PlannerV2InterpreterTest, WithWherePredicateOverAliasInlinesTheAliasAndDropsItsBind) {
+  // y is referenced only in the WHERE, never in the RETURN. The inline rewrite
+  // merges Identifier(y) with its definition (x * 2), so the predicate is
+  // extracted as x * 2 > 2: the filter reads {x}, and y's Bind is eliminated
+  // rather than kept. (Demand threading that keeps a predicate-only symbol alive
+  // is exercised instead by a non-inlinable Unwind symbol; see the pipeline
+  // suite's PredicateDemandKeepsUnwindBinding.) Only x in {2, 3} survives.
+  auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;"));
+  EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
   auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;");
   ASSERT_EQ(stream.GetResults().size(), 2U);
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
   EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereDisjunctionFiltersRows) {
+  // A single OR predicate: x < 2 (x = 1) OR x = 4 keeps the endpoints, drops 2 and 3.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4] AS x WITH x WHERE x < 2 OR x = 4 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 4);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithWhereNegationFiltersRows) {
+  // NOT over an equality: everything except 3 survives.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4] AS x WITH x WHERE NOT x = 3 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 4);
+}
+
+TEST_F(PlannerV2InterpreterTest, ChainedWithWhereAppliesEveryFilter) {
+  // Two WITH ... WHERE clauses stack into two Filters; the resolver threads scope
+  // through the lower Filter into the upper one. x > 1 then x < 5 leaves {2, 3, 4}.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4, 5] AS x WITH x WHERE x > 1 WITH x WHERE x < 5 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 4);
 }
 
 TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -988,12 +988,9 @@ TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
 }
 
 TEST_F(PlannerV2InterpreterTest, WithWherePredicateOverAliasInlinesTheAliasAndDropsItsBind) {
-  // y is referenced only in the WHERE, never in the RETURN. The inline rewrite
-  // merges Identifier(y) with its definition (x * 2), so the predicate is
-  // extracted as x * 2 > 2: the filter reads {x}, and y's Bind is eliminated
-  // rather than kept. (Demand threading that keeps a predicate-only symbol alive
-  // is exercised instead by a non-inlinable Unwind symbol; see the pipeline
-  // suite's PredicateDemandKeepsUnwindBinding.) Only x in {2, 3} survives.
+  // y is used only in the WHERE. The inline rewrite merges Identifier(y) with its
+  // definition, so the predicate extracts as x * 2 > 2 (filter reads {x}) and y's Bind
+  // is dropped, not kept. Demand-based keep-alive: see PredicateDemandKeepsUnwindBinding.
   auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;"));
   EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
   auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;");

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1047,6 +1047,15 @@ TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);
 }
 
+TEST_F(PlannerV2InterpreterTest, WherePatternPredicateReportsNotImplemented) {
+  // A graph-pattern sub-expression in a WHERE is what v1 compiles into a Filter's
+  // pattern_filters_. plan_v2 doesn't lower pattern expressions, so it refuses the
+  // predicate during expression lowering rather than building a Filter with pattern
+  // sub-plans - pattern_filters_ is always empty in plan_v2.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE size([(a)-[]->(b) | b]) > 0 RETURN x;"),
+               memgraph::query::QueryException);
+}
+
 TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
   // ORDER BY / SKIP / LIMIT aren't built yet; refused rather than silently dropped.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -987,22 +987,46 @@ TEST_F(PlannerV2InterpreterTest, WithWhereComposesBooleanPredicates) {
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
+TEST_F(PlannerV2InterpreterTest, WithWhereKeepsAliveASymbolUsedOnlyInThePredicate) {
+  // y is referenced only in the WHERE, never in the RETURN, so the resolver's
+  // demand threading must keep y's Bind alive. Only x*2 > 2 (x in {2, 3}) survives.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x, x * 2 AS y WHERE y > 2 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
 TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
-  // The WHERE lowers to a Filter operator above the projection.
-  auto stream = Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;");
-  EXPECT_NE(PlanText(stream).find("Filter"), std::string::npos) << PlanText(stream);
+  // Filter sits above the Unwind. The predicate text isn't asserted: Filter::Clone
+  // drops all_filters_ so the label renders empty (strengthened in the stacked fix).
+  auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;"));
+  auto const filter_pos = plan.find("Filter");
+  auto const unwind_pos = plan.find("Unwind");
+  ASSERT_NE(filter_pos, std::string::npos) << plan;
+  ASSERT_NE(unwind_pos, std::string::npos) << plan;
+  EXPECT_LT(filter_pos, unwind_pos) << plan;  // Filter above Unwind
 }
 
 TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
-  // An IN-list predicate is an unsupported expression node; it must surface a
-  // clear query error rather than crash or silently drop rows.
+  // IN-list is an unsupported expression node; it must error, not silently drop rows.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);
 }
 
 TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
-  // SKIP/LIMIT/ORDER BY are not built into operators yet. Rather than silently
-  // ignore the SKIP (wrong results), the query is refused.
+  // ORDER BY / SKIP / LIMIT aren't built yet; refused rather than silently dropped.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, TailClauseOnReturnReportsNotImplemented) {
+  // Same guard on the final RETURN body.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x LIMIT 2;"), memgraph::query::QueryException);
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY x;"), memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, DistinctReportsNotImplemented) {
+  // DISTINCT isn't lowered yet; dropping it would silently return duplicates.
+  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;"), memgraph::query::QueryException);
+  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x WITH DISTINCT x RETURN x;"), memgraph::query::QueryException);
 }
 
 TYPED_TEST(InterpreterTest, MultiplePulls) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1033,6 +1033,15 @@ TEST_F(PlannerV2InterpreterTest, ExplainShowsFilterOperator) {
   EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
 }
 
+TEST_F(PlannerV2InterpreterTest, WhereFilterIsAlwaysGenericNeverIndexClassified) {
+  // plan_v2 records every predicate as one Generic filter and never runs v1's index
+  // classification. id(x) classifies as an Id filter in v1 (labelled "id(x)"); here
+  // it must stay Generic - index selection is deferred to a future e-graph rewrite.
+  auto const plan = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x WITH x WHERE id(x) = 5 RETURN x;"));
+  EXPECT_NE(plan.find("Filter Generic {x}"), std::string::npos) << plan;
+  EXPECT_EQ(plan.find("id(x)"), std::string::npos) << plan;
+}
+
 TEST_F(PlannerV2InterpreterTest, UnsupportedPredicateReportsNotImplemented) {
   // IN-list is an unsupported expression node; it must error, not silently drop rows.
   EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x WHERE x IN [1, 2] RETURN x;"), memgraph::query::QueryException);

--- a/tests/unit/query_plan_v2_pipeline.cpp
+++ b/tests/unit/query_plan_v2_pipeline.cpp
@@ -773,6 +773,26 @@ INSTANTIATE_TEST_SUITE_P(
             .query = "UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;",
             .expected_details = {"Produce {x`1:x}", "Filter", "Unwind {x:literal}", "Once"},
             .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
+        },
+        // Two WITH ... WHERE clauses stack into two Filters; each no-op WITH x
+        // bind fuses away. Proves the resolver threads scope through a Filter
+        // whose input is itself a Filter.
+        PipelineTestCase{
+            .name = "ChainedWithWhereStacksTwoFilters",
+            .query = "UNWIND [1, 2, 3, 4, 5] AS x WITH x WHERE x > 1 WITH x WHERE x < 5 RETURN x;",
+            .expected_details = {"Produce {x`1:x}", "Filter", "Filter", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 2,  // both no-op WITH x binds are rewritten away
+        },
+        // x is used only in the predicate (RETURN is the constant 42), so without
+        // the WHERE the provable-length range elides to CardinalityScale. The
+        // predicate's demand for x forces the pipe to introduce it, blocking the
+        // elision: a real Unwind + Filter survive. Contrast the elision that fires
+        // in interpreter.cpp's UnwindOverProvableLengthRangeElidesUnusedBinding.
+        PipelineTestCase{
+            .name = "PredicateDemandKeepsUnwindBinding",
+            .query = "UNWIND range(1, 100) AS x WITH x WHERE x > 50 RETURN 42 AS r;",
+            .expected_details = {"Produce {r`1:42}", "Filter", "Unwind {x:RANGE(1, 100)}", "Once"},
+            .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
         }
     ),
     TestCaseName

--- a/tests/unit/query_plan_v2_pipeline.cpp
+++ b/tests/unit/query_plan_v2_pipeline.cpp
@@ -774,20 +774,17 @@ INSTANTIATE_TEST_SUITE_P(
             .expected_details = {"Produce {x`1:x}", "Filter", "Unwind {x:literal}", "Once"},
             .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
         },
-        // Two WITH ... WHERE clauses stack into two Filters; each no-op WITH x
-        // bind fuses away. Proves the resolver threads scope through a Filter
-        // whose input is itself a Filter.
+        // Two WITH ... WHERE clauses stack into two Filters (each no-op WITH x bind
+        // fuses away): the resolver threads scope through a Filter above a Filter.
         PipelineTestCase{
             .name = "ChainedWithWhereStacksTwoFilters",
             .query = "UNWIND [1, 2, 3, 4, 5] AS x WITH x WHERE x > 1 WITH x WHERE x < 5 RETURN x;",
             .expected_details = {"Produce {x`1:x}", "Filter", "Filter", "Unwind {x:literal}", "Once"},
             .expected_rewrites = 2,  // both no-op WITH x binds are rewritten away
         },
-        // x is used only in the predicate (RETURN is the constant 42), so without
-        // the WHERE the provable-length range elides to CardinalityScale. The
-        // predicate's demand for x forces the pipe to introduce it, blocking the
-        // elision: a real Unwind + Filter survive. Contrast the elision that fires
-        // in interpreter.cpp's UnwindOverProvableLengthRangeElidesUnusedBinding.
+        // x is used only in the predicate, so its demand forces the pipe to introduce
+        // it, blocking the CardinalityScale elision that fires when x is unused (cf.
+        // interpreter's UnwindOverProvableLengthRangeElidesUnusedBinding).
         PipelineTestCase{
             .name = "PredicateDemandKeepsUnwindBinding",
             .query = "UNWIND range(1, 100) AS x WITH x WHERE x > 50 RETURN 42 AS r;",

--- a/tests/unit/query_plan_v2_pipeline.cpp
+++ b/tests/unit/query_plan_v2_pipeline.cpp
@@ -765,6 +765,14 @@ INSTANTIATE_TEST_SUITE_P(
             .query = "UNWIND [1, 2, 3] AS x RETURN x;",
             .expected_details = {"Produce {x`1:x}", "Unwind {x:literal}", "Once"},
             .expected_rewrites = 0,
+        },
+        // A WHERE lowers to a Filter above the projection; the no-op WITH bind
+        // fuses away, leaving Produce -> Filter -> Unwind -> Once.
+        PipelineTestCase{
+            .name = "WithWhereFiltersRows",
+            .query = "UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;",
+            .expected_details = {"Produce {x`1:x}", "Filter", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
         }
     ),
     TestCaseName

--- a/tests/unit/query_plan_v2_pipeline.cpp
+++ b/tests/unit/query_plan_v2_pipeline.cpp
@@ -148,8 +148,8 @@ class SimplePlanChecker : public plan::HierarchicalLogicalOperatorVisitor {
     return true;
   }
 
-  bool PreVisit(plan::Filter &) override {
-    operator_details.push_back("Filter");
+  bool PreVisit(plan::Filter &op) override {
+    operator_details.push_back("Filter " + DescribeExpression(op.expression_));
     return true;
   }
 
@@ -771,7 +771,7 @@ INSTANTIATE_TEST_SUITE_P(
         PipelineTestCase{
             .name = "WithWhereFiltersRows",
             .query = "UNWIND [1, 2, 3] AS x WITH x WHERE x > 1 RETURN x;",
-            .expected_details = {"Produce {x`1:x}", "Filter", "Unwind {x:literal}", "Once"},
+            .expected_details = {"Produce {x`1:x}", "Filter (x > 1)", "Unwind {x:literal}", "Once"},
             .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
         },
         // Two WITH ... WHERE clauses stack into two Filters (each no-op WITH x bind
@@ -779,7 +779,7 @@ INSTANTIATE_TEST_SUITE_P(
         PipelineTestCase{
             .name = "ChainedWithWhereStacksTwoFilters",
             .query = "UNWIND [1, 2, 3, 4, 5] AS x WITH x WHERE x > 1 WITH x WHERE x < 5 RETURN x;",
-            .expected_details = {"Produce {x`1:x}", "Filter", "Filter", "Unwind {x:literal}", "Once"},
+            .expected_details = {"Produce {x`1:x}", "Filter (x < 5)", "Filter (x > 1)", "Unwind {x:literal}", "Once"},
             .expected_rewrites = 2,  // both no-op WITH x binds are rewritten away
         },
         // x is used only in the predicate, so its demand forces the pipe to introduce
@@ -788,7 +788,7 @@ INSTANTIATE_TEST_SUITE_P(
         PipelineTestCase{
             .name = "PredicateDemandKeepsUnwindBinding",
             .query = "UNWIND range(1, 100) AS x WITH x WHERE x > 50 RETURN 42 AS r;",
-            .expected_details = {"Produce {r`1:42}", "Filter", "Unwind {x:RANGE(1, 100)}", "Once"},
+            .expected_details = {"Produce {r`1:42}", "Filter (x > 50)", "Unwind {x:RANGE(1, 100)}", "Once"},
             .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
         }
     ),


### PR DESCRIPTION
Adds `WITH ... WHERE` predicate execution to the experimental plan_v2 planner (behind `--experimental-enabled=planner-v2`).

**What:** predicates on a `WITH` projection now execute instead of throwing `NotYetImplemented`. Unsupported tail clauses (`ORDER BY` / `SKIP` / `LIMIT` / `DISTINCT`) and unsupported predicate shapes fail closed with a "not yet supported" error rather than silently dropping rows.

**How:** introduces a `Filter` e-graph operator with children `[input, predicate]` (binds nothing), wired through the standard operator surface — child layout, make/cost/resolve/build traits, and clause lowering. The predicate reuses the existing expression lowering, and the built operator is the legacy `query::plan::Filter`, so runtime filtering is unchanged. Replaces `HashConsTailExpressions` (which silently dropped `ORDER BY`/`SKIP`/`LIMIT`) with a throwing `GuardUnsupportedTailClauses`. The built `Filter` records its predicate as a single `Generic` filter rather than running v1's `CollectFilterExpression` classification — so EXPLAIN always shows `Filter Generic {…}` and index selection is deferred to a future e-graph rewrite instead of being baked in at build time.

**Why:** first and smallest of the epic #4203 sub-issues ("execute every non-graph read query"), and a template for the operators that follow.

Closes #4193.