### PR TITLE
feat: use label-property index for STARTS WITH prefix seek

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1189,8 +1189,13 @@ TypedValue Rand(const TypedValue *args, int64_t nargs, const FunctionContext &ct
 
 template <class TPredicate>
 TypedValue StringMatchOperator(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Or<Null, String>, Or<Null, String>>(TPredicate::name, args, nargs);
-  if (args[0].IsNull() || args[1].IsNull()) return TypedValue(ctx.memory);
+  if (nargs != 2) {
+    throw QueryRuntimeException("'{}' requires exactly 2 arguments.", TPredicate::name);
+  }
+  // A null or non-string operand (either side) is a non-match (Null), not an error.
+  if (args[0].type() != TypedValue::Type::String || args[1].type() != TypedValue::Type::String) {
+    return TypedValue(ctx.memory);
+  }
   const auto &s1 = args[0].ValueString();
   const auto &s2 = args[1].ValueString();
   return TypedValue(TPredicate{}(s1, s2), ctx.memory);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -199,8 +199,10 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
       auto const &prefix = typed_value.ValueString();
       auto lower_bound = utils::MakeBoundInclusive(storage::PropertyValue(std::string(prefix)));
       auto const successor = utils::PrefixSuccessor(prefix);
-      auto upper_bound = successor ? std::make_optional(utils::MakeBoundExclusive(storage::PropertyValue(*successor)))
-                                   : storage::UpperBoundForType(storage::PropertyValueType::String);
+      // No successor (empty / all-0xFF prefix): leave the upper bound unset so the index supplies the
+      // string-type upper bound itself (consistent for node and edge scans).
+      std::optional<utils::Bound<storage::PropertyValue>> upper_bound;
+      if (successor) upper_bound = utils::MakeBoundExclusive(storage::PropertyValue(*successor));
       return storage::PropertyValueRange::Bounded(std::move(lower_bound), std::move(upper_bound));
     }
 
@@ -283,8 +285,9 @@ auto ExpressionRange::ResolveAtPlantime(Parameters const &params, storage::NameI
       auto const &prefix = property_value.ValueString();
       auto lower_bound = utils::MakeBoundInclusive(storage::PropertyValue(prefix));
       auto const successor = utils::PrefixSuccessor(prefix);
-      auto upper_bound = successor ? std::make_optional(utils::MakeBoundExclusive(storage::PropertyValue(*successor)))
-                                   : storage::UpperBoundForType(storage::PropertyValueType::String);
+      // No successor: leave the upper bound unset (the index supplies the string-type upper bound).
+      std::optional<utils::Bound<storage::PropertyValue>> upper_bound;
+      if (successor) upper_bound = utils::MakeBoundExclusive(storage::PropertyValue(*successor));
       return storage::PropertyValueRange::Bounded(std::move(lower_bound), std::move(upper_bound));
     }
 
@@ -1390,6 +1393,16 @@ ScanAllByEdgeTypePropertyRange::ScanAllByEdgeTypePropertyRange(
       lower_bound_(lower_bound),
       upper_bound_(upper_bound) {}
 
+ScanAllByEdgeTypePropertyRange::ScanAllByEdgeTypePropertyRange(const std::shared_ptr<LogicalOperator> &input,
+                                                               Symbol edge_symbol, Symbol node1_symbol,
+                                                               Symbol node2_symbol, EdgeAtom::Direction direction,
+                                                               storage::EdgeTypeId edge_type,
+                                                               storage::PropertyId property,
+                                                               ExpressionRange expression_range, storage::View view)
+    : ScanAllByEdge(input, edge_symbol, node1_symbol, node2_symbol, direction, {edge_type}, view),
+      property_(property),
+      expression_range_(std::move(expression_range)) {}
+
 ACCEPT_WITH_INPUT(ScanAllByEdgeTypePropertyRange)
 
 UniqueCursorPtr ScanAllByEdgeTypePropertyRange::MakeCursor(utils::MemoryResource *mem,
@@ -1401,6 +1414,16 @@ UniqueCursorPtr ScanAllByEdgeTypePropertyRange::MakeCursor(utils::MemoryResource
           view_, common_.edge_types[0], property_, std::nullopt, std::nullopt))> {
     auto *db = context.db_accessor;
     ExpressionEvaluator evaluator = ExpressionEvaluator{&frame, context, view_, nullptr, &context.number_of_hops};
+
+    if (expression_range_) {
+      // STARTS WITH prefix seek: a null/non-string term yields an invalid or null-bounded range (no match).
+      auto range = expression_range_->Evaluate(evaluator);
+      if (range.type_ == storage::PropertyValueRange::Type::INVALID ||
+          (range.lower_ && range.lower_->value().IsNull()) || (range.upper_ && range.upper_->value().IsNull())) {
+        return std::nullopt;
+      }
+      return std::make_optional(db->Edges(view_, common_.edge_types[0], property_, range.lower_, range.upper_));
+    }
 
     auto [maybe_lower, maybe_upper] = ConvertBoundsAndCheckNull(lower_bound_, upper_bound_, evaluator);
     if (!maybe_lower && !maybe_upper) return std::nullopt;
@@ -1442,6 +1465,9 @@ std::unique_ptr<LogicalOperator> ScanAllByEdgeTypePropertyRange::Clone(AstStorag
   if (upper_bound_) {
     object->upper_bound_.emplace(
         utils::Bound<Expression *>(upper_bound_->value()->Clone(storage), upper_bound_->type()));
+  }
+  if (expression_range_) {
+    object->expression_range_.emplace(*expression_range_, *storage);
   }
   return object;
 }
@@ -1542,6 +1568,14 @@ ScanAllByEdgePropertyRange::ScanAllByEdgePropertyRange(const std::shared_ptr<Log
       lower_bound_(lower_bound),
       upper_bound_(upper_bound) {}
 
+ScanAllByEdgePropertyRange::ScanAllByEdgePropertyRange(const std::shared_ptr<LogicalOperator> &input,
+                                                       Symbol edge_symbol, Symbol node1_symbol, Symbol node2_symbol,
+                                                       EdgeAtom::Direction direction, storage::PropertyId property,
+                                                       ExpressionRange expression_range, storage::View view)
+    : ScanAllByEdge(input, edge_symbol, node1_symbol, node2_symbol, direction, {}, view),
+      property_(property),
+      expression_range_(std::move(expression_range)) {}
+
 ACCEPT_WITH_INPUT(ScanAllByEdgePropertyRange)
 
 UniqueCursorPtr ScanAllByEdgePropertyRange::MakeCursor(utils::MemoryResource *mem,
@@ -1553,6 +1587,16 @@ UniqueCursorPtr ScanAllByEdgePropertyRange::MakeCursor(utils::MemoryResource *me
           view_, common_.edge_types[0], property_, std::nullopt, std::nullopt))> {
     auto *db = context.db_accessor;
     ExpressionEvaluator evaluator = ExpressionEvaluator{&frame, context, view_, nullptr, &context.number_of_hops};
+
+    if (expression_range_) {
+      // STARTS WITH prefix seek: a null/non-string term yields an invalid or null-bounded range (no match).
+      auto range = expression_range_->Evaluate(evaluator);
+      if (range.type_ == storage::PropertyValueRange::Type::INVALID ||
+          (range.lower_ && range.lower_->value().IsNull()) || (range.upper_ && range.upper_->value().IsNull())) {
+        return std::nullopt;
+      }
+      return std::make_optional(db->Edges(view_, property_, range.lower_, range.upper_));
+    }
 
     auto [maybe_lower, maybe_upper] = ConvertBoundsAndCheckNull(lower_bound_, upper_bound_, evaluator);
     if (!maybe_lower && !maybe_upper) return std::nullopt;
@@ -1587,6 +1631,9 @@ std::unique_ptr<LogicalOperator> ScanAllByEdgePropertyRange::Clone(AstStorage *s
   if (upper_bound_) {
     object->upper_bound_.emplace(
         utils::Bound<Expression *>(upper_bound_->value()->Clone(storage), upper_bound_->type()));
+  }
+  if (expression_range_) {
+    object->expression_range_.emplace(*expression_range_, *storage);
   }
   return object;
 }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -77,6 +77,7 @@
 #include "utils/pmr/vector.hpp"
 #include "utils/query_memory_tracker.hpp"
 #include "utils/readable_size.hpp"
+#include "utils/string.hpp"
 #include "utils/tag.hpp"
 #include "utils/temporal.hpp"
 #include "utils/timer.hpp"
@@ -136,6 +137,11 @@ auto ExpressionRange::Equal(Expression *value) -> ExpressionRange {
 
 auto ExpressionRange::RegexMatch() -> ExpressionRange { return {Type::REGEX_MATCH, std::nullopt, std::nullopt}; }
 
+auto ExpressionRange::Prefix(Expression *value) -> ExpressionRange {
+  // Prefix stored as inclusive lower bound; upper bound derived from PrefixSuccessor at evaluation.
+  return {Type::PREFIX, utils::MakeBoundInclusive(value), std::nullopt};
+}
+
 auto ExpressionRange::Range(std::optional<utils::Bound<Expression *>> lower,
                             std::optional<utils::Bound<Expression *>> upper) -> ExpressionRange {
   return {Type::RANGE, std::move(lower), std::move(upper)};
@@ -181,6 +187,21 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
       // InMemoryLabelPropertyIndex::Iterable is responsible to make sure an unset lower/upper
       // bound will be limitted to the same type as the other bound
       return storage::PropertyValueRange::Bounded(lower_bound, upper_bound);
+    }
+
+    case Type::PREFIX: {
+      // [prefix, PrefixSuccessor(prefix)); a null/non-string term matches nothing (invalid range).
+      auto const typed_value = lower_->value()->Accept(evaluator);
+      if (typed_value.type() != TypedValue::Type::String) {
+        auto null_bound = utils::MakeBoundInclusive(storage::PropertyValue());
+        return storage::PropertyValueRange::Invalid(null_bound, null_bound);
+      }
+      auto const &prefix = typed_value.ValueString();
+      auto lower_bound = utils::MakeBoundInclusive(storage::PropertyValue(std::string(prefix)));
+      auto const successor = utils::PrefixSuccessor(prefix);
+      auto upper_bound = successor ? std::make_optional(utils::MakeBoundExclusive(storage::PropertyValue(*successor)))
+                                   : storage::UpperBoundForType(storage::PropertyValueType::String);
+      return storage::PropertyValueRange::Bounded(std::move(lower_bound), std::move(upper_bound));
     }
 
     case Type::IS_NOT_NULL: {
@@ -251,6 +272,20 @@ auto ExpressionRange::ResolveAtPlantime(Parameters const &params, storage::NameI
       // InMemoryLabelPropertyIndex::Iterable is responsible to make sure an unset lower/upper
       // bound will be limitted to the same type as the other bound
       return storage::PropertyValueRange::Bounded(lower_bound, upper_bound);
+    }
+
+    case Type::PREFIX: {
+      // Costing only: nullopt (generic estimate) when the prefix is unknown or non-string at plan time.
+      auto intermediate_value = ConstExternalPropertyValue(lower_->value(), params);
+      if (!intermediate_value) return std::nullopt;
+      auto const property_value = storage::ToPropertyValue(*intermediate_value, name_id_mapper);
+      if (!property_value.IsString()) return std::nullopt;
+      auto const &prefix = property_value.ValueString();
+      auto lower_bound = utils::MakeBoundInclusive(storage::PropertyValue(prefix));
+      auto const successor = utils::PrefixSuccessor(prefix);
+      auto upper_bound = successor ? std::make_optional(utils::MakeBoundExclusive(storage::PropertyValue(*successor)))
+                                   : storage::UpperBoundForType(storage::PropertyValueType::String);
+      return storage::PropertyValueRange::Bounded(std::move(lower_bound), std::move(upper_bound));
     }
 
     case Type::IS_NOT_NULL: {

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -747,6 +747,12 @@ class ScanAllByEdgeTypePropertyRange : public memgraph::query::plan::ScanAllByEd
                                  Symbol node2_symbol, EdgeAtom::Direction direction, storage::EdgeTypeId edge_type,
                                  storage::PropertyId property, std::optional<Bound> lower_bound,
                                  std::optional<Bound> upper_bound, storage::View view = storage::View::OLD);
+  // STARTS WITH prefix seek: the range (incl. its exclusive upper bound) is derived at runtime from
+  // expression_range; lower_bound_/upper_bound_ are unused in this mode.
+  ScanAllByEdgeTypePropertyRange(const std::shared_ptr<LogicalOperator> &input, Symbol edge_symbol, Symbol node1_symbol,
+                                 Symbol node2_symbol, EdgeAtom::Direction direction, storage::EdgeTypeId edge_type,
+                                 storage::PropertyId property, ExpressionRange expression_range,
+                                 storage::View view = storage::View::OLD);
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
@@ -761,6 +767,7 @@ class ScanAllByEdgeTypePropertyRange : public memgraph::query::plan::ScanAllByEd
   storage::PropertyId property_;
   std::optional<Bound> lower_bound_;
   std::optional<Bound> upper_bound_;
+  std::optional<ExpressionRange> expression_range_;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -832,6 +839,10 @@ class ScanAllByEdgePropertyRange : public memgraph::query::plan::ScanAllByEdge {
                              Symbol node2_symbol, EdgeAtom::Direction direction, storage::PropertyId property,
                              std::optional<Bound> lower_bound, std::optional<Bound> upper_bound,
                              storage::View view = storage::View::OLD);
+  // STARTS WITH prefix seek: the range is derived at runtime from expression_range; bounds are unused.
+  ScanAllByEdgePropertyRange(const std::shared_ptr<LogicalOperator> &input, Symbol edge_symbol, Symbol node1_symbol,
+                             Symbol node2_symbol, EdgeAtom::Direction direction, storage::PropertyId property,
+                             ExpressionRange expression_range, storage::View view = storage::View::OLD);
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
@@ -846,6 +857,7 @@ class ScanAllByEdgePropertyRange : public memgraph::query::plan::ScanAllByEdge {
   storage::PropertyId property_;
   std::optional<Bound> lower_bound_;
   std::optional<Bound> upper_bound_;
+  std::optional<ExpressionRange> expression_range_;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -57,6 +57,8 @@ struct ExpressionRange {
 
   static auto Equal(Expression *value) -> ExpressionRange;
   static auto RegexMatch() -> ExpressionRange;
+  /// STARTS WITH prefix seek: the range [value, PrefixSuccessor(value)).
+  static auto Prefix(Expression *value) -> ExpressionRange;
   static auto Range(std::optional<utils::Bound<Expression *>> lower, std::optional<utils::Bound<Expression *>> upper)
       -> ExpressionRange;
   static auto IsNotNull() -> ExpressionRange;

--- a/src/query/plan/preprocess.cpp
+++ b/src/query/plan/preprocess.cpp
@@ -995,9 +995,12 @@ void Filters::AnalyzeAndStoreFilter(Expression *expr, const SymbolTable &symbol_
     }
   } else if (utils::Downcast<Exists>(expr)) {
     all_filters_.emplace_back(make_filter(FilterInfo::Type::Pattern));
-  } else if (utils::Downcast<Function>(expr)) {
+  } else if (auto *func = utils::Downcast<Function>(expr)) {
+    // n.prop STARTS WITH value -> PREFIX range. endsWith/contains aren't prefix-expressible (fall through).
+    bool is_prefix_filter = utils::ToUpperCase(func->function_name_) == "STARTSWITH" && func->arguments_.size() == 2 &&
+                            try_add_prop_filter(func->arguments_[0], func->arguments_[1], PropertyFilter::Type::PREFIX);
     // WHERE point.withinbbox()
-    if (!add_point_withinbbox_filter_unary(expr, WithinBBoxCondition::INSIDE)) {
+    if (!is_prefix_filter && !add_point_withinbbox_filter_unary(expr, WithinBBoxCondition::INSIDE)) {
       all_filters_.emplace_back(make_filter(FilterInfo::Type::Generic));
     }
   } else if (auto *or_operator = utils::Downcast<OrOperator>(expr)) {

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -264,7 +264,7 @@ class PropertyFilter {
 
   /// Depending on type, this PropertyFilter may be a value equality, regex
   /// matched value or a range with lower and (or) upper bounds, IN list filter.
-  enum class Type : uint8_t { EQUAL = 0, REGEX_MATCH = 1, RANGE = 2, IN = 3, IS_NOT_NULL = 4 };
+  enum class Type : uint8_t { EQUAL = 0, REGEX_MATCH = 1, RANGE = 2, IN = 3, IS_NOT_NULL = 4, PREFIX = 5 };
 
   /// Construct with Expression being the equality or regex match check.
   PropertyFilter(const SymbolTable &, const Symbol &, PropertyIx, Expression *, Type);

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -748,6 +748,7 @@ bool PlanToJsonVisitor::PreVisit(ScanAllByEdgeTypePropertyRange &op) {
   self["property"] = ToJson(op.property_, *dba_);
   self["lower_bound"] = op.lower_bound_ ? ToJson(*op.lower_bound_, *dba_) : json();
   self["upper_bound"] = op.upper_bound_ ? ToJson(*op.upper_bound_, *dba_) : json();
+  if (op.expression_range_) self["expression_range"] = ToJson(*op.expression_range_, *dba_);
   self["output_symbol"] = ToJson(op.common_.edge_symbol);
 
   op.input_->Accept(*this);
@@ -790,6 +791,7 @@ bool PlanToJsonVisitor::PreVisit(ScanAllByEdgePropertyRange &op) {
   self["property"] = ToJson(op.property_, *dba_);
   self["lower_bound"] = op.lower_bound_ ? ToJson(*op.lower_bound_, *dba_) : json();
   self["upper_bound"] = op.upper_bound_ ? ToJson(*op.upper_bound_, *dba_) : json();
+  if (op.expression_range_) self["expression_range"] = ToJson(*op.expression_range_, *dba_);
   self["output_symbol"] = ToJson(op.common_.edge_symbol);
 
   op.input_->Accept(*this);

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -215,6 +215,11 @@ nlohmann::json ToJson(const ExpressionRange &expression_range, const DbAccessor 
       result["type"] = "Regex";
       break;
     }
+    case PropertyFilter::Type::PREFIX: {
+      result["type"] = "Prefix";
+      result["expression"] = ToJson(expression_range.lower_->value(), dba);
+      break;
+    }
     case PropertyFilter::Type::RANGE: {
       result["type"] = "Range";
       result["lower_bound"] = expression_range.lower_ ? ToJson(*expression_range.lower_, dba) : json();

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -838,13 +838,6 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
           continue;
         }
 
-        // Exclude PREFIX: an edge index would misread it as an equality scan (wrong results); edge STARTS
-        // WITH falls back to ScanAllByEdgeType + Filter.
-        // TODO(edge-prefix-seek): support a real edge prefix seek via ScanAllByEdgeTypePropertyRange.
-        if (filter.property_filter->type_ == PropertyFilter::Type::PREFIX) {
-          continue;
-        }
-
         // Edge indexes are single-property; a nested lookup like `e.a.b` has a
         // multi-element path that no edge index covers, so it must stay a Filter
         // rather than be misread as a filter on the outer key.
@@ -873,11 +866,6 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         continue;
       }
 
-      // Exclude PREFIX: see GetCandidateIndicesFromFilter.
-      if (filter.property_filter->type_ == PropertyFilter::Type::PREFIX) {
-        continue;
-      }
-
       // Skip nested lookups: a single-property edge index cannot cover a multi-element path.
       if (filter.property_filter->property_ids_.path.size() != 1) {
         continue;
@@ -901,11 +889,6 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         // looking up or aren't bound. We cannot scan by such expressions. For
         // example, in `n.a = 2 + n.b` both sides of `=` refer to `n`, so we
         // cannot scan `n` by property index.
-        continue;
-      }
-
-      // Exclude PREFIX: see GetCandidateIndicesFromFilter.
-      if (filter.property_filter->type_ == PropertyFilter::Type::PREFIX) {
         continue;
       }
 
@@ -1084,6 +1067,18 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
                                                                 std::nullopt,
                                                                 view);
       }
+      if (prop_filter.type_ == PropertyFilter::Type::PREFIX) {
+        // STARTS WITH: prefix seek [value, PrefixSuccessor(value)); filter already dropped above.
+        return std::make_unique<ScanAllByEdgeTypePropertyRange>(input,
+                                                                common.edge_symbol,
+                                                                common.node1_symbol,
+                                                                common.node2_symbol,
+                                                                common.direction,
+                                                                GetEdgeType(found_index.value()),
+                                                                GetProperty(prop_filter.property_ids_.path[0]),
+                                                                ExpressionRange::Prefix(prop_filter.value_),
+                                                                view);
+      }
       if (prop_filter.type_ == PropertyFilter::Type::IN) {
         // TODO(buda): ScanAllByLabelProperties + Filter should be considered
         // here once the operator and the right cardinality estimation exist.
@@ -1188,6 +1183,17 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
                                                             GetProperty(prop_filter.property_ids_.path[0]),
                                                             std::make_optional(lower_bound),
                                                             std::nullopt,
+                                                            view);
+      }
+      if (prop_filter.type_ == PropertyFilter::Type::PREFIX) {
+        // STARTS WITH: prefix seek [value, PrefixSuccessor(value)); filter already dropped above.
+        return std::make_shared<ScanAllByEdgePropertyRange>(input,
+                                                            common.edge_symbol,
+                                                            common.node1_symbol,
+                                                            common.node2_symbol,
+                                                            common.direction,
+                                                            GetProperty(prop_filter.property_ids_.path[0]),
+                                                            ExpressionRange::Prefix(prop_filter.value_),
                                                             view);
       }
       if (prop_filter.type_ == PropertyFilter::Type::IN) {

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -838,6 +838,13 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
           continue;
         }
 
+        // Exclude PREFIX: an edge index would misread it as an equality scan (wrong results); edge STARTS
+        // WITH falls back to ScanAllByEdgeType + Filter.
+        // TODO(edge-prefix-seek): support a real edge prefix seek via ScanAllByEdgeTypePropertyRange.
+        if (filter.property_filter->type_ == PropertyFilter::Type::PREFIX) {
+          continue;
+        }
+
         // Edge indexes are single-property; a nested lookup like `e.a.b` has a
         // multi-element path that no edge index covers, so it must stay a Filter
         // rather than be misread as a filter on the outer key.
@@ -866,6 +873,11 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         continue;
       }
 
+      // Exclude PREFIX: see GetCandidateIndicesFromFilter.
+      if (filter.property_filter->type_ == PropertyFilter::Type::PREFIX) {
+        continue;
+      }
+
       // Skip nested lookups: a single-property edge index cannot cover a multi-element path.
       if (filter.property_filter->property_ids_.path.size() != 1) {
         continue;
@@ -889,6 +901,11 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         // looking up or aren't bound. We cannot scan by such expressions. For
         // example, in `n.a = 2 + n.b` both sides of `=` refer to `n`, so we
         // cannot scan `n` by property index.
+        continue;
+      }
+
+      // Exclude PREFIX: see GetCandidateIndicesFromFilter.
+      if (filter.property_filter->type_ == PropertyFilter::Type::PREFIX) {
         continue;
       }
 

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1258,6 +1258,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
               return 20.0;  // cheapest, just a raw scan of the index skip list
             case EQUAL:
               return 10.0;
+            case PREFIX:
+              return 8.0;  // tighter than a bounded RANGE, broader than EQUAL
             case RANGE: {
               if (fi.property_filter->lower_bound_ && fi.property_filter->upper_bound_) {
                 return 7.0;
@@ -1598,6 +1600,9 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         }
         case PropertyFilter::Type::REGEX_MATCH: {
           return ExpressionRange::RegexMatch();
+        }
+        case PropertyFilter::Type::PREFIX: {
+          return ExpressionRange::Prefix(filter.property_filter->value_);
         }
         case PropertyFilter::Type::RANGE: {
           return ExpressionRange::Range(filter.property_filter->lower_bound_, filter.property_filter->upper_bound_);

--- a/src/query/plan/rewrite/order_by_elimination.hpp
+++ b/src/query/plan/rewrite/order_by_elimination.hpp
@@ -297,6 +297,8 @@ class OrderByEliminator {
                 ++ob_ptr;
               } else if (i < s->expression_ranges_.size() &&
                          s->expression_ranges_[i].type_ == PropertyFilter::Type::EQUAL) {
+                // Note: PREFIX isn't skippable here (spans multiple values); a PREFIX on the ORDER BY column
+                // itself is order-preserving and already accepted by the match path above.
                 continue;
               } else {
                 return false;

--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -20,6 +20,7 @@
 #include <iomanip>
 #include <iterator>
 #include <locale>
+#include <optional>
 #include <random>
 #include <ranges>
 #include <sstream>
@@ -486,6 +487,21 @@ inline std::string DoubleToString(const double value) {
     sv = sv.substr(0, sv.size() - 1);
   }
   return std::string(sv);
+}
+
+/// Smallest string strictly greater than every string prefixed by @p prefix, giving the half-open range
+/// `[prefix, successor)`. Drops trailing 0xFF bytes then increments the last (byte-wise, UTF-8 safe).
+/// Returns nullopt when none exists (empty or all-0xFF prefix): the range is then unbounded above.
+inline std::optional<std::string> PrefixSuccessor(std::string_view prefix) {
+  std::string result(prefix);
+  while (!result.empty() && static_cast<unsigned char>(result.back()) == 0xFF) {
+    result.pop_back();
+  }
+  if (result.empty()) {
+    return std::nullopt;
+  }
+  ++result.back();
+  return result;
 }
 
 // Avoids copies if possible

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2486,32 +2486,44 @@ TYPED_TEST(FunctionTest, Rand) {
 
 TYPED_TEST(FunctionTest, StartsWith) {
   EXPECT_THROW(this->EvaluateFunction(kStartsWith), QueryRuntimeException);
-  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, "a", TypedValue()).IsNull());
-  EXPECT_THROW(this->EvaluateFunction(kStartsWith, TypedValue(), 1.3), QueryRuntimeException);
   EXPECT_TRUE(this->EvaluateFunction(kStartsWith, "abc", "abc").ValueBool());
   EXPECT_TRUE(this->EvaluateFunction(kStartsWith, "abcdef", "abc").ValueBool());
   EXPECT_FALSE(this->EvaluateFunction(kStartsWith, "abcdef", "aBc").ValueBool());
   EXPECT_FALSE(this->EvaluateFunction(kStartsWith, "abc", "abcd").ValueBool());
+  // A null or non-string operand (either side) is a non-match (Null), never an error.
+  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, "a", TypedValue()).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, TypedValue(), "a").IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, TypedValue(), 1.3).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, 123, "a").IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, 1.3, "a").IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, true, "a").IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kStartsWith, "abc", 1).IsNull());
 }
 
 TYPED_TEST(FunctionTest, EndsWith) {
   EXPECT_THROW(this->EvaluateFunction(kEndsWith), QueryRuntimeException);
-  EXPECT_TRUE(this->EvaluateFunction(kEndsWith, "a", TypedValue()).IsNull());
-  EXPECT_THROW(this->EvaluateFunction(kEndsWith, TypedValue(), 1.3), QueryRuntimeException);
   EXPECT_TRUE(this->EvaluateFunction(kEndsWith, "abc", "abc").ValueBool());
   EXPECT_TRUE(this->EvaluateFunction(kEndsWith, "abcdef", "def").ValueBool());
   EXPECT_FALSE(this->EvaluateFunction(kEndsWith, "abcdef", "dEf").ValueBool());
   EXPECT_FALSE(this->EvaluateFunction(kEndsWith, "bcd", "abcd").ValueBool());
+  // A null or non-string operand (either side) is a non-match (Null), never an error.
+  EXPECT_TRUE(this->EvaluateFunction(kEndsWith, "a", TypedValue()).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kEndsWith, TypedValue(), 1.3).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kEndsWith, 123, "a").IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kEndsWith, "abc", 1).IsNull());
 }
 
 TYPED_TEST(FunctionTest, Contains) {
   EXPECT_THROW(this->EvaluateFunction(kContains), QueryRuntimeException);
-  EXPECT_TRUE(this->EvaluateFunction(kContains, "a", TypedValue()).IsNull());
-  EXPECT_THROW(this->EvaluateFunction(kContains, TypedValue(), 1.3), QueryRuntimeException);
   EXPECT_TRUE(this->EvaluateFunction(kContains, "abc", "abc").ValueBool());
   EXPECT_TRUE(this->EvaluateFunction(kContains, "abcde", "bcd").ValueBool());
   EXPECT_FALSE(this->EvaluateFunction(kContains, "cde", "abcdef").ValueBool());
   EXPECT_FALSE(this->EvaluateFunction(kContains, "abcdef", "dEf").ValueBool());
+  // A null or non-string operand (either side) is a non-match (Null), never an error.
+  EXPECT_TRUE(this->EvaluateFunction(kContains, "a", TypedValue()).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kContains, TypedValue(), 1.3).IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kContains, 123, "a").IsNull());
+  EXPECT_TRUE(this->EvaluateFunction(kContains, "abc", 1).IsNull());
 }
 
 TYPED_TEST(FunctionTest, Assert) {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -1231,6 +1231,31 @@ TYPED_TEST(TestPlanner, EdgeRangeFilterWIndex1) {
             ExpectProduce());
 }
 
