### PR TITLE
fix: Handle null expression in parallel scan operators

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -10104,7 +10104,8 @@ UniqueCursorPtr ScanParallelByEdgePropertyValue::MakeCursor(utils::MemoryResourc
   auto get_chunks = [this](Frame &frame, ExecutionContext &context) {
     auto *db = context.db_accessor;
     auto maybe_prop_value = EvaluateExpressionToPropertyValue(expression_, frame, context, view_);
-    return db->ChunkedEdges(view_, property_, maybe_prop_value.value_or(storage::PropertyValue()), num_threads_);
+    if (!maybe_prop_value) return db->ChunkedEdges(view_, property_, storage::PropertyValue(), 0);
+    return db->ChunkedEdges(view_, property_, *maybe_prop_value, num_threads_);
   };
   return MakeUniqueCursorPtr<ScanParallelCursor<decltype(get_chunks)>>(
       mem, *this, mem, metric_handles, std::move(get_chunks));

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -9904,14 +9904,11 @@ UniqueCursorPtr ScanParallelByLabelProperties::MakeCursor(utils::MemoryResource 
     ExpressionEvaluator evaluator = ExpressionEvaluator{&frame, context, view_, nullptr, &context.number_of_hops};
 
     auto maybe_prop_value_ranges = EvaluateExpressionRangesAndCheckNull(expression_ranges_, evaluator);
-    // Return empty chunks if bounds are null - need to handle this case
-    // For now, we'll create a dummy chunks object, but this might need special handling
-    return db->ChunkedVertices(view_,
-                               label_,
-                               properties_,
-                               maybe_prop_value_ranges.value_or(std::vector<storage::PropertyValueRange>{}),
-                               num_threads_,
-                               index_order_);
+    if (!maybe_prop_value_ranges) {
+      return db->ChunkedVertices(
+          view_, label_, properties_, std::vector<storage::PropertyValueRange>{}, 0, index_order_);
+    }
+    return db->ChunkedVertices(view_, label_, properties_, *maybe_prop_value_ranges, num_threads_, index_order_);
   };
   return MakeUniqueCursorPtr<ScanParallelCursor<decltype(get_chunks)>>(
       mem, *this, mem, metric_handles, std::move(get_chunks));
@@ -10249,7 +10246,7 @@ UniqueCursorPtr ScanParallelByEdgeTypePropertyValue::MakeCursor(utils::MemoryRes
     auto maybe_prop_value = EvaluateExpressionToPropertyValue(expression_, frame, context, view_);
     if (!maybe_prop_value) {
       // Return empty chunks
-      return db->ChunkedEdges(view_, edge_type_, property_, std::nullopt, std::nullopt, num_threads_);
+      return db->ChunkedEdges(view_, edge_type_, property_, std::nullopt, std::nullopt, 0);
     }
     // Use range with equal bounds to simulate value lookup
     auto bound = utils::MakeBoundInclusive(*maybe_prop_value);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -9979,14 +9979,11 @@ UniqueCursorPtr ScanParallelByLabelProperties::MakeCursor(utils::MemoryResource 
     ExpressionEvaluator evaluator = ExpressionEvaluator{&frame, context, view_, nullptr, &context.number_of_hops};
 
     auto maybe_prop_value_ranges = EvaluateExpressionRangesAndCheckNull(expression_ranges_, evaluator);
-    // Return empty chunks if bounds are null - need to handle this case
-    // For now, we'll create a dummy chunks object, but this might need special handling
-    return db->ChunkedVertices(view_,
-                               label_,
-                               properties_,
-                               maybe_prop_value_ranges.value_or(std::vector<storage::PropertyValueRange>{}),
-                               num_threads_,
-                               index_order_);
+    if (!maybe_prop_value_ranges) {
+      return db->ChunkedVertices(
+          view_, label_, properties_, std::vector<storage::PropertyValueRange>{}, 0, index_order_);
+    }
+    return db->ChunkedVertices(view_, label_, properties_, *maybe_prop_value_ranges, num_threads_, index_order_);
   };
   return MakeUniqueCursorPtr<ScanParallelCursor<decltype(get_chunks)>>(
       mem, *this, mem, metric_handles, std::move(get_chunks));
@@ -10375,7 +10372,7 @@ UniqueCursorPtr ScanParallelByEdgeTypePropertyValue::MakeCursor(utils::MemoryRes
     auto maybe_prop_value = EvaluateExpressionToPropertyValue(expression_, frame, context, view_);
     if (!maybe_prop_value) {
       // Return empty chunks
-      return db->ChunkedEdges(view_, edge_type_, property_, std::nullopt, std::nullopt, num_threads_);
+      return db->ChunkedEdges(view_, edge_type_, property_, std::nullopt, std::nullopt, 0);
     }
     // Use range with equal bounds to simulate value lookup
     auto bound = utils::MakeBoundInclusive(*maybe_prop_value);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -10179,7 +10179,8 @@ UniqueCursorPtr ScanParallelByEdgePropertyValue::MakeCursor(utils::MemoryResourc
   auto get_chunks = [this](Frame &frame, ExecutionContext &context) {
     auto *db = context.db_accessor;
     auto maybe_prop_value = EvaluateExpressionToPropertyValue(expression_, frame, context, view_);
-    return db->ChunkedEdges(view_, property_, maybe_prop_value.value_or(storage::PropertyValue()), num_threads_);
+    if (!maybe_prop_value) return db->ChunkedEdges(view_, property_, storage::PropertyValue(), 0);
+    return db->ChunkedEdges(view_, property_, *maybe_prop_value, num_threads_);
   };
   return MakeUniqueCursorPtr<ScanParallelCursor<decltype(get_chunks)>>(
       mem, *this, mem, metric_handles, std::move(get_chunks));

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -299,6 +299,18 @@ class TestParallelIndices:
         """Test edge property index for all values."""
         verify_parallel_matches_serial(indexed_db, "MATCH ()-[e:KNOWS]->() WHERE e.since IS NOT NULL RETURN e")
 
+    def test_global_edge_property_index_null_value(self, memgraph):
+        """Parallel scan with null value on global edge property index returns no results."""
+        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
+        memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
+        try:
+            verify_parallel_matches_serial(
+                memgraph,
+                "MATCH ()-[e]->() WHERE e.val = head([]) RETURN count(e)",
+            )
+        finally:
+            memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
+
     @pytest.fixture
     def desc_indexed_db(self, memgraph):
         """Database with a DESC-ordered label+property index only."""

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -299,19 +299,6 @@ class TestParallelIndices:
         """Test edge property index for all values."""
         verify_parallel_matches_serial(indexed_db, "MATCH ()-[e:KNOWS]->() WHERE e.since IS NOT NULL RETURN e")
 
-    def test_global_edge_property_index_null_value(self, memgraph):
-        """Parallel scan with null value on global edge property index returns no results.
-        Uses head([]) instead of literal null so the planner selects the index scan."""
-        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
-        memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
-        try:
-            verify_parallel_matches_serial(
-                memgraph,
-                "MATCH ()-[e]->() WHERE e.val = head([]) RETURN count(e)",
-            )
-        finally:
-            memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
-
     @pytest.fixture
     def desc_indexed_db(self, memgraph):
         """Database with a DESC-ordered label+property index only."""
@@ -334,6 +321,20 @@ class TestParallelIndices:
     def test_vertex_property_index_desc_all(self, desc_indexed_db):
         """DESC index IS NOT NULL scan — parallel matches serial."""
         verify_parallel_matches_serial(desc_indexed_db, "MATCH (n:Person) WHERE n.age IS NOT NULL RETURN n")
+
+    def test_global_edge_property_index_null_value(self, memgraph):
+        """Parallel scan with null value on global edge property index returns no results.
+        Uses head([]) instead of literal null so the planner selects the index scan."""
+        setup_thread_count_db(memgraph, thread_count=100)
+        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
+        memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
+        try:
+            verify_parallel_matches_serial(
+                memgraph,
+                "MATCH ()-[e]->() WHERE e.val = head([]) RETURN count(e)",
+            )
+        finally:
+            memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
 
     def test_vertex_property_index_both_orders(self, memgraph):
         """Both ASC and DESC indices exist on same (label, prop) — parallel matches serial."""

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -300,7 +300,8 @@ class TestParallelIndices:
         verify_parallel_matches_serial(indexed_db, "MATCH ()-[e:KNOWS]->() WHERE e.since IS NOT NULL RETURN e")
 
     def test_global_edge_property_index_null_value(self, memgraph):
-        """Parallel scan with null value on global edge property index returns no results."""
+        """Parallel scan with null value on global edge property index returns no results.
+        Uses head([]) instead of literal null so the planner selects the index scan."""
         memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
         memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
         try:

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -336,6 +336,20 @@ class TestParallelIndices:
         finally:
             memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
 
+    def test_edge_type_property_index_null_value(self, memgraph):
+        """Parallel scan with null value on edge-type property index returns no results.
+        Uses head([]) instead of literal null so the planner selects the index scan."""
+        setup_thread_count_db(memgraph, thread_count=100)
+        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
+        memgraph.execute_query("CREATE EDGE INDEX ON :REL(val);")
+        try:
+            verify_parallel_matches_serial(
+                memgraph,
+                "MATCH ()-[e:REL]->() WHERE e.val = head([]) RETURN count(e)",
+            )
+        finally:
+            memgraph.execute_query("DROP EDGE INDEX ON :REL(val);")
+
     def test_vertex_property_index_both_orders(self, memgraph):
         """Both ASC and DESC indices exist on same (label, prop) — parallel matches serial."""
         setup_thread_count_db(memgraph, thread_count=100)

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -354,6 +354,20 @@ class TestParallelIndices:
         finally:
             memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
 
+    def test_edge_type_property_index_null_value(self, memgraph):
+        """Parallel scan with null value on edge-type property index returns no results.
+        Uses head([]) instead of literal null so the planner selects the index scan."""
+        setup_thread_count_db(memgraph, thread_count=100)
+        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
+        memgraph.execute_query("CREATE EDGE INDEX ON :REL(val);")
+        try:
+            verify_parallel_matches_serial(
+                memgraph,
+                "MATCH ()-[e:REL]->() WHERE e.val = head([]) RETURN count(e)",
+            )
+        finally:
+            memgraph.execute_query("DROP EDGE INDEX ON :REL(val);")
+
     def test_vertex_property_index_both_orders(self, memgraph):
         """Both ASC and DESC indices exist on same (label, prop) — parallel matches serial."""
         setup_thread_count_db(memgraph, thread_count=100)

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -318,7 +318,8 @@ class TestParallelIndices:
         verify_parallel_matches_serial(indexed_db, "MATCH (n) WHERE n.age > head([]) RETURN count(n)")
 
     def test_global_edge_property_index_null_value(self, memgraph):
-        """Parallel scan with null value on global edge property index returns no results."""
+        """Parallel scan with null value on global edge property index returns no results.
+        Uses head([]) instead of literal null so the planner selects the index scan."""
         memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
         memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
         try:

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -317,20 +317,6 @@ class TestParallelIndices:
         """Parallel range scan with null bounds returns no results."""
         verify_parallel_matches_serial(indexed_db, "MATCH (n) WHERE n.age > head([]) RETURN count(n)")
 
-    def test_global_edge_property_index_null_value(self, memgraph):
-        """Parallel scan with null value on global edge property index returns no results.
-        Uses head([]) instead of literal null so the planner selects the index scan."""
-        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
-        memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
-        try:
-            verify_parallel_matches_serial(
-                memgraph,
-                "MATCH ()-[e]->() WHERE e.val = head([]) RETURN count(e)",
-            )
-        finally:
-            memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
-
-
     @pytest.fixture
     def desc_indexed_db(self, memgraph):
         """Database with a DESC-ordered label+property index only."""
@@ -353,6 +339,20 @@ class TestParallelIndices:
     def test_vertex_property_index_desc_all(self, desc_indexed_db):
         """DESC index IS NOT NULL scan — parallel matches serial."""
         verify_parallel_matches_serial(desc_indexed_db, "MATCH (n:Person) WHERE n.age IS NOT NULL RETURN n")
+
+    def test_global_edge_property_index_null_value(self, memgraph):
+        """Parallel scan with null value on global edge property index returns no results.
+        Uses head([]) instead of literal null so the planner selects the index scan."""
+        setup_thread_count_db(memgraph, thread_count=100)
+        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
+        memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
+        try:
+            verify_parallel_matches_serial(
+                memgraph,
+                "MATCH ()-[e]->() WHERE e.val = head([]) RETURN count(e)",
+            )
+        finally:
+            memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
 
     def test_vertex_property_index_both_orders(self, memgraph):
         """Both ASC and DESC indices exist on same (label, prop) — parallel matches serial."""

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -317,6 +317,19 @@ class TestParallelIndices:
         """Parallel range scan with null bounds returns no results."""
         verify_parallel_matches_serial(indexed_db, "MATCH (n) WHERE n.age > head([]) RETURN count(n)")
 
+    def test_global_edge_property_index_null_value(self, memgraph):
+        """Parallel scan with null value on global edge property index returns no results."""
+        memgraph.execute_query("UNWIND range(1, 100) AS i CREATE (:A)-[:REL {val: i}]->(:B)")
+        memgraph.execute_query("CREATE GLOBAL EDGE INDEX ON :(val);")
+        try:
+            verify_parallel_matches_serial(
+                memgraph,
+                "MATCH ()-[e]->() WHERE e.val = head([]) RETURN count(e)",
+            )
+        finally:
+            memgraph.execute_query("DROP GLOBAL EDGE INDEX ON :(val);")
+
+
     @pytest.fixture
     def desc_indexed_db(self, memgraph):
         """Database with a DESC-ordered label+property index only."""

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -317,6 +317,14 @@ class TestParallelIndices:
         """Parallel range scan with null bounds returns no results."""
         verify_parallel_matches_serial(indexed_db, "MATCH (n) WHERE n.age > head([]) RETURN count(n)")
 
+    def test_global_vertex_property_index_null_value(self, indexed_db):
+        """Parallel value scan with null on global vertex property index returns no results."""
+        verify_parallel_matches_serial(indexed_db, "MATCH (n) WHERE n.age = head([]) RETURN count(n)")
+
+    def test_label_property_index_null_value(self, indexed_db):
+        """Parallel value scan with null on label-property index returns no results."""
+        verify_parallel_matches_serial(indexed_db, "MATCH (n:Person) WHERE n.age = head([]) RETURN count(n)")
+
     @pytest.fixture
     def desc_indexed_db(self, memgraph):
         """Database with a DESC-ordered label+property index only."""


### PR DESCRIPTION
When a parallel scan operator's filter expression evaluates to null (e.g. `WHERE e.val = head([])`), the scan should return zero results. Previously, several operators either passed a null value through to the index (spawning threads that scan empty ranges), or passed unbounded `nullopt` ranges with full thread count which scanned the entire index).
                                                                                                                                                                                
Fixed in:                                                                                                                                                                                
- `ScanParallelByEdgePropertyValue`
- `ScanParallelByEdgeTypePropertyValue`
- `ScanParallelByLabelProperties`
- `ScanParallelByEdgeTypePropertyRange`
- `ScanParallelByEdgePropertyRange`
                                                                                                                                                                                           
All now return empty chunks via `num_chunks=0` 