### PR TITLE
perf(storage): GC takes main_lock_ in READ instead of WRITE (transactional)

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2929,50 +2929,36 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
 }
 
 void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_guard, bool periodic) {
-  // NOTE: You do not need to consider cleanup of deleted object that occurred in
-  // different storage modes within the same CollectGarbage call. This is because
-  // SetStorageMode will ensure CollectGarbage is called before any new transactions
-  // with the new storage mode can start.
+  // NOTE: A single call need not handle objects deleted under a different storage mode: SetStorageMode
+  // runs GC before any transaction in the new mode can start.
 
-  // SetStorageMode will pass its unique_lock of main_lock_. We will use that lock,
-  // as reacquiring the lock would cause deadlock. Otherwise, we need to get our own
-  // lock.
-  // GC only reads the indices/constraints (each independently synchronized + COW), so in
-  // transactional mode it takes main_lock_ in READ, compatible with a concurrent READ_ONLY
-  // index/constraint DDL registration -- neither has to wait out the other. Analytical keeps a
-  // WRITE-mode shared hold (its snapshot/constraint vs GC interaction is not proven safe under
-  // READ). We take READ optimistically, then read storage_mode_ *under the hold* and swap to WRITE
-  // if analytical: SetStorageMode needs UNIQUE, so it cannot flip the mode while we hold any shared
-  // lock -- reading the mode only under the lock avoids both a data race on the non-atomic
-  // storage_mode_ and a stale read that could run analytical GC under READ. gc_read_shared then
-  // reflects the mode we actually hold, so lock and unlock always use the same LockReq.
-  bool gc_read_shared = false;
-  if (!main_guard.owns_lock()) {
-    // Aggressive mode escalates to a unique lock (blocks all new txns); otherwise take the shared
-    // hold, since GC can be slow and should not block everyone unless explicitly asked to.
-    if (!flags::run_time::GetStorageGcAggressive() || !main_guard.try_lock()) {
-      main_lock_.lock_shared<utils::ResourceLock::LockReq::READ>();
-      gc_read_shared = true;
-      if (storage_mode_ != StorageMode::IN_MEMORY_TRANSACTIONAL) {
-        // Analytical: re-take in WRITE. Mode is stable here (a shared hold blocks SetStorageMode).
-        main_lock_.unlock_shared<utils::ResourceLock::LockReq::READ>();
-        main_lock_.lock_shared();  // WRITE
-        gc_read_shared = false;
-      }
-    }
-  } else {
-    DMG_ASSERT(main_guard.mutex() == std::addressof(main_lock_), "main_guard should be only for the main_lock_");
-  }
-
-  utils::OnScopeExit lock_releaser{[&] {
+  using Guard = utils::ResourceLockGuard;
+  auto const main_lock_guard = [&] -> Guard {
+    // Adopt SetStorageMode's UNIQUE hold if it passed one; reacquiring would deadlock.
     if (main_guard.owns_lock()) {
-      main_guard.unlock();
-    } else if (gc_read_shared) {
-      main_lock_.unlock_shared<utils::ResourceLock::LockReq::READ>();
-    } else {
-      main_lock_.unlock_shared();  // WRITE (analytical)
+      DMG_ASSERT(main_guard.mutex() == std::addressof(main_lock_), "main_guard should be only for the main_lock_");
+      return Guard{std::move(main_guard)};
     }
-  }};
+
+    // Aggressive GC escalates to UNIQUE (blocks new txns); otherwise a shared hold, so slow GC does
+    // not block everyone.
+    if (flags::run_time::GetStorageGcAggressive()) {
+      auto unique_guard = Guard{main_lock_, Guard::UNIQUE, std::try_to_lock};
+      if (unique_guard.owns_lock()) return unique_guard;
+    }
+
+    // Transactional GC only reads the COW indices/constraints, so READ suffices and stays compatible
+    // with concurrent READ_ONLY DDL; analytical needs WRITE (GC vs snapshot not proven safe under
+    // READ). storage_mode_ must be read under a shared hold -- it blocks SetStorageMode's UNIQUE, so
+    // an unlocked read would both data-race the write (TSan) and risk acting on a stale mode (TOCTOU).
+    auto read_guard = Guard{main_lock_, Guard::READ};
+    if (storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) return read_guard;
+
+    // Analytical: acquire WRITE before read_guard releases READ at scope exit, so the mode stays
+    // pinned across a continuous hold (one thread may hold READ+WRITE: lock_guard_condition<WRITE>
+    // checks only ro_count/ro_pending).
+    return Guard{main_lock_, Guard::WRITE};
+  }();
 
   // Only one gc run at a time
   auto gc_guard = std::unique_lock{gc_lock_, std::try_to_lock};
@@ -2981,7 +2967,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   }
 
   // Publish run-state for SHOW TRANSACTIONS; cleared on scope exit (see GcProgress).