+TYPED_TEST(TestPlanner, EdgeTypePropertyStartsWithWIndex) {
+  // Test MATCH (n)-[r:TYPE]->(m) WHERE r.prop STARTS WITH "ab" RETURN n
+  FakeDbAccessor dba;
+  const auto edge_type_name = "TYPE";
+  const auto edge_type = dba.EdgeType(edge_type_name);
+  const auto property = PROPERTY_PAIR(dba, "prop");
+  dba.SetIndexCount(edge_type, property.second, 1);
+
+  auto *starts_with = FN("startsWith", PROPERTY_LOOKUP(dba, "r", property.second), LITERAL("ab"));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(
+          PATTERN(NODE("n"), EDGE("r", memgraph::query::EdgeAtom::Direction::OUT, {edge_type_name}, false), NODE("m"))),
+      WHERE(starts_with),
+      RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  // Prefix range on the edge index, so the residual Filter is dropped (no ExpectFilter). Crucially this is a
+  // range scan, not the equality ScanAllByEdgeTypePropertyValue.
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectScanAllByEdgeTypePropertyRange(edge_type, property.second, ExpressionRange::Prefix(LITERAL("ab"))),
+            ExpectProduce());
+}
+
 TYPED_TEST(TestPlanner, EdgeRangeFilterNoIndex2) {
   // Test MATCH (n)-[r:TYPE]->(m) WHERE 10 >= r.prop > 1 RETURN n
   FakeDbAccessor dba;

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2206,6 +2206,64 @@ TYPED_TEST(TestPlanner, FilterRegexMatchIndex) {
             ExpectProduce());
 }
 
