### PR TITLE
fix(storage): SetStorageMode double-unlock + non-blocking Try*Access primitives

### DIFF
--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -676,7 +676,7 @@ class DbAccessor final {
 
   void Abort() { accessor_->Abort(); }
 
-  storage::StorageMode GetStorageMode() const noexcept { return accessor_->GetCreationStorageMode(); }
+  storage::StorageMode GetStorageMode() const noexcept { return accessor_->GetPinnedStorageMode(); }
 
   bool LabelIndexReady(storage::LabelId label) const { return accessor_->LabelIndexReady(label); }
 

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -308,6 +308,17 @@ class TransactionSerializationException : public RetryBasicException {
   SPECIALIZE_GET_EXCEPTION_NAME(TransactionSerializationException)
 };
 
+// The storage mode selects which storage access a DDL query needs, so it is read before that
+// access is taken and a concurrent SET STORAGE MODE can land in between. Retrying picks the
+// access matching the new mode.
+class StorageModeChangedDuringSetupException : public RetryBasicException {
+ public:
+  StorageModeChangedDuringSetupException()
+      : RetryBasicException(
+            "The storage mode changed while this query was acquiring storage access. Retry this query.") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(StorageModeChangedDuringSetupException)
+};
+
 class ReconstructionException : public QueryException {
  public:
   ReconstructionException()

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9743,6 +9743,7 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
     }
 
     using enum storage::StorageAccessType;
+    mode_dependent_ = true;
     if (storage_mode_ == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
@@ -9759,6 +9760,7 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
     }
 
     using enum storage::StorageAccessType;
+    mode_dependent_ = true;
     if (storage_mode_ == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
@@ -9775,6 +9777,7 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
     }
 
     using enum storage::StorageAccessType;
+    mode_dependent_ = true;
     accessor_type_ = storage_mode_ == storage::StorageMode::ON_DISK_TRANSACTIONAL ? UNIQUE : READ_ONLY;
   }
 
@@ -9795,6 +9798,9 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
   std::optional<storage::StorageMode> storage_mode_;
 
   bool could_commit_ = false;
+  // Whether storage_mode_ fed accessor_type_ or isolation_level_override_. Only then does the
+  // caller re-check it; elsewhere a mode change is irrelevant and must not cost a retry.
+  bool mode_dependent_ = false;
   std::optional<storage::IsolationLevel> isolation_level_override_;
   std::optional<storage::StorageAccessType> accessor_type_;
 };
@@ -9989,6 +9995,16 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
           SetNextTransactionIsolationLevel(*transaction_requirements.isolation_level_override_);
         }
         SetupDatabaseTransaction(transaction_requirements.could_commit_, *transaction_requirements.accessor_type_);
+
+        // SET STORAGE MODE can land between the unlocked read of `storage_mode` and the accessor
+        // taking its hold, leaving the access type chosen for a mode no longer in force: an index
+        // create planned as transactional holds READ_ONLY where analytical wants UNIQUE. Retrying
+        // replans against the pinned mode. The throw unwinds into the catch below, releasing the
+        // hold.
+        if (transaction_requirements.mode_dependent_ &&
+            current_db_.db_transactional_accessor_->GetCreationStorageMode() != storage_mode) {
+          throw StorageModeChangedDuringSetupException();
+        }
       }
     }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10002,7 +10002,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
         // replans against the pinned mode. The throw unwinds into the catch below, releasing the
         // hold.
         if (transaction_requirements.mode_dependent_ &&
-            current_db_.db_transactional_accessor_->GetCreationStorageMode() != storage_mode) {
+            current_db_.db_transactional_accessor_->GetPinnedStorageMode() != storage_mode) {
           throw StorageModeChangedDuringSetupException();
         }
       }
@@ -10772,8 +10772,8 @@ void Interpreter::Commit() {
   });
 
   auto current_storage_mode = db->GetStorageMode();
