### PR TITLE
perf(query): plan cache read-lock on the hit path (LruCache::peek)

### DIFF
--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -248,15 +248,9 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
   // Skip plan cache when using experimental v2 planner - plans may change as v2 evolves
   const bool use_plan_cache = plan_cache && !flags::AreExperimentsEnabled(flags::Experiments::PLANNER_V2);
   if (use_plan_cache) {
-    // Cache-hit lookup uses a shared (read) lock + LRUCache::peek() instead of an
-    // exclusive lock + get(). get() mutates item_list to splice the hit to the front
-    // for recency tracking, which would race under concurrent readers; peek() only
-    // does a map lookup and returns a copy of the shared_ptr, so many Prepare()s can
-    // hit the cache in parallel instead of serializing on every lookup. Tradeoff:
-    // reads no longer bump LRU recency, so eviction becomes approximate-LRU rather
-    // than exact-LRU (see LRUCache::peek() doc comment in utils/lru_cache.hpp).
-    // Correctness is unaffected: put()/invalidate() below still take the exclusive
-    // WithLock, and the value handed back is an independent shared_ptr copy.
+    // Hit path: shared lock + peek() (non-mutating) instead of exclusive lock + get()
+    // (which bumps LRU recency), so concurrent Prepare()s don't serialize. Eviction
+    // becomes approximate-LRU; put()/invalidate() still take the write lock.
     auto existing_plan =
         plan_cache->WithReadLock([&](PlanCache_t const &cache) { return cache.peek(stripped_query.stripped_query()); });
     if (existing_plan) {

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -248,8 +248,17 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
   // Skip plan cache when using experimental v2 planner - plans may change as v2 evolves
   const bool use_plan_cache = plan_cache && !flags::AreExperimentsEnabled(flags::Experiments::PLANNER_V2);
   if (use_plan_cache) {
+    // Cache-hit lookup uses a shared (read) lock + LRUCache::peek() instead of an
+    // exclusive lock + get(). get() mutates item_list to splice the hit to the front
+    // for recency tracking, which would race under concurrent readers; peek() only
+    // does a map lookup and returns a copy of the shared_ptr, so many Prepare()s can
+    // hit the cache in parallel instead of serializing on every lookup. Tradeoff:
+    // reads no longer bump LRU recency, so eviction becomes approximate-LRU rather
+    // than exact-LRU (see LRUCache::peek() doc comment in utils/lru_cache.hpp).
+    // Correctness is unaffected: put()/invalidate() below still take the exclusive
+    // WithLock, and the value handed back is an independent shared_ptr copy.
     auto existing_plan =
-        plan_cache->WithLock([&](PlanCache_t &cache) { return cache.get(stripped_query.stripped_query()); });
+        plan_cache->WithReadLock([&](PlanCache_t const &cache) { return cache.peek(stripped_query.stripped_query()); });
     if (existing_plan) {
       // validate the index usage
       auto &ptr = existing_plan.value();

--- a/src/utils/lru_cache.hpp
+++ b/src/utils/lru_cache.hpp
@@ -30,13 +30,9 @@ namespace memgraph::utils {
 /// An entry is immutable once inserted: a put for a key already present keeps
 /// the stored value and only refreshes its recency.
 ///
-/// Thread-safety: put()/get()/invalidate()/reset() mutate item_list (recency
-/// order) and/or index and are NOT thread-safe against each other or against
-/// themselves concurrently. peek() is the sole exception: it performs only an
-/// index lookup and a value copy, mutating neither item_list nor index, so it
-/// is safe to call concurrently with other peek() calls (e.g. many readers
-/// holding only a shared/read lock) as long as no put()/get()/invalidate()/
-/// reset() runs at the same time (those still require exclusive access).
+/// Thread-safety: put()/get()/invalidate()/reset() mutate state and need
+/// exclusive access. peek() mutates nothing, so concurrent peek()s are safe
+/// (e.g. readers under a shared lock) provided no mutator runs concurrently.
 template <class TKey, class TVal, class TAlloc = std::allocator<std::pair<const TKey, TVal>>>
 class LRUCache {
   using Entry = std::pair<const TKey, const TVal>;
@@ -65,19 +61,11 @@ class LRUCache {
     return (*it)->second;
   }
 
-  /// Non-mutating lookup: returns the cached value (a copy) without moving
-  /// the entry to the front of item_list, i.e. WITHOUT bumping LRU recency.
-  /// Use this from concurrent readers that only need the value (e.g. a
-  /// plan-cache hit path) and cannot tolerate taking an exclusive lock just
-  /// to call get(). Tradeoff: entries looked up only via peek() age towards
-  /// eviction as if they were never accessed, so hot entries that are always
-  /// read via peek() (never put()/invalidated()) can be evicted "early" by
-  /// try_clean() even though they are still in active use. For a bounded
-  /// plan cache this is acceptable — eviction becomes approximate-LRU rather
-  /// than exact-LRU, but correctness is unaffected: a cache miss just costs a
-  /// re-plan, and the returned value is an independent copy (a shared_ptr
-  /// copy for the plan cache), so it stays valid regardless of what later
-  /// happens to the cache entry.
+  /// Non-mutating lookup: returns a copy of the value without bumping LRU
+  /// recency, so it is safe for concurrent readers (unlike get()). Tradeoff:
+  /// entries only ever read via peek() age as if unaccessed, so eviction is
+  /// approximate-LRU. Correctness is unaffected: a miss just costs a re-plan,
+  /// and the returned copy stays valid regardless of later cache changes.
   std::optional<TVal> peek(const TKey &key) const {
     auto const it = index.find(key);
     if (it == index.end()) {

--- a/src/utils/lru_cache.hpp
+++ b/src/utils/lru_cache.hpp
@@ -20,7 +20,6 @@
 namespace memgraph::utils {
 
 /// A simple LRU cache implementation.
-/// It is not thread-safe.
 ///
 /// The list owns each entry (key and value, both const) and carries the LRU
 /// order. The index is a set of list iterators, hashed and compared by the key
@@ -30,6 +29,14 @@ namespace memgraph::utils {
 ///
 /// An entry is immutable once inserted: a put for a key already present keeps
 /// the stored value and only refreshes its recency.
+///
+/// Thread-safety: put()/get()/invalidate()/reset() mutate item_list (recency
+/// order) and/or index and are NOT thread-safe against each other or against
+/// themselves concurrently. peek() is the sole exception: it performs only an
+/// index lookup and a value copy, mutating neither item_list nor index, so it
+/// is safe to call concurrently with other peek() calls (e.g. many readers
+/// holding only a shared/read lock) as long as no put()/get()/invalidate()/
+/// reset() runs at the same time (those still require exclusive access).
 template <class TKey, class TVal, class TAlloc = std::allocator<std::pair<const TKey, TVal>>>
 class LRUCache {
   using Entry = std::pair<const TKey, const TVal>;
@@ -55,6 +62,27 @@ class LRUCache {
       return std::nullopt;
     }
     item_list.splice(item_list.begin(), item_list, *it);
+    return (*it)->second;
+  }
+
+  /// Non-mutating lookup: returns the cached value (a copy) without moving
+  /// the entry to the front of item_list, i.e. WITHOUT bumping LRU recency.
+  /// Use this from concurrent readers that only need the value (e.g. a
+  /// plan-cache hit path) and cannot tolerate taking an exclusive lock just
+  /// to call get(). Tradeoff: entries looked up only via peek() age towards
+  /// eviction as if they were never accessed, so hot entries that are always
+  /// read via peek() (never put()/invalidated()) can be evicted "early" by
+  /// try_clean() even though they are still in active use. For a bounded
+  /// plan cache this is acceptable — eviction becomes approximate-LRU rather
+  /// than exact-LRU, but correctness is unaffected: a cache miss just costs a
+  /// re-plan, and the returned value is an independent copy (a shared_ptr
+  /// copy for the plan cache), so it stays valid regardless of what later
+  /// happens to the cache entry.
+  std::optional<TVal> peek(const TKey &key) const {
+    auto const it = index.find(key);
+    if (it == index.end()) {
+      return std::nullopt;
+    }
     return (*it)->second;
   }
 

--- a/tests/unit/lru_cache.cpp
+++ b/tests/unit/lru_cache.cpp
@@ -207,3 +207,61 @@ TEST(LRUCacheTest, InvalidateTest) {
   cache.invalidate(42);
   EXPECT_EQ(cache.size(), 2);
 }
+
+TEST(LRUCacheTest, PeekReturnsPresentAndAbsent) {
+  memgraph::utils::LRUCache<int, int> cache(2);
+  cache.put(1, 100);
+  cache.put(2, 200);
+
+  auto const &const_cache = cache;
+
+  std::optional<int> value = const_cache.peek(1);
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), 100);
+
+  value = const_cache.peek(2);
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), 200);
+
+  // Absent key
+  value = const_cache.peek(42);
+  EXPECT_FALSE(value.has_value());
+}
+
+TEST(LRUCacheTest, PeekDoesNotBumpRecencyUnlikeGet) {
+  // With cache_size == 2, filling with 1, 2 then inserting 3 evicts whichever
+  // of {1, 2} is least-recently-used. peek() must NOT count as a use: even
+  // after peeking at key 1 many times, it should be evicted just like a
+  // plain unaccessed entry, whereas get() would have kept it alive.
+  memgraph::utils::LRUCache<int, int> peek_cache(2);
+  peek_cache.put(1, 100);
+  peek_cache.put(2, 200);
+
+  auto const &const_peek_cache = peek_cache;
+  // Repeatedly peek at key 1 - must not affect recency.
+  for (int i = 0; i < 5; ++i) {
+    auto const value = const_peek_cache.peek(1);
+    EXPECT_TRUE(value.has_value());
+  }
+
+  // 2 was put after 1, so without any recency bump, 1 is the least-recently-used
+  // and must be the one evicted when 3 is inserted.
+  peek_cache.put(3, 300);
+  EXPECT_FALSE(const_peek_cache.peek(1).has_value());
+  EXPECT_TRUE(const_peek_cache.peek(2).has_value());
+  EXPECT_TRUE(const_peek_cache.peek(3).has_value());
+
+  // Control: the same sequence but using get() on key 1 instead of peek()
+  // must bump its recency, so 2 (never re-touched) is evicted instead.
+  memgraph::utils::LRUCache<int, int> get_cache(2);
+  get_cache.put(1, 100);
+  get_cache.put(2, 200);
+  for (int i = 0; i < 5; ++i) {
+    auto const value = get_cache.get(1);
+    EXPECT_TRUE(value.has_value());
+  }
+  get_cache.put(3, 300);
+  EXPECT_TRUE(get_cache.get(1).has_value());
+  EXPECT_FALSE(get_cache.get(2).has_value());
+  EXPECT_TRUE(get_cache.get(3).has_value());
+}

--- a/tests/unit/lru_cache.cpp
+++ b/tests/unit/lru_cache.cpp
@@ -229,30 +229,25 @@ TEST(LRUCacheTest, PeekReturnsPresentAndAbsent) {
 }
 
 TEST(LRUCacheTest, PeekDoesNotBumpRecencyUnlikeGet) {
-  // With cache_size == 2, filling with 1, 2 then inserting 3 evicts whichever
-  // of {1, 2} is least-recently-used. peek() must NOT count as a use: even
-  // after peeking at key 1 many times, it should be evicted just like a
-  // plain unaccessed entry, whereas get() would have kept it alive.
+  // peek() must NOT bump recency: repeatedly peeking key 1 still lets it be
+  // the LRU victim, whereas get() would have kept it alive.
   memgraph::utils::LRUCache<int, int> peek_cache(2);
   peek_cache.put(1, 100);
   peek_cache.put(2, 200);
 
   auto const &const_peek_cache = peek_cache;
-  // Repeatedly peek at key 1 - must not affect recency.
   for (int i = 0; i < 5; ++i) {
     auto const value = const_peek_cache.peek(1);
     EXPECT_TRUE(value.has_value());
   }
 
-  // 2 was put after 1, so without any recency bump, 1 is the least-recently-used
-  // and must be the one evicted when 3 is inserted.
+  // 1 was put first and never bumped, so it is evicted when 3 is inserted.
   peek_cache.put(3, 300);
   EXPECT_FALSE(const_peek_cache.peek(1).has_value());
   EXPECT_TRUE(const_peek_cache.peek(2).has_value());
   EXPECT_TRUE(const_peek_cache.peek(3).has_value());
 
-  // Control: the same sequence but using get() on key 1 instead of peek()
-  // must bump its recency, so 2 (never re-touched) is evicted instead.
+  // Control: get() on key 1 bumps recency, so 2 is evicted instead.
   memgraph::utils::LRUCache<int, int> get_cache(2);
   get_cache.put(1, 100);
   get_cache.put(2, 200);


### PR DESCRIPTION
Under high query concurrency every plan-cache lookup took the cache's exclusive lock only to splice the hit to MRU. Add a non-mutating LruCache::peek() (map lookup, no LRU reorder) and use it under WithReadLock on the cypher_query_interpreter hit path; put()/invalidate() stay exclusive. Removes a serialization point shared by all worker threads. 