+TYPED_TEST(TestPlanner, FilterStartsWithIndex) {
+  // Test MATCH (n :label) WHERE n.prop STARTS WITH "abc" RETURN n
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+  auto label = dba.Label("label");
+  dba.SetIndexCount(label, 0);
+  dba.SetIndexCount(label, prop, 0);
+  auto *prefix = LITERAL("abc");
+  auto *starts_with = FN("startsWith", PROPERTY_LOOKUP(dba, "n", prop), prefix);
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))), WHERE(starts_with), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  // The prefix range is exact for strings, so the residual Filter is dropped (no ExpectFilter).
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectScanAllByLabelProperties(
+                label, std::vector{ms::PropertyPath{prop}}, std::vector{ExpressionRange::Prefix(prefix)}),
+            ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, FilterStartsWithPreferEqualityIndex) {
+  // Test MATCH (n :label) WHERE n.prop STARTS WITH "abc" AND n.prop = "abcdef" RETURN n
+  FakeDbAccessor dba;
+  auto prop = PROPERTY_PAIR(dba, "prop");
+  auto label = dba.Label("label");
+  dba.SetIndexCount(label, 0);
+  dba.SetIndexCount(label, prop.second, 0);
+  auto *starts_with = FN("startsWith", PROPERTY_LOOKUP(dba, "n", prop), LITERAL("abc"));
+  auto *lit_val = LITERAL("abcdef");
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))),
+                                   WHERE(AND(starts_with, EQ(PROPERTY_LOOKUP(dba, "n", prop), lit_val))),
+                                   RETURN("n")));
+  // Equality (score 10) is preferred over the prefix range (score 8); the residual STARTS WITH stays a Filter.
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectScanAllByLabelProperties(
+                label, std::vector{ms::PropertyPath{prop.second}}, std::vector{ExpressionRange::Equal(lit_val)}),
+            ExpectFilter(),
+            ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, FilterEndsWithNoIndex) {
+  // Test MATCH (n :label) WHERE n.prop ENDS WITH "abc" RETURN n
+  // endsWith is not prefix-expressible, so it must stay ScanAllByLabel + Filter.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+  auto label = dba.Label("label");
+  dba.SetIndexCount(label, 0);
+  dba.SetIndexCount(label, prop, 0);
+  auto *ends_with = FN("endsWith", PROPERTY_LOOKUP(dba, "n", prop), LITERAL("abc"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))), WHERE(ends_with), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAllByLabel(), ExpectFilter(), ExpectProduce());
+}
+
 TYPED_TEST(TestPlanner, FilterRegexMatchPreferEqualityIndex) {
   // Test MATCH (n :label) WHERE n.prop =~ "regex" AND n.prop = 42 RETURN n
   FakeDbAccessor dba;

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -656,6 +656,10 @@ class ExpectScanAllByEdgeTypePropertyRange : public OpChecker<ScanAllByEdgeTypeP
                                        std::optional<ScanAllByEdgeTypePropertyRange::Bound> upper_bound)
       : edge_type_(edge_type), property_(property), lower_bound_(lower_bound), upper_bound_(upper_bound) {}
 
