### PR TITLE
feat: run DISTINCT / SKIP / LIMIT / ORDER BY queries in the plan_v2 planner

### DIFF
--- a/src/query/plan_v2/cost/cost_model.cpp
+++ b/src/query/plan_v2/cost/cost_model.cpp
@@ -58,6 +58,12 @@ inline constexpr double kFilterPerRowOverhead = 1.0;
 /// so it will matter once Filter rewrites add alternative plan shapes.
 inline constexpr double kFilterSelectivity = 0.5;
 
+/// Fixed per-operator overhead for the tail-clause row pipes (DISTINCT / ORDER
+/// BY).  Structural placeholders until measured data justifies a value; they
+/// bias nothing here since these queries have a single valid extraction.
+inline constexpr double kDistinctOverhead = 1.0;
+inline constexpr double kOrderByOverhead = 1.0;
+
 // Per-alternative leaf costs.  Structural placeholders, 1.0 until measured
 // data justifies divergent values.
 inline constexpr double kOnceLeaf = 1.0;
@@ -271,6 +277,50 @@ auto FilterFlatMap(CostFrontier const &input, CostFrontier const &predicate, pla
   });
 }
 
+/// Scalar-clause combine: SKIP / LIMIT.  The count is a constant evaluated once
+/// (not per row), so its cost is added once and cardinality passes through
+/// unchanged (SKIP/LIMIT are placeholder-costed: the runtime row count depends
+/// on the count value, which the execution-only model does not estimate).  The
+/// DemandMet guard mirrors the other operators for uniformity; the count carries
+/// no frame references, so it is always met.
+auto ScalarClauseCombine(CostFrontier const &input, CostFrontier const &count, planner::core::ENodeId enode_id)
+    -> CostFrontier {
+  return CostFrontier::cartesian_product_if(
+      input,
+      count,
+      [](Alternative const &in_alt, Alternative const &count_alt) {
+        DMG_ASSERT(in_alt.required.empty(), "operator Alt must have empty required");
+        return DemandMet(in_alt, count_alt);
+      },
+      [enode_id](Alternative const &in_alt, Alternative const &count_alt) {
+        return Alternative{.cost = in_alt.cost + count_alt.cost,
+                           .cardinality = in_alt.cardinality,
+                           .required = {},
+                           .introduces = in_alt.introduces,
+                           .enode_id = enode_id};
+      });
+}
+
+/// Demand that every symbol in `value_syms` is introduced (materialised) by the
+/// pipe.  DISTINCT / ORDER BY dedup / sort on frame slots, so an input alt that
+/// has not materialised a column - e.g. because the inline rewrite pushed the
+/// column's value downstream - cannot serve it.  Pruning those alts forces the
+/// projection to keep the column's binder alive.  Pass-through otherwise:
+/// cardinality and introduces are the input's; `required` stays empty.
+auto DemandValueSyms(CostFrontier const &input, VariableSet value_syms, planner::core::ENodeId enode_id)
+    -> CostFrontier {
+  return CostFrontier::flat_map(
+      input, [value_syms = std::move(value_syms), enode_id](Alternative const &input_alt, auto emit) {
+        DMG_ASSERT(input_alt.required.empty(), "operator Alt must have empty required");
+        if (!value_syms.is_subset_of(input_alt.introduces)) return;  // a demanded column isn't materialised
+        emit({.cost = input_alt.cost,
+              .cardinality = input_alt.cardinality,
+              .required = {},
+              .introduces = input_alt.introduces,
+              .enode_id = enode_id});
+      });
+}
+
 /// Subquery flat-map: scope-barrier row-pipe.  Non-importing CALL only - an
 /// importing inner is pruned to an empty frontier by its Output and rejected by
 /// the Subquery cost guard, so every inner alt reaching here is self-contained
@@ -424,6 +474,61 @@ struct symbol_cost_traits<Filter> {
   static auto cost(ENodeT const &, ENodeId id, CostChildren children, CostCtx const &) -> CostFrontier {
     using namespace child::filter;
     return FilterFlatMap(*children[input], *children[predicate], id);
+  }
+};
+
+template <>
+struct symbol_cost_traits<Distinct> {
+  // Row-pipe pass-through.  Children layout is [input, value_sym...]; the value
+  // syms are the dedup-key columns' Symbol e-classes.  They are not evaluated at
+  // runtime, only demanded: the input must have materialised each into a frame
+  // slot for DISTINCT to dedup on.  Introduces exactly what the input introduces.
+  static auto cost(ENodeT const &n, ENodeId id, CostChildren children, CostCtx const &ctx) -> CostFrontier {
+    using namespace child::distinct;
+    auto value_syms = ctx.syms.variable_index.to_variable_set(n.children().subspan(first_value));
+    return DemandValueSyms(Restamp(*children[input], kDistinctOverhead, id), std::move(value_syms), id);
+  }
+};
+
+template <>
+struct symbol_cost_traits<Skip> {
+  // Row-pipe pass-through; the count is evaluated once.  Children [input, count].
+  static auto cost(ENodeT const &, ENodeId id, CostChildren children, CostCtx const &) -> CostFrontier {
+    using namespace child::skip;
+    return ScalarClauseCombine(*children[input], *children[count], id);
+  }
+};
+
+template <>
+struct symbol_cost_traits<Limit> {
+  // Row-pipe pass-through; the count is evaluated once.  Children [input, count].
+  static auto cost(ENodeT const &, ENodeId id, CostChildren children, CostCtx const &) -> CostFrontier {
+    using namespace child::limit;
+    return ScalarClauseCombine(*children[input], *children[count], id);
+  }
+};
+
+template <>
+struct symbol_cost_traits<OrderBy> {
+  // Row-pipe pass-through.  Children [input, sort_key..., value_sym...].  A child
+  // after the input is a value-column Symbol e-class (registered in the variable
+  // index) or a sort-key expression: the value syms are demanded (materialised
+  // and remembered through the sort), the sort keys are folded via OutputCombine
+  // (per-row evaluation + their own symbol demand).  Introduces exactly what the
+  // input introduces.
+  static auto cost(ENodeT const &n, ENodeId id, CostChildren children, CostCtx const &ctx) -> CostFrontier {
+    using namespace child::order_by;
+    auto const child_eclasses = n.children();
+    auto result = Restamp(*children[input], kOrderByOverhead, id);
+    VariableSet value_syms;
+    for (std::size_t i = first_expr; i < child_eclasses.size(); ++i) {
+      if (ctx.syms.variable_index.contains(child_eclasses[i])) {
+        value_syms.set(ctx.syms.variable_index.bit_of(child_eclasses[i]));
+      } else {
+        result = OutputCombine(result, *children[i], id);
+      }
+    }
+    return DemandValueSyms(result, std::move(value_syms), id);
   }
 };
 

--- a/src/query/plan_v2/cost/cost_model.cpp
+++ b/src/query/plan_v2/cost/cost_model.cpp
@@ -58,9 +58,7 @@ inline constexpr double kFilterPerRowOverhead = 1.0;
 /// so it will matter once Filter rewrites add alternative plan shapes.
 inline constexpr double kFilterSelectivity = 0.5;
 
-/// Fixed per-operator overhead for the tail-clause row pipes (DISTINCT / ORDER
-/// BY).  Structural placeholders until measured data justifies a value; they
-/// bias nothing here since these queries have a single valid extraction.
+/// Placeholder per-operator overhead for DISTINCT / ORDER BY, 1.0 until measured.
 inline constexpr double kDistinctOverhead = 1.0;
 inline constexpr double kOrderByOverhead = 1.0;
 
@@ -277,12 +275,9 @@ auto FilterFlatMap(CostFrontier const &input, CostFrontier const &predicate, pla
   });
 }
 
-/// Scalar-clause combine: SKIP / LIMIT.  The count is a constant evaluated once
-/// (not per row), so its cost is added once and cardinality passes through
-/// unchanged (SKIP/LIMIT are placeholder-costed: the runtime row count depends
-/// on the count value, which the execution-only model does not estimate).  The
-/// DemandMet guard mirrors the other operators for uniformity; the count carries
-/// no frame references, so it is always met.
+/// SKIP / LIMIT: the count is evaluated once, so add its cost once and pass
+/// cardinality through (the count value isn't modelled). The count has no frame
+/// references, so the uniform DemandMet guard is always met.
 auto ScalarClauseCombine(CostFrontier const &input, CostFrontier const &count, planner::core::ENodeId enode_id)
     -> CostFrontier {
   return CostFrontier::cartesian_product_if(
@@ -301,12 +296,9 @@ auto ScalarClauseCombine(CostFrontier const &input, CostFrontier const &count, p
       });
 }
 
