### PR TITLE
fix: correct filterStartNode/minHops and bidirectional filter in path.subgraph_all/subgraph_nodes

### DIFF
--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -488,6 +488,11 @@ void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int6
 }
 
 void Path::PathSubgraph::TryInsertNode(const mgp::Node &node, int64_t hop_count, LabelBools &label_bools) {
+  // Nodes closer than minHops are still traversed but must not be returned.
+  if (!path_data_.helper_.PathSizeOk(hop_count)) {
+    return;
+  }
+
   if (path_data_.helper_.IsNotStartOrFiltersStartNode(hop_count == 0)) {
     if (path_data_.helper_.AreLabelsValid(label_bools)) {
       to_be_returned_nodes_.AppendExtend(mgp::Value(node));

--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -477,9 +477,10 @@ void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int6
       queue.emplace(next_node, pair.second + 1);
     } else if (wanted_direction == RelDirection::kBoth) {
       if (outgoing && seen.contains({type, relationship.To().Id().AsInt()})) {
+        // Enqueue only; the node is returned when dequeued via TryInsertNode, which applies the
+        // hop-range and label filters and avoids the double insert that a direct append would cause.
         path_data_.visited_.insert(next_node.Id().AsInt());
         queue.emplace(next_node, pair.second + 1);
-        to_be_returned_nodes_.AppendExtend(mgp::Value{next_node});
       } else {
         seen.insert({type, relationship.From().Id().AsInt()});
       }

--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -73,7 +73,7 @@ Path::PathHelper::PathHelper(const mgp::Map &config) {
   FilterLabelBoolStatus();
 
   value = config.At("filterStartNode");
-  config_.filter_start_node = value.IsNull() ? true : value.ValueBool();
+  config_.filter_start_node = value.IsNull() ? false : value.ValueBool();
 
   value = config.At("beginSequenceAtStart");
   config_.begin_sequence_at_start = value.IsNull() ? true : value.ValueBool();
@@ -495,7 +495,13 @@ void Path::PathSubgraph::TryInsertNode(const mgp::Node &node, int64_t hop_count,
     return;
   }
 
-  to_be_returned_nodes_.AppendExtend(mgp::Value(node));
+  // Unfiltered start node: its own labels are exempt, so it behaves like a plain whitelisted node.
+  // It is returned only in whitelist / no-filter mode, never forced into an end/termination result set.
+  LabelBools exempt_start;
+  exempt_start.whitelisted = true;
+  if (path_data_.helper_.AreLabelsValid(exempt_start)) {
+    to_be_returned_nodes_.AppendExtend(mgp::Value(node));
+  }
 }
 
 mgp::List Path::PathSubgraph::BFS() {

--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -82,7 +82,7 @@ Path::PathHelper::PathHelper(const mgp::Map &config) {
   config_.bfs = value.IsNull() ? false : value.ValueBool();
 }
 
-Path::RelDirection Path::PathHelper::GetDirection(const std::string &rel_type) const {
+Path::RelDirection Path::PathHelper::GetDirection(std::string_view rel_type) const {
   auto it = config_.relationship_sets.find(rel_type);
   if (it == config_.relationship_sets.end()) {
     return RelDirection::kNone;
@@ -345,7 +345,8 @@ void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp::Relationshi
                                                int64_t path_size,
                                                std::set<std::pair<std::string_view, int64_t>> &seen) {
   for (const auto relationship : relationships) {
-    auto type = std::string(relationship.Type());
+    // Type() returns a view into the graph's interned edge-type storage, so it is safe to keep in `seen`.
+    const std::string_view type = relationship.Type();
     auto wanted_direction = path_data_.helper_.GetDirection(type);
 
     if ((wanted_direction == RelDirection::kNone && !path_data_.helper_.AnyDirected(outgoing)) ||
@@ -460,7 +461,8 @@ void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int6
       continue;
     }
 
-    auto type = std::string(relationship.Type());
+    // Type() returns a view into the graph's interned edge-type storage, so it is safe to keep in `seen`.
+    const std::string_view type = relationship.Type();
     auto wanted_direction = path_data_.helper_.GetDirection(type);
 
     if (path_data_.helper_.IsNotStartOrFilterStartRel(pair.second == 0)) {
@@ -474,13 +476,12 @@ void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int6
     if (wanted_direction == RelDirection::kAny || curr_direction == wanted_direction ||
         path_data_.helper_.AnyDirected(outgoing)) {
       path_data_.visited_.insert(next_node.Id().AsInt());
-      queue.emplace(next_node, pair.second + 1);
+      queue.emplace(std::move(next_node), pair.second + 1);
     } else if (wanted_direction == RelDirection::kBoth) {
       if (outgoing && seen.contains({type, relationship.To().Id().AsInt()})) {
-        // Enqueue only; the node is returned when dequeued via TryInsertNode, which applies the
-        // hop-range and label filters and avoids the double insert that a direct append would cause.
+        // Enqueue only; TryInsertNode emits it once on dequeue with hop/label filters applied.
         path_data_.visited_.insert(next_node.Id().AsInt());
-        queue.emplace(next_node, pair.second + 1);
+        queue.emplace(std::move(next_node), pair.second + 1);
       } else {
         seen.insert({type, relationship.From().Id().AsInt()});
       }
@@ -488,7 +489,7 @@ void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int6
   }
 }
 
-void Path::PathSubgraph::TryInsertNode(const mgp::Node &node, int64_t hop_count, LabelBools &label_bools) {
+void Path::PathSubgraph::TryInsertNode(const mgp::Node &node, int64_t hop_count, const LabelBools &label_bools) {
   // Nodes closer than minHops are still traversed but must not be returned.
   if (!path_data_.helper_.PathSizeOk(hop_count)) {
     return;
@@ -501,10 +502,8 @@ void Path::PathSubgraph::TryInsertNode(const mgp::Node &node, int64_t hop_count,
     return;
   }
 
-  // Unfiltered start node: its own labels are exempt, so it behaves like a plain whitelisted node.
-  // It is returned only in whitelist / no-filter mode, never forced into an end/termination result set.
-  LabelBools exempt_start;
-  exempt_start.whitelisted = true;
+  // Unfiltered start: its own labels are exempt, so treat it as a plain whitelisted node.
+  constexpr LabelBools exempt_start{.whitelisted = true};
   if (path_data_.helper_.AreLabelsValid(exempt_start)) {
     to_be_returned_nodes_.AppendExtend(mgp::Value(node));
   }
@@ -519,7 +518,7 @@ mgp::List Path::PathSubgraph::BFS() {
   }
 
   while (!queue.empty()) {
-    auto pair = queue.front();
+    auto pair = std::move(queue.front());
     queue.pop();
 
     if (path_data_.helper_.PathTooBig(pair.second)) {

--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -342,10 +342,9 @@ void Path::PathExpand::ExpandPath(mgp::Path &path, const mgp::Relationship &rela
 }
 
 void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp::Relationships relationships, bool outgoing,
-                                               int64_t path_size,
-                                               std::set<std::pair<std::string_view, int64_t>> &seen) {
+                                               int64_t path_size, std::set<std::pair<std::string, int64_t>> &seen) {
   for (const auto relationship : relationships) {
-    // Type() returns a view into the graph's interned edge-type storage, so it is safe to keep in `seen`.
+    // string_view keeps the GetDirection lookup allocation-free; `seen` below owns its key.
     const std::string_view type = relationship.Type();
     auto wanted_direction = path_data_.helper_.GetDirection(type);
 
@@ -360,10 +359,10 @@ void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp::Relationshi
         path_data_.helper_.AnyDirected(outgoing)) {
       ExpandPath(path, relationship, path_size);
     } else if (wanted_direction == RelDirection::kBoth) {
-      if (outgoing && seen.contains({type, relationship.To().Id().AsInt()})) {
+      if (outgoing && seen.contains({std::string(type), relationship.To().Id().AsInt()})) {
         ExpandPath(path, relationship, path_size);
       } else {
-        seen.insert({type, relationship.From().Id().AsInt()});
+        seen.insert({std::string(type), relationship.From().Id().AsInt()});
       }
     }
   }
@@ -383,7 +382,7 @@ void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size) {
     return;
   }
 
-  std::set<std::pair<std::string_view, int64_t>> seen;
+  std::set<std::pair<std::string, int64_t>> seen;
   this->ExpandFromRelationships(path, node.InRelationships(), false, path_size, seen);
   this->ExpandFromRelationships(path, node.OutRelationships(), true, path_size, seen);
 }
@@ -453,7 +452,7 @@ void Path::PathSubgraph::Parse(const mgp::Value &value) {
 void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int64_t> &pair,
                                                  const mgp::Relationships relationships, bool outgoing,
                                                  std::queue<std::pair<mgp::Node, int64_t>> &queue,
-                                                 std::set<std::pair<std::string_view, int64_t>> &seen) {
+                                                 std::set<std::pair<std::string, int64_t>> &seen) {
   for (const auto relationship : relationships) {
     auto next_node = outgoing ? relationship.To() : relationship.From();
 
@@ -461,7 +460,7 @@ void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int6
       continue;
     }
 
-    // Type() returns a view into the graph's interned edge-type storage, so it is safe to keep in `seen`.
+    // string_view keeps the GetDirection lookup allocation-free; `seen` below owns its key.
     const std::string_view type = relationship.Type();
     auto wanted_direction = path_data_.helper_.GetDirection(type);
 
@@ -478,12 +477,12 @@ void Path::PathSubgraph::ExpandFromRelationships(const std::pair<mgp::Node, int6
       path_data_.visited_.insert(next_node.Id().AsInt());
       queue.emplace(std::move(next_node), pair.second + 1);
     } else if (wanted_direction == RelDirection::kBoth) {
-      if (outgoing && seen.contains({type, relationship.To().Id().AsInt()})) {
+      if (outgoing && seen.contains({std::string(type), relationship.To().Id().AsInt()})) {
         // Enqueue only; TryInsertNode emits it once on dequeue with hop/label filters applied.
         path_data_.visited_.insert(next_node.Id().AsInt());
         queue.emplace(std::move(next_node), pair.second + 1);
       } else {
-        seen.insert({type, relationship.From().Id().AsInt()});
+        seen.insert({std::string(type), relationship.From().Id().AsInt()});
       }
     }
   }
@@ -531,7 +530,7 @@ mgp::List Path::PathSubgraph::BFS() {
       continue;
     }
 
-    std::set<std::pair<std::string_view, int64_t>> seen;
+    std::set<std::pair<std::string, int64_t>> seen;
     this->ExpandFromRelationships(pair, pair.first.InRelationships(), false, queue, seen);
     this->ExpandFromRelationships(pair, pair.first.OutRelationships(), true, queue, seen);
   }

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -114,7 +114,7 @@ struct Config {
   int64_t max_hops = std::numeric_limits<int64_t>::max();
   bool any_incoming = false;
   bool any_outgoing = false;
-  bool filter_start_node = true;
+  bool filter_start_node = false;
   bool begin_sequence_at_start = true;
   bool bfs = false;
 };
@@ -171,7 +171,7 @@ class PathExpand {
 
   void ExpandPath(mgp::Path &path, const mgp::Relationship &relationship, int64_t path_size);
   void ExpandFromRelationships(mgp::Path &path, mgp::Relationships relationships, bool outgoing, int64_t path_size,
-                               std::set<std::pair<std::string_view, int64_t>> &seen);
+                               std::set<std::pair<std::string, int64_t>> &seen);
   void StartAlgorithm(mgp::Node node);
   void Parse(const mgp::Value &value);
   void DFS(mgp::Path &path, int64_t path_size);
@@ -187,7 +187,7 @@ class PathSubgraph {
 
   void ExpandFromRelationships(const std::pair<mgp::Node, int64_t> &pair, mgp::Relationships relationships,
                                bool outgoing, std::queue<std::pair<mgp::Node, int64_t>> &queue,
-                               std::set<std::pair<std::string_view, int64_t>> &seen);
+                               std::set<std::pair<std::string, int64_t>> &seen);
   void Parse(const mgp::Value &value);
   void TryInsertNode(const mgp::Node &node, int64_t hop_count, const LabelBools &label_bools);
   mgp::List BFS();

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,9 +13,11 @@
 
 #include <mgp.hpp>
 
+#include <functional>
 #include <limits>
 #include <queue>
 #include <set>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -97,9 +99,16 @@ struct LabelBoolsStatus {
 
 enum class RelDirection { kNone = -1, kAny = 0, kIncoming = 1, kOutgoing = 2, kBoth = 3 };
 
+// Enables heterogeneous string_view lookup so relationship types can be looked up without allocating.
+struct TransparentStringHash {
+  using is_transparent = void;
+
+  [[nodiscard]] size_t operator()(std::string_view sv) const noexcept { return std::hash<std::string_view>{}(sv); }
+};
+
 struct Config {
   LabelBoolsStatus label_bools_status;
-  std::unordered_map<std::string, RelDirection> relationship_sets;
+  std::unordered_map<std::string, RelDirection, TransparentStringHash, std::equal_to<>> relationship_sets;
   LabelSets label_sets;
   int64_t min_hops = 0;
   int64_t max_hops = std::numeric_limits<int64_t>::max();
@@ -115,7 +124,7 @@ class PathHelper {
   explicit PathHelper(const mgp::List &labels, const mgp::List &relationships, int64_t min_hops, int64_t max_hops);
   explicit PathHelper(const mgp::Map &config);
 
-  RelDirection GetDirection(const std::string &rel_type) const;
+  RelDirection GetDirection(std::string_view rel_type) const;
   LabelBools GetLabelBools(const mgp::Node &node) const;
 
   bool AnyDirected(bool outgoing) const { return outgoing ? config_.any_outgoing : config_.any_incoming; }
@@ -180,7 +189,7 @@ class PathSubgraph {
                                bool outgoing, std::queue<std::pair<mgp::Node, int64_t>> &queue,
                                std::set<std::pair<std::string_view, int64_t>> &seen);
   void Parse(const mgp::Value &value);
-  void TryInsertNode(const mgp::Node &node, int64_t hop_count, LabelBools &label_bools);
+  void TryInsertNode(const mgp::Node &node, int64_t hop_count, const LabelBools &label_bools);
   mgp::List BFS();
 
  private:

--- a/tests/mage/e2e/path_test/test_subgraph_all_10/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_all_10/input.cyp
@@ -1,0 +1,1 @@
+CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (D:Node {name: 'D'}) CREATE (E:Node {name: 'E'}) CREATE (A)-[:CONNECTED_TO]->(B) CREATE (A)-[:CONNECTED_TO]->(C) CREATE (C)-[:CONNECTED_TO]->(D) CREATE (B)-[:CONNECTED_TO]->(E) CREATE (E)-[:CONNECTED_TO]->(D);

--- a/tests/mage/e2e/path_test/test_subgraph_all_10/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_10/test.yml
@@ -1,0 +1,19 @@
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_all(a, {relationshipFilter: ['CONNECTED_TO>'], minHops: 2, maxHops: 5})
+  YIELD nodes, rels
+  RETURN nodes, rels
+
+output:
+  - nodes:
+      - labels:
+          - Node
+        properties:
+          name: E
+      - labels:
+          - Node
+        properties:
+          name: D
+    rels:
+      - label: CONNECTED_TO
+        properties: {}

--- a/tests/mage/e2e/path_test/test_subgraph_all_10/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_10/test.yml
@@ -2,18 +2,20 @@ query: >
   MATCH (a:Node {name: "A"})
   CALL path.subgraph_all(a, {relationshipFilter: ['CONNECTED_TO>'], minHops: 2, maxHops: 5})
   YIELD nodes, rels
-  RETURN nodes, rels
+  UNWIND nodes AS node
+  WITH rels, node ORDER BY node.name
+  RETURN collect(node) AS nodes, rels
 
 output:
   - nodes:
       - labels:
           - Node
         properties:
-          name: E
+          name: D
       - labels:
           - Node
         properties:
-          name: D
+          name: E
     rels:
       - label: CONNECTED_TO
         properties: {}

--- a/tests/mage/e2e/path_test/test_subgraph_all_11/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_all_11/input.cyp
@@ -1,0 +1,1 @@
+CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (A)-[:R]->(B) CREATE (B)-[:R]->(A) CREATE (B)-[:R]->(C) CREATE (C)-[:R]->(B);

--- a/tests/mage/e2e/path_test/test_subgraph_all_11/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_all_11/input.cyp
@@ -1,1 +1,1 @@
-CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (A)-[:R]->(B) CREATE (B)-[:R]->(A) CREATE (B)-[:R]->(C) CREATE (C)-[:R]->(B);
+CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (A)-[:R {seq: 1}]->(B) CREATE (B)-[:R {seq: 2}]->(A) CREATE (B)-[:R {seq: 3}]->(C) CREATE (C)-[:R {seq: 4}]->(B);

--- a/tests/mage/e2e/path_test/test_subgraph_all_11/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_11/test.yml
@@ -1,0 +1,29 @@
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_all(a, {relationshipFilter: ['<R>'], maxHops: 5})
+  YIELD nodes, rels
+  RETURN nodes, rels
+
+output:
+  - nodes:
+      - labels:
+          - Node
+        properties:
+          name: A
+      - labels:
+          - Node
+        properties:
+          name: B
+      - labels:
+          - Node
+        properties:
+          name: C
+    rels:
+      - label: R
+        properties: {}
+      - label: R
+        properties: {}
+      - label: R
+        properties: {}
+      - label: R
+        properties: {}

--- a/tests/mage/e2e/path_test/test_subgraph_all_11/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_11/test.yml
@@ -20,10 +20,14 @@ output:
           name: C
     rels:
       - label: R
-        properties: {}
+        properties:
+          seq: 1
       - label: R
-        properties: {}
+        properties:
+          seq: 2
       - label: R
-        properties: {}
+        properties:
+          seq: 3
       - label: R
-        properties: {}
+        properties:
+          seq: 4

--- a/tests/mage/e2e/path_test/test_subgraph_all_11/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_11/test.yml
@@ -2,7 +2,12 @@ query: >
   MATCH (a:Node {name: "A"})
   CALL path.subgraph_all(a, {relationshipFilter: ['<R>'], maxHops: 5})
   YIELD nodes, rels
-  RETURN nodes, rels
+  UNWIND nodes AS node
+  WITH rels, node ORDER BY node.name
+  WITH collect(node) AS nodes, rels
+  UNWIND rels AS rel
+  WITH nodes, rel ORDER BY rel.seq
+  RETURN nodes, collect(rel) AS rels
 
 output:
   - nodes:

--- a/tests/mage/e2e/path_test/test_subgraph_all_4/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_4/test.yml
@@ -7,11 +7,6 @@ query: >
 output:
   - nodes:
       - labels:
-          - Dog
-        properties: {}
-      - labels:
           - Mouse
         properties: {}
-    rels:
-      - label: FRIENDS_WITH
-        properties: {}
+    rels: []

--- a/tests/mage/e2e/path_test/test_subgraph_all_7/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_7/test.yml
@@ -5,5 +5,8 @@ query: >
   RETURN nodes, rels
 
 output:
-  - nodes: []
+  - nodes:
+      - labels:
+          - Human
+        properties: {}
     rels: []

--- a/tests/mage/e2e/path_test/test_subgraph_all_8/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_8/test.yml
@@ -7,9 +7,6 @@ query: >
 output:
   - nodes:
       - labels:
-          - Cat
-        properties: {}
-      - labels:
           - Human
         properties: {}
     rels: []

--- a/tests/mage/e2e/path_test/test_subgraph_all_9/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_all_9/test.yml
@@ -7,16 +7,11 @@ query: >
 output:
   - nodes:
       - labels:
-          - Cat
-        properties: {}
-      - labels:
           - Dog
         properties: {}
       - labels:
           - Human
         properties: {}
     rels:
-      - label: "CATCHES"
-        properties: {}
       - label: "OWNS"
         properties: {}

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_10/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_10/input.cyp
@@ -1,0 +1,1 @@
+CREATE (a:Node {name: 'A'}) CREATE (b:Node {name: 'B'}) CREATE (a)-[:R]->(a) CREATE (a)-[:R]->(b);

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_10/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_10/test.yml
@@ -1,0 +1,11 @@
+# Self-loop on the start node: the visited set must prevent re-enqueue, so the start is
+# returned once and traversal still reaches its other neighbour.
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_nodes(a, {relationshipFilter: ['R>'], maxHops: 5})
+  YIELD nodes
+  RETURN nodes.name AS name ORDER BY name ASC;
+
+output:
+  - name: A
+  - name: B

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_4/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_4/input.cyp
@@ -1,0 +1,1 @@
+CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (D:Node {name: 'D'}) CREATE (E:Node {name: 'E'}) CREATE (A)-[:CONNECTED_TO]->(B) CREATE (A)-[:CONNECTED_TO]->(C) CREATE (C)-[:CONNECTED_TO]->(D) CREATE (B)-[:CONNECTED_TO]->(E) CREATE (E)-[:CONNECTED_TO]->(D);

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_4/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_4/test.yml
@@ -1,0 +1,17 @@
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_nodes(a, {relationshipFilter: ['CONNECTED_TO>'], minHops: 1, maxHops: 1})
+  YIELD nodes
+  RETURN nodes ORDER BY id(nodes) ASC;
+
+output:
+      - nodes:
+          labels:
+            - Node
+          properties:
+            name: B
+      - nodes:
+          labels:
+            - Node
+          properties:
+            name: C

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_5/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_5/input.cyp
@@ -1,0 +1,1 @@
+CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (A)-[:R]->(B) CREATE (B)-[:R]->(A) CREATE (B)-[:R]->(C) CREATE (C)-[:R]->(B);

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_5/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_5/test.yml
@@ -1,0 +1,10 @@
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_nodes(a, {relationshipFilter: ['<R>'], maxHops: 5})
+  YIELD nodes
+  RETURN nodes.name AS name ORDER BY name ASC;
+
+output:
+  - name: A
+  - name: B
+  - name: C

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_6/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_6/input.cyp
@@ -1,0 +1,1 @@
+CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (A)-[:R]->(B) CREATE (B)-[:R]->(A) CREATE (B)-[:R]->(C) CREATE (C)-[:R]->(B);

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_6/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_6/test.yml
@@ -1,0 +1,8 @@
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_nodes(a, {relationshipFilter: ['<R>'], minHops: 2, maxHops: 5})
+  YIELD nodes
+  RETURN nodes.name AS name ORDER BY name ASC;
+
+output:
+  - name: C

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_7/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_7/input.cyp
@@ -1,0 +1,1 @@
+CREATE (A:Node {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (A)-[:R]->(B) CREATE (B)-[:R]->(C);

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_7/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_7/test.yml
@@ -1,0 +1,8 @@
+# Inverted window (minHops > maxHops) yields no nodes rather than throwing.
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_nodes(a, {relationshipFilter: ['R>'], minHops: 5, maxHops: 3})
+  YIELD nodes
+  RETURN nodes.name AS name ORDER BY name ASC;
+
+output: []

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_8/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_8/input.cyp
@@ -1,0 +1,1 @@
+CREATE (A:Node:Target {name: 'A'}) CREATE (B:Node {name: 'B'}) CREATE (C:Node {name: 'C'}) CREATE (D:Node:Target {name: 'D'}) CREATE (A)-[:R]->(B) CREATE (B)-[:R]->(A) CREATE (B)-[:R]->(C) CREATE (C)-[:R]->(B) CREATE (C)-[:R]->(D) CREATE (D)-[:R]->(C);

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_8/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_8/test.yml
@@ -1,0 +1,10 @@
+# Bidirectional filter + end-node filter + minHops together: dedup, hop window, and label gate
+# all active. Start A is a Target end node but excluded by minHops:1; only D survives all three.
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.subgraph_nodes(a, {relationshipFilter: ['<R>'], labelFilter: ['>Target'], minHops: 1, maxHops: 5})
+  YIELD nodes
+  RETURN nodes.name AS name ORDER BY name ASC;
+
+output:
+  - name: D

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_9/input.cyp
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_9/input.cyp
@@ -1,0 +1,1 @@
+CREATE (a:Node {name: 'A'}) CREATE (b:Node {name: 'B'}) CREATE (c:Node {name: 'C'}) CREATE (d:Node {name: 'D'}) CREATE (a)-[:R]->(b) CREATE (c)-[:R]->(d);

--- a/tests/mage/e2e/path_test/test_subgraph_nodes_9/test.yml
+++ b/tests/mage/e2e/path_test/test_subgraph_nodes_9/test.yml
@@ -1,0 +1,13 @@
+# Multiple start nodes: each seeds the BFS, so both disconnected components are returned in full.
+query: >
+  MATCH (n:Node) WHERE n.name IN ['A', 'C']
+  WITH collect(n) AS starts
+  CALL path.subgraph_nodes(starts, {relationshipFilter: ['R>'], maxHops: 5})
+  YIELD nodes
+  RETURN nodes.name AS name ORDER BY name ASC;
+
+output:
+  - name: A
+  - name: B
+  - name: C
+  - name: D


### PR DESCRIPTION
Fixes config-option handling in `path.subgraph_all` / `path.subgraph_nodes`.

**What**
- `filterStartNode` now defaults to `false`. When the start node is unfiltered it is treated as a plain whitelisted node instead of being returned unconditionally, so it no longer leaks into end/termination result sets while traversal through it still continues.
- `minHops` is now honored. The subgraph BFS previously enforced only the upper hop bound, so nodes closer than `minHops` were still returned. Nodes are returned when their distance falls within `[minHops, maxHops]`.
- The bidirectional (`<TYPE>`) relationship filter no longer returns duplicate nodes (and, in `subgraph_all`, duplicate relationships), and now respects the hop-range and label filters like every other traversal branch.
- The bidirectional dedup set previously keyed on a `string_view` whose backing wasn't guaranteed to outlive the traversal (a per-iteration local string, later a view into edge-type storage that still dangled for projected-graph edges); it now holds an owning key, with the per-edge direction lookup kept allocation-free.

**How**
In `path_module/algorithm/path.cpp`:
- Flip the `filterStartNode` default in the config reader, and in `PathSubgraph::TryInsertNode` gate insertion on `PathSizeOk(hop)` (full hop range) while treating an unfiltered start node as whitelisted-only. Closer-than-`minHops` nodes are still traversed, just not returned.
- In `ExpandFromRelationships`, the bidirectional-match branch now only enqueues the matched node instead of also appending it directly to the result set; the node is returned once via `TryInsertNode` on dequeue, which applies the hop-range and label filters and avoids the double insert.
- Also in `ExpandFromRelationships`, `seen` now keys on `std::string`; the transparent-hash `relationship_sets` lookup still takes a `string_view`, so the hot path allocates nothing.

E2E coverage updated/added under `tests/e2e/path_test`, including the previously-untested bidirectional path (node dedup, `minHops` window, and the `subgraph_all` node/relationship sets).

**Why**
The config options were mis-handled: `filterStartNode` had an inverted default and over-included the start node, `minHops` was silently ignored, and the bidirectional relationship filter duplicated results while bypassing the hop-range and label filters — all producing incorrect subgraph results.

**Note**
`minHops >= 2` returns nodes whose distance is within `[minHops, maxHops]` (a distance window), rather than rejecting the call.