+  ExpectScanAllByEdgeTypePropertyRange(memgraph::storage::EdgeTypeId edge_type, memgraph::storage::PropertyId property,
+                                       ExpressionRange expression_range)
+      : edge_type_(edge_type), property_(property), expression_range_(std::move(expression_range)) {}
+
   void ExpectOp(ScanAllByEdgeTypePropertyRange &scan_all, const SymbolTable &) override {
     EXPECT_EQ(scan_all.common_.edge_types[0], edge_type_);
     EXPECT_EQ(scan_all.property_, property_);
@@ -671,6 +675,10 @@ class ExpectScanAllByEdgeTypePropertyRange : public OpChecker<ScanAllByEdgeTypeP
       EXPECT_EQ(typeid(scan_all.upper_bound_->value()).hash_code(), typeid(upper_bound_->value()).hash_code());
       EXPECT_EQ(scan_all.upper_bound_->type(), upper_bound_->type());
     }
+    if (expression_range_) {
+      ASSERT_TRUE(scan_all.expression_range_);
+      EXPECT_EQ(scan_all.expression_range_->type_, expression_range_->type_);
+    }
   }
 
  private:
@@ -678,6 +686,7 @@ class ExpectScanAllByEdgeTypePropertyRange : public OpChecker<ScanAllByEdgeTypeP
   memgraph::storage::PropertyId property_;
   std::optional<ScanAllByEdgeTypePropertyRange::Bound> lower_bound_;
   std::optional<ScanAllByEdgeTypePropertyRange::Bound> upper_bound_;
