### PR TITLE
refactor(utils): index the LRU cache by node iterators

### DIFF
--- a/src/utils/lru_cache.hpp
+++ b/src/utils/lru_cache.hpp
@@ -11,73 +11,103 @@
 
 #pragma once
 
+#include <cstddef>
 #include <list>
 #include <optional>
-#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace memgraph::utils {
 
 /// A simple LRU cache implementation.
 /// It is not thread-safe.
-
+///
+/// The list owns each entry (key and value, both const) and carries the LRU
+/// order. The index is a set of list iterators, hashed and compared by the key
+/// they point at, so a lookup locates the node in O(1) with no second copy of
+/// the key and no linear scan. Lookups pass the bare key through transparent
+/// hashing and allocate nothing.
+///
+/// An entry is immutable once inserted: a put for a key already present keeps
+/// the stored value and only refreshes its recency.
 template <class TKey, class TVal, class TAlloc = std::allocator<std::pair<const TKey, TVal>>>
 class LRUCache {
+  using Entry = std::pair<const TKey, const TVal>;
+  using ListType = std::list<Entry, typename std::allocator_traits<TAlloc>::template rebind_alloc<Entry>>;
+  using ListIt = typename ListType::iterator;
+
  public:
   explicit LRUCache(std::size_t cache_size_) : cache_size(cache_size_) {};
 
   void put(const TKey &key, const TVal &val) {
-    auto it = item_map.find(key);
-    if (it != item_map.end()) {
-      item_list.erase(it->second);
-      item_map.erase(it);
+    if (auto it = index.find(key); it != index.end()) {
+      item_list.splice(item_list.begin(), item_list, *it);
+      return;
     }
     item_list.emplace_front(key, val);
-    item_map.insert(std::make_pair(key, item_list.begin()));
+    index.insert(item_list.begin());
     try_clean();
   };
 
   std::optional<TVal> get(const TKey &key) {
-    auto const it = item_map.find(key);
-    if (it == item_map.end()) {
+    auto const it = index.find(key);
+    if (it == index.end()) {
       return std::nullopt;
     }
-    item_list.splice(item_list.begin(), item_list, it->second);
-    return it->second->second;
+    item_list.splice(item_list.begin(), item_list, *it);
+    return (*it)->second;
   }
 
   void invalidate(const TKey &key) {
-    auto const it = item_map.find(key);
-    if (it != item_map.end()) {
-      item_list.erase(it->second);
-      item_map.erase(it);
+    auto const it = index.find(key);
+    if (it != index.end()) {
+      ListIt const node = *it;
+      index.erase(it);
+      item_list.erase(node);
     }
   }
 
   void reset() {
+    index.clear();
     item_list.clear();
-    item_map.clear();
   };
 
-  std::size_t size() const { return item_map.size(); }
+  std::size_t size() const { return index.size(); }
 
  private:
+  struct IterHash {
+    using is_transparent = void;
+
+    std::size_t operator()(ListIt it) const noexcept { return std::hash<TKey>{}(it->first); }
+
+    std::size_t operator()(const TKey &key) const noexcept { return std::hash<TKey>{}(key); }
+  };
+
+  struct IterEqual {
+    using is_transparent = void;
+
+    bool operator()(ListIt lhs, ListIt rhs) const { return lhs->first == rhs->first; }
+
+    bool operator()(ListIt lhs, const TKey &rhs) const { return lhs->first == rhs; }
+
+    bool operator()(const TKey &lhs, ListIt rhs) const { return lhs == rhs->first; }
+  };
+
   void try_clean() {
-    while (item_map.size() > cache_size) {
+    while (index.size() > cache_size) {
       auto last = std::prev(item_list.end());
-      item_map.erase(last->first);
+      // Erase the index entry before freeing the node: erasing hashes the key,
+      // which the node still owns.
+      index.erase(last);
       item_list.pop_back();
     }
   };
 
-  using ListType = std::list<std::pair<TKey, TVal>,
-                             typename std::allocator_traits<TAlloc>::template rebind_alloc<std::pair<TKey, TVal>>>;
   ListType item_list;
 
-  using MapType = std::unordered_map<TKey, typename ListType::iterator, std::hash<TKey>, std::equal_to<TKey>,
-                                     typename std::allocator_traits<TAlloc>::template rebind_alloc<
-                                         std::pair<const TKey, typename ListType::iterator>>>;
-  MapType item_map;
+  using IndexType = std::unordered_set<ListIt, IterHash, IterEqual,
+                                       typename std::allocator_traits<TAlloc>::template rebind_alloc<ListIt>>;
+  IndexType index;
 
   std::size_t cache_size;
 };

--- a/tests/unit/lru_cache.cpp
+++ b/tests/unit/lru_cache.cpp
@@ -13,6 +13,44 @@
 #include <optional>
 #include "gtest/gtest.h"
 
+namespace {
+// A key that counts both its live instances and its total constructions, so a
+// test can assert how many times the cache materializes a key.
+struct CountingKey {
+  static inline int live = 0;
+  static inline int constructed = 0;
+
+  explicit CountingKey(int value) : value{value} {
+    ++live;
+    ++constructed;
+  }
+
+  CountingKey(const CountingKey &other) : value{other.value} {
+    ++live;
+    ++constructed;
+  }
+
+  CountingKey(CountingKey &&other) noexcept : value{other.value} {
+    ++live;
+    ++constructed;
+  }
+
+  CountingKey &operator=(const CountingKey &) = default;
+  CountingKey &operator=(CountingKey &&) = default;
+
+  ~CountingKey() { --live; }
+
+  bool operator==(const CountingKey &other) const { return value == other.value; }
+
+  int value;
+};
+}  // namespace
+
+template <>
+struct std::hash<CountingKey> {
+  size_t operator()(const CountingKey &key) const noexcept { return std::hash<int>{}(key.value); }
+};
+
 TEST(LRUCacheTest, BasicTest) {
   memgraph::utils::LRUCache<int, int> cache(2);
   cache.put(1, 1);
@@ -44,20 +82,31 @@ TEST(LRUCacheTest, BasicTest) {
   EXPECT_EQ(cache.size(), 2);
 }
 
-TEST(LRUCacheTest, DuplicatePutTest) {
+// An entry is immutable once cached: a put for a key already present keeps the
+// stored value rather than overwriting it.
+TEST(LRUCacheTest, DuplicatePutKeepsExistingValue) {
   memgraph::utils::LRUCache<int, int> cache(2);
   cache.put(1, 1);
   cache.put(2, 2);
   cache.put(1, 10);
 
-  std::optional<int> value;
-  value = cache.get(1);
-  EXPECT_TRUE(value.has_value());
-  EXPECT_EQ(value.value(), 10);
+  EXPECT_EQ(cache.get(1).value(), 1);
+  EXPECT_EQ(cache.get(2).value(), 2);
+}
 
-  value = cache.get(2);
-  EXPECT_TRUE(value.has_value());
-  EXPECT_EQ(value.value(), 2);
+// A put for a present key, though it does not change the value, still refreshes
+// recency: the entry becomes most-recently-used and so survives the next
+// eviction that a fresh insert triggers.
+TEST(LRUCacheTest, DuplicatePutPromotesToMru) {
+  memgraph::utils::LRUCache<int, int> cache(2);
+  cache.put(1, 1);
+  cache.put(2, 2);   // order MRU..LRU: 2, 1
+  cache.put(1, 99);  // key present: value kept, 1 promoted -> 1, 2
+  cache.put(3, 3);   // capacity reached: evicts LRU, which is now 2
+
+  EXPECT_FALSE(cache.get(2).has_value());
+  EXPECT_EQ(cache.get(1).value(), 1);
+  EXPECT_TRUE(cache.get(3).has_value());
 }
 
 TEST(LRUCacheTest, ResizeTest) {
@@ -110,35 +159,51 @@ TEST(LRUCacheTest, LargeCacheTest) {
   }
 }
 
+TEST(LRUCacheTest, KeyMaterializedOncePerEntry) {
+  constexpr int kEntries = 100;
+  ASSERT_EQ(CountingKey::live, 0);
+  {
+    memgraph::utils::LRUCache<CountingKey, int> cache(kEntries);
+    for (int i = 0; i < kEntries; ++i) {
+      cache.put(CountingKey{i}, i);
+    }
+    // Each resident entry materializes exactly one key: the list node owns it
+    // and the index stores only an iterator, not a second copy.
+    EXPECT_EQ(CountingKey::live, kEntries);
+
+    // A get() resolves the bare key through transparent lookup, constructing no
+    // key of its own on either a hit or a miss.
+    const int constructed_after_fill = CountingKey::constructed;
+    for (int i = 0; i < kEntries; ++i) {
+      EXPECT_TRUE(cache.get(CountingKey{i}).has_value());  // hit
+    }
+    EXPECT_FALSE(cache.get(CountingKey{-1}).has_value());  // miss
+    // The only keys built here are the throwaway lookup arguments: one per call,
+    // none retained.
+    EXPECT_EQ(CountingKey::live, kEntries);
+    EXPECT_EQ(CountingKey::constructed, constructed_after_fill + kEntries + 1);
+  }
+  EXPECT_EQ(CountingKey::live, 0);
+}
+
 TEST(LRUCacheTest, InvalidateTest) {
   memgraph::utils::LRUCache<int, int> cache(3);
   cache.put(1, 100);
   cache.put(2, 200);
   cache.put(3, 300);
 
-  // Ensure all elements are present
   EXPECT_TRUE(cache.get(1).has_value());
   EXPECT_TRUE(cache.get(2).has_value());
   EXPECT_TRUE(cache.get(3).has_value());
 
-  // Invalidate one key
   cache.invalidate(2);
 
-  // Key 2 should be removed
-  std::optional<int> value = cache.get(2);
-  EXPECT_FALSE(value.has_value());
-
-  // Other keys should still be present
-  EXPECT_TRUE(cache.get(1).has_value());
+  EXPECT_FALSE(cache.get(2).has_value());
   EXPECT_EQ(cache.get(1).value(), 100);
-
-  EXPECT_TRUE(cache.get(3).has_value());
   EXPECT_EQ(cache.get(3).value(), 300);
-
-  // Cache size should be 2 now
   EXPECT_EQ(cache.size(), 2);
 
-  // Invalidate a non-existent key (should not crash or change state)
+  // Invalidating an absent key is a no-op.
   cache.invalidate(42);
   EXPECT_EQ(cache.size(), 2);
 }


### PR DESCRIPTION
LRUCache kept a std::list of entries and a std::unordered_map from key to list iterator. The map's key was a second copy of the entry key, so a large key (the AST and plan caches key on a stripped query, its full normalized text) was stored twice per entry.

Index by the list node instead. The list owns each entry (key and value, both const) and carries the LRU order; the index is a std::unordered_set of list iterators, hashed and compared by the key they point at through transparent functors. A lookup takes the bare key and locates the node in O(1) with no second key copy and no allocation. Each entry now holds one key and one index locator.

Entries are also immutable: a put for a key already present keeps the stored value and only refreshes recency, matching how both caches use it (they insert only after a lookup miss). The unit tests cover the contract, including that a key is materialized once and that a lookup constructs none.