### PR TITLE
fix(utils): give a waiting UNIQUE priority over new shared acquirers

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2954,10 +2954,16 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     auto read_guard = Guard{main_lock_, Guard::READ};
     if (storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) return read_guard;
 
-    // Analytical: acquire WRITE before read_guard releases READ at scope exit, so the mode stays
-    // pinned across a continuous hold (one thread may hold READ+WRITE: lock_guard_condition<WRITE>
-    // checks only ro_count/ro_pending).
-    return Guard{main_lock_, Guard::WRITE};
+    // Analytical. Release READ before requesting WRITE: acquiring a second shared hold while still
+    // holding one deadlocks against a UNIQUE acquirer that registers as pending in between, because
+    // lock_guard_condition<WRITE> is gated on unique_pending_ and that acquirer is in turn waiting
+    // on the READ we would still be holding.
+    read_guard.unlock();
+    auto write_guard = Guard{main_lock_, Guard::WRITE};
+    // The mode can flip in the gap, so re-read it under the hold we will actually use. Downgrading
+    // is non-blocking, unlike the escalation above.
+    if (storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) write_guard.downgrade_to_read();
+    return write_guard;
   }();
 
   // Only one gc run at a time

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -74,12 +74,16 @@ struct ResourceLock {
   // If upon unlock we could possible unblock another lock then
   // we would want to notify to make sure we rapidly make progress
   // WRITE -> If w_count goes down to 0, READ_ONLY and UNIQUE maybe unblocked, hence: Notify All
-  // READ -> If r_count goes down to 0 (and other counts were already 0), UNIQUE maybe unblocked, hence: Notify One
+  // READ -> If r_count goes down to 0 (and other counts were already 0), UNIQUE maybe unblocked, hence: Notify All.
+  //   Must be All (not One): with writer-preference a READ acquirer can park on unique_pending_ != 0, so a lone
+  //   notify_one may wake such a shared waiter that immediately re-parks (its unique_pending_ == 0 predicate is
+  //   still false), consuming the only notification and stranding a pending UNIQUE whose predicate is now satisfied.
+  //   Notifying all wakes the UNIQUE too; the redundant shared wake just re-parks.
   // READ_ONLY -> If ro_count goes down to 0, WRITE and  UNIQUE maybe unblocked, hence: Notify All
   enum class NotifyKind : uint8_t { None, One, All };
   template <LockReq Req> NotifyKind unlock_should_notify() const;
   template <> NotifyKind unlock_should_notify<LockReq::WRITE>() const { return w_count == 0 ? NotifyKind::All : NotifyKind::None; }
-  template <> NotifyKind unlock_should_notify<LockReq::READ>() const { return (r_count == 0 && w_count == 0 && ro_count == 0) ? NotifyKind::One : NotifyKind::None; }
+  template <> NotifyKind unlock_should_notify<LockReq::READ>() const { return (r_count == 0 && w_count == 0 && ro_count == 0) ? NotifyKind::All : NotifyKind::None; }
   template <> NotifyKind unlock_should_notify<LockReq::READ_ONLY>() const { return ro_count == 0 ? NotifyKind::All : NotifyKind::None; }
 
   // A READ_ONLY lock request can block a WRITE lock request, on failure we should notify if ro_pending_count is now 0
@@ -115,8 +119,18 @@ struct ResourceLock {
     unique_pending_.fetch_add(1, std::memory_order_acq_rel);
     bool acquired = false;
     OnScopeExit pending_guard{[this, &acquired, &lock] {
-      if (unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1 && !acquired) {
-        if (lock.owns_lock()) lock.unlock();
+      // Release the ambient lock (cv.wait re-acquires it on every exit path) so the decrement can
+      // retake mtx cleanly. Decrement under mtx, mirroring ~UniquePendingScope's discipline: it
+      // serializes against a shared acquirer testing unique_pending_ == 0 in its cv.wait predicate,
+      // so fetch_sub + notify can't slip between that check and its enqueue and lose the wake.
+      // Release mtx before notifying (never notify under mtx).
+      if (lock.owns_lock()) lock.unlock();
+      bool was_last_waiter = false;
+      {
+        auto guard = std::unique_lock{mtx};
+        was_last_waiter = unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1;
+      }
+      if (was_last_waiter && !acquired) {
         cv.notify_all();
       }
     }};
@@ -143,8 +157,15 @@ struct ResourceLock {
     unique_pending_.fetch_add(1, std::memory_order_acq_rel);
     bool acquired = false;
     OnScopeExit pending_guard{[this, &acquired, &lock] {
-      if (unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1 && !acquired) {
-        if (lock.owns_lock()) lock.unlock();
+      // See lock(): release the ambient lock, decrement under mtx (mirroring ~UniquePendingScope),
+      // then notify after releasing mtx (never notify under mtx).
+      if (lock.owns_lock()) lock.unlock();
+      bool was_last_waiter = false;
+      {
+        auto guard = std::unique_lock{mtx};
+        was_last_waiter = unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1;
+      }
+      if (was_last_waiter && !acquired) {
         cv.notify_all();
       }
     }};

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -599,7 +599,18 @@ class UniquePendingScope {
 
   ~UniquePendingScope() {
     if (lock_ == nullptr) return;  // ownership already transferred out by a successful try_acquire()
-    if (lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    // Decrement the pending counter *under mtx*, mirroring ResourceLock::lock()'s failure path.
+    // A shared acquirer tests `unique_pending_ == 0` inside cv.wait's predicate while holding mtx;
+    // if we mutated the counter off-mtx, our fetch_sub + notify_all could land in the window
+    // between that thread's predicate check and its enqueue on the cv, losing the wake and hanging
+    // it forever. Mutating under the waiter's mutex serializes against that check. Release mtx
+    // before notifying (never notify_all while holding mtx).
+    bool was_last_waiter = false;
+    {
+      auto guard = std::unique_lock{lock_->mtx};
+      was_last_waiter = lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1;
+    }
+    if (was_last_waiter) {
       // We were the last pending UNIQUE waiter and never acquired -- wake shared acquirers that
       // were gated purely on unique_pending_ == 0 so they can re-check now (same notify this
       // counter's blocking counterpart, ResourceLock::lock(), performs on its failure path).
@@ -662,7 +673,15 @@ class ReadOnlyPendingScope {
 
   ~ReadOnlyPendingScope() {
     if (lock_ == nullptr) return;  // ownership already transferred out by a successful try_acquire()
-    if (lock_->ro_pending_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    // Decrement *under mtx* -- see ~UniquePendingScope for the lost-wakeup rationale (here the
+    // gated waiter is a blocking lock_shared<WRITE>() testing `ro_pending_count == 0`). Release
+    // before notifying.
+    bool was_last_waiter = false;
+    {
+      auto guard = std::unique_lock{lock_->mtx};
+      was_last_waiter = lock_->ro_pending_count.fetch_sub(1, std::memory_order_acq_rel) == 1;
+    }
+    if (was_last_waiter) {
       lock_->cv.notify_all();
     }
   }

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -42,18 +42,65 @@ struct ResourceLock {
  private:
   enum states : uint8_t { UNLOCKED, UNIQUE, SHARED };
 
+  // Acquire-path dispatch tag: the exclusive acquisition plus the three shared modes. Kept separate
+  // from the public LockReq (which names shared modes only) so UNIQUE never reaches the
+  // release-path tables, where it would have no meaning.
+  enum class AcquireKind : uint8_t { READ, WRITE, READ_ONLY, UNIQUE };
+
+  static constexpr AcquireKind acquire_kind_of(LockReq req) {
+    switch (req) {
+      case LockReq::READ:
+        return AcquireKind::READ;
+      case LockReq::WRITE:
+        return AcquireKind::WRITE;
+      case LockReq::READ_ONLY:
+        return AcquireKind::READ_ONLY;
+    }
+  }
+
+  // Notifying one is never correct here, hence no such alternative: all waiters share one condition
+  // variable but not one predicate, so notify_one can hand the wake-up to a waiter whose predicate
+  // is still false (a shared acquirer gated on unique_pending_count, say); it re-checks, sleeps
+  // again, and the waiter that could have made progress is never woken.
+  enum class NotifyKind : uint8_t { None, All };
+
   // clang-format off
-  // A waiting UNIQUE (unique_pending_) gates new shared acquisitions (writer-preference), mirroring
-  // ro_pending_count's READ_ONLY-over-WRITE priority.
-  template <LockReq Req> bool lock_guard_condition() const;
-  template <> bool lock_guard_condition<LockReq::WRITE>() const     { return ro_count == 0 && ro_pending_count.load(std::memory_order_acquire) == 0 && unique_pending_.load(std::memory_order_acquire) == 0; }
-  template <> bool lock_guard_condition<LockReq::READ>() const      { return unique_pending_.load(std::memory_order_acquire) == 0; }
-  template <> bool lock_guard_condition<LockReq::READ_ONLY>() const { return w_count == 0 && unique_pending_.load(std::memory_order_acquire) == 0; }
+  // Admission rule, evaluated under mtx (as the wait predicate, and by the non-blocking probes).
+  // A waiting UNIQUE (unique_pending_count) gates new shared acquisitions (writer-preference),
+  // mirroring ro_pending_count's READ_ONLY-over-WRITE priority.
+  template <AcquireKind K> bool can_acquire() const;
+  template <> bool can_acquire<AcquireKind::WRITE>() const      { return state != UNIQUE && ro_count == 0 && ro_pending_count == 0 && unique_pending_count == 0; }
+  template <> bool can_acquire<AcquireKind::READ>() const       { return state != UNIQUE && unique_pending_count == 0; }
+  template <> bool can_acquire<AcquireKind::READ_ONLY>() const  { return state != UNIQUE && w_count == 0 && unique_pending_count == 0; }
+  template <> bool can_acquire<AcquireKind::UNIQUE>() const     { return state == UNLOCKED; }
 
   template <LockReq Req> void lock_state_updater();
   template <> void lock_state_updater<LockReq::WRITE>()     { ++w_count; };
   template <> void lock_state_updater<LockReq::READ>()      { ++r_count; };
   template <> void lock_state_updater<LockReq::READ_ONLY>() { ++ro_count; }
+
+  // Applied once admitted; leaves the lock in the state the acquisition claims.
+  template <AcquireKind K> void commit_state();
+  template <> void commit_state<AcquireKind::WRITE>()     { state = SHARED; lock_state_updater<LockReq::WRITE>(); }
+  template <> void commit_state<AcquireKind::READ>()      { state = SHARED; lock_state_updater<LockReq::READ>(); }
+  template <> void commit_state<AcquireKind::READ_ONLY>() { state = SHARED; lock_state_updater<LockReq::READ_ONLY>(); }
+  template <> void commit_state<AcquireKind::UNIQUE>()    { state = UNIQUE; }
+
+  // Pending registration, held for as long as a caller is waiting to acquire, so the kinds it gates
+  // yield to it (see can_acquire). READ and WRITE gate nobody, so they register nothing.
+  template <AcquireKind K> void pending_add() {}
+  template <> void pending_add<AcquireKind::READ_ONLY>() { ++ro_pending_count; }
+  template <> void pending_add<AcquireKind::UNIQUE>()    { ++unique_pending_count; }
+
+  template <AcquireKind K> void pending_sub() {}
+  template <> void pending_sub<AcquireKind::READ_ONLY>() { --ro_pending_count; }
+  template <> void pending_sub<AcquireKind::UNIQUE>()    { --unique_pending_count; }
+
+  // Giving up without acquiring can be the event that ungates whoever we were holding back, and
+  // nothing else will wake them: their predicate came true because we deregistered.
+  template <AcquireKind K> NotifyKind pending_release_should_notify() const { return NotifyKind::None; }
+  template <> NotifyKind pending_release_should_notify<AcquireKind::READ_ONLY>() const { return ro_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
+  template <> NotifyKind pending_release_should_notify<AcquireKind::UNIQUE>() const { return unique_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
 
   template <LockReq Req> void unlock_state_updater();
   template <> void unlock_state_updater<LockReq::WRITE>()     { --w_count; };
@@ -65,116 +112,109 @@ struct ResourceLock {
   template <> bool unlock_has_fully_unlocked<LockReq::READ>() const      { return r_count == 0 && ro_count == 0 && w_count == 0; };
   template <> bool unlock_has_fully_unlocked<LockReq::READ_ONLY>() const { return ro_count == 0 && r_count == 0; };
 
-  template <LockReq Req> void lock_pre_state_change(){}
-  template <> void lock_pre_state_change<LockReq::READ_ONLY>(){ ro_pending_count.fetch_add(1,std::memory_order_acq_rel); }
-
-  template <LockReq Req> void lock_post_state_change(){}
-  template <> void lock_post_state_change<LockReq::READ_ONLY>(){ ro_pending_count.fetch_sub(1,std::memory_order_acq_rel); }
-
   // If upon unlock we could possible unblock another lock then
   // we would want to notify to make sure we rapidly make progress
   // WRITE -> If w_count goes down to 0, READ_ONLY and UNIQUE maybe unblocked, hence: Notify All
-  // READ -> If r_count goes down to 0 (and other counts were already 0), UNIQUE maybe unblocked, hence: Notify All.
-  //   Must be All (not One): with writer-preference a READ acquirer can park on unique_pending_ != 0, so a lone
-  //   notify_one may wake such a shared waiter that immediately re-parks (its unique_pending_ == 0 predicate is
-  //   still false), consuming the only notification and stranding a pending UNIQUE whose predicate is now satisfied.
-  //   Notifying all wakes the UNIQUE too; the redundant shared wake just re-parks.
+  // READ -> If r_count goes down to 0 (and other counts were already 0), UNIQUE maybe unblocked
   // READ_ONLY -> If ro_count goes down to 0, WRITE and  UNIQUE maybe unblocked, hence: Notify All
-  enum class NotifyKind : uint8_t { None, One, All };
   template <LockReq Req> NotifyKind unlock_should_notify() const;
   template <> NotifyKind unlock_should_notify<LockReq::WRITE>() const { return w_count == 0 ? NotifyKind::All : NotifyKind::None; }
   template <> NotifyKind unlock_should_notify<LockReq::READ>() const { return (r_count == 0 && w_count == 0 && ro_count == 0) ? NotifyKind::All : NotifyKind::None; }
   template <> NotifyKind unlock_should_notify<LockReq::READ_ONLY>() const { return ro_count == 0 ? NotifyKind::All : NotifyKind::None; }
 
-  // A READ_ONLY lock request can block a WRITE lock request, on failure we should notify if ro_pending_count is now 0
-  template <LockReq Req> NotifyKind lock_failed_wait_should_notify() const;
-  template <> NotifyKind lock_failed_wait_should_notify<LockReq::WRITE>() const { return NotifyKind::None; }
-  template <> NotifyKind lock_failed_wait_should_notify<LockReq::READ>() const { return NotifyKind::None; }
-  template <> NotifyKind lock_failed_wait_should_notify<LockReq::READ_ONLY>() const { return ro_pending_count.load(std::memory_order_acquire) == 0 ? NotifyKind::All : NotifyKind::None; }
-
   // clang-format on
 
-  template <LockReq Req>
   void maybe_notify(std::unique_lock<std::mutex> &lock, NotifyKind kind) {
     lock.unlock();
-    switch (kind) {
-      case NotifyKind::One:
-        cv.notify_one();
-        break;
-      case NotifyKind::All:
-        cv.notify_all();
-        break;
-      case NotifyKind::None:
-        break;
-    }
+    if (kind == NotifyKind::All) cv.notify_all();
+  }
+
+  /// Acquires in kind `K`, `wait` supplying the wait strategy. Requires `lock` to own mtx; leaves
+  /// it owned iff the acquisition succeeded.
+  ///
+  /// The pending registration is dropped by RAII because it must survive a timeout and an exception
+  /// out of the wait too: leak it once and every kind it gates is blocked for the lifetime of the
+  /// process. The handler runs with mtx still held (cv.wait/wait_for re-acquire it
+  /// on every exit path, and `lock` outlives the guard declared after it), which is what serializes
+  /// the deregistration against another thread reading that same counter inside its own wait
+  /// predicate: mutate it off-mtx and the decrement plus notify can land between that thread's
+  /// check and its enqueue on the cv, losing the wake.
+  template <AcquireKind K>
+  bool acquire(std::unique_lock<std::mutex> &lock, auto &&wait) {
+    pending_add<K>();
+    bool acquired = false;
+    OnScopeExit pending_guard{[&] {
+      pending_sub<K>();
+      if (!acquired) maybe_notify(lock, pending_release_should_notify<K>());
+    }};
+    if (!wait(lock, [this] { return can_acquire<K>(); })) return false;
+    commit_state<K>();
+    acquired = true;
+    return true;
+  }
+
+  /// Non-blocking probe. Requires mtx. Never registers as pending: an attempt that does not wait
+  /// has nothing to give priority to.
+  template <AcquireKind K>
+  bool try_acquire() {
+    if (!can_acquire<K>()) return false;
+    commit_state<K>();
+    return true;
+  }
+
+  auto blocking_wait() {
+    return [this](std::unique_lock<std::mutex> &lock, auto pred) {
+      cv.wait(lock, pred);
+      return true;
+    };
+  }
+
+  template <class Rep, class Period>
+  auto timed_wait(std::chrono::duration<Rep, Period> const &time) {
+    return [this, time](std::unique_lock<std::mutex> &lock, auto pred) { return cv.wait_for(lock, time, pred); };
+  }
+
+  // The pending registration acquire() holds across a wait, exposed for the pending scopes to hold
+  // across a campaign of non-blocking probes instead. See UniquePendingScope.
+  template <AcquireKind K>
+  void register_pending() {
+    auto guard = std::unique_lock{mtx};
+    pending_add<K>();
+  }
+
+  template <AcquireKind K>
+  void unregister_pending() {
+    auto lock = std::unique_lock{mtx};
+    pending_sub<K>();
+    maybe_notify(lock, pending_release_should_notify<K>());
+  }
+
+  /// Probe that also transitions pending -> held on success. Deregisters without notifying: as on
+  /// acquire()'s success path, waking the kinds we gated is deferred to the eventual release, since
+  /// we hold the resource now and they still cannot have it.
+  template <AcquireKind K>
+  bool try_acquire_pending() {
+    auto guard = std::unique_lock{mtx};
+    if (!try_acquire<K>()) return false;
+    pending_sub<K>();
+    return true;
   }
 
  public:
   void lock() {
     auto lock = std::unique_lock{mtx};
-    // Register as a pending UNIQUE waiter before blocking so new shared acquirers yield to us
-    // (writer-preference; see lock_guard_condition). RAII decrements on every exit path (incl. an
-    // exception out of cv.wait) and, if we were the last pending waiter without acquiring, wakes
-    // shared acquirers gated on unique_pending_. Unlock before notify_all (never notify under mtx).
-    unique_pending_.fetch_add(1, std::memory_order_acq_rel);
-    bool acquired = false;
-    OnScopeExit pending_guard{[this, &acquired, &lock] {
-      // Release the ambient lock (cv.wait re-acquires it on every exit path) so the decrement can
-      // retake mtx cleanly. Decrement under mtx, mirroring ~UniquePendingScope's discipline: it
-      // serializes against a shared acquirer testing unique_pending_ == 0 in its cv.wait predicate,
-      // so fetch_sub + notify can't slip between that check and its enqueue and lose the wake.
-      // Release mtx before notifying (never notify under mtx).
-      if (lock.owns_lock()) lock.unlock();
-      bool was_last_waiter = false;
-      {
-        auto guard = std::unique_lock{mtx};
-        was_last_waiter = unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1;
-      }
-      if (was_last_waiter && !acquired) {
-        cv.notify_all();
-      }
-    }};
-    // block until available
-    cv.wait(lock, [this] { return state == UNLOCKED; });
-    state = UNIQUE;
-    acquired = true;
+    acquire<AcquireKind::UNIQUE>(lock, blocking_wait());
   }
 
   bool try_lock() {
     auto lock = std::unique_lock{mtx};
-    // Non-blocking: never registers as pending (nothing to give priority to).
-    if (state == UNLOCKED) {
-      state = UNIQUE;
-      return true;
-    }
-    return false;
+    return try_acquire<AcquireKind::UNIQUE>();
   }
 
   template <class Rep, class Period>
   bool try_lock_for(const std::chrono::duration<Rep, Period> &timeout_duration) {
     auto lock = std::unique_lock{mtx};
-    // Registers as a pending UNIQUE waiter; see lock() for the writer-preference rationale.
-    unique_pending_.fetch_add(1, std::memory_order_acq_rel);
-    bool acquired = false;
-    OnScopeExit pending_guard{[this, &acquired, &lock] {
-      // See lock(): release the ambient lock, decrement under mtx (mirroring ~UniquePendingScope),
-      // then notify after releasing mtx (never notify under mtx).
-      if (lock.owns_lock()) lock.unlock();
-      bool was_last_waiter = false;
-      {
-        auto guard = std::unique_lock{mtx};
-        was_last_waiter = unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1;
-      }
-      if (was_last_waiter && !acquired) {
-        cv.notify_all();
-      }
-    }};
-    if (!cv.wait_for(lock, timeout_duration, [this] { return state == UNLOCKED; })) {
-      return false;
-    }
-    state = UNIQUE;
-    acquired = true;
-    return true;
+    return acquire<AcquireKind::UNIQUE>(lock, timed_wait(timeout_duration));
   }
 
   void unlock() {
@@ -188,24 +228,13 @@ struct ResourceLock {
   template <LockReq Req = LockReq::WRITE>
   void lock_shared() {
     auto lock = std::unique_lock{mtx};
-    lock_pre_state_change<Req>();
-    // RAII: run lock_post_state_change on every exit path (incl. an exception out of cv.wait) so a
-    // pending-counter (e.g. ro_pending_count) never leaks.
-    OnScopeExit post_state_change_guard{[this] { lock_post_state_change<Req>(); }};
-    cv.wait(lock, [this] { return state != UNIQUE && lock_guard_condition<Req>(); });
-    state = SHARED;
-    lock_state_updater<Req>();
+    acquire<acquire_kind_of(Req)>(lock, blocking_wait());
   }
 
   template <LockReq Req = LockReq::WRITE>
   bool try_lock_shared() {
     auto lock = std::unique_lock{mtx};
-    if (state != UNIQUE && lock_guard_condition<Req>()) {
-      state = SHARED;
-      lock_state_updater<Req>();
-      return true;
-    }
-    return false;
+    return try_acquire<acquire_kind_of(Req)>();
   }
 
   template <LockReq Req>
@@ -214,30 +243,14 @@ struct ResourceLock {
     if (state != SHARED) return false;
     unlock_state_updater<Req>();
     lock_state_updater<LockReq::READ>();
-    maybe_notify<Req>(lock, unlock_should_notify<Req>());
+    maybe_notify(lock, unlock_should_notify<Req>());
     return true;
   }
 
   template <typename Rep, typename Period, LockReq Req = LockReq::WRITE>
   bool try_lock_shared_for(std::chrono::duration<Rep, Period> const &time) {
     auto lock = std::unique_lock{mtx};
-    lock_pre_state_change<Req>();
-    bool acquired = false;
-    // RAII: run lock_post_state_change on every exit path (see lock_shared); on the non-acquired
-    // path also notify so anything gated on the pending-counter reaching 0 is woken.
-    OnScopeExit post_state_change_guard{[this, &acquired, &lock] {
-      lock_post_state_change<Req>();
-      if (!acquired) {
-        maybe_notify<Req>(lock, lock_failed_wait_should_notify<Req>());
-      }
-    }};
-    if (!cv.wait_for(lock, time, [this] { return state != UNIQUE && lock_guard_condition<Req>(); })) {
-      return false;
-    }
-    state = SHARED;
-    lock_state_updater<Req>();
-    acquired = true;
-    return true;
+    return acquire<acquire_kind_of(Req)>(lock, timed_wait(time));
   }
 
   template <LockReq Req = LockReq::WRITE>
@@ -247,20 +260,24 @@ struct ResourceLock {
     if (unlock_has_fully_unlocked<Req>()) {
       state = UNLOCKED;
     }
-    maybe_notify<Req>(lock, unlock_should_notify<Req>());
+    maybe_notify(lock, unlock_should_notify<Req>());
   }
 
  private:
+  // Every member below is read and written under mtx only, the pending counters included: a reader
+  // evaluates them inside its cv.wait predicate while holding mtx, so an off-mtx mutation could
+  // land between that check and the reader's enqueue on the cv and lose the wake. Plain integers
+  // rather than atomics, so that discipline is the only way to touch them.
   std::mutex mtx;
   std::condition_variable cv;
   states state = UNLOCKED;
   uint32_t ro_count = 0;
-  std::atomic<uint32_t> ro_pending_count = 0;
+  uint32_t ro_pending_count = 0;
   uint32_t w_count = 0;
   uint32_t r_count = 0;
-  // Threads waiting to acquire UNIQUE (blocking lock()/try_lock_for() or a UniquePendingScope).
-  // Gates new shared acquisitions for writer-preference; see lock_guard_condition.
-  std::atomic<uint32_t> unique_pending_ = 0;
+  // Callers waiting to acquire UNIQUE (blocking lock()/try_lock_for(), or a UniquePendingScope
+  // campaign). Gates new shared acquisitions for writer-preference; see can_acquire.
+  uint32_t unique_pending_count = 0;
 };
 
 struct SharedResourceLockGuard {
@@ -569,38 +586,27 @@ struct ResourceLockGuard {
 /// probe campaign, for callers that cannot block on lock()'s cv (e.g. a coroutine that must yield
 /// to a scheduler) but still want writer-preference while they poll try_acquire().
 ///
-/// A bare try_lock() loop never touches unique_pending_, so it is just another unprivileged
-/// contender each iteration and can starve behind back-to-back shared holders. This scope bumps
-/// unique_pending_ once up front, gating new shared acquirers (see lock_guard_condition) so the
-/// shared pool drains and the probe eventually finds state == UNLOCKED.
+/// A bare try_lock() loop never registers as pending, so it is just another unprivileged contender
+/// each iteration and can starve behind back-to-back shared holders. This scope registers once up
+/// front, gating new shared acquirers (see can_acquire) so the shared pool drains and the probe
+/// eventually finds state == UNLOCKED.
 ///
 /// Ownership: try_acquire() returns nullopt (still pending, gate stays up) or a
 /// std::unique_lock<ResourceLock> owning the acquired lock. On success the scope stops counting as
 /// pending and becomes inert (destructor is a no-op); the returned lock owns the unlock(). If
-/// destroyed without acquiring, the destructor decrements unique_pending_ and wakes gated shared
-/// acquirers (as lock()'s failure path does).
+/// destroyed without acquiring, the destructor deregisters and wakes gated shared acquirers (as
+/// acquire()'s failure path does).
 ///
 /// Not copyable or movable: the registration is tied 1:1 to this scope's lifetime.
 class UniquePendingScope {
  public:
   explicit UniquePendingScope(ResourceLock &lock) : lock_{&lock} {
-    auto guard = std::unique_lock{lock_->mtx};
-    lock_->unique_pending_.fetch_add(1, std::memory_order_acq_rel);
+    lock_->register_pending<ResourceLock::AcquireKind::UNIQUE>();
   }
 
   ~UniquePendingScope() {
     if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
-    // Decrement under mtx to serialize against a shared acquirer testing unique_pending_ == 0 in
-    // cv.wait's predicate; otherwise fetch_sub + notify could slip between its check and enqueue
-    // and lose the wake. Release mtx before notifying (never notify under mtx).
-    bool was_last_waiter = false;
-    {
-      auto guard = std::unique_lock{lock_->mtx};
-      was_last_waiter = lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1;
-    }
-    if (was_last_waiter) {
-      lock_->cv.notify_all();
-    }
+    lock_->unregister_pending<ResourceLock::AcquireKind::UNIQUE>();
   }
 
   UniquePendingScope(const UniquePendingScope &) = delete;
@@ -613,18 +619,7 @@ class UniquePendingScope {
   /// intact for the next attempt.
   std::optional<std::unique_lock<ResourceLock>> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
-    bool acquired = false;
-    {
-      auto guard = std::unique_lock{lock_->mtx};
-      if (lock_->state == ResourceLock::UNLOCKED) {
-        lock_->state = ResourceLock::UNIQUE;
-        acquired = true;
-      }
-    }
-    if (!acquired) return std::nullopt;
-    // pending -> held: decrement (no longer waiting) without notifying; like lock()'s success path,
-    // waking gated shared acquirers is deferred to unlock() (state is still UNIQUE).
-    lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel);
+    if (!lock_->try_acquire_pending<ResourceLock::AcquireKind::UNIQUE>()) return std::nullopt;
     ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
     return std::unique_lock<ResourceLock>{*acquired_lock, std::adopt_lock};
   }
@@ -642,21 +637,12 @@ class UniquePendingScope {
 class ReadOnlyPendingScope {
  public:
   explicit ReadOnlyPendingScope(ResourceLock &lock) : lock_{&lock} {
-    auto guard = std::unique_lock{lock_->mtx};
-    lock_->ro_pending_count.fetch_add(1, std::memory_order_acq_rel);
+    lock_->register_pending<ResourceLock::AcquireKind::READ_ONLY>();
   }
 
   ~ReadOnlyPendingScope() {
     if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
-    // Decrement under mtx; see ~UniquePendingScope for the lost-wakeup rationale.
-    bool was_last_waiter = false;
-    {
-      auto guard = std::unique_lock{lock_->mtx};
-      was_last_waiter = lock_->ro_pending_count.fetch_sub(1, std::memory_order_acq_rel) == 1;
-    }
-    if (was_last_waiter) {
-      lock_->cv.notify_all();
-    }
+    lock_->unregister_pending<ResourceLock::AcquireKind::READ_ONLY>();
   }
 
   ReadOnlyPendingScope(const ReadOnlyPendingScope &) = delete;
@@ -664,23 +650,11 @@ class ReadOnlyPendingScope {
   ReadOnlyPendingScope(ReadOnlyPendingScope &&) = delete;
   ReadOnlyPendingScope &operator=(ReadOnlyPendingScope &&) = delete;
 
-  /// Non-blocking attempt to take READ_ONLY; needs w_count == 0 && unique_pending_ == 0 (same as
-  /// lock_guard_condition<READ_ONLY>). Safe to call repeatedly.
+  /// Non-blocking attempt to take READ_ONLY, admitted by the same rule a blocking
+  /// lock_shared<READ_ONLY>() waits on (see can_acquire<READ_ONLY>). Safe to call repeatedly.
   std::optional<SharedResourceLockGuard> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
-    bool acquired = false;
-    {
-      auto guard = std::unique_lock{lock_->mtx};
-      if (lock_->state != ResourceLock::UNIQUE && lock_->w_count == 0 &&
-          lock_->unique_pending_.load(std::memory_order_acquire) == 0) {
-        lock_->state = ResourceLock::SHARED;
-        ++lock_->ro_count;
-        acquired = true;
-      }
-    }
-    if (!acquired) return std::nullopt;
-    // pending -> held: decrement without notifying (see UniquePendingScope::try_acquire).
-    lock_->ro_pending_count.fetch_sub(1, std::memory_order_acq_rel);
+    if (!lock_->try_acquire_pending<ResourceLock::AcquireKind::READ_ONLY>()) return std::nullopt;
     ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
     return SharedResourceLockGuard{*acquired_lock, SharedResourceLockGuard::Type::READ_ONLY, std::adopt_lock};
   }

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -37,26 +37,13 @@ struct ResourceLock {
   friend class UniquePendingScope;
   friend class ReadOnlyPendingScope;
 
-  enum class LockReq : uint8_t { READ, WRITE, READ_ONLY };
+  // The four ways to hold the lock. UNIQUE is exclusive of all of them, including itself; the other
+  // three are the shared modes, mutually compatible except that WRITE and READ_ONLY exclude each
+  // other. Every acquisition and every release dispatches on this.
+  enum class LockReq : uint8_t { READ, WRITE, READ_ONLY, UNIQUE };
 
  private:
   enum states : uint8_t { UNLOCKED, UNIQUE, SHARED };
-
-  // Acquire-path dispatch tag: the exclusive acquisition plus the three shared modes. Kept separate
-  // from the public LockReq (which names shared modes only) so UNIQUE never reaches the
-  // release-path tables, where it would have no meaning.
-  enum class AcquireKind : uint8_t { READ, WRITE, READ_ONLY, UNIQUE };
-
-  static constexpr AcquireKind acquire_kind_of(LockReq req) {
-    switch (req) {
-      case LockReq::READ:
-        return AcquireKind::READ;
-      case LockReq::WRITE:
-        return AcquireKind::WRITE;
-      case LockReq::READ_ONLY:
-        return AcquireKind::READ_ONLY;
-    }
-  }
 
   // Notifying one is never correct here, hence no such alternative: all waiters share one condition
   // variable but not one predicate, so notify_one can hand the wake-up to a waiter whose predicate
@@ -68,54 +55,54 @@ struct ResourceLock {
   // Admission rule, evaluated under mtx (as the wait predicate, and by the non-blocking probes).
   // A waiting UNIQUE (unique_pending_count) gates new shared acquisitions (writer-preference),
   // mirroring ro_pending_count's READ_ONLY-over-WRITE priority.
-  template <AcquireKind K> bool can_acquire() const;
-  template <> bool can_acquire<AcquireKind::WRITE>() const      { return state != UNIQUE && ro_count == 0 && ro_pending_count == 0 && unique_pending_count == 0; }
-  template <> bool can_acquire<AcquireKind::READ>() const       { return state != UNIQUE && unique_pending_count == 0; }
-  template <> bool can_acquire<AcquireKind::READ_ONLY>() const  { return state != UNIQUE && w_count == 0 && unique_pending_count == 0; }
-  template <> bool can_acquire<AcquireKind::UNIQUE>() const     { return state == UNLOCKED; }
+  template <LockReq Req> bool can_acquire() const;
+  template <> bool can_acquire<LockReq::WRITE>() const      { return state != UNIQUE && ro_count == 0 && ro_pending_count == 0 && unique_pending_count == 0; }
+  template <> bool can_acquire<LockReq::READ>() const       { return state != UNIQUE && unique_pending_count == 0; }
+  template <> bool can_acquire<LockReq::READ_ONLY>() const  { return state != UNIQUE && w_count == 0 && unique_pending_count == 0; }
+  template <> bool can_acquire<LockReq::UNIQUE>() const     { return state == UNLOCKED; }
 
   template <LockReq Req> void lock_state_updater();
-  template <> void lock_state_updater<LockReq::WRITE>()     { ++w_count; };
-  template <> void lock_state_updater<LockReq::READ>()      { ++r_count; };
+  template <> void lock_state_updater<LockReq::WRITE>()     { ++w_count; }
+  template <> void lock_state_updater<LockReq::READ>()      { ++r_count; }
   template <> void lock_state_updater<LockReq::READ_ONLY>() { ++ro_count; }
+  template <> void lock_state_updater<LockReq::UNIQUE>()    { }
 
   // Applied once admitted; leaves the lock in the state the acquisition claims.
-  template <AcquireKind K> void commit_state();
-  template <> void commit_state<AcquireKind::WRITE>()     { state = SHARED; lock_state_updater<LockReq::WRITE>(); }
-  template <> void commit_state<AcquireKind::READ>()      { state = SHARED; lock_state_updater<LockReq::READ>(); }
-  template <> void commit_state<AcquireKind::READ_ONLY>() { state = SHARED; lock_state_updater<LockReq::READ_ONLY>(); }
-  template <> void commit_state<AcquireKind::UNIQUE>()    { state = UNIQUE; }
+  template <LockReq Req> void commit_state()             { state = SHARED; lock_state_updater<Req>(); }
+  template <> void commit_state<LockReq::UNIQUE>()       { state = UNIQUE; }
 
   // Pending registration, held for as long as a caller is waiting to acquire, so the kinds it gates
   // yield to it (see can_acquire). READ and WRITE gate nobody, so they register nothing.
-  template <AcquireKind K> void pending_add() {}
-  template <> void pending_add<AcquireKind::READ_ONLY>() { ++ro_pending_count; }
-  template <> void pending_add<AcquireKind::UNIQUE>()    { ++unique_pending_count; }
+  template <LockReq Req> void pending_add() {}
+  template <> void pending_add<LockReq::READ_ONLY>() { ++ro_pending_count; }
+  template <> void pending_add<LockReq::UNIQUE>()    { ++unique_pending_count; }
 
-  template <AcquireKind K> void pending_sub() {}
-  template <> void pending_sub<AcquireKind::READ_ONLY>() { --ro_pending_count; }
-  template <> void pending_sub<AcquireKind::UNIQUE>()    { --unique_pending_count; }
+  template <LockReq Req> void pending_sub() {}
+  template <> void pending_sub<LockReq::READ_ONLY>() { --ro_pending_count; }
+  template <> void pending_sub<LockReq::UNIQUE>()    { --unique_pending_count; }
 
   // Giving up without acquiring can be the event that ungates whoever we were holding back, and
   // nothing else will wake them: their predicate came true because we deregistered.
-  template <AcquireKind K> NotifyKind pending_release_should_notify() const { return NotifyKind::None; }
-  template <> NotifyKind pending_release_should_notify<AcquireKind::READ_ONLY>() const { return ro_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
-  template <> NotifyKind pending_release_should_notify<AcquireKind::UNIQUE>() const { return unique_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
+  template <LockReq Req> NotifyKind pending_release_should_notify() const { return NotifyKind::None; }
+  template <> NotifyKind pending_release_should_notify<LockReq::READ_ONLY>() const { return ro_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
+  template <> NotifyKind pending_release_should_notify<LockReq::UNIQUE>() const { return unique_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
 
   template <LockReq Req> void unlock_state_updater();
-  template <> void unlock_state_updater<LockReq::WRITE>()     { --w_count; };
-  template <> void unlock_state_updater<LockReq::READ>()      { --r_count; };
+  template <> void unlock_state_updater<LockReq::WRITE>()     { --w_count; }
+  template <> void unlock_state_updater<LockReq::READ>()      { --r_count; }
   template <> void unlock_state_updater<LockReq::READ_ONLY>() { --ro_count; }
+  template <> void unlock_state_updater<LockReq::UNIQUE>()    { }
 
   // WRITE omits ro_count, and READ_ONLY omits w_count, because the two are mutually exclusive by
   // admission (can_acquire<WRITE> demands ro_count == 0, can_acquire<READ_ONLY> demands
   // w_count == 0), so the omitted count is necessarily 0 whenever the other is being released.
   // Relax either admission rule without revisiting these and the lock declares itself UNLOCKED
-  // while a holder is still live.
+  // while a holder is still live. UNIQUE excludes every shared mode, so no count can be standing.
   template <LockReq Req> bool unlock_has_fully_unlocked() const;
-  template <> bool unlock_has_fully_unlocked<LockReq::WRITE>() const     { return w_count == 0 && r_count == 0; };
-  template <> bool unlock_has_fully_unlocked<LockReq::READ>() const      { return r_count == 0 && ro_count == 0 && w_count == 0; };
-  template <> bool unlock_has_fully_unlocked<LockReq::READ_ONLY>() const { return ro_count == 0 && r_count == 0; };
+  template <> bool unlock_has_fully_unlocked<LockReq::WRITE>() const     { return w_count == 0 && r_count == 0; }
+  template <> bool unlock_has_fully_unlocked<LockReq::READ>() const      { return r_count == 0 && ro_count == 0 && w_count == 0; }
+  template <> bool unlock_has_fully_unlocked<LockReq::READ_ONLY>() const { return ro_count == 0 && r_count == 0; }
+  template <> bool unlock_has_fully_unlocked<LockReq::UNIQUE>() const    { return true; }
 
   // If upon unlock we could possible unblock another lock then
   // we would want to notify to make sure we rapidly make progress
@@ -127,11 +114,13 @@ struct ResourceLock {
   // 0 admits READ_ONLY resp. WRITE even while a READ hold keeps the lock SHARED, and no later event
   // is guaranteed to fire (that READ may be held indefinitely). READ notifies on exactly the
   // fully-unlocked condition because no acquirer is gated on r_count, so a READ release can only
-  // ever admit UNIQUE, and only by freeing the lock.
+  // ever admit UNIQUE, and only by freeing the lock. Releasing UNIQUE always frees the lock, so it
+  // can admit any waiter and always notifies.
   template <LockReq Req> NotifyKind unlock_should_notify() const;
   template <> NotifyKind unlock_should_notify<LockReq::WRITE>() const { return w_count == 0 ? NotifyKind::All : NotifyKind::None; }
   template <> NotifyKind unlock_should_notify<LockReq::READ>() const { return (r_count == 0 && w_count == 0 && ro_count == 0) ? NotifyKind::All : NotifyKind::None; }
   template <> NotifyKind unlock_should_notify<LockReq::READ_ONLY>() const { return ro_count == 0 ? NotifyKind::All : NotifyKind::None; }
+  template <> NotifyKind unlock_should_notify<LockReq::UNIQUE>() const { return NotifyKind::All; }
 
   // clang-format on
 
@@ -140,7 +129,7 @@ struct ResourceLock {
     if (kind == NotifyKind::All) cv.notify_all();
   }
 
-  /// Acquires in kind `K`, `wait` supplying the wait strategy. Requires `lock` to own mtx; leaves
+  /// Acquires in mode `Req`, `wait` supplying the wait strategy. Requires `lock` to own mtx; leaves
   /// it owned iff the acquisition succeeded.
   ///
   /// The pending registration is dropped by RAII because it must survive a timeout and an exception
@@ -150,26 +139,26 @@ struct ResourceLock {
   /// deregistration against another thread reading that same counter inside its own wait predicate:
   /// mutate it off-mtx and the decrement plus notify can land between that thread's check and its
   /// enqueue on the cv, losing the wake.
-  template <AcquireKind K>
+  template <LockReq Req>
   bool acquire(std::unique_lock<std::mutex> &lock, auto &&wait) {
-    pending_add<K>();
+    pending_add<Req>();
     bool acquired = false;
-    OnScopeExit pending_guard{[&] {
-      pending_sub<K>();
-      if (!acquired) maybe_notify(lock, pending_release_should_notify<K>());
+    auto const pending_guard = OnScopeExit{[&] {
+      pending_sub<Req>();
+      if (!acquired) maybe_notify(lock, pending_release_should_notify<Req>());
     }};
-    if (!wait(lock, [this] { return can_acquire<K>(); })) return false;
-    commit_state<K>();
+    if (!wait(lock, [this] { return can_acquire<Req>(); })) return false;
+    commit_state<Req>();
     acquired = true;
     return true;
   }
 
   /// Non-blocking probe. Requires mtx. Never registers as pending: an attempt that does not wait
   /// has nothing to give priority to.
-  template <AcquireKind K>
+  template <LockReq Req>
   bool try_acquire() {
-    if (!can_acquire<K>()) return false;
-    commit_state<K>();
+    if (!can_acquire<Req>()) return false;
+    commit_state<Req>();
     return true;
   }
 
@@ -187,68 +176,80 @@ struct ResourceLock {
 
   // The pending registration acquire() holds across a wait, exposed for the pending scopes to hold
   // across a campaign of non-blocking probes instead. See UniquePendingScope.
-  template <AcquireKind K>
+  template <LockReq Req>
   void register_pending() {
     auto guard = std::unique_lock{mtx};
-    pending_add<K>();
+    pending_add<Req>();
   }
 
-  template <AcquireKind K>
+  template <LockReq Req>
   void unregister_pending() {
     auto lock = std::unique_lock{mtx};
-    pending_sub<K>();
-    maybe_notify(lock, pending_release_should_notify<K>());
+    pending_sub<Req>();
+    maybe_notify(lock, pending_release_should_notify<Req>());
+  }
+
+  /// Releases a hold taken in mode `Req`: drop its count, free the lock if that was the last hold,
+  /// and notify whoever the release may have admitted. UNIQUE excludes every other mode, so it has
+  /// no count to drop, always frees the lock, and always has someone to admit.
+  template <LockReq Req>
+  void release() {
+    auto lock = std::unique_lock{mtx};
+    unlock_state_updater<Req>();
+    if (unlock_has_fully_unlocked<Req>()) {
+      state = UNLOCKED;
+    }
+    maybe_notify(lock, unlock_should_notify<Req>());
   }
 
   /// Probe that also transitions pending -> held on success. Deregisters without notifying: as on
   /// acquire()'s success path, waking the kinds we gated is deferred to the eventual release, since
   /// we hold the resource now and they still cannot have it.
-  template <AcquireKind K>
+  template <LockReq Req>
   bool try_acquire_pending() {
     auto guard = std::unique_lock{mtx};
-    if (!try_acquire<K>()) return false;
-    pending_sub<K>();
+    if (!try_acquire<Req>()) return false;
+    pending_sub<Req>();
     return true;
   }
 
  public:
   void lock() {
     auto lock = std::unique_lock{mtx};
-    acquire<AcquireKind::UNIQUE>(lock, blocking_wait());
+    acquire<LockReq::UNIQUE>(lock, blocking_wait());
   }
 
   bool try_lock() {
     auto lock = std::unique_lock{mtx};
-    return try_acquire<AcquireKind::UNIQUE>();
+    return try_acquire<LockReq::UNIQUE>();
   }
 
   template <class Rep, class Period>
   bool try_lock_for(const std::chrono::duration<Rep, Period> &timeout_duration) {
     auto lock = std::unique_lock{mtx};
-    return acquire<AcquireKind::UNIQUE>(lock, timed_wait(timeout_duration));
+    return acquire<LockReq::UNIQUE>(lock, timed_wait(timeout_duration));
   }
 
-  void unlock() {
-    {
-      auto lock = std::unique_lock{mtx};
-      state = UNLOCKED;
-    }
-    cv.notify_all();  // multiple lock_shared maybe waiting
-  }
+  void unlock() { release<LockReq::UNIQUE>(); }
 
   template <LockReq Req = LockReq::WRITE>
+    requires(Req != LockReq::UNIQUE)
   void lock_shared() {
     auto lock = std::unique_lock{mtx};
-    acquire<acquire_kind_of(Req)>(lock, blocking_wait());
+    acquire<Req>(lock, blocking_wait());
   }
 
   template <LockReq Req = LockReq::WRITE>
+    requires(Req != LockReq::UNIQUE)
   bool try_lock_shared() {
     auto lock = std::unique_lock{mtx};
-    return try_acquire<acquire_kind_of(Req)>();
+    return try_acquire<Req>();
   }
 
+  /// Demotes a held shared mode to READ. Not an acquisition: the caller already holds the lock, so
+  /// no admission rule applies and a pending UNIQUE cannot block it.
   template <LockReq Req>
+    requires(Req != LockReq::UNIQUE)
   bool downgrade_to_read() {
     auto lock = std::unique_lock{mtx};
     if (state != SHARED) return false;
@@ -259,19 +260,16 @@ struct ResourceLock {
   }
 
   template <typename Rep, typename Period, LockReq Req = LockReq::WRITE>
+    requires(Req != LockReq::UNIQUE)
   bool try_lock_shared_for(std::chrono::duration<Rep, Period> const &time) {
     auto lock = std::unique_lock{mtx};
-    return acquire<acquire_kind_of(Req)>(lock, timed_wait(time));
+    return acquire<Req>(lock, timed_wait(time));
   }
 
   template <LockReq Req = LockReq::WRITE>
+    requires(Req != LockReq::UNIQUE)
   void unlock_shared() {
-    auto lock = std::unique_lock{mtx};
-    unlock_state_updater<Req>();
-    if (unlock_has_fully_unlocked<Req>()) {
-      state = UNLOCKED;
-    }
-    maybe_notify(lock, unlock_should_notify<Req>());
+    release<Req>();
   }
 
  private:
@@ -612,12 +610,12 @@ struct ResourceLockGuard {
 class UniquePendingScope {
  public:
   explicit UniquePendingScope(ResourceLock &lock) : lock_{&lock} {
-    lock_->register_pending<ResourceLock::AcquireKind::UNIQUE>();
+    lock_->register_pending<ResourceLock::LockReq::UNIQUE>();
   }
 
   ~UniquePendingScope() {
     if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
-    lock_->unregister_pending<ResourceLock::AcquireKind::UNIQUE>();
+    lock_->unregister_pending<ResourceLock::LockReq::UNIQUE>();
   }
 
   UniquePendingScope(const UniquePendingScope &) = delete;
@@ -630,7 +628,7 @@ class UniquePendingScope {
   /// intact for the next attempt.
   std::optional<std::unique_lock<ResourceLock>> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
-    if (!lock_->try_acquire_pending<ResourceLock::AcquireKind::UNIQUE>()) return std::nullopt;
+    if (!lock_->try_acquire_pending<ResourceLock::LockReq::UNIQUE>()) return std::nullopt;
     ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
     return std::unique_lock<ResourceLock>{*acquired_lock, std::adopt_lock};
   }
@@ -648,12 +646,12 @@ class UniquePendingScope {
 class ReadOnlyPendingScope {
  public:
   explicit ReadOnlyPendingScope(ResourceLock &lock) : lock_{&lock} {
-    lock_->register_pending<ResourceLock::AcquireKind::READ_ONLY>();
+    lock_->register_pending<ResourceLock::LockReq::READ_ONLY>();
   }
 
   ~ReadOnlyPendingScope() {
     if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
-    lock_->unregister_pending<ResourceLock::AcquireKind::READ_ONLY>();
+    lock_->unregister_pending<ResourceLock::LockReq::READ_ONLY>();
   }
 
   ReadOnlyPendingScope(const ReadOnlyPendingScope &) = delete;
@@ -665,7 +663,7 @@ class ReadOnlyPendingScope {
   /// lock_shared<READ_ONLY>() waits on (see can_acquire<READ_ONLY>). Safe to call repeatedly.
   std::optional<SharedResourceLockGuard> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
-    if (!lock_->try_acquire_pending<ResourceLock::AcquireKind::READ_ONLY>()) return std::nullopt;
+    if (!lock_->try_acquire_pending<ResourceLock::LockReq::READ_ONLY>()) return std::nullopt;
     ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
     return SharedResourceLockGuard{*acquired_lock, SharedResourceLockGuard::Type::READ_ONLY, std::adopt_lock};
   }

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -13,7 +13,10 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include <utility>
+
+#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::utils {
 
@@ -24,18 +27,31 @@ namespace memgraph::utils {
  * and unlocked in another.
  */
 
+// Forward declarations: RAII helpers (defined below, after SharedResourceLockGuard) that keep a
+// pending registration (unique_pending_ / ro_pending_count) alive across a *campaign* of
+// non-blocking probes -- see their definitions for the full rationale. They need friend access
+// to touch mtx/cv/state/counters directly, the same way the member functions above do.
+class UniquePendingScope;
+class ReadOnlyPendingScope;
+
 /// Priority is given to read-only locks over read and write locks
 struct ResourceLock {
+  friend class UniquePendingScope;
+  friend class ReadOnlyPendingScope;
+
   enum class LockReq : uint8_t { READ, WRITE, READ_ONLY };
 
  private:
   enum states : uint8_t { UNLOCKED, UNIQUE, SHARED };
 
   // clang-format off
+  // A pending (blocked-and-waiting) UNIQUE request also gates new shared acquisitions, mirroring
+  // ro_pending_count's priority mechanism for READ_ONLY over WRITE. This gives UNIQUE
+  // writer-preference against a continuous stream of shared (READ/WRITE/READ_ONLY) acquirers.
   template <LockReq Req> bool lock_guard_condition() const;
-  template <> bool lock_guard_condition<LockReq::WRITE>() const     { return ro_count == 0 && ro_pending_count.load(std::memory_order_acquire) == 0; }
-  template <> bool lock_guard_condition<LockReq::READ>() const      { return true; }
-  template <> bool lock_guard_condition<LockReq::READ_ONLY>() const { return w_count == 0; }
+  template <> bool lock_guard_condition<LockReq::WRITE>() const     { return ro_count == 0 && ro_pending_count.load(std::memory_order_acquire) == 0 && unique_pending_.load(std::memory_order_acquire) == 0; }
+  template <> bool lock_guard_condition<LockReq::READ>() const      { return unique_pending_.load(std::memory_order_acquire) == 0; }
+  template <> bool lock_guard_condition<LockReq::READ_ONLY>() const { return w_count == 0 && unique_pending_.load(std::memory_order_acquire) == 0; }
 
   template <LockReq Req> void lock_state_updater();
   template <> void lock_state_updater<LockReq::WRITE>()     { ++w_count; };
@@ -95,13 +111,34 @@ struct ResourceLock {
  public:
   void lock() {
     auto lock = std::unique_lock{mtx};
+    // Register as a pending UNIQUE waiter *before* blocking: this is checked by the shared
+    // acquisition guard conditions (lock_guard_condition<READ|WRITE|READ_ONLY>) so that new shared
+    // acquirers yield to a waiting UNIQUE instead of starving it out indefinitely (mirrors
+    // ro_pending_count's writer-preference mechanism for READ_ONLY over WRITE).
+    unique_pending_.fetch_add(1, std::memory_order_acq_rel);
+    bool acquired = false;
+    // RAII so the decrement (and, if warranted, the wake-up of shared waiters gated on
+    // unique_pending_) happens on every exit path, including an exception thrown out of cv.wait.
+    OnScopeExit pending_guard{[this, &acquired, &lock] {
+      if (unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1 && !acquired) {
+        // We were the last pending UNIQUE waiter and did not acquire (only reachable via an
+        // exception here, since lock() itself never times out) -- wake shared acquirers that were
+        // gated purely on unique_pending_ == 0. Unlock first (matches maybe_notify's style): never
+        // notify_all while still holding mtx.
+        if (lock.owns_lock()) lock.unlock();
+        cv.notify_all();
+      }
+    }};
     // block until available
     cv.wait(lock, [this] { return state == UNLOCKED; });
     state = UNIQUE;
+    acquired = true;
   }
 
   bool try_lock() {
     auto lock = std::unique_lock{mtx};
+    // Non-blocking: never registers as a pending waiter, it never waits so there is nothing to
+    // give priority to.
     if (state == UNLOCKED) {
       state = UNIQUE;
       return true;
@@ -112,10 +149,22 @@ struct ResourceLock {
   template <class Rep, class Period>
   bool try_lock_for(const std::chrono::duration<Rep, Period> &timeout_duration) {
     auto lock = std::unique_lock{mtx};
+    // See lock() above for why this registers as a pending UNIQUE waiter.
+    unique_pending_.fetch_add(1, std::memory_order_acq_rel);
+    bool acquired = false;
+    OnScopeExit pending_guard{[this, &acquired, &lock] {
+      if (unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1 && !acquired) {
+        // Timed out (or threw) without acquiring: if we were the last pending UNIQUE waiter, wake
+        // shared acquirers that were gated purely on unique_pending_ == 0 so they can re-check now.
+        if (lock.owns_lock()) lock.unlock();
+        cv.notify_all();
+      }
+    }};
     if (!cv.wait_for(lock, timeout_duration, [this] { return state == UNLOCKED; })) {
       return false;
     }
     state = UNIQUE;
+    acquired = true;
     return true;
   }
 
@@ -131,10 +180,12 @@ struct ResourceLock {
   void lock_shared() {
     auto lock = std::unique_lock{mtx};
     lock_pre_state_change<Req>();
+    // RAII: guarantees lock_post_state_change runs on every exit path (including an exception
+    // thrown out of cv.wait), so a pending-counter (e.g. ro_pending_count) can never leak.
+    OnScopeExit post_state_change_guard{[this] { lock_post_state_change<Req>(); }};
     cv.wait(lock, [this] { return state != UNIQUE && lock_guard_condition<Req>(); });
     state = SHARED;
     lock_state_updater<Req>();
-    lock_post_state_change<Req>();
   }
 
   template <LockReq Req = LockReq::WRITE>
@@ -162,14 +213,23 @@ struct ResourceLock {
   bool try_lock_shared_for(std::chrono::duration<Rep, Period> const &time) {
     auto lock = std::unique_lock{mtx};
     lock_pre_state_change<Req>();
-    if (!cv.wait_for(lock, time, [this] { return state != UNIQUE && lock_guard_condition<Req>(); })) {
+    bool acquired = false;
+    // RAII: guarantees lock_post_state_change runs on every exit path (including an exception
+    // thrown out of cv.wait_for), so a pending-counter (e.g. ro_pending_count) can never leak.
+    // On the non-acquired path (timeout or exception) also fire the same notify the old explicit
+    // failure branch used, so anything gated on the pending-counter reaching 0 is woken.
+    OnScopeExit post_state_change_guard{[this, &acquired, &lock] {
       lock_post_state_change<Req>();
-      maybe_notify<Req>(lock, lock_failed_wait_should_notify<Req>());
+      if (!acquired) {
+        maybe_notify<Req>(lock, lock_failed_wait_should_notify<Req>());
+      }
+    }};
+    if (!cv.wait_for(lock, time, [this] { return state != UNIQUE && lock_guard_condition<Req>(); })) {
       return false;
     }
     state = SHARED;
     lock_state_updater<Req>();
-    lock_post_state_change<Req>();
+    acquired = true;
     return true;
   }
 
@@ -191,6 +251,11 @@ struct ResourceLock {
   std::atomic<uint32_t> ro_pending_count = 0;
   uint32_t w_count = 0;
   uint32_t r_count = 0;
+  // Number of threads currently blocked in lock()/try_lock_for() waiting to acquire UNIQUE.
+  // Gates new shared (READ/WRITE/READ_ONLY) acquisitions (see lock_guard_condition) to give a
+  // waiting UNIQUE writer-preference against continuous shared load. try_lock() (non-blocking)
+  // never touches this counter.
+  std::atomic<uint32_t> unique_pending_ = 0;
 };
 
 struct SharedResourceLockGuard {
@@ -204,6 +269,14 @@ struct SharedResourceLockGuard {
   SharedResourceLockGuard(ResourceLock &l, Type type, std::try_to_lock_t /*tag*/) : ptr_{&l}, type_{type} {
     try_lock();
   }
+
+  /// Adopts a shared lock of `type` on `l` that the caller has *already* acquired (e.g. via
+  /// ReadOnlyPendingScope::try_acquire()). Mirrors std::unique_lock's std::adopt_lock_t
+  /// constructor: no locking is attempted here, the guard simply takes ownership of an
+  /// acquisition that has already happened, so unlock() runs exactly once when this guard is
+  /// destroyed or explicitly unlocked.
+  SharedResourceLockGuard(ResourceLock &l, Type type, std::adopt_lock_t /*tag*/)
+      : ptr_{&l}, type_{type}, locked_{true} {}
 
   ~SharedResourceLockGuard() { unlock(); }
 
@@ -487,6 +560,143 @@ struct ResourceLockGuard {
   ResourceLock *ptr_;
   Type type_;
   bool locked_{false};
+};
+
+/// RAII helper that keeps a single caller registered as a pending UNIQUE waiter across a
+/// non-blocking *probe campaign*: a caller that cannot afford to block on lock()'s condition
+/// variable (e.g. a coroutine that must yield back to a scheduler instead of sleeping) but still
+/// wants writer-preference against a continuous stream of new shared (READ/WRITE/READ_ONLY)
+/// acquirers while it repeatedly polls try_acquire().
+///
+/// Why this is needed: a bare try_lock() (see ResourceLock::try_lock()) never touches
+/// unique_pending_ -- by design, since a single non-blocking attempt has nothing to give
+/// priority to. But a *retrying* caller that loops try_lock() is therefore just another
+/// unprivileged contender on every iteration and can starve forever behind back-to-back short
+/// shared holders. Holding a UniquePendingScope for the duration of the whole retry loop bumps
+/// unique_pending_ once, up front, which gates *new* shared acquirers exactly as a blocking
+/// lock() waiter would (see lock_guard_condition<READ|WRITE|READ_ONLY>): in-flight shared
+/// holders are left alone to drain, but fresh ones are blocked, so the pool of shared holders
+/// shrinks to zero and the retrying UNIQUE probe eventually finds state == UNLOCKED.
+///
+/// Ownership on success: try_acquire() either returns std::nullopt (still not acquired -- the
+/// scope remains registered as pending so the *next* try_acquire() call keeps the same
+/// writer-preference gate up) or a std::unique_lock<ResourceLock> that has taken over the
+/// acquired UNIQUE lock. On success the scope stops counting as pending immediately -- it now
+/// HOLDS the lock, it is no longer merely waiting for one -- and becomes inert: its destructor
+/// is a no-op from that point on (ownership, including the eventual unlock(), belongs solely to
+/// the returned std::unique_lock, mirroring Accessor::ReleaseUniqueGuard()'s single-owner
+/// hand-off). If the scope is destroyed without ever having succeeded, its destructor decrements
+/// unique_pending_ and, mirroring lock()'s own pending cleanup, wakes any shared acquirers that
+/// were gated purely on unique_pending_ reaching 0.
+///
+/// Not copyable or movable: the pending registration is tied 1:1 to this scope's lifetime.
+class UniquePendingScope {
+ public:
+  explicit UniquePendingScope(ResourceLock &lock) : lock_{&lock} {
+    auto guard = std::unique_lock{lock_->mtx};
+    lock_->unique_pending_.fetch_add(1, std::memory_order_acq_rel);
+  }
+
+  ~UniquePendingScope() {
+    if (lock_ == nullptr) return;  // ownership already transferred out by a successful try_acquire()
+    if (lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      // We were the last pending UNIQUE waiter and never acquired -- wake shared acquirers that
+      // were gated purely on unique_pending_ == 0 so they can re-check now (same notify this
+      // counter's blocking counterpart, ResourceLock::lock(), performs on its failure path).
+      lock_->cv.notify_all();
+    }
+  }
+
+  UniquePendingScope(const UniquePendingScope &) = delete;
+  UniquePendingScope &operator=(const UniquePendingScope &) = delete;
+  UniquePendingScope(UniquePendingScope &&) = delete;
+  UniquePendingScope &operator=(UniquePendingScope &&) = delete;
+
+  /// Non-blocking attempt to take UNIQUE. Succeeds only when the lock is currently UNLOCKED
+  /// (existing UNIQUE/SHARED holders are never preempted -- only new shared acquirers are gated
+  /// by this scope's pending registration). Safe to call repeatedly; each failed call leaves the
+  /// pending registration intact for the next attempt.
+  std::optional<std::unique_lock<ResourceLock>> try_acquire() {
+    if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
+    bool acquired = false;
+    {
+      auto guard = std::unique_lock{lock_->mtx};
+      if (lock_->state == ResourceLock::UNLOCKED) {
+        lock_->state = ResourceLock::UNIQUE;
+        acquired = true;
+      }
+    }
+    if (!acquired) return std::nullopt;
+    // Transition pending -> held: decrement the counter (we are no longer *waiting*) but do not
+    // notify here -- exactly like ResourceLock::lock()'s success path, waking gated shared
+    // acquirers is deferred until this thread eventually calls unlock() (state is still UNIQUE,
+    // so there is nothing for them to do yet).
+    lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel);
+    ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
+    return std::unique_lock<ResourceLock>{*acquired_lock, std::adopt_lock};
+  }
+
+ private:
+  ResourceLock *lock_;
+};
+
+/// Same shape as UniquePendingScope, but for READ_ONLY: keeps a single caller registered as a
+/// pending READ_ONLY waiter (bumping ro_pending_count, ResourceLock's existing mechanism for
+/// giving READ_ONLY priority over WRITE) across a non-blocking probe campaign, so a retrying
+/// try_acquire() gets the same "new WRITE acquirers are gated" priority a blocking
+/// lock_shared<READ_ONLY>() call already gets.
+///
+/// Ownership on success mirrors UniquePendingScope: try_acquire() returns a
+/// SharedResourceLockGuard that has adopted the acquired READ_ONLY lock (see
+/// SharedResourceLockGuard's std::adopt_lock_t constructor), the scope stops counting as pending
+/// immediately, and becomes inert (destructor is a no-op) -- the returned guard owns the
+/// eventual unlock_shared() call. If destroyed without ever succeeding, the destructor
+/// decrements ro_pending_count and, if it reached 0, wakes acquirers gated on that (mirrors
+/// ResourceLock::lock_failed_wait_should_notify<READ_ONLY>).
+class ReadOnlyPendingScope {
+ public:
+  explicit ReadOnlyPendingScope(ResourceLock &lock) : lock_{&lock} {
+    auto guard = std::unique_lock{lock_->mtx};
+    lock_->ro_pending_count.fetch_add(1, std::memory_order_acq_rel);
+  }
+
+  ~ReadOnlyPendingScope() {
+    if (lock_ == nullptr) return;  // ownership already transferred out by a successful try_acquire()
+    if (lock_->ro_pending_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      lock_->cv.notify_all();
+    }
+  }
+
+  ReadOnlyPendingScope(const ReadOnlyPendingScope &) = delete;
+  ReadOnlyPendingScope &operator=(const ReadOnlyPendingScope &) = delete;
+  ReadOnlyPendingScope(ReadOnlyPendingScope &&) = delete;
+  ReadOnlyPendingScope &operator=(ReadOnlyPendingScope &&) = delete;
+
+  /// Non-blocking attempt to take READ_ONLY. Needs w_count == 0 && unique_pending_ == 0 (same
+  /// condition as ResourceLock::lock_guard_condition<READ_ONLY>): existing WRITE holders drain
+  /// naturally, and a pending/held UNIQUE keeps its writer-preference over us too.
+  std::optional<SharedResourceLockGuard> try_acquire() {
+    if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
+    bool acquired = false;
+    {
+      auto guard = std::unique_lock{lock_->mtx};
+      if (lock_->state != ResourceLock::UNIQUE && lock_->w_count == 0 &&
+          lock_->unique_pending_.load(std::memory_order_acquire) == 0) {
+        lock_->state = ResourceLock::SHARED;
+        ++lock_->ro_count;
+        acquired = true;
+      }
+    }
+    if (!acquired) return std::nullopt;
+    // Transition pending -> held: decrement without notifying, mirroring UniquePendingScope's
+    // success path (nothing to unblock yet -- we now hold the resource ourselves).
+    lock_->ro_pending_count.fetch_sub(1, std::memory_order_acq_rel);
+    ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
+    return SharedResourceLockGuard{*acquired_lock, SharedResourceLockGuard::Type::READ_ONLY, std::adopt_lock};
+  }
+
+ private:
+  ResourceLock *lock_;
 };
 
 }  // namespace memgraph::utils

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -107,6 +107,11 @@ struct ResourceLock {
   template <> void unlock_state_updater<LockReq::READ>()      { --r_count; };
   template <> void unlock_state_updater<LockReq::READ_ONLY>() { --ro_count; }
 
+  // WRITE omits ro_count, and READ_ONLY omits w_count, because the two are mutually exclusive by
+  // admission (can_acquire<WRITE> demands ro_count == 0, can_acquire<READ_ONLY> demands
+  // w_count == 0), so the omitted count is necessarily 0 whenever the other is being released.
+  // Relax either admission rule without revisiting these and the lock declares itself UNLOCKED
+  // while a holder is still live.
   template <LockReq Req> bool unlock_has_fully_unlocked() const;
   template <> bool unlock_has_fully_unlocked<LockReq::WRITE>() const     { return w_count == 0 && r_count == 0; };
   template <> bool unlock_has_fully_unlocked<LockReq::READ>() const      { return r_count == 0 && ro_count == 0 && w_count == 0; };
@@ -117,6 +122,12 @@ struct ResourceLock {
   // WRITE -> If w_count goes down to 0, READ_ONLY and UNIQUE maybe unblocked, hence: Notify All
   // READ -> If r_count goes down to 0 (and other counts were already 0), UNIQUE maybe unblocked
   // READ_ONLY -> If ro_count goes down to 0, WRITE and  UNIQUE maybe unblocked, hence: Notify All
+  //
+  // WRITE and READ_ONLY notify on a weaker condition than the fully-unlocked one above: dropping to
+  // 0 admits READ_ONLY resp. WRITE even while a READ hold keeps the lock SHARED, and no later event
+  // is guaranteed to fire (that READ may be held indefinitely). READ notifies on exactly the
+  // fully-unlocked condition because no acquirer is gated on r_count, so a READ release can only
+  // ever admit UNIQUE, and only by freeing the lock.
   template <LockReq Req> NotifyKind unlock_should_notify() const;
   template <> NotifyKind unlock_should_notify<LockReq::WRITE>() const { return w_count == 0 ? NotifyKind::All : NotifyKind::None; }
   template <> NotifyKind unlock_should_notify<LockReq::READ>() const { return (r_count == 0 && w_count == 0 && ro_count == 0) ? NotifyKind::All : NotifyKind::None; }
@@ -134,11 +145,11 @@ struct ResourceLock {
   ///
   /// The pending registration is dropped by RAII because it must survive a timeout and an exception
   /// out of the wait too: leak it once and every kind it gates is blocked for the lifetime of the
-  /// process. The handler runs with mtx still held (cv.wait/wait_for re-acquire it
-  /// on every exit path, and `lock` outlives the guard declared after it), which is what serializes
-  /// the deregistration against another thread reading that same counter inside its own wait
-  /// predicate: mutate it off-mtx and the decrement plus notify can land between that thread's
-  /// check and its enqueue on the cv, losing the wake.
+  /// process. The handler runs with mtx still held (cv.wait/wait_for re-acquire it on every exit
+  /// path, and `lock` outlives the guard declared after it), which is what serializes the
+  /// deregistration against another thread reading that same counter inside its own wait predicate:
+  /// mutate it off-mtx and the decrement plus notify can land between that thread's check and its
+  /// enqueue on the cv, losing the wake.
   template <AcquireKind K>
   bool acquire(std::unique_lock<std::mutex> &lock, auto &&wait) {
     pending_add<K>();

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -27,10 +27,8 @@ namespace memgraph::utils {
  * and unlocked in another.
  */
 
-// Forward declarations: RAII helpers (defined below, after SharedResourceLockGuard) that keep a
-// pending registration (unique_pending_ / ro_pending_count) alive across a *campaign* of
-// non-blocking probes -- see their definitions for the full rationale. They need friend access
-// to touch mtx/cv/state/counters directly, the same way the member functions above do.
+// RAII helpers (defined below) that keep a pending registration alive across a campaign of
+// non-blocking probes; need friend access to the lock internals. See their definitions.
 class UniquePendingScope;
 class ReadOnlyPendingScope;
 
@@ -45,9 +43,8 @@ struct ResourceLock {
   enum states : uint8_t { UNLOCKED, UNIQUE, SHARED };
 
   // clang-format off
-  // A pending (blocked-and-waiting) UNIQUE request also gates new shared acquisitions, mirroring
-  // ro_pending_count's priority mechanism for READ_ONLY over WRITE. This gives UNIQUE
-  // writer-preference against a continuous stream of shared (READ/WRITE/READ_ONLY) acquirers.
+  // A waiting UNIQUE (unique_pending_) gates new shared acquisitions (writer-preference), mirroring
+  // ro_pending_count's READ_ONLY-over-WRITE priority.
   template <LockReq Req> bool lock_guard_condition() const;
   template <> bool lock_guard_condition<LockReq::WRITE>() const     { return ro_count == 0 && ro_pending_count.load(std::memory_order_acquire) == 0 && unique_pending_.load(std::memory_order_acquire) == 0; }
   template <> bool lock_guard_condition<LockReq::READ>() const      { return unique_pending_.load(std::memory_order_acquire) == 0; }
@@ -111,20 +108,14 @@ struct ResourceLock {
  public:
   void lock() {
     auto lock = std::unique_lock{mtx};
-    // Register as a pending UNIQUE waiter *before* blocking: this is checked by the shared
-    // acquisition guard conditions (lock_guard_condition<READ|WRITE|READ_ONLY>) so that new shared
-    // acquirers yield to a waiting UNIQUE instead of starving it out indefinitely (mirrors
-    // ro_pending_count's writer-preference mechanism for READ_ONLY over WRITE).
+    // Register as a pending UNIQUE waiter before blocking so new shared acquirers yield to us
+    // (writer-preference; see lock_guard_condition). RAII decrements on every exit path (incl. an
+    // exception out of cv.wait) and, if we were the last pending waiter without acquiring, wakes
+    // shared acquirers gated on unique_pending_. Unlock before notify_all (never notify under mtx).
     unique_pending_.fetch_add(1, std::memory_order_acq_rel);
     bool acquired = false;
-    // RAII so the decrement (and, if warranted, the wake-up of shared waiters gated on
-    // unique_pending_) happens on every exit path, including an exception thrown out of cv.wait.
     OnScopeExit pending_guard{[this, &acquired, &lock] {
       if (unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1 && !acquired) {
-        // We were the last pending UNIQUE waiter and did not acquire (only reachable via an
-        // exception here, since lock() itself never times out) -- wake shared acquirers that were
-        // gated purely on unique_pending_ == 0. Unlock first (matches maybe_notify's style): never
-        // notify_all while still holding mtx.
         if (lock.owns_lock()) lock.unlock();
         cv.notify_all();
       }
@@ -137,8 +128,7 @@ struct ResourceLock {
 
   bool try_lock() {
     auto lock = std::unique_lock{mtx};
-    // Non-blocking: never registers as a pending waiter, it never waits so there is nothing to
-    // give priority to.
+    // Non-blocking: never registers as pending (nothing to give priority to).
     if (state == UNLOCKED) {
       state = UNIQUE;
       return true;
@@ -149,13 +139,11 @@ struct ResourceLock {
   template <class Rep, class Period>
   bool try_lock_for(const std::chrono::duration<Rep, Period> &timeout_duration) {
     auto lock = std::unique_lock{mtx};
-    // See lock() above for why this registers as a pending UNIQUE waiter.
+    // Registers as a pending UNIQUE waiter; see lock() for the writer-preference rationale.
     unique_pending_.fetch_add(1, std::memory_order_acq_rel);
     bool acquired = false;
     OnScopeExit pending_guard{[this, &acquired, &lock] {
       if (unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1 && !acquired) {
-        // Timed out (or threw) without acquiring: if we were the last pending UNIQUE waiter, wake
-        // shared acquirers that were gated purely on unique_pending_ == 0 so they can re-check now.
         if (lock.owns_lock()) lock.unlock();
         cv.notify_all();
       }
@@ -180,8 +168,8 @@ struct ResourceLock {
   void lock_shared() {
     auto lock = std::unique_lock{mtx};
     lock_pre_state_change<Req>();
-    // RAII: guarantees lock_post_state_change runs on every exit path (including an exception
-    // thrown out of cv.wait), so a pending-counter (e.g. ro_pending_count) can never leak.
+    // RAII: run lock_post_state_change on every exit path (incl. an exception out of cv.wait) so a
+    // pending-counter (e.g. ro_pending_count) never leaks.
     OnScopeExit post_state_change_guard{[this] { lock_post_state_change<Req>(); }};
     cv.wait(lock, [this] { return state != UNIQUE && lock_guard_condition<Req>(); });
     state = SHARED;
@@ -214,10 +202,8 @@ struct ResourceLock {
     auto lock = std::unique_lock{mtx};
     lock_pre_state_change<Req>();
     bool acquired = false;
-    // RAII: guarantees lock_post_state_change runs on every exit path (including an exception
-    // thrown out of cv.wait_for), so a pending-counter (e.g. ro_pending_count) can never leak.
-    // On the non-acquired path (timeout or exception) also fire the same notify the old explicit
-    // failure branch used, so anything gated on the pending-counter reaching 0 is woken.
+    // RAII: run lock_post_state_change on every exit path (see lock_shared); on the non-acquired
+    // path also notify so anything gated on the pending-counter reaching 0 is woken.
     OnScopeExit post_state_change_guard{[this, &acquired, &lock] {
       lock_post_state_change<Req>();
       if (!acquired) {
@@ -251,10 +237,8 @@ struct ResourceLock {
   std::atomic<uint32_t> ro_pending_count = 0;
   uint32_t w_count = 0;
   uint32_t r_count = 0;
-  // Number of threads currently blocked in lock()/try_lock_for() waiting to acquire UNIQUE.
-  // Gates new shared (READ/WRITE/READ_ONLY) acquisitions (see lock_guard_condition) to give a
-  // waiting UNIQUE writer-preference against continuous shared load. try_lock() (non-blocking)
-  // never touches this counter.
+  // Threads waiting to acquire UNIQUE (blocking lock()/try_lock_for() or a UniquePendingScope).
+  // Gates new shared acquisitions for writer-preference; see lock_guard_condition.
   std::atomic<uint32_t> unique_pending_ = 0;
 };
 
@@ -270,11 +254,9 @@ struct SharedResourceLockGuard {
     try_lock();
   }
 
-  /// Adopts a shared lock of `type` on `l` that the caller has *already* acquired (e.g. via
-  /// ReadOnlyPendingScope::try_acquire()). Mirrors std::unique_lock's std::adopt_lock_t
-  /// constructor: no locking is attempted here, the guard simply takes ownership of an
-  /// acquisition that has already happened, so unlock() runs exactly once when this guard is
-  /// destroyed or explicitly unlocked.
+  /// Adopts a shared lock of `type` already acquired by the caller (e.g. via
+  /// ReadOnlyPendingScope::try_acquire()), like std::unique_lock's std::adopt_lock_t ctor: takes
+  /// ownership without locking, so unlock() runs exactly once on destruction.
   SharedResourceLockGuard(ResourceLock &l, Type type, std::adopt_lock_t /*tag*/)
       : ptr_{&l}, type_{type}, locked_{true} {}
 
@@ -562,34 +544,22 @@ struct ResourceLockGuard {
   bool locked_{false};
 };
 
-/// RAII helper that keeps a single caller registered as a pending UNIQUE waiter across a
-/// non-blocking *probe campaign*: a caller that cannot afford to block on lock()'s condition
-/// variable (e.g. a coroutine that must yield back to a scheduler instead of sleeping) but still
-/// wants writer-preference against a continuous stream of new shared (READ/WRITE/READ_ONLY)
-/// acquirers while it repeatedly polls try_acquire().
+/// RAII helper that keeps a caller registered as a pending UNIQUE waiter across a non-blocking
+/// probe campaign, for callers that cannot block on lock()'s cv (e.g. a coroutine that must yield
+/// to a scheduler) but still want writer-preference while they poll try_acquire().
 ///
-/// Why this is needed: a bare try_lock() (see ResourceLock::try_lock()) never touches
-/// unique_pending_ -- by design, since a single non-blocking attempt has nothing to give
-/// priority to. But a *retrying* caller that loops try_lock() is therefore just another
-/// unprivileged contender on every iteration and can starve forever behind back-to-back short
-/// shared holders. Holding a UniquePendingScope for the duration of the whole retry loop bumps
-/// unique_pending_ once, up front, which gates *new* shared acquirers exactly as a blocking
-/// lock() waiter would (see lock_guard_condition<READ|WRITE|READ_ONLY>): in-flight shared
-/// holders are left alone to drain, but fresh ones are blocked, so the pool of shared holders
-/// shrinks to zero and the retrying UNIQUE probe eventually finds state == UNLOCKED.
+/// A bare try_lock() loop never touches unique_pending_, so it is just another unprivileged
+/// contender each iteration and can starve behind back-to-back shared holders. This scope bumps
+/// unique_pending_ once up front, gating new shared acquirers (see lock_guard_condition) so the
+/// shared pool drains and the probe eventually finds state == UNLOCKED.
 ///
-/// Ownership on success: try_acquire() either returns std::nullopt (still not acquired -- the
-/// scope remains registered as pending so the *next* try_acquire() call keeps the same
-/// writer-preference gate up) or a std::unique_lock<ResourceLock> that has taken over the
-/// acquired UNIQUE lock. On success the scope stops counting as pending immediately -- it now
-/// HOLDS the lock, it is no longer merely waiting for one -- and becomes inert: its destructor
-/// is a no-op from that point on (ownership, including the eventual unlock(), belongs solely to
-/// the returned std::unique_lock, mirroring Accessor::ReleaseUniqueGuard()'s single-owner
-/// hand-off). If the scope is destroyed without ever having succeeded, its destructor decrements
-/// unique_pending_ and, mirroring lock()'s own pending cleanup, wakes any shared acquirers that
-/// were gated purely on unique_pending_ reaching 0.
+/// Ownership: try_acquire() returns nullopt (still pending, gate stays up) or a
+/// std::unique_lock<ResourceLock> owning the acquired lock. On success the scope stops counting as
+/// pending and becomes inert (destructor is a no-op); the returned lock owns the unlock(). If
+/// destroyed without acquiring, the destructor decrements unique_pending_ and wakes gated shared
+/// acquirers (as lock()'s failure path does).
 ///
-/// Not copyable or movable: the pending registration is tied 1:1 to this scope's lifetime.
+/// Not copyable or movable: the registration is tied 1:1 to this scope's lifetime.
 class UniquePendingScope {
  public:
   explicit UniquePendingScope(ResourceLock &lock) : lock_{&lock} {
@@ -598,22 +568,16 @@ class UniquePendingScope {
   }
 
   ~UniquePendingScope() {
-    if (lock_ == nullptr) return;  // ownership already transferred out by a successful try_acquire()
-    // Decrement the pending counter *under mtx*, mirroring ResourceLock::lock()'s failure path.
-    // A shared acquirer tests `unique_pending_ == 0` inside cv.wait's predicate while holding mtx;
-    // if we mutated the counter off-mtx, our fetch_sub + notify_all could land in the window
-    // between that thread's predicate check and its enqueue on the cv, losing the wake and hanging
-    // it forever. Mutating under the waiter's mutex serializes against that check. Release mtx
-    // before notifying (never notify_all while holding mtx).
+    if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
+    // Decrement under mtx to serialize against a shared acquirer testing unique_pending_ == 0 in
+    // cv.wait's predicate; otherwise fetch_sub + notify could slip between its check and enqueue
+    // and lose the wake. Release mtx before notifying (never notify under mtx).
     bool was_last_waiter = false;
     {
       auto guard = std::unique_lock{lock_->mtx};
       was_last_waiter = lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel) == 1;
     }
     if (was_last_waiter) {
-      // We were the last pending UNIQUE waiter and never acquired -- wake shared acquirers that
-      // were gated purely on unique_pending_ == 0 so they can re-check now (same notify this
-      // counter's blocking counterpart, ResourceLock::lock(), performs on its failure path).
       lock_->cv.notify_all();
     }
   }
@@ -623,10 +587,9 @@ class UniquePendingScope {
   UniquePendingScope(UniquePendingScope &&) = delete;
   UniquePendingScope &operator=(UniquePendingScope &&) = delete;
 
-  /// Non-blocking attempt to take UNIQUE. Succeeds only when the lock is currently UNLOCKED
-  /// (existing UNIQUE/SHARED holders are never preempted -- only new shared acquirers are gated
-  /// by this scope's pending registration). Safe to call repeatedly; each failed call leaves the
-  /// pending registration intact for the next attempt.
+  /// Non-blocking attempt to take UNIQUE; succeeds only when the lock is UNLOCKED (existing holders
+  /// are never preempted). Safe to call repeatedly; a failed call leaves the pending registration
+  /// intact for the next attempt.
   std::optional<std::unique_lock<ResourceLock>> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
     bool acquired = false;
@@ -638,10 +601,8 @@ class UniquePendingScope {
       }
     }
     if (!acquired) return std::nullopt;
-    // Transition pending -> held: decrement the counter (we are no longer *waiting*) but do not
-    // notify here -- exactly like ResourceLock::lock()'s success path, waking gated shared
-    // acquirers is deferred until this thread eventually calls unlock() (state is still UNIQUE,
-    // so there is nothing for them to do yet).
+    // pending -> held: decrement (no longer waiting) without notifying; like lock()'s success path,
+    // waking gated shared acquirers is deferred to unlock() (state is still UNIQUE).
     lock_->unique_pending_.fetch_sub(1, std::memory_order_acq_rel);
     ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
     return std::unique_lock<ResourceLock>{*acquired_lock, std::adopt_lock};
@@ -651,19 +612,12 @@ class UniquePendingScope {
   ResourceLock *lock_;
 };
 
-/// Same shape as UniquePendingScope, but for READ_ONLY: keeps a single caller registered as a
-/// pending READ_ONLY waiter (bumping ro_pending_count, ResourceLock's existing mechanism for
-/// giving READ_ONLY priority over WRITE) across a non-blocking probe campaign, so a retrying
-/// try_acquire() gets the same "new WRITE acquirers are gated" priority a blocking
-/// lock_shared<READ_ONLY>() call already gets.
-///
-/// Ownership on success mirrors UniquePendingScope: try_acquire() returns a
-/// SharedResourceLockGuard that has adopted the acquired READ_ONLY lock (see
-/// SharedResourceLockGuard's std::adopt_lock_t constructor), the scope stops counting as pending
-/// immediately, and becomes inert (destructor is a no-op) -- the returned guard owns the
-/// eventual unlock_shared() call. If destroyed without ever succeeding, the destructor
-/// decrements ro_pending_count and, if it reached 0, wakes acquirers gated on that (mirrors
-/// ResourceLock::lock_failed_wait_should_notify<READ_ONLY>).
+/// Like UniquePendingScope, but for READ_ONLY: registers a pending READ_ONLY waiter (bumping
+/// ro_pending_count, the existing READ_ONLY-over-WRITE priority mechanism) across a non-blocking
+/// probe campaign, so a retrying try_acquire() gets the same gating a blocking
+/// lock_shared<READ_ONLY>() gets. Ownership/lifetime mirror UniquePendingScope: try_acquire()
+/// returns a SharedResourceLockGuard that adopted the lock; if destroyed without acquiring, the
+/// destructor decrements ro_pending_count and wakes gated acquirers.
 class ReadOnlyPendingScope {
  public:
   explicit ReadOnlyPendingScope(ResourceLock &lock) : lock_{&lock} {
@@ -672,10 +626,8 @@ class ReadOnlyPendingScope {
   }
 
   ~ReadOnlyPendingScope() {
-    if (lock_ == nullptr) return;  // ownership already transferred out by a successful try_acquire()
-    // Decrement *under mtx* -- see ~UniquePendingScope for the lost-wakeup rationale (here the
-    // gated waiter is a blocking lock_shared<WRITE>() testing `ro_pending_count == 0`). Release
-    // before notifying.
+    if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
+    // Decrement under mtx; see ~UniquePendingScope for the lost-wakeup rationale.
     bool was_last_waiter = false;
     {
       auto guard = std::unique_lock{lock_->mtx};
@@ -691,9 +643,8 @@ class ReadOnlyPendingScope {
   ReadOnlyPendingScope(ReadOnlyPendingScope &&) = delete;
   ReadOnlyPendingScope &operator=(ReadOnlyPendingScope &&) = delete;
 
-  /// Non-blocking attempt to take READ_ONLY. Needs w_count == 0 && unique_pending_ == 0 (same
-  /// condition as ResourceLock::lock_guard_condition<READ_ONLY>): existing WRITE holders drain
-  /// naturally, and a pending/held UNIQUE keeps its writer-preference over us too.
+  /// Non-blocking attempt to take READ_ONLY; needs w_count == 0 && unique_pending_ == 0 (same as
+  /// lock_guard_condition<READ_ONLY>). Safe to call repeatedly.
   std::optional<SharedResourceLockGuard> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
     bool acquired = false;
@@ -707,8 +658,7 @@ class ReadOnlyPendingScope {
       }
     }
     if (!acquired) return std::nullopt;
-    // Transition pending -> held: decrement without notifying, mirroring UniquePendingScope's
-    // success path (nothing to unblock yet -- we now hold the resource ourselves).
+    // pending -> held: decrement without notifying (see UniquePendingScope::try_acquire).
     lock_->ro_pending_count.fetch_sub(1, std::memory_order_acq_rel);
     ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
     return SharedResourceLockGuard{*acquired_lock, SharedResourceLockGuard::Type::READ_ONLY, std::adopt_lock};

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -12,8 +12,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <limits>
+#include <thread>
 
 #include "disk_test_utils.hpp"
 #include "storage/v2/disk/storage.hpp"
@@ -2824,4 +2827,59 @@ TYPED_TEST(StorageV2Test, UpdatesLabelsCountAfterAbort) {
     ASSERT_EQ(counts[label2], 1);
     ASSERT_EQ(counts[label3], 0);
   }
+}
+
+// A GC pass in analytical mode must never block a UNIQUE acquirer out. GC picks its lock mode by
+// reading storage_mode_ under a shared hold; escalating that hold rather than replacing it would
+// deadlock against a UNIQUE acquirer registering as pending in between, since the WRITE guard
+// condition is gated on unique_pending_ and that acquirer waits on the READ still held.
+//
+// The acquirers take a timeout so such a deadlock reports as a timeout instead of hanging the
+// binary. GC holds one mode at a time, so its holds are short and no acquirer should time out.
+TEST(StorageAnalyticalGcTest, GcDoesNotBlockOutUniqueAcquirers) {
+  using namespace std::chrono_literals;
+  constexpr auto kUniqueTimeout = 500ms;
+  constexpr auto kDuration = 2s;
+  constexpr int kGcThreads = 4;
+  constexpr int kUniqueThreads = 1;
+
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+  store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> unique_timeouts{0};
+  std::atomic<int> unique_acquisitions{0};
+
+  std::vector<std::jthread> threads;
+  threads.reserve(kGcThreads + kUniqueThreads);
+
+  for (int i = 0; i < kGcThreads; ++i) {
+    threads.emplace_back([&] {
+      // Qualified: InMemoryStorage's two-arg override hides the base's no-arg convenience overload.
+      while (!stop.load(std::memory_order_relaxed)) store.Storage::FreeMemory();
+    });
+  }
+
+  for (int i = 0; i < kUniqueThreads; ++i) {
+    threads.emplace_back([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        try {
+          auto acc = store.UniqueAccess(std::nullopt, kUniqueTimeout);
+          unique_acquisitions.fetch_add(1, std::memory_order_relaxed);
+          acc->Abort();
+        } catch (memgraph::storage::UniqueAccessTimeout const &) {
+          unique_timeouts.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(kDuration);
+  stop.store(true, std::memory_order_relaxed);
+  threads.clear();
+
+  EXPECT_GT(unique_acquisitions.load(), 0) << "no UNIQUE acquirer ever got in; the test proved nothing";
+  EXPECT_EQ(unique_timeouts.load(), 0) << "a UNIQUE acquirer was blocked out for " << kUniqueTimeout.count()
+                                       << "ms by a concurrent analytical GC pass";
 }

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -1028,6 +1028,116 @@ TEST_F(ResourceLockTest, ReadReleaseWakesBothPendingUniqueAndGatedReader) {
   EXPECT_TRUE(reader_acquired.load(std::memory_order_acquire));
 }
 
+// A downgraded hold must still free the lock when released. Downgrading rewrites the shared counts
+// without consulting the admission rules, so a slip there leaves a count standing that no release
+// will ever clear: the lock never returns to unlocked and a waiting UNIQUE waits forever. Both
+// source modes are covered because both are downgraded in anger, WRITE by garbage collection and
+// READ_ONLY at the end of index creation.
+TEST_F(ResourceLockTest, DowngradedHoldStillFreesTheLockForAWaitingUnique) {
+  using namespace std::chrono_literals;
+
+  auto check = [this](SharedResourceLockGuard::Type from) {
+    auto guard = SharedResourceLockGuard(lock, from);
+    ASSERT_TRUE(guard.owns_lock());
+
+    std::atomic<bool> unique_acquired{false};
+    auto unique_fut = std::async(std::launch::async, [&] {
+      lock.lock();  // parks: the shared hold keeps the lock from being free
+      unique_acquired.store(true, std::memory_order_release);
+      lock.unlock();
+    });
+
+    std::this_thread::sleep_for(50ms);
+    ASSERT_FALSE(unique_acquired.load(std::memory_order_acquire));
+
+    ASSERT_TRUE(guard.downgrade_to_read());
+    // Still a shared hold, so the UNIQUE stays parked: downgrading gives up exclusivity against
+    // other shared modes, not the hold itself.
+    std::this_thread::sleep_for(50ms);
+    ASSERT_FALSE(unique_acquired.load(std::memory_order_acquire));
+
+    guard.unlock();  // releases in READ, the mode it now holds
+
+    // Bounded so a stranded count fails the test instead of hanging the suite forever.
+    const auto status = unique_fut.wait_for(5s);
+    EXPECT_EQ(status, std::future_status::ready)
+        << "UNIQUE never acquired after the downgraded hold was released: the release did not "
+           "return the lock to unlocked";
+    if (status != std::future_status::ready) {
+      unique_fut.wait();  // failure path only: the parked thread still owns the future
+      return;
+    }
+    unique_fut.get();
+  };
+
+  check(SharedResourceLockGuard::WRITE);
+  check(SharedResourceLockGuard::READ_ONLY);
+}
+
+// A timed UNIQUE request gates new shared acquisitions for as long as it is waiting, exactly as the
+// untimed one does. This is the storage access-timeout path: acquisitions that wait out a timeout
+// are routine, so the registration has to behave the same as on the path that waits forever.
+TEST_F(ResourceLockTest, TimedUniqueGatesNewSharedAcquisitionsWhilePending) {
+  using namespace std::chrono_literals;
+
+  // A READ hold keeps the lock SHARED so the timed UNIQUE cannot acquire and stays pending. READ is
+  // otherwise compatible with READ, so a refused probe below can only be the pending-UNIQUE gate.
+  auto held_read = SharedResourceLockGuard(lock, SharedResourceLockGuard::READ);
+
+  auto timed_unique = std::async(std::launch::async, [&] { return lock.try_lock_for(1s); });
+
+  // Let it register as pending before probing.
+  std::this_thread::sleep_for(50ms);
+  EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ>());
+  EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::WRITE>());
+  EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ_ONLY>());
+
+  EXPECT_FALSE(timed_unique.get()) << "timed UNIQUE acquired while a READ was held";
+  held_read.unlock();
+}
+
+// A timed UNIQUE that gives up must take its gate down with it, and wake what it was gating. The
+// waiting side is the whole point: a shared acquirer parked on that gate has no other event coming,
+// since the timeout is not a state change anyone else observes. Leaving the registration behind
+// blocks every later shared acquisition of every kind, for the lifetime of the lock.
+TEST_F(ResourceLockTest, TimedUniqueTimeoutWakesSharedAcquirerItGated) {
+  using namespace std::chrono_literals;
+
+  auto held_read = SharedResourceLockGuard(lock, SharedResourceLockGuard::READ);  // keeps state SHARED
+
+  auto timed_unique = std::async(std::launch::async, [&] { return lock.try_lock_for(200ms); });
+
+  // Let the timed UNIQUE register before the reader parks on its gate.
+  std::this_thread::sleep_for(50ms);
+
+  std::atomic<bool> reader_acquired{false};
+  auto reader = std::async(std::launch::async, [&] {
+    lock.lock_shared<ResourceLock::LockReq::READ>();  // parks on the pending-UNIQUE gate
+    reader_acquired.store(true, std::memory_order_release);
+    lock.unlock_shared<ResourceLock::LockReq::READ>();
+  });
+
+  // Let the reader reach cv.wait, then confirm the gate (not scheduling) is holding it.
+  std::this_thread::sleep_for(50ms);
+  ASSERT_FALSE(reader_acquired.load(std::memory_order_acquire));
+
+  EXPECT_FALSE(timed_unique.get()) << "timed UNIQUE acquired while a READ was held";
+
+  // Bounded so an absent wake fails the test instead of hanging the suite forever.
+  const auto status = reader.wait_for(5s);
+  EXPECT_EQ(status, std::future_status::ready)
+      << "READ acquirer gated by the timed UNIQUE was not woken when that UNIQUE timed out";
+  if (status != std::future_status::ready) {
+    held_read.unlock();  // failure path only: rescue the parked thread so ~future cannot block
+    reader.wait();
+    return;
+  }
+  reader.get();
+  EXPECT_TRUE(reader_acquired.load(std::memory_order_acquire));
+
+  held_read.unlock();
+}
+
 // A WRITE release that does not free the lock still has to notify. w_count reaching 0 admits
 // READ_ONLY, which is compatible with the READ hold that keeps the lock in SHARED, so the wake-up
 // cannot be deferred to whenever the lock happens to become free: the READ holder may hold for as

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -627,8 +627,9 @@ TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousReadHammer) {
   } else {
     ADD_FAILURE() << "UNIQUE lock() did not acquire within " << kWatchdogBound.count()
                   << "s under continuous READ churn from " << kNumHammers
-                  << " hammer threads — ResourceLock::lock() has no anti-starvation mechanism against shared "
-                     "holders, this is a liveness/fairness bug, not a memory-safety one.";
+                  << " hammer threads — ResourceLock::lock() DOES have a unique_pending_ writer-preference "
+                     "mechanism, so this firing indicates a REGRESSION of that mechanism (e.g. the READ-release "
+                     "notify_all lost-wakeup bug), not an accepted absence of anti-starvation.";
     unique_future.get();  // reap the async thread now that hammers have stopped
   }
 }
@@ -672,8 +673,9 @@ TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousWriteHammer) {
   } else {
     ADD_FAILURE() << "UNIQUE lock() did not acquire within " << kWatchdogBound.count()
                   << "s under continuous WRITE churn from " << kNumHammers
-                  << " hammer threads — ResourceLock::lock() has no anti-starvation mechanism against shared "
-                     "holders, this is a liveness/fairness bug, not a memory-safety one.";
+                  << " hammer threads — ResourceLock::lock() DOES have a unique_pending_ writer-preference "
+                     "mechanism, so this firing indicates a REGRESSION of that mechanism (e.g. the READ-release "
+                     "notify_all lost-wakeup bug), not an accepted absence of anti-starvation.";
     unique_future.get();
   }
 }
@@ -853,10 +855,10 @@ TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarv
 
     if (control_result) {
       lock.unlock();  // release so later tests start from UNLOCKED
-      // The ungated control is expected to starve; its success is timing-dependent, so log
-      // (non-fatal) rather than abort.
-      ADD_FAILURE() << "bare try_lock() control unexpectedly acquired within " << control_result->count()
-                    << "ms under continuous WRITE churn — expected it to starve (soft/environment-dependent check)";
+      // The ungated control is expected to starve, but its success is probabilistic and
+      // environment-dependent, so record it (non-fatal) rather than abort — a chance acquire must not
+      // fail CI. The deterministic PendingScope campaign above is the real writer-preference signal.
+      RecordProperty("bare_try_lock_acquired_ms", std::to_string(control_result->count()));
     }
   }
 }
@@ -962,6 +964,68 @@ TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) 
   EXPECT_TRUE(reader_acquired.load(std::memory_order_acquire));
 
   guard_w0.unlock();
+}
+
+// Test 4c-iii: liveness smoke test for the B1 fix (READ-release notify_all). Holds a READ, then parks
+// both a UNIQUE lock() (blocked on state == SHARED, registering unique_pending_) and a second READ
+// acquirer (blocked on the unique_pending_ gate). Releasing the held READ must wake BOTH: the UNIQUE
+// acquires, and once it drains the gated READ acquires too.
+//
+// NOTE: this is a liveness smoke test, not a deterministic B1 tripwire. On glibc >= 2.34 the futex
+// wait queue is effectively FIFO, so even the pre-fix notify_one would usually wake the right waiter
+// and mask the lost-wakeup. It documents intent and guards the fix's shape (a READ release must be
+// able to wake a pending UNIQUE), and would catch a gross regression such as dropping the notify.
+TEST_F(ResourceLockTest, ReadReleaseWakesBothPendingUniqueAndGatedReader) {
+  using namespace std::chrono_literals;
+
+  auto held_read = SharedResourceLockGuard(lock, SharedResourceLockGuard::READ);  // state == SHARED
+
+  std::atomic<bool> unique_acquired{false};
+  std::atomic<bool> reader_acquired{false};
+
+  auto unique_fut = std::async(std::launch::async, [&] {
+    lock.lock();  // parks (state == SHARED); registers unique_pending_
+    unique_acquired.store(true, std::memory_order_release);
+    lock.unlock();  // hand off to the gated reader
+  });
+
+  // Let the UNIQUE waiter register unique_pending_ before the reader parks on that gate.
+  std::this_thread::sleep_for(50ms);
+
+  auto reader_fut = std::async(std::launch::async, [&] {
+    lock.lock_shared<ResourceLock::LockReq::READ>();  // parks on unique_pending_ != 0
+    reader_acquired.store(true, std::memory_order_release);
+    lock.unlock_shared<ResourceLock::LockReq::READ>();
+  });
+
+  // Let the reader reach cv.wait, then confirm the gate (not scheduling) is holding both.
+  std::this_thread::sleep_for(50ms);
+  ASSERT_FALSE(unique_acquired.load(std::memory_order_acquire));
+  ASSERT_FALSE(reader_acquired.load(std::memory_order_acquire));
+
+  held_read.unlock();  // READ release -> notify_all must wake the pending UNIQUE
+
+  // Bounded so a lost/absent wake fails the test instead of hanging the suite forever.
+  const auto u_status = unique_fut.wait_for(5s);
+  const auto r_status = reader_fut.wait_for(5s);
+  EXPECT_EQ(u_status, std::future_status::ready)
+      << "pending UNIQUE lock() was not woken by the READ release (lost wakeup / B1 regression)";
+  EXPECT_EQ(r_status, std::future_status::ready)
+      << "READ acquirer gated on unique_pending_ was not woken after the UNIQUE drained";
+
+  if (u_status != std::future_status::ready || r_status != std::future_status::ready) {
+    // Failure path only: re-issue the notify_all that was apparently lost so the parked threads
+    // finish and ~future does not block the suite forever. State is already UNLOCKED here, so this
+    // unlock() only serves as a rescue notify. (On success this branch is never taken.)
+    lock.unlock();
+    unique_fut.wait();
+    reader_fut.wait();
+    return;
+  }
+  unique_fut.get();
+  reader_fut.get();
+  EXPECT_TRUE(unique_acquired.load(std::memory_order_acquire));
+  EXPECT_TRUE(reader_acquired.load(std::memory_order_acquire));
 }
 
 // Test 4d: mutual-exclusion fuzzer (like Test 1) with UniquePendingScope / ReadOnlyPendingScope

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -1028,6 +1028,79 @@ TEST_F(ResourceLockTest, ReadReleaseWakesBothPendingUniqueAndGatedReader) {
   EXPECT_TRUE(reader_acquired.load(std::memory_order_acquire));
 }
 
+// A WRITE release that does not free the lock still has to notify. w_count reaching 0 admits
+// READ_ONLY, which is compatible with the READ hold that keeps the lock in SHARED, so the wake-up
+// cannot be deferred to whenever the lock happens to become free: the READ holder may hold for as
+// long as it likes. Narrowing unlock_should_notify<WRITE> to the fully-unlocked condition (as
+// unlock_should_notify<READ> legitimately is, since no acquirer is gated on r_count) hangs this.
+TEST_F(ResourceLockTest, WriteReleaseWakesGatedReadOnlyWhileReadersStillHold) {
+  using namespace std::chrono_literals;
+
+  auto held_read = SharedResourceLockGuard(lock, SharedResourceLockGuard::READ);    // r_count == 1
+  auto held_write = SharedResourceLockGuard(lock, SharedResourceLockGuard::WRITE);  // w_count == 1
+
+  std::atomic<bool> ro_acquired{false};
+  auto ro_fut = std::async(std::launch::async, [&] {
+    lock.lock_shared<ResourceLock::LockReq::READ_ONLY>();  // parks on w_count != 0
+    ro_acquired.store(true, std::memory_order_release);
+    lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+  });
+
+  // Let the READ_ONLY acquirer reach cv.wait, then confirm the gate (not scheduling) holds it.
+  std::this_thread::sleep_for(50ms);
+  ASSERT_FALSE(ro_acquired.load(std::memory_order_acquire));
+
+  held_write.unlock();  // w_count 1 -> 0; lock stays SHARED (the READ is still held)
+
+  // Bounded so a lost/absent wake fails the test instead of hanging the suite forever.
+  const auto status = ro_fut.wait_for(5s);
+  EXPECT_EQ(status, std::future_status::ready)
+      << "READ_ONLY acquirer gated on w_count was not woken by the WRITE release";
+  if (status != std::future_status::ready) {
+    held_read.unlock();  // failure path only: rescue the parked thread so ~future cannot block
+    ro_fut.wait();
+    return;
+  }
+  ro_fut.get();
+  EXPECT_TRUE(ro_acquired.load(std::memory_order_acquire));
+
+  held_read.unlock();
+}
+
+// The mirror of the above: a READ_ONLY release that does not free the lock admits WRITE (ro_count
+// reaching 0), which is likewise compatible with the READ hold keeping the lock in SHARED.
+TEST_F(ResourceLockTest, ReadOnlyReleaseWakesGatedWriteWhileReadersStillHold) {
+  using namespace std::chrono_literals;
+
+  auto held_read = SharedResourceLockGuard(lock, SharedResourceLockGuard::READ);            // r_count == 1
+  auto held_read_only = SharedResourceLockGuard(lock, SharedResourceLockGuard::READ_ONLY);  // ro_count == 1
+
+  std::atomic<bool> writer_acquired{false};
+  auto writer_fut = std::async(std::launch::async, [&] {
+    lock.lock_shared<ResourceLock::LockReq::WRITE>();  // parks on ro_count != 0
+    writer_acquired.store(true, std::memory_order_release);
+    lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  });
+
+  std::this_thread::sleep_for(50ms);
+  ASSERT_FALSE(writer_acquired.load(std::memory_order_acquire));
+
+  held_read_only.unlock();  // ro_count 1 -> 0; lock stays SHARED (the READ is still held)
+
+  const auto status = writer_fut.wait_for(5s);
+  EXPECT_EQ(status, std::future_status::ready)
+      << "WRITE acquirer gated on ro_count was not woken by the READ_ONLY release";
+  if (status != std::future_status::ready) {
+    held_read.unlock();  // failure path only: rescue the parked thread so ~future cannot block
+    writer_fut.wait();
+    return;
+  }
+  writer_fut.get();
+  EXPECT_TRUE(writer_acquired.load(std::memory_order_acquire));
+
+  held_read.unlock();
+}
+
 // Test 4d: mutual-exclusion fuzzer (like Test 1) with UniquePendingScope / ReadOnlyPendingScope
 // try_acquire() mixed in, to cover the new code paths (mtx-protected mutation + adopt_lock).
 TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzzWithPendingScopes) {

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -432,8 +432,8 @@ TEST_F(ResourceLockTest, GuardTryLockForUniqueTimesOutWhenHeld) {
 // Stress tests: a varied TSan surface plus liveness probes (UNIQUE starvation vs shared holders,
 // READ_ONLY latency vs new writers).
 
-// Test 1: mutual-exclusion fuzzer. Threads hammer every entry point while atomic counters are
-// checked against the lock's invariants on each acquisition (catches violations + TSan races).
+// Mutual-exclusion fuzzer. Threads hammer every entry point while atomic counters are checked
+// against the lock's invariants on each acquisition (catches violations + TSan races).
 TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzz) {
   using namespace std::chrono_literals;
   constexpr int kNumThreads = 24;
@@ -584,9 +584,9 @@ TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzz) {
   ASSERT_FALSE(invariant_violated.load()) << violation_message;
 }
 
-// Test 2a: UNIQUE-starvation probe under continuous READ churn. With writer-preference,
-// unique_pending_ gates new READ holders so lock() acquires within the watchdog bound; a hung
-// acquire becomes a soft, logged failure instead of a hung binary.
+// UNIQUE-starvation probe under continuous READ churn. With writer-preference, unique_pending_
+// gates new READ holders so lock() acquires within the watchdog bound; a hung acquire becomes a
+// soft, logged failure instead of a hung binary.
 TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousReadHammer) {
   using namespace std::chrono_literals;
   constexpr int kNumHammers = 8;
@@ -627,14 +627,14 @@ TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousReadHammer) {
   } else {
     ADD_FAILURE() << "UNIQUE lock() did not acquire within " << kWatchdogBound.count()
                   << "s under continuous READ churn from " << kNumHammers
-                  << " hammer threads — ResourceLock::lock() DOES have a unique_pending_ writer-preference "
-                     "mechanism, so this firing indicates a REGRESSION of that mechanism (e.g. the READ-release "
-                     "notify_all lost-wakeup bug), not an accepted absence of anti-starvation.";
+                  << " hammer threads. lock() registers as pending and gates new shared acquirers, so this is a "
+                     "regression of that gate or of the wake-up that follows a shared release, not an accepted "
+                     "absence of anti-starvation.";
     unique_future.get();  // reap the async thread now that hammers have stopped
   }
 }
 
-// Test 2b: same probe, hammering WRITE instead of READ.
+// The same starvation probe, with WRITE the churning shared mode.
 TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousWriteHammer) {
   using namespace std::chrono_literals;
   constexpr int kNumHammers = 8;
@@ -673,14 +673,14 @@ TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousWriteHammer) {
   } else {
     ADD_FAILURE() << "UNIQUE lock() did not acquire within " << kWatchdogBound.count()
                   << "s under continuous WRITE churn from " << kNumHammers
-                  << " hammer threads — ResourceLock::lock() DOES have a unique_pending_ writer-preference "
-                     "mechanism, so this firing indicates a REGRESSION of that mechanism (e.g. the READ-release "
-                     "notify_all lost-wakeup bug), not an accepted absence of anti-starvation.";
+                  << " hammer threads. lock() registers as pending and gates new shared acquirers, so this is a "
+                     "regression of that gate or of the wake-up that follows a shared release, not an accepted "
+                     "absence of anti-starvation.";
     unique_future.get();
   }
 }
 
-// Test 3: READ_ONLY vs WRITE priority. A mid-stream READ_ONLY registers ro_pending_count, gating
+// READ_ONLY vs WRITE priority. A mid-stream READ_ONLY registers ro_pending_count, gating
 // new WRITEs, so its latency is bounded by draining in-flight writers, not by the queued burst.
 // Measured with a small and a large late-writer burst; latency must not grow with burst size.
 TEST_F(ResourceLockTest, ReadOnlyLatencyIndependentOfNewWriterCount) {
@@ -747,7 +747,7 @@ TEST_F(ResourceLockTest, ReadOnlyLatencyIndependentOfNewWriterCount) {
     inflight.clear();
 
     EXPECT_EQ(late_before_ro.load(), 0) << "new WRITE attempts registered after READ_ONLY was pending managed to "
-                                           "acquire before it — ro_pending_count priority not honoured";
+                                           "acquire before it: ro_pending_count priority not honoured";
 
     return std::chrono::duration_cast<std::chrono::microseconds>(t_acquired - t_start);
   };
@@ -758,13 +758,13 @@ TEST_F(ResourceLockTest, ReadOnlyLatencyIndependentOfNewWriterCount) {
   RecordProperty("ro_latency_small_burst_us", std::to_string(latency_small_burst.count()));
   RecordProperty("ro_latency_large_burst_us", std::to_string(latency_large_burst.count()));
 
-  // The large burst has 12x more new writers queued behind the READ_ONLY request; if priority is
+  // The large burst queues far more new writers behind the READ_ONLY request; if priority is
   // honoured, that should barely move the READ_ONLY latency (bounded by in-flight-writer drain
   // time), not scale with the queue length.
   EXPECT_LT(latency_large_burst, latency_small_burst + 50ms)
       << "READ_ONLY latency grew with the number of new writers queued behind it (small burst="
       << latency_small_burst.count() << "us, large burst=" << latency_large_burst.count()
-      << "us) — ro_pending_count priority/starvation regression";
+      << "us): ro_pending_count priority/starvation regression";
 }
 
 // UniquePendingScope / ReadOnlyPendingScope tests: a pending-scope retry loop gets writer-
@@ -792,7 +792,7 @@ std::vector<std::jthread> SpawnHammers(ResourceLock &target_lock, std::atomic<bo
 }
 }  // namespace
 
-// Test 4a: a UniquePendingScope retry loop acquires within a bound under continuous WRITE churn,
+// A UniquePendingScope retry loop acquires within a bound under continuous WRITE churn,
 // whereas a bare try_lock() loop is expected to starve (soft/environment-dependent control).
 TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarves) {
   using namespace std::chrono_literals;
@@ -827,7 +827,7 @@ TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarv
     } else {
       ADD_FAILURE() << "UniquePendingScope::try_acquire() campaign did not acquire within "
                     << kPendingScopeBound.count() << "s under continuous WRITE churn from " << kNumHammers
-                    << " hammer threads — pending-scope writer-preference regression";
+                    << " hammer threads: pending-scope writer-preference regression";
       scoped_future.get();  // reap the async thread now that hammers have stopped
     }
   }
@@ -856,14 +856,14 @@ TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarv
     if (control_result) {
       lock.unlock();  // release so later tests start from UNLOCKED
       // The ungated control is expected to starve, but its success is probabilistic and
-      // environment-dependent, so record it (non-fatal) rather than abort — a chance acquire must not
+      // environment-dependent, so record it (non-fatal) rather than abort: a chance acquire must not
       // fail CI. The deterministic PendingScope campaign above is the real writer-preference signal.
       RecordProperty("bare_try_lock_acquired_ms", std::to_string(control_result->count()));
     }
   }
 }
 
-// Test 4b: same contrast, but ReadOnlyPendingScope against continuous WRITE hammers.
+// The same campaign for ReadOnlyPendingScope, against continuous WRITE hammers.
 TEST_F(ResourceLockTest, ReadOnlyPendingScopeCampaignAcquiresUnderContinuousWriteHammer) {
   using namespace std::chrono_literals;
   constexpr int kNumHammers = 8;
@@ -896,13 +896,13 @@ TEST_F(ResourceLockTest, ReadOnlyPendingScopeCampaignAcquiresUnderContinuousWrit
   } else {
     ADD_FAILURE() << "ReadOnlyPendingScope::try_acquire() campaign did not acquire within " << kBound.count()
                   << "s under continuous WRITE churn from " << kNumHammers
-                  << " hammer threads — pending-scope priority regression";
+                  << " hammer threads: pending-scope priority regression";
     scoped_future.get();  // reap the async thread now that hammers have stopped
   }
 }
 
-// Test 4c: deterministic check that a live, not-yet-successful UniquePendingScope gates new shared
-// acquisitions of every kind, and that the gate clears the moment it is destroyed unacquired.
+// A live, not-yet-successful UniquePendingScope gates new shared acquisitions of every kind, and
+// the gate clears the moment it is destroyed unacquired.
 TEST_F(ResourceLockTest, UniquePendingScopeGatesNewSharedAcquisitionUntilDestroyed) {
   // Hold WRITE so the scope's try_acquire() can't succeed (state != UNLOCKED), keeping it pending.
   auto guard_w0 = SharedResourceLockGuard(lock, SharedResourceLockGuard::WRITE);
@@ -922,10 +922,12 @@ TEST_F(ResourceLockTest, UniquePendingScopeGatesNewSharedAcquisitionUntilDestroy
   guard_w0.unlock();
 }
 
-// Test 4c-ii: destroying a still-pending UniquePendingScope must WAKE a thread genuinely blocked in
-// lock_shared() (parked in cv.wait), exercising the destructor's notify path. A dropped notify or
-// off-mtx counter would hang and fail via the bounded wait_for. (The narrow notify-races-enqueue
-// window isn't deterministically reproducible; that rests on the mtx discipline + the fuzz test.)
+// Destroying a still-pending UniquePendingScope must wake a thread genuinely blocked in
+// lock_shared(), not merely let the next acquirer through: the parked thread has no other event
+// coming, since deregistering is not a state change anyone else observes. A dropped notify, or a
+// counter mutated off mtx, hangs the reader and fails via the bounded wait_for. The window in which
+// an off-mtx notify races the waiter's enqueue is not deterministically reproducible; that rests on
+// the mtx discipline and the fuzz test.
 TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) {
   using namespace std::chrono_literals;
   // Hold WRITE so state == SHARED (never UNLOCKED): the scope stays pending, and a READ acquirer is
@@ -949,7 +951,7 @@ TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) 
 
   scope.reset();  // ~UniquePendingScope: unique_pending_ 1 -> 0 under mtx, then notify_all -> wake
 
-  // Bounded so a lost/absent wake fails the test (~5s) instead of hanging the suite forever.
+  // Bounded so a lost/absent wake fails the test instead of hanging the suite forever.
   const auto status = reader.wait_for(5s);
   EXPECT_EQ(status, std::future_status::ready)
       << "reader blocked in lock_shared() was not woken by ~UniquePendingScope (lost/absent wakeup)";
@@ -966,15 +968,13 @@ TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) 
   guard_w0.unlock();
 }
 
-// Test 4c-iii: liveness smoke test for the B1 fix (READ-release notify_all). Holds a READ, then parks
-// both a UNIQUE lock() (blocked on state == SHARED, registering unique_pending_) and a second READ
-// acquirer (blocked on the unique_pending_ gate). Releasing the held READ must wake BOTH: the UNIQUE
-// acquires, and once it drains the gated READ acquires too.
+// A READ release frees the lock for a pending UNIQUE, and the UNIQUE's own release then admits a
+// READ acquirer that was gated behind it. A held READ parks both: the UNIQUE on state == SHARED,
+// the second READ on the pending-UNIQUE gate, so releasing the READ must set the whole chain going.
 //
-// NOTE: this is a liveness smoke test, not a deterministic B1 tripwire. On glibc >= 2.34 the futex
-// wait queue is effectively FIFO, so even the pre-fix notify_one would usually wake the right waiter
-// and mask the lost-wakeup. It documents intent and guards the fix's shape (a READ release must be
-// able to wake a pending UNIQUE), and would catch a gross regression such as dropping the notify.
+// Liveness smoke test rather than a tripwire for the breadth of the notify: on glibc the futex wait
+// queue is effectively FIFO, so waking a single waiter would usually pick the right one anyway and
+// mask a too-narrow notify. What it does catch is a release that stops notifying at all.
 TEST_F(ResourceLockTest, ReadReleaseWakesBothPendingUniqueAndGatedReader) {
   using namespace std::chrono_literals;
 
@@ -1009,7 +1009,7 @@ TEST_F(ResourceLockTest, ReadReleaseWakesBothPendingUniqueAndGatedReader) {
   const auto u_status = unique_fut.wait_for(5s);
   const auto r_status = reader_fut.wait_for(5s);
   EXPECT_EQ(u_status, std::future_status::ready)
-      << "pending UNIQUE lock() was not woken by the READ release (lost wakeup / B1 regression)";
+      << "pending UNIQUE lock() was not woken by the READ release (lost wakeup)";
   EXPECT_EQ(r_status, std::future_status::ready)
       << "READ acquirer gated on unique_pending_ was not woken after the UNIQUE drained";
 
@@ -1211,8 +1211,8 @@ TEST_F(ResourceLockTest, ReadOnlyReleaseWakesGatedWriteWhileReadersStillHold) {
   held_read.unlock();
 }
 
-// Test 4d: mutual-exclusion fuzzer (like Test 1) with UniquePendingScope / ReadOnlyPendingScope
-// try_acquire() mixed in, to cover the new code paths (mtx-protected mutation + adopt_lock).
+// Mutual-exclusion fuzzer again, with UniquePendingScope / ReadOnlyPendingScope try_acquire() among
+// the hammered entry points, so a scope that adopts the lock is held to the same invariants.
 TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzzWithPendingScopes) {
   using namespace std::chrono_literals;
   constexpr int kNumThreads = 24;

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -429,22 +429,11 @@ TEST_F(ResourceLockTest, GuardTryLockForUniqueTimesOutWhenHeld) {
   ASSERT_FALSE(guard.owns_lock());
 }
 
-// ---------------------------------------------------------------------------------------------
-// Stress tests below. These exist to (a) give TSan a large, varied surface to find data races on
-// ResourceLock's internal bookkeeping, and (b) empirically probe two liveness properties flagged
-// by a prior audit:
-//   - `lock()` (UNIQUE) has no explicit anti-starvation mechanism against a continuously-refilled
-//     stream of READ/WRITE shared holders (unlike READ_ONLY, which has `ro_pending_count` giving
-//     it priority over *new* WRITE acquisitions).
-//   - READ_ONLY's priority over WRITE should bound its acquisition latency by the *already
-//     in-flight* writers at the time it registers, not by how many new writers pile up afterwards.
-// ---------------------------------------------------------------------------------------------
+// Stress tests: a varied TSan surface plus liveness probes (UNIQUE starvation vs shared holders,
+// READ_ONLY latency vs new writers).
 
-// Test 1: mutual-exclusion invariant fuzzer. Many threads hammer every entry point (READ, WRITE,
-// READ_ONLY blocking + timed try, UNIQUE try_lock + try_lock_for, plus downgrade_to_read) for a
-// fixed duration while a set of atomic counters is checked against the lock's documented
-// invariants on every acquisition. This is the TSan catch-all: a real bug here should show up
-// either as a hard invariant violation (deterministic ASSERT) or as a TSan-reported data race.
+// Test 1: mutual-exclusion fuzzer. Threads hammer every entry point while atomic counters are
+// checked against the lock's invariants on each acquisition (catches violations + TSan races).
 TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzz) {
   using namespace std::chrono_literals;
   constexpr int kNumThreads = 24;
@@ -595,14 +584,9 @@ TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzz) {
   ASSERT_FALSE(invariant_violated.load()) << violation_message;
 }
 
-// Test 2a: UNIQUE-starvation probe under continuous READ churn.
-//
-// `lock()` only waits for `state == UNLOCKED`, i.e. it has *no* priority/aging mechanism against
-// a steady stream of READ acquisitions (unlike READ_ONLY vs WRITE, which is arbitrated via
-// `ro_pending_count`). If READ holders keep the shared count above zero back-to-back, a blocking
-// `lock()` call can in principle wait indefinitely. This test hammers READ acquisitions with tight
-// overlap and uses a generous watchdog to turn "acquisition never happens" into a soft, logged
-// failure instead of a hung test binary.
+// Test 2a: UNIQUE-starvation probe under continuous READ churn. With writer-preference,
+// unique_pending_ gates new READ holders so lock() acquires within the watchdog bound; a hung
+// acquire becomes a soft, logged failure instead of a hung binary.
 TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousReadHammer) {
   using namespace std::chrono_literals;
   constexpr int kNumHammers = 8;
@@ -649,9 +633,7 @@ TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousReadHammer) {
   }
 }
 
-// Test 2b: same probe, but hammering WRITE (shared writer) acquisitions instead of READ. WRITE
-// shares the same `state == UNLOCKED` gate for UNIQUE as READ does, so the same potential
-// starvation applies.
+// Test 2b: same probe, hammering WRITE instead of READ.
 TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousWriteHammer) {
   using namespace std::chrono_literals;
   constexpr int kNumHammers = 8;
@@ -696,12 +678,9 @@ TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousWriteHammer) {
   }
 }
 
-// Test 3: READ_ONLY vs WRITE priority. WRITE hammers keep the lock busy; a READ_ONLY arrives
-// mid-stream and registers `ro_pending_count`, which should block any *new* WRITE acquisition
-// until the READ_ONLY succeeds. That means READ_ONLY's acquisition latency should be governed by
-// draining the writer(s) already in flight at the moment it registered, not by how many new
-// writer threads pile up afterwards. We measure the latency with a small burst of new writers and
-// again with a much larger burst, and assert the latency does not grow with the burst size.
+// Test 3: READ_ONLY vs WRITE priority. A mid-stream READ_ONLY registers ro_pending_count, gating
+// new WRITEs, so its latency is bounded by draining in-flight writers, not by the queued burst.
+// Measured with a small and a large late-writer burst; latency must not grow with burst size.
 TEST_F(ResourceLockTest, ReadOnlyLatencyIndependentOfNewWriterCount) {
   using namespace std::chrono_literals;
 
@@ -786,19 +765,13 @@ TEST_F(ResourceLockTest, ReadOnlyLatencyIndependentOfNewWriterCount) {
       << "us) — ro_pending_count priority/starvation regression";
 }
 
-// ---------------------------------------------------------------------------------------------
-// UniquePendingScope / ReadOnlyPendingScope: RAII helpers that keep a *non-blocking* probe
-// campaign registered as pending (bumping unique_pending_ / ro_pending_count respectively) so a
-// retrying try_acquire() loop gets the same writer-preference a blocking lock()/lock_shared()
-// call already gets. The tests below directly exercise the liveness contrast this is meant to
-// fix (bare try_lock() loop starves, a pending-scope loop does not) plus the deterministic gating
-// and mutual-exclusion invariants.
-// ---------------------------------------------------------------------------------------------
+// UniquePendingScope / ReadOnlyPendingScope tests: a pending-scope retry loop gets writer-
+// preference (acquires under continuous shared churn where a bare try_lock() loop starves), plus
+// deterministic gating and mutual-exclusion invariants.
 
 namespace {
-// Spins up `kNumHammers` threads that continuously take/release a shared lock of type `Req`,
-// staggered so releases don't line up in lockstep (keeping shared occupancy continuous). Returns
-// the thread pool; caller flips `stop` and lets the vector go out of scope to join.
+// Spins up kNumHammers threads that continuously take/release a shared lock of type Req, staggered
+// to keep shared occupancy continuous. Caller flips `stop` and lets the vector join.
 template <ResourceLock::LockReq Req>
 std::vector<std::jthread> SpawnHammers(ResourceLock &target_lock, std::atomic<bool> &stop, int kNumHammers) {
   std::vector<std::jthread> hammers;
@@ -817,12 +790,8 @@ std::vector<std::jthread> SpawnHammers(ResourceLock &target_lock, std::atomic<bo
 }
 }  // namespace
 
-// Test 4a: a UniquePendingScope held across a try_acquire() retry loop should acquire within a
-// bounded time under a continuous stream of new WRITE shared acquirers, whereas a bare
-// `lock.try_lock()` retry loop against the same kind of hammer stream is expected to starve (its
-// probes never register as pending, so it never gates the hammers out) — this is the soft/control
-// half of the assertion, since starvation of an unprivileged contender is a probabilistic
-// (environment-dependent) property, not a hard guarantee.
+// Test 4a: a UniquePendingScope retry loop acquires within a bound under continuous WRITE churn,
+// whereas a bare try_lock() loop is expected to starve (soft/environment-dependent control).
 TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarves) {
   using namespace std::chrono_literals;
   constexpr int kNumHammers = 8;
@@ -883,10 +852,9 @@ TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarv
     hammers.clear();
 
     if (control_result) {
-      lock.unlock();  // it did acquire; release so later tests in the suite start from UNLOCKED
-      // Soft: the control loop is *expected* to starve, but since it isn't gated at all its
-      // success is a timing-dependent (not impossible) outcome — log it as a non-fatal note
-      // rather than aborting the test.
+      lock.unlock();  // release so later tests start from UNLOCKED
+      // The ungated control is expected to starve; its success is timing-dependent, so log
+      // (non-fatal) rather than abort.
       ADD_FAILURE() << "bare try_lock() control unexpectedly acquired within " << control_result->count()
                     << "ms under continuous WRITE churn — expected it to starve (soft/environment-dependent check)";
     }
@@ -931,13 +899,10 @@ TEST_F(ResourceLockTest, ReadOnlyPendingScopeCampaignAcquiresUnderContinuousWrit
   }
 }
 
-// Test 4c: deterministic (non-timing-dependent) check that a live, not-yet-successful
-// UniquePendingScope gates *new* shared acquisitions of every kind (READ, WRITE, READ_ONLY),
-// exactly like a blocked lock() waiter would, and that the gate is released the moment the scope
-// is destroyed without ever having acquired.
+// Test 4c: deterministic check that a live, not-yet-successful UniquePendingScope gates new shared
+// acquisitions of every kind, and that the gate clears the moment it is destroyed unacquired.
 TEST_F(ResourceLockTest, UniquePendingScopeGatesNewSharedAcquisitionUntilDestroyed) {
-  // Hold a WRITE lock first so the scope's own try_acquire() cannot succeed (state != UNLOCKED),
-  // keeping it "pending" for the whole block below.
+  // Hold WRITE so the scope's try_acquire() can't succeed (state != UNLOCKED), keeping it pending.
   auto guard_w0 = SharedResourceLockGuard(lock, SharedResourceLockGuard::WRITE);
 
   {
@@ -948,27 +913,21 @@ TEST_F(ResourceLockTest, UniquePendingScopeGatesNewSharedAcquisitionUntilDestroy
     EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ>());
     EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ_ONLY>());
   }
-  // scope destroyed without acquiring -> unique_pending_ back to 0, new shared acquisitions
-  // compatible with the still-held WRITE lock should succeed again.
+  // scope destroyed unacquired -> unique_pending_ == 0, WRITE-compatible acquisitions succeed again.
   ASSERT_TRUE(lock.try_lock_shared<ResourceLock::LockReq::WRITE>());
   lock.unlock_shared<ResourceLock::LockReq::WRITE>();
 
   guard_w0.unlock();
 }
 
-// Test 4c-ii: destroying a still-pending UniquePendingScope must WAKE a thread that is genuinely
-// blocked in lock_shared() (parked in cv.wait), not merely clear the gate for a later non-blocking
-// try_lock_shared() (which 4c above already covers). This exercises the destructor's notify path
-// against a real waiter. NOTE: this deterministically guards that the wake happens *at all* (e.g. a
-// future refactor that drops the notify_all, or fails to publish the counter under mtx, would hang
-// here and fail via the bounded wait_for). It does not by itself reproduce the narrow notify-races-
-// enqueue window that motivated mutating unique_pending_ under mtx -- that window is not
-// deterministically reproducible in a unit test; correctness there rests on the mtx discipline
-// (same as ResourceLock::lock()'s failure path) plus the fuzz test below.
+// Test 4c-ii: destroying a still-pending UniquePendingScope must WAKE a thread genuinely blocked in
+// lock_shared() (parked in cv.wait), exercising the destructor's notify path. A dropped notify or
+// off-mtx counter would hang and fail via the bounded wait_for. (The narrow notify-races-enqueue
+// window isn't deterministically reproducible; that rests on the mtx discipline + the fuzz test.)
 TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) {
   using namespace std::chrono_literals;
-  // Hold WRITE so state == SHARED (never UNLOCKED): the scope can never acquire and stays pending,
-  // and a READ acquirer is compatible with the held WRITE once the unique_pending_ gate clears.
+  // Hold WRITE so state == SHARED (never UNLOCKED): the scope stays pending, and a READ acquirer is
+  // compatible with the held WRITE once the unique_pending_ gate clears.
   auto guard_w0 = SharedResourceLockGuard(lock, SharedResourceLockGuard::WRITE);
 
   auto scope = std::optional<UniquePendingScope>{std::in_place, lock};  // unique_pending_ == 1
@@ -976,15 +935,13 @@ TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) 
 
   std::atomic<bool> reader_acquired{false};
   auto reader = std::async(std::launch::async, [&] {
-    // Blocks: predicate is (state != UNIQUE && unique_pending_ == 0); unique_pending_ == 1 here,
-    // so this parks in cv.wait until the scope below is destroyed.
+    // Parks in cv.wait (unique_pending_ == 1) until the scope below is destroyed.
     lock.lock_shared<ResourceLock::LockReq::READ>();
     reader_acquired.store(true, std::memory_order_release);
     lock.unlock_shared<ResourceLock::LockReq::READ>();
   });
 
-  // Give the reader ample time to reach cv.wait, then confirm it is actually still blocked (the gate
-  // is holding it, not a scheduling delay).
+  // Let the reader reach cv.wait, then confirm the gate (not a scheduling delay) is holding it.
   std::this_thread::sleep_for(50ms);
   ASSERT_FALSE(reader_acquired.load(std::memory_order_acquire));
 
@@ -995,10 +952,8 @@ TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) 
   EXPECT_EQ(status, std::future_status::ready)
       << "reader blocked in lock_shared() was not woken by ~UniquePendingScope (lost/absent wakeup)";
   if (status != std::future_status::ready) {
-    // Rescue the still-parked reader so the std::future destructor does not block forever: releasing
-    // the WRITE guard notifies_all (unlock_should_notify<WRITE>), which wakes it (unique_pending_ is
-    // already 0). Do this ONLY on the failure path -- doing it before the assertion would wake the
-    // reader regardless of the scope's own notify and destroy the test's discriminating power.
+    // Failure path only: release WRITE to notify_all and rescue the parked reader so ~future does
+    // not block forever. Doing this earlier would mask the scope's own notify under test.
     guard_w0.unlock();
     reader.wait();
     return;
@@ -1009,10 +964,8 @@ TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) 
   guard_w0.unlock();
 }
 
-// Test 4d: mutual-exclusion invariant fuzzer (same style as ConcurrentMutualExclusionInvariantsFuzz
-// above), extended with UniquePendingScope / ReadOnlyPendingScope try_acquire() attempts mixed in
-// alongside the existing blocking/try entry points, to give TSan and the invariant checker a shot
-// at the new code paths (mtx-protected state mutation + adopt_lock hand-off).
+// Test 4d: mutual-exclusion fuzzer (like Test 1) with UniquePendingScope / ReadOnlyPendingScope
+// try_acquire() mixed in, to cover the new code paths (mtx-protected mutation + adopt_lock).
 TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzzWithPendingScopes) {
   using namespace std::chrono_literals;
   constexpr int kNumThreads = 24;

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -12,10 +12,17 @@
 #include "utils/resource_lock.hpp"
 
 #include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
 #include <future>
 #include <latch>
+#include <mutex>
+#include <optional>
+#include <random>
 #include <shared_mutex>
+#include <string>
 #include <thread>
+#include <vector>
 
 using namespace memgraph::utils;
 
@@ -420,4 +427,673 @@ TEST_F(ResourceLockTest, GuardTryLockForUniqueTimesOutWhenHeld) {
   ASSERT_FALSE(guard.try_lock_for(10ms));
   ASSERT_GE(std::chrono::steady_clock::now() - start, 10ms);
   ASSERT_FALSE(guard.owns_lock());
+}
+
+// ---------------------------------------------------------------------------------------------
+// Stress tests below. These exist to (a) give TSan a large, varied surface to find data races on
+// ResourceLock's internal bookkeeping, and (b) empirically probe two liveness properties flagged
+// by a prior audit:
+//   - `lock()` (UNIQUE) has no explicit anti-starvation mechanism against a continuously-refilled
+//     stream of READ/WRITE shared holders (unlike READ_ONLY, which has `ro_pending_count` giving
+//     it priority over *new* WRITE acquisitions).
+//   - READ_ONLY's priority over WRITE should bound its acquisition latency by the *already
+//     in-flight* writers at the time it registers, not by how many new writers pile up afterwards.
+// ---------------------------------------------------------------------------------------------
+
+// Test 1: mutual-exclusion invariant fuzzer. Many threads hammer every entry point (READ, WRITE,
+// READ_ONLY blocking + timed try, UNIQUE try_lock + try_lock_for, plus downgrade_to_read) for a
+// fixed duration while a set of atomic counters is checked against the lock's documented
+// invariants on every acquisition. This is the TSan catch-all: a real bug here should show up
+// either as a hard invariant violation (deterministic ASSERT) or as a TSan-reported data race.
+TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzz) {
+  using namespace std::chrono_literals;
+  constexpr int kNumThreads = 24;
+  constexpr auto kDuration = 400ms;
+
+  struct Counters {
+    std::atomic<int> active_read{0};
+    std::atomic<int> active_write{0};
+    std::atomic<int> active_ro{0};
+    std::atomic<int> active_unique{0};
+  } counters;
+
+  std::atomic<bool> invariant_violated{false};
+  std::mutex violation_mutex;
+  std::string violation_message;
+
+  auto record_violation = [&](const std::string &msg) {
+    bool expected = false;
+    if (invariant_violated.compare_exchange_strong(expected, true)) {
+      std::lock_guard<std::mutex> lg(violation_mutex);
+      violation_message = msg;
+    }
+  };
+
+  // Invariants (per the lock's contract):
+  //  1. WRITE and READ_ONLY are never simultaneously active.
+  //  2. UNIQUE active implies nothing else is active (and vice versa).
+  //  3. At most one UNIQUE holder at a time.
+  auto check_invariants = [&](const char *where) {
+    const int aw = counters.active_write.load(std::memory_order_acquire);
+    const int aro = counters.active_ro.load(std::memory_order_acquire);
+    const int ar = counters.active_read.load(std::memory_order_acquire);
+    const int au = counters.active_unique.load(std::memory_order_acquire);
+    if (aw > 0 && aro > 0) {
+      record_violation(std::string(where) + ": WRITE(" + std::to_string(aw) + ") and READ_ONLY(" + std::to_string(aro) +
+                       ") concurrently active");
+    }
+    if (au > 0 && (aw > 0 || ar > 0 || aro > 0)) {
+      record_violation(std::string(where) + ": UNIQUE(" + std::to_string(au) + ") active alongside shared holders (w=" +
+                       std::to_string(aw) + ", r=" + std::to_string(ar) + ", ro=" + std::to_string(aro) + ")");
+    }
+    if (au > 1) {
+      record_violation(std::string(where) + ": more than one UNIQUE holder concurrently (" + std::to_string(au) + ")");
+    }
+  };
+
+  std::atomic<bool> stop{false};
+
+  auto worker = [&](int seed) {
+    std::mt19937 rng(static_cast<unsigned>(seed) * 2654435761u ^
+                     static_cast<unsigned>(std::hash<std::thread::id>{}(std::this_thread::get_id())));
+    std::uniform_int_distribution<int> op_pick(0, 5);
+    std::uniform_int_distribution<int> hold_us(0, 50);
+    std::uniform_int_distribution<int> downgrade_roll(0, 3);
+
+    while (!stop.load(std::memory_order_relaxed) && !invariant_violated.load(std::memory_order_relaxed)) {
+      switch (op_pick(rng)) {
+        case 0: {  // READ: never conflicts with anything but UNIQUE
+          lock.lock_shared<ResourceLock::LockReq::READ>();
+          counters.active_read.fetch_add(1, std::memory_order_acq_rel);
+          check_invariants("READ");
+          std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+          counters.active_read.fetch_sub(1, std::memory_order_acq_rel);
+          lock.unlock_shared<ResourceLock::LockReq::READ>();
+          break;
+        }
+        case 1: {  // WRITE (shared writer), conflicts with READ_ONLY
+          lock.lock_shared<ResourceLock::LockReq::WRITE>();
+          counters.active_write.fetch_add(1, std::memory_order_acq_rel);
+          check_invariants("WRITE");
+          std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+          if (downgrade_roll(rng) == 0) {
+            counters.active_write.fetch_sub(1, std::memory_order_acq_rel);
+            ASSERT_TRUE(lock.downgrade_to_read<ResourceLock::LockReq::WRITE>());
+            counters.active_read.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("WRITE->READ downgrade");
+            counters.active_read.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock_shared<ResourceLock::LockReq::READ>();
+          } else {
+            counters.active_write.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+          }
+          break;
+        }
+        case 2: {  // READ_ONLY, blocking, conflicts with WRITE
+          lock.lock_shared<ResourceLock::LockReq::READ_ONLY>();
+          counters.active_ro.fetch_add(1, std::memory_order_acq_rel);
+          check_invariants("READ_ONLY(block)");
+          std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+          if (downgrade_roll(rng) == 0) {
+            counters.active_ro.fetch_sub(1, std::memory_order_acq_rel);
+            ASSERT_TRUE(lock.downgrade_to_read<ResourceLock::LockReq::READ_ONLY>());
+            counters.active_read.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("READ_ONLY->READ downgrade");
+            counters.active_read.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock_shared<ResourceLock::LockReq::READ>();
+          } else {
+            counters.active_ro.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+          }
+          break;
+        }
+        case 3: {  // READ_ONLY, timed try with a short timeout (frequently expected to fail)
+          if (lock.try_lock_shared_for<std::chrono::microseconds::rep, std::micro, ResourceLock::LockReq::READ_ONLY>(
+                  std::chrono::microseconds(200))) {
+            counters.active_ro.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("READ_ONLY(try_for)");
+            std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+            counters.active_ro.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+          }
+          break;
+        }
+        case 4: {  // UNIQUE via try_lock
+          if (lock.try_lock()) {
+            counters.active_unique.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("UNIQUE(try_lock)");
+            std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+            counters.active_unique.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock();
+          }
+          break;
+        }
+        case 5: {  // UNIQUE via try_lock_for
+          if (lock.try_lock_for(std::chrono::microseconds(200))) {
+            counters.active_unique.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("UNIQUE(try_lock_for)");
+            std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+            counters.active_unique.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock();
+          }
+          break;
+        }
+      }
+    }
+  };
+
+  std::vector<std::jthread> threads;
+  threads.reserve(kNumThreads);
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back(worker, i);
+  }
+
+  std::this_thread::sleep_for(kDuration);
+  stop.store(true, std::memory_order_relaxed);
+  threads.clear();  // joins all workers
+
+  ASSERT_FALSE(invariant_violated.load()) << violation_message;
+}
+
+// Test 2a: UNIQUE-starvation probe under continuous READ churn.
+//
+// `lock()` only waits for `state == UNLOCKED`, i.e. it has *no* priority/aging mechanism against
+// a steady stream of READ acquisitions (unlike READ_ONLY vs WRITE, which is arbitrated via
+// `ro_pending_count`). If READ holders keep the shared count above zero back-to-back, a blocking
+// `lock()` call can in principle wait indefinitely. This test hammers READ acquisitions with tight
+// overlap and uses a generous watchdog to turn "acquisition never happens" into a soft, logged
+// failure instead of a hung test binary.
+TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousReadHammer) {
+  using namespace std::chrono_literals;
+  constexpr int kNumHammers = 8;
+  constexpr auto kWatchdogBound = 5s;
+
+  std::atomic<bool> stop{false};
+  std::vector<std::jthread> hammers;
+  hammers.reserve(kNumHammers);
+  for (int i = 0; i < kNumHammers; ++i) {
+    hammers.emplace_back([&, i] {
+      // Stagger starts so hammers don't all release in lockstep, keeping overlap continuous.
+      std::this_thread::sleep_for(std::chrono::microseconds(i * 13));
+      while (!stop.load(std::memory_order_relaxed)) {
+        lock.lock_shared<ResourceLock::LockReq::READ>();
+        std::this_thread::sleep_for(100us);
+        lock.unlock_shared<ResourceLock::LockReq::READ>();
+      }
+    });
+  }
+
+  auto unique_future = std::async(std::launch::async, [&] {
+    auto start = std::chrono::steady_clock::now();
+    lock.lock();
+    auto acquired = std::chrono::steady_clock::now();
+    lock.unlock();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(acquired - start);
+  });
+
+  const bool acquired_in_time = unique_future.wait_for(kWatchdogBound) == std::future_status::ready;
+
+  // Stop the hammers regardless of outcome so the async UNIQUE task (and this test) can finish.
+  stop.store(true, std::memory_order_relaxed);
+  hammers.clear();
+
+  if (acquired_in_time) {
+    const auto latency = unique_future.get();
+    RecordProperty("unique_acquire_latency_ms", std::to_string(latency.count()));
+  } else {
+    ADD_FAILURE() << "UNIQUE lock() did not acquire within " << kWatchdogBound.count()
+                  << "s under continuous READ churn from " << kNumHammers
+                  << " hammer threads — ResourceLock::lock() has no anti-starvation mechanism against shared "
+                     "holders, this is a liveness/fairness bug, not a memory-safety one.";
+    unique_future.get();  // reap the async thread now that hammers have stopped
+  }
+}
+
+// Test 2b: same probe, but hammering WRITE (shared writer) acquisitions instead of READ. WRITE
+// shares the same `state == UNLOCKED` gate for UNIQUE as READ does, so the same potential
+// starvation applies.
+TEST_F(ResourceLockTest, UniqueStarvationUnderContinuousWriteHammer) {
+  using namespace std::chrono_literals;
+  constexpr int kNumHammers = 8;
+  constexpr auto kWatchdogBound = 5s;
+
+  std::atomic<bool> stop{false};
+  std::vector<std::jthread> hammers;
+  hammers.reserve(kNumHammers);
+  for (int i = 0; i < kNumHammers; ++i) {
+    hammers.emplace_back([&, i] {
+      std::this_thread::sleep_for(std::chrono::microseconds(i * 13));
+      while (!stop.load(std::memory_order_relaxed)) {
+        lock.lock_shared<ResourceLock::LockReq::WRITE>();
+        std::this_thread::sleep_for(100us);
+        lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+      }
+    });
+  }
+
+  auto unique_future = std::async(std::launch::async, [&] {
+    auto start = std::chrono::steady_clock::now();
+    lock.lock();
+    auto acquired = std::chrono::steady_clock::now();
+    lock.unlock();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(acquired - start);
+  });
+
+  const bool acquired_in_time = unique_future.wait_for(kWatchdogBound) == std::future_status::ready;
+
+  stop.store(true, std::memory_order_relaxed);
+  hammers.clear();
+
+  if (acquired_in_time) {
+    const auto latency = unique_future.get();
+    RecordProperty("unique_acquire_latency_ms", std::to_string(latency.count()));
+  } else {
+    ADD_FAILURE() << "UNIQUE lock() did not acquire within " << kWatchdogBound.count()
+                  << "s under continuous WRITE churn from " << kNumHammers
+                  << " hammer threads — ResourceLock::lock() has no anti-starvation mechanism against shared "
+                     "holders, this is a liveness/fairness bug, not a memory-safety one.";
+    unique_future.get();
+  }
+}
+
+// Test 3: READ_ONLY vs WRITE priority. WRITE hammers keep the lock busy; a READ_ONLY arrives
+// mid-stream and registers `ro_pending_count`, which should block any *new* WRITE acquisition
+// until the READ_ONLY succeeds. That means READ_ONLY's acquisition latency should be governed by
+// draining the writer(s) already in flight at the moment it registered, not by how many new
+// writer threads pile up afterwards. We measure the latency with a small burst of new writers and
+// again with a much larger burst, and assert the latency does not grow with the burst size.
+TEST_F(ResourceLockTest, ReadOnlyLatencyIndependentOfNewWriterCount) {
+  using namespace std::chrono_literals;
+
+  auto measure = [&](int num_inflight_writers, int num_late_writers) {
+    std::atomic<bool> stop_inflight{false};
+    std::vector<std::jthread> inflight;
+    inflight.reserve(num_inflight_writers);
+    for (int i = 0; i < num_inflight_writers; ++i) {
+      inflight.emplace_back([&] {
+        while (!stop_inflight.load(std::memory_order_relaxed)) {
+          lock.lock_shared<ResourceLock::LockReq::WRITE>();
+          std::this_thread::sleep_for(200us);
+          lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+        }
+      });
+    }
+    // Give the in-flight writers time to actually be holding the lock before RO registers.
+    std::this_thread::sleep_for(2ms);
+
+    std::atomic<bool> ro_registered{false};
+    std::atomic<bool> ro_done{false};
+    std::chrono::steady_clock::time_point t_start;
+    std::chrono::steady_clock::time_point t_acquired;
+
+    std::jthread ro_thread([&] {
+      t_start = std::chrono::steady_clock::now();
+      ro_registered.store(true, std::memory_order_release);
+      lock.lock_shared<ResourceLock::LockReq::READ_ONLY>();
+      t_acquired = std::chrono::steady_clock::now();
+      ro_done.store(true, std::memory_order_release);
+      std::this_thread::sleep_for(1ms);
+      lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+    });
+
+    while (!ro_registered.load(std::memory_order_acquire)) {
+      std::this_thread::yield();
+    }
+    // Small buffer so `ro_pending_count` is very likely already incremented before the burst.
+    std::this_thread::sleep_for(300us);
+
+    std::atomic<int> late_before_ro{0};
+    std::atomic<int> late_after_ro{0};
+    std::vector<std::jthread> late;
+    late.reserve(num_late_writers);
+    for (int i = 0; i < num_late_writers; ++i) {
+      late.emplace_back([&] {
+        lock.lock_shared<ResourceLock::LockReq::WRITE>();
+        const bool already_done = ro_done.load(std::memory_order_acquire);
+        std::this_thread::sleep_for(30us);
+        lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+        if (already_done) {
+          late_after_ro.fetch_add(1, std::memory_order_relaxed);
+        } else {
+          late_before_ro.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+    }
+
+    ro_thread.join();
+    late.clear();
+    stop_inflight.store(true, std::memory_order_relaxed);
+    inflight.clear();
+
+    EXPECT_EQ(late_before_ro.load(), 0) << "new WRITE attempts registered after READ_ONLY was pending managed to "
+                                           "acquire before it — ro_pending_count priority not honoured";
+
+    return std::chrono::duration_cast<std::chrono::microseconds>(t_acquired - t_start);
+  };
+
+  const auto latency_small_burst = measure(/*num_inflight_writers=*/2, /*num_late_writers=*/5);
+  const auto latency_large_burst = measure(/*num_inflight_writers=*/2, /*num_late_writers=*/60);
+
+  RecordProperty("ro_latency_small_burst_us", std::to_string(latency_small_burst.count()));
+  RecordProperty("ro_latency_large_burst_us", std::to_string(latency_large_burst.count()));
+
+  // The large burst has 12x more new writers queued behind the READ_ONLY request; if priority is
+  // honoured, that should barely move the READ_ONLY latency (bounded by in-flight-writer drain
+  // time), not scale with the queue length.
+  EXPECT_LT(latency_large_burst, latency_small_burst + 50ms)
+      << "READ_ONLY latency grew with the number of new writers queued behind it (small burst="
+      << latency_small_burst.count() << "us, large burst=" << latency_large_burst.count()
+      << "us) — ro_pending_count priority/starvation regression";
+}
+
+// ---------------------------------------------------------------------------------------------
+// UniquePendingScope / ReadOnlyPendingScope: RAII helpers that keep a *non-blocking* probe
+// campaign registered as pending (bumping unique_pending_ / ro_pending_count respectively) so a
+// retrying try_acquire() loop gets the same writer-preference a blocking lock()/lock_shared()
+// call already gets. The tests below directly exercise the liveness contrast this is meant to
+// fix (bare try_lock() loop starves, a pending-scope loop does not) plus the deterministic gating
+// and mutual-exclusion invariants.
+// ---------------------------------------------------------------------------------------------
+
+namespace {
+// Spins up `kNumHammers` threads that continuously take/release a shared lock of type `Req`,
+// staggered so releases don't line up in lockstep (keeping shared occupancy continuous). Returns
+// the thread pool; caller flips `stop` and lets the vector go out of scope to join.
+template <ResourceLock::LockReq Req>
+std::vector<std::jthread> SpawnHammers(ResourceLock &target_lock, std::atomic<bool> &stop, int kNumHammers) {
+  std::vector<std::jthread> hammers;
+  hammers.reserve(kNumHammers);
+  for (int i = 0; i < kNumHammers; ++i) {
+    hammers.emplace_back([&target_lock, &stop, i] {
+      std::this_thread::sleep_for(std::chrono::microseconds(i * 13));
+      while (!stop.load(std::memory_order_relaxed)) {
+        target_lock.lock_shared<Req>();
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+        target_lock.unlock_shared<Req>();
+      }
+    });
+  }
+  return hammers;
+}
+}  // namespace
+
+// Test 4a: a UniquePendingScope held across a try_acquire() retry loop should acquire within a
+// bounded time under a continuous stream of new WRITE shared acquirers, whereas a bare
+// `lock.try_lock()` retry loop against the same kind of hammer stream is expected to starve (its
+// probes never register as pending, so it never gates the hammers out) — this is the soft/control
+// half of the assertion, since starvation of an unprivileged contender is a probabilistic
+// (environment-dependent) property, not a hard guarantee.
+TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarves) {
+  using namespace std::chrono_literals;
+  constexpr int kNumHammers = 8;
+  constexpr auto kPendingScopeBound = 5s;
+  constexpr auto kControlBound = 300ms;
+
+  // --- Scenario 1: UniquePendingScope campaign against continuous WRITE hammers ---
+  {
+    std::atomic<bool> stop{false};
+    auto hammers = SpawnHammers<ResourceLock::LockReq::WRITE>(lock, stop, kNumHammers);
+
+    auto scoped_future = std::async(std::launch::async, [&] {
+      auto start = std::chrono::steady_clock::now();
+      UniquePendingScope scope(lock);
+      std::optional<std::unique_lock<ResourceLock>> acquired;
+      while (!acquired) {
+        acquired = scope.try_acquire();
+        if (!acquired) std::this_thread::sleep_for(20us);
+      }
+      auto latency = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+      return latency;  // `acquired` unlocks on scope exit here
+    });
+
+    const bool acquired_in_time = scoped_future.wait_for(kPendingScopeBound) == std::future_status::ready;
+    stop.store(true, std::memory_order_relaxed);
+    hammers.clear();
+
+    if (acquired_in_time) {
+      const auto latency = scoped_future.get();
+      RecordProperty("unique_pending_scope_latency_ms", std::to_string(latency.count()));
+    } else {
+      ADD_FAILURE() << "UniquePendingScope::try_acquire() campaign did not acquire within "
+                    << kPendingScopeBound.count() << "s under continuous WRITE churn from " << kNumHammers
+                    << " hammer threads — pending-scope writer-preference regression";
+      scoped_future.get();  // reap the async thread now that hammers have stopped
+    }
+  }
+
+  // --- Scenario 2 (control): bare try_lock() retry loop against the same kind of hammer stream ---
+  {
+    std::atomic<bool> stop{false};
+    auto hammers = SpawnHammers<ResourceLock::LockReq::WRITE>(lock, stop, kNumHammers);
+
+    auto control_future = std::async(std::launch::async, [&] {
+      auto start = std::chrono::steady_clock::now();
+      while (std::chrono::steady_clock::now() - start < kControlBound) {
+        if (lock.try_lock()) {
+          return std::optional{
+              std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start)};
+        }
+        std::this_thread::sleep_for(20us);
+      }
+      return std::optional<std::chrono::milliseconds>{};
+    });
+
+    auto control_result = control_future.get();
+    stop.store(true, std::memory_order_relaxed);
+    hammers.clear();
+
+    if (control_result) {
+      lock.unlock();  // it did acquire; release so later tests in the suite start from UNLOCKED
+      // Soft: the control loop is *expected* to starve, but since it isn't gated at all its
+      // success is a timing-dependent (not impossible) outcome — log it as a non-fatal note
+      // rather than aborting the test.
+      ADD_FAILURE() << "bare try_lock() control unexpectedly acquired within " << control_result->count()
+                    << "ms under continuous WRITE churn — expected it to starve (soft/environment-dependent check)";
+    }
+  }
+}
+
+// Test 4b: same contrast, but ReadOnlyPendingScope against continuous WRITE hammers.
+TEST_F(ResourceLockTest, ReadOnlyPendingScopeCampaignAcquiresUnderContinuousWriteHammer) {
+  using namespace std::chrono_literals;
+  constexpr int kNumHammers = 8;
+  constexpr auto kBound = 5s;
+
+  std::atomic<bool> stop{false};
+  auto hammers = SpawnHammers<ResourceLock::LockReq::WRITE>(lock, stop, kNumHammers);
+
+  auto scoped_future = std::async(std::launch::async, [&] {
+    auto start = std::chrono::steady_clock::now();
+    ReadOnlyPendingScope scope(lock);
+    std::optional<SharedResourceLockGuard> acquired;
+    while (!acquired) {
+      acquired = scope.try_acquire();
+      if (!acquired) std::this_thread::sleep_for(20us);
+    }
+    auto latency = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+    const auto acquired_type = acquired->type();
+    return std::pair{latency, acquired_type};  // guard unlocks on scope exit here
+  });
+
+  const bool acquired_in_time = scoped_future.wait_for(kBound) == std::future_status::ready;
+  stop.store(true, std::memory_order_relaxed);
+  hammers.clear();
+
+  if (acquired_in_time) {
+    const auto [latency, acquired_type] = scoped_future.get();
+    EXPECT_EQ(acquired_type, SharedResourceLockGuard::READ_ONLY);
+    RecordProperty("ro_pending_scope_latency_ms", std::to_string(latency.count()));
+  } else {
+    ADD_FAILURE() << "ReadOnlyPendingScope::try_acquire() campaign did not acquire within " << kBound.count()
+                  << "s under continuous WRITE churn from " << kNumHammers
+                  << " hammer threads — pending-scope priority regression";
+    scoped_future.get();  // reap the async thread now that hammers have stopped
+  }
+}
+
+// Test 4c: deterministic (non-timing-dependent) check that a live, not-yet-successful
+// UniquePendingScope gates *new* shared acquisitions of every kind (READ, WRITE, READ_ONLY),
+// exactly like a blocked lock() waiter would, and that the gate is released the moment the scope
+// is destroyed without ever having acquired.
+TEST_F(ResourceLockTest, UniquePendingScopeGatesNewSharedAcquisitionUntilDestroyed) {
+  // Hold a WRITE lock first so the scope's own try_acquire() cannot succeed (state != UNLOCKED),
+  // keeping it "pending" for the whole block below.
+  auto guard_w0 = SharedResourceLockGuard(lock, SharedResourceLockGuard::WRITE);
+
+  {
+    UniquePendingScope scope(lock);
+    ASSERT_FALSE(scope.try_acquire().has_value());
+
+    EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::WRITE>());
+    EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ>());
+    EXPECT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ_ONLY>());
+  }
+  // scope destroyed without acquiring -> unique_pending_ back to 0, new shared acquisitions
+  // compatible with the still-held WRITE lock should succeed again.
+  ASSERT_TRUE(lock.try_lock_shared<ResourceLock::LockReq::WRITE>());
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+
+  guard_w0.unlock();
+}
+
+// Test 4d: mutual-exclusion invariant fuzzer (same style as ConcurrentMutualExclusionInvariantsFuzz
+// above), extended with UniquePendingScope / ReadOnlyPendingScope try_acquire() attempts mixed in
+// alongside the existing blocking/try entry points, to give TSan and the invariant checker a shot
+// at the new code paths (mtx-protected state mutation + adopt_lock hand-off).
+TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzzWithPendingScopes) {
+  using namespace std::chrono_literals;
+  constexpr int kNumThreads = 24;
+  constexpr auto kDuration = 400ms;
+
+  struct Counters {
+    std::atomic<int> active_read{0};
+    std::atomic<int> active_write{0};
+    std::atomic<int> active_ro{0};
+    std::atomic<int> active_unique{0};
+  } counters;
+
+  std::atomic<bool> invariant_violated{false};
+  std::mutex violation_mutex;
+  std::string violation_message;
+
+  auto record_violation = [&](const std::string &msg) {
+    bool expected = false;
+    if (invariant_violated.compare_exchange_strong(expected, true)) {
+      std::lock_guard<std::mutex> lg(violation_mutex);
+      violation_message = msg;
+    }
+  };
+
+  auto check_invariants = [&](const char *where) {
+    const int aw = counters.active_write.load(std::memory_order_acquire);
+    const int aro = counters.active_ro.load(std::memory_order_acquire);
+    const int ar = counters.active_read.load(std::memory_order_acquire);
+    const int au = counters.active_unique.load(std::memory_order_acquire);
+    if (aw > 0 && aro > 0) {
+      record_violation(std::string(where) + ": WRITE(" + std::to_string(aw) + ") and READ_ONLY(" + std::to_string(aro) +
+                       ") concurrently active");
+    }
+    if (au > 0 && (aw > 0 || ar > 0 || aro > 0)) {
+      record_violation(std::string(where) + ": UNIQUE(" + std::to_string(au) + ") active alongside shared holders (w=" +
+                       std::to_string(aw) + ", r=" + std::to_string(ar) + ", ro=" + std::to_string(aro) + ")");
+    }
+    if (au > 1) {
+      record_violation(std::string(where) + ": more than one UNIQUE holder concurrently (" + std::to_string(au) + ")");
+    }
+  };
+
+  std::atomic<bool> stop{false};
+
+  auto worker = [&](int seed) {
+    std::mt19937 rng(static_cast<unsigned>(seed) * 2654435761u ^
+                     static_cast<unsigned>(std::hash<std::thread::id>{}(std::this_thread::get_id())));
+    std::uniform_int_distribution<int> op_pick(0, 6);
+    std::uniform_int_distribution<int> hold_us(0, 50);
+
+    while (!stop.load(std::memory_order_relaxed) && !invariant_violated.load(std::memory_order_relaxed)) {
+      switch (op_pick(rng)) {
+        case 0: {  // READ
+          lock.lock_shared<ResourceLock::LockReq::READ>();
+          counters.active_read.fetch_add(1, std::memory_order_acq_rel);
+          check_invariants("READ");
+          std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+          counters.active_read.fetch_sub(1, std::memory_order_acq_rel);
+          lock.unlock_shared<ResourceLock::LockReq::READ>();
+          break;
+        }
+        case 1: {  // WRITE
+          lock.lock_shared<ResourceLock::LockReq::WRITE>();
+          counters.active_write.fetch_add(1, std::memory_order_acq_rel);
+          check_invariants("WRITE");
+          std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+          counters.active_write.fetch_sub(1, std::memory_order_acq_rel);
+          lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+          break;
+        }
+        case 2: {  // READ_ONLY, blocking
+          lock.lock_shared<ResourceLock::LockReq::READ_ONLY>();
+          counters.active_ro.fetch_add(1, std::memory_order_acq_rel);
+          check_invariants("READ_ONLY(block)");
+          std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+          counters.active_ro.fetch_sub(1, std::memory_order_acq_rel);
+          lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+          break;
+        }
+        case 3: {  // UNIQUE via try_lock
+          if (lock.try_lock()) {
+            counters.active_unique.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("UNIQUE(try_lock)");
+            std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+            counters.active_unique.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock();
+          }
+          break;
+        }
+        case 4: {  // UNIQUE via a single-shot UniquePendingScope::try_acquire()
+          UniquePendingScope scope(lock);
+          if (auto acquired = scope.try_acquire()) {
+            counters.active_unique.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("UNIQUE(pending_scope)");
+            std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+            counters.active_unique.fetch_sub(1, std::memory_order_acq_rel);
+            // *acquired unlocks on scope exit below (std::unique_lock<ResourceLock> dtor)
+          }
+          break;
+        }
+        case 5: {  // READ_ONLY via a single-shot ReadOnlyPendingScope::try_acquire()
+          ReadOnlyPendingScope scope(lock);
+          if (auto acquired = scope.try_acquire()) {
+            counters.active_ro.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("READ_ONLY(pending_scope)");
+            std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+            counters.active_ro.fetch_sub(1, std::memory_order_acq_rel);
+            // *acquired unlocks on scope exit below (SharedResourceLockGuard dtor)
+          }
+          break;
+        }
+        case 6: {  // plain try_lock_shared READ_ONLY (existing entry point, for contrast)
+          if (lock.try_lock_shared<ResourceLock::LockReq::READ_ONLY>()) {
+            counters.active_ro.fetch_add(1, std::memory_order_acq_rel);
+            check_invariants("READ_ONLY(try)");
+            std::this_thread::sleep_for(std::chrono::microseconds(hold_us(rng)));
+            counters.active_ro.fetch_sub(1, std::memory_order_acq_rel);
+            lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+          }
+          break;
+        }
+      }
+    }
+  };
+
+  std::vector<std::jthread> threads;
+  threads.reserve(kNumThreads);
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back(worker, i);
+  }
+
+  std::this_thread::sleep_for(kDuration);
+  stop.store(true, std::memory_order_relaxed);
+  threads.clear();
+
+  ASSERT_FALSE(invariant_violated.load()) << violation_message;
 }

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -956,6 +956,59 @@ TEST_F(ResourceLockTest, UniquePendingScopeGatesNewSharedAcquisitionUntilDestroy
   guard_w0.unlock();
 }
 
+// Test 4c-ii: destroying a still-pending UniquePendingScope must WAKE a thread that is genuinely
+// blocked in lock_shared() (parked in cv.wait), not merely clear the gate for a later non-blocking
+// try_lock_shared() (which 4c above already covers). This exercises the destructor's notify path
+// against a real waiter. NOTE: this deterministically guards that the wake happens *at all* (e.g. a
+// future refactor that drops the notify_all, or fails to publish the counter under mtx, would hang
+// here and fail via the bounded wait_for). It does not by itself reproduce the narrow notify-races-
+// enqueue window that motivated mutating unique_pending_ under mtx -- that window is not
+// deterministically reproducible in a unit test; correctness there rests on the mtx discipline
+// (same as ResourceLock::lock()'s failure path) plus the fuzz test below.
+TEST_F(ResourceLockTest, UniquePendingScopeDestructionWakesBlockedSharedReader) {
+  using namespace std::chrono_literals;
+  // Hold WRITE so state == SHARED (never UNLOCKED): the scope can never acquire and stays pending,
+  // and a READ acquirer is compatible with the held WRITE once the unique_pending_ gate clears.
+  auto guard_w0 = SharedResourceLockGuard(lock, SharedResourceLockGuard::WRITE);
+
+  auto scope = std::optional<UniquePendingScope>{std::in_place, lock};  // unique_pending_ == 1
+  ASSERT_FALSE(scope->try_acquire().has_value());
+
+  std::atomic<bool> reader_acquired{false};
+  auto reader = std::async(std::launch::async, [&] {
+    // Blocks: predicate is (state != UNIQUE && unique_pending_ == 0); unique_pending_ == 1 here,
+    // so this parks in cv.wait until the scope below is destroyed.
+    lock.lock_shared<ResourceLock::LockReq::READ>();
+    reader_acquired.store(true, std::memory_order_release);
+    lock.unlock_shared<ResourceLock::LockReq::READ>();
+  });
+
+  // Give the reader ample time to reach cv.wait, then confirm it is actually still blocked (the gate
+  // is holding it, not a scheduling delay).
+  std::this_thread::sleep_for(50ms);
+  ASSERT_FALSE(reader_acquired.load(std::memory_order_acquire));
+
+  scope.reset();  // ~UniquePendingScope: unique_pending_ 1 -> 0 under mtx, then notify_all -> wake
+
+  // Bounded so a lost/absent wake fails the test (~5s) instead of hanging the suite forever.
+  const auto status = reader.wait_for(5s);
+  EXPECT_EQ(status, std::future_status::ready)
+      << "reader blocked in lock_shared() was not woken by ~UniquePendingScope (lost/absent wakeup)";
+  if (status != std::future_status::ready) {
+    // Rescue the still-parked reader so the std::future destructor does not block forever: releasing
+    // the WRITE guard notifies_all (unlock_should_notify<WRITE>), which wakes it (unique_pending_ is
+    // already 0). Do this ONLY on the failure path -- doing it before the assertion would wake the
+    // reader regardless of the scope's own notify and destroy the test's discriminating power.
+    guard_w0.unlock();
+    reader.wait();
+    return;
+  }
+  reader.get();
+  EXPECT_TRUE(reader_acquired.load(std::memory_order_acquire));
+
+  guard_w0.unlock();
+}
+
 // Test 4d: mutual-exclusion invariant fuzzer (same style as ConcurrentMutualExclusionInvariantsFuzz
 // above), extended with UniquePendingScope / ReadOnlyPendingScope try_acquire() attempts mixed in
 // alongside the existing blocking/try entry points, to give TSan and the invariant checker a shot


### PR DESCRIPTION
A `ResourceLock` acquirer waiting for UNIQUE could be starved indefinitely by a continuous stream of shared acquirers (READ, WRITE, READ_ONLY), since nothing made new shared acquisitions yield to it.

A waiting UNIQUE now registers as pending for as long as it waits, and a pending UNIQUE gates new shared acquisitions, mirroring the existing READ_ONLY-over-WRITE priority. The registration is RAII, so it survives a timeout or an exception out of the wait rather than blocking every shared acquisition for the lifetime of the lock. Both pending counters are plain integers mutated only under the mutex: a waiter reads them inside its wait predicate, so an off-mutex mutation can land between that check and the waiter's enqueue on the condition variable and lose the wake.

`UniquePendingScope` and `ReadOnlyPendingScope` give the same priority to callers that cannot block on the condition variable, such as a coroutine that must yield to a scheduler. The scope registers as pending once, then polls a non-blocking `try_acquire()` that hands ownership over on success. This is the foundation for non-blocking accessor acquisition in the stacked storage PR.

Analytical garbage collection took READ, read the storage mode under it, then acquired WRITE without releasing READ. With shared acquisition now gated on a pending UNIQUE that escalation deadlocks, so GC releases READ before requesting WRITE and re-reads the mode under the hold it will use.

Internally there is now one acquire path and one release path for all four ways to hold the lock, parameterised on the wait strategy, in place of a separate implementation per acquisition kind.
