### PR TITLE
testing: Improve interactive_mg_runner.py script

### DIFF
--- a/tests/e2e/interactive_mg_runner.py
+++ b/tests/e2e/interactive_mg_runner.py
@@ -26,6 +26,7 @@
 # approaches have to be employed.
 # NOTE: The instance description / context should be compatible with tests/e2e/runner.py
 
+import concurrent.futures
 import logging
 import os
 import secrets
@@ -70,7 +71,46 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
 }
 
 
+HISTORY_MAX_SIZE = 1000
+HISTORY_FILE = os.path.expanduser("~/.interactive_mg_runner_history")
+ACTION_HISTORY = []
+history_loaded = False
+
+
+def load_history():
+    global history_loaded
+    if history_loaded:
+        return
+    history_loaded = True
+    try:
+        with open(HISTORY_FILE, "r") as f:
+            entries = [line.rstrip("\n") for line in f if line.strip()]
+    except OSError:
+        return
+    ACTION_HISTORY.extend(entries[-HISTORY_MAX_SIZE:])
+
+
+def save_history():
+    try:
+        with open(HISTORY_FILE, "w") as f:
+            f.writelines(entry + "\n" for entry in ACTION_HISTORY)
+    except OSError as e:
+        log.warning(f"Could not save action history to {HISTORY_FILE}: {e}")
+
+
+def add_to_history(line):
+    if not line.strip():
+        return
+    if ACTION_HISTORY and ACTION_HISTORY[-1] == line:
+        return
+    ACTION_HISTORY.append(line)
+    if len(ACTION_HISTORY) > HISTORY_MAX_SIZE:
+        del ACTION_HISTORY[: len(ACTION_HISTORY) - HISTORY_MAX_SIZE]
+    save_history()
+
+
 def read_action_line(prompt="ACTION> "):
+    load_history()
     sys.stdout.write(prompt)
     sys.stdout.flush()
 
@@ -84,6 +124,14 @@ def read_action_line(prompt="ACTION> "):
 
     try:
         buf = []
+        # Index into ACTION_HISTORY while scrolling; len(ACTION_HISTORY) means "current (not yet submitted) line".
+        history_index = len(ACTION_HISTORY)
+        pending_line = ""
+
+        def redraw():
+            sys.stdout.write("\r\x1b[K" + prompt + "".join(buf))
+            sys.stdout.flush()
+
         while True:
             ch = os.read(fd, 1)
             if not ch:
@@ -94,7 +142,9 @@ def read_action_line(prompt="ACTION> "):
             if c in ("\n", "\r"):
                 sys.stdout.write("\n")
                 sys.stdout.flush()
-                return "".join(buf)
+                line = "".join(buf)
+                add_to_history(line)
+                return line
 
             # Backspace (DEL)
             if c == "\x7f":
@@ -104,19 +154,36 @@ def read_action_line(prompt="ACTION> "):
                     sys.stdout.flush()
                 continue
 
-            # ESC sequences (arrows, Home/End, etc.) — swallow them completely
+            # ESC sequences (arrows, Home/End, etc.)
             if c == "\x1b":
                 # Typical CSI: ESC [ ... final
                 nxt = os.read(fd, 1).decode("utf-8", "ignore")
                 if nxt == "[":
                     # Read until final byte of CSI sequence (@ A–Z a–z ~)
+                    seq = ""
                     while True:
                         d = os.read(fd, 1).decode("utf-8", "ignore")
                         if not d:
                             break
+                        seq += d
                         if d.isalpha() or d in "@~":
                             break
-                # Ignore whole sequence (don’t echo)
+                    # Up: recall older history entry
+                    if seq == "A" and history_index > 0:
+                        if history_index == len(ACTION_HISTORY):
+                            pending_line = "".join(buf)
+                        history_index -= 1
+                        buf = list(ACTION_HISTORY[history_index])
+                        redraw()
+                    # Down: recall newer history entry or restore the pending line
+                    elif seq == "B" and history_index < len(ACTION_HISTORY):
+                        history_index += 1
+                        if history_index < len(ACTION_HISTORY):
+                            buf = list(ACTION_HISTORY[history_index])
+                        else:
+                            buf = list(pending_line)
+                        redraw()
+                # Ignore all other sequences (don’t echo)
                 continue
 
             # Regular printable characters
@@ -227,9 +294,16 @@ def _start(
     storage_snapshot_on_exit: bool = False,
     gdb_port=None,
 ):