+  std::optional<ExpressionRange> expression_range_;
 };
 
 class ExpectScanAllByEdgeTypeProperty : public OpChecker<ScanAllByEdgeTypeProperty> {

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -219,3 +219,25 @@ TEST(String, StringToUint32) {
   EXPECT_THROW(ParseStringToUint<uint32_t>("10 "), ParseException);
   EXPECT_THROW(ParseStringToUint<uint32_t>(""), ParseException);
 }
+
+TEST(String, PrefixSuccessor) {
+  // Ordinary prefix: increment the last byte.
+  EXPECT_EQ(PrefixSuccessor("abc"), "abd");
+  EXPECT_EQ(PrefixSuccessor("a"), "b");
+  // Empty prefix has no successor (range unbounded above).
+  EXPECT_EQ(PrefixSuccessor(""), std::nullopt);
+  // Trailing 0xFF bytes are dropped, then the previous byte is incremented.
+  EXPECT_EQ(PrefixSuccessor(std::string("a\xFF")), std::string("b"));
+  EXPECT_EQ(PrefixSuccessor(std::string("a\xFF\xFF")), std::string("b"));
+  EXPECT_EQ(PrefixSuccessor(std::string("ab\xFF")), std::string("ac"));
+  // All-0xFF prefix has no successor.
+  EXPECT_EQ(PrefixSuccessor(std::string("\xFF")), std::nullopt);
+  EXPECT_EQ(PrefixSuccessor(std::string("\xFF\xFF")), std::nullopt);
+  // The successor is a strict upper bound: every string with the prefix is < successor,
+  // and the shortest non-prefixed string is >= successor.
+  auto succ = PrefixSuccessor("abc");
+  ASSERT_TRUE(succ.has_value());
+  EXPECT_LT(std::string("abc"), *succ);
+  EXPECT_LT(std::string("abcZZZ"), *succ);
+  EXPECT_FALSE(std::string("abd") < *succ);
+}


### PR DESCRIPTION
**What:** the query planner now serves `WHERE x.p STARTS WITH v` with an index prefix seek instead of a full scan + `Filter` — for node label-property indexes as well as edge-type-property and global edge-property indexes.

**How:** `x.p STARTS WITH v` is detected during filter preprocessing and lowered to a new `PropertyFilter::Type::PREFIX`. At scan time it produces the half-open range `[v, PrefixSuccessor(v))` restricted to strings (`utils::PrefixSuccessor` drops trailing `0xFF` bytes and increments the last byte; the upper bound is left unset when there is no successor, so the index supplies the string-type upper bound). The range is exact for strings, so the residual `Filter` is dropped, and it is scored between an equality and a bounded range during index selection. Nodes scan via `ScanAllByLabelProperties`; edges via `ScanAllByEdgeTypePropertyRange` / `ScanAllByEdgePropertyRange`, which gain an optional `ExpressionRange`. The `startsWith`/`endsWith`/`contains` predicates now treat a null or non-string operand as a non-match (return `null`) rather than throwing, so index and no-index paths return identical results on mixed-type data; a non-string search term produces an empty range (matches nothing).

**Why:** `STARTS WITH` on an indexed property previously scanned every node/edge and filtered, which is unnecessarily slow when an index exists.