### PR TITLE
feat: add generic Result::SetValue(const Value&) overload to the module API

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -1788,6 +1788,8 @@ class Result {
   inline void SetValue(const Point3d &point);
   /// @brief Sets an @ref Enum value to be returned.
   inline void SetValue(const Enum &enum_v);
+  /// @brief Sets an arbitrary @ref Value to be returned.
+  inline void SetValue(const Value &value);
 
   void SetErrorMessage(std::string_view error_msg) const;
 
@@ -5206,6 +5208,11 @@ inline void Result::SetValue(const Enum &enum_v) {
     mgp::MemHandlerCallback(func_result_set_value, result_, mgp_val);
   }
   mgp::value_destroy(mgp_val);
+}
+
+inline void Result::SetValue(const Value &value) {
+  // func_result_set_value copies the value, so passing the wrapped pointer directly is safe.
+  mgp::MemHandlerCallback(func_result_set_value, result_, value.ptr());
 }
 
 inline void Result::SetErrorMessage(const std::string_view error_msg) const {


### PR DESCRIPTION
## What

Add a generic `mgp::Result::SetValue(const Value &)` overload to the C++ module API (`include/mgp.hpp`).

## Why

`mgp::Result` exposes one `SetValue` overload per concrete type but none that accepts a runtime `mgp::Value`. Modules that need to forward a value whose type is only known at runtime (e.g. returning whatever a map key holds) have had to hand-roll a large `switch (value.Type())` that decomposes the value into a typed scalar just to call the matching typed overload — duplicated across modules and easy to let drift when a new `mgp::Type` is added.

## How

The underlying C API `mgp_func_result_set_value` already deep-copies the value (`res->value = ToTypedValue(*value, ...)`), so the overload simply forwards the wrapped pointer:

```cpp
inline void Result::SetValue(const Value &value) {
  mgp::MemHandlerCallback(func_result_set_value, result_, value.ptr());
}
```

This lets modules replace their per-type dispatch switches with a single call, and removes the "unhandled type → throw" gap those switches carried.

## Notes

Base PR of a small stack — the map-functions and collections PRs build on top of this and use the overload.