-    assert (
-        name not in MEMGRAPH_INSTANCES.keys()
-    ), "If this raises, you are trying to start an instance with the same name as the one running."
+    """
+    Returns True if the instance was started, False if it was already running and the start was skipped.
+    """
+    existing_instance = MEMGRAPH_INSTANCES.get(name)
+    if existing_instance is not None:
+        if existing_instance.is_running():
+            log.info(f"Instance with name {name} is already running, skipping start.")
+            return False
+        log.info(f"Instance with name {name} is registered but not running, starting it again.")
+        MEMGRAPH_INSTANCES.pop(name)
 
     bolt_port = extract_bolt_port(args)
     assert wait_until_port_is_free(
@@ -263,6 +337,7 @@ def _start(
         storage_snapshot_on_exit=storage_snapshot_on_exit,
     )
     assert mg_instance.is_running(), "An error occurred after starting Memgraph instance: application stopped running."
+    return True
 
 
 def stop_all(keep_directories=True):
@@ -274,18 +349,27 @@ def stop_all(keep_directories=True):
     MEMGRAPH_INSTANCES.clear()
 
 
+def parse_instance_names(names):
+    """
+    Parses a comma-separated list of instance names, e.g. 'coordinator_1,coordinator_2', into a list of names.
+    """
+    return [name.strip() for name in str(names).split(",") if name.strip()]
+
+
 def stop(context, name, keep_directories=True):
     """
+    Stops one or more comma-separated instances, e.g. 'coordinator_1,coordinator_2'.
     Idempotent in a sense that stopping already stopped instance won't fail program.
     """
-    if name not in context:
-        log.error(f"{name} is not an active instance name")
-        return
-    for key, _ in context.items():
-        if key != name:
+    for instance_name in parse_instance_names(name):
+        if instance_name not in context:
+            log.error(f"{instance_name} is not an active instance name")
             continue
-        MEMGRAPH_INSTANCES[name].stop(keep_directories)
-        MEMGRAPH_INSTANCES.pop(name)
+        instance = MEMGRAPH_INSTANCES.pop(instance_name, None)
+        if instance is None:
+            log.info(f"Instance with name {instance_name} is not running, skipping stop.")
+            continue
+        instance.stop(keep_directories)
 
 
 def kill_all(keep_directories=True):
@@ -309,82 +393,105 @@ def kill(context, name, keep_directories=True):
 
 
 def start_wrapper(instances, instance_name, procdir="", gdb_port=None):
+    """
+    Starts 'all' instances, a single instance or multiple comma-separated instances,
+    e.g. 'coordinator_1,coordinator_2'. Multiple instances are started in parallel.
+    """
     if instance_name == "all":
         start_all(instances, procdir, gdb_port=gdb_port)
-    else:
-        start(instances, instance_name, procdir, gdb_port=gdb_port)
-
-
-def start(instances, instance_name, procdir="", gdb_port=None):
-    mg_instances = {}
-
-    if instance_name not in instances:
-        log.error(f"{instance_name} is not an active instance name")
         return
 
-    for key, value in instances.items():
-        if key != instance_name:
-            continue
-        args = value["args"]
-        log_file = value["log_file"]
+    instance_names = parse_instance_names(instance_name)
+    known_names = [name for name in instance_names if name in instances]
+    for unknown_name in set(instance_names) - set(known_names):
+        log.error(f"{unknown_name} is not an active instance name")
 
-        setup_queries = value["setup_queries"] if "setup_queries" in value else []
+    if len(known_names) == 1:
+        start(instances, known_names[0], procdir, gdb_port=gdb_port)
+    elif known_names:
+        start_all_keep_others({name: instances[name] for name in known_names}, procdir, gdb_port=gdb_port)
 
-        use_ssl = False
-        if "ssl" in value:
-            use_ssl = bool(value["ssl"])
-            value.pop("ssl")
 
-        # If nothing specified, use 8-character random string.
-        data_directory = value["data_directory"] if "data_directory" in value else secrets.token_hex(4)
+def start(instances, instance_name, procdir="", gdb_port=None, run_setup_queries=True):
+    """
+    Returns True if the instance was started, False if it was skipped or unknown. When `run_setup_queries` is False,
+    setup queries are not executed and the caller is responsible for running them once all instances are up.
+    """
+    if instance_name not in instances:
+        log.error(f"{instance_name} is not an active instance name")
+        return False
 
-        username = value["username"] if "username" in value else None
-        password = value["password"] if "password" in value else None
+    value = instances[instance_name]
+    args = value["args"]
+    log_file = value["log_file"]
 
-        storage_snapshot_on_exit = value["storage_snapshot_on_exit"] if "storage_snapshot_on_exit" in value else False
+    setup_queries = value["setup_queries"] if "setup_queries" in value else []
+    if not run_setup_queries:
+        setup_queries = []
 
-        instance = _start(
-            instance_name,
-            args,
-            log_file,
-            setup_queries,
-            use_ssl,
-            procdir,
-            data_directory,
-            username,
-            password,
-            storage_snapshot_on_exit=storage_snapshot_on_exit,
-            gdb_port=gdb_port,
-        )
+    use_ssl = False
+    if "ssl" in value:
+        use_ssl = bool(value["ssl"])
+        value.pop("ssl")
+
+    # If nothing specified, use 8-character random string.
+    data_directory = value["data_directory"] if "data_directory" in value else secrets.token_hex(4)
+
+    username = value["username"] if "username" in value else None
+    password = value["password"] if "password" in value else None
+
+    storage_snapshot_on_exit = value["storage_snapshot_on_exit"] if "storage_snapshot_on_exit" in value else False
+
+    started = _start(
+        instance_name,
+        args,
+        log_file,
+        setup_queries,
+        use_ssl,
+        procdir,
+        data_directory,
+        username,
+        password,
+        storage_snapshot_on_exit=storage_snapshot_on_exit,
+        gdb_port=gdb_port,
+    )
+    if started:
         log.info(f"Instance with name {instance_name} started")
-        mg_instances[instance_name] = instance
-
-    assert len(mg_instances) == 1
+    return started
 
 
 def start_all(context, procdir="", keep_directories=True, gdb_port=None):
     """
-    Start all instances by first stopping all instances and then calling start_instance for each instance from the `context`.
+    Start all instances by first stopping all instances and then starting all instances from the `context` in parallel.
     If gdb_port is set, only the first instance will be started under gdbserver.
     """
     stop_all(keep_directories)
-    first_instance = True
-    for key, _ in context.items():
-        # Only attach gdb to the first instance to avoid port conflicts
-        port = gdb_port if first_instance else None
-        start(context, key, procdir, gdb_port=port)
-        first_instance = False
+    start_all_keep_others(context, procdir, gdb_port=gdb_port)
 
 
 def start_all_keep_others(context, procdir="", gdb_port=None):
     """
-    Start all instances from the context but don't stop currently running instances.
+    Start all instances from the context in parallel but don't stop currently running instances.
+    Instances must be started in parallel because e.g. coordinators cannot finish their startup until a quorum of them
+    is reachable. Setup queries are executed sequentially in context order only after all instances are up.
     """
-    first_instance = True
-    for key, _ in context.items():
-        port = gdb_port if first_instance else None
-        start(context, key, procdir, gdb_port=port)
-        first_instance = False
+    if not context:
+        return
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(context)) as executor:
+        futures = {}
+        for idx, key in enumerate(context.keys()):
+            # Only attach gdb to the first instance to avoid port conflicts
+            port = gdb_port if idx == 0 else None
+            futures[executor.submit(start, context, key, procdir, gdb_port=port, run_setup_queries=False)] = key
+        started = {key: future.result() for future, key in futures.items()}
+
+    for key, value in context.items():
+        if not started.get(key):
+            continue
+        setup_queries = value.get("setup_queries", [])
+        if setup_queries:
+            MEMGRAPH_INSTANCES[key].execute_setup_queries(setup_queries)
+            log.info(f"Executed setup queries for instance with name {key}.")
 
 
 def info(context):