-/// Demand that every symbol in `value_syms` is introduced (materialised) by the
-/// pipe.  DISTINCT / ORDER BY dedup / sort on frame slots, so an input alt that
-/// has not materialised a column - e.g. because the inline rewrite pushed the
-/// column's value downstream - cannot serve it.  Pruning those alts forces the
-/// projection to keep the column's binder alive.  Pass-through otherwise:
-/// cardinality and introduces are the input's; `required` stays empty.
+/// Prune input alts that haven't materialised every `value_syms` column (DISTINCT
+/// / ORDER BY work on frame slots), forcing the projection to keep the binder
+/// alive. Otherwise pass-through.
 auto DemandValueSyms(CostFrontier const &input, VariableSet value_syms, planner::core::ENodeId enode_id)
     -> CostFrontier {
   return CostFrontier::flat_map(
@@ -479,10 +471,10 @@ struct symbol_cost_traits<Filter> {
 
 template <>
 struct symbol_cost_traits<Distinct> {
-  // Row-pipe pass-through.  Children layout is [input, value_sym...]; the value
-  // syms are the dedup-key columns' Symbol e-classes.  They are not evaluated at
-  // runtime, only demanded: the input must have materialised each into a frame
-  // slot for DISTINCT to dedup on.  Introduces exactly what the input introduces.
+  // Demand the value syms (dedup columns); introduces what the input does.
+  // Cardinality passes through: DISTINCT does reduce rows, but like v1 (see
+  // cost_estimator.hpp) we don't model an end-of-query-part modifier that runs the
+  // same for every candidate plan and so can't change plan choice.
   static auto cost(ENodeT const &n, ENodeId id, CostChildren children, CostCtx const &ctx) -> CostFrontier {
     using namespace child::distinct;
     auto value_syms = ctx.syms.variable_index.to_variable_set(n.children().subspan(first_value));
@@ -492,7 +484,7 @@ struct symbol_cost_traits<Distinct> {
 
 template <>
 struct symbol_cost_traits<Skip> {
-  // Row-pipe pass-through; the count is evaluated once.  Children [input, count].
+  // Count evaluated once; cardinality passes through.
   static auto cost(ENodeT const &, ENodeId id, CostChildren children, CostCtx const &) -> CostFrontier {
     using namespace child::skip;
     return ScalarClauseCombine(*children[input], *children[count], id);
@@ -501,7 +493,7 @@ struct symbol_cost_traits<Skip> {
 
 template <>
 struct symbol_cost_traits<Limit> {
-  // Row-pipe pass-through; the count is evaluated once.  Children [input, count].
+  // Count evaluated once; cardinality passes through.
   static auto cost(ENodeT const &, ENodeId id, CostChildren children, CostCtx const &) -> CostFrontier {
     using namespace child::limit;
     return ScalarClauseCombine(*children[input], *children[count], id);
@@ -510,21 +502,23 @@ struct symbol_cost_traits<Limit> {
 
 template <>
 struct symbol_cost_traits<OrderBy> {
-  // Row-pipe pass-through.  Children [input, sort_key..., value_sym...].  A child
-  // after the input is a value-column Symbol e-class (registered in the variable
-  // index) or a sort-key expression: the value syms are demanded (materialised
-  // and remembered through the sort), the sort keys are folded via OutputCombine
-  // (per-row evaluation + their own symbol demand).  Introduces exactly what the
-  // input introduces.
+  // Value-sym children (registered Symbols) are demanded and remembered through
+  // the sort; sort-key children are folded via OutputCombine (per-row eval + their
+  // own demand). Introduces what the input does.
   static auto cost(ENodeT const &n, ENodeId id, CostChildren children, CostCtx const &ctx) -> CostFrontier {
     using namespace child::order_by;
     auto const child_eclasses = n.children();
     auto result = Restamp(*children[input], kOrderByOverhead, id);
     VariableSet value_syms;
+    bool seen_value_sym = false;
     for (std::size_t i = first_expr; i < child_eclasses.size(); ++i) {
       if (ctx.syms.variable_index.contains(child_eclasses[i])) {
         value_syms.set(ctx.syms.variable_index.bit_of(child_eclasses[i]));
+        seen_value_sym = true;
       } else {
+        // Sort keys precede value syms; a non-Symbol after a value Symbol means
+        // this type-split disagrees with the builder's orderings.size() split.
+        DMG_ASSERT(!seen_value_sym, "OrderBy children not partitioned [sort_keys..., value_syms...]");
         result = OutputCombine(result, *children[i], id);
       }
     }

--- a/src/query/plan_v2/egraph/child_layout.hpp
+++ b/src/query/plan_v2/egraph/child_layout.hpp
@@ -40,13 +40,15 @@ namespace filter {
 inline constexpr std::size_t input = 0, predicate = 1;
 }
 
-// DISTINCT: [input row pipe, value_ident...]. The value idents are the projected
-// columns to dedup on; the build recovers their symbols. Introduces no binding.
+// DISTINCT: [input, value_sym...]. Dedup columns as bare Symbol e-classes (not
+// Identifier-wrapped) so the inline rewrite can't push their values past the
+// operator; the cost model demands them, forcing the projection to materialise
+// them. No binding.
 namespace distinct {
 inline constexpr std::size_t input = 0, first_value = 1;
 }
 
-// SKIP / LIMIT: [input row pipe, count expression]. count is evaluated once.
+// SKIP / LIMIT: [input, count expression]. count evaluated once.
 namespace skip {
 inline constexpr std::size_t input = 0, count = 1;
 }
@@ -55,11 +57,10 @@ namespace limit {
 inline constexpr std::size_t input = 0, count = 1;
 }
 
-// ORDER BY: [input row pipe, sort_key..., value_ident...]. The first `orderings`
-// children after the input are the sort keys; the remainder are the value idents
-// to remember through the sort. The sort-key count is the interned orderings
-// length carried in the disambiguator, so cost/resolve treat all expression
-// children uniformly and only the build splits them. Introduces no binding.
+// ORDER BY: [input, sort_key..., value_sym...]. Sort keys first, then value syms
+// to remember through the sort (bare Symbols, materialised like DISTINCT). The
+// sort-key count is the interned orderings length (the disambiguator), so only
+// the build splits the tail; cost/resolve treat it uniformly. No binding.
 namespace order_by {
 inline constexpr std::size_t input = 0, first_expr = 1;
 }

--- a/src/query/plan_v2/egraph/child_layout.hpp
+++ b/src/query/plan_v2/egraph/child_layout.hpp
@@ -40,6 +40,30 @@ namespace filter {
 inline constexpr std::size_t input = 0, predicate = 1;
 }
 
+// DISTINCT: [input row pipe, value_ident...]. The value idents are the projected
+// columns to dedup on; the build recovers their symbols. Introduces no binding.
+namespace distinct {
+inline constexpr std::size_t input = 0, first_value = 1;
+}
+
+// SKIP / LIMIT: [input row pipe, count expression]. count is evaluated once.
+namespace skip {
+inline constexpr std::size_t input = 0, count = 1;
+}
+
+namespace limit {
+inline constexpr std::size_t input = 0, count = 1;
+}
+
+// ORDER BY: [input row pipe, sort_key..., value_ident...]. The first `orderings`
+// children after the input are the sort keys; the remainder are the value idents
+// to remember through the sort. The sort-key count is the interned orderings
+// length carried in the disambiguator, so cost/resolve treat all expression
+// children uniformly and only the build splits them. Introduces no binding.
+namespace order_by {
+inline constexpr std::size_t input = 0, first_expr = 1;
+}
+
 namespace identifier {
 inline constexpr std::size_t sym = 0;
 }

--- a/src/query/plan_v2/egraph/egraph.cpp
+++ b/src/query/plan_v2/egraph/egraph.cpp
@@ -14,9 +14,11 @@
 #include <cstdint>
 #include <optional>
 #include <span>
+#include <vector>
 
 #include "query/plan_v2/egraph/builtin_functions.hpp"
 #include "query/plan_v2/egraph/egraph_internal.hpp"
+#include "utils/logging.hpp"
 
 namespace memgraph::query::plan::v2 {
 
@@ -145,6 +147,34 @@ auto egraph::MakeUnwind(eclass input, eclass sym, eclass list_expr) -> eclass {
 
 auto egraph::MakeFilter(eclass input, eclass predicate) -> eclass {
   return from_core(pimpl_->graph.Make<Filter>(to_core(input), to_core(predicate)).eclass_id);
+}
+
+auto egraph::MakeDistinct(eclass input, std::span<eclass const> value_syms) -> eclass {
+  auto children = utils::small_vector<planner::core::EClassId>{};
+  children.reserve(1 + value_syms.size());
+  children.push_back(to_core(input));
+  for (auto e : value_syms) children.push_back(to_core(e));
+  return from_core(pimpl_->graph.Make<Distinct>(std::move(children)).eclass_id);
+}
+
+auto egraph::MakeSkip(eclass input, eclass count) -> eclass {
+  return from_core(pimpl_->graph.Make<Skip>(to_core(input), to_core(count)).eclass_id);
+}
+
+auto egraph::MakeLimit(eclass input, eclass count) -> eclass {
+  return from_core(pimpl_->graph.Make<Limit>(to_core(input), to_core(count)).eclass_id);
+}
+
+auto egraph::MakeOrderBy(eclass input, std::span<eclass const> sort_keys, std::span<Ordering const> orderings,
+                         std::span<eclass const> value_syms) -> eclass {
+  DMG_ASSERT(sort_keys.size() == orderings.size(), "OrderBy sort keys and orderings must be parallel");
+  auto children_after_input = utils::small_vector<planner::core::EClassId>{};
+  children_after_input.reserve(sort_keys.size() + value_syms.size());
+  for (auto e : sort_keys) children_after_input.push_back(to_core(e));
+  for (auto e : value_syms) children_after_input.push_back(to_core(e));
+  auto orderings_vec = std::vector<Ordering>(orderings.begin(), orderings.end());
+  return from_core(
+      pimpl_->graph.Make<OrderBy>(to_core(input), std::move(children_after_input), std::move(orderings_vec)).eclass_id);
 }
 
 auto egraph::MakeSubquery(eclass outer_input, eclass inner_root, std::span<eclass const> exposed_syms) -> eclass {

--- a/src/query/plan_v2/egraph/egraph.hpp
+++ b/src/query/plan_v2/egraph/egraph.hpp
@@ -17,6 +17,7 @@
 #include <span>
 #include <string_view>
 
+#include "query/frontend/ast/ordering.hpp"
 #include "query/plan_v2/egraph/builtin_functions.hpp"
 #include "query/plan_v2/egraph/op_ast_lists.hpp"
 #include "storage/v2/property_value.hpp"
@@ -61,6 +62,21 @@ struct egraph {
 
   auto MakeUnwind(eclass input, eclass sym, eclass list_expr) -> eclass;
   auto MakeFilter(eclass input, eclass predicate) -> eclass;
+
+  /// DISTINCT over the pipe. `value_syms` are the Symbol e-classes of the
+  /// projected columns to dedup on. They are demanded by the cost model, which
+  /// forces the projection to materialise them into frame slots (the operator
+  /// dedups on slots) instead of the inline rewrite pushing the values past it.
+  auto MakeDistinct(eclass input, std::span<eclass const> value_syms) -> eclass;
+  auto MakeSkip(eclass input, eclass count) -> eclass;
+  auto MakeLimit(eclass input, eclass count) -> eclass;
+
+  /// ORDER BY over the pipe. `sort_keys` and `orderings` are parallel (one
+  /// direction per key); `value_syms` are the Symbol e-classes of the projected
+  /// columns to remember through the sort (demanded, same as Distinct).
+  auto MakeOrderBy(eclass input, std::span<eclass const> sort_keys, std::span<Ordering const> orderings,
+                   std::span<eclass const> value_syms) -> eclass;
+
   auto MakeSubquery(eclass outer_input, eclass inner_root, std::span<eclass const> exposed_syms) -> eclass;
 
   auto MakeSubquery(eclass outer_input, eclass inner_root, std::initializer_list<eclass> exposed_syms) -> eclass {

--- a/src/query/plan_v2/egraph/egraph.hpp
+++ b/src/query/plan_v2/egraph/egraph.hpp
@@ -63,17 +63,14 @@ struct egraph {
   auto MakeUnwind(eclass input, eclass sym, eclass list_expr) -> eclass;
   auto MakeFilter(eclass input, eclass predicate) -> eclass;
 
-  /// DISTINCT over the pipe. `value_syms` are the Symbol e-classes of the
-  /// projected columns to dedup on. They are demanded by the cost model, which
-  /// forces the projection to materialise them into frame slots (the operator
-  /// dedups on slots) instead of the inline rewrite pushing the values past it.
+  /// DISTINCT over the pipe. `value_syms` are the dedup columns' Symbol e-classes
+  /// (demanded by cost to force materialisation; see child_layout).
   auto MakeDistinct(eclass input, std::span<eclass const> value_syms) -> eclass;
   auto MakeSkip(eclass input, eclass count) -> eclass;
   auto MakeLimit(eclass input, eclass count) -> eclass;
 
   /// ORDER BY over the pipe. `sort_keys` and `orderings` are parallel (one
-  /// direction per key); `value_syms` are the Symbol e-classes of the projected
-  /// columns to remember through the sort (demanded, same as Distinct).
+  /// direction per key); `value_syms` are the columns to remember through the sort.
   auto MakeOrderBy(eclass input, std::span<eclass const> sort_keys, std::span<Ordering const> orderings,
                    std::span<eclass const> value_syms) -> eclass;
 

--- a/src/query/plan_v2/egraph/symbol_lists.hpp
+++ b/src/query/plan_v2/egraph/symbol_lists.hpp
@@ -57,7 +57,19 @@
   /* only the explicit exposed_sym children become visible to the outer scope. */      \
   X(Subquery)                                                                          \
   /* WHERE filter: 2 children [input, predicate_expr]; introduces no binding. */       \
-  X(Filter)
+  X(Filter)                                                                            \
+  /* DISTINCT: variadic [input, value_ident_1, ...]; the value idents are the */       \
+  /* projected columns to dedup on (Identifiers so the inline rewrite tracks the */    \
+  /* flowing symbol). Introduces no binding. */                                        \
+  X(Distinct)                                                                          \
+  /* SKIP: 2 children [input, count_expr]; count evaluated once. */                    \
+  X(Skip)                                                                              \
+  /* LIMIT: 2 children [input, count_expr]; count evaluated once. */                   \
+  X(Limit)                                                                             \
+  /* ORDER BY: variadic [input, sort_key_1, ..., value_ident_1, ...]; the sort-key */  \
+  /* count is the interned orderings length (the disambiguator), the rest are the */   \
+  /* value idents to remember through the sort. Introduces no binding. */              \
+  X(OrderBy)
 
 #define EGRAPH_ALL_SYMBOLS(X) \
   EGRAPH_LEAF_SYMBOLS(X)      \
@@ -77,7 +89,11 @@
   X(Output)                        \
   X(Unwind)                        \
   X(Subquery)                      \
-  X(Filter)
+  X(Filter)                        \
+  X(Distinct)                      \
+  X(Skip)                          \
+  X(Limit)                         \
+  X(OrderBy)
 
 // Symbol: e-class denotes a binding. Singleton by invariant.
 #define EGRAPH_SYMBOL_KIND_SYMBOLS(X) X(Symbol)

--- a/src/query/plan_v2/egraph/symbol_lists.hpp
+++ b/src/query/plan_v2/egraph/symbol_lists.hpp
@@ -58,17 +58,13 @@
   X(Subquery)                                                                          \
   /* WHERE filter: 2 children [input, predicate_expr]; introduces no binding. */       \
   X(Filter)                                                                            \
-  /* DISTINCT: variadic [input, value_ident_1, ...]; the value idents are the */       \
-  /* projected columns to dedup on (Identifiers so the inline rewrite tracks the */    \
-  /* flowing symbol). Introduces no binding. */                                        \
+  /* DISTINCT: variadic [input, value_sym...]; dedup columns. See child_layout. */     \
   X(Distinct)                                                                          \
-  /* SKIP: 2 children [input, count_expr]; count evaluated once. */                    \
+  /* SKIP: 2 children [input, count_expr]. */                                          \
   X(Skip)                                                                              \
-  /* LIMIT: 2 children [input, count_expr]; count evaluated once. */                   \
+  /* LIMIT: 2 children [input, count_expr]. */                                         \
   X(Limit)                                                                             \
-  /* ORDER BY: variadic [input, sort_key_1, ..., value_ident_1, ...]; the sort-key */  \
-  /* count is the interned orderings length (the disambiguator), the rest are the */   \
-  /* value idents to remember through the sort. Introduces no binding. */              \
+  /* ORDER BY: variadic [input, sort_key..., value_sym...]. See child_layout. */       \
   X(OrderBy)
 
 #define EGRAPH_ALL_SYMBOLS(X) \

--- a/src/query/plan_v2/egraph/symbol_make_traits.cpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.cpp
@@ -100,4 +100,38 @@ auto symbol_make_traits<Subquery>::make(storage_type & /*s*/, utils::small_vecto
           .seed = default_analysis_seed<Subquery>()};
 }
 
+auto symbol_make_traits<Distinct>::make(storage_type & /*s*/, utils::small_vector<planner::core::EClassId> children)
+    -> seeded_node {
+  return {.lowered = {.children = std::move(children), .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Distinct>()};
+}
+
+auto symbol_make_traits<Skip>::make(storage_type & /*s*/, planner::core::EClassId input, planner::core::EClassId count)
+    -> seeded_node {
+  return {.lowered = {.children = utils::small_vector{input, count}, .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Skip>()};
+}
+
+auto symbol_make_traits<Limit>::make(storage_type & /*s*/, planner::core::EClassId input, planner::core::EClassId count)
+    -> seeded_node {
+  return {.lowered = {.children = utils::small_vector{input, count}, .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Limit>()};
+}
+
+auto symbol_make_traits<OrderBy>::make(storage_type &s, planner::core::EClassId input,
+                                       utils::small_vector<planner::core::EClassId> children_after_input,
+                                       std::vector<Ordering> orderings) -> seeded_node {
+  // Intern the ordering vector: same directions -> same disambiguator (hash-cons),
+  // different directions -> distinct e-node even with identical sort-key children.
+  auto [it, inserted] = s.store.try_emplace(std::move(orderings), s.info.size());
+  if (inserted) s.info.push_back(it->first);
+
+  auto children = utils::small_vector<planner::core::EClassId>{};
+  children.reserve(1 + children_after_input.size());
+  children.push_back(input);
+  for (auto c : children_after_input) children.push_back(c);
+  return {.lowered = {.children = std::move(children), .disambiguator = it->second},
+          .seed = default_analysis_seed<OrderBy>()};
+}
+
 }  // namespace memgraph::query::plan::v2

--- a/src/query/plan_v2/egraph/symbol_make_traits.cpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.cpp
@@ -121,8 +121,7 @@ auto symbol_make_traits<Limit>::make(storage_type & /*s*/, planner::core::EClass
 auto symbol_make_traits<OrderBy>::make(storage_type &s, planner::core::EClassId input,
                                        utils::small_vector<planner::core::EClassId> children_after_input,
                                        std::vector<Ordering> orderings) -> seeded_node {
-  // Intern the ordering vector: same directions -> same disambiguator (hash-cons),
-  // different directions -> distinct e-node even with identical sort-key children.
+  // Intern the ordering vector: same directions -> same disambiguator, different -> distinct e-node.
   auto [it, inserted] = s.store.try_emplace(std::move(orderings), s.info.size());
   if (inserted) s.info.push_back(it->first);
 

--- a/src/query/plan_v2/egraph/symbol_make_traits.cpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.cpp
@@ -99,4 +99,38 @@ auto symbol_make_traits<Subquery>::make(storage_type & /*s*/, utils::small_vecto
           .seed = default_analysis_seed<Subquery>()};
 }
 
+auto symbol_make_traits<Distinct>::make(storage_type & /*s*/, utils::small_vector<planner::core::EClassId> children)
+    -> seeded_node {
+  return {.lowered = {.children = std::move(children), .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Distinct>()};
+}
+
+auto symbol_make_traits<Skip>::make(storage_type & /*s*/, planner::core::EClassId input, planner::core::EClassId count)
+    -> seeded_node {
+  return {.lowered = {.children = utils::small_vector{input, count}, .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Skip>()};
+}
+
+auto symbol_make_traits<Limit>::make(storage_type & /*s*/, planner::core::EClassId input, planner::core::EClassId count)
+    -> seeded_node {
+  return {.lowered = {.children = utils::small_vector{input, count}, .disambiguator = std::nullopt},
+          .seed = default_analysis_seed<Limit>()};
+}
+
+auto symbol_make_traits<OrderBy>::make(storage_type &s, planner::core::EClassId input,
+                                       utils::small_vector<planner::core::EClassId> children_after_input,
+                                       std::vector<Ordering> orderings) -> seeded_node {
+  // Intern the ordering vector: same directions -> same disambiguator (hash-cons),
+  // different directions -> distinct e-node even with identical sort-key children.
+  auto [it, inserted] = s.store.try_emplace(std::move(orderings), s.info.size());
+  if (inserted) s.info.push_back(it->first);
+
+  auto children = utils::small_vector<planner::core::EClassId>{};
+  children.reserve(1 + children_after_input.size());
+  children.push_back(input);
+  for (auto c : children_after_input) children.push_back(c);
+  return {.lowered = {.children = std::move(children), .disambiguator = it->second},
+          .seed = default_analysis_seed<OrderBy>()};
+}
+
 }  // namespace memgraph::query::plan::v2

--- a/src/query/plan_v2/egraph/symbol_make_traits.cpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.cpp
@@ -120,8 +120,7 @@ auto symbol_make_traits<Limit>::make(storage_type & /*s*/, planner::core::EClass
 auto symbol_make_traits<OrderBy>::make(storage_type &s, planner::core::EClassId input,
                                        utils::small_vector<planner::core::EClassId> children_after_input,
                                        std::vector<Ordering> orderings) -> seeded_node {
-  // Intern the ordering vector: same directions -> same disambiguator (hash-cons),
-  // different directions -> distinct e-node even with identical sort-key children.
+  // Intern the ordering vector: same directions -> same disambiguator, different -> distinct e-node.
   auto [it, inserted] = s.store.try_emplace(std::move(orderings), s.info.size());
   if (inserted) s.info.push_back(it->first);
 

--- a/src/query/plan_v2/egraph/symbol_make_traits.hpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.hpp
@@ -21,6 +21,7 @@
 #include <boost/unordered/unordered_flat_map.hpp>
 #include <boost/unordered/unordered_node_map.hpp>
 
+#include "query/frontend/ast/ordering.hpp"
 #include "query/plan_v2/egraph/builtin_functions.hpp"
 #include "query/plan_v2/egraph/symbol.hpp"
 #include "query/plan_v2/resolve/analysis.hpp"
@@ -202,6 +203,50 @@ struct symbol_make_traits<symbol::Filter> {
   struct storage_type {};
 
   static auto make(storage_type &, planner::core::EClassId input, planner::core::EClassId predicate) -> seeded_node;
+};
+
+/// Distinct: no storage; children are [input, value_ident...]. Mirrors Output's
+/// full-children shape (input prepended by the facade). Introduces no binding.
+template <>
+struct symbol_make_traits<symbol::Distinct> {
+  struct storage_type {};
+
+  static auto make(storage_type &, utils::small_vector<planner::core::EClassId> children) -> seeded_node;
+};
+
+/// Skip / Limit: no storage; children are [input, count_expr]. The count is a
+/// constant (no frame references) evaluated once. Introduces no binding.
+template <>
+struct symbol_make_traits<symbol::Skip> {
+  struct storage_type {};
+
+  static auto make(storage_type &, planner::core::EClassId input, planner::core::EClassId count) -> seeded_node;
+};
+
+template <>
+struct symbol_make_traits<symbol::Limit> {
+  struct storage_type {};
+
+  static auto make(storage_type &, planner::core::EClassId input, planner::core::EClassId count) -> seeded_node;
+};
+
+/// OrderBy: interns the per-key ordering vector to a stable id (the
+/// disambiguator), so two OrderBys with identical sort-key children but
+/// different ASC/DESC directions stay distinct e-nodes. `store` (orderings ->
+/// id) is the hash-consing direction; `info` (id -> orderings, indexed by
+/// disambiguator) is the reverse the Builder reads to split the children and
+/// rebuild the SortItems. Children are [input, sort_key..., value_ident...]; the
+/// sort-key count is `orderings.size()`.
+template <>
+struct symbol_make_traits<symbol::OrderBy> {
+  struct storage_type {
+    std::map<std::vector<Ordering>, uint64_t> store;
+    std::vector<std::vector<Ordering>> info;
+  };
+
+  static auto make(storage_type &s, planner::core::EClassId input,
+                   utils::small_vector<planner::core::EClassId> children_after_input, std::vector<Ordering> orderings)
+      -> seeded_node;
 };
 
 /// Subquery: no storage; children are [outer_input, inner_root, exposed_syms...].

--- a/src/query/plan_v2/egraph/symbol_make_traits.hpp
+++ b/src/query/plan_v2/egraph/symbol_make_traits.hpp
@@ -205,8 +205,8 @@ struct symbol_make_traits<symbol::Filter> {
   static auto make(storage_type &, planner::core::EClassId input, planner::core::EClassId predicate) -> seeded_node;
 };
 
-/// Distinct: no storage; children are [input, value_ident...]. Mirrors Output's
-/// full-children shape (input prepended by the facade). Introduces no binding.
+/// Distinct: no storage; children [input, value_sym...] via the full-children
+/// facade like Output.
 template <>
 struct symbol_make_traits<symbol::Distinct> {
   struct storage_type {};
@@ -214,8 +214,7 @@ struct symbol_make_traits<symbol::Distinct> {
   static auto make(storage_type &, utils::small_vector<planner::core::EClassId> children) -> seeded_node;
 };
 
-/// Skip / Limit: no storage; children are [input, count_expr]. The count is a
-/// constant (no frame references) evaluated once. Introduces no binding.
+/// Skip / Limit: no storage; children [input, count_expr].
 template <>
 struct symbol_make_traits<symbol::Skip> {
   struct storage_type {};
@@ -230,13 +229,10 @@ struct symbol_make_traits<symbol::Limit> {
   static auto make(storage_type &, planner::core::EClassId input, planner::core::EClassId count) -> seeded_node;
 };
 
-/// OrderBy: interns the per-key ordering vector to a stable id (the
-/// disambiguator), so two OrderBys with identical sort-key children but
-/// different ASC/DESC directions stay distinct e-nodes. `store` (orderings ->
-/// id) is the hash-consing direction; `info` (id -> orderings, indexed by
-/// disambiguator) is the reverse the Builder reads to split the children and
-/// rebuild the SortItems. Children are [input, sort_key..., value_ident...]; the
-/// sort-key count is `orderings.size()`.
+/// OrderBy: interns the ordering vector to a disambiguator, so OrderBys with the
+/// same sort-key children but different ASC/DESC stay distinct e-nodes. `store`
+/// (orderings -> id) hash-conses; `info` (id -> orderings) is the reverse the
+/// builder reads to split the children and rebuild the SortItems.
 template <>
 struct symbol_make_traits<symbol::OrderBy> {
   struct storage_type {

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -294,12 +294,40 @@ auto Lower(LoweringCtx &ctx, Expression &expr) -> eclass {
 
 auto LowerSingleQuery(SingleQuery &sq, LoweringCtx &ctx) -> eclass;
 
-// ORDER BY / SKIP / LIMIT / DISTINCT aren't lowered yet; refuse them rather than
-// silently drop them (wrong results). Replaced when those operators land.
-void GuardUnsupportedTailClauses(ReturnBody const &body) {
-  if (!body.order_by.empty() || body.skip || body.limit || body.distinct) {
-    ThrowNotImplementedYet("ORDER BY / SKIP / LIMIT / DISTINCT");
+// Lower a WITH/RETURN body's tail clauses onto the projected `pipe`, in the
+// order the v1 planner applies them (GenReturnBody): projection -> DISTINCT ->
+// ORDER BY -> SKIP -> LIMIT. For WITH the caller then stacks WHERE above this.
+//
+// DISTINCT dedups on, and ORDER BY remembers, the projected columns, carried as
+// the columns' Symbol e-classes. Cost then demands those symbols be introduced,
+// which forces the projection to materialise them into frame slots (the operator
+// dedups/sorts on slots) rather than letting the inline rewrite push the column
+// values past the operator.
+auto LowerTailClauses(ReturnBody const &body, eclass pipe, LoweringCtx &ctx) -> eclass {
+  if (body.distinct) {
+    auto frame = ctx.OpenScratch();
+    for (auto *ne : body.named_expressions) frame.push(SymEclassFor(ctx, *ne));
+    pipe = ctx.g.MakeDistinct(pipe, frame.as_span());
   }
+  if (!body.order_by.empty()) {
+    std::vector<eclass> sort_keys;
+    std::vector<Ordering> orderings;
+    sort_keys.reserve(body.order_by.size());
+    orderings.reserve(body.order_by.size());
+    for (auto const &item : body.order_by) {
+      sort_keys.push_back(Lower(ctx, *item.expression));
+      orderings.push_back(item.ordering);
+    }
+    std::vector<eclass> value_syms;
+    value_syms.reserve(body.named_expressions.size());
+    for (auto *ne : body.named_expressions) value_syms.push_back(SymEclassFor(ctx, *ne));
+    pipe = ctx.g.MakeOrderBy(pipe, sort_keys, orderings, value_syms);
+  }
+  // SKIP/LIMIT counts are constants evaluated once (no frame references); the
+  // expression lowering throws NotYetImplemented for any unsupported sub-node.
+  if (body.skip) pipe = ctx.g.MakeSkip(pipe, Lower(ctx, *body.skip));
+  if (body.limit) pipe = ctx.g.MakeLimit(pipe, Lower(ctx, *body.limit));
+  return pipe;
 }
 
 // exposed_syms come from the inner cypher_query_'s last RETURN clause.
@@ -329,8 +357,10 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
     auto expr = Lower(ctx, *ne->expression_);
     pipe = ctx.g.MakeBind(pipe, SymEclassFor(ctx, *ne), expr);
   }
-  GuardUnsupportedTailClauses(with.body_);
-  // WHERE filters the projected rows, so Filter sits above the projection Binds.
+  pipe = LowerTailClauses(with.body_, pipe, ctx);
+  // WHERE filters the projected rows and, per v1 (GenReturnBody), comes after
+  // DISTINCT/ORDER BY/SKIP/LIMIT. The predicate reuses expression lowering
+  // (unsupported sub-nodes throw NotYetImplemented there).
   if (with.where_) {
     auto predicate = Lower(ctx, *with.where_->expression_);
     pipe = ctx.g.MakeFilter(pipe, predicate);
@@ -360,8 +390,7 @@ auto LowerReturn(query::Return &ret, eclass pipe, LoweringCtx &ctx) -> eclass {
     frame.push(ctx.g.MakeNamedOutput(OutputDisplayName(ctx, *ne), SymEclassFor(ctx, *ne), expr));
   }
   auto output = ctx.g.MakeOutput(pipe, frame.as_span());
-  GuardUnsupportedTailClauses(ret.body_);
-  return output;
+  return LowerTailClauses(ret.body_, output, ctx);
 }
 
 auto LowerUnwind(query::Unwind &unwind, eclass pipe, LoweringCtx &ctx) -> eclass {

--- a/src/query/plan_v2/frontend/ast_converter.cpp
+++ b/src/query/plan_v2/frontend/ast_converter.cpp
@@ -294,15 +294,10 @@ auto Lower(LoweringCtx &ctx, Expression &expr) -> eclass {
 
 auto LowerSingleQuery(SingleQuery &sq, LoweringCtx &ctx) -> eclass;
 
-// Lower a WITH/RETURN body's tail clauses onto the projected `pipe`, in the
-// order the v1 planner applies them (GenReturnBody): projection -> DISTINCT ->
-// ORDER BY -> SKIP -> LIMIT. For WITH the caller then stacks WHERE above this.
-//
-// DISTINCT dedups on, and ORDER BY remembers, the projected columns, carried as
-// the columns' Symbol e-classes. Cost then demands those symbols be introduced,
-// which forces the projection to materialise them into frame slots (the operator
-// dedups/sorts on slots) rather than letting the inline rewrite push the column
-// values past the operator.
+// Lower a WITH/RETURN body's tail clauses onto `pipe`, in v1's order
+// (GenReturnBody): DISTINCT -> ORDER BY -> SKIP -> LIMIT (WITH stacks WHERE above).
+// DISTINCT/ORDER BY carry their columns as Symbol e-classes; cost demands them,
+// forcing the projection to materialise them (see child_layout).
 auto LowerTailClauses(ReturnBody const &body, eclass pipe, LoweringCtx &ctx) -> eclass {
   if (body.distinct) {
     auto frame = ctx.OpenScratch();
@@ -323,8 +318,7 @@ auto LowerTailClauses(ReturnBody const &body, eclass pipe, LoweringCtx &ctx) -> 
     for (auto *ne : body.named_expressions) value_syms.push_back(SymEclassFor(ctx, *ne));
     pipe = ctx.g.MakeOrderBy(pipe, sort_keys, orderings, value_syms);
   }
-  // SKIP/LIMIT counts are constants evaluated once (no frame references); the
-  // expression lowering throws NotYetImplemented for any unsupported sub-node.
+  // SKIP/LIMIT counts are constants; expression lowering throws for unsupported nodes.
   if (body.skip) pipe = ctx.g.MakeSkip(pipe, Lower(ctx, *body.skip));
   if (body.limit) pipe = ctx.g.MakeLimit(pipe, Lower(ctx, *body.limit));
   return pipe;
@@ -358,9 +352,7 @@ auto LowerWith(query::With &with, eclass pipe, LoweringCtx &ctx) -> eclass {
     pipe = ctx.g.MakeBind(pipe, SymEclassFor(ctx, *ne), expr);
   }
   pipe = LowerTailClauses(with.body_, pipe, ctx);
-  // WHERE filters the projected rows and, per v1 (GenReturnBody), comes after
-  // DISTINCT/ORDER BY/SKIP/LIMIT. The predicate reuses expression lowering
-  // (unsupported sub-nodes throw NotYetImplemented there).
+  // WHERE comes after the tail clauses (v1 GenReturnBody) and filters projected rows.
   if (with.where_) {
     auto predicate = Lower(ctx, *with.where_->expression_);
     pipe = ctx.g.MakeFilter(pipe, predicate);

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -65,10 +65,9 @@ struct Children {
            std::views::transform([](ChildRef c) -> typename Slot::type { return as<typename Slot::type>(c); });
   }
 
-  // Built child at a runtime index, cast to `T`. For nodes whose child types
-  // vary by position and split at a runtime boundary (OrderBy: sort-key
-  // Expressions then value-column Symbols), where a compile-time slot can't name
-  // the range.
+  // Built child at a runtime index, cast to `T`. For nodes split at a runtime
+  // boundary (OrderBy: sort-key Expressions then value Symbols) that a
+  // compile-time slot can't name.
   template <typename T>
   auto at(std::size_t index) const -> T const & {
     if (refs.size() <= index) ThrowPlannerBug("missing child node");
@@ -346,10 +345,8 @@ struct symbol_build_traits<symbol::Distinct> {
     using values = ChildRestSlot<child::distinct::first_value, Symbol>;
   };
 
-  // DISTINCT dedups on the projected columns' frame slots. The cost model
-  // demanded these Symbols, so the projection materialised them (the value
-  // Symbol children are read straight back here rather than from
-  // input->OutputSymbols(), which an inlined WITH projection would leave empty).
+  // The value Symbols were demanded by cost (materialised), so read them straight
+  // back here rather than from input->OutputSymbols() (empty for an inlined WITH).
   static auto build(BuildState & /*state*/, ENodeRef /*node*/, Children children) -> result_type {
     auto const &input = children.get<slots::input>();
     auto value_symbols = children.get<slots::values>() | ranges::to<std::vector>;
@@ -398,10 +395,8 @@ struct symbol_build_traits<symbol::OrderBy> {
     using input = ChildSlot<child::order_by::input, LogicalOperatorPtr>;
   };
 
-  // Children are [input, sort_key_Expression x num_keys, value_Symbol x rest].
-  // The boundary is the interned orderings count, so the tail is split by index:
-  // the first num_keys are sort-key Expressions, the remainder value Symbols to
-  // remember through the sort (materialised, since the cost model demanded them).
+  // Split the tail by the interned orderings count: first num_keys are sort-key
+  // Expressions, the rest value Symbols to remember through the sort.
   static auto build(BuildState &state, ENodeRef node, Children children) -> result_type {
     using namespace child::order_by;
     auto const &input = children.get<slots::input>();

--- a/src/query/plan_v2/frontend/builder.cpp
+++ b/src/query/plan_v2/frontend/builder.cpp
@@ -65,6 +65,16 @@ struct Children {
            std::views::transform([](ChildRef c) -> typename Slot::type { return as<typename Slot::type>(c); });
   }
 
+  // Built child at a runtime index, cast to `T`. For nodes whose child types
+  // vary by position and split at a runtime boundary (OrderBy: sort-key
+  // Expressions then value-column Symbols), where a compile-time slot can't name
+  // the range.
+  template <typename T>
+  auto at(std::size_t index) const -> T const & {
+    if (refs.size() <= index) ThrowPlannerBug("missing child node");
+    return as<T>(refs[index]);
+  }
+
   [[nodiscard]] auto size() const -> std::size_t { return refs.size(); }
 
  private:
@@ -324,6 +334,95 @@ struct symbol_build_traits<symbol::Filter> {
         {query::plan::FilterInfo{query::plan::FilterInfo::Type::Generic, predicate, std::move(collector.symbols_)}});
     return std::static_pointer_cast<LogicalOperator>(std::make_shared<query::plan::Filter>(
         input, std::vector<std::shared_ptr<LogicalOperator>>{}, predicate, std::move(all_filters)));
+  }
+};
+
+template <>
+struct symbol_build_traits<symbol::Distinct> {
+  using result_type = LogicalOperatorPtr;
+
+  struct slots {
+    using input = ChildSlot<child::distinct::input, LogicalOperatorPtr>;
+    using values = ChildRestSlot<child::distinct::first_value, Symbol>;
+  };
+
+  // DISTINCT dedups on the projected columns' frame slots. The cost model
+  // demanded these Symbols, so the projection materialised them (the value
+  // Symbol children are read straight back here rather than from
+  // input->OutputSymbols(), which an inlined WITH projection would leave empty).
+  static auto build(BuildState & /*state*/, ENodeRef /*node*/, Children children) -> result_type {
+    auto const &input = children.get<slots::input>();
+    auto value_symbols = children.get<slots::values>() | ranges::to<std::vector>;
+    return std::static_pointer_cast<LogicalOperator>(
+        std::make_shared<query::plan::Distinct>(input, std::move(value_symbols)));
+  }
+};
+
+template <>
+struct symbol_build_traits<symbol::Skip> {
+  using result_type = LogicalOperatorPtr;
+
+  struct slots {
+    using input = ChildSlot<child::skip::input, LogicalOperatorPtr>;
+    using count = ChildSlot<child::skip::count, Expression *>;
+  };
+
+  static auto build(BuildState & /*state*/, ENodeRef /*node*/, Children children) -> result_type {
+    auto const &input = children.get<slots::input>();
+    auto *count = children.get<slots::count>();
+    return std::static_pointer_cast<LogicalOperator>(std::make_shared<query::plan::Skip>(input, count));
+  }
+};
+
+template <>
+struct symbol_build_traits<symbol::Limit> {
+  using result_type = LogicalOperatorPtr;
+
+  struct slots {
+    using input = ChildSlot<child::limit::input, LogicalOperatorPtr>;
+    using count = ChildSlot<child::limit::count, Expression *>;
+  };
+
+  static auto build(BuildState & /*state*/, ENodeRef /*node*/, Children children) -> result_type {
+    auto const &input = children.get<slots::input>();
+    auto *count = children.get<slots::count>();
+    return std::static_pointer_cast<LogicalOperator>(std::make_shared<query::plan::Limit>(input, count));
+  }
+};
+
+template <>
+struct symbol_build_traits<symbol::OrderBy> {
+  using result_type = LogicalOperatorPtr;
+
+  struct slots {
+    using input = ChildSlot<child::order_by::input, LogicalOperatorPtr>;
+  };
+
+  // Children are [input, sort_key_Expression x num_keys, value_Symbol x rest].
+  // The boundary is the interned orderings count, so the tail is split by index:
+  // the first num_keys are sort-key Expressions, the remainder value Symbols to
+  // remember through the sort (materialised, since the cost model demanded them).
+  static auto build(BuildState &state, ENodeRef node, Children children) -> result_type {
+    using namespace child::order_by;
+    auto const &input = children.get<slots::input>();
+    auto const dis = node.disambiguator();
+    DMG_ASSERT(dis < state.orderby_info.size(), "OrderBy id out of range");
+    auto const &orderings = state.orderby_info[dis];
+    auto const num_keys = orderings.size();
+    DMG_ASSERT(children.size() >= first_expr + num_keys, "OrderBy has fewer children than sort keys");
+
+    std::vector<SortItem> order_by;
+    order_by.reserve(num_keys);
+    for (std::size_t i = 0; i < num_keys; ++i) {
+      order_by.push_back(SortItem{.ordering = orderings[i], .expression = children.at<Expression *>(first_expr + i)});
+    }
+    std::vector<Symbol> output_symbols;
+    output_symbols.reserve(children.size() - first_expr - num_keys);
+    for (std::size_t i = first_expr + num_keys; i < children.size(); ++i) {
+      output_symbols.push_back(children.at<Symbol>(i));
+    }
+    return std::static_pointer_cast<LogicalOperator>(
+        std::make_shared<query::plan::OrderBy>(input, order_by, output_symbols));
   }
 };
 

--- a/src/query/plan_v2/frontend/builder.hpp
+++ b/src/query/plan_v2/frontend/builder.hpp
@@ -51,9 +51,8 @@ struct BuildState {
   std::vector<std::string_view> const &named_output_info;
   std::map<std::int32_t, SymbolInfo> const &symbol_store;
   std::vector<FunctionInfo> const &function_info;
-  /// id -> per-key ORDER BY directions, indexed by the OrderBy disambiguator.
-  /// The build reads it to split OrderBy's children into sort keys / value idents
-  /// and rebuild the SortItems.
+  /// id -> per-key ORDER BY directions, indexed by the OrderBy disambiguator; the
+  /// build reads it to split children into sort keys / value syms.
   std::vector<std::vector<Ordering>> const &orderby_info;
   /// The e-graph, so a build body can read an e-class's analysis facts (e.g.
   /// dead Unwind reading its list's statically known length).

--- a/src/query/plan_v2/frontend/builder.hpp
+++ b/src/query/plan_v2/frontend/builder.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "frontend/ast/ast_storage.hpp"
+#include "query/frontend/ast/ordering.hpp"
 #include "query/frontend/semantic/symbol_table.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan_v2/egraph/builtin_functions.hpp"
@@ -50,6 +51,10 @@ struct BuildState {
   std::vector<std::string_view> const &named_output_info;
   std::map<std::int32_t, SymbolInfo> const &symbol_store;
   std::vector<FunctionInfo> const &function_info;
+  /// id -> per-key ORDER BY directions, indexed by the OrderBy disambiguator.
+  /// The build reads it to split OrderBy's children into sort keys / value idents
+  /// and rebuild the SortItems.
+  std::vector<std::vector<Ordering>> const &orderby_info;
   /// The e-graph, so a build body can read an e-class's analysis facts (e.g.
   /// dead Unwind reading its list's statically known length).
   EGraph const &egraph;

--- a/src/query/plan_v2/frontend/egraph_converter.cpp
+++ b/src/query/plan_v2/frontend/egraph_converter.cpp
@@ -123,6 +123,7 @@ auto BuildOperatorTree(auto const &impl, QueryPlannerContext::Impl &ctx) -> Buil
       .named_output_info = impl.graph.template storage<NamedOutput>().info,
       .symbol_store = impl.graph.template storage<Symbol>().store,
       .function_info = impl.graph.template storage<Function>().info,
+      .orderby_info = impl.graph.template storage<symbol::OrderBy>().info,
       .egraph = impl.graph.core(),
   };
   auto const resolved_entries = ctx.build.resolved_entries();

--- a/src/query/plan_v2/resolve/pre_extraction.hpp
+++ b/src/query/plan_v2/resolve/pre_extraction.hpp
@@ -34,6 +34,13 @@ inline auto BuildPreExtractionData(EGraph const &core) -> PreExtractionData {
   using enum symbol;
   PreExtractionData out;
   boost::container::small_vector<planner::core::EClassId, 32> identifier_referenced;
+  // DISTINCT / ORDER BY carry their dedup/remember columns as Symbol children.
+  // Those are a demand on the bound variable exactly like an Identifier
+  // reference (they keep the value materialized), but they are not Identifiers,
+  // so collect them here and fold them into referenced_syms after the walk. The
+  // input child is an operator e-class, never a Symbol, so it is filtered out by
+  // the `contains` check below along with ORDER BY's sort-key expression children.
+  boost::container::small_vector<planner::core::EClassId, 32> column_referenced;
   for (auto eclass_id : core.canonical_eclass_ids()) {
     for (auto enode_id : core.eclass(eclass_id).nodes()) {
       auto const &enode = core.get_enode(enode_id);
@@ -44,10 +51,17 @@ inline auto BuildPreExtractionData(EGraph const &core) -> PreExtractionData {
         // The sym child is canonical: EGraph::emplace canonicalizes children
         // at insert time and rebuild() re-canonicalizes via canonicalize_in_place().
         identifier_referenced.push_back(enode.children()[child::identifier::sym]);
+      } else if (sym == Distinct || sym == OrderBy) {
+        for (auto child : enode.children().subspan(child::distinct::first_value)) column_referenced.push_back(child);
       }
     }
   }
   out.referenced_syms = out.variable_index.to_variable_set(identifier_referenced);
+  // Only the Symbol children (bound-variable columns) carry a bit; sort-key /
+  // input children are skipped, so `bit_of`'s registered-only contract holds.
+  for (auto eclass_id : column_referenced) {
+    if (out.variable_index.contains(eclass_id)) out.referenced_syms.set(out.variable_index.bit_of(eclass_id));
+  }
   return out;
 }
 

--- a/src/query/plan_v2/resolve/pre_extraction.hpp
+++ b/src/query/plan_v2/resolve/pre_extraction.hpp
@@ -34,12 +34,11 @@ inline auto BuildPreExtractionData(EGraph const &core) -> PreExtractionData {
   using enum symbol;
   PreExtractionData out;
   boost::container::small_vector<planner::core::EClassId, 32> identifier_referenced;
-  // DISTINCT / ORDER BY carry their dedup/remember columns as Symbol children.
-  // Those are a demand on the bound variable exactly like an Identifier
-  // reference (they keep the value materialized), but they are not Identifiers,
-  // so collect them here and fold them into referenced_syms after the walk. The
-  // input child is an operator e-class, never a Symbol, so it is filtered out by
-  // the `contains` check below along with ORDER BY's sort-key expression children.
+  // DISTINCT / ORDER BY carry their dedup/remember columns as bare Symbol
+  // children - a demand like an Identifier reference, but not Identifiers - so
+  // collect them here and fold into referenced_syms after the walk. ORDER BY's
+  // sort-key expression children are swept in too but discarded below by
+  // `contains` (only Symbol e-classes carry a bit).
   boost::container::small_vector<planner::core::EClassId, 32> column_referenced;
   for (auto eclass_id : core.canonical_eclass_ids()) {
     for (auto enode_id : core.eclass(eclass_id).nodes()) {
@@ -51,14 +50,15 @@ inline auto BuildPreExtractionData(EGraph const &core) -> PreExtractionData {
         // The sym child is canonical: EGraph::emplace canonicalizes children
         // at insert time and rebuild() re-canonicalizes via canonicalize_in_place().
         identifier_referenced.push_back(enode.children()[child::identifier::sym]);
-      } else if (sym == Distinct || sym == OrderBy) {
+      } else if (sym == Distinct) {
         for (auto child : enode.children().subspan(child::distinct::first_value)) column_referenced.push_back(child);
+      } else if (sym == OrderBy) {
+        for (auto child : enode.children().subspan(child::order_by::first_expr)) column_referenced.push_back(child);
       }
     }
   }
   out.referenced_syms = out.variable_index.to_variable_set(identifier_referenced);
-  // Only the Symbol children (bound-variable columns) carry a bit; sort-key /
-  // input children are skipped, so `bit_of`'s registered-only contract holds.
+  // `contains` skips sort-key children, keeping bit_of's registered-only contract.
   for (auto eclass_id : column_referenced) {
     if (out.variable_index.contains(eclass_id)) out.referenced_syms.set(out.variable_index.bit_of(eclass_id));
   }

--- a/src/query/plan_v2/resolve/resolver.hpp
+++ b/src/query/plan_v2/resolve/resolver.hpp
@@ -211,6 +211,58 @@ struct symbol_resolve_traits<symbol::Filter> {
   }
 };
 
+// The tail-clause row pipes (DISTINCT / SKIP / LIMIT / ORDER BY) are all
+// "pipe + non-introducing reader children" like Filter: they bind nothing, so
+// the pipe must introduce the chosen alt's full set (⊇ parent demand AND ⊇
+// every reader child's demand, enforced by the cost model) and each reader
+// reads parent.in_scope ∪ that set. The readers after the input are a mix of
+// expressions (SKIP/LIMIT count, ORDER BY sort keys) and value-column Symbol
+// leaves; the Symbols resolve trivially in any scope, so all thread uniformly
+// through ResolvePipeThenReaders.
+template <>
+struct symbol_resolve_traits<symbol::Distinct> {
+  static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,
+                               VariableSet const &chosen_introduces, SymbolContext const & /*syms*/,
+                               planner::core::extract::ChildSink<ResolverKey> auto visit) {
+    using namespace child::distinct;
+    auto const &children = enode.children();
+    ResolvePipeThenReaders(children[input], children.subspan(first_value), parent_key, chosen_introduces, visit);
+  }
+};
+
+template <>
+struct symbol_resolve_traits<symbol::Skip> {
+  static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,
+                               VariableSet const &chosen_introduces, SymbolContext const & /*syms*/,
+                               planner::core::extract::ChildSink<ResolverKey> auto visit) {
+    using namespace child::skip;
+    auto const &children = enode.children();
+    ResolvePipeThenReaders(children[input], children.subspan(count, 1), parent_key, chosen_introduces, visit);
+  }
+};
+
+template <>
+struct symbol_resolve_traits<symbol::Limit> {
+  static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,
+                               VariableSet const &chosen_introduces, SymbolContext const & /*syms*/,
+                               planner::core::extract::ChildSink<ResolverKey> auto visit) {
+    using namespace child::limit;
+    auto const &children = enode.children();
+    ResolvePipeThenReaders(children[input], children.subspan(count, 1), parent_key, chosen_introduces, visit);
+  }
+};
+
+template <>
+struct symbol_resolve_traits<symbol::OrderBy> {
+  static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,
+                               VariableSet const &chosen_introduces, SymbolContext const & /*syms*/,
+                               planner::core::extract::ChildSink<ResolverKey> auto visit) {
+    using namespace child::order_by;
+    auto const &children = enode.children();
+    ResolvePipeThenReaders(children[input], children.subspan(first_expr), parent_key, chosen_introduces, visit);
+  }
+};
+
 // Expression ops and structural leaves: uniform threading.
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define MG_UNIFORM_RESOLVE(SYM) \

--- a/src/query/plan_v2/resolve/resolver.hpp
+++ b/src/query/plan_v2/resolve/resolver.hpp
@@ -211,14 +211,11 @@ struct symbol_resolve_traits<symbol::Filter> {
   }
 };
 
-// The tail-clause row pipes (DISTINCT / SKIP / LIMIT / ORDER BY) are all
-// "pipe + non-introducing reader children" like Filter: they bind nothing, so
-// the pipe must introduce the chosen alt's full set (⊇ parent demand AND ⊇
-// every reader child's demand, enforced by the cost model) and each reader
-// reads parent.in_scope ∪ that set. The readers after the input are a mix of
-// expressions (SKIP/LIMIT count, ORDER BY sort keys) and value-column Symbol
-// leaves; the Symbols resolve trivially in any scope, so all thread uniformly
-// through ResolvePipeThenReaders.
+// The tail-clause row pipes (DISTINCT / SKIP / LIMIT / ORDER BY) bind nothing,
+// like Filter: the pipe introduces the chosen alt's full set and each reader
+// reads parent.in_scope plus that set. Readers after the input mix expressions
+// (counts, sort keys) and value Symbols; all thread uniformly through
+// ResolvePipeThenReaders.
 template <>
 struct symbol_resolve_traits<symbol::Distinct> {
   static void resolve_children(planner::core::ENode<symbol> const &enode, ResolverKey const &parent_key,

--- a/src/query/plan_v2/resolve/variable_index.hpp
+++ b/src/query/plan_v2/resolve/variable_index.hpp
@@ -45,6 +45,11 @@ class VariableIndex {
     return it->second;
   }
 
+  /// Whether `eclass` was assigned a bit, i.e. it is a Symbol e-class the
+  /// pre-pass registered.  Lets a caller tell a Symbol child (a bound variable)
+  /// apart from an expression child without dereferencing the e-graph.
+  [[nodiscard]] auto contains(planner::core::EClassId eclass) const -> bool { return by_eclass_.contains(eclass); }
+
   /// EClassId for `bit`.  Inverse of `bit_of`.
   [[nodiscard]] auto eclass_of(uint16_t bit) const -> planner::core::EClassId {
     DMG_ASSERT(bit < by_bit_.size(), "VariableIndex: bit out of range");

--- a/src/query/plan_v2/resolve/variable_index.hpp
+++ b/src/query/plan_v2/resolve/variable_index.hpp
@@ -45,9 +45,8 @@ class VariableIndex {
     return it->second;
   }
 
-  /// Whether `eclass` was assigned a bit, i.e. it is a Symbol e-class the
-  /// pre-pass registered.  Lets a caller tell a Symbol child (a bound variable)
-  /// apart from an expression child without dereferencing the e-graph.
+  /// Whether `eclass` was assigned a bit (a Symbol e-class the pre-pass
+  /// registered), telling a Symbol child from an expression child.
   [[nodiscard]] auto contains(planner::core::EClassId eclass) const -> bool { return by_eclass_.contains(eclass); }
 
   /// EClassId for `bit`.  Inverse of `bit_of`.

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -453,6 +453,21 @@ TEST_F(PlannerV2InterpreterTest, WherePatternPredicateReportsNotImplemented) {
                memgraph::query::QueryException);
 }
 
+TEST_F(PlannerV2InterpreterTest, OrderByUnsupportedSortKeyReportsNotImplemented) {
+  // ORDER BY sort keys go through the same expression lowering as WHERE, so an
+  // unsupported node (here a pattern comprehension) must throw rather than build
+  // an OrderBy that silently ignores the key.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY size([(a)-[]->(b) | b]);"),
+               memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, SkipUnsupportedCountReportsNotImplemented) {
+  // SKIP/LIMIT counts also lower through Lower(); an unsupported count node (CASE)
+  // must throw. SKIP forbids variables, so the count is variable-free.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x SKIP CASE WHEN true THEN 1 ELSE 0 END;"),
+               memgraph::query::QueryException);
+}
+
 TEST_F(PlannerV2InterpreterTest, ReturnDistinctDeduplicatesRows) {
   // DISTINCT dedups on the projected column: 1 appears twice, so two rows remain.
   auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;");

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -529,7 +529,7 @@ TEST_F(PlannerV2InterpreterTest, WithDistinctOnComputedColumnUnusedDownstream) {
   // z's binder alive (exercises the pre-extraction column-reference marking).
   // [1,2,3] -> x+1 = [2,3,4], all distinct -> 3 rows of "1".
   auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH DISTINCT x + 1 AS z RETURN 1;");
-  EXPECT_EQ(stream.GetResults().size(), 3U) << "rows=" << stream.GetResults().size();
+  EXPECT_EQ(stream.GetResults().size(), 3U);
 }
 
 TEST_F(PlannerV2InterpreterTest, ReturnDistinctOnConstantColumn) {
@@ -541,12 +541,12 @@ TEST_F(PlannerV2InterpreterTest, ReturnDistinctOnConstantColumn) {
 TEST_F(PlannerV2InterpreterTest, WithDistinctBareVarUnusedDownstream) {
   // element feeds only DISTINCT; RETURN ignores it. One row per distinct element.
   auto stream = Interpret("UNWIND [1, 1, 2] AS element WITH DISTINCT element RETURN 1;");
-  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+  EXPECT_EQ(stream.GetResults().size(), 2U);
 }
 
 TEST_F(PlannerV2InterpreterTest, WithDistinctRenameChain) {
   auto stream = Interpret("UNWIND [1, 1, 2] AS x WITH x AS y WITH DISTINCT y RETURN y;");
-  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+  EXPECT_EQ(stream.GetResults().size(), 2U);
 }
 
 TEST_F(PlannerV2InterpreterTest, WithOrderByOnComputedColumnMaterialisesIt) {
@@ -558,13 +558,21 @@ TEST_F(PlannerV2InterpreterTest, WithOrderByOnComputedColumnMaterialisesIt) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiColumnDistinct) {
-  // Dedup on the (x, x*2) pair: 1,1,2 -> (1,2),(1,2),(2,4) -> 2 distinct rows.
-  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x, x * 2 AS y;");
-  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+TEST_F(PlannerV2InterpreterTest, WithOrderByRememberedColumnUnusedDownstream) {
+  // b is remembered by ORDER BY but neither the sort key (a) nor read downstream:
+  // only the pre-extraction column fold keeps its binder alive (ORDER BY analogue
+  // of WithDistinctOnComputedColumnUnusedDownstream).
+  auto stream = Interpret("UNWIND [3, 1, 2] AS x WITH x AS a, x * 10 AS b ORDER BY a RETURN 1;");
+  EXPECT_EQ(stream.GetResults().size(), 3U);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiKeyOrderBy) {
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctMultiColumnDedupsOnTuple) {
+  // Dedup on the (x, x*2) pair: 1,1,2 -> (1,2),(1,2),(2,4) -> 2 distinct rows.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x, x * 2 AS y;");
+  EXPECT_EQ(stream.GetResults().size(), 2U);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByMultiKeyTieBreaks) {
   // ORDER BY x DESC, then y ASC as tie-break. x in {1,2}; group desc by x.
   auto stream = Interpret("UNWIND [1, 2] AS x RETURN x, x * 10 AS y ORDER BY x DESC, y ASC;");
   ASSERT_EQ(stream.GetResults().size(), 2U);
@@ -572,7 +580,7 @@ TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiKeyOrderBy) {
   EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 1);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByExpression) {
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByExpressionSortsRows) {
   auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY -x;");
   ASSERT_EQ(stream.GetResults().size(), 3U);
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
@@ -580,7 +588,7 @@ TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByExpression) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 1);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByPreProjectionVariable) {
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByPreProjectionVariableSortsRows) {
   // Output column is y = x*10, but the sort key references x (pre-projection).
   auto stream = Interpret("UNWIND [3, 1, 2] AS x RETURN x * 10 AS y ORDER BY x;");
   ASSERT_EQ(stream.GetResults().size(), 3U);
@@ -589,14 +597,14 @@ TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByPreProjectionVariable) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeAllFourChained) {
+TEST_F(PlannerV2InterpreterTest, ReturnAllFourTailClausesChained) {
   // DISTINCT -> ORDER BY DESC -> SKIP 1 -> LIMIT 1: {1,2,3} desc [3,2,1], skip1 [2,1], limit1 [2].
   auto stream = Interpret("UNWIND [3, 1, 2, 1, 3] AS x RETURN DISTINCT x ORDER BY x DESC SKIP 1 LIMIT 1;");
   ASSERT_EQ(stream.GetResults().size(), 1U);
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeWithDistinctThenWhere) {
+TEST_F(PlannerV2InterpreterTest, WithDistinctThenWhereFiltersAfterDedup) {
   // v1 order: DISTINCT then WHERE. distinct{1,2,3}, filter >1 -> {2,3}.
   auto stream = Interpret("UNWIND [1, 1, 2, 2, 3] AS x WITH DISTINCT x WHERE x > 1 RETURN x;");
   ASSERT_EQ(stream.GetResults().size(), 2U);

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -453,21 +453,173 @@ TEST_F(PlannerV2InterpreterTest, WherePatternPredicateReportsNotImplemented) {
                memgraph::query::QueryException);
 }
 
-TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
-  // ORDER BY / SKIP / LIMIT aren't built yet; refused rather than silently dropped.
-  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctDeduplicatesRows) {
+  // DISTINCT dedups on the projected column: 1 appears twice, so two rows remain.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
 }
 
-TEST_F(PlannerV2InterpreterTest, TailClauseOnReturnReportsNotImplemented) {
-  // Same guard on the final RETURN body.
-  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x LIMIT 2;"), memgraph::query::QueryException);
-  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY x;"), memgraph::query::QueryException);
+TEST_F(PlannerV2InterpreterTest, ReturnSkipLimitWindowsRows) {
+  // SKIP drops the first row, LIMIT keeps the next two: 1,[2,3],4 -> 2,3.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4] AS x RETURN x SKIP 1 LIMIT 2;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
 }
 
-TEST_F(PlannerV2InterpreterTest, DistinctReportsNotImplemented) {
-  // DISTINCT isn't lowered yet; dropping it would silently return duplicates.
-  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;"), memgraph::query::QueryException);
-  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x WITH DISTINCT x RETURN x;"), memgraph::query::QueryException);
+TEST_F(PlannerV2InterpreterTest, ReturnLimitZeroYieldsNoRows) {
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x LIMIT 0;");
+  EXPECT_EQ(stream.GetResults().size(), 0U);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByAscendingSortsRows) {
+  auto stream = Interpret("UNWIND [3, 1, 2] AS x RETURN x ORDER BY x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByDescendingSortsRows) {
+  // DESC vs ASC must reach the operator: same sort-key children, opposite order.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY x DESC;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 1);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctThenOrderByCompose) {
+  // DISTINCT then ORDER BY chain onto one projection: dedup {1,2,3}, sorted.
+  auto stream = Interpret("UNWIND [3, 1, 2, 1, 3] AS x RETURN DISTINCT x ORDER BY x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctDeduplicatesProjectedRows) {
+  // WITH DISTINCT: the identity WITH projection is inlined away, so the value
+  // symbol is recovered from the (inlined) Identifier, not the input operator.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x WITH DISTINCT x RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctOnComputedColumnMaterialisesIt) {
+  // z = x + 1 is a computed WITH column. DISTINCT demands z, so the projection
+  // must materialise it (the inline rewrite must not push x+1 past the DISTINCT).
+  auto stream = Interpret("UNWIND [1, 2] AS x WITH DISTINCT x + 1 AS z RETURN z;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctOnConstantColumnCollapsesToOneRow) {
+  auto stream = Interpret("UNWIND [1, 2] AS x WITH DISTINCT 5 AS c RETURN c;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 5);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctOnComputedColumnUnusedDownstream) {
+  // z is dedup'd but never read again: only the DISTINCT column reference keeps
+  // z's binder alive (exercises the pre-extraction column-reference marking).
+  // [1,2,3] -> x+1 = [2,3,4], all distinct -> 3 rows of "1".
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH DISTINCT x + 1 AS z RETURN 1;");
+  EXPECT_EQ(stream.GetResults().size(), 3U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctOnConstantColumn) {
+  auto stream = Interpret("UNWIND [1, 2] AS x RETURN DISTINCT 5 AS c;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 5);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctBareVarUnusedDownstream) {
+  // element feeds only DISTINCT; RETURN ignores it. One row per distinct element.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS element WITH DISTINCT element RETURN 1;");
+  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctRenameChain) {
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x WITH x AS y WITH DISTINCT y RETURN y;");
+  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, WithOrderByOnComputedColumnMaterialisesIt) {
+  // Same materialisation requirement for ORDER BY's remembered columns.
+  auto stream = Interpret("UNWIND [2, 1, 3] AS x WITH x * 10 AS z ORDER BY z RETURN z;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 10);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 20);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiColumnDistinct) {
+  // Dedup on the (x, x*2) pair: 1,1,2 -> (1,2),(1,2),(2,4) -> 2 distinct rows.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x, x * 2 AS y;");
+  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiKeyOrderBy) {
+  // ORDER BY x DESC, then y ASC as tie-break. x in {1,2}; group desc by x.
+  auto stream = Interpret("UNWIND [1, 2] AS x RETURN x, x * 10 AS y ORDER BY x DESC, y ASC;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 1);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByExpression) {
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY -x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 1);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByPreProjectionVariable) {
+  // Output column is y = x*10, but the sort key references x (pre-projection).
+  auto stream = Interpret("UNWIND [3, 1, 2] AS x RETURN x * 10 AS y ORDER BY x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 10);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 20);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeAllFourChained) {
+  // DISTINCT -> ORDER BY DESC -> SKIP 1 -> LIMIT 1: {1,2,3} desc [3,2,1], skip1 [2,1], limit1 [2].
+  auto stream = Interpret("UNWIND [3, 1, 2, 1, 3] AS x RETURN DISTINCT x ORDER BY x DESC SKIP 1 LIMIT 1;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeWithDistinctThenWhere) {
+  // v1 order: DISTINCT then WHERE. distinct{1,2,3}, filter >1 -> {2,3}.
+  auto stream = Interpret("UNWIND [1, 1, 2, 2, 3] AS x WITH DISTINCT x WHERE x > 1 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithSkipDropsLeadingRows) {
+  // A tail clause on a WITH body now executes rather than being refused.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, ExplainShowsTailClauseOperators) {
+  auto const distinct = PlanText(Interpret("EXPLAIN UNWIND [1, 1] AS x RETURN DISTINCT x;"));
+  EXPECT_NE(distinct.find("Distinct"), std::string::npos) << distinct;
+  auto const skip_limit = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x RETURN x SKIP 1 LIMIT 1;"));
+  EXPECT_NE(skip_limit.find("Skip"), std::string::npos) << skip_limit;
+  EXPECT_NE(skip_limit.find("Limit"), std::string::npos) << skip_limit;
+  auto const order_by = PlanText(Interpret("EXPLAIN UNWIND [2, 1] AS x RETURN x ORDER BY x;"));
+  EXPECT_NE(order_by.find("OrderBy"), std::string::npos) << order_by;
 }
 
 TYPED_TEST(InterpreterTest, MultiplePulls) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1132,7 +1132,7 @@ TEST_F(PlannerV2InterpreterTest, WithDistinctOnComputedColumnUnusedDownstream) {
   // z's binder alive (exercises the pre-extraction column-reference marking).
   // [1,2,3] -> x+1 = [2,3,4], all distinct -> 3 rows of "1".
   auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH DISTINCT x + 1 AS z RETURN 1;");
-  EXPECT_EQ(stream.GetResults().size(), 3U) << "rows=" << stream.GetResults().size();
+  EXPECT_EQ(stream.GetResults().size(), 3U);
 }
 
 TEST_F(PlannerV2InterpreterTest, ReturnDistinctOnConstantColumn) {
@@ -1144,12 +1144,12 @@ TEST_F(PlannerV2InterpreterTest, ReturnDistinctOnConstantColumn) {
 TEST_F(PlannerV2InterpreterTest, WithDistinctBareVarUnusedDownstream) {
   // element feeds only DISTINCT; RETURN ignores it. One row per distinct element.
   auto stream = Interpret("UNWIND [1, 1, 2] AS element WITH DISTINCT element RETURN 1;");
-  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+  EXPECT_EQ(stream.GetResults().size(), 2U);
 }
 
 TEST_F(PlannerV2InterpreterTest, WithDistinctRenameChain) {
   auto stream = Interpret("UNWIND [1, 1, 2] AS x WITH x AS y WITH DISTINCT y RETURN y;");
-  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+  EXPECT_EQ(stream.GetResults().size(), 2U);
 }
 
 TEST_F(PlannerV2InterpreterTest, WithOrderByOnComputedColumnMaterialisesIt) {
@@ -1161,13 +1161,21 @@ TEST_F(PlannerV2InterpreterTest, WithOrderByOnComputedColumnMaterialisesIt) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiColumnDistinct) {
-  // Dedup on the (x, x*2) pair: 1,1,2 -> (1,2),(1,2),(2,4) -> 2 distinct rows.
-  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x, x * 2 AS y;");
-  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+TEST_F(PlannerV2InterpreterTest, WithOrderByRememberedColumnUnusedDownstream) {
+  // b is remembered by ORDER BY but neither the sort key (a) nor read downstream:
+  // only the pre-extraction column fold keeps its binder alive (ORDER BY analogue
+  // of WithDistinctOnComputedColumnUnusedDownstream).
+  auto stream = Interpret("UNWIND [3, 1, 2] AS x WITH x AS a, x * 10 AS b ORDER BY a RETURN 1;");
+  EXPECT_EQ(stream.GetResults().size(), 3U);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiKeyOrderBy) {
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctMultiColumnDedupsOnTuple) {
+  // Dedup on the (x, x*2) pair: 1,1,2 -> (1,2),(1,2),(2,4) -> 2 distinct rows.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x, x * 2 AS y;");
+  EXPECT_EQ(stream.GetResults().size(), 2U);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByMultiKeyTieBreaks) {
   // ORDER BY x DESC, then y ASC as tie-break. x in {1,2}; group desc by x.
   auto stream = Interpret("UNWIND [1, 2] AS x RETURN x, x * 10 AS y ORDER BY x DESC, y ASC;");
   ASSERT_EQ(stream.GetResults().size(), 2U);
@@ -1175,7 +1183,7 @@ TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiKeyOrderBy) {
   EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 1);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByExpression) {
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByExpressionSortsRows) {
   auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY -x;");
   ASSERT_EQ(stream.GetResults().size(), 3U);
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
@@ -1183,7 +1191,7 @@ TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByExpression) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 1);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByPreProjectionVariable) {
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByPreProjectionVariableSortsRows) {
   // Output column is y = x*10, but the sort key references x (pre-projection).
   auto stream = Interpret("UNWIND [3, 1, 2] AS x RETURN x * 10 AS y ORDER BY x;");
   ASSERT_EQ(stream.GetResults().size(), 3U);
@@ -1192,14 +1200,14 @@ TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByPreProjectionVariable) {
   EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeAllFourChained) {
+TEST_F(PlannerV2InterpreterTest, ReturnAllFourTailClausesChained) {
   // DISTINCT -> ORDER BY DESC -> SKIP 1 -> LIMIT 1: {1,2,3} desc [3,2,1], skip1 [2,1], limit1 [2].
   auto stream = Interpret("UNWIND [3, 1, 2, 1, 3] AS x RETURN DISTINCT x ORDER BY x DESC SKIP 1 LIMIT 1;");
   ASSERT_EQ(stream.GetResults().size(), 1U);
   EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
 }
 
-TEST_F(PlannerV2InterpreterTest, ScopeProbeWithDistinctThenWhere) {
+TEST_F(PlannerV2InterpreterTest, WithDistinctThenWhereFiltersAfterDedup) {
   // v1 order: DISTINCT then WHERE. distinct{1,2,3}, filter >1 -> {2,3}.
   auto stream = Interpret("UNWIND [1, 1, 2, 2, 3] AS x WITH DISTINCT x WHERE x > 1 RETURN x;");
   ASSERT_EQ(stream.GetResults().size(), 2U);

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1056,6 +1056,21 @@ TEST_F(PlannerV2InterpreterTest, WherePatternPredicateReportsNotImplemented) {
                memgraph::query::QueryException);
 }
 
+TEST_F(PlannerV2InterpreterTest, OrderByUnsupportedSortKeyReportsNotImplemented) {
+  // ORDER BY sort keys go through the same expression lowering as WHERE, so an
+  // unsupported node (here a pattern comprehension) must throw rather than build
+  // an OrderBy that silently ignores the key.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY size([(a)-[]->(b) | b]);"),
+               memgraph::query::QueryException);
+}
+
+TEST_F(PlannerV2InterpreterTest, SkipUnsupportedCountReportsNotImplemented) {
+  // SKIP/LIMIT counts also lower through Lower(); an unsupported count node (CASE)
+  // must throw. SKIP forbids variables, so the count is variable-free.
+  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x SKIP CASE WHEN true THEN 1 ELSE 0 END;"),
+               memgraph::query::QueryException);
+}
+
 TEST_F(PlannerV2InterpreterTest, ReturnDistinctDeduplicatesRows) {
   // DISTINCT dedups on the projected column: 1 appears twice, so two rows remain.
   auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;");

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1056,21 +1056,173 @@ TEST_F(PlannerV2InterpreterTest, WherePatternPredicateReportsNotImplemented) {
                memgraph::query::QueryException);
 }
 
-TEST_F(PlannerV2InterpreterTest, TailClauseOnWithReportsNotImplemented) {
-  // ORDER BY / SKIP / LIMIT aren't built yet; refused rather than silently dropped.
-  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;"), memgraph::query::QueryException);
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctDeduplicatesRows) {
+  // DISTINCT dedups on the projected column: 1 appears twice, so two rows remain.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
 }
 
-TEST_F(PlannerV2InterpreterTest, TailClauseOnReturnReportsNotImplemented) {
-  // Same guard on the final RETURN body.
-  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x LIMIT 2;"), memgraph::query::QueryException);
-  EXPECT_THROW(Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY x;"), memgraph::query::QueryException);
+TEST_F(PlannerV2InterpreterTest, ReturnSkipLimitWindowsRows) {
+  // SKIP drops the first row, LIMIT keeps the next two: 1,[2,3],4 -> 2,3.
+  auto stream = Interpret("UNWIND [1, 2, 3, 4] AS x RETURN x SKIP 1 LIMIT 2;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
 }
 
-TEST_F(PlannerV2InterpreterTest, DistinctReportsNotImplemented) {
-  // DISTINCT isn't lowered yet; dropping it would silently return duplicates.
-  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x;"), memgraph::query::QueryException);
-  EXPECT_THROW(Interpret("UNWIND [1, 1, 2] AS x WITH DISTINCT x RETURN x;"), memgraph::query::QueryException);
+TEST_F(PlannerV2InterpreterTest, ReturnLimitZeroYieldsNoRows) {
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x LIMIT 0;");
+  EXPECT_EQ(stream.GetResults().size(), 0U);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByAscendingSortsRows) {
+  auto stream = Interpret("UNWIND [3, 1, 2] AS x RETURN x ORDER BY x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnOrderByDescendingSortsRows) {
+  // DESC vs ASC must reach the operator: same sort-key children, opposite order.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY x DESC;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 1);
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctThenOrderByCompose) {
+  // DISTINCT then ORDER BY chain onto one projection: dedup {1,2,3}, sorted.
+  auto stream = Interpret("UNWIND [3, 1, 2, 1, 3] AS x RETURN DISTINCT x ORDER BY x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctDeduplicatesProjectedRows) {
+  // WITH DISTINCT: the identity WITH projection is inlined away, so the value
+  // symbol is recovered from the (inlined) Identifier, not the input operator.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x WITH DISTINCT x RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctOnComputedColumnMaterialisesIt) {
+  // z = x + 1 is a computed WITH column. DISTINCT demands z, so the projection
+  // must materialise it (the inline rewrite must not push x+1 past the DISTINCT).
+  auto stream = Interpret("UNWIND [1, 2] AS x WITH DISTINCT x + 1 AS z RETURN z;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctOnConstantColumnCollapsesToOneRow) {
+  auto stream = Interpret("UNWIND [1, 2] AS x WITH DISTINCT 5 AS c RETURN c;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 5);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctOnComputedColumnUnusedDownstream) {
+  // z is dedup'd but never read again: only the DISTINCT column reference keeps
+  // z's binder alive (exercises the pre-extraction column-reference marking).
+  // [1,2,3] -> x+1 = [2,3,4], all distinct -> 3 rows of "1".
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH DISTINCT x + 1 AS z RETURN 1;");
+  EXPECT_EQ(stream.GetResults().size(), 3U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, ReturnDistinctOnConstantColumn) {
+  auto stream = Interpret("UNWIND [1, 2] AS x RETURN DISTINCT 5 AS c;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 5);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctBareVarUnusedDownstream) {
+  // element feeds only DISTINCT; RETURN ignores it. One row per distinct element.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS element WITH DISTINCT element RETURN 1;");
+  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, WithDistinctRenameChain) {
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x WITH x AS y WITH DISTINCT y RETURN y;");
+  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, WithOrderByOnComputedColumnMaterialisesIt) {
+  // Same materialisation requirement for ORDER BY's remembered columns.
+  auto stream = Interpret("UNWIND [2, 1, 3] AS x WITH x * 10 AS z ORDER BY z RETURN z;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 10);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 20);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiColumnDistinct) {
+  // Dedup on the (x, x*2) pair: 1,1,2 -> (1,2),(1,2),(2,4) -> 2 distinct rows.
+  auto stream = Interpret("UNWIND [1, 1, 2] AS x RETURN DISTINCT x, x * 2 AS y;");
+  EXPECT_EQ(stream.GetResults().size(), 2U) << "rows=" << stream.GetResults().size();
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeMultiKeyOrderBy) {
+  // ORDER BY x DESC, then y ASC as tie-break. x in {1,2}; group desc by x.
+  auto stream = Interpret("UNWIND [1, 2] AS x RETURN x, x * 10 AS y ORDER BY x DESC, y ASC;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 1);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByExpression) {
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x RETURN x ORDER BY -x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 3);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 1);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeOrderByPreProjectionVariable) {
+  // Output column is y = x*10, but the sort key references x (pre-projection).
+  auto stream = Interpret("UNWIND [3, 1, 2] AS x RETURN x * 10 AS y ORDER BY x;");
+  ASSERT_EQ(stream.GetResults().size(), 3U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 10);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 20);
+  EXPECT_EQ(stream.GetResults()[2][0].ValueInt(), 30);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeAllFourChained) {
+  // DISTINCT -> ORDER BY DESC -> SKIP 1 -> LIMIT 1: {1,2,3} desc [3,2,1], skip1 [2,1], limit1 [2].
+  auto stream = Interpret("UNWIND [3, 1, 2, 1, 3] AS x RETURN DISTINCT x ORDER BY x DESC SKIP 1 LIMIT 1;");
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+}
+
+TEST_F(PlannerV2InterpreterTest, ScopeProbeWithDistinctThenWhere) {
+  // v1 order: DISTINCT then WHERE. distinct{1,2,3}, filter >1 -> {2,3}.
+  auto stream = Interpret("UNWIND [1, 1, 2, 2, 3] AS x WITH DISTINCT x WHERE x > 1 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, WithSkipDropsLeadingRows) {
+  // A tail clause on a WITH body now executes rather than being refused.
+  auto stream = Interpret("UNWIND [1, 2, 3] AS x WITH x SKIP 1 RETURN x;");
+  ASSERT_EQ(stream.GetResults().size(), 2U);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 3);
+}
+
+TEST_F(PlannerV2InterpreterTest, ExplainShowsTailClauseOperators) {
+  auto const distinct = PlanText(Interpret("EXPLAIN UNWIND [1, 1] AS x RETURN DISTINCT x;"));
+  EXPECT_NE(distinct.find("Distinct"), std::string::npos) << distinct;
+  auto const skip_limit = PlanText(Interpret("EXPLAIN UNWIND [1, 2, 3] AS x RETURN x SKIP 1 LIMIT 1;"));
+  EXPECT_NE(skip_limit.find("Skip"), std::string::npos) << skip_limit;
+  EXPECT_NE(skip_limit.find("Limit"), std::string::npos) << skip_limit;
+  auto const order_by = PlanText(Interpret("EXPLAIN UNWIND [2, 1] AS x RETURN x ORDER BY x;"));
+  EXPECT_NE(order_by.find("OrderBy"), std::string::npos) << order_by;
 }
 
 TYPED_TEST(InterpreterTest, MultiplePulls) {

--- a/tests/unit/query_plan_v2_pipeline.cpp
+++ b/tests/unit/query_plan_v2_pipeline.cpp
@@ -183,6 +183,26 @@ class SimplePlanChecker : public plan::HierarchicalLogicalOperatorVisitor {
     operator_details.push_back("Apply");
     return true;
   }
+
+  bool PreVisit(plan::Distinct &) override {
+    operator_details.push_back("Distinct");
+    return true;
+  }
+
+  bool PreVisit(plan::Skip &) override {
+    operator_details.push_back("Skip");
+    return true;
+  }
+
+  bool PreVisit(plan::Limit &) override {
+    operator_details.push_back("Limit");
+    return true;
+  }
+
+  bool PreVisit(plan::OrderBy &op) override {
+    operator_details.push_back(op.ToString());
+    return true;
+  }
 };
 
 // Test case data for parameterized testing
@@ -790,6 +810,27 @@ INSTANTIATE_TEST_SUITE_P(
             .query = "UNWIND range(1, 100) AS x WITH x WHERE x > 50 RETURN 42 AS r;",
             .expected_details = {"Produce {r`1:42}", "Filter (x > 50)", "Unwind {x:RANGE(1, 100)}", "Once"},
             .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
+        },
+        // DISTINCT stacks above the RETURN projection.
+        PipelineTestCase{
+            .name = "ReturnDistinct",
+            .query = "UNWIND [1, 1, 2] AS x RETURN DISTINCT x;",
+            .expected_details = {"Distinct", "Produce {x`1:x}", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 0,
+        },
+        // SKIP then LIMIT stack above the projection, Limit outermost (v1 order).
+        PipelineTestCase{
+            .name = "ReturnSkipLimit",
+            .query = "UNWIND [1, 2, 3, 4] AS x RETURN x SKIP 1 LIMIT 2;",
+            .expected_details = {"Limit", "Skip", "Produce {x`1:x}", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 0,
+        },
+        // ORDER BY stacks above the projection and remembers the output column.
+        PipelineTestCase{
+            .name = "ReturnOrderBy",
+            .query = "UNWIND [3, 1, 2] AS x RETURN x ORDER BY x;",
+            .expected_details = {"OrderBy {x}", "Produce {x`1:x}", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 0,
         }
     ),
     TestCaseName

--- a/tests/unit/query_plan_v2_pipeline.cpp
+++ b/tests/unit/query_plan_v2_pipeline.cpp
@@ -183,6 +183,26 @@ class SimplePlanChecker : public plan::HierarchicalLogicalOperatorVisitor {
     operator_details.push_back("Apply");
     return true;
   }
+
+  bool PreVisit(plan::Distinct &) override {
+    operator_details.push_back("Distinct");
+    return true;
+  }
+
+  bool PreVisit(plan::Skip &) override {
+    operator_details.push_back("Skip");
+    return true;
+  }
+
+  bool PreVisit(plan::Limit &) override {
+    operator_details.push_back("Limit");
+    return true;
+  }
+
+  bool PreVisit(plan::OrderBy &op) override {
+    operator_details.push_back(op.ToString(nullptr));
+    return true;
+  }
 };
 
 // Test case data for parameterized testing
@@ -790,6 +810,27 @@ INSTANTIATE_TEST_SUITE_P(
             .query = "UNWIND range(1, 100) AS x WITH x WHERE x > 50 RETURN 42 AS r;",
             .expected_details = {"Produce {r`1:42}", "Filter (x > 50)", "Unwind {x:RANGE(1, 100)}", "Once"},
             .expected_rewrites = 1,  // the no-op WITH x bind is rewritten away
+        },
+        // DISTINCT stacks above the RETURN projection.
+        PipelineTestCase{
+            .name = "ReturnDistinct",
+            .query = "UNWIND [1, 1, 2] AS x RETURN DISTINCT x;",
+            .expected_details = {"Distinct", "Produce {x`1:x}", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 0,
+        },
+        // SKIP then LIMIT stack above the projection, Limit outermost (v1 order).
+        PipelineTestCase{
+            .name = "ReturnSkipLimit",
+            .query = "UNWIND [1, 2, 3, 4] AS x RETURN x SKIP 1 LIMIT 2;",
+            .expected_details = {"Limit", "Skip", "Produce {x`1:x}", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 0,
+        },
+        // ORDER BY stacks above the projection and remembers the output column.
+        PipelineTestCase{
+            .name = "ReturnOrderBy",
+            .query = "UNWIND [3, 1, 2] AS x RETURN x ORDER BY x;",
+            .expected_details = {"OrderBy {x}", "Produce {x`1:x}", "Unwind {x:literal}", "Once"},
+            .expected_rewrites = 0,
         }
     ),
     TestCaseName


### PR DESCRIPTION
Adds `DISTINCT` / `SKIP` / `LIMIT` / `ORDER BY` execution on `WITH` / `RETURN` bodies to the experimental plan_v2 planner (behind `--experimental-enabled=planner-v2`).

**What:** these tail clauses now execute instead of throwing `NotYetImplemented`. Stacked on the `WITH ... WHERE` PR #4398.

**How:** introduces four e-graph operators — `Distinct`, `Skip`, `Limit`, `OrderBy` — each wired through the standard operator surface (child layout, make/cost/resolve/build traits). `GuardUnsupportedTailClauses` is replaced by `LowerTailClauses`, which lowers the clauses in the legacy planner's `GenReturnBody` order (`DISTINCT` → `ORDER BY` → `SKIP` → `LIMIT`, with `WHERE` stacked above for `WITH`). `DISTINCT`/`ORDER BY` carry their dedup/remember columns as bare `Symbol` e-classes; the cost model demands those symbols, forcing the projection to materialise them into frame slots rather than letting the inline rewrite push column values past the operator. `OrderBy` interns its per-key `ASC`/`DESC` vector to a disambiguator, so orderings participate in e-node identity (`ORDER BY x` and `ORDER BY x DESC` stay distinct e-nodes). `SKIP`/`LIMIT` counts are constants evaluated once. The built operators are the legacy `query::plan::{Distinct,Skip,Limit,OrderBy}`, so runtime behaviour is unchanged.

**Why:** next sub-issue of epic #4203 ("execute every non-graph read query").

Closes #4194.