-  gc_progress_.Start(periodic, main_guard.owns_lock());
+  gc_progress_.Start(periodic, main_lock_guard.is_exclusive());
   const utils::OnScopeExit gc_run_state_reset{[&] { gc_progress_.Reset(); }};
 
   // Diagnostic trace
@@ -3096,7 +3082,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     // Deltas from previous GC runs or from aborts can be cleaned up here
     garbage_undo_buffers_.WithLock([&](auto &garbage_undo_buffers) {
       guard.unlock();
-      if (main_guard.owns_lock() || mark_timestamp == oldest_active_start_timestamp) {
+      if (main_lock_guard.is_exclusive() || mark_timestamp == oldest_active_start_timestamp) {
         // We know no transaction is active, it is safe to simply delete all the garbage undos
         // Nothing can be reading them
         garbage_undo_buffers.clear();
@@ -3350,7 +3336,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     auto guard = std::unique_lock{engine_lock_};
     uint64_t mark_timestamp = timestamp_;  // a timestamp no active transaction can currently have
 
-    if (main_guard.owns_lock() || mark_timestamp == oldest_active_start_timestamp) {
+    if (main_lock_guard.is_exclusive() || mark_timestamp == oldest_active_start_timestamp) {
       guard.unlock();
       // if lucky, there are no active transactions, hence nothing looking at the deltas
       // remove them all now

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2937,15 +2937,22 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // SetStorageMode will pass its unique_lock of main_lock_. We will use that lock,
   // as reacquiring the lock would cause deadlock. Otherwise, we need to get our own
   // lock.
+  // GC only reads the indices/constraints (each independently synchronized + COW), so in
+  // transactional mode it takes main_lock_ in READ, compatible with a concurrent READ_ONLY
+  // index/constraint DDL registration -- neither has to wait out the other. Analytical keeps the
+  // WRITE-mode shared hold (its snapshot/constraint vs GC interaction is not proven safe under
+  // READ). Captured once so lock and unlock use the same LockReq; SetStorageMode (UNIQUE) cannot
+  // flip the mode while we hold the shared lock.
+  const bool gc_read_shared = storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL;
   if (!main_guard.owns_lock()) {
-    // If aggressive mode is enabled, try to get unique lock first.
-    // Perf note: Do not try to get unique lock if aggressive mode is disabled. GC maybe expensive,
-    // do not assume it is fast, unique lock will blocks all new storage transactions.
+    // Aggressive mode escalates to a unique lock (blocks all new txns); otherwise take the shared
+    // hold, since GC can be slow and should not block everyone unless explicitly asked to.
     if (!flags::run_time::GetStorageGcAggressive() || !main_guard.try_lock()) {
-      // Because the garbage collector iterates through the indices and constraints
-      // to clean them up, it must take the main lock for reading to make sure that
-      // the indices and constraints aren't concurrently being modified.
-      main_lock_.lock_shared();
+      if (gc_read_shared) {
+        main_lock_.lock_shared<utils::ResourceLock::LockReq::READ>();
+      } else {
+        main_lock_.lock_shared();  // WRITE (analytical)
+      }
     }
   } else {
     DMG_ASSERT(main_guard.mutex() == std::addressof(main_lock_), "main_guard should be only for the main_lock_");
@@ -2954,8 +2961,10 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   utils::OnScopeExit lock_releaser{[&] {
     if (main_guard.owns_lock()) {
       main_guard.unlock();
+    } else if (gc_read_shared) {
+      main_lock_.unlock_shared<utils::ResourceLock::LockReq::READ>();
     } else {
-      main_lock_.unlock_shared();
+      main_lock_.unlock_shared();  // WRITE (analytical)
     }
   }};
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2939,19 +2939,25 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // lock.
   // GC only reads the indices/constraints (each independently synchronized + COW), so in
   // transactional mode it takes main_lock_ in READ, compatible with a concurrent READ_ONLY
-  // index/constraint DDL registration -- neither has to wait out the other. Analytical keeps the
+  // index/constraint DDL registration -- neither has to wait out the other. Analytical keeps a
   // WRITE-mode shared hold (its snapshot/constraint vs GC interaction is not proven safe under
-  // READ). Captured once so lock and unlock use the same LockReq; SetStorageMode (UNIQUE) cannot
-  // flip the mode while we hold the shared lock.
-  const bool gc_read_shared = storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL;
+  // READ). We take READ optimistically, then read storage_mode_ *under the hold* and swap to WRITE
+  // if analytical: SetStorageMode needs UNIQUE, so it cannot flip the mode while we hold any shared
+  // lock -- reading the mode only under the lock avoids both a data race on the non-atomic
+  // storage_mode_ and a stale read that could run analytical GC under READ. gc_read_shared then
+  // reflects the mode we actually hold, so lock and unlock always use the same LockReq.
+  bool gc_read_shared = false;
   if (!main_guard.owns_lock()) {
     // Aggressive mode escalates to a unique lock (blocks all new txns); otherwise take the shared
     // hold, since GC can be slow and should not block everyone unless explicitly asked to.
     if (!flags::run_time::GetStorageGcAggressive() || !main_guard.try_lock()) {
-      if (gc_read_shared) {
-        main_lock_.lock_shared<utils::ResourceLock::LockReq::READ>();
-      } else {
-        main_lock_.lock_shared();  // WRITE (analytical)
+      main_lock_.lock_shared<utils::ResourceLock::LockReq::READ>();
+      gc_read_shared = true;
+      if (storage_mode_ != StorageMode::IN_MEMORY_TRANSACTIONAL) {
+        // Analytical: re-take in WRITE. Mode is stable here (a shared hold blocks SetStorageMode).
+        main_lock_.unlock_shared<utils::ResourceLock::LockReq::READ>();
+        main_lock_.lock_shared();  // WRITE
+        gc_read_shared = false;
       }
     }
   } else {

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -325,4 +325,168 @@ struct SharedResourceLockGuard {
   bool locked_{false};
 };
 
+// RAII guard over ResourceLock spanning every hold kind: the exclusive UNIQUE hold and the three
+// shared modes. The mode is a runtime tag rather than a std::variant<> because every alternative
+// shares the same payload (a ResourceLock*) -- there is no per-alternative state, so a tag + switch
+// is the whole of it. Move-only; releases in the correct mode on scope exit.
+struct ResourceLockGuard {
+ public:
+  enum Type : std::uint8_t { UNIQUE, WRITE, READ, READ_ONLY };
+
+  ResourceLockGuard(ResourceLock &l, Type type) : ptr_{&l}, type_{type} { lock(); }
+
+  ResourceLockGuard(ResourceLock &l, Type type, std::defer_lock_t /*tag*/) : ptr_{&l}, type_{type} {}
+
+  ResourceLockGuard(ResourceLock &l, Type type, std::try_to_lock_t /*tag*/) : ptr_{&l}, type_{type} { try_lock(); }
+
+  // Adopt a hold the caller already owns in `type` (e.g. SetStorageMode handing its UNIQUE hold to
+  // CollectGarbage, where reacquiring would deadlock). Mirrors std::adopt_lock: no acquisition, but
+  // the guard now owns the release.
+  ResourceLockGuard(ResourceLock &l, Type type, std::adopt_lock_t /*tag*/) : ptr_{&l}, type_{type}, locked_{true} {}
+
+  // Take over a std::unique_lock's exclusive hold: a UNIQUE-mode guard that adopts the hold if `lock`
+  // owns it, or is left unlocked (but bound to the same ResourceLock) otherwise. `lock` is
+  // disassociated from its mutex either way, so ownership is never duplicated.
+  explicit ResourceLockGuard(std::unique_lock<ResourceLock> &&lock)
+      : ptr_{lock.mutex()}, type_{UNIQUE}, locked_{lock.owns_lock()} {
+    lock.release();
+  }
+
+  ~ResourceLockGuard() { unlock(); }
+
+  ResourceLockGuard(const ResourceLockGuard &) = delete;
+  ResourceLockGuard &operator=(const ResourceLockGuard &) = delete;
+
+  ResourceLockGuard(ResourceLockGuard &&other) noexcept
+      : ptr_{std::exchange(other.ptr_, nullptr)}, type_{other.type_}, locked_{std::exchange(other.locked_, false)} {}
+
+  ResourceLockGuard &operator=(ResourceLockGuard &&other) noexcept {
+    if (this != &other) {
+      // First unlock if guard is protecting a resource
+      if (owns_lock()) unlock();
+      // Then move
+      ptr_ = std::exchange(other.ptr_, nullptr);
+      type_ = other.type_;
+      locked_ = std::exchange(other.locked_, false);
+    }
+    return *this;
+  }
+
+  void lock() {
+    if (ptr_ && !locked_) {
+      switch (type_) {
+        case UNIQUE:
+          ptr_->lock();
+          break;
+        case WRITE:
+          ptr_->lock_shared<ResourceLock::LockReq::WRITE>();
+          break;
+        case READ:
+          ptr_->lock_shared<ResourceLock::LockReq::READ>();
+          break;
+        case READ_ONLY:
+          ptr_->lock_shared<ResourceLock::LockReq::READ_ONLY>();
+          break;
+      }
+      locked_ = true;
+    }
+  }
+
+  bool try_lock() {
+    if (ptr_ && !locked_) {
+      switch (type_) {
+        case UNIQUE:
+          locked_ = ptr_->try_lock();
+          break;
+        case WRITE:
+          locked_ = ptr_->try_lock_shared<ResourceLock::LockReq::WRITE>();
+          break;
+        case READ:
+          locked_ = ptr_->try_lock_shared<ResourceLock::LockReq::READ>();
+          break;
+        case READ_ONLY:
+          locked_ = ptr_->try_lock_shared<ResourceLock::LockReq::READ_ONLY>();
+          break;
+      }
+    }
+    return locked_;
+  }
+
+  template <typename Rep, typename Period>
+  bool try_lock_for(std::chrono::duration<Rep, Period> const &time) {
+    if (ptr_ && !locked_) {
+      switch (type_) {
+        case UNIQUE:
+          locked_ = ptr_->try_lock_for(time);
+          break;
+        case WRITE:
+          locked_ = ptr_->try_lock_shared_for<Rep, Period, ResourceLock::LockReq::WRITE>(time);
+          break;
+        case READ:
+          locked_ = ptr_->try_lock_shared_for<Rep, Period, ResourceLock::LockReq::READ>(time);
+          break;
+        case READ_ONLY:
+          locked_ = ptr_->try_lock_shared_for<Rep, Period, ResourceLock::LockReq::READ_ONLY>(time);
+          break;
+      }
+    }
+    return locked_;
+  }
+
+  void unlock() {
+    if (ptr_ && locked_) {
+      switch (type_) {
+        case UNIQUE:
+          ptr_->unlock();
+          break;
+        case WRITE:
+          ptr_->unlock_shared<ResourceLock::LockReq::WRITE>();
+          break;
+        case READ:
+          ptr_->unlock_shared<ResourceLock::LockReq::READ>();
+          break;
+        case READ_ONLY:
+          ptr_->unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+          break;
+      }
+      locked_ = false;
+    }
+  }
+
+  // Demote a held WRITE/READ_ONLY shared hold to READ. Not valid from UNIQUE (downgrade_to_read only
+  // transitions the SHARED state); a UNIQUE guard cannot be downgraded and reports false.
+  bool downgrade_to_read() {
+    if (ptr_ && locked_) {
+      switch (type_) {
+        case UNIQUE:
+          return false;
+        case READ:
+          return true;  // can't downgrade from read to read
+        case WRITE: {
+          auto res = ptr_->downgrade_to_read<ResourceLock::LockReq::WRITE>();
+          if (res) type_ = READ;
+          return res;
+        }
+        case READ_ONLY: {
+          auto res = ptr_->downgrade_to_read<ResourceLock::LockReq::READ_ONLY>();
+          if (res) type_ = READ;
+          return res;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool is_exclusive() const { return type_ == UNIQUE; }
+
+  bool owns_lock() const { return ptr_ && locked_; }
+
+  Type type() const { return type_; }
+
+ private:
+  ResourceLock *ptr_;
+  Type type_;
+  bool locked_{false};
+};
+
 }  // namespace memgraph::utils

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -258,4 +258,166 @@ TEST_F(ResourceLockTest, ReadOnlyLockTryForWillNotifyWaitingWriterUponFailure) {
     auto reader_result = ro_outcome.get();
     ASSERT_TRUE(reader_result);
   }
+}
+
+TEST_F(ResourceLockTest, GuardUniqueIsExclusive) {
+  {
+    auto guard = ResourceLockGuard(lock, ResourceLockGuard::UNIQUE);
+    ASSERT_TRUE(guard.owns_lock());
+    ASSERT_TRUE(guard.is_exclusive());
+    // UNIQUE hold blocks any other acquisition.
+    ASSERT_FALSE(lock.try_lock());
+    ASSERT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ>());
+  }
+  // Released on scope exit in UNIQUE mode.
+  ASSERT_TRUE(lock.try_lock());
+  lock.unlock();
+}
+
+TEST_F(ResourceLockTest, GuardSharedIsNotExclusive) {
+  auto guard = ResourceLockGuard(lock, ResourceLockGuard::READ);
+  ASSERT_TRUE(guard.owns_lock());
+  ASSERT_FALSE(guard.is_exclusive());
+  // A shared READ hold does not block another READ.
+  ASSERT_TRUE(lock.try_lock_shared<ResourceLock::LockReq::READ>());
+  lock.unlock_shared<ResourceLock::LockReq::READ>();
+}
+
+TEST_F(ResourceLockTest, GuardAdoptsPreLockedUnique) {
+  // Caller acquires UNIQUE directly, then hands ownership to the guard.
+  lock.lock();
+  {
+    auto guard = ResourceLockGuard(lock, ResourceLockGuard::UNIQUE, std::adopt_lock);
+    ASSERT_TRUE(guard.owns_lock());
+    ASSERT_TRUE(guard.is_exclusive());
+  }
+  // The guard released the adopted hold; the lock is free again.
+  ASSERT_TRUE(lock.try_lock());
+  lock.unlock();
+}
+
+TEST_F(ResourceLockTest, GuardMoveAssignSwapsReadToWriteKeepingHold) {
+  // Move-assigning a WRITE guard over a held READ guard keeps a continuous hold: WRITE is acquired
+  // before the READ hold is released.
+  auto guard = ResourceLockGuard(lock, ResourceLockGuard::READ);
+  ASSERT_EQ(guard.type(), ResourceLockGuard::READ);
+
+  guard = ResourceLockGuard(lock, ResourceLockGuard::WRITE);
+  ASSERT_TRUE(guard.owns_lock());
+  ASSERT_EQ(guard.type(), ResourceLockGuard::WRITE);
+
+  // The shared hold was never fully dropped, so UNIQUE cannot be acquired while it is held.
+  ASSERT_FALSE(lock.try_lock());
+
+  guard.unlock();
+  // Both the READ and WRITE holds are gone; the lock is fully free.
+  ASSERT_TRUE(lock.try_lock());
+  lock.unlock();
+}
+
+TEST_F(ResourceLockTest, GuardFromOwningUniqueLockAdopts) {
+  {
+    auto ul = std::unique_lock{lock};  // acquires UNIQUE
+    auto guard = ResourceLockGuard{std::move(ul)};
+    ASSERT_TRUE(guard.owns_lock());
+    ASSERT_TRUE(guard.is_exclusive());
+    ASSERT_FALSE(ul.owns_lock());  // ownership transferred, no double-unlock on ul's dtor
+  }
+  ASSERT_TRUE(lock.try_lock());
+  lock.unlock();
+}
+
+TEST_F(ResourceLockTest, GuardFromDeferredUniqueLockIsUnlockedUnique) {
+  auto ul = std::unique_lock{lock, std::defer_lock};
+  auto guard = ResourceLockGuard{std::move(ul)};
+  ASSERT_FALSE(guard.owns_lock());
+  ASSERT_TRUE(guard.is_exclusive());  // typed UNIQUE, ready to escalate
+  ASSERT_TRUE(guard.try_lock());
+  ASSERT_TRUE(guard.owns_lock());
+}
+
+TEST_F(ResourceLockTest, GuardMoveConstructTransfersOwnershipNoDoubleRelease) {
+  auto original = ResourceLockGuard{lock, ResourceLockGuard::WRITE};
+  ASSERT_TRUE(original.owns_lock());
+  {
+    auto moved = std::move(original);
+    ASSERT_TRUE(moved.owns_lock());
+    ASSERT_EQ(moved.type(), ResourceLockGuard::WRITE);
+    ASSERT_FALSE(original.owns_lock());  // source disowned by the move
+  }
+  // `moved` released WRITE on scope exit; the moved-from `original` must not double-release.
+  ASSERT_TRUE(lock.try_lock());
+  lock.unlock();
+}
+
+TEST_F(ResourceLockTest, GuardTryLockUniqueFailsWhenHeld) {
+  auto held = ResourceLockGuard(lock, ResourceLockGuard::READ);
+
+  auto guard = ResourceLockGuard(lock, ResourceLockGuard::UNIQUE, std::try_to_lock);
+  ASSERT_FALSE(guard.owns_lock());
+
+  held.unlock();
+  ASSERT_TRUE(guard.try_lock());
+  ASSERT_TRUE(guard.is_exclusive());
+}
+
+TEST_F(ResourceLockTest, GuardDowngradeFromUniqueIsRejected) {
+  auto guard = ResourceLockGuard{lock, ResourceLockGuard::UNIQUE};
+  // A UNIQUE hold cannot be downgraded (downgrade_to_read only transitions the SHARED state).
+  ASSERT_FALSE(guard.downgrade_to_read());
+  ASSERT_TRUE(guard.is_exclusive());  // still UNIQUE, hold intact
+  ASSERT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ>());
+}
+
+TEST_F(ResourceLockTest, GuardDowngradeWriteToReadReleasesWriteExclusivity) {
+  auto guard = ResourceLockGuard{lock, ResourceLockGuard::WRITE};
+  // WRITE blocks a READ_ONLY acquirer (READ_ONLY needs w_count == 0).
+  ASSERT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::READ_ONLY>());
+
+  ASSERT_TRUE(guard.downgrade_to_read());
+  ASSERT_EQ(guard.type(), ResourceLockGuard::READ);
+
+  // Now a READ_ONLY acquirer can proceed.
+  ASSERT_TRUE(lock.try_lock_shared<ResourceLock::LockReq::READ_ONLY>());
+  lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+}
+
+TEST_F(ResourceLockTest, GuardDowngradeReadOnlyToReadReleasesReadOnlyExclusivity) {
+  auto guard = ResourceLockGuard{lock, ResourceLockGuard::READ_ONLY};
+  // READ_ONLY blocks a WRITE acquirer (WRITE needs ro_count == 0).
+  ASSERT_FALSE(lock.try_lock_shared<ResourceLock::LockReq::WRITE>());
+
+  ASSERT_TRUE(guard.downgrade_to_read());
+  ASSERT_EQ(guard.type(), ResourceLockGuard::READ);
+
+  // Now a WRITE acquirer can proceed.
+  ASSERT_TRUE(lock.try_lock_shared<ResourceLock::LockReq::WRITE>());
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+}
+
+TEST_F(ResourceLockTest, GuardDeferredThenExplicitLock) {
+  auto guard = ResourceLockGuard{lock, ResourceLockGuard::WRITE, std::defer_lock};
+  ASSERT_FALSE(guard.owns_lock());
+  guard.lock();
+  ASSERT_TRUE(guard.owns_lock());
+  ASSERT_EQ(guard.type(), ResourceLockGuard::WRITE);
+}
+
+TEST_F(ResourceLockTest, GuardTryLockForUniqueAcquiresWhenFree) {
+  using namespace std::chrono_literals;
+  auto guard = ResourceLockGuard{lock, ResourceLockGuard::UNIQUE, std::defer_lock};
+  ASSERT_TRUE(guard.try_lock_for(50ms));
+  ASSERT_TRUE(guard.owns_lock());
+  ASSERT_TRUE(guard.is_exclusive());
+}
+
+TEST_F(ResourceLockTest, GuardTryLockForUniqueTimesOutWhenHeld) {
+  using namespace std::chrono_literals;
+  auto held = ResourceLockGuard{lock, ResourceLockGuard::READ};  // a shared hold blocks UNIQUE
+  auto guard = ResourceLockGuard{lock, ResourceLockGuard::UNIQUE, std::defer_lock};
+
+  auto const start = std::chrono::steady_clock::now();
+  ASSERT_FALSE(guard.try_lock_for(10ms));
+  ASSERT_GE(std::chrono::steady_clock::now() - start, 10ms);
+  ASSERT_FALSE(guard.owns_lock());
 }


### PR DESCRIPTION
In `IN_MEMORY_TRANSACTIONAL` mode, `InMemoryStorage::CollectGarbage` now takes `main_lock_` in **READ** instead of **WRITE**. Analytical mode is unchanged (it keeps the WRITE-mode shared hold).

## Why

GC's shared hold defaulted to WRITE, which is mutually exclusive with READ_ONLY. `CREATE INDEX` / `CREATE CONSTRAINT` take READ_ONLY, so a running GC blocked that DDL, and a *pending* READ_ONLY request stalled a fresh GC acquisition (the `ro_pending_count` gate). GC only *reads* the indices and constraints (each independently synchronized and copy-on-write), so READ suffices, and READ is compatible with READ_ONLY: GC and index/constraint DDL no longer wait on each other. This addresses the GC-correlated latency stalls seen under index-heavy workloads.

## Correctness

The storage mode selects the lock mode, so GC must read it without racing a concurrent `SetStorageMode`. The mode is now read only while holding a shared lock: GC takes READ optimistically, reads `storage_mode_` under that hold, and swaps to WRITE if the mode is analytical. Because any shared hold blocks `SetStorageMode`'s UNIQUE acquisition, the mode cannot change while GC holds the lock, so the value GC reads stays valid for the whole pass.

Reading the mode *before* acquiring the lock was wrong in two ways. First, the non-atomic `storage_mode_` was read with no lock held while `SetStorageMode` could be writing it under UNIQUE: a data race (undefined behavior, and flagged by ThreadSanitizer). Second, even setting the race aside, the mode could change between the check and the acquire (a time-of-check to time-of-use gap): GC could read TRANSACTIONAL, decide on READ, and by the time it acquired the lock the store had flipped to analytical, running analytical GC under a READ hold. Reading under the hold closes both.

## Refactor

The lock-mode handling is consolidated behind a new `utils::ResourceLockGuard`: a move-only RAII guard whose runtime mode tag spans UNIQUE plus the three shared modes. It replaces the hand-rolled `OnScopeExit` release in `CollectGarbage`, so one guard always releases in whatever mode it holds. Unit tests cover its constructors, move semantics, `downgrade_to_read`, and `try_lock_for`.