@@ -403,7 +510,7 @@ def process_actions(instances, data):
     """
     Processes all `actions` using the `context` as context.
     """
-    data = data.split(" ")
+    data = data.split()
     data.reverse()
     while len(data) > 0:
         arg = data.pop()
@@ -423,7 +530,11 @@ def process_actions(instances, data):
             if len(data) == 0:
                 log.error(f"Not enough args provided. Expected 1 but found 0 for action {arg}")
             else:
-                action(instances, data.pop())
+                action_arg = data.pop()
+                # Merge comma-separated lists split by spaces, e.g. 'stop a, b' or 'stop a , b'.
+                while len(data) > 0 and (action_arg.endswith(",") or data[-1].startswith(",")):
+                    action_arg += data.pop()
+                action(instances, action_arg)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/interactive_mg_runner.py
+++ b/tests/e2e/interactive_mg_runner.py
@@ -398,7 +398,7 @@ def start_wrapper(instances, instance_name, procdir="", gdb_port=None):
     e.g. 'coordinator_1,coordinator_2'. Multiple instances are started in parallel.
     """
     if instance_name == "all":
-        start_all(instances, procdir, gdb_port=gdb_port)
+        start_all(instances, procdir, gdb_port=gdb_port, ignore_setup_failures=True)
         return
 
     instance_names = parse_instance_names(instance_name)
@@ -406,10 +406,10 @@ def start_wrapper(instances, instance_name, procdir="", gdb_port=None):
     for unknown_name in set(instance_names) - set(known_names):
         log.error(f"{unknown_name} is not an active instance name")
 
-    if len(known_names) == 1:
-        start(instances, known_names[0], procdir, gdb_port=gdb_port)
-    elif known_names:
-        start_all_keep_others({name: instances[name] for name in known_names}, procdir, gdb_port=gdb_port)
+    if known_names:
+        start_all_keep_others(
+            {name: instances[name] for name in known_names}, procdir, gdb_port=gdb_port, ignore_setup_failures=True
+        )
 
 
 def start(instances, instance_name, procdir="", gdb_port=None, run_setup_queries=True):
@@ -460,20 +460,22 @@ def start(instances, instance_name, procdir="", gdb_port=None, run_setup_queries
     return started
 
 
-def start_all(context, procdir="", keep_directories=True, gdb_port=None):
+def start_all(context, procdir="", keep_directories=True, gdb_port=None, ignore_setup_failures=False):
     """
     Start all instances by first stopping all instances and then starting all instances from the `context` in parallel.
     If gdb_port is set, only the first instance will be started under gdbserver.
     """
     stop_all(keep_directories)
-    start_all_keep_others(context, procdir, gdb_port=gdb_port)
+    start_all_keep_others(context, procdir, gdb_port=gdb_port, ignore_setup_failures=ignore_setup_failures)
 
 
-def start_all_keep_others(context, procdir="", gdb_port=None):
+def start_all_keep_others(context, procdir="", gdb_port=None, ignore_setup_failures=False):
     """
     Start all instances from the context in parallel but don't stop currently running instances.
     Instances must be started in parallel because e.g. coordinators cannot finish their startup until a quorum of them
     is reachable. Setup queries are executed sequentially in context order only after all instances are up.
