### PR TITLE
fix(query): reset per-connection sticky state on RESET/LogOff + idle-in-transaction watchdog

### DIFF
--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -255,15 +255,9 @@ DEFINE_string(query_callable_mappings_path, "",
               "pairs in a json file. With this option query module procedures that do not exist in memgraph can be "
               "mapped to ones that exist.");
 
-// Idle-in-transaction watchdog. An explicit BEGIN holds its storage accessor (and any
-// main_lock_ share/unique) until COMMIT/ROLLBACK/RESET/close; the per-query execution timeout
-// (--query-execution-timeout-sec) only fires while a query is actually running, so a session
-// that issues BEGIN and then goes idle can hold those resources forever. The background scan
-// (InterpreterContext::ScanIdleTransactions) always tracks + warns once idle time crosses the
-// warn threshold (set to 0 to disable warning); it only *aborts* -- via the same cross-thread
-// termination path TERMINATE TRANSACTIONS uses -- when the abort threshold is explicitly set
-// above 0. Default is 0 (disabled): no deployment starts auto-terminating idle sessions unless
-// an operator opts in.
+// Idle-in-transaction watchdog: a BEGIN'd transaction holds its accessor/main_lock_ until
+// COMMIT/ROLLBACK/RESET, and the per-query timeout never fires while idle. Warn-tracking always
+// runs; abort is opt-in via the TERMINATE TRANSACTIONS path (threshold 0 = disabled default).
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_VALIDATED_uint64(query_idle_in_transaction_warn_sec, 60,
                         "Warn (and count in metrics) when an explicit (BEGIN'd) transaction has been idle -- no "

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -255,6 +255,28 @@ DEFINE_string(query_callable_mappings_path, "",
               "pairs in a json file. With this option query module procedures that do not exist in memgraph can be "
               "mapped to ones that exist.");
 
+// Idle-in-transaction watchdog. An explicit BEGIN holds its storage accessor (and any
+// main_lock_ share/unique) until COMMIT/ROLLBACK/RESET/close; the per-query execution timeout
+// (--query-execution-timeout-sec) only fires while a query is actually running, so a session
+// that issues BEGIN and then goes idle can hold those resources forever. The background scan
+// (InterpreterContext::ScanIdleTransactions) always tracks + warns once idle time crosses the
+// warn threshold (set to 0 to disable warning); it only *aborts* -- via the same cross-thread
+// termination path TERMINATE TRANSACTIONS uses -- when the abort threshold is explicitly set
+// above 0. Default is 0 (disabled): no deployment starts auto-terminating idle sessions unless
+// an operator opts in.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_VALIDATED_uint64(query_idle_in_transaction_warn_sec, 60,
+                        "Warn (and count in metrics) when an explicit (BEGIN'd) transaction has been idle -- no "
+                        "query currently executing -- for this many seconds. Set to 0 to disable.",
+                        FLAG_IN_RANGE(0, 30UL * 24 * 3600));
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_VALIDATED_uint64(query_idle_in_transaction_abort_sec, 0,
+                        "Abort an explicit (BEGIN'd) transaction that has been idle -- no query currently executing "
+                        "-- for this many seconds, using the same cross-thread termination path as TERMINATE "
+                        "TRANSACTIONS. 0 (default) disables aborting; only --query-idle-in-transaction-warn-sec "
+                        "tracking is ever on by default.",
+                        FLAG_IN_RANGE(0, 30UL * 24 * 3600));
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_HIDDEN_string(license_key, "", "License key for Memgraph Enterprise.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -139,6 +139,15 @@ DECLARE_string(query_modules_directory);
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_string(query_callable_mappings_path);
 
+// Idle-in-transaction watchdog: an explicit (BEGIN'd) transaction that is holding its storage
+// accessor / main_lock_ share with no query currently executing. Warn-tracking is always on
+// (disable by setting the warn threshold to 0); the abort side is opt-in and defaults to
+// disabled (0) so no existing deployment starts auto-terminating sessions.
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_uint64(query_idle_in_transaction_warn_sec);
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_uint64(query_idle_in_transaction_abort_sec);
+
 namespace memgraph::flags {
 auto ParseQueryModulesDirectory() -> std::vector<std::filesystem::path>;
 }  // namespace memgraph::flags

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -139,10 +139,8 @@ DECLARE_string(query_modules_directory);
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_string(query_callable_mappings_path);
 
-// Idle-in-transaction watchdog: an explicit (BEGIN'd) transaction that is holding its storage
-// accessor / main_lock_ share with no query currently executing. Warn-tracking is always on
-// (disable by setting the warn threshold to 0); the abort side is opt-in and defaults to
-// disabled (0) so no existing deployment starts auto-terminating sessions.
+// Idle-in-transaction watchdog thresholds (seconds). Warn-tracking is always on (0 disables);
+// abort is opt-in and defaults to 0 (disabled) so no deployment starts auto-terminating sessions.
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint64(query_idle_in_transaction_warn_sec);
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -363,11 +363,9 @@ void SessionHL::LogOff() {
 void SessionHL::Abort() {
   interpreter_.ResetCachedFga();
   interpreter_.Abort();
-  // SessionHL::Abort() is RESET-specific: its only callers are the Bolt RESET handler
-  // (HandleReset -> session.Abort()) and LogOff() (full teardown). Neither is a mid-session
-  // rollback/error path (those call interpreter_.RollbackTransaction() / interpreter_.Abort()
-  // directly), so it is safe here -- and only here -- to clear per-connection sticky state that
-  // must not leak into the next logically-unrelated session on a pooled connection.
+  // RESET-specific path (only callers: Bolt RESET handler and LogOff, never a mid-session
+  // rollback), so clearing per-connection sticky state that must not leak onto a pooled
+  // connection's next session is safe only here.
   interpreter_.ResetForConnectionReuse();
 #ifdef MG_ENTERPRISE
   runtime_config_.ResetForConnectionReuse();

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -363,6 +363,15 @@ void SessionHL::LogOff() {
 void SessionHL::Abort() {
   interpreter_.ResetCachedFga();
   interpreter_.Abort();
+  // SessionHL::Abort() is RESET-specific: its only callers are the Bolt RESET handler
+  // (HandleReset -> session.Abort()) and LogOff() (full teardown). Neither is a mid-session
+  // rollback/error path (those call interpreter_.RollbackTransaction() / interpreter_.Abort()
+  // directly), so it is safe here -- and only here -- to clear per-connection sticky state that
+  // must not leak into the next logically-unrelated session on a pooled connection.
+  interpreter_.ResetForConnectionReuse();
+#ifdef MG_ENTERPRISE
+  runtime_config_.ResetForConnectionReuse();
+#endif
 }
 
 bolt_map_t SessionHL::Discard(std::optional<int> n, std::optional<int> qid) {

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -38,12 +38,9 @@ class RuntimeConfig {
 
   void Configure(const bolt_map_t &run_time_info, bool in_explicit_tx);
 
-  // Invalidate the "run_time_info unchanged since last call => skip" cache below (see
-  // Configure()) so the next RUN/BEGIN after a Bolt RESET/LogOff is forced to fully re-derive
-  // user + db instead of silently keeping whatever a previous, logically unrelated, pooled
-  // session configured. Without this, Interpreter::ResetForConnectionReuse()'s ResetDB() would
-  // have no visible effect whenever the next session's extra/metadata map happens to be
-  // identical to the one before RESET/LogOff.
+  // Invalidate Configure()'s "run_time_info unchanged => skip" cache so the next RUN/BEGIN after
+  // RESET/LogOff fully re-derives user + db (otherwise ResetDB() has no effect when the next
+  // session's metadata happens to match the previous one's).
   void ResetForConnectionReuse() { previous_run_time_info_.reset(); }
 
   bool db_explicit_ = false;

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -38,6 +38,14 @@ class RuntimeConfig {
 
   void Configure(const bolt_map_t &run_time_info, bool in_explicit_tx);
 
+  // Invalidate the "run_time_info unchanged since last call => skip" cache below (see
+  // Configure()) so the next RUN/BEGIN after a Bolt RESET/LogOff is forced to fully re-derive
+  // user + db instead of silently keeping whatever a previous, logically unrelated, pooled
+  // session configured. Without this, Interpreter::ResetForConnectionReuse()'s ResetDB() would
+  // have no visible effect whenever the next session's extra/metadata map happens to be
+  // identical to the one before RESET/LogOff.
+  void ResetForConnectionReuse() { previous_run_time_info_.reset(); }
+
   bool db_explicit_ = false;
   bool user_explicit_ = false;
 

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -554,6 +554,17 @@ PrometheusMetrics::PrometheusMetrics()
                                           .Name("memgraph_database_resume_latency_seconds")
                                           .Help("Latency of a successful database RESUME in seconds")
                                           .Register(registry_)},
+      // Idle-in-transaction watchdog
+      idle_in_transaction_warnings_family_{prometheus::BuildCounter()
+                                               .Name("memgraph_idle_in_transaction_warnings_total")
+                                               .Help("Number of scan ticks that found an explicit transaction idle "
+                                                     "past the warn threshold")
+                                               .Register(registry_)},
+      idle_in_transaction_aborted_family_{prometheus::BuildCounter()
+                                              .Name("memgraph_idle_in_transaction_aborted_total")
+                                              .Help("Number of explicit transactions terminated by the "
+                                                    "idle-in-transaction watchdog")
+                                              .Register(registry_)},
       // HighAvailability counters
       successful_failovers_family_{prometheus::BuildCounter()
                                        .Name("memgraph_successful_failovers_total")
@@ -844,6 +855,8 @@ PrometheusMetrics::PrometheusMetrics()
   global.cold_databases = &cold_databases_family_.Add(no_labels);
   global.database_suspend_latency_seconds = &database_suspend_latency_family_.Add(no_labels, kLatencyBuckets);
   global.database_resume_latency_seconds = &database_resume_latency_family_.Add(no_labels, kLatencyBuckets);
+  global.idle_in_transaction_warnings = &idle_in_transaction_warnings_family_.Add(no_labels);
+  global.idle_in_transaction_aborted = &idle_in_transaction_aborted_family_.Add(no_labels);
   // No-db fallback counters: same family as per-db, but with no database label.
   // Incremented only when a query fires outside any database context.
   global.transient_errors = &transient_errors_family_.Add(no_labels);
@@ -2031,6 +2044,16 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfo() const {
   out.push_back({"ColdDatabases", "HotCold", "Gauge", static_cast<int64_t>(global.cold_databases->Value())});
   AppendHistogramPercentiles(out, "DatabaseSuspendLatency", "HotCold", *global.database_suspend_latency_seconds);
   AppendHistogramPercentiles(out, "DatabaseResumeLatency", "HotCold", *global.database_resume_latency_seconds);
+
+  // Idle-in-transaction watchdog (global only)
+  out.push_back({"IdleInTransactionWarnings",
+                 "Transaction",
+                 "Counter",
+                 static_cast<int64_t>(global.idle_in_transaction_warnings->Value())});
+  out.push_back({"IdleInTransactionAborted",
+                 "Transaction",
+                 "Counter",
+                 static_cast<int64_t>(global.idle_in_transaction_aborted->Value())});
 
   // Session
   out.push_back({"ActiveSessions", "Session", "Gauge", static_cast<int64_t>(global.active_sessions->Value())});

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -300,9 +300,8 @@ struct GlobalMetricHandles {
   prometheus::Counter *write_query;
   prometheus::Counter *read_write_query;
 
-  // Idle-in-transaction watchdog (global — instance-wide scan, not attributed to a single db).
-  // warnings: bumped every scan tick a transaction is found idle past the warn threshold.
-  // aborted: bumped once per transaction actually terminated past the abort threshold.
+  // Idle-in-transaction watchdog (global). warnings: bumped every scan tick a tx is idle past the
+  // warn threshold; aborted: bumped once per tx terminated past the abort threshold.
   prometheus::Counter *idle_in_transaction_warnings;
   prometheus::Counter *idle_in_transaction_aborted;
 

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -300,6 +300,12 @@ struct GlobalMetricHandles {
   prometheus::Counter *write_query;
   prometheus::Counter *read_write_query;
 
+  // Idle-in-transaction watchdog (global — instance-wide scan, not attributed to a single db).
+  // warnings: bumped every scan tick a transaction is found idle past the warn threshold.
+  // aborted: bumped once per transaction actually terminated past the abort threshold.
+  prometheus::Counter *idle_in_transaction_warnings;
+  prometheus::Counter *idle_in_transaction_aborted;
+
   // HighAvailability counters
   prometheus::Counter *successful_failovers;
   prometheus::Counter *raft_failed_failovers;
@@ -574,6 +580,10 @@ class PrometheusMetrics {
   prometheus::Family<prometheus::Histogram> &database_resume_latency_family_;
 
   // No separate global families needed — global no-db counters reuse the per-db families with no label
+
+  // Global metric families — idle-in-transaction watchdog
+  prometheus::Family<prometheus::Counter> &idle_in_transaction_warnings_family_;
+  prometheus::Family<prometheus::Counter> &idle_in_transaction_aborted_family_;
 
   // Global metric families — HA counters
   prometheus::Family<prometheus::Counter> &successful_failovers_family_;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9750,10 +9750,8 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
     accessor_type_ = cypher_access_type();
   }
 
-  // NOTE: could_commit_ intentionally stays false for PROFILE. PROFILE always ABORTs its
-  // transaction by design (PrepareProfileQuery returns QueryHandlerResult::ABORT, interpreter.cpp
-  // ~3932; the write never commits), so before/after-COMMIT triggers correctly do NOT fire — there
-  // is no commit. (Verified: a PROFILE'd write persists nothing; empirical stress run confirmed.)
+  // could_commit_ stays false: PROFILE always ABORTs its transaction (PrepareProfileQuery returns
+  // QueryHandlerResult::ABORT), so there is no commit and before/after-COMMIT triggers must not fire.
   void Visit(ProfileQuery & /*unused*/) override { accessor_type_ = cypher_access_type(); }
 
   void Visit(TriggerQuery & /*unused*/) override { accessor_type_ = storage::StorageAccessType::WRITE; }
@@ -9823,10 +9821,8 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 
 Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParameters_fn params_getter,
                                                 QueryExtras const &extras) {
-  // Idle-in-transaction watchdog: mark this interpreter as actively working for the duration of
-  // Prepare(), and stamp the last-activity clock on exit (success or exception) so a background
-  // scan (InterpreterContext::ScanIdleTransactions) never mistakes in-flight parsing/planning for
-  // an idle gap between statements of an explicit (BEGIN'd) transaction.
+  // Idle-in-transaction watchdog: flag active work for the duration of Prepare() and stamp the
+  // last-activity clock on exit, so the background scan never counts in-flight work as idle.
   query_in_progress_.store(true, std::memory_order_release);
   const utils::OnScopeExit idle_watchdog_activity_guard([this] {
     last_activity_steady_ns_.store(std::chrono::steady_clock::now().time_since_epoch().count(),
@@ -10449,10 +10445,8 @@ void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {
   current_transaction_ = tx_id;
   transaction_start_time_ = std::chrono::system_clock::now();
   transaction_start_steady_ = std::chrono::steady_clock::now();
-  // Idle-in-transaction watchdog: a freshly started transaction is, by definition, not idle yet.
-  // Without this the field could still hold a stale value (0 on a brand-new Interpreter, or the
-  // end-time of a previous transaction on this same connection), which would make the very first
-  // scan tick after BEGIN look idle for however long the process/connection has actually been up.
+  // Idle-in-transaction watchdog: a fresh transaction is not idle yet; reset the clock so the
+  // first scan tick after BEGIN doesn't treat a stale value as idle time.
   last_activity_steady_ns_.store(transaction_start_steady_.time_since_epoch().count(), std::memory_order_relaxed);
   // Release publishes the start-time writes above to verifier-holding readers.
   transaction_status_.store(TransactionStatus::ACTIVE, std::memory_order_release);
@@ -10545,33 +10539,22 @@ void Interpreter::Abort() {
 }
 
 void Interpreter::ResetForConnectionReuse() {
-  // One-shot: `SET NEXT TRANSACTION ISOLATION LEVEL` targets the very next transaction on *this*
-  // connection. On RESET (or LogOff) that transaction will never start, so the pending override
-  // must be dropped here -- otherwise it silently leaks into the first transaction of whichever
-  // logically unrelated session picks up this (pooled) connection next.
+  // One-shot `SET NEXT TRANSACTION ISOLATION LEVEL`: its target transaction never starts on
+  // RESET/LogOff, so drop it or it leaks into the next pooled session's first transaction.
   next_transaction_isolation_level.reset();
 
 #ifdef MG_ENTERPRISE
-  // `USE <db>` / Bolt-level db-routing metadata sets current_db_.db_acc_ + in_explicit_db_, which
-  // is per-connection state. It must not leak into the next pooled session either --
-  // TryDefaultDB()/RuntimeConfig::Configure() re-establish the correct db (default, or explicitly
-  // requested) on the next RUN/BEGIN.
+  // `USE <db>` pins per-connection db state (db_acc_ + in_explicit_db_); clear it so the next
+  // pooled session re-establishes its db via TryDefaultDB()/RuntimeConfig::Configure().
   ResetDB();
 #endif
 
-  // `SET SESSION ISOLATION LEVEL ...` (session-scoped) is also cleared on RESET. RESET's documented
-  // intent (bolt HandleReset) is to return the connection to a clean state before it is handed back
-  // to a connection pool; the next, logically unrelated, pooled session must not inherit a previous
-  // session's isolation level. (A silently-wrong isolation level is a worse failure mode than a
-  // reset one; a client that RESETs mid-session and relies on its SET SESSION persisting can re-issue
-  // it.) After clearing, GetIsolationLevelOverride() falls back to the storage/config default.
+  // Session-scoped `SET SESSION ISOLATION LEVEL`: cleared so the next pooled session falls back to
+  // the storage/config default rather than inheriting a previous session's override.
   interpreter_isolation_level.reset();
 
-  // `SET SESSION TRACE` and `SET SESSION SETTING ...` mutate the per-connection SessionLogContext
-  // overlay in-band (outside the Bolt metadata that Configure() compares), so they are the same
-  // leak class as db/isolation above: without this they would persist into the next pooled logical
-  // session. Clear the query-driven overlay (trace flag + session runtime-setting overrides); the
-  // connection identity (session_uuid_) and auth user_ are intentionally preserved.
+  // `SET SESSION TRACE`/`SETTING` mutate the SessionLogContext overlay in-band (invisible to
+  // Configure()), so clear the query-driven overlay too; connection identity + auth user are kept.
   session_log_ctx_.ResetForConnectionReuse();
 }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9750,6 +9750,10 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
     accessor_type_ = cypher_access_type();
   }
 
+  // NOTE: could_commit_ intentionally stays false for PROFILE. PROFILE always ABORTs its
+  // transaction by design (PrepareProfileQuery returns QueryHandlerResult::ABORT, interpreter.cpp
+  // ~3932; the write never commits), so before/after-COMMIT triggers correctly do NOT fire — there
+  // is no commit. (Verified: a PROFILE'd write persists nothing; empirical stress run confirmed.)
   void Visit(ProfileQuery & /*unused*/) override { accessor_type_ = cypher_access_type(); }
 
   void Visit(TriggerQuery & /*unused*/) override { accessor_type_ = storage::StorageAccessType::WRITE; }
@@ -9819,6 +9823,17 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 
 Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParameters_fn params_getter,
                                                 QueryExtras const &extras) {
+  // Idle-in-transaction watchdog: mark this interpreter as actively working for the duration of
+  // Prepare(), and stamp the last-activity clock on exit (success or exception) so a background
+  // scan (InterpreterContext::ScanIdleTransactions) never mistakes in-flight parsing/planning for
+  // an idle gap between statements of an explicit (BEGIN'd) transaction.
+  query_in_progress_.store(true, std::memory_order_release);
+  const utils::OnScopeExit idle_watchdog_activity_guard([this] {
+    last_activity_steady_ns_.store(std::chrono::steady_clock::now().time_since_epoch().count(),
+                                   std::memory_order_relaxed);
+    query_in_progress_.store(false, std::memory_order_release);
+  });
+
   std::optional<memory::DbArenaScope> db_arena_scope;
   if (current_db_.db_acc_) {
     db_arena_scope.emplace(current_db_.db_acc_->get());
@@ -10434,6 +10449,11 @@ void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {
   current_transaction_ = tx_id;
   transaction_start_time_ = std::chrono::system_clock::now();
   transaction_start_steady_ = std::chrono::steady_clock::now();
+  // Idle-in-transaction watchdog: a freshly started transaction is, by definition, not idle yet.
+  // Without this the field could still hold a stale value (0 on a brand-new Interpreter, or the
+  // end-time of a previous transaction on this same connection), which would make the very first
+  // scan tick after BEGIN look idle for however long the process/connection has actually been up.
+  last_activity_steady_ns_.store(transaction_start_steady_.time_since_epoch().count(), std::memory_order_relaxed);
   // Release publishes the start-time writes above to verifier-holding readers.
   transaction_status_.store(TransactionStatus::ACTIVE, std::memory_order_release);
   session_log_ctx_.SetTxId(tx_id);
@@ -10522,6 +10542,37 @@ void Interpreter::Abort() {
     if (qe) qe->CleanRuntimeData();
   }
   frame_change_collector_.reset();
+}
+
+void Interpreter::ResetForConnectionReuse() {
+  // One-shot: `SET NEXT TRANSACTION ISOLATION LEVEL` targets the very next transaction on *this*
+  // connection. On RESET (or LogOff) that transaction will never start, so the pending override
+  // must be dropped here -- otherwise it silently leaks into the first transaction of whichever
+  // logically unrelated session picks up this (pooled) connection next.
+  next_transaction_isolation_level.reset();
+
+#ifdef MG_ENTERPRISE
+  // `USE <db>` / Bolt-level db-routing metadata sets current_db_.db_acc_ + in_explicit_db_, which
+  // is per-connection state. It must not leak into the next pooled session either --
+  // TryDefaultDB()/RuntimeConfig::Configure() re-establish the correct db (default, or explicitly
+  // requested) on the next RUN/BEGIN.
+  ResetDB();
+#endif
+
+  // `SET SESSION ISOLATION LEVEL ...` (session-scoped) is also cleared on RESET. RESET's documented
+  // intent (bolt HandleReset) is to return the connection to a clean state before it is handed back
+  // to a connection pool; the next, logically unrelated, pooled session must not inherit a previous
+  // session's isolation level. (A silently-wrong isolation level is a worse failure mode than a
+  // reset one; a client that RESETs mid-session and relies on its SET SESSION persisting can re-issue
+  // it.) After clearing, GetIsolationLevelOverride() falls back to the storage/config default.
+  interpreter_isolation_level.reset();
+
+  // `SET SESSION TRACE` and `SET SESSION SETTING ...` mutate the per-connection SessionLogContext
+  // overlay in-band (outside the Bolt metadata that Configure() compares), so they are the same
+  // leak class as db/isolation above: without this they would persist into the next pooled logical
+  // session. Clear the query-driven overlay (trace flag + session runtime-setting overrides); the
+  // connection identity (session_uuid_) and auth user_ are intentionally preserved.
+  session_log_ctx_.ResetForConnectionReuse();
 }
 
 std::optional<Interpreter::TxVerifier> Interpreter::TryAcquireForVerification() {

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -256,10 +256,8 @@ struct CurrentDB {
     db_transactional_accessor_.reset();
     execution_db_accessor_.reset();
     trigger_context_collector_.reset();
-    // Without this, a session that pinned an explicit db (Bolt-level db-routing metadata, see
-    // RuntimeConfig::Configure()) would leave in_explicit_db_ == true even though db_acc_ is now
-    // empty, wrongly blocking `USE <db>` (see PrepareUseDatabaseQuery's in_explicit_db_ check) for
-    // whatever session/config comes next on this CurrentDB.
+    // Clear too: a stale in_explicit_db_ == true with an empty db_acc_ would wrongly block a later
+    // `USE <db>` (PrepareUseDatabaseQuery's in_explicit_db_ check) on this CurrentDB.
     in_explicit_db_ = false;
   }
 
@@ -455,16 +453,10 @@ class Interpreter final {
   void Abort();
 
   /**
-   * Clear per-connection "sticky" state that must not leak across a pooled Bolt connection
-   * reuse (RESET) or a full LogOff/teardown.
-   *
-   * This is intentionally NOT folded into Abort(): Abort() is also invoked for ordinary
-   * ROLLBACK, CheckAuthorized() failures, and autocommit-abort paths (AbortCommand()), all of
-   * which happen mid-session -- clearing a USE'd db or the one-shot next-transaction isolation
-   * override there would incorrectly wipe out state set earlier in the very same logical
-   * session. Only call this from a RESET-specific or teardown path; today that is exactly
-   * SessionHL::Abort(), which is itself invoked only from the Bolt RESET handler and from
-   * SessionHL::LogOff() -- never from a mid-session rollback/error.
+   * Clear per-connection "sticky" state that must not leak across a pooled Bolt connection reuse
+   * (RESET) or LogOff/teardown. Deliberately NOT folded into Abort(): Abort() also runs on
+   * mid-session ROLLBACK/auth-failure/autocommit-abort, where this state must survive. Call only
+   * from a RESET/teardown path (today just SessionHL::Abort()).
    */
   void ResetForConnectionReuse();
 
@@ -509,16 +501,10 @@ class Interpreter final {
   std::chrono::steady_clock::time_point transaction_start_steady_{};
 
   // Idle-in-transaction watchdog support (InterpreterContext::ScanIdleTransactions).
-  // last_activity_steady_ns_ is stamped (steady_clock, nanosecond rep) every time this
-  // interpreter finishes a unit of work: transaction start (SetupInterpreterTransaction),
-  // Prepare(), or Pull(). query_in_progress_ is true strictly while a Prepare()/Pull() call is
-  // actually running on this interpreter's owning thread. Both are plain atomics with
-  // relaxed/acquire-release ordering local to themselves -- this is advisory monitoring data
-  // read by a background scan, not something other code depends on for correctness, so it does
-  // not need to ride the transaction_status_ VERIFYING protocol the way current_transaction_ and
-  // transaction_start_* do. The scan still reads in_explicit_transaction_ under
-  // TryAcquireForVerification() (same as ShowTransactionsUsingDBName), since that field itself
-  // is a plain bool with no atomicity of its own.
+  // last_activity_steady_ns_ is stamped on every unit of work (transaction start, Prepare, Pull);
+  // query_in_progress_ is true only while a Prepare()/Pull() runs. Both are advisory monitoring
+  // data (plain atomics), not correctness-critical, so they skip the transaction_status_ VERIFYING
+  // protocol -- but the scan still reads in_explicit_transaction_ under TryAcquireForVerification().
   std::atomic<int64_t> last_activity_steady_ns_{0};
   std::atomic<bool> query_in_progress_{false};
 
@@ -678,10 +664,8 @@ class Interpreter final {
 template <typename TStream>
 std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std::optional<int> n,
                                                     std::optional<int> qid) {
-  // Idle-in-transaction watchdog: mark this interpreter as actively working for the duration of
-  // Pull(), and stamp the last-activity clock on exit (success or exception) so a background scan
-  // (InterpreterContext::ScanIdleTransactions) never mistakes an in-flight pull for an idle gap
-  // between statements of an explicit (BEGIN'd) transaction.
+  // Idle-in-transaction watchdog: flag active work for the duration of Pull() and stamp the
+  // last-activity clock on exit, so the background scan never counts an in-flight pull as idle.
   query_in_progress_.store(true, std::memory_order_release);
   const utils::OnScopeExit idle_watchdog_activity_guard([this] {
     last_activity_steady_ns_.store(std::chrono::steady_clock::now().time_since_epoch().count(),

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -28,6 +28,7 @@
 #include "system/transaction.hpp"
 #include "utils/event_trigger.hpp"
 #include "utils/memory.hpp"
+#include "utils/on_scope_exit.hpp"
 #include "utils/priorities.hpp"
 #include "utils/session_context.hpp"
 #include "utils/spin_lock.hpp"
@@ -255,6 +256,11 @@ struct CurrentDB {
     db_transactional_accessor_.reset();
     execution_db_accessor_.reset();
     trigger_context_collector_.reset();
+    // Without this, a session that pinned an explicit db (Bolt-level db-routing metadata, see
+    // RuntimeConfig::Configure()) would leave in_explicit_db_ == true even though db_acc_ is now
+    // empty, wrongly blocking `USE <db>` (see PrepareUseDatabaseQuery's in_explicit_db_ check) for
+    // whatever session/config comes next on this CurrentDB.
+    in_explicit_db_ = false;
   }
 
   std::string name() const { return db_acc_ ? db_acc_->get()->name() : ""; }
@@ -448,6 +454,20 @@ class Interpreter final {
    */
   void Abort();
 
+  /**
+   * Clear per-connection "sticky" state that must not leak across a pooled Bolt connection
+   * reuse (RESET) or a full LogOff/teardown.
+   *
+   * This is intentionally NOT folded into Abort(): Abort() is also invoked for ordinary
+   * ROLLBACK, CheckAuthorized() failures, and autocommit-abort paths (AbortCommand()), all of
+   * which happen mid-session -- clearing a USE'd db or the one-shot next-transaction isolation
+   * override there would incorrectly wipe out state set earlier in the very same logical
+   * session. Only call this from a RESET-specific or teardown path; today that is exactly
+   * SessionHL::Abort(), which is itself invoked only from the Bolt RESET handler and from
+   * SessionHL::LogOff() -- never from a mid-session rollback/error.
+   */
+  void ResetForConnectionReuse();
+
   struct TxVerifier {
     TxVerifier(TransactionStatus original_status, std::atomic<TransactionStatus> &transaction_status)
         : original_status_(original_status), transaction_status_(transaction_status) {}
@@ -487,6 +507,20 @@ class Interpreter final {
   // is used for start_time; steady_clock for elapsed_ms (immune to NTP / manual clock jumps).
   std::chrono::system_clock::time_point transaction_start_time_{};
   std::chrono::steady_clock::time_point transaction_start_steady_{};
+
+  // Idle-in-transaction watchdog support (InterpreterContext::ScanIdleTransactions).
+  // last_activity_steady_ns_ is stamped (steady_clock, nanosecond rep) every time this
+  // interpreter finishes a unit of work: transaction start (SetupInterpreterTransaction),
+  // Prepare(), or Pull(). query_in_progress_ is true strictly while a Prepare()/Pull() call is
+  // actually running on this interpreter's owning thread. Both are plain atomics with
+  // relaxed/acquire-release ordering local to themselves -- this is advisory monitoring data
+  // read by a background scan, not something other code depends on for correctness, so it does
+  // not need to ride the transaction_status_ VERIFYING protocol the way current_transaction_ and
+  // transaction_start_* do. The scan still reads in_explicit_transaction_ under
+  // TryAcquireForVerification() (same as ShowTransactionsUsingDBName), since that field itself
+  // is a plain bool with no atomicity of its own.
+  std::atomic<int64_t> last_activity_steady_ns_{0};
+  std::atomic<bool> query_in_progress_{false};
 
   void ResetUser();
 
@@ -644,6 +678,17 @@ class Interpreter final {
 template <typename TStream>
 std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std::optional<int> n,
                                                     std::optional<int> qid) {
+  // Idle-in-transaction watchdog: mark this interpreter as actively working for the duration of
+  // Pull(), and stamp the last-activity clock on exit (success or exception) so a background scan
+  // (InterpreterContext::ScanIdleTransactions) never mistakes an in-flight pull for an idle gap
+  // between statements of an explicit (BEGIN'd) transaction.
+  query_in_progress_.store(true, std::memory_order_release);
+  const utils::OnScopeExit idle_watchdog_activity_guard([this] {
+    last_activity_steady_ns_.store(std::chrono::steady_clock::now().time_since_epoch().count(),
+                                   std::memory_order_relaxed);
+    query_in_progress_.store(false, std::memory_order_release);
+  });
+
   // Update the TLS arena index used to route allocations to the correct database arena.
   // The previous arena is restored on scope exit so pool threads are unaffected.
   std::optional<memory::DbArenaScope> plan_cache_db_arena_scope;

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -9,19 +9,38 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <algorithm>
+#include <chrono>
 #include <memory>
 #include <utility>
 
 #include "query/interpreter_context.hpp"
 
+#include "flags/general.hpp"
+#include "metrics/prometheus_metrics.hpp"
 #include "parameters/parameters.hpp"
 #include "query/interpreter.hpp"
 #include "query/query_user.hpp"
+#include "spdlog/spdlog.h"
 
 #include "system/include/system/system.hpp"
 #include "utils/resource_monitoring.hpp"
 
 namespace memgraph::query {
+
+namespace {
+// Poll cadence for the idle-in-transaction watchdog. Deliberately a fixed constant rather than
+// another flag: the warn/abort thresholds are configured in tens of seconds to minutes, so a 5s
+// granularity is more than fine, and the scan itself is a cheap walk of `interpreters` guarded by
+// per-interpreter atomics -- no need to make the poll interval independently tunable.
+constexpr auto kIdleTransactionScanInterval = std::chrono::seconds(5);
+
+// Log lines for a still-idle transaction are throttled to at most once per this cooldown so a
+// transaction stuck idle for hours doesn't spam the log once per scan tick. The metric counter
+// (global.idle_in_transaction_warnings) is NOT throttled -- it increments every tick so its rate
+// stays meaningful for alerting.
+constexpr auto kIdleWarnLogCooldown = std::chrono::seconds(60);
+}  // namespace
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::optional<InterpreterContext> InterpreterContextHolder::instance{};
@@ -54,6 +73,12 @@ InterpreterContext::InterpreterContext(InterpreterConfig interpreter_config, mem
       system_{&system},
       bolt_server_context_(bolt_server_context),
       worker_pool(worker_pool) {
+  // Idle-in-transaction watchdog: always scheduled (mirrors the storage GC runner pattern of
+  // starting a periodic utils::Scheduler task from the owning object's constructor). The scan
+  // itself is cheap and no-ops immediately if both thresholds are 0, so there is no cost to
+  // leaving this on unconditionally rather than gating construction on a flag.
+  idle_transaction_scanner_.SetInterval(kIdleTransactionScanInterval);
+  idle_transaction_scanner_.Run("Idle Tx Watchdog", [this] { ScanIdleTransactions(); });
 }
 
 std::vector<std::vector<TypedValue>> InterpreterContext::TerminateTransactions(
@@ -140,5 +165,106 @@ std::vector<uint64_t> InterpreterContext::ShowTransactionsUsingDBName(
     }
   }
   return results;
+}
+
+void InterpreterContext::ScanIdleTransactions() {
+  const uint64_t warn_threshold_sec = FLAGS_query_idle_in_transaction_warn_sec;
+  const uint64_t abort_threshold_sec = FLAGS_query_idle_in_transaction_abort_sec;
+  // Fully disabled: neither warn-tracking nor abort is configured. Cheap early exit so an
+  // instance that doesn't want the watchdog pays essentially nothing for the scheduler tick.
+  if (warn_threshold_sec == 0 && abort_threshold_sec == 0) return;
+
+  const auto now = std::chrono::steady_clock::now();
+  std::vector<uint64_t> to_abort;
+  // (transaction id, idle seconds) for transactions past the warn threshold this tick; used below
+  // to decide whether the log line is due (rate-limited) or just the metric bump.
+  std::vector<std::pair<uint64_t, int64_t>> to_warn;
+
+  interpreters.WithLock([&](auto &interpreters_set) {
+    for (Interpreter *interpreter : interpreters_set) {
+      // Cheap fast-path: skip interpreters actively executing a statement before paying for the
+      // TryAcquireForVerification() CAS below. query_in_progress_ is a plain atomic, safe to read
+      // from any thread.
+      if (interpreter->query_in_progress_.load(std::memory_order_acquire)) continue;
+
+      // Same reused mechanism ShowTransactionsUsingDBName uses to safely read this interpreter's
+      // otherwise-unsynchronized transaction fields (in_explicit_transaction_ below) from another
+      // thread: CAS the transaction into VERIFYING for the duration of the read.
+      const auto verifier = interpreter->TryAcquireForVerification();
+      if (!verifier) continue;  // no transaction alive enough to be worth watching right now
+
+      if (!interpreter->in_explicit_transaction_) continue;  // autocommit; idle-in-tx cannot apply
+
+      const std::optional<uint64_t> tx_id = interpreter->GetTransactionId();
+      if (!tx_id) continue;
+
+      const auto last_activity_ns = interpreter->last_activity_steady_ns_.load(std::memory_order_relaxed);
+      const std::chrono::steady_clock::time_point last_activity{std::chrono::steady_clock::duration{last_activity_ns}};
+      const auto idle_sec = std::chrono::duration_cast<std::chrono::seconds>(now - last_activity).count();
+      if (idle_sec < 0) continue;  // clock artifact guard; nothing sane to report
+
+      if (abort_threshold_sec > 0 && static_cast<uint64_t>(idle_sec) >= abort_threshold_sec) {
+        to_abort.push_back(*tx_id);
+        continue;  // abort supersedes warn for this tick
+      }
+      if (warn_threshold_sec > 0 && static_cast<uint64_t>(idle_sec) >= warn_threshold_sec) {
+        to_warn.emplace_back(*tx_id, idle_sec);
+      }
+    }
+
+    if (to_abort.empty()) return;
+
+    // Reuse the exact TERMINATE TRANSACTIONS path -- the same transaction_status_ CAS both the
+    // owning session thread and TERMINATE TRANSACTIONS already contend on -- instead of inventing
+    // a new cross-thread abort. Passing user_or_role=nullptr with an always-true privilege
+    // checker makes this an unconditional system-initiated termination: the operator already
+    // opted in by setting --query-idle-in-transaction-abort-sec > 0, so no further per-user
+    // authorization is meaningful here.
+    auto results =
+        TerminateTransactions(interpreters_set,
+                              std::move(to_abort),
+                              /*user_or_role=*/nullptr,
+                              [](QueryUserOrRole * /*user_or_role*/, std::string const & /*db_name*/) { return true; });
+
+    for (auto &row : results) {
+      if (row.size() != 2 || !row[1].IsBool() || !row[1].ValueBool()) continue;  // not found / not killed
+      metrics::Metrics().global.idle_in_transaction_aborted->Increment();
+      spdlog::warn(
+          "Idle-in-transaction watchdog: terminated transaction {} for exceeding the "
+          "--query-idle-in-transaction-abort-sec={} threshold.",
+          row[0].ValueString(),
+          abort_threshold_sec);
+    }
+  });
+
+  if (to_warn.empty()) return;
+
+  // Metric: bump once per idle transaction per tick (unthrottled -- its rate is exactly "how many
+  // idle-transaction-ticks were observed", useful for alerting). Log: throttled per transaction
+  // id so a session stuck idle for hours logs once per cooldown window, not once per 5s tick.
+  idle_warn_last_logged_.WithLock([&](auto &last_logged) {
+    for (const auto &[tx_id, idle_sec] : to_warn) {
+      metrics::Metrics().global.idle_in_transaction_warnings->Increment();
+
+      auto it = last_logged.find(tx_id);
+      const bool due = it == last_logged.end() || (now - it->second) >= kIdleWarnLogCooldown;
+      if (due) {
+        spdlog::warn(
+            "Transaction {} has been idle-in-transaction for {}s (BEGIN issued, no query "
+            "currently executing); consider COMMIT/ROLLBACK. Warn threshold is "
+            "--query-idle-in-transaction-warn-sec={}s.",
+            tx_id,
+            idle_sec,
+            warn_threshold_sec);
+        last_logged[tx_id] = now;
+      }
+    }
+
+    // Prune entries for transactions that are no longer idle-past-threshold this tick (resolved,
+    // or activity resumed) so this map never grows unbounded over the process lifetime.
+    std::erase_if(last_logged, [&](const auto &entry) {
+      return std::ranges::none_of(to_warn, [&](const auto &w) { return w.first == entry.first; });
+    });
+  });
 }
 }  // namespace memgraph::query

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -223,8 +223,10 @@ void InterpreterContext::ScanIdleTransactions() {
     }
   });
 
-  if (to_warn.empty()) return;
-
+  // Always run the prune block, even when to_warn is empty: the erase_if below is the only place
+  // that evicts resolved tx ids from idle_warn_last_logged_, so skipping it on quiet ticks would
+  // leak entries. With an empty to_warn the loop bumps no metric and logs nothing (preserving
+  // "bump only on a real warn"), while erase_if drops every stale entry.
   // Metric bumps every tick (unthrottled, for alerting); the log line is throttled per tx id.
   idle_warn_last_logged_.WithLock([&](auto &last_logged) {
     for (const auto &[tx_id, idle_sec] : to_warn) {

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -29,16 +29,12 @@
 namespace memgraph::query {
 
 namespace {
-// Poll cadence for the idle-in-transaction watchdog. Deliberately a fixed constant rather than
-// another flag: the warn/abort thresholds are configured in tens of seconds to minutes, so a 5s
-// granularity is more than fine, and the scan itself is a cheap walk of `interpreters` guarded by
-// per-interpreter atomics -- no need to make the poll interval independently tunable.
+// Poll cadence for the idle-in-transaction watchdog. Fixed (not a flag): thresholds are in tens of
+// seconds to minutes, so 5s granularity is fine and the scan is cheap.
 constexpr auto kIdleTransactionScanInterval = std::chrono::seconds(5);
 
-// Log lines for a still-idle transaction are throttled to at most once per this cooldown so a
-// transaction stuck idle for hours doesn't spam the log once per scan tick. The metric counter
-// (global.idle_in_transaction_warnings) is NOT throttled -- it increments every tick so its rate
-// stays meaningful for alerting.
+// Per-transaction log cooldown so a long-idle transaction doesn't spam the log once per tick. The
+// metric counter is NOT throttled -- it bumps every tick so its rate stays meaningful for alerting.
 constexpr auto kIdleWarnLogCooldown = std::chrono::seconds(60);
 }  // namespace
 
@@ -73,10 +69,8 @@ InterpreterContext::InterpreterContext(InterpreterConfig interpreter_config, mem
       system_{&system},
       bolt_server_context_(bolt_server_context),
       worker_pool(worker_pool) {
-  // Idle-in-transaction watchdog: always scheduled (mirrors the storage GC runner pattern of
-  // starting a periodic utils::Scheduler task from the owning object's constructor). The scan
-  // itself is cheap and no-ops immediately if both thresholds are 0, so there is no cost to
-  // leaving this on unconditionally rather than gating construction on a flag.
+  // Idle-in-transaction watchdog: always scheduled (like the storage GC runner). The scan no-ops
+  // when both thresholds are 0, so running it unconditionally costs nothing.
   idle_transaction_scanner_.SetInterval(kIdleTransactionScanInterval);
   idle_transaction_scanner_.Run("Idle Tx Watchdog", [this] { ScanIdleTransactions(); });
 }
@@ -170,26 +164,21 @@ std::vector<uint64_t> InterpreterContext::ShowTransactionsUsingDBName(
 void InterpreterContext::ScanIdleTransactions() {
   const uint64_t warn_threshold_sec = FLAGS_query_idle_in_transaction_warn_sec;
   const uint64_t abort_threshold_sec = FLAGS_query_idle_in_transaction_abort_sec;
-  // Fully disabled: neither warn-tracking nor abort is configured. Cheap early exit so an
-  // instance that doesn't want the watchdog pays essentially nothing for the scheduler tick.
+  // Disabled: nothing configured, cheap early exit.
   if (warn_threshold_sec == 0 && abort_threshold_sec == 0) return;
 
   const auto now = std::chrono::steady_clock::now();
   std::vector<uint64_t> to_abort;
-  // (transaction id, idle seconds) for transactions past the warn threshold this tick; used below
-  // to decide whether the log line is due (rate-limited) or just the metric bump.
+  // (transaction id, idle seconds) for transactions past the warn threshold this tick.
   std::vector<std::pair<uint64_t, int64_t>> to_warn;
 
   interpreters.WithLock([&](auto &interpreters_set) {
     for (Interpreter *interpreter : interpreters_set) {
-      // Cheap fast-path: skip interpreters actively executing a statement before paying for the
-      // TryAcquireForVerification() CAS below. query_in_progress_ is a plain atomic, safe to read
-      // from any thread.
+      // Fast-path: skip actively-executing interpreters before paying for the verification CAS.
       if (interpreter->query_in_progress_.load(std::memory_order_acquire)) continue;
 
-      // Same reused mechanism ShowTransactionsUsingDBName uses to safely read this interpreter's
-      // otherwise-unsynchronized transaction fields (in_explicit_transaction_ below) from another
-      // thread: CAS the transaction into VERIFYING for the duration of the read.
+      // CAS into VERIFYING to safely read the interpreter's transaction fields from this thread
+      // (same mechanism as ShowTransactionsUsingDBName).
       const auto verifier = interpreter->TryAcquireForVerification();
       if (!verifier) continue;  // no transaction alive enough to be worth watching right now
 
@@ -214,12 +203,9 @@ void InterpreterContext::ScanIdleTransactions() {
 
     if (to_abort.empty()) return;
 
-    // Reuse the exact TERMINATE TRANSACTIONS path -- the same transaction_status_ CAS both the
-    // owning session thread and TERMINATE TRANSACTIONS already contend on -- instead of inventing
-    // a new cross-thread abort. Passing user_or_role=nullptr with an always-true privilege
-    // checker makes this an unconditional system-initiated termination: the operator already
-    // opted in by setting --query-idle-in-transaction-abort-sec > 0, so no further per-user
-    // authorization is meaningful here.
+    // Reuse the TERMINATE TRANSACTIONS path rather than inventing a new cross-thread abort. The
+    // null user + always-true privilege check make this an unconditional system termination (the
+    // operator opted in via --query-idle-in-transaction-abort-sec > 0).
     auto results =
         TerminateTransactions(interpreters_set,
                               std::move(to_abort),
@@ -239,9 +225,7 @@ void InterpreterContext::ScanIdleTransactions() {
 
   if (to_warn.empty()) return;
 
-  // Metric: bump once per idle transaction per tick (unthrottled -- its rate is exactly "how many
-  // idle-transaction-ticks were observed", useful for alerting). Log: throttled per transaction
-  // id so a session stuck idle for hours logs once per cooldown window, not once per 5s tick.
+  // Metric bumps every tick (unthrottled, for alerting); the log line is throttled per tx id.
   idle_warn_last_logged_.WithLock([&](auto &last_logged) {
     for (const auto &[tx_id, idle_sec] : to_warn) {
       metrics::Metrics().global.idle_in_transaction_warnings->Increment();
@@ -260,8 +244,7 @@ void InterpreterContext::ScanIdleTransactions() {
       }
     }
 
-    // Prune entries for transactions that are no longer idle-past-threshold this tick (resolved,
-    // or activity resumed) so this map never grows unbounded over the process lifetime.
+    // Prune ids no longer idle-past-threshold this tick so the map can't grow unbounded.
     std::erase_if(last_logged, [&](const auto &entry) {
       return std::ranges::none_of(to_warn, [&](const auto &w) { return w.first == entry.first; });
     });

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -118,17 +118,23 @@ struct InterpreterContext {
   /// no new cross-thread abort mechanism is introduced.
   void ScanIdleTransactions();
 
-  // Drives ScanIdleTransactions() at a fixed cadence. Owned here (not in storage/dbms) because
-  // this is the one place that already owns cross-session access to `interpreters`, the same way
-  // SHOW/TERMINATE TRANSACTIONS do.
-  utils::Scheduler idle_transaction_scanner_;
-
   // Rate-limits the *log line* emitted per idle transaction id (the metric counter itself still
   // bumps every scan tick). Keyed by transaction id; pruned each tick to drop ids that are no
   // longer idle-in-transaction (committed/rolled back/dropped below threshold), so this never
   // grows unbounded.
   utils::Synchronized<std::unordered_map<uint64_t, std::chrono::steady_clock::time_point>, utils::SpinLock>
       idle_warn_last_logged_;
+
+  // Drives ScanIdleTransactions() at a fixed cadence. Owned here (not in storage/dbms) because
+  // this is the one place that already owns cross-session access to `interpreters`, the same way
+  // SHOW/TERMINATE TRANSACTIONS do.
+  //
+  // MUST be the last-declared data member: ~Scheduler() request-stops and joins the scan thread,
+  // and members are destroyed in reverse declaration order. Declaring it last guarantees the scan
+  // thread is joined before every member ScanIdleTransactions() touches (`interpreters`,
+  // `idle_warn_last_logged_`) is destroyed -- otherwise a final scan tick would use-after-free
+  // those members during teardown. Keep it here; do not move it earlier.
+  utils::Scheduler idle_transaction_scanner_;
 
   // TODO: Make this constructor private
   InterpreterContext(InterpreterConfig interpreter_config, memgraph::utils::Settings *settings,

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -109,31 +109,19 @@ struct InterpreterContext {
   static std::vector<uint64_t> ShowTransactionsUsingDBName(const std::unordered_set<Interpreter *> &interpreters,
                                                            std::string_view db_name);
 
-  /// Idle-in-transaction watchdog: periodic scan (driven by idle_transaction_scanner_) over
-  /// `interpreters` that finds explicit (BEGIN'd) transactions with no query currently executing
-  /// whose last activity is older than --query-idle-in-transaction-warn-sec /
-  /// --query-idle-in-transaction-abort-sec. Warn tracking always runs (log + metric); abort is
-  /// opt-in (threshold defaults to 0 = disabled) and, when it fires, reuses the exact same
-  /// transaction_status_ CAS path as TERMINATE TRANSACTIONS (TerminateTransactions() below) --
-  /// no new cross-thread abort mechanism is introduced.
+  /// Idle-in-transaction watchdog scan over `interpreters`: warns (log + metric) past the warn
+  /// threshold, and past the opt-in abort threshold (default 0 = off) terminates via the same
+  /// transaction_status_ CAS path as TERMINATE TRANSACTIONS.
   void ScanIdleTransactions();
 
-  // Rate-limits the *log line* emitted per idle transaction id (the metric counter itself still
-  // bumps every scan tick). Keyed by transaction id; pruned each tick to drop ids that are no
-  // longer idle-in-transaction (committed/rolled back/dropped below threshold), so this never
-  // grows unbounded.
+  // Throttles the per-tx log line (metric still bumps every tick); pruned each tick so it can't
+  // grow unbounded.
   utils::Synchronized<std::unordered_map<uint64_t, std::chrono::steady_clock::time_point>, utils::SpinLock>
       idle_warn_last_logged_;
 
-  // Drives ScanIdleTransactions() at a fixed cadence. Owned here (not in storage/dbms) because
-  // this is the one place that already owns cross-session access to `interpreters`, the same way
-  // SHOW/TERMINATE TRANSACTIONS do.
-  //
-  // MUST be the last-declared data member: ~Scheduler() request-stops and joins the scan thread,
-  // and members are destroyed in reverse declaration order. Declaring it last guarantees the scan
-  // thread is joined before every member ScanIdleTransactions() touches (`interpreters`,
-  // `idle_warn_last_logged_`) is destroyed -- otherwise a final scan tick would use-after-free
-  // those members during teardown. Keep it here; do not move it earlier.
+  // Drives ScanIdleTransactions(). MUST be the last-declared member: ~Scheduler() joins the scan
+  // thread, and reverse-order destruction then guarantees the members the scan touches
+  // (`interpreters`, `idle_warn_last_logged_`) still exist. Do not move it earlier.
   utils::Scheduler idle_transaction_scanner_;
 
   // TODO: Make this constructor private

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -13,9 +13,11 @@
 
 #include <atomic>
 #include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -33,6 +35,7 @@
 #include "utils/gatekeeper.hpp"
 #include "utils/priority_thread_pool.hpp"
 #include "utils/resource_monitoring.hpp"
+#include "utils/scheduler.hpp"
 #include "utils/settings.hpp"
 #include "utils/spin_lock.hpp"
 #include "utils/synchronized.hpp"
@@ -105,6 +108,27 @@ struct InterpreterContext {
 
   static std::vector<uint64_t> ShowTransactionsUsingDBName(const std::unordered_set<Interpreter *> &interpreters,
                                                            std::string_view db_name);
+
+  /// Idle-in-transaction watchdog: periodic scan (driven by idle_transaction_scanner_) over
+  /// `interpreters` that finds explicit (BEGIN'd) transactions with no query currently executing
+  /// whose last activity is older than --query-idle-in-transaction-warn-sec /
+  /// --query-idle-in-transaction-abort-sec. Warn tracking always runs (log + metric); abort is
+  /// opt-in (threshold defaults to 0 = disabled) and, when it fires, reuses the exact same
+  /// transaction_status_ CAS path as TERMINATE TRANSACTIONS (TerminateTransactions() below) --
+  /// no new cross-thread abort mechanism is introduced.
+  void ScanIdleTransactions();
+
+  // Drives ScanIdleTransactions() at a fixed cadence. Owned here (not in storage/dbms) because
+  // this is the one place that already owns cross-session access to `interpreters`, the same way
+  // SHOW/TERMINATE TRANSACTIONS do.
+  utils::Scheduler idle_transaction_scanner_;
+
+  // Rate-limits the *log line* emitted per idle transaction id (the metric counter itself still
+  // bumps every scan tick). Keyed by transaction id; pruned each tick to drop ids that are no
+  // longer idle-in-transaction (committed/rolled back/dropped below threshold), so this never
+  // grows unbounded.
+  utils::Synchronized<std::unordered_map<uint64_t, std::chrono::steady_clock::time_point>, utils::SpinLock>
+      idle_warn_last_logged_;
 
   // TODO: Make this constructor private
   InterpreterContext(InterpreterConfig interpreter_config, memgraph::utils::Settings *settings,

--- a/src/utils/session_context.hpp
+++ b/src/utils/session_context.hpp
@@ -76,6 +76,16 @@ class SessionLogContext {
     return std::string_view{it->second};
   }
 
+  // Clear the per-logical-session mutable overlay on a connection-reuse boundary (Bolt RESET /
+  // LogOff), so an in-band `SET SESSION TRACE` / `SET SESSION SETTING` from one logical session
+  // does not leak into the next logical session that reuses this pooled connection. Deliberately
+  // does NOT touch session_uuid_ (physical-connection identity), user_ (auth-managed via LOGON/
+  // LogOff), or tx_id_ (transaction-scoped) -- only the query-driven, session-scoped overlay.
+  void ResetForConnectionReuse() noexcept {
+    trace_enabled_ = false;
+    session_settings_overlay_.clear();
+  }
+
  private:
   // Transparent hashing so reads/resets look up by string_view without allocating
   // a temporary std::string on every query.

--- a/src/utils/session_context.hpp
+++ b/src/utils/session_context.hpp
@@ -76,11 +76,9 @@ class SessionLogContext {
     return std::string_view{it->second};
   }
 
-  // Clear the per-logical-session mutable overlay on a connection-reuse boundary (Bolt RESET /
-  // LogOff), so an in-band `SET SESSION TRACE` / `SET SESSION SETTING` from one logical session
-  // does not leak into the next logical session that reuses this pooled connection. Deliberately
-  // does NOT touch session_uuid_ (physical-connection identity), user_ (auth-managed via LOGON/
-  // LogOff), or tx_id_ (transaction-scoped) -- only the query-driven, session-scoped overlay.
+  // On a connection-reuse boundary (RESET/LogOff), clear the session overlay (SET SESSION
+  // TRACE/SETTING) so it doesn't leak to the next pooled session. Deliberately keeps session_uuid_
+  // (connection identity), user_ (auth-managed), and tx_id_ (transaction-scoped).
   void ResetForConnectionReuse() noexcept {
     trace_enabled_ = false;
     session_settings_overlay_.clear();

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -110,6 +110,7 @@ add_subdirectory(show_privileges)
 add_subdirectory(kshortest_limit)
 add_subdirectory(user_profiles)
 add_subdirectory(load_remote_snapshot)
+add_subdirectory(reset_session_isolation)
 
 copy_e2e_python_files(pytest_runner pytest_runner.sh "")
 copy_e2e_python_files(x x.sh "")

--- a/tests/e2e/reset_session_isolation/CMakeLists.txt
+++ b/tests/e2e/reset_session_isolation/CMakeLists.txt
@@ -1,0 +1,6 @@
+copy_e2e_python_files(reset_session_isolation common.py)
+copy_e2e_python_files(reset_session_isolation reset_leak_tests.py)
+copy_e2e_python_files_from_parent_folder(reset_session_isolation ".." memgraph.py)
+copy_e2e_python_files_from_parent_folder(reset_session_isolation ".." interactive_mg_runner.py)
+
+copy_e2e_files(reset_session_isolation workloads.yaml)

--- a/tests/e2e/reset_session_isolation/common.py
+++ b/tests/e2e/reset_session_isolation/common.py
@@ -15,16 +15,12 @@ import mgclient
 
 
 def get_data_path(file: str, test: str):
-    """
-    Data is stored in the reset_session_isolation folder.
-    """
+    """Data path under the reset_session_isolation folder."""
     return f"reset_session_isolation/{file}/{test}"
 
 
 def get_logs_path(file: str, test: str):
-    """
-    Logs are stored in the reset_session_isolation folder.
-    """
+    """Logs path under the reset_session_isolation folder."""
     return f"reset_session_isolation/{file}/{test}"
 
 

--- a/tests/e2e/reset_session_isolation/common.py
+++ b/tests/e2e/reset_session_isolation/common.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import typing
+
+import mgclient
+
+
+def get_data_path(file: str, test: str):
+    """
+    Data is stored in the reset_session_isolation folder.
+    """
+    return f"reset_session_isolation/{file}/{test}"
+
+
+def get_logs_path(file: str, test: str):
+    """
+    Logs are stored in the reset_session_isolation folder.
+    """
+    return f"reset_session_isolation/{file}/{test}"
+
+
+def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
+    cursor.execute(query, params)
+    return cursor.fetchall()
+
+
+def connect(**kwargs) -> mgclient.Connection:
+    connection = mgclient.connect(**kwargs)
+    connection.autocommit = True
+    return connection

--- a/tests/e2e/reset_session_isolation/reset_leak_tests.py
+++ b/tests/e2e/reset_session_isolation/reset_leak_tests.py
@@ -1,0 +1,398 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+"""
+E2E regression tests for the Bolt RESET-scoped "sticky state" leak fixes.
+
+Background
+----------
+A pooled Bolt connection can be handed to a logically unrelated session after a
+RESET (Bolt HandleReset -> session.Abort(), see
+src/communication/bolt/v1/states/handlers.hpp and src/glue/SessionHL.cpp). Two
+kinds of per-connection state used to leak across that boundary:
+
+  1. Isolation level overrides: SET NEXT TRANSACTION ISOLATION LEVEL (one-shot,
+     meant for the very next transaction on this connection) and SET SESSION
+     TRANSACTION ISOLATION LEVEL (meant for the rest of this Bolt session) were
+     never cleared on RESET, so the next, unrelated, pooled session silently
+     inherited them.
+
+  2. USE DATABASE (Bolt-level db routing / explicit `USE <db>`, enterprise
+     multi-tenancy) similarly stuck around after RESET; a stale
+     `in_explicit_db_ == true` flag additionally blocked a *subsequent*
+     explicit `USE <db>` from taking effect.
+
+The fix (see src/query/interpreter.{hpp,cpp}, src/glue/SessionHL.{hpp,cpp}):
+  * Interpreter::ResetForConnectionReuse() clears next_transaction_isolation_level,
+    interpreter_isolation_level, and (enterprise only) calls ResetDB() -- which now
+    also resets in_explicit_db_ (src/query/interpreter.hpp CurrentDB::ResetDB()).
+  * RuntimeConfig::ResetForConnectionReuse() (src/glue/SessionHL.hpp) invalidates the
+    "run_time_info unchanged since last call => skip re-derivation" cache in
+    RuntimeConfig::Configure(), so the very next RUN after RESET is forced through the
+    full db/user re-derivation path instead of silently keeping the previous session's
+    resolved db.
+  * Both are called ONLY from SessionHL::Abort() (RESET and LogOff), never from the
+    ordinary mid-session ROLLBACK / CheckAuthorized-failure / autocommit-abort paths
+    (those call Interpreter::Abort()/RollbackTransaction() directly without touching
+    the new reset hooks) -- so a mid-session abort must NOT clear this state.
+
+Why a real Bolt RESET, not driver.session().close()
+----------------------------------------------------
+The high-level neo4j driver session API is designed to *avoid* ever sending a
+wire-level RESET on a clean connection: Session.close() drains/rolls back
+anything outstanding itself and only asks the connection pool to send RESET if
+the connection isn't already back in the READY state (see the vendored
+`neo4j` package's `_sync/io/_pool.py::release()` and `_bolt5.py::is_reset`). A
+plain `SET ... ISOLATION LEVEL ...` or `USE DATABASE ...` followed by
+`session.close()` never dirties the connection, so no RESET is ever put on the
+wire that way.
+
+The Bolt protocol *does* guarantee a real RESET is sent in one standard,
+public-API situation: after a FAILURE response, the client must RESET before
+reusing the connection (see HandleReset's signature check, Marker::TinyStruct,
+0x0F, in src/communication/bolt/v1/states/handlers.hpp), and the neo4j driver
+implements this automatically. `force_bolt_reset()` below uses exactly that --
+a deliberately invalid query -- to get a deterministic, protocol-correct RESET
+onto the wire without reaching into driver-private internals or hand-rolling
+PackStream framing.
+
+Known limitation: clean pooled reuse of a no-`database=` session
+----------------------------------------------------------------
+Because a clean session.close() sends no RESET (above) and a `database=None` session sends no
+`db` field on its RUN, the server sees byte-identical traffic whether the same logical session
+is continuing or a new logical session is reusing the pooled connection. It therefore cannot
+know a boundary occurred, and (correctly) keeps the connection-sticky state -- so a `USE
+DATABASE` (and equally SET SESSION isolation/trace/setting) from one no-`database=` session
+persists into the next no-`database=` session on the same pooled connection. This is a protocol
+limitation, analogous to Postgres `SET` leaking across pgbouncer transaction-pooled clients, not
+a server bug: the RESET-scoped reset is complete for every case the driver *does* signal (a real
+RESET, or an explicit `db` field on the RUN). The leak-free, recommended usage is
+`driver.session(database=...)`, which sends the `db` field on every RUN and routes correctly
+regardless of connection stickiness (asserted as the MITIGATION in the USE-DATABASE test below).
+
+Coverage note: the same Interpreter::ResetForConnectionReuse() also clears the per-connection
+SessionLogContext overlay -- SET SESSION TRACE and SET SESSION SETTING -- on RESET/LogOff (unit-
+tested in tests/unit/logging.cpp), closing the same leak class for those in-band session settings.
+"""
+
+import os
+import sys
+
+import interactive_mg_runner
+import pytest
+
+# Neo4j driver is used because it reliably triggers a real wire-level Bolt RESET (see the
+# module docstring); pymgclient does not expose RESET at all.
+neo4j = pytest.importorskip("neo4j", reason="neo4j driver required to trigger a real Bolt RESET")
+
+import mgclient
+from common import get_data_path, get_logs_path
+from neo4j import GraphDatabase
+
+interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+interactive_mg_runner.PROJECT_DIR = os.path.normpath(
+    os.path.join(interactive_mg_runner.SCRIPT_DIR, "..", "..", "..", "..")
+)
+interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
+interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
+
+FILE = "reset_session_isolation"
+BOLT_PORT = 17691
+
+
+def get_instances_description(test_name: str):
+    """Single instance is enough: the leak is entirely connection/session-local."""
+    return {
+        "main": {
+            "args": [
+                "--bolt-port",
+                str(BOLT_PORT),
+                "--log-level=TRACE",
+                # Pin the default so the leak probes (which compare against "the default
+                # isolation level") are deterministic regardless of the build's compiled-in default.
+                "--isolation-level=SNAPSHOT_ISOLATION",
+            ],
+            "log_file": f"{get_logs_path(FILE, test_name)}/main.log",
+            "data_directory": f"{get_data_path(FILE, test_name)}/main",
+            "setup_queries": [],
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    interactive_mg_runner.kill_all(keep_directories=False)
+    yield
+    interactive_mg_runner.kill_all(keep_directories=False)
+
+
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
+def _bolt_uri() -> str:
+    return f"bolt://127.0.0.1:{BOLT_PORT}"
+
+
+def force_bolt_reset(session) -> None:
+    """Force a real wire-level Bolt RESET onto `session`'s underlying connection.
+
+    See the module docstring for why this (an intentionally invalid query, which the
+    driver reacts to by auto-sending RESET) is the deterministic, public-API way to do
+    this, and why session.close() alone does not reach the same server-side code path.
+    """
+    with pytest.raises(Exception):
+        session.run("THIS IS NOT VALID CYPHER SYNTAX !!!").consume()
+
+
+def _mgclient_connect() -> mgclient.Connection:
+    connection = mgclient.connect(host="127.0.0.1", port=BOLT_PORT)
+    connection.autocommit = True
+    return connection
+
+
+def _create_clean_database(db_name: str) -> None:
+    """Setup helper: (re)create `db_name` from scratch via a throwaway mgclient connection."""
+    connection = _mgclient_connect()
+    cursor = connection.cursor()
+    cursor.execute("USE DATABASE memgraph")
+    try:
+        cursor.execute(f"DROP DATABASE {db_name}")
+    except mgclient.DatabaseError:
+        pass  # db_name did not exist yet
+    cursor.execute(f"CREATE DATABASE {db_name}")
+    connection.close()
+
+
+def _sees_uncommitted_write(reader_session, writer_session, label: str) -> bool:
+    """Behavioral probe for the isolation level actually in effect on `reader_session`.
+
+    Starts a transaction on reader_session, has writer_session CREATE a node of `label`
+    and leave it uncommitted, then checks whether reader_session's transaction can see
+    it:
+      * SNAPSHOT ISOLATION / READ COMMITTED -> does not see it (returns False)
+      * READ UNCOMMITTED                    -> sees it (returns True)
+
+    This mirrors tests/e2e/isolation_levels/isolation_levels.cpp's
+    TestSnapshotIsolation/TestReadCommitted/TestReadUncommitted: there is no SHOW
+    TRANSACTIONS column exposing "isolation level of this transaction", so the
+    established way to verify it e2e is this dirty-read-visibility technique.
+    """
+    tx_r = reader_session.begin_transaction()
+    tx_r.run(f"MATCH (n:{label}) RETURN count(n) AS c").consume()  # starts the tx / takes its snapshot
+    tx_w = writer_session.begin_transaction()
+    tx_w.run(f"CREATE (:{label})").consume()  # left uncommitted on purpose
+    count = tx_r.run(f"MATCH (n:{label}) RETURN count(n) AS c").single()["c"]
+    tx_w.rollback()
+    tx_r.commit()
+    return count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test A: isolation-level leak across RESET
+# ---------------------------------------------------------------------------
+
+
+def test_reset_clears_next_transaction_isolation_override(test_name):
+    """SET NEXT TRANSACTION ISOLATION LEVEL must not leak across a Bolt RESET.
+
+    Needs the post-rebuild binary: on the pre-fix binary, `next_transaction_isolation_level`
+    is never cleared by SessionHL::Abort(), so the first transaction after RESET can run
+    under the leaked READ UNCOMMITTED override instead of the connection's default.
+    """
+    instances = get_instances_description(test_name)
+    interactive_mg_runner.start_all(instances, keep_directories=False)
+
+    driver = GraphDatabase.driver(_bolt_uri(), auth=None, encrypted=False, max_connection_pool_size=1)
+    writer_driver = GraphDatabase.driver(_bolt_uri(), auth=None, encrypted=False, max_connection_pool_size=1)
+    try:
+        pooled = driver.session()
+        pooled.run("SET NEXT TRANSACTION ISOLATION LEVEL READ UNCOMMITTED").consume()
+
+        # The overridden transaction never starts: RESET happens first.
+        force_bolt_reset(pooled)
+
+        writer = writer_driver.session()
+        leaked = _sees_uncommitted_write(pooled, writer, "NextIsoLeakProbe")
+        writer.close()
+        pooled.close()
+
+        assert not leaked, (
+            "SET NEXT TRANSACTION ISOLATION LEVEL leaked across a Bolt RESET: the first "
+            "transaction after RESET ran under READ UNCOMMITTED instead of the connection's "
+            "default (SNAPSHOT ISOLATION) isolation level."
+        )
+    finally:
+        driver.close()
+        writer_driver.close()
+
+
+def test_reset_clears_session_isolation_override(test_name):
+    """SET SESSION TRANSACTION ISOLATION LEVEL must not leak across a Bolt RESET.
+
+    Needs the post-rebuild binary: on the pre-fix binary, `interpreter_isolation_level`
+    is never cleared by SessionHL::Abort(), so a session-scoped override set before RESET
+    can still be in effect for the next, logically unrelated, pooled session.
+    """
+    instances = get_instances_description(test_name)
+    interactive_mg_runner.start_all(instances, keep_directories=False)
+
+    driver = GraphDatabase.driver(_bolt_uri(), auth=None, encrypted=False, max_connection_pool_size=1)
+    writer_driver = GraphDatabase.driver(_bolt_uri(), auth=None, encrypted=False, max_connection_pool_size=1)
+    try:
+        pooled = driver.session()
+        pooled.run("SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED").consume()
+
+        force_bolt_reset(pooled)
+
+        writer = writer_driver.session()
+        leaked = _sees_uncommitted_write(pooled, writer, "SessionIsoLeakProbe")
+        writer.close()
+        pooled.close()
+
+        assert not leaked, (
+            "SET SESSION TRANSACTION ISOLATION LEVEL leaked across a Bolt RESET: the next "
+            "pooled session ran under READ UNCOMMITTED instead of the connection's default "
+            "(SNAPSHOT ISOLATION) isolation level."
+        )
+    finally:
+        driver.close()
+        writer_driver.close()
+
+
+# ---------------------------------------------------------------------------
+# Test B: USE-db leak across RESET (enterprise / multi-database)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_clears_use_database_and_allows_subsequent_use(test_name):
+    """USE DATABASE must not leak across a Bolt RESET, and a later USE must not be rejected.
+
+    Needs the post-rebuild binary: on the pre-fix binary, RuntimeConfig::Configure()'s
+    "run_time_info unchanged since last call => skip" cache is never invalidated across a
+    RESET, so a query with no db-routing metadata after RESET can still silently target the
+    previously-USE'd database. Also covers the in_explicit_db_ stuck-true regression: before
+    the CurrentDB::ResetDB() fix, a stale in_explicit_db_ == true could block a subsequent
+    explicit USE from being accepted.
+    """
+    instances = get_instances_description(test_name)
+    interactive_mg_runner.start_all(instances, keep_directories=False)
+    _create_clean_database("db_b")
+
+    driver = GraphDatabase.driver(_bolt_uri(), auth=None, encrypted=False, max_connection_pool_size=1)
+    try:
+        pooled = driver.session()
+        pooled.run("USE DATABASE db_b").consume()
+        current = pooled.run("SHOW DATABASE").single()["Current"]
+        assert current == "db_b", f"USE DATABASE db_b did not take effect (got '{current}')"
+
+        force_bolt_reset(pooled)
+
+        # No db routing metadata on this session (driver.session() with no `database=` param):
+        # a query here must target the DEFAULT db, not the leaked db_b.
+        current_after_reset = pooled.run("SHOW DATABASE").single()["Current"]
+        assert current_after_reset == "memgraph", (
+            f"USE DATABASE leaked across RESET: a query with no db routing metadata after RESET "
+            f"targeted '{current_after_reset}' instead of the default database 'memgraph'."
+        )
+
+        # Regression check: a later explicit USE must not be rejected (in_explicit_db_ stuck-true).
+        pooled.run("USE DATABASE db_b").consume()
+        current_after_reuse = pooled.run("SHOW DATABASE").single()["Current"]
+        assert current_after_reuse == "db_b", "A later explicit USE DATABASE was rejected/ignored after RESET"
+
+        pooled.close()  # clean close: driver leaves the connection READY and sends NO wire RESET
+
+        # KNOWN LIMITATION (documented protocol gap, NOT a fix failure): a pooled connection reused
+        # WITHOUT a wire-level RESET keeps its connection-sticky USE'd db. On a clean close the neo4j
+        # driver sends no RESET (it only RESETs a connection left mid-stream/FAILED) and nothing on
+        # checkout; a session opened with no `database=` then sends no `db` field on its RUN. So the
+        # server sees byte-identical traffic to "the same session continuing" and has no signal that
+        # a new logical session began -- it therefore (correctly) keeps the sticky db. Analogous to
+        # Postgres `SET` leaking across pgbouncer transaction-pooled clients. Assert the actual,
+        # documented behaviour (sticky db_b), not an outcome the server has no signal to produce:
+        reopened = driver.session()
+        current_reopened = reopened.run("SHOW DATABASE").single()["Current"]
+        assert current_reopened == "db_b", (
+            "expected connection-sticky 'db_b' on clean no-RESET pooled reuse (documented protocol "
+            f"limitation -- see module docstring); got '{current_reopened}'"
+        )
+        reopened.close()
+
+        # MITIGATION (recommended usage): a session that names its database explicitly always routes
+        # correctly regardless of connection stickiness -- the `db` field is sent on every RUN and
+        # bypasses the run_time_info short-circuit. This is the leak-free way to use pooled connections.
+        explicit_default = driver.session(database="memgraph")
+        assert explicit_default.run("SHOW DATABASE").single()["Current"] == "memgraph"
+        explicit_default.close()
+        explicit_b = driver.session(database="db_b")
+        assert explicit_b.run("SHOW DATABASE").single()["Current"] == "db_b"
+        explicit_b.close()
+    finally:
+        driver.close()
+
+
+# ---------------------------------------------------------------------------
+# Non-regression: mid-session ROLLBACK WITHOUT RESET must NOT clear sticky state
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_without_reset_preserves_use_database_and_session_isolation(test_name):
+    """A mid-session BEGIN...ROLLBACK (no RESET) must keep USE'd db + SET SESSION isolation.
+
+    This is the guard rail proving the fix is RESET-scoped: Interpreter::ResetForConnectionReuse()
+    is called ONLY from SessionHL::Abort() (Bolt RESET / LogOff), never from the ordinary
+    ROLLBACK / autocommit-abort path (Interpreter::RollbackTransaction() / Interpreter::Abort()).
+    This test should already pass on the pre-fix binary (it never touches the new code path);
+    it exists to catch a regression where the fix is applied too broadly (e.g. folded into
+    Interpreter::Abort() directly) rather than scoped to RESET/LogOff as intended.
+    """
+    instances = get_instances_description(test_name)
+    interactive_mg_runner.start_all(instances, keep_directories=False)
+    _create_clean_database("db_b")
+
+    driver = GraphDatabase.driver(_bolt_uri(), auth=None, encrypted=False, max_connection_pool_size=1)
+    writer_driver = GraphDatabase.driver(_bolt_uri(), auth=None, encrypted=False, max_connection_pool_size=1)
+    try:
+        pooled = driver.session()
+        pooled.run("USE DATABASE db_b").consume()
+        pooled.run("SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED").consume()
+
+        # Mid-session abort WITHOUT a Bolt RESET: an explicit BEGIN ... ROLLBACK.
+        tx = pooled.begin_transaction()
+        tx.run("RETURN 1").consume()
+        tx.rollback()
+
+        # Same session, same connection, no RESET in between: USE'd db must still be in effect.
+        current = pooled.run("SHOW DATABASE").single()["Current"]
+        assert current == "db_b", (
+            "A mid-session ROLLBACK (without RESET) incorrectly cleared the USE'd database; the "
+            "fix must be scoped to RESET/LogOff, not every transaction abort."
+        )
+
+        # ... and SET SESSION TRANSACTION ISOLATION LEVEL must still be in effect too.
+        writer = writer_driver.session(database="db_b")
+        still_read_uncommitted = _sees_uncommitted_write(pooled, writer, "RollbackNoResetProbe")
+        writer.close()
+        assert still_read_uncommitted, (
+            "A mid-session ROLLBACK (without RESET) incorrectly cleared SET SESSION TRANSACTION "
+            "ISOLATION LEVEL; the fix must be scoped to RESET/LogOff, not every transaction abort."
+        )
+
+        pooled.close()
+    finally:
+        driver.close()
+        writer_driver.close()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/reset_session_isolation/reset_leak_tests.py
+++ b/tests/e2e/reset_session_isolation/reset_leak_tests.py
@@ -52,6 +52,13 @@ interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactiv
 FILE = "reset_session_isolation"
 BOLT_PORT = 17691
 
+# Multi-database (CREATE/USE DATABASE) is enterprise-gated, so tests that exercise it can only run
+# with a license present. Isolation-only tests below stay runnable on community builds.
+requires_enterprise = pytest.mark.skipif(
+    not (os.environ.get("MEMGRAPH_ENTERPRISE_LICENSE") and os.environ.get("MEMGRAPH_ORGANIZATION_NAME")),
+    reason="multi-database RESET tests need an enterprise license (MEMGRAPH_ENTERPRISE_LICENSE + MEMGRAPH_ORGANIZATION_NAME)",
+)
+
 
 def get_instances_description(test_name: str):
     """Single instance is enough: the leak is entirely connection/session-local."""
@@ -193,6 +200,7 @@ def test_reset_clears_session_isolation_override(test_name):
 # ---------------------------------------------------------------------------
 
 
+@requires_enterprise
 def test_reset_clears_use_database_and_allows_subsequent_use(test_name):
     """USE DATABASE must not leak across a Bolt RESET, and a later USE must not be rejected
     (covers the in_explicit_db_ stuck-true regression)."""
@@ -251,6 +259,7 @@ def test_reset_clears_use_database_and_allows_subsequent_use(test_name):
 # ---------------------------------------------------------------------------
 
 
+@requires_enterprise
 def test_rollback_without_reset_preserves_use_database_and_session_isolation(test_name):
     """A mid-session BEGIN...ROLLBACK (no RESET) must keep USE'd db + SET SESSION isolation.
 

--- a/tests/e2e/reset_session_isolation/reset_leak_tests.py
+++ b/tests/e2e/reset_session_isolation/reset_leak_tests.py
@@ -12,75 +12,20 @@
 """
 E2E regression tests for the Bolt RESET-scoped "sticky state" leak fixes.
 
-Background
-----------
-A pooled Bolt connection can be handed to a logically unrelated session after a
-RESET (Bolt HandleReset -> session.Abort(), see
-src/communication/bolt/v1/states/handlers.hpp and src/glue/SessionHL.cpp). Two
-kinds of per-connection state used to leak across that boundary:
+A pooled Bolt connection can be handed to an unrelated session after a RESET. Per-connection
+state that used to leak across that boundary and is now cleared by ResetForConnectionReuse()
+(called only from SessionHL::Abort(), i.e. RESET/LogOff, never a mid-session rollback):
+isolation-level overrides (SET NEXT/SESSION TRANSACTION ISOLATION LEVEL) and USE DATABASE
+(including a stale in_explicit_db_ that used to block a later USE). SET SESSION TRACE/SETTING
+are the same leak class, unit-tested in tests/unit/logging.cpp.
 
-  1. Isolation level overrides: SET NEXT TRANSACTION ISOLATION LEVEL (one-shot,
-     meant for the very next transaction on this connection) and SET SESSION
-     TRANSACTION ISOLATION LEVEL (meant for the rest of this Bolt session) were
-     never cleared on RESET, so the next, unrelated, pooled session silently
-     inherited them.
+These tests need a real wire-level RESET, which a clean session.close() does not send. The neo4j
+driver auto-RESETs a connection only after a FAILURE, so force_bolt_reset() runs an invalid query
+to get a deterministic RESET onto the wire (see force_bolt_reset).
 
-  2. USE DATABASE (Bolt-level db routing / explicit `USE <db>`, enterprise
-     multi-tenancy) similarly stuck around after RESET; a stale
-     `in_explicit_db_ == true` flag additionally blocked a *subsequent*
-     explicit `USE <db>` from taking effect.
-
-The fix (see src/query/interpreter.{hpp,cpp}, src/glue/SessionHL.{hpp,cpp}):
-  * Interpreter::ResetForConnectionReuse() clears next_transaction_isolation_level,
-    interpreter_isolation_level, and (enterprise only) calls ResetDB() -- which now
-    also resets in_explicit_db_ (src/query/interpreter.hpp CurrentDB::ResetDB()).
-  * RuntimeConfig::ResetForConnectionReuse() (src/glue/SessionHL.hpp) invalidates the
-    "run_time_info unchanged since last call => skip re-derivation" cache in
-    RuntimeConfig::Configure(), so the very next RUN after RESET is forced through the
-    full db/user re-derivation path instead of silently keeping the previous session's
-    resolved db.
-  * Both are called ONLY from SessionHL::Abort() (RESET and LogOff), never from the
-    ordinary mid-session ROLLBACK / CheckAuthorized-failure / autocommit-abort paths
-    (those call Interpreter::Abort()/RollbackTransaction() directly without touching
-    the new reset hooks) -- so a mid-session abort must NOT clear this state.
-
-Why a real Bolt RESET, not driver.session().close()
-----------------------------------------------------
-The high-level neo4j driver session API is designed to *avoid* ever sending a
-wire-level RESET on a clean connection: Session.close() drains/rolls back
-anything outstanding itself and only asks the connection pool to send RESET if
-the connection isn't already back in the READY state (see the vendored
-`neo4j` package's `_sync/io/_pool.py::release()` and `_bolt5.py::is_reset`). A
-plain `SET ... ISOLATION LEVEL ...` or `USE DATABASE ...` followed by
-`session.close()` never dirties the connection, so no RESET is ever put on the
-wire that way.
-
-The Bolt protocol *does* guarantee a real RESET is sent in one standard,
-public-API situation: after a FAILURE response, the client must RESET before
-reusing the connection (see HandleReset's signature check, Marker::TinyStruct,
-0x0F, in src/communication/bolt/v1/states/handlers.hpp), and the neo4j driver
-implements this automatically. `force_bolt_reset()` below uses exactly that --
-a deliberately invalid query -- to get a deterministic, protocol-correct RESET
-onto the wire without reaching into driver-private internals or hand-rolling
-PackStream framing.
-
-Known limitation: clean pooled reuse of a no-`database=` session
-----------------------------------------------------------------
-Because a clean session.close() sends no RESET (above) and a `database=None` session sends no
-`db` field on its RUN, the server sees byte-identical traffic whether the same logical session
-is continuing or a new logical session is reusing the pooled connection. It therefore cannot
-know a boundary occurred, and (correctly) keeps the connection-sticky state -- so a `USE
-DATABASE` (and equally SET SESSION isolation/trace/setting) from one no-`database=` session
-persists into the next no-`database=` session on the same pooled connection. This is a protocol
-limitation, analogous to Postgres `SET` leaking across pgbouncer transaction-pooled clients, not
-a server bug: the RESET-scoped reset is complete for every case the driver *does* signal (a real
-RESET, or an explicit `db` field on the RUN). The leak-free, recommended usage is
-`driver.session(database=...)`, which sends the `db` field on every RUN and routes correctly
-regardless of connection stickiness (asserted as the MITIGATION in the USE-DATABASE test below).
-
-Coverage note: the same Interpreter::ResetForConnectionReuse() also clears the per-connection
-SessionLogContext overlay -- SET SESSION TRACE and SET SESSION SETTING -- on RESET/LogOff (unit-
-tested in tests/unit/logging.cpp), closing the same leak class for those in-band session settings.
+Known protocol limitation (not a server bug, analogous to pgbouncer SET leaks): on a clean
+no-RESET reuse of a database=None session the server sees identical traffic and keeps the sticky
+state. The leak-free usage is driver.session(database=...), asserted as the MITIGATION below.
 """
 
 import os
@@ -116,8 +61,7 @@ def get_instances_description(test_name: str):
                 "--bolt-port",
                 str(BOLT_PORT),
                 "--log-level=TRACE",
-                # Pin the default so the leak probes (which compare against "the default
-                # isolation level") are deterministic regardless of the build's compiled-in default.
+                # Pin the default so the leak probes are deterministic across builds.
                 "--isolation-level=SNAPSHOT_ISOLATION",
             ],
             "log_file": f"{get_logs_path(FILE, test_name)}/main.log",
@@ -144,12 +88,7 @@ def _bolt_uri() -> str:
 
 
 def force_bolt_reset(session) -> None:
-    """Force a real wire-level Bolt RESET onto `session`'s underlying connection.
-
-    See the module docstring for why this (an intentionally invalid query, which the
-    driver reacts to by auto-sending RESET) is the deterministic, public-API way to do
-    this, and why session.close() alone does not reach the same server-side code path.
-    """
+    """Force a real wire-level Bolt RESET via an invalid query (see module docstring)."""
     with pytest.raises(Exception):
         session.run("THIS IS NOT VALID CYPHER SYNTAX !!!").consume()
 
@@ -174,18 +113,8 @@ def _create_clean_database(db_name: str) -> None:
 
 
 def _sees_uncommitted_write(reader_session, writer_session, label: str) -> bool:
-    """Behavioral probe for the isolation level actually in effect on `reader_session`.
-
-    Starts a transaction on reader_session, has writer_session CREATE a node of `label`
-    and leave it uncommitted, then checks whether reader_session's transaction can see
-    it:
-      * SNAPSHOT ISOLATION / READ COMMITTED -> does not see it (returns False)
-      * READ UNCOMMITTED                    -> sees it (returns True)
-
-    This mirrors tests/e2e/isolation_levels/isolation_levels.cpp's
-    TestSnapshotIsolation/TestReadCommitted/TestReadUncommitted: there is no SHOW
-    TRANSACTIONS column exposing "isolation level of this transaction", so the
-    established way to verify it e2e is this dirty-read-visibility technique.
+    """Probe reader_session's effective isolation via dirty-read visibility: returns True iff it
+    sees writer_session's uncommitted write (READ UNCOMMITTED) vs. not (SNAPSHOT/READ COMMITTED).
     """
     tx_r = reader_session.begin_transaction()
     tx_r.run(f"MATCH (n:{label}) RETURN count(n) AS c").consume()  # starts the tx / takes its snapshot
@@ -203,12 +132,7 @@ def _sees_uncommitted_write(reader_session, writer_session, label: str) -> bool:
 
 
 def test_reset_clears_next_transaction_isolation_override(test_name):
-    """SET NEXT TRANSACTION ISOLATION LEVEL must not leak across a Bolt RESET.
-
-    Needs the post-rebuild binary: on the pre-fix binary, `next_transaction_isolation_level`
-    is never cleared by SessionHL::Abort(), so the first transaction after RESET can run
-    under the leaked READ UNCOMMITTED override instead of the connection's default.
-    """
+    """SET NEXT TRANSACTION ISOLATION LEVEL must not leak across a Bolt RESET."""
     instances = get_instances_description(test_name)
     interactive_mg_runner.start_all(instances, keep_directories=False)
 
@@ -237,12 +161,7 @@ def test_reset_clears_next_transaction_isolation_override(test_name):
 
 
 def test_reset_clears_session_isolation_override(test_name):
-    """SET SESSION TRANSACTION ISOLATION LEVEL must not leak across a Bolt RESET.
-
-    Needs the post-rebuild binary: on the pre-fix binary, `interpreter_isolation_level`
-    is never cleared by SessionHL::Abort(), so a session-scoped override set before RESET
-    can still be in effect for the next, logically unrelated, pooled session.
-    """
+    """SET SESSION TRANSACTION ISOLATION LEVEL must not leak across a Bolt RESET."""
     instances = get_instances_description(test_name)
     interactive_mg_runner.start_all(instances, keep_directories=False)
 
@@ -275,15 +194,8 @@ def test_reset_clears_session_isolation_override(test_name):
 
 
 def test_reset_clears_use_database_and_allows_subsequent_use(test_name):
-    """USE DATABASE must not leak across a Bolt RESET, and a later USE must not be rejected.
-
-    Needs the post-rebuild binary: on the pre-fix binary, RuntimeConfig::Configure()'s
-    "run_time_info unchanged since last call => skip" cache is never invalidated across a
-    RESET, so a query with no db-routing metadata after RESET can still silently target the
-    previously-USE'd database. Also covers the in_explicit_db_ stuck-true regression: before
-    the CurrentDB::ResetDB() fix, a stale in_explicit_db_ == true could block a subsequent
-    explicit USE from being accepted.
-    """
+    """USE DATABASE must not leak across a Bolt RESET, and a later USE must not be rejected
+    (covers the in_explicit_db_ stuck-true regression)."""
     instances = get_instances_description(test_name)
     interactive_mg_runner.start_all(instances, keep_directories=False)
     _create_clean_database("db_b")
@@ -312,14 +224,8 @@ def test_reset_clears_use_database_and_allows_subsequent_use(test_name):
 
         pooled.close()  # clean close: driver leaves the connection READY and sends NO wire RESET
 
-        # KNOWN LIMITATION (documented protocol gap, NOT a fix failure): a pooled connection reused
-        # WITHOUT a wire-level RESET keeps its connection-sticky USE'd db. On a clean close the neo4j
-        # driver sends no RESET (it only RESETs a connection left mid-stream/FAILED) and nothing on
-        # checkout; a session opened with no `database=` then sends no `db` field on its RUN. So the
-        # server sees byte-identical traffic to "the same session continuing" and has no signal that
-        # a new logical session began -- it therefore (correctly) keeps the sticky db. Analogous to
-        # Postgres `SET` leaking across pgbouncer transaction-pooled clients. Assert the actual,
-        # documented behaviour (sticky db_b), not an outcome the server has no signal to produce:
+        # KNOWN LIMITATION (protocol gap, see module docstring): a no-RESET reuse of a
+        # database=None session keeps the sticky db_b, since the server sees identical traffic.
         reopened = driver.session()
         current_reopened = reopened.run("SHOW DATABASE").single()["Current"]
         assert current_reopened == "db_b", (
@@ -328,9 +234,8 @@ def test_reset_clears_use_database_and_allows_subsequent_use(test_name):
         )
         reopened.close()
 
-        # MITIGATION (recommended usage): a session that names its database explicitly always routes
-        # correctly regardless of connection stickiness -- the `db` field is sent on every RUN and
-        # bypasses the run_time_info short-circuit. This is the leak-free way to use pooled connections.
+        # MITIGATION: naming the database explicitly sends the `db` field on every RUN and routes
+        # correctly regardless of stickiness -- the leak-free way to use pooled connections.
         explicit_default = driver.session(database="memgraph")
         assert explicit_default.run("SHOW DATABASE").single()["Current"] == "memgraph"
         explicit_default.close()
@@ -349,12 +254,7 @@ def test_reset_clears_use_database_and_allows_subsequent_use(test_name):
 def test_rollback_without_reset_preserves_use_database_and_session_isolation(test_name):
     """A mid-session BEGIN...ROLLBACK (no RESET) must keep USE'd db + SET SESSION isolation.
 
-    This is the guard rail proving the fix is RESET-scoped: Interpreter::ResetForConnectionReuse()
-    is called ONLY from SessionHL::Abort() (Bolt RESET / LogOff), never from the ordinary
-    ROLLBACK / autocommit-abort path (Interpreter::RollbackTransaction() / Interpreter::Abort()).
-    This test should already pass on the pre-fix binary (it never touches the new code path);
-    it exists to catch a regression where the fix is applied too broadly (e.g. folded into
-    Interpreter::Abort() directly) rather than scoped to RESET/LogOff as intended.
+    Guard rail proving the fix is RESET-scoped, not applied to every transaction abort.
     """
     instances = get_instances_description(test_name)
     interactive_mg_runner.start_all(instances, keep_directories=False)

--- a/tests/e2e/reset_session_isolation/workloads.yaml
+++ b/tests/e2e/reset_session_isolation/workloads.yaml
@@ -1,0 +1,4 @@
+workloads:
+  - name: "Reset session isolation leak"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["reset_session_isolation/reset_leak_tests.py"]

--- a/tests/unit/logging.cpp
+++ b/tests/unit/logging.cpp
@@ -305,10 +305,8 @@ TEST_F(SessionTraceEmitTest, LevelAboveInfoSkipsArgumentFormatting) {
   EXPECT_TRUE(sink_->messages.empty());
 }
 
-// SET SESSION TRACE / SET SESSION SETTING mutate the per-connection overlay in-band; a connection-
-// reuse boundary (Bolt RESET / LogOff, via Interpreter::ResetForConnectionReuse) must clear them so
-// they do not leak into the next pooled logical session -- while preserving connection identity and
-// the auth user (which are managed by connect/auth, not by the logical-session boundary).
+// ResetForConnectionReuse clears the session overlay (SET SESSION TRACE/SETTING) but keeps
+// connection identity and auth user.
 TEST(SessionLogContext, ResetForConnectionReuseClearsOverlayButKeepsIdentity) {
   SessionLogContext ctx;
   ctx.SetSessionUuid("conn-1");

--- a/tests/unit/logging.cpp
+++ b/tests/unit/logging.cpp
@@ -305,6 +305,27 @@ TEST_F(SessionTraceEmitTest, LevelAboveInfoSkipsArgumentFormatting) {
   EXPECT_TRUE(sink_->messages.empty());
 }
 
+// SET SESSION TRACE / SET SESSION SETTING mutate the per-connection overlay in-band; a connection-
+// reuse boundary (Bolt RESET / LogOff, via Interpreter::ResetForConnectionReuse) must clear them so
+// they do not leak into the next pooled logical session -- while preserving connection identity and
+// the auth user (which are managed by connect/auth, not by the logical-session boundary).
+TEST(SessionLogContext, ResetForConnectionReuseClearsOverlayButKeepsIdentity) {
+  SessionLogContext ctx;
+  ctx.SetSessionUuid("conn-1");
+  ctx.SetUser("alice");
+  ctx.SetTrace(true);
+  ctx.SetSetting("query-log-min-duration-ms", "500");
+  ASSERT_TRUE(ctx.trace_enabled());
+  ASSERT_TRUE(ctx.GetSetting("query-log-min-duration-ms").has_value());
+
+  ctx.ResetForConnectionReuse();
+
+  EXPECT_FALSE(ctx.trace_enabled());
+  EXPECT_FALSE(ctx.GetSetting("query-log-min-duration-ms").has_value());
+  EXPECT_EQ(ctx.session_uuid(), "conn-1");  // physical-connection identity preserved
+  EXPECT_EQ(ctx.user(), "alice");           // auth user preserved (reset via LogOff, not RESET)
+}
+
 // Pre-formatted overload: braces in the payload are emitted verbatim, not as format spec.
 TEST_F(SessionTraceEmitTest, PreFormattedOverloadEmitsBracesVerbatim) {
   SessionLogContext ctx;


### PR DESCRIPTION
Two connection-lifecycle fixes:
1. RESET/LogOff sticky-state leak — on a pooled-connection reuse boundary, Interpreter::ResetForConnectionReuse() now clears per-connection state that in-band Cypher can mutate: current database (ResetDB, incl. in_explicit_db_), session + next-transaction isolation level, and the SessionLogContext overlay (SET SESSION TRACE / SET SESSION SETTING). Wired only from SessionHL::Abort() (RESET + LogOff), never from mid-session ROLLBACK. Known limitation documented: a clean no-RESET pooled reuse has no boundary signal (mitigate with session(database=...)).
2. Idle-in-transaction watchdog — a background scan warns (default 60 s) and optionally aborts (opt-in, default 0 = off) explicit BEGIN'd transactions that sit idle holding their accessor, reusing the exact TERMINATE TRANSACTIONS cross-thread CAS path. Flags --query-idle-in-transaction-{warn,abort}-sec + Prometheus counters.