### PR TITLE
feat: add label-property index range mgp C API

### DIFF
--- a/include/_mgp.hpp
+++ b/include/_mgp.hpp
@@ -363,6 +363,29 @@ inline bool graph_has_text_index(mgp_graph *graph, const char *index_name) {
   return MgInvoke<int>(mgp_graph_has_text_index, graph, index_name);
 }
 
+// label-property index
+
+inline bool graph_has_label_property_index(mgp_graph *graph, const char *label, const char *property) {
+  return MgInvoke<int>(mgp_graph_has_label_property_index, graph, label, property);
+}
+
+inline mgp_label_property_range *label_property_range_make(mgp_memory *memory) {
+  return MgInvoke<mgp_label_property_range *>(mgp_label_property_range_make, memory);
+}
+
+inline void label_property_range_destroy(mgp_label_property_range *range) { mgp_label_property_range_destroy(range); }
+
+inline void label_property_range_add_property(mgp_label_property_range *range, const char *property, mgp_value *lower,
+                                              mgp_bound_type lower_type, mgp_value *upper, mgp_bound_type upper_type) {
+  MgInvokeVoid(mgp_label_property_range_add_property, range, property, lower, lower_type, upper, upper_type);
+}
+
+inline mgp_vertices_iterator *graph_vertices_by_label_property_range(mgp_graph *graph, const char *label,
+                                                                     mgp_label_property_range *range,
+                                                                     mgp_memory *memory) {
+  return MgInvoke<mgp_vertices_iterator *>(mgp_graph_vertices_by_label_property_range, graph, label, range, memory);
+}
+
 inline mgp_map *graph_search_text_index(mgp_graph *graph, const char *index_name, const char *search_query,
                                         text_search_mode search_mode, std::size_t limit, std::uint8_t fuzzy_distance,
                                         bool fuzzy_prefix, bool fuzzy_transpositions, mgp_memory *memory) {

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -1005,6 +1005,51 @@ enum mgp_error mgp_graph_get_vertex_by_id(struct mgp_graph *g, struct mgp_vertex
 /// The current implementation always returns without errors.
 enum mgp_error mgp_graph_has_text_index(struct mgp_graph *graph, const char *index_name, int *result);
 
+/// Result is non-zero if a ready label-property index over (`label`, `property`) exists.
+enum mgp_error mgp_graph_has_label_property_index(struct mgp_graph *graph, const char *label, const char *property,
+                                                  int *result);
+
+/// Bound inclusivity for a single side of a property range. A NULL value passed for that side means the
+/// side is unbounded and the bound type is ignored.
+MGP_ENUM_CLASS mgp_bound_type{
+    MGP_BOUND_TYPE_INCLUSIVE,
+    MGP_BOUND_TYPE_EXCLUSIVE,
+};
+
+/// A specification of per-property value ranges used to scan a label-property index. Build it with
+/// mgp_label_property_range_make, add one entry per property with mgp_label_property_range_add_property,
+/// then pass it to mgp_graph_vertices_by_label_property_range. A single entry targets a single-property
+/// index; multiple entries (in the order added) target a composite index over those properties.
+struct mgp_label_property_range;
+
+/// Create an empty label-property range specification.
+/// You need to free the created instance with mgp_label_property_range_destroy.
+/// Return mgp_error::MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate.
+enum mgp_error mgp_label_property_range_make(struct mgp_memory *memory, struct mgp_label_property_range **result);
+
+/// Free the memory used by a mgp_label_property_range.
+void mgp_label_property_range_destroy(struct mgp_label_property_range *range);
+
+/// Append a property and its value range to the specification. `lower` / `upper` are copied; pass NULL for
+/// a side to leave it unbounded (its bound type is then ignored). The pair (`lower`, `upper`) with equal
+/// inclusive bounds expresses exact equality.
+/// Return mgp_error::MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate.
+enum mgp_error mgp_label_property_range_add_property(struct mgp_label_property_range *range, const char *property,
+                                                     struct mgp_value *lower, enum mgp_bound_type lower_type,
+                                                     struct mgp_value *upper, enum mgp_bound_type upper_type);
+
+struct mgp_vertices_iterator;
+
+/// Start iterating over vertices with the given `label` whose properties fall within `range`.
+/// This is an index-only fast path: a ready label-property index over `label` and the range's properties
+/// must exist (check with mgp_graph_has_label_property_index); no internal scan fallback is performed.
+/// Resulting mgp_vertices_iterator needs to be deallocated with mgp_vertices_iterator_destroy.
+/// Return mgp_error::MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_vertices_iterator.
+enum mgp_error mgp_graph_vertices_by_label_property_range(struct mgp_graph *graph, const char *label,
+                                                          struct mgp_label_property_range *range,
+                                                          struct mgp_memory *memory,
+                                                          struct mgp_vertices_iterator **result);
+
 /// Available modes of searching text indices.
 MGP_ENUM_CLASS text_search_mode{
     SPECIFIED_PROPERTIES,

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -290,6 +290,15 @@ class Graph {
   /// @note For the reason why the process must abort consider using MustAbort method instead
   void CheckMustAbort() const;
 
+  /// @brief Returns whether a ready label-property index over (`label`, `property`) exists.
+  bool HasLabelPropertyIndex(std::string_view label, std::string_view property) const;
+
+  /// @brief Returns an iterable of nodes with `label` whose `property` falls within the given bounds,
+  /// scanning a label-property index (which must already exist — check with HasLabelPropertyIndex).
+  /// A null bound pointer leaves that side unbounded.
+  GraphNodes NodesByLabelPropertyRange(std::string_view label, std::string_view property, const Value *lower,
+                                       bool lower_inclusive, const Value *upper, bool upper_inclusive) const;
+
  private:
   mgp_graph *graph_;
 };
@@ -2421,6 +2430,37 @@ inline int64_t Graph::Size() const {
 
 inline GraphNodes Graph::Nodes() const {
   auto *nodes_it = mgp::MemHandlerCallback(graph_iter_vertices, graph_);
+  if (nodes_it == nullptr) {
+    throw mg_exception::NotEnoughMemoryException();
+  }
+  return GraphNodes(nodes_it);
+}
+
+inline bool Graph::HasLabelPropertyIndex(std::string_view label, std::string_view property) const {
+  return mgp::graph_has_label_property_index(graph_, label.data(), property.data());
+}
+
+inline GraphNodes Graph::NodesByLabelPropertyRange(std::string_view label, std::string_view property,
+                                                   const Value *lower, bool lower_inclusive, const Value *upper,
+                                                   bool upper_inclusive) const {
+  const auto bound_type = [](bool inclusive) {
+    return inclusive ? mgp_bound_type::MGP_BOUND_TYPE_INCLUSIVE : mgp_bound_type::MGP_BOUND_TYPE_EXCLUSIVE;
+  };
+  auto *range = mgp::MemHandlerCallback(label_property_range_make);
+  mgp_vertices_iterator *nodes_it = nullptr;
+  try {
+    mgp::label_property_range_add_property(range,
+                                           property.data(),
+                                           lower ? lower->ptr() : nullptr,
+                                           bound_type(lower_inclusive),
+                                           upper ? upper->ptr() : nullptr,
+                                           bound_type(upper_inclusive));
+    nodes_it = mgp::MemHandlerCallback(graph_vertices_by_label_property_range, graph_, label.data(), range);
+  } catch (...) {
+    mgp::label_property_range_destroy(range);
+    throw;
+  }
+  mgp::label_property_range_destroy(range);
   if (nodes_it == nullptr) {
     throw mg_exception::NotEnoughMemoryException();
   }

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -4048,6 +4048,24 @@ mgp_error mgp_graph_has_text_index(mgp_graph *graph, const char *index_name, int
   });
 }
 
+mgp_error mgp_graph_has_label_property_index(mgp_graph *graph, const char *label, const char *property, int *result) {
+  return WrapExceptions([graph, label, property, result]() {
+    const auto has_index = [label, property](memgraph::query::DbAccessor *impl) {
+      std::array<memgraph::storage::PropertyPath, 1> properties{
+          memgraph::storage::PropertyPath{impl->NameToProperty(property)}};
+      return impl->LabelPropertyIndexReady(impl->NameToLabel(label), properties) ? 1 : 0;
+    };
+    *result = std::visit(
+        memgraph::utils::Overloaded{
+            has_index,
+            [&](memgraph::query::SubgraphDbAccessor *impl) { return has_index(impl->GetAccessor()); },
+            [](memgraph::query::VirtualGraphDbAccessor *) -> int {
+              throw ImmutableObjectException{"mgp_graph_has_label_property_index is not supported on a virtual graph"};
+            }},
+        graph->impl);
+  });
+}
+
 mgp_vertex *GetVertexByGid(mgp_graph *graph, memgraph::storage::Gid id, mgp_memory *memory) {
   auto get_vertex_by_gid = memgraph::utils::Overloaded{
       [graph, id, memory](memgraph::query::DbAccessor *impl) -> mgp_vertex * {
@@ -5016,10 +5034,109 @@ mgp_vertices_iterator::mgp_vertices_iterator(mgp_graph *graph, allocator_type al
   }
 }
 
+/// @throw anything VerticesIterable may throw
+mgp_vertices_iterator::mgp_vertices_iterator(mgp_graph *graph, memgraph::storage::LabelId label,
+                                             std::span<memgraph::storage::PropertyPath const> properties,
+                                             std::span<memgraph::storage::PropertyValueRange const> property_ranges,
+                                             allocator_type alloc)
+    : alloc(alloc), graph(graph) {
+  auto vertices = std::visit(
+      memgraph::utils::Overloaded{
+          [&](memgraph::query::DbAccessor *impl) {
+            // Guard the index-only fast path: storage's index lookup only DMG_ASSERTs the index exists
+            // (a no-op in Release), so without a ready index it would be UB. Fail cleanly instead.
+            if (!impl->LabelPropertyIndexReady(label, properties)) {
+              throw std::logic_error{
+                  "label-property index range scan requires a ready index over the given label and property"};
+            }
+            return impl->Vertices(graph->view, label, properties, property_ranges);
+          },
+          [](memgraph::query::SubgraphDbAccessor *) -> memgraph::query::VerticesIterable {
+            throw std::logic_error{"label-property index range scan is not supported on a projected subgraph"};
+          },
+          [](memgraph::query::VirtualGraphDbAccessor *) -> memgraph::query::VerticesIterable {
+            throw ImmutableObjectException{"label-property index range scan is not supported on a virtual graph"};
+          }},
+      graph->impl);
+  auto &rc = cursor.emplace<RealCursor>(std::move(vertices));
+#ifdef MG_ENTERPRISE
+  if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
+    NextPermitted(rc, *graph);
+  }
+#endif
+  if (rc.it != rc.vertices.end()) {
+    current_v.emplace(*rc.it, graph, alloc);
+  }
+}
+
 void mgp_vertices_iterator_destroy(mgp_vertices_iterator *it) { DeleteRawMgpObject(it); }
 
 mgp_error mgp_graph_iter_vertices(mgp_graph *graph, mgp_memory *memory, mgp_vertices_iterator **result) {
   return WrapExceptions([graph, memory] { return NewRawMgpObject<mgp_vertices_iterator>(memory, graph); }, result);
+}
+
+mgp_error mgp_label_property_range_make(mgp_memory *memory, mgp_label_property_range **result) {
+  return WrapExceptions([memory] { return NewRawMgpObject<mgp_label_property_range>(memory); }, result);
+}
+
+void mgp_label_property_range_destroy(mgp_label_property_range *range) { DeleteRawMgpObject(range); }
+
+mgp_error mgp_label_property_range_add_property(mgp_label_property_range *range, const char *property, mgp_value *lower,
+                                                mgp_bound_type lower_type, mgp_value *upper,
+                                                mgp_bound_type upper_type) {
+  return WrapExceptions([range, property, lower, lower_type, upper, upper_type] {
+    const auto to_bound =
+        [](mgp_value *value,
+           mgp_bound_type type) -> std::optional<memgraph::utils::Bound<memgraph::storage::PropertyValue>> {
+      if (value == nullptr) return std::nullopt;  // unbounded on this side
+      switch (value->type) {
+        case MGP_VALUE_TYPE_LIST:
+        case MGP_VALUE_TYPE_MAP:
+        case MGP_VALUE_TYPE_VERTEX:
+        case MGP_VALUE_TYPE_EDGE:
+        case MGP_VALUE_TYPE_PATH:
+          throw std::logic_error{"a label-property range bound must be a scalar value"};
+        default:
+          break;
+      }
+      // Scalars/temporals never dereference the name mapper, so nullptr is safe here.
+      auto property_value = ToPropertyValue(*value, nullptr);
+      return type == mgp_bound_type::MGP_BOUND_TYPE_INCLUSIVE
+                 ? memgraph::utils::MakeBoundInclusive(std::move(property_value))
+                 : memgraph::utils::MakeBoundExclusive(std::move(property_value));
+    };
+    auto lower_bound = to_bound(lower, lower_type);
+    auto upper_bound = to_bound(upper, upper_type);
+    range->properties.emplace_back(property);
+    range->ranges.push_back(
+        memgraph::storage::PropertyValueRange::Bounded(std::move(lower_bound), std::move(upper_bound)));
+  });
+}
+
+mgp_error mgp_graph_vertices_by_label_property_range(mgp_graph *graph, const char *label,
+                                                     mgp_label_property_range *range, mgp_memory *memory,
+                                                     mgp_vertices_iterator **result) {
+  return WrapExceptions(
+      [graph, label, range, memory]() -> mgp_vertices_iterator * {
+        // The ABI accepts a composite spec (several properties), but the index range scan currently
+        // supports only a single-property index; composite is a separate follow-up.
+        if (range->properties.size() != 1) {
+          throw std::logic_error{range->properties.empty()
+                                     ? "label-property range requires at least one property"
+                                     : "composite label-property range lookup is not yet supported"};
+        }
+        const auto label_id = std::visit([label](auto *impl) { return impl->NameToLabel(label); }, graph->impl);
+        const auto property_id =
+            std::visit([range](auto *impl) { return impl->NameToProperty(range->properties.front()); }, graph->impl);
+        std::array<memgraph::storage::PropertyPath, 1> properties{memgraph::storage::PropertyPath{property_id}};
+        return NewRawMgpObject<mgp_vertices_iterator>(
+            memory,
+            graph,
+            label_id,
+            std::span<memgraph::storage::PropertyPath const>{properties},
+            std::span<memgraph::storage::PropertyValueRange const>{range->ranges});
+      },
+      result);
 }
 
 mgp_error mgp_graph_approximate_vertex_count(mgp_graph *graph, size_t *result) {

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -1029,12 +1029,33 @@ struct mgp_vertices_iterator {
   /// @throw anything VerticesIterable may throw
   mgp_vertices_iterator(mgp_graph *graph, allocator_type alloc);
 
+  /// Iterate a label-property index range. Enforces label-level READ auth like the plain iterator;
+  /// property-level filtering is the caller's concern (consistent with mgp_graph_iter_vertices).
+  /// @throw anything VerticesIterable may throw
+  mgp_vertices_iterator(mgp_graph *graph, memgraph::storage::LabelId label,
+                        std::span<memgraph::storage::PropertyPath const> properties,
+                        std::span<memgraph::storage::PropertyValueRange const> property_ranges, allocator_type alloc);
+
   memgraph::utils::MemoryResource *GetMemoryResource() const { return alloc.resource(); }
 
   allocator_type alloc;
   mgp_graph *graph;
   Cursor cursor;
   std::optional<mgp_vertex> current_v;
+};
+
+struct mgp_label_property_range {
+  using allocator_type = memgraph::utils::Allocator<mgp_label_property_range>;
+
+  explicit mgp_label_property_range(allocator_type alloc) : properties(alloc), ranges(alloc), alloc(alloc) {}
+
+  memgraph::utils::MemoryResource *GetMemoryResource() const { return alloc.resource(); }
+
+  // Parallel vectors: properties[i] is bounded by ranges[i]. One entry ⇒ single-property index;
+  // several ⇒ composite index over the properties in insertion order.
+  memgraph::utils::pmr::vector<memgraph::utils::pmr::string> properties;
+  memgraph::utils::pmr::vector<memgraph::storage::PropertyValueRange> ranges;
+  allocator_type alloc;
 };
 
 struct mgp_type {

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -9,6 +9,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <set>
+
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
@@ -1181,6 +1183,97 @@ TYPED_TEST(CppApiTestFixture, TestLabelPropertyIndex) {
     mgp_graph raw_graph = this->CreateGraph(db_acc.get());
     ASSERT_FALSE(mgp::DropLabelPropertyIndex(&raw_graph, "User", "nonexistent"));
     ASSERT_TRUE(db_acc->Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
+TYPED_TEST(CppApiTestFixture, TestHasLabelPropertyIndex) {
+  // No index exists yet.
+  {
+    auto storage_acc = this->storage->Access(AccessorType::WRITE);
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    auto graph = mgp::Graph(&raw_graph);
+    ASSERT_FALSE(graph.HasLabelPropertyIndex("User", "name"));
+  }
+  // Create a label-property index on (User, name).
+  {
+    auto storage_acc = this->CreateIndexAccessor();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "User", "name"));
+    ASSERT_TRUE(db_acc->Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // Reported present only for the exact (label, property) that was indexed.
+  {
+    auto storage_acc = this->storage->Access(AccessorType::WRITE);
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    auto graph = mgp::Graph(&raw_graph);
+    ASSERT_TRUE(graph.HasLabelPropertyIndex("User", "name"));
+    ASSERT_FALSE(graph.HasLabelPropertyIndex("User", "age"));
+    ASSERT_FALSE(graph.HasLabelPropertyIndex("Company", "name"));
+  }
+}
+
+TYPED_TEST(CppApiTestFixture, TestNodesByLabelPropertyRange) {
+  if constexpr (!std::is_same<TypeParam, memgraph::storage::InMemoryStorage>::value) {
+    GTEST_SKIP() << "TestNodesByLabelPropertyRange runs only on InMemoryStorage.";
+  }
+  // Index on (User, name).
+  {
+    auto storage_acc = this->CreateIndexAccessor();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "User", "name"));
+    ASSERT_TRUE(db_acc->Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // Data: four indexed users, one User without the property, one non-User carrying the property.
+  {
+    auto storage_acc = this->storage->Access(AccessorType::WRITE);
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    auto graph = mgp::Graph(&raw_graph);
+    for (const auto *name : {"alice", "bob", "carol", "dave"}) {
+      auto node = graph.CreateNode();
+      node.AddLabel("User");
+      node.SetProperty("name", mgp::Value(name));
+    }
+    auto without_property = graph.CreateNode();
+    without_property.AddLabel("User");
+    auto wrong_label = graph.CreateNode();
+    wrong_label.SetProperty("name", mgp::Value("alice"));
+    ASSERT_TRUE(db_acc->Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // Collect the `name`s returned by a range scan.
+  auto names_in_range =
+      [this](const mgp::Value *lower, bool lower_inclusive, const mgp::Value *upper, bool upper_inclusive) {
+        auto storage_acc = this->storage->Access(AccessorType::WRITE);
+        auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+        mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+        auto graph = mgp::Graph(&raw_graph);
+        std::set<std::string> names;
+        for (const auto node :
+             graph.NodesByLabelPropertyRange("User", "name", lower, lower_inclusive, upper, upper_inclusive)) {
+          names.insert(std::string(node.GetProperty("name").ValueString()));
+        }
+        return names;
+      };
+
+  {  // exact match [bob, bob]
+    mgp::Value bob{"bob"};
+    EXPECT_EQ(names_in_range(&bob, true, &bob, true), (std::set<std::string>{"bob"}));
+  }
+  {  // half-open [b, d): bob, carol
+    mgp::Value lower{"b"}, upper{"d"};
+    EXPECT_EQ(names_in_range(&lower, true, &upper, false), (std::set<std::string>{"bob", "carol"}));
+  }
+  {  // unbounded lower, exclusive upper (-inf, bob): alice
+    mgp::Value upper{"bob"};
+    EXPECT_EQ(names_in_range(nullptr, false, &upper, false), (std::set<std::string>{"alice"}));
+  }
+  {  // inclusive lower, unbounded upper [carol, +inf): carol, dave
+    mgp::Value lower{"carol"};
+    EXPECT_EQ(names_in_range(&lower, true, nullptr, false), (std::set<std::string>{"carol", "dave"}));
   }
 }
 


### PR DESCRIPTION
Add a procedure-facing mgp C API to look up vertices through a label-property index by a typed range, plus an existence check for such an index.

**What**
- `mgp_label_property_range` (`make` / `add_property` / `destroy`) — an opaque, typed range spec.
- `mgp_graph_vertices_by_label_property_range` — iterate vertices of a label through a label-property index within the range.
- `mgp_graph_has_label_property_index` — check whether such an index exists.
- Matching `mgp.hpp` C++ wrappers: `Graph::HasLabelPropertyIndex`, `Graph::NodesByLabelPropertyRange`.

**How**
Bounds are typed `PropertyValue`s tagged inclusive / exclusive / unbounded, so equality, open and closed ranges, and prefix lookups are all expressed through one call. The scan is index-only (no internal fallback) and enforces label-level read permissions through the standard permitted-vertex iterator; the glue routes to the `DbAccessor::Vertices` range overload.

**Why**
mgp modules could previously query only text and vector indices, not label-property indices. This exposes label-property index range lookups to modules as a general kernel primitive. There is no in-tree consumer in this PR — it stands as a reusable capability for query-module authors.

Covered by `cpp_api` unit tests for both the existence check (in-memory and on-disk) and the range scan (in-memory).