+    When `ignore_setup_failures` is set, individual setup query failures are logged and skipped, e.g. when restarting
+    instances on which the queries were already applied.
     """
     if not context:
         return
@@ -490,7 +492,7 @@ def start_all_keep_others(context, procdir="", gdb_port=None):
             continue
         setup_queries = value.get("setup_queries", [])
         if setup_queries:
-            MEMGRAPH_INSTANCES[key].execute_setup_queries(setup_queries)
+            MEMGRAPH_INSTANCES[key].execute_setup_queries(setup_queries, ignore_failures=ignore_setup_failures)
             log.info(f"Executed setup queries for instance with name {key}.")
 
 

--- a/tests/e2e/interactive_mg_runner.py
+++ b/tests/e2e/interactive_mg_runner.py
@@ -29,9 +29,9 @@
 import concurrent.futures
 import logging
 import os
+import readline
 import secrets
 import sys
-import termios
 import time
 from argparse import ArgumentParser
 from inspect import signature
@@ -73,7 +73,6 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
 
 HISTORY_MAX_SIZE = 1000
 HISTORY_FILE = os.path.expanduser("~/.interactive_mg_runner_history")
-ACTION_HISTORY = []
 history_loaded = False
 
 
@@ -82,118 +81,33 @@ def load_history():
     if history_loaded:
         return
     history_loaded = True
+    readline.set_history_length(HISTORY_MAX_SIZE)
     try:
-        with open(HISTORY_FILE, "r") as f:
-            entries = [line.rstrip("\n") for line in f if line.strip()]
+        readline.read_history_file(HISTORY_FILE)
     except OSError:
-        return
-    ACTION_HISTORY.extend(entries[-HISTORY_MAX_SIZE:])
+        pass
 
 
 def save_history():
     try:
-        with open(HISTORY_FILE, "w") as f:
-            f.writelines(entry + "\n" for entry in ACTION_HISTORY)
+        readline.write_history_file(HISTORY_FILE)
     except OSError as e:
         log.warning(f"Could not save action history to {HISTORY_FILE}: {e}")
 
 
-def add_to_history(line):
-    if not line.strip():
-        return
-    if ACTION_HISTORY and ACTION_HISTORY[-1] == line:
-        return
-    ACTION_HISTORY.append(line)
-    if len(ACTION_HISTORY) > HISTORY_MAX_SIZE:
-        del ACTION_HISTORY[: len(ACTION_HISTORY) - HISTORY_MAX_SIZE]
-    save_history()
-
-
 def read_action_line(prompt="ACTION> "):
     load_history()
-    sys.stdout.write(prompt)
-    sys.stdout.flush()
-
-    fd = sys.stdin.fileno()
-    old_attrs = termios.tcgetattr(fd)
-    new_attrs = termios.tcgetattr(fd)
-
-    # Turn off ECHO and ICANON (so keys don't print themselves and we read byte-by-byte)
-    new_attrs[3] &= ~(termios.ECHO | termios.ICANON)
-    termios.tcsetattr(fd, termios.TCSADRAIN, new_attrs)
-
     try:
-        buf = []
-        # Index into ACTION_HISTORY while scrolling; len(ACTION_HISTORY) means "current (not yet submitted) line".
-        history_index = len(ACTION_HISTORY)
-        pending_line = ""
-
-        def redraw():
-            sys.stdout.write("\r\x1b[K" + prompt + "".join(buf))
-            sys.stdout.flush()
-
-        while True:
-            ch = os.read(fd, 1)
-            if not ch:
-                continue
-            c = ch.decode("utf-8", "ignore")
-
-            # Enter
-            if c in ("\n", "\r"):
-                sys.stdout.write("\n")
-                sys.stdout.flush()
-                line = "".join(buf)
-                add_to_history(line)
-                return line
-
-            # Backspace (DEL)
-            if c == "\x7f":
-                if buf:
-                    buf.pop()
-                    sys.stdout.write("\b \b")
-                    sys.stdout.flush()
-                continue
-
-            # ESC sequences (arrows, Home/End, etc.)
-            if c == "\x1b":
-                # Typical CSI: ESC [ ... final
-                nxt = os.read(fd, 1).decode("utf-8", "ignore")
-                if nxt == "[":
-                    # Read until final byte of CSI sequence (@ A–Z a–z ~)
-                    seq = ""
-                    while True:
-                        d = os.read(fd, 1).decode("utf-8", "ignore")
-                        if not d:
-                            break
-                        seq += d
-                        if d.isalpha() or d in "@~":
-                            break
-                    # Up: recall older history entry
-                    if seq == "A" and history_index > 0:
-                        if history_index == len(ACTION_HISTORY):
-                            pending_line = "".join(buf)
-                        history_index -= 1
-                        buf = list(ACTION_HISTORY[history_index])
-                        redraw()
-                    # Down: recall newer history entry or restore the pending line
-                    elif seq == "B" and history_index < len(ACTION_HISTORY):
-                        history_index += 1
-                        if history_index < len(ACTION_HISTORY):
-                            buf = list(ACTION_HISTORY[history_index])
-                        else:
-                            buf = list(pending_line)
-                        redraw()
-                # Ignore all other sequences (don’t echo)
-                continue
-
-            # Regular printable characters
-            if c.isprintable():
-                buf.append(c)
-                sys.stdout.write(c)
-                sys.stdout.flush()
-            # ignore everything else silently
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+        line = input(prompt)
+    except EOFError:
+        sys.stdout.write("\n")
+        sys.exit(0)
+    # Drop consecutive duplicates, which readline adds unconditionally.
+    length = readline.get_current_history_length()
+    if length >= 2 and readline.get_history_item(length) == readline.get_history_item(length - 1):
+        readline.remove_history_item(length - 1)
+    save_history()
+    return line
 
 
 def clear_screen():

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -170,20 +170,23 @@ class MemgraphInstanceRunner:
 
         return data
 
-    def execute_setup_queries(self, setup_queries=List):
+    def execute_setup_queries(self, setup_queries=List, ignore_failures=False):
         """
         Executes setup queries. The element inside `setup_queries` can be a string or a list. Connection is closed at the end and cannot be
