### PR TITLE
fix: Routing table deduplication

### DIFF
--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -28,6 +28,22 @@
 
 namespace memgraph::coordination {
 
+namespace {
+// Older versions allowed re-adding an already existing coordinator id, so persisted state can contain duplicate
+// entries. All id-based lookups and updates always operated on the first occurrence, so keep it and drop the rest.
+auto DedupCoordinatorInstances(std::vector<CoordinatorInstanceContext> instances)
+    -> std::vector<CoordinatorInstanceContext> {
+  std::vector<CoordinatorInstanceContext> result;
+  result.reserve(instances.size());
+  for (auto &instance : instances) {
+    if (!std::ranges::contains(result, instance.id, &CoordinatorInstanceContext::id)) {
+      result.push_back(std::move(instance));
+    }
+  }
+  return result;
+}
+}  // namespace
+
 CoordinatorClusterState::CoordinatorClusterState(CoordinatorClusterState const &other) {
   auto lock = std::lock_guard{other.app_lock_};
   // NOLINTBEGIN
@@ -129,7 +145,7 @@ auto CoordinatorClusterState::DoAction(CoordinatorClusterStateDelta delta_state)
     data_instances_ = std::move(*delta_state.data_instances_);
   }
   if (delta_state.coordinator_instances_.has_value()) {
-    coordinator_instances_ = std::move(*delta_state.coordinator_instances_);
+    coordinator_instances_ = DedupCoordinatorInstances(std::move(*delta_state.coordinator_instances_));
   }
   if (delta_state.current_main_uuid_.has_value()) {
     current_main_uuid_ = *delta_state.current_main_uuid_;
@@ -251,7 +267,7 @@ auto CoordinatorClusterState::GetGlobalReadOnly() const -> bool {
 
 void CoordinatorClusterState::SetCoordinatorInstances(std::vector<CoordinatorInstanceContext> coordinator_instances) {
   auto lock = std::lock_guard{app_lock_};
-  coordinator_instances_ = std::move(coordinator_instances);
+  coordinator_instances_ = DedupCoordinatorInstances(std::move(coordinator_instances));
 }
 
 void CoordinatorClusterState::SetDataInstances(std::vector<DataInstanceContext> data_instances) {

--- a/tests/unit/coordinator_cluster_state.cpp
+++ b/tests/unit/coordinator_cluster_state.cpp
@@ -317,3 +317,53 @@ TEST_F(CoordinatorClusterStateTest, RoutingPoliciesSwitch) {
   ASSERT_EQ(deserialized_cluster_state.GetInstanceDownTimeoutSec(), 5);
   ASSERT_EQ(deserialized_cluster_state.GetInstanceHealthCheckFrequencySec(), std::chrono::seconds{1});
 }
+
+TEST_F(CoordinatorClusterStateTest, DedupCoordinatorsOnDoAction) {
+  CoordinatorClusterState cluster_state;
+
+  // Duplicate id 1 with a different bolt server, as created by older versions which allowed re-adding an
+  // existing coordinator.
+  std::vector<CoordinatorInstanceContext> coord_instances{
+      CoordinatorInstanceContext{.id = 1, .bolt_server = "127.0.0.1:7690"},
+      CoordinatorInstanceContext{.id = 2, .bolt_server = "127.0.0.1:7691"},
+      CoordinatorInstanceContext{.id = 1, .bolt_server = "127.0.0.1:7699"},
+  };
+
+  // NOLINTNEXTLINE
+  CoordinatorClusterStateDelta const delta_state{.coordinator_instances_ = std::move(coord_instances)};
+  cluster_state.DoAction(delta_state);
+
+  auto const coord_instances_res = cluster_state.GetCoordinatorInstancesContext();
+  ASSERT_EQ(coord_instances_res.size(), 2);
+  ASSERT_EQ(coord_instances_res[0].id, 1);
+  ASSERT_EQ(coord_instances_res[0].bolt_server, "127.0.0.1:7690");
+  ASSERT_EQ(coord_instances_res[1].id, 2);
+  ASSERT_EQ(coord_instances_res[1].bolt_server, "127.0.0.1:7691");
+}
+
+TEST_F(CoordinatorClusterStateTest, DedupCoordinatorsOnDeserialize) {
+  std::vector<DataInstanceContext> data_instances;
+  auto const uuid = UUID{};
+
+  std::vector coord_instances{
+      CoordinatorInstanceContext{.id = 1, .bolt_server = "127.0.0.1:7690"},
+      CoordinatorInstanceContext{.id = 2, .bolt_server = "127.0.0.1:7691"},
+      CoordinatorInstanceContext{.id = 1, .bolt_server = "127.0.0.1:7699"},
+  };
+
+  auto json = nlohmann::json{{memgraph::coordination::kDataInstances.data(), data_instances},
+                             {memgraph::coordination::kMainUUID.data(), uuid},
+                             {memgraph::coordination::kCoordinatorInstances.data(), coord_instances}};
+
+  auto const log = json.dump();
+  ptr<buffer> data = buffer::alloc(sizeof(uint32_t) + log.size());
+  nuraft::buffer_serializer bs(data);
+  bs.put_str(log);
+
+  auto deserialized_cluster_state = CoordinatorClusterState::Deserialize(*data);
+  std::vector const expected_coord_instances{
+      CoordinatorInstanceContext{.id = 1, .bolt_server = "127.0.0.1:7690"},
+      CoordinatorInstanceContext{.id = 2, .bolt_server = "127.0.0.1:7691"},
+  };
+  ASSERT_EQ(deserialized_cluster_state.GetCoordinatorInstancesContext(), expected_coord_instances);
+}


### PR DESCRIPTION
Removes stale entries from coordinators' routing table when applying Raft logs and Raft snapshots.