-  auto creation_mode = current_db_.db_transactional_accessor_->GetCreationStorageMode();
-  if (creation_mode != storage::StorageMode::ON_DISK_TRANSACTIONAL &&
+  auto pinned_mode = current_db_.db_transactional_accessor_->GetPinnedStorageMode();
+  if (pinned_mode != storage::StorageMode::ON_DISK_TRANSACTIONAL &&
       current_storage_mode == storage::StorageMode::ON_DISK_TRANSACTIONAL) {
     throw QueryException(
         "Cannot commit transaction because the storage mode has changed from in-memory storage to on-disk storage.");

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -287,19 +287,9 @@ DiskStorage::~DiskStorage() {
   kvstore_->options_.comparator = nullptr;
 }
 
-DiskStorage::DiskAccessor::DiskAccessor(Accessor::SharedAccess tag, DiskStorage *storage,
-                                        std::optional<IsolationLevel> override_isolation_level,
-                                        StorageAccessType rw_type)
-    : Accessor(tag, storage, override_isolation_level, rw_type, /*no timeout*/ std::nullopt) {
-  rocksdb::WriteOptions write_options;
-  auto txOptions = rocksdb::TransactionOptions{.set_snapshot = true};
-  transaction_.disk_transaction_ = storage->kvstore_->db_->BeginTransaction(write_options, txOptions);
-  transaction_.disk_transaction_->SetReadTimestampForValidation(transaction_.start_timestamp);
-}
-
-DiskStorage::DiskAccessor::DiskAccessor(auto tag, DiskStorage *storage,
-                                        std::optional<IsolationLevel> override_isolation_level)
-    : Accessor(tag, storage, override_isolation_level, /*no timeout*/ std::nullopt) {
+DiskStorage::DiskAccessor::DiskAccessor(DiskStorage *storage, std::optional<IsolationLevel> override_isolation_level,
+                                        utils::ResourceLockGuard guard)
+    : Accessor(storage, override_isolation_level, std::move(guard)) {
   rocksdb::WriteOptions write_options;
   auto txOptions = rocksdb::TransactionOptions{.set_snapshot = true};
   transaction_.disk_transaction_ = storage->kvstore_->db_->BeginTransaction(write_options, txOptions);
@@ -2517,7 +2507,7 @@ std::unique_ptr<Storage::Accessor> DiskStorage::Access(StorageAccessType rw_type
     throw utils::NotYetImplemented("Disk storage supports only SNAPSHOT isolation level. {}", kErrorMessage);
   }
   return std::unique_ptr<DiskAccessor>(
-      new DiskAccessor{Storage::Accessor::shared_access, this, override_isolation_level, rw_type});
+      new DiskAccessor{this, override_isolation_level, AcquireGuardOrThrow(this, rw_type, std::nullopt)});
 }
 
 std::unique_ptr<Storage::Accessor> DiskStorage::UniqueAccess(std::optional<IsolationLevel> override_isolation_level,
@@ -2526,8 +2516,8 @@ std::unique_ptr<Storage::Accessor> DiskStorage::UniqueAccess(std::optional<Isola
   if (isolation_level != IsolationLevel::SNAPSHOT_ISOLATION) {
     throw utils::NotYetImplemented("Disk storage supports only SNAPSHOT isolation level. {}", kErrorMessage);
   }
-  return std::unique_ptr<DiskAccessor>(
-      new DiskAccessor{Storage::Accessor::unique_access, this, override_isolation_level});
+  return std::unique_ptr<DiskAccessor>(new DiskAccessor{
+      this, override_isolation_level, AcquireGuardOrThrow(this, StorageAccessType::UNIQUE, std::nullopt)});
 }
 
 std::unique_ptr<Storage::Accessor> DiskStorage::ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level,
@@ -2536,8 +2526,8 @@ std::unique_ptr<Storage::Accessor> DiskStorage::ReadOnlyAccess(std::optional<Iso
   if (isolation_level != IsolationLevel::SNAPSHOT_ISOLATION) {
     throw utils::NotYetImplemented("Disk storage supports only SNAPSHOT isolation level. {}", kErrorMessage);
   }
-  return std::unique_ptr<DiskAccessor>(
-      new DiskAccessor{Storage::Accessor::read_only_access, this, override_isolation_level});
+  return std::unique_ptr<DiskAccessor>(new DiskAccessor{
+      this, override_isolation_level, AcquireGuardOrThrow(this, StorageAccessType::READ_ONLY, std::nullopt)});
 }
 
 bool DiskStorage::DiskAccessor::LabelPropertyIndexExists(LabelId label,

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -288,18 +288,18 @@ DiskStorage::~DiskStorage() {
 }
 
 DiskStorage::DiskAccessor::DiskAccessor(Accessor::SharedAccess tag, DiskStorage *storage,
-                                        IsolationLevel isolation_level, StorageMode storage_mode,
+                                        std::optional<IsolationLevel> override_isolation_level,
                                         StorageAccessType rw_type)
-    : Accessor(tag, storage, isolation_level, storage_mode, rw_type, /*no timeout*/ std::nullopt) {
+    : Accessor(tag, storage, override_isolation_level, rw_type, /*no timeout*/ std::nullopt) {
   rocksdb::WriteOptions write_options;
   auto txOptions = rocksdb::TransactionOptions{.set_snapshot = true};
   transaction_.disk_transaction_ = storage->kvstore_->db_->BeginTransaction(write_options, txOptions);
   transaction_.disk_transaction_->SetReadTimestampForValidation(transaction_.start_timestamp);
 }
 
-DiskStorage::DiskAccessor::DiskAccessor(auto tag, DiskStorage *storage, IsolationLevel isolation_level,
-                                        StorageMode storage_mode)
-    : Accessor(tag, storage, isolation_level, storage_mode, /*no timeout*/ std::nullopt) {
+DiskStorage::DiskAccessor::DiskAccessor(auto tag, DiskStorage *storage,
+                                        std::optional<IsolationLevel> override_isolation_level)
+    : Accessor(tag, storage, override_isolation_level, /*no timeout*/ std::nullopt) {
   rocksdb::WriteOptions write_options;
   auto txOptions = rocksdb::TransactionOptions{.set_snapshot = true};
   transaction_.disk_transaction_ = storage->kvstore_->db_->BeginTransaction(write_options, txOptions);
@@ -2517,7 +2517,7 @@ std::unique_ptr<Storage::Accessor> DiskStorage::Access(StorageAccessType rw_type
     throw utils::NotYetImplemented("Disk storage supports only SNAPSHOT isolation level. {}", kErrorMessage);
   }
   return std::unique_ptr<DiskAccessor>(
-      new DiskAccessor{Storage::Accessor::shared_access, this, isolation_level, storage_mode_, rw_type});
+      new DiskAccessor{Storage::Accessor::shared_access, this, override_isolation_level, rw_type});
 }
 
 std::unique_ptr<Storage::Accessor> DiskStorage::UniqueAccess(std::optional<IsolationLevel> override_isolation_level,
@@ -2527,7 +2527,7 @@ std::unique_ptr<Storage::Accessor> DiskStorage::UniqueAccess(std::optional<Isola
     throw utils::NotYetImplemented("Disk storage supports only SNAPSHOT isolation level. {}", kErrorMessage);
   }
   return std::unique_ptr<DiskAccessor>(
-      new DiskAccessor{Storage::Accessor::unique_access, this, isolation_level, storage_mode_});
+      new DiskAccessor{Storage::Accessor::unique_access, this, override_isolation_level});
 }
 
 std::unique_ptr<Storage::Accessor> DiskStorage::ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level,
@@ -2537,7 +2537,7 @@ std::unique_ptr<Storage::Accessor> DiskStorage::ReadOnlyAccess(std::optional<Iso
     throw utils::NotYetImplemented("Disk storage supports only SNAPSHOT isolation level. {}", kErrorMessage);
   }
   return std::unique_ptr<DiskAccessor>(
-      new DiskAccessor{Storage::Accessor::read_only_access, this, isolation_level, storage_mode_});
+      new DiskAccessor{Storage::Accessor::read_only_access, this, override_isolation_level});
 }
 
 bool DiskStorage::DiskAccessor::LabelPropertyIndexExists(LabelId label,

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -56,9 +56,8 @@ class DiskStorage final : public Storage {
    private:
     friend class DiskStorage;
 
-    explicit DiskAccessor(SharedAccess tag, DiskStorage *storage,
-                          std::optional<IsolationLevel> override_isolation_level, StorageAccessType rw_type);
-    explicit DiskAccessor(auto tag, DiskStorage *storage, std::optional<IsolationLevel> override_isolation_level);
+    explicit DiskAccessor(DiskStorage *storage, std::optional<IsolationLevel> override_isolation_level,
+                          utils::ResourceLockGuard guard);
 
    public:
     DiskAccessor(const DiskAccessor &) = delete;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -597,7 +597,7 @@ class DiskStorage final : public Storage {
     // Disk storage doesn't track and cache live label counts, so this is a no-op
   }
 
-  void FreeMemory(std::unique_lock<utils::ResourceLock> /*lock*/, bool /*periodic*/) override {}
+  void FreeMemory(std::optional<utils::ResourceLockGuard> /*lock*/, bool /*periodic*/) override {}
 
   void PrepareForNewEpoch() override { throw utils::BasicException("Disk storage mode does not support replication."); }
 

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -56,9 +56,9 @@ class DiskStorage final : public Storage {
    private:
     friend class DiskStorage;
 
-    explicit DiskAccessor(SharedAccess tag, DiskStorage *storage, IsolationLevel isolation_level,
-                          StorageMode storage_mode, StorageAccessType rw_type);
-    explicit DiskAccessor(auto tag, DiskStorage *storage, IsolationLevel isolation_level, StorageMode storage_mode);
+    explicit DiskAccessor(SharedAccess tag, DiskStorage *storage,
+                          std::optional<IsolationLevel> override_isolation_level, StorageAccessType rw_type);
+    explicit DiskAccessor(auto tag, DiskStorage *storage, std::optional<IsolationLevel> override_isolation_level);
 
    public:
     DiskAccessor(const DiskAccessor &) = delete;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -596,7 +596,7 @@ class DiskStorage final : public Storage {
     // Disk storage doesn't track and cache live label counts, so this is a no-op
   }
 
-  void FreeMemory(std::optional<utils::ResourceLockGuard> /*lock*/, bool /*periodic*/) override {}
+  void FreeMemory(utils::ResourceLockGuard /*lock*/, bool /*periodic*/) override {}
 
   void PrepareForNewEpoch() override { throw utils::BasicException("Disk storage mode does not support replication."); }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -569,7 +569,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
   if (free_mem_fn_override) {
     free_memory_func_ = *std::move(free_mem_fn_override);
   } else {
-    free_memory_func_ = [this](std::optional<utils::ResourceLockGuard> main_guard, bool periodic) {
+    free_memory_func_ = [this](utils::ResourceLockGuard main_guard, bool periodic) {
       CollectGarbage(std::move(main_guard), periodic);
 
       // Indices
@@ -610,7 +610,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
     gc_runner_.SetInterval(config_.gc.interval);
     gc_runner_.Run("Storage GC", [this] {
       const memory::DbArenaScope db_arena_scope{db_arena_};
-      this->FreeMemory(std::nullopt, true);
+      this->FreeMemory({}, true);
     });
   }
 
@@ -2923,19 +2923,19 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
   }
 }
 
-void InMemoryStorage::CollectGarbage(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) {
+void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool periodic) {
   // NOTE: A single call need not handle objects deleted under a different storage mode: SetStorageMode
   // runs GC before any transaction in the new mode can start.
 
   using Guard = utils::ResourceLockGuard;
   auto const main_lock_guard = [&] -> Guard {
     // Adopt SetStorageMode's UNIQUE hold if it passed one; reacquiring would deadlock.
-    if (main_guard) {
+    if (main_guard.owns_lock()) {
       // Adopted in place of choosing a mode below, so it has to be exclusive: analytical GC is not
       // proven safe under a shared hold (see the WRITE choice further down).
-      DMG_ASSERT(main_guard->mutex() == std::addressof(main_lock_) && main_guard->is_exclusive(),
+      DMG_ASSERT(main_guard.mutex() == std::addressof(main_lock_) && main_guard.is_exclusive(),
                  "an adopted main_guard must be an exclusive hold on this storage's main_lock_");
-      return *std::move(main_guard);
+      return std::move(main_guard);
     }
 
     // Aggressive GC escalates to UNIQUE (blocks new txns); otherwise a shared hold, so slow GC does
@@ -4610,7 +4610,7 @@ std::vector<SnapshotFileInfo> InMemoryStorage::ShowSnapshots() {
   return res;
 }
 
-void InMemoryStorage::FreeMemory(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) {
+void InMemoryStorage::FreeMemory(utils::ResourceLockGuard main_guard, bool periodic) {
   std::invoke(free_memory_func_, std::move(main_guard), periodic);
 }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -569,7 +569,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
   if (free_mem_fn_override) {
     free_memory_func_ = *std::move(free_mem_fn_override);
   } else {
-    free_memory_func_ = [this](std::unique_lock<utils::ResourceLock> main_guard, bool periodic) {
+    free_memory_func_ = [this](std::optional<utils::ResourceLockGuard> main_guard, bool periodic) {
       CollectGarbage(std::move(main_guard), periodic);
 
       // Indices
@@ -610,7 +610,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
     gc_runner_.SetInterval(config_.gc.interval);
     gc_runner_.Run("Storage GC", [this] {
       const memory::DbArenaScope db_arena_scope{db_arena_};
-      this->FreeMemory(std::unique_lock{main_lock_, std::defer_lock}, true);
+      this->FreeMemory(std::nullopt, true);
     });
   }
 
@@ -2027,8 +2027,8 @@ auto InMemoryStorage::InMemoryAccessor::CreateIndex(LabelId label, PropertiesPat
 }
 
 void InMemoryStorage::InMemoryAccessor::DowngradeToReadIfValid() {
-  if (storage_guard_.owns_lock() && storage_guard_.type() == utils::SharedResourceLockGuard::Type::READ_ONLY) {
-    storage_guard_.downgrade_to_read();
+  if (guard_.owns_lock() && guard_.type() == utils::ResourceLockGuard::READ_ONLY) {
+    guard_.downgrade_to_read();
   }
 }
 
@@ -2930,16 +2930,16 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
   }
 }
 
-void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_guard, bool periodic) {
+void InMemoryStorage::CollectGarbage(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) {
   // NOTE: A single call need not handle objects deleted under a different storage mode: SetStorageMode
   // runs GC before any transaction in the new mode can start.
 
   using Guard = utils::ResourceLockGuard;
   auto const main_lock_guard = [&] -> Guard {
     // Adopt SetStorageMode's UNIQUE hold if it passed one; reacquiring would deadlock.
-    if (main_guard.owns_lock()) {
-      DMG_ASSERT(main_guard.mutex() == std::addressof(main_lock_), "main_guard should be only for the main_lock_");
-      return Guard{std::move(main_guard)};
+    if (main_guard) {
+      DMG_ASSERT(main_guard->mutex() == std::addressof(main_lock_), "main_guard should be only for the main_lock_");
+      return *std::move(main_guard);
     }
 
     // Aggressive GC escalates to UNIQUE (blocks new txns); otherwise a shared hold, so slow GC does
@@ -4614,7 +4614,7 @@ std::vector<SnapshotFileInfo> InMemoryStorage::ShowSnapshots() {
   return res;
 }
 
-void InMemoryStorage::FreeMemory(std::unique_lock<utils::ResourceLock> main_guard, bool periodic) {
+void InMemoryStorage::FreeMemory(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) {
   std::invoke(free_memory_func_, std::move(main_guard), periodic);
 }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -4670,6 +4670,13 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
       this, override_isolation_level, AcquireGuardOrThrow(this, StorageAccessType::READ_ONLY, timeout)});
 }
 
+std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccess(StorageAccessType rw_type,
+                                                              std::optional<IsolationLevel> override_isolation_level) {
+  utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::try_to_lock};
+  if (!guard.owns_lock()) return nullptr;
+  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{this, override_isolation_level, std::move(guard)});
+}
+
 void InMemoryStorage::CreateSnapshotHandler(
     std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb) {
   create_snapshot_handler = [cb = std::move(cb)](std::string_view trigger) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2924,7 +2924,9 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
       snapshot_runner_.Resume();
     }
     storage_mode_ = new_storage_mode;
-    FreeMemory(std::unique_lock{main_lock_, std::adopt_lock}, false);
+    // Hand off the same lock unique_accessor already holds; adopting main_lock_ into a second
+    // lock would give the one hold two owners and release it twice.
+    FreeMemory(unique_accessor->ReleaseUniqueGuard(), false);
   }
 }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -684,16 +684,10 @@ void InMemoryStorage::UpdateLabelCount(LabelId const label, int64_t const change
   }
 }
 
-InMemoryStorage::InMemoryAccessor::InMemoryAccessor(SharedAccess tag, InMemoryStorage *storage,
+InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryStorage *storage,
                                                     std::optional<IsolationLevel> override_isolation_level,
-                                                    StorageAccessType rw_type,
-                                                    std::optional<std::chrono::milliseconds> timeout)
-    : Accessor(tag, storage, override_isolation_level, rw_type, timeout), config_(storage->config_.salient.items) {}
-
-InMemoryStorage::InMemoryAccessor::InMemoryAccessor(auto tag, InMemoryStorage *storage,
-                                                    std::optional<IsolationLevel> override_isolation_level,
-                                                    std::optional<std::chrono::milliseconds> timeout)
-    : Accessor(tag, storage, override_isolation_level, timeout), config_(storage->config_.salient.items) {}
+                                                    utils::ResourceLockGuard guard)
+    : Accessor(storage, override_isolation_level, std::move(guard)), config_(storage->config_.salient.items) {}
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryAccessor &&other) noexcept
     : Accessor(std::move(other)), config_(other.config_) {}
@@ -2925,7 +2919,7 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
     storage_mode_ = new_storage_mode;
     // Hand off the same lock unique_accessor already holds; adopting main_lock_ into a second
     // lock would give the one hold two owners and release it twice.
-    FreeMemory(unique_accessor->ReleaseUniqueGuard(), false);
+    FreeMemory(unique_accessor->ReleaseGuard(), false);
   }
 }
 
@@ -2937,7 +2931,10 @@ void InMemoryStorage::CollectGarbage(std::optional<utils::ResourceLockGuard> mai
   auto const main_lock_guard = [&] -> Guard {
     // Adopt SetStorageMode's UNIQUE hold if it passed one; reacquiring would deadlock.
     if (main_guard) {
-      DMG_ASSERT(main_guard->mutex() == std::addressof(main_lock_), "main_guard should be only for the main_lock_");
+      // Adopted in place of choosing a mode below, so it has to be exclusive: analytical GC is not
+      // proven safe under a shared hold (see the WRITE choice further down).
+      DMG_ASSERT(main_guard->mutex() == std::addressof(main_lock_) && main_guard->is_exclusive(),
+                 "an adopted main_guard must be an exclusive hold on this storage's main_lock_");
       return *std::move(main_guard);
     }
 
@@ -4656,20 +4653,21 @@ utils::FileRetainer::FileLockerAccessor::ret_type InMemoryStorage::UnlockPath() 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::Access(StorageAccessType rw_type,
                                                            std::optional<IsolationLevel> override_isolation_level,
                                                            std::optional<std::chrono::milliseconds> timeout) {
+  DMG_ASSERT(rw_type != StorageAccessType::UNIQUE, "UNIQUE access must go through UniqueAccess()");
   return std::unique_ptr<InMemoryAccessor>(
-      new InMemoryAccessor{Storage::Accessor::shared_access, this, override_isolation_level, rw_type, timeout});
+      new InMemoryAccessor{this, override_isolation_level, AcquireGuardOrThrow(this, rw_type, timeout)});
 }
 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::UniqueAccess(std::optional<IsolationLevel> override_isolation_level,
                                                                  std::optional<std::chrono::milliseconds> timeout) {
-  return std::unique_ptr<InMemoryAccessor>(
-      new InMemoryAccessor{Storage::Accessor::unique_access, this, override_isolation_level, timeout});
+  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{
+      this, override_isolation_level, AcquireGuardOrThrow(this, StorageAccessType::UNIQUE, timeout)});
 }
 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
     std::optional<IsolationLevel> override_isolation_level, std::optional<std::chrono::milliseconds> timeout) {
-  return std::unique_ptr<InMemoryAccessor>(
-      new InMemoryAccessor{Storage::Accessor::read_only_access, this, override_isolation_level, timeout});
+  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{
+      this, override_isolation_level, AcquireGuardOrThrow(this, StorageAccessType::READ_ONLY, timeout)});
 }
 
 void InMemoryStorage::CreateSnapshotHandler(

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1351,7 +1351,7 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
   transaction_.commit_callbacks_.RunAll(*commit_timestamp_);
 
   // Dispatch to another async work to create requested auto-indexes in their own transaction
-  if (mem_storage->storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) {
+  if (transaction_.storage_mode == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     transaction_.async_index_helper_.DispatchRequests(mem_storage->async_indexer_);
   }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -685,16 +685,15 @@ void InMemoryStorage::UpdateLabelCount(LabelId const label, int64_t const change
 }
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(SharedAccess tag, InMemoryStorage *storage,
-                                                    IsolationLevel isolation_level, StorageMode storage_mode,
+                                                    std::optional<IsolationLevel> override_isolation_level,
                                                     StorageAccessType rw_type,
                                                     std::optional<std::chrono::milliseconds> timeout)
-    : Accessor(tag, storage, isolation_level, storage_mode, rw_type, timeout),
-      config_(storage->config_.salient.items) {}
+    : Accessor(tag, storage, override_isolation_level, rw_type, timeout), config_(storage->config_.salient.items) {}
 
-InMemoryStorage::InMemoryAccessor::InMemoryAccessor(auto tag, InMemoryStorage *storage, IsolationLevel isolation_level,
-                                                    StorageMode storage_mode,
+InMemoryStorage::InMemoryAccessor::InMemoryAccessor(auto tag, InMemoryStorage *storage,
+                                                    std::optional<IsolationLevel> override_isolation_level,
                                                     std::optional<std::chrono::milliseconds> timeout)
-    : Accessor(tag, storage, isolation_level, storage_mode, timeout), config_(storage->config_.salient.items) {}
+    : Accessor(tag, storage, override_isolation_level, timeout), config_(storage->config_.salient.items) {}
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryAccessor &&other) noexcept
     : Accessor(std::move(other)), config_(other.config_) {}
@@ -4657,30 +4656,20 @@ utils::FileRetainer::FileLockerAccessor::ret_type InMemoryStorage::UnlockPath() 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::Access(StorageAccessType rw_type,
                                                            std::optional<IsolationLevel> override_isolation_level,
                                                            std::optional<std::chrono::milliseconds> timeout) {
-  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{Storage::Accessor::shared_access,
-                                                                this,
-                                                                override_isolation_level.value_or(isolation_level_),
-                                                                storage_mode_,
-                                                                rw_type,
-                                                                timeout});
+  return std::unique_ptr<InMemoryAccessor>(
+      new InMemoryAccessor{Storage::Accessor::shared_access, this, override_isolation_level, rw_type, timeout});
 }
 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::UniqueAccess(std::optional<IsolationLevel> override_isolation_level,
                                                                  std::optional<std::chrono::milliseconds> timeout) {
-  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{Storage::Accessor::unique_access,
-                                                                this,
-                                                                override_isolation_level.value_or(isolation_level_),
-                                                                storage_mode_,
-                                                                timeout});
+  return std::unique_ptr<InMemoryAccessor>(
+      new InMemoryAccessor{Storage::Accessor::unique_access, this, override_isolation_level, timeout});
 }
 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
     std::optional<IsolationLevel> override_isolation_level, std::optional<std::chrono::milliseconds> timeout) {
-  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{Storage::Accessor::read_only_access,
-                                                                this,
-                                                                override_isolation_level.value_or(isolation_level_),
-                                                                storage_mode_,
-                                                                timeout});
+  return std::unique_ptr<InMemoryAccessor>(
+      new InMemoryAccessor{Storage::Accessor::read_only_access, this, override_isolation_level, timeout});
 }
 
 void InMemoryStorage::CreateSnapshotHandler(

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -189,11 +189,11 @@ class InMemoryStorage final : public Storage {
    private:
     friend class InMemoryStorage;
 
-    explicit InMemoryAccessor(SharedAccess tag, InMemoryStorage *storage, IsolationLevel isolation_level,
-                              StorageMode storage_mode, StorageAccessType rw_type,
+    explicit InMemoryAccessor(SharedAccess tag, InMemoryStorage *storage,
+                              std::optional<IsolationLevel> override_isolation_level, StorageAccessType rw_type,
                               std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-    explicit InMemoryAccessor(auto tag, InMemoryStorage *storage, IsolationLevel isolation_level,
-                              StorageMode storage_mode,
+    explicit InMemoryAccessor(auto tag, InMemoryStorage *storage,
+                              std::optional<IsolationLevel> override_isolation_level,
                               std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
     std::expected<void, ConstraintViolation> ExistenceConstraintsViolation() const;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -125,7 +125,7 @@ class InMemoryStorage final : public Storage {
   friend class InMemoryUniqueConstraints;
 
  public:
-  using free_mem_fn = std::function<void(std::optional<utils::ResourceLockGuard>, bool)>;
+  using free_mem_fn = std::function<void(utils::ResourceLockGuard, bool)>;
 
   /// Light-weight wrapper around DbAwareAllocator<Edge> for light-edge
   /// allocation and destruction. DbAwareAllocator is stateless (reads the
@@ -763,7 +763,7 @@ class InMemoryStorage final : public Storage {
   std::unique_ptr<Accessor> TryAccess(StorageAccessType rw_type,
                                       std::optional<IsolationLevel> override_isolation_level = {});
 
-  void FreeMemory(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) override;
+  void FreeMemory(utils::ResourceLockGuard main_guard, bool periodic) override;
 
   utils::FileRetainer::FileLockerAccessor::ret_type IsPathLocked();
   utils::FileRetainer::FileLockerAccessor::ret_type LockPath();
@@ -832,7 +832,7 @@ class InMemoryStorage final : public Storage {
  private:
   /// @throw std::system_error
   /// @throw std::bad_alloc
-  void CollectGarbage(std::optional<utils::ResourceLockGuard> main_guard, bool periodic);
+  void CollectGarbage(utils::ResourceLockGuard main_guard, bool periodic);
 
   bool InitializeWalFile(std::string_view epoch_id);
   void FinalizeWalFile();

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -189,12 +189,9 @@ class InMemoryStorage final : public Storage {
    private:
     friend class InMemoryStorage;
 
-    explicit InMemoryAccessor(SharedAccess tag, InMemoryStorage *storage,
-                              std::optional<IsolationLevel> override_isolation_level, StorageAccessType rw_type,
-                              std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-    explicit InMemoryAccessor(auto tag, InMemoryStorage *storage,
-                              std::optional<IsolationLevel> override_isolation_level,
-                              std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+    /// Takes ownership of a hold the caller acquired; see Accessor's constructor.
+    explicit InMemoryAccessor(InMemoryStorage *storage, std::optional<IsolationLevel> override_isolation_level,
+                              utils::ResourceLockGuard guard);
 
     std::expected<void, ConstraintViolation> ExistenceConstraintsViolation() const;
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -659,7 +659,7 @@ class InMemoryStorage final : public Storage {
         if (repl_args.is_main) {
           // Only if MAIN, do we proactivly make indexes
           // REPLICA will recieve deltas from MAIN that will create the indexes
-          if (GetCreationStorageMode() == StorageMode::IN_MEMORY_TRANSACTIONAL) {
+          if (GetPinnedStorageMode() == StorageMode::IN_MEMORY_TRANSACTIONAL) {
             // Use non-blocking async indexer
             auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
             // Async index creation -> happens in separate transaction

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -746,6 +746,23 @@ class InMemoryStorage final : public Storage {
   std::unique_ptr<Accessor> ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level,
                                            std::optional<std::chrono::milliseconds> timeout) override;
 
+  /// Acquires an accessor in mode `rw_type` if `main_lock_` admits it right now, returning nullptr
+  /// if it does not. Never blocks, never throws, and creates no transaction when it fails.
+  ///
+  /// Admission, not just "is it free": a waiting UNIQUE gates the shared modes, so this reports
+  /// failure while one is pending even though nobody holds the lock. That yields to the waiter
+  /// rather than jumping ahead of it.
+  ///
+  /// One probe, so it grants no priority of its own: a caller looping on this is an ordinary
+  /// contender each time and can be starved by a stream of compatible holders. A caller that needs
+  /// to be preferred while it retries holds a UniquePendingScope or ReadOnlyPendingScope across the
+  /// whole loop.
+  ///
+  /// InMemoryStorage's alone: DiskStorage has no probe rather than one that always fails, so a
+  /// caller polling it would spin instead of learning that it should just block.
+  std::unique_ptr<Accessor> TryAccess(StorageAccessType rw_type,
+                                      std::optional<IsolationLevel> override_isolation_level = {});
+
   void FreeMemory(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) override;
 
   utils::FileRetainer::FileLockerAccessor::ret_type IsPathLocked();

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -125,7 +125,7 @@ class InMemoryStorage final : public Storage {
   friend class InMemoryUniqueConstraints;
 
  public:
-  using free_mem_fn = std::function<void(std::unique_lock<utils::ResourceLock>, bool)>;
+  using free_mem_fn = std::function<void(std::optional<utils::ResourceLockGuard>, bool)>;
 
   /// Light-weight wrapper around DbAwareAllocator<Edge> for light-edge
   /// allocation and destruction. DbAwareAllocator is stateless (reads the
@@ -749,7 +749,7 @@ class InMemoryStorage final : public Storage {
   std::unique_ptr<Accessor> ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level,
                                            std::optional<std::chrono::milliseconds> timeout) override;
 
-  void FreeMemory(std::unique_lock<utils::ResourceLock> main_guard, bool periodic) override;
+  void FreeMemory(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) override;
 
   utils::FileRetainer::FileLockerAccessor::ret_type IsPathLocked();
   utils::FileRetainer::FileLockerAccessor::ret_type LockPath();
@@ -818,7 +818,7 @@ class InMemoryStorage final : public Storage {
  private:
   /// @throw std::system_error
   /// @throw std::bad_alloc
-  void CollectGarbage(std::unique_lock<utils::ResourceLock> main_guard, bool periodic);
+  void CollectGarbage(std::optional<utils::ResourceLockGuard> main_guard, bool periodic);
 
   bool InitializeWalFile(std::string_view epoch_id);
   void FinalizeWalFile();

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -668,6 +668,9 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                                               bool const reset_needed) const {
   auto const &main_db_name = main_storage->name();
 
+  // A guardrail, not a decision point: read without a hold, so the mode could flip right after.
+  // Data instances are barred from analytical at query time, and taking main_lock_ on this
+  // background task would risk deadlocking against the commits it is recovering.
   if (main_storage->storage_mode_ != StorageMode::IN_MEMORY_TRANSACTIONAL) {
     throw utils::BasicException("Only InMemoryTransactional mode supports replication!");
   }

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -119,55 +119,60 @@ std::unique_ptr<Accessor> Storage::ReadOnlyAccess(std::optional<IsolationLevel> 
 
 std::unique_ptr<Accessor> Storage::ReadOnlyAccess() { return ReadOnlyAccess({}, std::nullopt); }
 
-Storage::Accessor::Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level,
-                            StorageMode storage_mode, StorageAccessType rw_type,
+Storage::Accessor::Accessor(SharedAccess /* tag */, Storage *storage,
+                            std::optional<IsolationLevel> override_isolation_level, StorageAccessType rw_type,
                             const std::optional<std::chrono::milliseconds> timeout)
     : storage_(storage),
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
       guard_(CreateGuard(storage, rw_type, timeout)),
-      transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
+      creation_storage_mode_(storage->storage_mode_),
+      transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
+                                              creation_storage_mode_)),
       is_transaction_active_(true),
-      original_access_type_(rw_type),
-      creation_storage_mode_(storage_mode) {
+      original_access_type_(rw_type) {
   // UNIQUE has its own tag and its own public entry point. Reaching exclusive access through the
   // shared one means a caller computed rw_type and got it wrong; CreateGuard would grant it.
   DMG_ASSERT(rw_type != StorageAccessType::UNIQUE, "UNIQUE access must go through UniqueAccess()");
 }
 
-Storage::Accessor::Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level,
-                            StorageMode storage_mode, const std::optional<std::chrono::milliseconds> timeout)
+Storage::Accessor::Accessor(UniqueAccess /* tag */, Storage *storage,
+                            std::optional<IsolationLevel> override_isolation_level,
+                            const std::optional<std::chrono::milliseconds> timeout)
     : storage_(storage),
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
       guard_(CreateGuard(storage, StorageAccessType::UNIQUE, timeout)),
-      transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
+      creation_storage_mode_(storage->storage_mode_),
+      transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
+                                              creation_storage_mode_)),
       is_transaction_active_(true),
-      original_access_type_(StorageAccessType::UNIQUE),
-      creation_storage_mode_(storage_mode) {}
+      original_access_type_(StorageAccessType::UNIQUE) {}
 
-Storage::Accessor::Accessor(ReadOnlyAccess /* tag */, Storage *storage, IsolationLevel isolation_level,
-                            StorageMode storage_mode, const std::optional<std::chrono::milliseconds> timeout)
+Storage::Accessor::Accessor(ReadOnlyAccess /* tag */, Storage *storage,
+                            std::optional<IsolationLevel> override_isolation_level,
+                            const std::optional<std::chrono::milliseconds> timeout)
     : storage_(storage),
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
       guard_(CreateGuard(storage, READ_ONLY, timeout)),
-      transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
+      creation_storage_mode_(storage->storage_mode_),
+      transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
+                                              creation_storage_mode_)),
       is_transaction_active_(true),
-      original_access_type_(StorageAccessType::READ_ONLY),
-      creation_storage_mode_(storage_mode) {}
+      original_access_type_(StorageAccessType::READ_ONLY) {}
 
 Storage::Accessor::Accessor(Accessor &&other) noexcept
     : storage_(other.storage_),
       guard_(std::move(other.guard_)),
+      creation_storage_mode_(other.creation_storage_mode_),
       transaction_(std::move(other.transaction_)),
       commit_timestamp_(other.commit_timestamp_),
       is_transaction_active_(other.is_transaction_active_),
-      original_access_type_(other.original_access_type_),
-      creation_storage_mode_(other.creation_storage_mode_) {
+      original_access_type_(other.original_access_type_) {
   // Don't allow the other accessor to abort our transaction in destructor.
   other.is_transaction_active_ = false;
   other.commit_timestamp_.reset();

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -450,9 +450,19 @@ EdgeInfoForDeletion Storage::Accessor::PrepareDeletableEdges(const std::unordere
     }
   }
 
+  // deleted() reads the same word as delta(), which CreateAndLinkDelta writes under the object
+  // lock, so it has to be read under that lock too. One endpoint at a time: holding both would
+  // need gid ordering to avoid a cycle (see FindEdges) and a self-loop case, and buys nothing.
+  // The pair is not a snapshot either way, since the authoritative check is PrepareForWrite under
+  // the same lock further down; this only skips work that is already pointless.
+  auto const is_deleted = [](Vertex *vertex) {
+    auto guard = std::shared_lock{vertex->lock};
+    return vertex->deleted();
+  };
+
   // also add edges which we want to delete from the query
   for (const auto &edge_accessor : edges) {
-    if (edge_accessor->from_vertex_->deleted() || edge_accessor->to_vertex_->deleted()) {
+    if (is_deleted(edge_accessor->from_vertex_) || is_deleted(edge_accessor->to_vertex_)) {
       continue;
     }
     partial_src_vertices.insert(edge_accessor->from_vertex_);

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -125,9 +125,9 @@ Storage::Accessor::Accessor(Storage *storage, std::optional<IsolationLevel> over
       // The hold is taken before the transaction is created, so a freshly created transaction can
       // never dangle in an active state during an exclusive operation.
       guard_(std::move(guard)),
-      creation_storage_mode_(storage->storage_mode_),
+      // Both reads are under guard_, already constructed above, so the hold pins them.
       transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
-                                              creation_storage_mode_)),
+                                              storage->storage_mode_)),
       is_transaction_active_(true),
       original_access_type_(ToAccessType(guard_.type())) {
   DMG_ASSERT(guard_.owns_lock() && guard_.mutex() == std::addressof(storage_->main_lock_),
@@ -137,7 +137,6 @@ Storage::Accessor::Accessor(Storage *storage, std::optional<IsolationLevel> over
 Storage::Accessor::Accessor(Accessor &&other) noexcept
     : storage_(other.storage_),
       guard_(std::move(other.guard_)),
-      creation_storage_mode_(other.creation_storage_mode_),
       transaction_(std::move(other.transaction_)),
       commit_timestamp_(other.commit_timestamp_),
       is_transaction_active_(other.is_transaction_active_),
@@ -152,7 +151,7 @@ StorageMode Storage::GetStorageMode() const noexcept { return storage_mode_; }
 IsolationLevel Storage::GetIsolationLevel() const noexcept { return isolation_level_; }
 
 std::expected<void, Storage::SetIsolationLevelError> Storage::SetIsolationLevel(IsolationLevel isolation_level) {
-  std::unique_lock main_guard{main_lock_};
+  auto const main_guard = std::unique_lock{main_lock_};
   isolation_level_ = isolation_level;
   return {};
 }
@@ -161,7 +160,7 @@ std::vector<EdgeTypeId> Storage::ListAllPossiblyPresentEdgeTypes() const { retur
 
 std::vector<LabelId> Storage::ListAllPossiblyPresentVertexLabels() const { return stored_node_labels_.vectorize(); }
 
-StorageMode Storage::Accessor::GetCreationStorageMode() const noexcept { return creation_storage_mode_; }
+StorageMode Storage::Accessor::GetPinnedStorageMode() const noexcept { return transaction_.storage_mode; }
 
 std::optional<uint64_t> Storage::Accessor::GetStartTimestamp() const {
   if (is_transaction_active_) {
@@ -183,7 +182,7 @@ void Storage::Accessor::AdvanceCommand() {
 Result<std::optional<VertexAccessor>> Storage::Accessor::DeleteVertex(VertexAccessor *vertex) {
   /// NOTE: Checking whether the vertex can be deleted must be done by loading edges from disk.
   /// Loading edges is done through VertexAccessor so we do it here.
-  if (creation_storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
+  if (transaction_.storage_mode == StorageMode::ON_DISK_TRANSACTIONAL) {
     auto out_edges_res = vertex->OutEdges(View::OLD);
     auto in_edges_res = vertex->InEdges(View::OLD);
     if (!out_edges_res && out_edges_res.error() != Error::NONEXISTENT_OBJECT) {
@@ -225,7 +224,7 @@ Result<std::optional<VertexAccessor>> Storage::Accessor::DeleteVertex(VertexAcce
 Result<std::optional<std::pair<VertexAccessor, std::vector<EdgeAccessor>>>> Storage::Accessor::DetachDeleteVertex(
     VertexAccessor *vertex) {
   using ReturnType = std::pair<VertexAccessor, std::vector<EdgeAccessor>>;
-  if (creation_storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
+  if (transaction_.storage_mode == StorageMode::ON_DISK_TRANSACTIONAL) {
     auto out_edges_res = vertex->OutEdges(View::OLD);
     auto in_edges_res = vertex->InEdges(View::OLD);
     if (!out_edges_res && out_edges_res.error() != Error::NONEXISTENT_OBJECT) {
@@ -281,7 +280,7 @@ Result<std::optional<EdgeAccessor>> Storage::Accessor::DeleteEdge(EdgeAccessor *
 Result<std::optional<std::pair<std::vector<VertexAccessor>, std::vector<EdgeAccessor>>>>
 Storage::Accessor::DetachDelete(std::vector<VertexAccessor *> nodes, std::vector<EdgeAccessor *> edges, bool detach) {
   using ReturnType = std::pair<std::vector<VertexAccessor>, std::vector<EdgeAccessor>>;
-  if (creation_storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
+  if (transaction_.storage_mode == StorageMode::ON_DISK_TRANSACTIONAL) {
     for (const auto *vertex : nodes) {
       /// TODO: (andi) Extract into a separate function.
       auto out_edges_res = vertex->OutEdges(View::OLD);

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -57,9 +57,10 @@ namespace {
   }
 }
 
-/// Acquires `main_lock_` in the mode `rw_type` names, blocking indefinitely without a timeout and
-/// throwing the timeout exception for that mode with one.
-auto CreateGuard(Storage *storage, StorageAccessType rw_type, const std::optional<std::chrono::milliseconds> timeout) {
+}  // namespace
+
+utils::ResourceLockGuard AcquireGuardOrThrow(Storage *storage, StorageAccessType rw_type,
+                                             std::optional<std::chrono::milliseconds> timeout) {
   utils::ResourceLockGuard guard(storage->main_lock_, ToGuardType(rw_type), std::defer_lock);
   if (!timeout) {
     guard.lock();
@@ -68,7 +69,6 @@ auto CreateGuard(Storage *storage, StorageAccessType rw_type, const std::optiona
   }
   return guard;
 }
-}  // namespace
 
 Storage::Storage(Config config, StorageMode storage_mode, PlanInvalidatorPtr invalidator,
                  metrics::DatabaseMetricHandles metric_handles, memory::ArenaPool *db_arena_pool,
@@ -119,51 +119,20 @@ std::unique_ptr<Accessor> Storage::ReadOnlyAccess(std::optional<IsolationLevel> 
 
 std::unique_ptr<Accessor> Storage::ReadOnlyAccess() { return ReadOnlyAccess({}, std::nullopt); }
 
-Storage::Accessor::Accessor(SharedAccess /* tag */, Storage *storage,
-                            std::optional<IsolationLevel> override_isolation_level, StorageAccessType rw_type,
-                            const std::optional<std::chrono::milliseconds> timeout)
+Storage::Accessor::Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level,
+                            utils::ResourceLockGuard guard)
     : storage_(storage),
-      // The lock must be acquired before creating the transaction object to
-      // prevent freshly created transactions from dangling in an active state
-      // during exclusive operations.
-      guard_(CreateGuard(storage, rw_type, timeout)),
+      // The hold is taken before the transaction is created, so a freshly created transaction can
+      // never dangle in an active state during an exclusive operation.
+      guard_(std::move(guard)),
       creation_storage_mode_(storage->storage_mode_),
       transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
                                               creation_storage_mode_)),
       is_transaction_active_(true),
-      original_access_type_(rw_type) {
-  // UNIQUE has its own tag and its own public entry point. Reaching exclusive access through the
-  // shared one means a caller computed rw_type and got it wrong; CreateGuard would grant it.
-  DMG_ASSERT(rw_type != StorageAccessType::UNIQUE, "UNIQUE access must go through UniqueAccess()");
+      original_access_type_(ToAccessType(guard_.type())) {
+  DMG_ASSERT(guard_.owns_lock() && guard_.mutex() == std::addressof(storage_->main_lock_),
+             "an accessor's guard must be a held guard on its own storage's main_lock_");
 }
-
-Storage::Accessor::Accessor(UniqueAccess /* tag */, Storage *storage,
-                            std::optional<IsolationLevel> override_isolation_level,
-                            const std::optional<std::chrono::milliseconds> timeout)
-    : storage_(storage),
-      // The lock must be acquired before creating the transaction object to
-      // prevent freshly created transactions from dangling in an active state
-      // during exclusive operations.
-      guard_(CreateGuard(storage, StorageAccessType::UNIQUE, timeout)),
-      creation_storage_mode_(storage->storage_mode_),
-      transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
-                                              creation_storage_mode_)),
-      is_transaction_active_(true),
-      original_access_type_(StorageAccessType::UNIQUE) {}
-
-Storage::Accessor::Accessor(ReadOnlyAccess /* tag */, Storage *storage,
-                            std::optional<IsolationLevel> override_isolation_level,
-                            const std::optional<std::chrono::milliseconds> timeout)
-    : storage_(storage),
-      // The lock must be acquired before creating the transaction object to
-      // prevent freshly created transactions from dangling in an active state
-      // during exclusive operations.
-      guard_(CreateGuard(storage, READ_ONLY, timeout)),
-      creation_storage_mode_(storage->storage_mode_),
-      transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
-                                              creation_storage_mode_)),
-      is_transaction_active_(true),
-      original_access_type_(StorageAccessType::READ_ONLY) {}
 
 Storage::Accessor::Accessor(Accessor &&other) noexcept
     : storage_(other.storage_),

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -40,50 +40,33 @@ namespace memgraph::storage {
 class InMemoryStorage;
 
 namespace {
-void TryLock(auto &guard, auto timeout) {
-  if (timeout) {  // With timeout
-    if (!guard.try_lock_for(*timeout)) {
-      if constexpr (std::is_same_v<decltype(guard), utils::SharedResourceLockGuard &>) {
-        if (guard.type() == utils::SharedResourceLockGuard::Type::READ_ONLY) throw ReadOnlyAccessTimeout{};
-        throw SharedAccessTimeout{};
-      }
-      throw UniqueAccessTimeout{};
-    }
-  } else {  // Default
-    guard.lock();
-  }
-}
-
-auto CreateSharedGuard(Storage *storage, StorageAccessType rw_type,
-                       const std::optional<std::chrono::milliseconds> timeout) {
-  utils::SharedResourceLockGuard::Type shared_type{};
+[[noreturn]] void ThrowAccessTimeout(StorageAccessType rw_type) {
   switch (rw_type) {
     using enum StorageAccessType;
-    case NO_ACCESS:
-      [[fallthrough]];
     case UNIQUE:
-      LOG_FATAL("Invalid storage accessor type!");
-      break;
-
-    case WRITE:
-      shared_type = utils::SharedResourceLockGuard::Type::WRITE;
-      break;
-    case READ:
-      shared_type = utils::SharedResourceLockGuard::Type::READ;
-      break;
+      throw UniqueAccessTimeout{};
     case READ_ONLY:
-      shared_type = utils::SharedResourceLockGuard::Type::READ_ONLY;
-      break;
+      throw ReadOnlyAccessTimeout{};
+    case WRITE:
+    case READ:
+      throw SharedAccessTimeout{};
+    case NO_ACCESS:
+      // Unreachable: the caller maps rw_type through ToGuardType first, which rejects NO_ACCESS.
+      // Present so the switch stays exhaustive and every path out of this [[noreturn]] diverges.
+      LOG_FATAL("NO_ACCESS names the absence of a hold; there is nothing to time out acquiring");
   }
-  utils::SharedResourceLockGuard lock(storage->main_lock_, shared_type, std::defer_lock);
-  TryLock(lock, timeout);
-  return lock;
 }
 
-auto CreateUniqueGuard(Storage *storage, const std::optional<std::chrono::milliseconds> timeout) {
-  std::unique_lock<utils::ResourceLock> unique_lock(storage->main_lock_, std::defer_lock);
-  TryLock(unique_lock, timeout);
-  return unique_lock;
+/// Acquires `main_lock_` in the mode `rw_type` names, blocking indefinitely without a timeout and
+/// throwing the timeout exception for that mode with one.
+auto CreateGuard(Storage *storage, StorageAccessType rw_type, const std::optional<std::chrono::milliseconds> timeout) {
+  utils::ResourceLockGuard guard(storage->main_lock_, ToGuardType(rw_type), std::defer_lock);
+  if (!timeout) {
+    guard.lock();
+  } else if (!guard.try_lock_for(*timeout)) {
+    ThrowAccessTimeout(rw_type);
+  }
+  return guard;
 }
 }  // namespace
 
@@ -143,12 +126,15 @@ Storage::Accessor::Accessor(SharedAccess /* tag */, Storage *storage, IsolationL
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
-      storage_guard_(CreateSharedGuard(storage, rw_type, timeout)),
-      unique_guard_(storage_->main_lock_, std::defer_lock),
+      guard_(CreateGuard(storage, rw_type, timeout)),
       transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
       is_transaction_active_(true),
       original_access_type_(rw_type),
-      creation_storage_mode_(storage_mode) {}
+      creation_storage_mode_(storage_mode) {
+  // UNIQUE has its own tag and its own public entry point. Reaching exclusive access through the
+  // shared one means a caller computed rw_type and got it wrong; CreateGuard would grant it.
+  DMG_ASSERT(rw_type != StorageAccessType::UNIQUE, "UNIQUE access must go through UniqueAccess()");
+}
 
 Storage::Accessor::Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level,
                             StorageMode storage_mode, const std::optional<std::chrono::milliseconds> timeout)
@@ -156,8 +142,7 @@ Storage::Accessor::Accessor(UniqueAccess /* tag */, Storage *storage, IsolationL
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
-      storage_guard_(storage_->main_lock_, {/* unused */}, std::defer_lock),
-      unique_guard_(CreateUniqueGuard(storage, timeout)),
+      guard_(CreateGuard(storage, StorageAccessType::UNIQUE, timeout)),
       transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
       is_transaction_active_(true),
       original_access_type_(StorageAccessType::UNIQUE),
@@ -169,8 +154,7 @@ Storage::Accessor::Accessor(ReadOnlyAccess /* tag */, Storage *storage, Isolatio
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
-      storage_guard_(CreateSharedGuard(storage, READ_ONLY, timeout)),
-      unique_guard_(storage_->main_lock_, std::defer_lock),
+      guard_(CreateGuard(storage, READ_ONLY, timeout)),
       transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
       is_transaction_active_(true),
       original_access_type_(StorageAccessType::READ_ONLY),
@@ -178,8 +162,7 @@ Storage::Accessor::Accessor(ReadOnlyAccess /* tag */, Storage *storage, Isolatio
 
 Storage::Accessor::Accessor(Accessor &&other) noexcept
     : storage_(other.storage_),
-      storage_guard_(std::move(other.storage_guard_)),
-      unique_guard_(std::move(other.unique_guard_)),
+      guard_(std::move(other.guard_)),
       transaction_(std::move(other.transaction_)),
       commit_timestamp_(other.commit_timestamp_),
       is_transaction_active_(other.is_transaction_active_),

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -183,7 +183,7 @@ void Storage::Accessor::AdvanceCommand() {
 Result<std::optional<VertexAccessor>> Storage::Accessor::DeleteVertex(VertexAccessor *vertex) {
   /// NOTE: Checking whether the vertex can be deleted must be done by loading edges from disk.
   /// Loading edges is done through VertexAccessor so we do it here.
-  if (storage_->storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
+  if (creation_storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
     auto out_edges_res = vertex->OutEdges(View::OLD);
     auto in_edges_res = vertex->InEdges(View::OLD);
     if (!out_edges_res && out_edges_res.error() != Error::NONEXISTENT_OBJECT) {
@@ -225,7 +225,7 @@ Result<std::optional<VertexAccessor>> Storage::Accessor::DeleteVertex(VertexAcce
 Result<std::optional<std::pair<VertexAccessor, std::vector<EdgeAccessor>>>> Storage::Accessor::DetachDeleteVertex(
     VertexAccessor *vertex) {
   using ReturnType = std::pair<VertexAccessor, std::vector<EdgeAccessor>>;
-  if (storage_->storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
+  if (creation_storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
     auto out_edges_res = vertex->OutEdges(View::OLD);
     auto in_edges_res = vertex->InEdges(View::OLD);
     if (!out_edges_res && out_edges_res.error() != Error::NONEXISTENT_OBJECT) {
@@ -281,7 +281,7 @@ Result<std::optional<EdgeAccessor>> Storage::Accessor::DeleteEdge(EdgeAccessor *
 Result<std::optional<std::pair<std::vector<VertexAccessor>, std::vector<EdgeAccessor>>>>
 Storage::Accessor::DetachDelete(std::vector<VertexAccessor *> nodes, std::vector<EdgeAccessor *> edges, bool detach) {
   using ReturnType = std::pair<std::vector<VertexAccessor>, std::vector<EdgeAccessor>>;
-  if (storage_->storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
+  if (creation_storage_mode_ == StorageMode::ON_DISK_TRANSACTIONAL) {
     for (const auto *vertex : nodes) {
       /// TODO: (andi) Extract into a separate function.
       auto out_edges_res = vertex->OutEdges(View::OLD);

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -349,9 +349,9 @@ class Storage {
     return config_.durability.snapshot_wal_mode == Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
   }
 
-  virtual void FreeMemory(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) = 0;
+  virtual void FreeMemory(utils::ResourceLockGuard main_guard, bool periodic) = 0;
 
-  void FreeMemory() { FreeMemory(std::nullopt, false); }
+  void FreeMemory() { FreeMemory({}, false); }
 
   virtual std::unique_ptr<Accessor> Access(StorageAccessType rw_type,
                                            std::optional<IsolationLevel> override_isolation_level,

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -533,6 +533,17 @@ class Accessor {
     return NO_ACCESS;
   }
 
+  /// Moves out this accessor's UNIQUE hold on `main_lock_`, making the returned lock its sole
+  /// owner (this accessor then reports NO_ACCESS and releases nothing at destruction).
+  ///
+  /// A caller passing its held hold onward (e.g. to FreeMemory) must move this same object.
+  /// Adopting `main_lock_` into a second lock instead gives the one hold two owners, so it is
+  /// released twice: once by the callee, again when this accessor is destroyed.
+  auto ReleaseUniqueGuard() -> std::unique_lock<utils::ResourceLock> {
+    MG_ASSERT(unique_guard_.owns_lock(), "ReleaseUniqueGuard requires the accessor to hold UNIQUE");
+    return std::move(unique_guard_);
+  }
+
   virtual VertexAccessor CreateVertex() = 0;
 
   virtual std::optional<VertexAccessor> FindVertex(Gid gid, View view) = 0;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <optional>
 #include <set>
 #include <string>
@@ -453,8 +454,15 @@ class Storage {
   uint64_t timestamp_{kTimestampInitialId};
   uint64_t transaction_id_{kTransactionInitialId};
 
-  IsolationLevel isolation_level_;
-  StorageMode storage_mode_;
+  // Written under a UNIQUE hold on main_lock_ by SetIsolationLevel/SetStorageMode, but read
+  // without one: the accessor factories evaluate them as constructor arguments, so the read
+  // happens before the constructor acquires anything, and replication reads storage_mode_ with no
+  // hold at all. Atomic so those reads are not a data race.
+  //
+  // This orders the reads; it does not make them fresh. A reader can still observe a mode, then
+  // block on main_lock_, and construct its transaction after the mode has changed underneath it.
+  std::atomic<IsolationLevel> isolation_level_;
+  std::atomic<StorageMode> storage_mode_;
   memory::ArenaPool *db_arena_pool_{nullptr};
 
   metrics::DatabaseMetricHandles metric_handles_{};

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -456,8 +456,8 @@ class Storage {
 
   // Written under a UNIQUE hold on main_lock_. UNIQUE excludes all three shared modes, so any hold
   // pins both values for its life, and releasing one un-pins them: a reader that reacquires must
-  // re-read. Within a transaction read what the accessor pinned instead, creation_storage_mode_ or
-  // transaction_.isolation_level.
+  // re-read. Within a transaction read what the accessor pinned instead, transaction_.storage_mode
+  // or transaction_.isolation_level.
   //
   // Atomic for the readers that hold nothing. Some only report (the getters below, GetInfo, SHOW
   // REPLICAS) and are stale on return regardless. The rest cannot take a hold first because the
@@ -806,7 +806,9 @@ class Accessor {
 
   EdgeTypeId NameToEdgeType(std::string_view name) { return storage_->NameToEdgeType(name); }
 
-  StorageMode GetCreationStorageMode() const noexcept;
+  /// The storage mode this accessor's hold pins, in force for the life of that hold. Prefer it over
+  /// Storage::GetStorageMode(), which holds nothing and is stale on return.
+  StorageMode GetPinnedStorageMode() const noexcept;
 
   std::string id() const { return storage_->name(); }
 
@@ -1270,10 +1272,8 @@ class Accessor {
   /// One guard for all four ways to hold main_lock_. The mode is mutable state, not a property of
   /// this type: a READ_ONLY hold downgrades to READ, and ReleaseUniqueGuard() leaves nothing held.
   utils::ResourceLockGuard guard_;
-  /// Read from the storage under `guard_`, so it must be declared (and so initialised) after it and
-  /// before transaction_, which is created with the mode it names.
-  StorageMode creation_storage_mode_;
-  /// IMPORTANT: transaction_ has to be constructed after the guard (so that destruction is in correct order)
+  /// IMPORTANT: constructed after the guard, both for destruction order and so that the mode and
+  /// isolation level it captures are read under that guard.
   Transaction transaction_;
   std::optional<uint64_t> commit_timestamp_;
   bool is_transaction_active_;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -454,18 +454,15 @@ class Storage {
   uint64_t timestamp_{kTimestampInitialId};
   uint64_t transaction_id_{kTransactionInitialId};
 
-  // Written under a UNIQUE hold on main_lock_ by SetIsolationLevel and SetStorageMode.
+  // Written under a UNIQUE hold on main_lock_. UNIQUE excludes all three shared modes, so any hold
+  // pins both values for its life, and releasing one un-pins them: a reader that reacquires must
+  // re-read. Within a transaction read what the accessor pinned instead, creation_storage_mode_ or
+  // transaction_.isolation_level.
   //
-  // An accessor reads them in its constructor, after taking its hold, so the mode it builds its
-  // transaction with is the mode in force for the whole life of that hold. Reading before
-  // acquiring would let the value change while the reader waits, leaving an analytical transaction
-  // running against transactional storage: it writes no deltas and no WAL, so its work is neither
-  // durable, replicated, nor abortable.
-  //
-  // Atomic because plenty of readers take no hold at all, and are not going to: the noexcept
-  // getters below, GetInfo(), and replication's mode checks. Those reads are stale the moment they
-  // return whatever we do here; atomic only keeps them from being a data race. Anything that acts
-  // on the value, rather than reporting it, should read it under a hold instead.
+  // Atomic for the readers that hold nothing. Some only report (the getters below, GetInfo, SHOW
+  // REPLICAS) and are stale on return regardless. The rest cannot take a hold first because the
+  // hold is what the value decides, or because taking it would deadlock. For those the rule is: an
+  // unlocked read may choose, but only a read under a hold may commit to the choice.
   std::atomic<IsolationLevel> isolation_level_;
   std::atomic<StorageMode> storage_mode_;
   memory::ArenaPool *db_arena_pool_{nullptr};

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -454,13 +454,18 @@ class Storage {
   uint64_t timestamp_{kTimestampInitialId};
   uint64_t transaction_id_{kTransactionInitialId};
 
-  // Written under a UNIQUE hold on main_lock_ by SetIsolationLevel/SetStorageMode, but read
-  // without one: the accessor factories evaluate them as constructor arguments, so the read
-  // happens before the constructor acquires anything, and replication reads storage_mode_ with no
-  // hold at all. Atomic so those reads are not a data race.
+  // Written under a UNIQUE hold on main_lock_ by SetIsolationLevel and SetStorageMode.
   //
-  // This orders the reads; it does not make them fresh. A reader can still observe a mode, then
-  // block on main_lock_, and construct its transaction after the mode has changed underneath it.
+  // An accessor reads them in its constructor, after taking its hold, so the mode it builds its
+  // transaction with is the mode in force for the whole life of that hold. Reading before
+  // acquiring would let the value change while the reader waits, leaving an analytical transaction
+  // running against transactional storage: it writes no deltas and no WAL, so its work is neither
+  // durable, replicated, nor abortable.
+  //
+  // Atomic because plenty of readers take no hold at all, and are not going to: the noexcept
+  // getters below, GetInfo(), and replication's mode checks. Those reads are stale the moment they
+  // return whatever we do here; atomic only keeps them from being a data race. Anything that acts
+  // on the value, rather than reporting it, should read it under a hold instead.
   std::atomic<IsolationLevel> isolation_level_;
   std::atomic<StorageMode> storage_mode_;
   memory::ArenaPool *db_arena_pool_{nullptr};
@@ -541,12 +546,16 @@ class Accessor {
   static constexpr struct ReadOnlyAccess {
   } read_only_access;
 
-  Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
+  /// The isolation level and storage mode are read from `storage` once the hold is taken, not
+  /// passed in: a caller reading them itself would read them before this constructor acquires
+  /// anything, and SetIsolationLevel/SetStorageMode write them under UNIQUE. Reading them early
+  /// means blocking here and then building the transaction against a mode that has since changed.
+  Accessor(SharedAccess /* tag */, Storage *storage, std::optional<IsolationLevel> override_isolation_level,
            StorageAccessType rw_type = StorageAccessType::WRITE,
            std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-  Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
+  Accessor(UniqueAccess /* tag */, Storage *storage, std::optional<IsolationLevel> override_isolation_level,
            std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-  Accessor(ReadOnlyAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
+  Accessor(ReadOnlyAccess /* tag */, Storage *storage, std::optional<IsolationLevel> override_isolation_level,
            std::optional<std::chrono::milliseconds> timeout = std::nullopt);
   Accessor(const Accessor &) = delete;
   Accessor &operator=(const Accessor &) = delete;
@@ -1267,6 +1276,9 @@ class Accessor {
   /// One guard for all four ways to hold main_lock_. The mode is mutable state, not a property of
   /// this type: a READ_ONLY hold downgrades to READ, and ReleaseUniqueGuard() leaves nothing held.
   utils::ResourceLockGuard guard_;
+  /// Read from the storage under `guard_`, so it must be declared (and so initialised) after it and
+  /// before transaction_, which is created with the mode it names.
+  StorageMode creation_storage_mode_;
   /// IMPORTANT: transaction_ has to be constructed after the guard (so that destruction is in correct order)
   Transaction transaction_;
   std::optional<uint64_t> commit_timestamp_;
@@ -1289,7 +1301,6 @@ class Accessor {
   void MarkEdgeAsDeleted(Edge *edge);
 
  private:
-  StorageMode creation_storage_mode_;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -53,6 +53,40 @@ class MemoryTracker;
 }
 
 namespace memgraph::storage {
+
+/// StorageAccessType and ResourceLockGuard::Type name the same four ways to hold main_lock_, one
+/// in storage's vocabulary and one in the lock's. Convert only here, so the two enums stay
+/// independent (utils/ must not learn storage's vocabulary) without the mapping being restated at
+/// each acquisition site. NO_ACCESS has no counterpart: it means no hold, which a guard expresses
+/// by not owning one.
+constexpr utils::ResourceLockGuard::Type ToGuardType(StorageAccessType rw_type) {
+  switch (rw_type) {
+    case StorageAccessType::UNIQUE:
+      return utils::ResourceLockGuard::UNIQUE;
+    case StorageAccessType::WRITE:
+      return utils::ResourceLockGuard::WRITE;
+    case StorageAccessType::READ:
+      return utils::ResourceLockGuard::READ;
+    case StorageAccessType::READ_ONLY:
+      return utils::ResourceLockGuard::READ_ONLY;
+    case StorageAccessType::NO_ACCESS:
+      LOG_FATAL("NO_ACCESS names the absence of a hold; it has no lock mode");
+  }
+}
+
+constexpr StorageAccessType ToAccessType(utils::ResourceLockGuard::Type type) {
+  switch (type) {
+    case utils::ResourceLockGuard::UNIQUE:
+      return StorageAccessType::UNIQUE;
+    case utils::ResourceLockGuard::WRITE:
+      return StorageAccessType::WRITE;
+    case utils::ResourceLockGuard::READ:
+      return StorageAccessType::READ;
+    case utils::ResourceLockGuard::READ_ONLY:
+      return StorageAccessType::READ_ONLY;
+  }
+}
+
 class SharedAccessTimeout : public utils::BasicException {
  public:
   SharedAccessTimeout()
@@ -314,9 +348,9 @@ class Storage {
     return config_.durability.snapshot_wal_mode == Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
   }
 
-  virtual void FreeMemory(std::unique_lock<utils::ResourceLock> main_guard, bool periodic) = 0;
+  virtual void FreeMemory(std::optional<utils::ResourceLockGuard> main_guard, bool periodic) = 0;
 
-  void FreeMemory() { FreeMemory(std::unique_lock{main_lock_, std::defer_lock}, false); }
+  void FreeMemory() { FreeMemory(std::nullopt, false); }
 
   virtual std::unique_ptr<Accessor> Access(StorageAccessType rw_type,
                                            std::optional<IsolationLevel> override_isolation_level,
@@ -516,32 +550,23 @@ class Accessor {
 
   StorageAccessType original_access_type() const { return original_access_type_; }
 
+  /// The mode currently held, which is not always the one requested: a READ_ONLY hold downgrades
+  /// to READ, and a released hold leaves NO_ACCESS. For what was asked for, see
+  /// original_access_type().
   StorageAccessType type() const {
-    if (unique_guard_.owns_lock()) {
-      return UNIQUE;
-    }
-    if (storage_guard_.owns_lock()) {
-      switch (storage_guard_.type()) {
-        case utils::SharedResourceLockGuard::Type::WRITE:
-          return WRITE;
-        case utils::SharedResourceLockGuard::Type::READ:
-          return READ;
-        case utils::SharedResourceLockGuard::Type::READ_ONLY:
-          return READ_ONLY;
-      }
-    }
-    return NO_ACCESS;
+    if (!guard_.owns_lock()) return NO_ACCESS;
+    return ToAccessType(guard_.type());
   }
 
-  /// Moves out this accessor's UNIQUE hold on `main_lock_`, making the returned lock its sole
+  /// Moves out this accessor's UNIQUE hold on `main_lock_`, making the returned guard its sole
   /// owner (this accessor then reports NO_ACCESS and releases nothing at destruction).
   ///
   /// A caller passing its held hold onward (e.g. to FreeMemory) must move this same object.
-  /// Adopting `main_lock_` into a second lock instead gives the one hold two owners, so it is
+  /// Adopting `main_lock_` into a second guard instead gives the one hold two owners, so it is
   /// released twice: once by the callee, again when this accessor is destroyed.
-  auto ReleaseUniqueGuard() -> std::unique_lock<utils::ResourceLock> {
-    MG_ASSERT(unique_guard_.owns_lock(), "ReleaseUniqueGuard requires the accessor to hold UNIQUE");
-    return std::move(unique_guard_);
+  auto ReleaseUniqueGuard() -> utils::ResourceLockGuard {
+    MG_ASSERT(type() == UNIQUE, "ReleaseUniqueGuard requires the accessor to hold UNIQUE");
+    return std::move(guard_);
   }
 
   virtual VertexAccessor CreateVertex() = 0;
@@ -875,7 +900,7 @@ class Accessor {
   auto GetTransaction() -> Transaction * { return std::addressof(transaction_); }
 
   auto GetEnumStoreUnique() -> EnumStore & {
-    DMG_ASSERT(unique_guard_.owns_lock());
+    DMG_ASSERT(type() == UNIQUE);
     return storage_->enum_store_;
   }
 
@@ -1231,9 +1256,10 @@ class Accessor {
 #endif
  protected:
   Storage *storage_;
-  utils::SharedResourceLockGuard storage_guard_;
-  std::unique_lock<utils::ResourceLock> unique_guard_;  // TODO: Split the accessor into Shared/Unique
-  /// IMPORTANT: transaction_ has to be constructed after the guards (so that destruction is in correct order)
+  /// One guard for all four ways to hold main_lock_. The mode is mutable state, not a property of
+  /// this type: a READ_ONLY hold downgrades to READ, and ReleaseUniqueGuard() leaves nothing held.
+  utils::ResourceLockGuard guard_;
+  /// IMPORTANT: transaction_ has to be constructed after the guard (so that destruction is in correct order)
   Transaction transaction_;
   std::optional<uint64_t> commit_timestamp_;
   bool is_transaction_active_;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -535,28 +535,27 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
   return os;
 }
 
+/// Acquires `main_lock_` in the mode `rw_type` names. Blocks indefinitely without a timeout; with
+/// one, throws the timeout exception belonging to that mode.
+utils::ResourceLockGuard AcquireGuardOrThrow(Storage *storage, StorageAccessType rw_type,
+                                             std::optional<std::chrono::milliseconds> timeout);
+
 class Accessor {
  public:
-  static constexpr struct SharedAccess {
-  } shared_access;
+  /// Takes ownership of a hold on `storage`'s main_lock_. The caller acquires it: blocking with a
+  /// timeout via AcquireGuardOrThrow, or non-blocking via a try_to_lock guard. Construction itself
+  /// never blocks and never fails, so a probe can decide whether to build an accessor at all.
+  ///
+  /// The access type comes from the guard, not alongside it. It is recorded as
+  /// original_access_type_, which the WAL carries to replicas to pick the mode they replay under,
+  /// so a guard and a type that disagreed would have a replica take a different hold than we did.
+  /// Nothing is lost by deriving it: no downgrade can have happened yet.
+  ///
+  /// The isolation level and storage mode are read from `storage` under the guard rather than
+  /// passed in: SetIsolationLevel and SetStorageMode write them under UNIQUE, so a caller reading
+  /// them before acquiring could build a transaction against a mode that has since changed.
+  Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level, utils::ResourceLockGuard guard);
 
-  static constexpr struct UniqueAccess {
-  } unique_access;
-
-  static constexpr struct ReadOnlyAccess {
-  } read_only_access;
-
-  /// The isolation level and storage mode are read from `storage` once the hold is taken, not
-  /// passed in: a caller reading them itself would read them before this constructor acquires
-  /// anything, and SetIsolationLevel/SetStorageMode write them under UNIQUE. Reading them early
-  /// means blocking here and then building the transaction against a mode that has since changed.
-  Accessor(SharedAccess /* tag */, Storage *storage, std::optional<IsolationLevel> override_isolation_level,
-           StorageAccessType rw_type = StorageAccessType::WRITE,
-           std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-  Accessor(UniqueAccess /* tag */, Storage *storage, std::optional<IsolationLevel> override_isolation_level,
-           std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-  Accessor(ReadOnlyAccess /* tag */, Storage *storage, std::optional<IsolationLevel> override_isolation_level,
-           std::optional<std::chrono::milliseconds> timeout = std::nullopt);
   Accessor(const Accessor &) = delete;
   Accessor &operator=(const Accessor &) = delete;
   Accessor &operator=(Accessor &&other) = delete;
@@ -575,16 +574,14 @@ class Accessor {
     return ToAccessType(guard_.type());
   }
 
-  /// Moves out this accessor's UNIQUE hold on `main_lock_`, making the returned guard its sole
-  /// owner (this accessor then reports NO_ACCESS and releases nothing at destruction).
+  /// Moves out this accessor's hold on `main_lock_`, making the returned guard its sole owner
+  /// (this accessor then reports NO_ACCESS and releases nothing at destruction).
   ///
-  /// A caller passing its held hold onward (e.g. to FreeMemory) must move this same object.
-  /// Adopting `main_lock_` into a second guard instead gives the one hold two owners, so it is
-  /// released twice: once by the callee, again when this accessor is destroyed.
-  auto ReleaseUniqueGuard() -> utils::ResourceLockGuard {
-    MG_ASSERT(type() == UNIQUE, "ReleaseUniqueGuard requires the accessor to hold UNIQUE");
-    return std::move(guard_);
-  }
+  /// A caller passing its hold onward (e.g. to FreeMemory) must move this same object. Adopting
+  /// `main_lock_` into a second guard instead gives the one hold two owners, so it is released
+  /// twice: once by the callee, again when this accessor is destroyed. What the callee requires of
+  /// the hold is the callee's to check.
+  auto ReleaseGuard() -> utils::ResourceLockGuard { return std::move(guard_); }
 
   virtual VertexAccessor CreateVertex() = 0;
 

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <utility>
 
+#include "utils/logging.hpp"
 #include "utils/on_scope_exit.hpp"
 
 namespace memgraph::utils {
@@ -87,10 +88,13 @@ struct ResourceLock {
   template <> NotifyKind pending_release_should_notify<LockReq::READ_ONLY>() const { return ro_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
   template <> NotifyKind pending_release_should_notify<LockReq::UNIQUE>() const { return unique_pending_count == 0 ? NotifyKind::All : NotifyKind::None; }
 
+  // The counts are unsigned: an unmatched release wraps one rather than going negative, and the
+  // mode it guards is then blocked for the lifetime of the process, silently and far from the
+  // cause. Assert the balance at the release itself.
   template <LockReq Req> void unlock_state_updater();
-  template <> void unlock_state_updater<LockReq::WRITE>()     { --w_count; }
-  template <> void unlock_state_updater<LockReq::READ>()      { --r_count; }
-  template <> void unlock_state_updater<LockReq::READ_ONLY>() { --ro_count; }
+  template <> void unlock_state_updater<LockReq::WRITE>()     { DMG_ASSERT(w_count > 0, "unlock_shared<WRITE> without a matching lock_shared<WRITE>"); --w_count; }
+  template <> void unlock_state_updater<LockReq::READ>()      { DMG_ASSERT(r_count > 0, "unlock_shared<READ> without a matching lock_shared<READ>"); --r_count; }
+  template <> void unlock_state_updater<LockReq::READ_ONLY>() { DMG_ASSERT(ro_count > 0, "unlock_shared<READ_ONLY> without a matching lock_shared<READ_ONLY>"); --ro_count; }
   template <> void unlock_state_updater<LockReq::UNIQUE>()    { }
 
   // WRITE omits ro_count, and READ_ONLY omits w_count, because the two are mutually exclusive by
@@ -195,6 +199,9 @@ struct ResourceLock {
   template <LockReq Req>
   void release() {
     auto lock = std::unique_lock{mtx};
+    // A second release of the same hold drops `state` while another thread owns it.
+    [[maybe_unused]] constexpr auto expected = Req == LockReq::UNIQUE ? UNIQUE : SHARED;
+    DMG_ASSERT(state == expected, "release() on a lock that is not held in the mode being released");
     unlock_state_updater<Req>();
     if (unlock_has_fully_unlocked<Req>()) {
       state = UNLOCKED;

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -28,15 +28,15 @@ namespace memgraph::utils {
  * and unlocked in another.
  */
 
-// RAII helpers (defined below) that keep a pending registration alive across a campaign of
-// non-blocking probes; need friend access to the lock internals. See their definitions.
-class UniquePendingScope;
-class ReadOnlyPendingScope;
+// RAII helper (defined below) that keeps a pending registration alive across a campaign of
+// non-blocking probes; needs friend access to the lock internals. See its definition.
+template <typename Lock, auto Req>
+class PendingScope;
 
 /// Priority is given to read-only locks over read and write locks
 struct ResourceLock {
-  friend class UniquePendingScope;
-  friend class ReadOnlyPendingScope;
+  template <typename Lock, auto Req>
+  friend class PendingScope;
 
   // The four ways to hold the lock. UNIQUE is exclusive of all of them, including itself; the other
   // three are the shared modes, mutually compatible except that WRITE and READ_ONLY exclude each
@@ -602,85 +602,70 @@ struct ResourceLockGuard {
   bool locked_{false};
 };
 
-/// RAII helper that keeps a caller registered as a pending UNIQUE waiter across a non-blocking
-/// probe campaign, for callers that cannot block on lock()'s cv (e.g. a coroutine that must yield
-/// to a scheduler) but still want writer-preference while they poll try_acquire().
+/// Maps a lock request to the guard mode that holds it, so PendingScope can hand back the same
+/// vocabulary every other acquisition path speaks.
+constexpr ResourceLockGuard::Type ToGuardType(ResourceLock::LockReq req) {
+  switch (req) {
+    case ResourceLock::LockReq::UNIQUE:
+      return ResourceLockGuard::UNIQUE;
+    case ResourceLock::LockReq::WRITE:
+      return ResourceLockGuard::WRITE;
+    case ResourceLock::LockReq::READ:
+      return ResourceLockGuard::READ;
+    case ResourceLock::LockReq::READ_ONLY:
+      return ResourceLockGuard::READ_ONLY;
+  }
+}
+
+/// Keeps a caller registered as a pending waiter in mode `Req` across a campaign of non-blocking
+/// probes, for callers that cannot block on the condition variable (a coroutine that must yield to
+/// a scheduler, say) but still want the priority a blocking acquirer would get.
 ///
 /// A bare try_lock() loop never registers as pending, so it is just another unprivileged contender
-/// each iteration and can starve behind back-to-back shared holders. This scope registers once up
-/// front, gating new shared acquirers (see can_acquire) so the shared pool drains and the probe
-/// eventually finds state == UNLOCKED.
+/// each iteration and can starve behind back-to-back holders. This scope registers once up front,
+/// gating whoever `Req` gates (see can_acquire) so the holders drain and a probe eventually finds
+/// the lock admitting it.
 ///
-/// Ownership: try_acquire() returns nullopt (still pending, gate stays up) or a
-/// std::unique_lock<ResourceLock> owning the acquired lock. On success the scope stops counting as
-/// pending and becomes inert (destructor is a no-op); the returned lock owns the unlock(). If
-/// destroyed without acquiring, the destructor deregisters and wakes gated shared acquirers (as
-/// acquire()'s failure path does).
+/// Ownership: try_acquire() returns nullopt (still pending, gate stays up) or a ResourceLockGuard
+/// owning the acquired hold. On success the scope stops counting as pending and becomes inert
+/// (destructor is a no-op); the guard owns the release. If destroyed without acquiring, the
+/// destructor deregisters and wakes whoever it was gating (as acquire()'s failure path does).
+///
+/// READ and WRITE gate nobody, so registering them is a no-op and the scope degenerates to a plain
+/// probe loop. That is deliberate: it lets a caller that picks a mode at runtime use one type for
+/// all four rather than special-casing the two that have nothing to register.
 ///
 /// Not copyable or movable: the registration is tied 1:1 to this scope's lifetime.
-class UniquePendingScope {
+template <typename Lock, auto Req>
+class PendingScope {
  public:
-  explicit UniquePendingScope(ResourceLock &lock) : lock_{&lock} {
-    lock_->register_pending<ResourceLock::LockReq::UNIQUE>();
-  }
+  explicit PendingScope(Lock &lock) : lock_{&lock} { lock_->template register_pending<Req>(); }
 
-  ~UniquePendingScope() {
+  ~PendingScope() {
     if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
-    lock_->unregister_pending<ResourceLock::LockReq::UNIQUE>();
+    lock_->template unregister_pending<Req>();
   }
 
-  UniquePendingScope(const UniquePendingScope &) = delete;
-  UniquePendingScope &operator=(const UniquePendingScope &) = delete;
-  UniquePendingScope(UniquePendingScope &&) = delete;
-  UniquePendingScope &operator=(UniquePendingScope &&) = delete;
+  PendingScope(const PendingScope &) = delete;
+  PendingScope &operator=(const PendingScope &) = delete;
+  PendingScope(PendingScope &&) = delete;
+  PendingScope &operator=(PendingScope &&) = delete;
 
-  /// Non-blocking attempt to take UNIQUE; succeeds only when the lock is UNLOCKED (existing holders
-  /// are never preempted). Safe to call repeatedly; a failed call leaves the pending registration
-  /// intact for the next attempt.
-  std::optional<std::unique_lock<ResourceLock>> try_acquire() {
+  /// Non-blocking attempt, admitted by the same rule a blocking acquirer in `Req` waits on (see
+  /// can_acquire). Existing holders are never preempted. Safe to call repeatedly; a failed call
+  /// leaves the pending registration intact for the next attempt.
+  std::optional<ResourceLockGuard> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
-    if (!lock_->try_acquire_pending<ResourceLock::LockReq::UNIQUE>()) return std::nullopt;
-    ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
-    return std::unique_lock<ResourceLock>{*acquired_lock, std::adopt_lock};
+    if (!lock_->template try_acquire_pending<Req>()) return std::nullopt;
+    Lock *acquired_lock = std::exchange(lock_, nullptr);
+    return ResourceLockGuard{*acquired_lock, ToGuardType(Req), std::adopt_lock};
   }
 
  private:
-  ResourceLock *lock_;
+  Lock *lock_;
 };
 
-/// Like UniquePendingScope, but for READ_ONLY: registers a pending READ_ONLY waiter (bumping
-/// ro_pending_count, the existing READ_ONLY-over-WRITE priority mechanism) across a non-blocking
-/// probe campaign, so a retrying try_acquire() gets the same gating a blocking
-/// lock_shared<READ_ONLY>() gets. Ownership/lifetime mirror UniquePendingScope: try_acquire()
-/// returns a SharedResourceLockGuard that adopted the lock; if destroyed without acquiring, the
-/// destructor decrements ro_pending_count and wakes gated acquirers.
-class ReadOnlyPendingScope {
- public:
-  explicit ReadOnlyPendingScope(ResourceLock &lock) : lock_{&lock} {
-    lock_->register_pending<ResourceLock::LockReq::READ_ONLY>();
-  }
-
-  ~ReadOnlyPendingScope() {
-    if (lock_ == nullptr) return;  // ownership transferred out by a successful try_acquire()
-    lock_->unregister_pending<ResourceLock::LockReq::READ_ONLY>();
-  }
-
-  ReadOnlyPendingScope(const ReadOnlyPendingScope &) = delete;
-  ReadOnlyPendingScope &operator=(const ReadOnlyPendingScope &) = delete;
-  ReadOnlyPendingScope(ReadOnlyPendingScope &&) = delete;
-  ReadOnlyPendingScope &operator=(ReadOnlyPendingScope &&) = delete;
-
-  /// Non-blocking attempt to take READ_ONLY, admitted by the same rule a blocking
-  /// lock_shared<READ_ONLY>() waits on (see can_acquire<READ_ONLY>). Safe to call repeatedly.
-  std::optional<SharedResourceLockGuard> try_acquire() {
-    if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
-    if (!lock_->try_acquire_pending<ResourceLock::LockReq::READ_ONLY>()) return std::nullopt;
-    ResourceLock *acquired_lock = std::exchange(lock_, nullptr);
-    return SharedResourceLockGuard{*acquired_lock, SharedResourceLockGuard::Type::READ_ONLY, std::adopt_lock};
-  }
-
- private:
-  ResourceLock *lock_;
-};
+using UniquePendingScope = PendingScope<ResourceLock, ResourceLock::LockReq::UNIQUE>;
+using ReadOnlyPendingScope = PendingScope<ResourceLock, ResourceLock::LockReq::READ_ONLY>;
 
 }  // namespace memgraph::utils

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -592,6 +592,10 @@ struct ResourceLockGuard {
 
   Type type() const { return type_; }
 
+  /// The lock this guard is bound to, held or not. Mirrors std::unique_lock::mutex(), and lets a
+  /// callee assert that a guard handed to it belongs to the lock it expects.
+  ResourceLock *mutex() const { return ptr_; }
+
  private:
   ResourceLock *ptr_;
   Type type_;

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -442,6 +442,11 @@ struct ResourceLockGuard {
  public:
   enum Type : std::uint8_t { UNIQUE, WRITE, READ, READ_ONLY };
 
+  /// A guard bound to no lock, holding nothing. The state a moved-from guard is already left in, so
+  /// every operation below already tolerates it. Lets "no hold" be passed around as a guard rather
+  /// than wrapped in an optional.
+  ResourceLockGuard() = default;
+
   ResourceLockGuard(ResourceLock &l, Type type) : ptr_{&l}, type_{type} { lock(); }
 
   ResourceLockGuard(ResourceLock &l, Type type, std::defer_lock_t /*tag*/) : ptr_{&l}, type_{type} {}
@@ -597,8 +602,8 @@ struct ResourceLockGuard {
   ResourceLock *mutex() const { return ptr_; }
 
  private:
-  ResourceLock *ptr_;
-  Type type_;
+  ResourceLock *ptr_{nullptr};
+  Type type_{UNIQUE};
   bool locked_{false};
 };
 

--- a/tests/e2e/analytical_mode/CMakeLists.txt
+++ b/tests/e2e/analytical_mode/CMakeLists.txt
@@ -5,5 +5,6 @@ endfunction()
 copy_analytical_mode_e2e_python_files(common.py)
 copy_analytical_mode_e2e_python_files(free_memory.py)
 copy_analytical_mode_e2e_python_files(analytical_data_instance.py)
+copy_analytical_mode_e2e_python_files(storage_mode_stress.py)
 
 copy_e2e_files(analytical_mode workloads.yaml)

--- a/tests/e2e/analytical_mode/storage_mode_stress.py
+++ b/tests/e2e/analytical_mode/storage_mode_stress.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+"""
+Stress regression test for the InMemoryStorage::SetStorageMode double-unlock fix: it used to
+hand FreeMemory() a second std::unique_lock adopting main_lock_, causing a double-unlock that
+broke UNIQUE/SHARED mutual exclusion. Hammers the observable symptom (not the mechanism): flip
+storage mode in a loop while other connections read/write, and confirm the server survives
+without crashing, hanging, or erroring.
+"""
+
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import mgclient
+import pytest
+from common import connect, execute_and_fetch_all
+
+DURATION_SECONDS = 5
+NUM_WRITERS = 4
+NUM_READERS = 4
+JOIN_TIMEOUT_SECONDS = 60
+
+
+def _flip_storage_mode(stop_event: threading.Event, errors: list) -> None:
+    connection = mgclient.connect(host="localhost", port=7687)
+    connection.autocommit = True
+    cursor = connection.cursor()
+    try:
+        while not stop_event.is_set():
+            execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL;")
+            execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL;")
+    except Exception as exc:  # noqa: BLE001 - any exception here is itself the failure signal
+        errors.append(("storage-mode-flipper", repr(exc)))
+    finally:
+        connection.close()
+
+
+def _hammer_writes(worker_id: int, stop_event: threading.Event, errors: list) -> None:
+    connection = mgclient.connect(host="localhost", port=7687)
+    connection.autocommit = True
+    cursor = connection.cursor()
+    try:
+        while not stop_event.is_set():
+            execute_and_fetch_all(cursor, f"CREATE (:StorageModeStress {{writer: {worker_id}}})")
+    except Exception as exc:  # noqa: BLE001
+        errors.append((f"writer-{worker_id}", repr(exc)))
+    finally:
+        connection.close()
+
+
+def _hammer_reads(worker_id: int, stop_event: threading.Event, errors: list) -> None:
+    connection = mgclient.connect(host="localhost", port=7687)
+    connection.autocommit = True
+    cursor = connection.cursor()
+    try:
+        while not stop_event.is_set():
+            execute_and_fetch_all(cursor, "MATCH (n:StorageModeStress) RETURN count(n)")
+    except Exception as exc:  # noqa: BLE001
+        errors.append((f"reader-{worker_id}", repr(exc)))
+    finally:
+        connection.close()
+
+
+def test_storage_mode_flip_under_concurrent_load(connect):
+    """Flip storage mode under concurrent read/write load; assert no crash/hang/error.
+
+    The symptom is a race, not deterministic, so this only meaningfully proves the fix on the
+    post-fix binary. A hang (TimeoutError from as_completed) counts as failure just like a raised
+    exception -- broken mutual exclusion can manifest as either.
+    """
+    stop_event = threading.Event()
+    errors: list = []
+
+    with ThreadPoolExecutor(max_workers=1 + NUM_WRITERS + NUM_READERS) as pool:
+        futures = [pool.submit(_flip_storage_mode, stop_event, errors)]
+        futures += [pool.submit(_hammer_writes, i, stop_event, errors) for i in range(NUM_WRITERS)]
+        futures += [pool.submit(_hammer_reads, i, stop_event, errors) for i in range(NUM_READERS)]
+
+        time.sleep(DURATION_SECONDS)
+        stop_event.set()
+
+        for future in as_completed(futures, timeout=JOIN_TIMEOUT_SECONDS):
+            future.result()  # re-raise anything a worker thread didn't catch itself
+
+    assert not errors, f"Concurrent storage-mode flips produced unexpected errors: {errors}"
+
+    # Final connectivity check: the server must still be alive and responsive.
+    cursor = connect.cursor()
+    execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL;")
+    result = execute_and_fetch_all(cursor, "RETURN 1")
+    assert result == [(1,)]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/analytical_mode/workloads.yaml
+++ b/tests/e2e/analytical_mode/workloads.yaml
@@ -25,3 +25,8 @@ workloads:
     binary: "tests/e2e/pytest_runner.sh"
     args: ["analytical_mode/analytical_data_instance.py"]
     <<: *analytical_mode_data_instance
+
+  - name: "Storage mode flip under concurrent load"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["analytical_mode/storage_mode_stress.py"]
+    <<: *analytical_mode_cluster

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3036,3 +3036,66 @@ TEST_F(StorageAccessorLockModeTest, MovePreservesTheHold) {
   EXPECT_EQ(acc->type(), NO_ACCESS) << "the moved-from accessor must no longer own the hold";
   EXPECT_FALSE(store.main_lock_.try_lock()) << "the hold must survive the move, not be dropped";
 }
+
+// storage_mode_ and isolation_level_ are written by SetStorageMode/SetIsolationLevel under a
+// UNIQUE hold on main_lock_. The blocking accessor factories read them to build the accessor, so
+// those reads must happen under a hold too. They are evaluated as constructor arguments, i.e.
+// before the constructor acquires anything, so an unsynchronised read races the locked write.
+//
+// This is a race detector's test: without -fsanitize=thread it passes whether or not the reads are
+// synchronised, because a torn or stale enum read is not observable here. Under TSan it reports
+// the write/read pair directly.
+TEST(StorageAccessRaceTest, ReadsModeAndIsolationWithoutRacingTheWriter) {
+  using namespace std::chrono_literals;
+  constexpr auto kDuration = 2s;
+  constexpr int kReaders = 4;
+
+  // Switching to analytical writes a snapshot, so keep it out of the working directory.
+  const auto data_directory = std::filesystem::temp_directory_path() / "MG_test_unit_storage_v2_access_race";
+  std::filesystem::remove_all(data_directory);
+  const memgraph::utils::OnScopeExit cleanup{[&] { std::filesystem::remove_all(data_directory); }};
+
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .durability{.storage_directory = data_directory},
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> accessors{0};
+
+  std::vector<std::jthread> threads;
+  threads.reserve(kReaders + 2);
+
+  for (int i = 0; i < kReaders; ++i) {
+    threads.emplace_back([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        try {
+          auto acc = store.Access(memgraph::storage::READ, std::nullopt, 50ms);
+          accessors.fetch_add(1, std::memory_order_relaxed);
+          acc->Abort();
+        } catch (memgraph::storage::SharedAccessTimeout const &) {
+          // Expected while the mode switch holds UNIQUE.
+        }
+      }
+    });
+  }
+
+  threads.emplace_back([&] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+      store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+    }
+  });
+
+  threads.emplace_back([&] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      [[maybe_unused]] auto ignored = store.SetIsolationLevel(memgraph::storage::IsolationLevel::READ_COMMITTED);
+      ignored = store.SetIsolationLevel(memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION);
+    }
+  });
+
+  std::this_thread::sleep_for(kDuration);
+  stop.store(true, std::memory_order_relaxed);
+  threads.clear();
+
+  EXPECT_GT(accessors.load(), 0) << "no accessor was ever created; the test raced nothing";
+}

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -26,6 +26,7 @@
 #include "storage/v2/vertex_accessor.hpp"
 #include "storage_test_utils.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "utils/on_scope_exit.hpp"
 
 using testing::Types;
 using testing::UnorderedElementsAre;
@@ -2882,4 +2883,69 @@ TEST(StorageAnalyticalGcTest, GcDoesNotBlockOutUniqueAcquirers) {
   EXPECT_GT(unique_acquisitions.load(), 0) << "no UNIQUE acquirer ever got in; the test proved nothing";
   EXPECT_EQ(unique_timeouts.load(), 0) << "a UNIQUE acquirer was blocked out for " << kUniqueTimeout.count()
                                        << "ms by a concurrent analytical GC pass";
+}
+
+// UNIQUE stays exclusive while SetStorageMode runs. It holds UNIQUE across the mode switch and
+// hands that same hold on to FreeMemory(), so the hold must have exactly one owner throughout: a
+// hold released twice is admitted to a second thread while the first still believes it holds it.
+//
+// Detected by symptom rather than mechanism: probers take UNIQUE and check no other prober holds
+// it at the same time. Two simultaneous holders are only reachable if a hold was released twice.
+// A short timeout keeps a prober from parking behind the mode-switcher for the whole run, so the
+// probers stay dense enough to catch the overlap; a timeout is not itself a failure here.
+TEST(StorageSetStorageModeTest, ConcurrentUniqueHoldersAreNeverBothAdmitted) {
+  using namespace std::chrono_literals;
+  constexpr auto kDuration = 3s;
+  constexpr auto kProbeTimeout = 50ms;
+  constexpr int kProbers = 4;
+
+  // Switching to analytical writes a snapshot, so give it a scratch directory rather than the
+  // default relative "storage" path in the working directory.
+  const auto data_directory = std::filesystem::temp_directory_path() / "MG_test_unit_storage_v2_set_storage_mode";
+  std::filesystem::remove_all(data_directory);
+  const memgraph::utils::OnScopeExit cleanup{[&] { std::filesystem::remove_all(data_directory); }};
+
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .durability{.storage_directory = data_directory},
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> concurrent_holders{0};
+  std::atomic<int> violations{0};
+  std::atomic<int> acquisitions{0};
+
+  std::vector<std::jthread> threads;
+  threads.reserve(kProbers + 1);
+
+  for (int i = 0; i < kProbers; ++i) {
+    threads.emplace_back([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        try {
+          auto acc = store.UniqueAccess(std::nullopt, kProbeTimeout);
+          if (concurrent_holders.fetch_add(1, std::memory_order_acq_rel) != 0) {
+            violations.fetch_add(1, std::memory_order_relaxed);
+          }
+          acquisitions.fetch_add(1, std::memory_order_relaxed);
+          concurrent_holders.fetch_sub(1, std::memory_order_acq_rel);
+          acc->Abort();
+        } catch (memgraph::storage::UniqueAccessTimeout const &) {
+          // Expected under contention; only simultaneous holders are a failure.
+        }
+      }
+    });
+  }
+
+  threads.emplace_back([&] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+      store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+    }
+  });
+
+  std::this_thread::sleep_for(kDuration);
+  stop.store(true, std::memory_order_relaxed);
+  threads.clear();
+
+  EXPECT_GT(acquisitions.load(), 0) << "no prober ever acquired UNIQUE; the test proved nothing";
+  EXPECT_EQ(violations.load(), 0) << "two threads held the UNIQUE lock at the same time";
 }

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3005,14 +3005,14 @@ TEST_F(StorageAccessorLockModeTest, ReadOnlyDowngradesToRead) {
 
 // SetStorageMode's hand-off: after releasing the hold the accessor owns nothing, so it must not
 // release anything at destruction. The returned lock is the sole owner until it goes away.
-TEST_F(StorageAccessorLockModeTest, ReleasingTheUniqueGuardLeavesNothingHeld) {
+TEST_F(StorageAccessorLockModeTest, ReleasingTheGuardLeavesNothingHeld) {
   using namespace memgraph::storage;
 
   auto acc = store.UniqueAccess();
   ASSERT_EQ(acc->type(), UNIQUE);
 
   {
-    auto released = acc->ReleaseUniqueGuard();
+    auto released = acc->ReleaseGuard();
     EXPECT_EQ(acc->type(), NO_ACCESS);
     EXPECT_TRUE(released.owns_lock());
     EXPECT_FALSE(store.main_lock_.try_lock()) << "the released lock is still the sole owner";

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -2949,3 +2949,90 @@ TEST(StorageSetStorageModeTest, ConcurrentUniqueHoldersAreNeverBothAdmitted) {
   EXPECT_GT(acquisitions.load(), 0) << "no prober ever acquired UNIQUE; the test proved nothing";
   EXPECT_EQ(violations.load(), 0) << "two threads held the UNIQUE lock at the same time";
 }
+
+// Accessor::type() reports the mode currently held, and that changes during an accessor's life:
+// a READ_ONLY hold downgrades to READ, and handing the UNIQUE hold away leaves nothing held. The
+// mode is therefore runtime state, not a property of the accessor's type, and type() must be
+// derived from the hold itself rather than from what was originally requested.
+class StorageAccessorLockModeTest : public ::testing::Test {
+ protected:
+  using InMemoryAccessor = memgraph::storage::InMemoryStorage::InMemoryAccessor;
+
+  static InMemoryAccessor &AsInMemory(std::unique_ptr<memgraph::storage::Storage::Accessor> &acc) {
+    return static_cast<InMemoryAccessor &>(*acc);
+  }
+
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+};
+
+TEST_F(StorageAccessorLockModeTest, ReportsTheModeItHolds) {
+  using namespace memgraph::storage;
+
+  auto read = store.Access(READ);
+  EXPECT_EQ(read->type(), READ);
+  read.reset();
+
+  auto write = store.Access(WRITE);
+  EXPECT_EQ(write->type(), WRITE);
+  write.reset();
+
+  auto read_only = store.ReadOnlyAccess();
+  EXPECT_EQ(read_only->type(), READ_ONLY);
+  read_only.reset();
+
+  auto unique = store.UniqueAccess();
+  EXPECT_EQ(unique->type(), UNIQUE);
+}
+
+// The downgrade is what lets an index build stop excluding writers partway through, so type() has
+// to follow the hold rather than the original request.
+TEST_F(StorageAccessorLockModeTest, ReadOnlyDowngradesToRead) {
+  using namespace memgraph::storage;
+
+  auto acc = store.ReadOnlyAccess();
+  ASSERT_EQ(acc->type(), READ_ONLY);
+  // READ_ONLY excludes WRITE; READ does not. The downgrade is observable through that.
+  EXPECT_FALSE(store.main_lock_.try_lock_shared<memgraph::utils::ResourceLock::LockReq::WRITE>());
+
+  AsInMemory(acc).DowngradeToReadIfValid();
+
+  EXPECT_EQ(acc->type(), READ);
+  EXPECT_EQ(acc->original_access_type(), READ_ONLY) << "the original request must survive the downgrade";
+  ASSERT_TRUE(store.main_lock_.try_lock_shared<memgraph::utils::ResourceLock::LockReq::WRITE>());
+  store.main_lock_.unlock_shared<memgraph::utils::ResourceLock::LockReq::WRITE>();
+}
+
+// SetStorageMode's hand-off: after releasing the hold the accessor owns nothing, so it must not
+// release anything at destruction. The returned lock is the sole owner until it goes away.
+TEST_F(StorageAccessorLockModeTest, ReleasingTheUniqueGuardLeavesNothingHeld) {
+  using namespace memgraph::storage;
+
+  auto acc = store.UniqueAccess();
+  ASSERT_EQ(acc->type(), UNIQUE);
+
+  {
+    auto released = acc->ReleaseUniqueGuard();
+    EXPECT_EQ(acc->type(), NO_ACCESS);
+    EXPECT_TRUE(released.owns_lock());
+    EXPECT_FALSE(store.main_lock_.try_lock()) << "the released lock is still the sole owner";
+  }
+
+  // The lock went away with the released owner, and destroying the accessor must not release it a
+  // second time.
+  ASSERT_TRUE(store.main_lock_.try_lock());
+  store.main_lock_.unlock();
+}
+
+TEST_F(StorageAccessorLockModeTest, MovePreservesTheHold) {
+  using namespace memgraph::storage;
+
+  auto acc = store.Access(WRITE);
+  ASSERT_EQ(acc->type(), WRITE);
+
+  auto moved = InMemoryAccessor{std::move(AsInMemory(acc))};
+
+  EXPECT_EQ(moved.type(), WRITE);
+  EXPECT_EQ(acc->type(), NO_ACCESS) << "the moved-from accessor must no longer own the hold";
+  EXPECT_FALSE(store.main_lock_.try_lock()) << "the hold must survive the move, not be dropped";
+}

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3099,3 +3099,102 @@ TEST(StorageAccessRaceTest, ReadsModeAndIsolationWithoutRacingTheWriter) {
 
   EXPECT_GT(accessors.load(), 0) << "no accessor was ever created; the test raced nothing";
 }
+
+// InMemoryStorage::TryAccess: acquire an accessor if main_lock_ admits it right now, or return
+// nullptr. Outside the TYPED_TEST_SUITE because it is InMemoryStorage's alone; DiskStorage has no
+// probe rather than a probe that always fails.
+class StorageTryAccessTest : public ::testing::Test {
+ protected:
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+};
+
+TEST_F(StorageTryAccessTest, SucceedsAndReturnsUsableAccessorWhenFree) {
+  using namespace memgraph::storage;
+
+  auto acc = store.TryAccess(READ);
+  ASSERT_NE(acc, nullptr);
+  EXPECT_EQ(acc->type(), READ);
+  EXPECT_NO_THROW(acc->CreateVertex());
+  EXPECT_NO_THROW(acc->Abort());
+  acc.reset();  // destroy the accessor to release its main_lock_ share (Abort() alone does not)
+
+  auto write_acc = store.TryAccess(WRITE);
+  ASSERT_NE(write_acc, nullptr);
+  EXPECT_EQ(write_acc->type(), WRITE);
+  EXPECT_NO_THROW(write_acc->Abort());
+  write_acc.reset();
+
+  auto unique_acc = store.TryAccess(UNIQUE);
+  ASSERT_NE(unique_acc, nullptr);
+  EXPECT_EQ(unique_acc->type(), UNIQUE);
+  EXPECT_NO_THROW(unique_acc->Abort());
+  unique_acc.reset();
+
+  auto ro_acc = store.TryAccess(READ_ONLY);
+  ASSERT_NE(ro_acc, nullptr);
+  EXPECT_EQ(ro_acc->type(), READ_ONLY);
+  EXPECT_NO_THROW(ro_acc->Abort());
+}
+
+// UNIQUE held -> every probe returns nullopt without throwing or creating a transaction. The
+// "no transaction created" part is proven via the strictly-monotonic transaction_id: it only
+// advances on CreateTransaction(), so a spurious probe would make the next id jump by >1.
+TEST_F(StorageTryAccessTest, UniqueHeldBlocksNewSharedWithoutCreatingATransaction) {
+  using namespace memgraph::storage;
+
+  auto unique_acc = store.UniqueAccess();  // blocking call; trivially succeeds, nothing else held
+  ASSERT_NE(unique_acc, nullptr);
+  const uint64_t unique_id = unique_acc->GetTransaction()->transaction_id;
+
+  EXPECT_EQ(store.TryAccess(READ), nullptr);
+  EXPECT_EQ(store.TryAccess(WRITE), nullptr);
+  EXPECT_EQ(store.TryAccess(READ_ONLY), nullptr);
+  EXPECT_EQ(store.TryAccess(UNIQUE), nullptr);
+
+  unique_acc->Abort();
+  unique_acc.reset();  // releases the UNIQUE hold on main_lock_
+
+  auto after = store.TryAccess(READ);
+  ASSERT_NE(after, nullptr);
+  EXPECT_EQ(after->GetTransaction()->transaction_id, unique_id + 1)
+      << "a TryAccess nullopt path created a transaction it "
+         "should not have";
+  after->Abort();
+}
+
+// Mirror of the above but the OTHER conflict direction: a held shared (READ) lock must block a
+// new TryAccess(UNIQUE), while still allowing further compatible shared acquisitions through.
+TEST_F(StorageTryAccessTest, SharedHeldBlocksNewUniqueButNotNewCompatibleShared) {
+  using namespace memgraph::storage;
+
+  auto read_acc = store.Access(READ);  // blocking call; trivially succeeds
+  ASSERT_NE(read_acc, nullptr);
+
+  EXPECT_EQ(store.TryAccess(UNIQUE), nullptr);
+
+  // READ is not exclusive with itself/WRITE -- a second READ probe should still succeed.
+  auto another_read = store.TryAccess(READ);
+  ASSERT_NE(another_read, nullptr);
+  EXPECT_NO_THROW(another_read->Abort());
+
+  read_acc->Abort();
+}
+
+// READ_ONLY held -> conflicts with WRITE (both directly and via TryAccess(WRITE)), matching the
+// existing WRITE vs READ_ONLY mutual exclusion enforced by ResourceLock.
+TEST_F(StorageTryAccessTest, ReadOnlyHeldBlocksNewWrite) {
+  using namespace memgraph::storage;
+
+  auto ro_acc = store.ReadOnlyAccess();  // blocking call; trivially succeeds
+  ASSERT_NE(ro_acc, nullptr);
+
+  EXPECT_EQ(store.TryAccess(WRITE), nullptr);
+
+  ro_acc->Abort();
+  ro_acc.reset();  // destroy the accessor to release its READ_ONLY main_lock_ share (Abort() alone does not)
+
+  auto write_acc = store.TryAccess(WRITE);
+  ASSERT_NE(write_acc, nullptr);
+  EXPECT_NO_THROW(write_acc->Abort());
+}

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -29,6 +29,11 @@ using testing::UnorderedElementsAre;
 
 namespace ms = memgraph::storage;
 
+// Forces a synchronous GC pass by handing FreeMemory a hold it must adopt rather than acquire.
+inline auto UniqueGuard(memgraph::utils::ResourceLock &lock) {
+  return memgraph::utils::ResourceLockGuard{lock, memgraph::utils::ResourceLockGuard::UNIQUE};
+}
+
 class StorageV2GcMetricsTest : public testing::Test {
  protected:
   void SetUp() override {
@@ -358,7 +363,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithCommittedContributorsAreGa
   }
 
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
@@ -407,14 +412,14 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithAbortedContributorsAreGarb
   // First GC: moves `waiting_gc_deltas_` to `aborted_transactions_` or
   // `committed_transactions_`
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
   // Second GC: committed deltas are unlinked, and all deltas (be they committed
   // or aborted) move to `garbage_undo_buffers_` for reclamation.
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
@@ -464,19 +469,19 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithMultipleAbortsAreGarbageCo
 
   // First GC: moves from waiting_gc_deltas_ to aborted_transactions_
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
   // Second GC: moves to garbage_undo_buffers_
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
   // Third GC: frees the deltas
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
@@ -533,7 +538,7 @@ TEST_F(StorageV2GcMetricsTest, DownstreamDeltaChainsAreGarbageCollected) {
 
   // Multiple GC cycles to process the downstream chain
   for (int i = 0; i < 4; ++i) {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
@@ -589,7 +594,7 @@ TEST_F(StorageV2GcMetricsTest, MixedCommitAbortCommitNonSequentialDeltasAreGarba
 
   // Multiple GC cycles to handle mixed commit/abort
   for (int i = 0; i < 4; ++i) {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
@@ -644,7 +649,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithTwoContributorsAreGarbaged
   }
 
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->FreeMemory(std::move(main_guard), false);
   }
 
@@ -1523,7 +1528,7 @@ TEST(StorageV2Gc, ClearDrainsWaitingGcDeltas) {
   // Clear should discard entire storage state, including pending
   // non-sequential deltas in the waiting_gc_deltas_ list.
   {
-    auto main_guard = std::unique_lock{storage->main_lock_};
+    auto main_guard = UniqueGuard(storage->main_lock_);
     storage->Clear();
   }
 
@@ -1743,7 +1748,7 @@ TEST(StorageV2GcLightEdge, AnalyticalModeDeleteGoesToGraveyard) {
 
   // Run GC explicitly a second time to drain the graveyard.
   {
-    auto main_guard = std::unique_lock{mem_storage->main_lock_};
+    auto main_guard = UniqueGuard(mem_storage->main_lock_);
     mem_storage->FreeMemory(std::move(main_guard), false);
   }
 

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -1350,3 +1350,62 @@ TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzzWithPendingScope
 
   ASSERT_FALSE(invariant_violated.load()) << violation_message;
 }
+
+// A pending UNIQUE waiter must not miss its wake-up to a waiter that cannot use it.
+//
+// Every waiter parks on the same condition variable but each has its own predicate, so a
+// notify_one can be delivered to a waiter whose predicate is still false: a shared acquirer gated
+// on unique_pending_, say. It re-checks, sleeps again, and consumes the only notification, leaving
+// the waiter that could have made progress asleep until its timeout.
+//
+// Both crowds are load-bearing: several shared acquirers parked to absorb the notification, and
+// several UNIQUE waiters so the one woken is not reliably the one waiting longest. With a single
+// UNIQUE waiter of either kind the interleaving cannot arise and the test asserts nothing.
+TEST_F(ResourceLockTest, PendingUniqueIsWokenWhenSharedAcquirersAreAlsoParked) {
+  using namespace std::chrono_literals;
+  constexpr auto kUniqueTimeout = 500ms;
+  constexpr auto kDuration = 2s;
+  constexpr int kSharedCyclers = 4;
+  constexpr int kUniqueWaiters = 4;
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> unique_timeouts{0};
+  std::atomic<int> unique_acquisitions{0};
+
+  std::vector<std::jthread> threads;
+  threads.reserve(kSharedCyclers + kUniqueWaiters);
+
+  // Each cycler drives the lock down to fully-unlocked (firing the notify) and, whenever a UNIQUE
+  // is pending, parks on the acquisition gated by unique_pending_ (becoming a potential absorber).
+  for (int i = 0; i < kSharedCyclers; ++i) {
+    threads.emplace_back([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        lock.lock_shared<ResourceLock::LockReq::READ>();
+        lock.unlock_shared<ResourceLock::LockReq::READ>();
+        lock.lock_shared<ResourceLock::LockReq::WRITE>();
+        lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+      }
+    });
+  }
+
+  for (int i = 0; i < kUniqueWaiters; ++i) {
+    threads.emplace_back([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        if (lock.try_lock_for(kUniqueTimeout)) {
+          unique_acquisitions.fetch_add(1, std::memory_order_relaxed);
+          lock.unlock();
+        } else {
+          unique_timeouts.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(kDuration);
+  stop.store(true, std::memory_order_relaxed);
+  threads.clear();
+
+  EXPECT_GT(unique_acquisitions.load(), 0) << "the UNIQUE waiter never acquired; the test proved nothing";
+  EXPECT_EQ(unique_timeouts.load(), 0) << "a pending UNIQUE waiter was not woken within " << kUniqueTimeout.count()
+                                       << "ms while " << kSharedCyclers << " shared acquirers were parked";
+}

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -817,7 +817,7 @@ TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresUnderContinuousWriteH
     auto scoped_future = std::async(std::launch::async, [&] {
       auto start = std::chrono::steady_clock::now();
       UniquePendingScope scope(lock);
-      std::optional<std::unique_lock<ResourceLock>> acquired;
+      std::optional<ResourceLockGuard> acquired;
       while (!acquired) {
         acquired = scope.try_acquire();
         if (!acquired) std::this_thread::sleep_for(20us);
@@ -883,7 +883,7 @@ TEST_F(ResourceLockTest, ReadOnlyPendingScopeCampaignAcquiresUnderContinuousWrit
   auto scoped_future = std::async(std::launch::async, [&] {
     auto start = std::chrono::steady_clock::now();
     ReadOnlyPendingScope scope(lock);
-    std::optional<SharedResourceLockGuard> acquired;
+    std::optional<ResourceLockGuard> acquired;
     while (!acquired) {
       acquired = scope.try_acquire();
       if (!acquired) std::this_thread::sleep_for(20us);
@@ -899,7 +899,7 @@ TEST_F(ResourceLockTest, ReadOnlyPendingScopeCampaignAcquiresUnderContinuousWrit
 
   if (acquired_in_time) {
     const auto [latency, acquired_type] = scoped_future.get();
-    EXPECT_EQ(acquired_type, SharedResourceLockGuard::READ_ONLY);
+    EXPECT_EQ(acquired_type, ResourceLockGuard::READ_ONLY);
     RecordProperty("ro_pending_scope_latency_ms", std::to_string(latency.count()));
   } else {
     ADD_FAILURE() << "ReadOnlyPendingScope::try_acquire() campaign did not acquire within " << kBound.count()

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -792,9 +792,18 @@ std::vector<std::jthread> SpawnHammers(ResourceLock &target_lock, std::atomic<bo
 }
 }  // namespace
 
-// A UniquePendingScope retry loop acquires within a bound under continuous WRITE churn,
-// whereas a bare try_lock() loop is expected to starve (soft/environment-dependent control).
-TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarves) {
+// A UniquePendingScope held across a try_acquire() retry loop should acquire within a
+// bounded time under a continuous stream of new WRITE shared acquirers. A bare `lock.try_lock()`
+// retry loop against the same hammer stream is expected to starve, since its probes never register
+// as pending and so never gate the hammers out.
+//
+// Only the campaign's acquisition is asserted; the control is recorded, not asserted. The hammers
+// overlap statistically rather than by construction, so "the bare loop did not get in" asserts that
+// a rare event did not occur across many probes, which no choice of bound makes reliable: a longer
+// bound makes it likelier to fire, a shorter one weakens it to nothing. The gate's mechanism has
+// its own deterministic test, holding a shared lock and checking that new shared acquisitions fail
+// while a pending scope lives and succeed once it dies.
+TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresUnderContinuousWriteHammer) {
   using namespace std::chrono_literals;
   constexpr int kNumHammers = 8;
   constexpr auto kPendingScopeBound = 5s;
@@ -854,11 +863,10 @@ TEST_F(ResourceLockTest, UniquePendingScopeCampaignAcquiresWhileBareTryLockStarv
     hammers.clear();
 
     if (control_result) {
-      lock.unlock();  // release so later tests start from UNLOCKED
-      // The ungated control is expected to starve, but its success is probabilistic and
-      // environment-dependent, so record it (non-fatal) rather than abort: a chance acquire must not
-      // fail CI. The deterministic PendingScope campaign above is the real writer-preference signal.
+      lock.unlock();  // it did acquire; release so later tests in the suite start from UNLOCKED
       RecordProperty("bare_try_lock_acquired_ms", std::to_string(control_result->count()));
+    } else {
+      RecordProperty("bare_try_lock_acquired_ms", "starved");
     }
   }
 }


### PR DESCRIPTION
SetStorageMode held main_lock_ in UNIQUE and passed that hold to FreeMemory by
adopting it into a second lock, so one hold had two owners and was released
twice. The second release drops the lock while another thread may already hold
it in UNIQUE. The hold is now handed off, so exactly one owner releases it.

The storage mode and isolation level were read outside any hold: by the accessor
factories, as constructor arguments evaluated before the constructor acquired
anything, and by replication. They are now atomic, and the constructor reads
them under the hold it keeps, so a transaction runs in the mode in force for the
life of that hold. Query preparation has to read the mode before taking the
access it decides, so it re-checks against the pinned copy afterwards and raises
a transient error on mismatch.

An Accessor now holds one ResourceLockGuard covering all four lock modes, and is
constructed from the hold it will keep rather than a tag. That makes the
non-blocking TryAccess, TryUniqueAccess and TryReadOnlyAccess expressible: one
probe, reporting busy instead of blocking or throwing. No caller yet; they are
for the parkable query preparation that follows.

Carried along: PrepareDeletableEdges read edge endpoints' deleted() with no
vertex lock, and that bit shares a non-atomic word with the delta pointer.
ResourceLock now asserts release balance, since the unsigned hold counts wrap on
an unmatched release and silently block a mode for the life of the process.