-        reused. Failures of individual setup queries are ignored since on a restart the queries were already applied.
+        reused. When `ignore_failures` is set, failures of individual setup queries are logged and skipped, e.g. when
+        restarting an instance on which the queries were already applied.
         """
         conn = self.get_connection(self.username or "", self.password or "")
         conn.autocommit = True
         cursor = conn.cursor()
 
-        def execute_ignore_failure(cursor, query):
+        def execute_one(cursor, query):
             try:
                 cursor.execute(query)
                 return cursor
             except Exception as e:
+                if not ignore_failures:
+                    raise
                 log.warning(f"Ignoring failed setup query '{query}': {e}")
                 # The connection may be left in a bad state after a failed query, use a fresh one.
                 nonlocal conn
@@ -197,10 +200,10 @@ class MemgraphInstanceRunner:
 
         for query_coll in setup_queries:
             if isinstance(query_coll, str):
-                cursor = execute_ignore_failure(cursor, query_coll)
+                cursor = execute_one(cursor, query_coll)
             elif isinstance(query_coll, list):
                 for query in query_coll:
-                    cursor = execute_ignore_failure(cursor, query)
+                    cursor = execute_one(cursor, query)
 
         cursor.close()
         conn.close()

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -173,18 +173,34 @@ class MemgraphInstanceRunner:
     def execute_setup_queries(self, setup_queries=List):
         """
         Executes setup queries. The element inside `setup_queries` can be a string or a list. Connection is closed at the end and cannot be
-        reused.
+        reused. Failures of individual setup queries are ignored since on a restart the queries were already applied.
         """
         conn = self.get_connection(self.username or "", self.password or "")
         conn.autocommit = True
         cursor = conn.cursor()
 
+        def execute_ignore_failure(cursor, query):
+            try:
+                cursor.execute(query)
+                return cursor
+            except Exception as e:
+                log.warning(f"Ignoring failed setup query '{query}': {e}")
+                # The connection may be left in a bad state after a failed query, use a fresh one.
+                nonlocal conn
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                conn = self.get_connection(self.username or "", self.password or "")
+                conn.autocommit = True
+                return conn.cursor()
+
         for query_coll in setup_queries:
             if isinstance(query_coll, str):
-                cursor.execute(query_coll)
+                cursor = execute_ignore_failure(cursor, query_coll)
             elif isinstance(query_coll, list):
                 for query in query_coll:
-                    cursor.execute(query)
+                    cursor = execute_ignore_failure(cursor, query)
 
         cursor.close()
         conn.close()

--- a/tests/e2e/system_replication/auth.py
+++ b/tests/e2e/system_replication/auth.py
@@ -679,10 +679,7 @@ def test_auth_replication(connection, test_name):
 
     # 1/
     def check(f, expected_data):
-        # mg_sleep_and_assert(
-        # REPLICA 1 is SYNC, should already be ready
-        assert expected_data == f(cursor_replica1)()
-        # )
+        mg_sleep_and_assert(expected_data, f(cursor_replica1))
         mg_sleep_and_assert(expected_data, f(cursor_replica2))
 
     # CREATE USER

--- a/tests/e2e/system_replication/auth.py
+++ b/tests/e2e/system_replication/auth.py
@@ -1110,9 +1110,7 @@ def test_user_profile_replication(connection, test_name):
     cursor_replica2 = connection(BOLT_PORTS["replica_2"], "replica").cursor()
 
     def check(f, expected_data):
-        # REPLICA 1 is SYNC, should already be ready
-        assert expected_data == f(cursor_replica1)()
-        # REPLICA 2 is ASYNC, should wait for it
+        mg_sleep_and_assert(expected_data, f(cursor_replica1))
         mg_sleep_and_assert(expected_data, f(cursor_replica2))
 
     def resource_check(instance_name, instance_type, username, expected_usage):

--- a/tests/e2e/system_replication/multitenancy.py
+++ b/tests/e2e/system_replication/multitenancy.py
@@ -1525,7 +1525,7 @@ def test_multitenancy_snapshot_recovery(connection, test_name):
     # 6/ Validate that the transaction is still active and working and that the replica2 is not pointing to anything
 
     # 0/
-    MEMGRAPH_INSTANCES_DESCRIPTION = create_memgraph_instances_with_role_recovery(test_name)
+    MEMGRAPH_INSTANCES_DESCRIPTION = create_memgraph_instances_with_role_recovery(test_name, data_recovery=True)
     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
     do_manual_setting_up(connection)


### PR DESCRIPTION
Improvements:
- Starting an already started instance won't fail.
- You can now start/stop multiple instances
- There is a persisted history through which you can iterate using keys up and down
- If setup queries fail, the exception is caught and a warning caught
- Instances are now started in parallel so that more than coordinator can be restarted at once

