### PR TITLE
fix(storage): pin object stores during index-cleanup GC to prevent edge-index use-after-free

### DIFF
--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -27,19 +27,22 @@
 
 namespace memgraph::storage {
 
-void Indices::RemoveObsoleteVertexEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) const {
-  static_cast<InMemoryLabelIndex *>(label_index_.get())->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
+void Indices::RemoveObsoleteVertexEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
+                                          std::stop_token token) const {
+  static_cast<InMemoryLabelIndex *>(label_index_.get())
+      ->RemoveObsoleteEntries(storage, oldest_active_start_timestamp, token);
   static_cast<InMemoryLabelPropertyIndex *>(label_property_index_.get())
-      ->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
+      ->RemoveObsoleteEntries(storage, oldest_active_start_timestamp, token);
 }
 
-void Indices::RemoveObsoleteEdgeEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) const {
+void Indices::RemoveObsoleteEdgeEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
+                                        std::stop_token token) const {
   static_cast<InMemoryEdgeTypeIndex *>(edge_type_index_.get())
-      ->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
+      ->RemoveObsoleteEntries(storage, oldest_active_start_timestamp, token);
   static_cast<InMemoryEdgeTypePropertyIndex *>(edge_type_property_index_.get())
-      ->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
+      ->RemoveObsoleteEntries(storage, oldest_active_start_timestamp, token);
   static_cast<InMemoryEdgePropertyIndex *>(edge_property_index_.get())
-      ->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
+      ->RemoveObsoleteEntries(storage, oldest_active_start_timestamp, token);
 }
 
 void Indices::RemoveVerticesFromVectorIndices(std::vector<Vertex *> const &vertices_to_remove) const {

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -34,6 +34,8 @@ class MemoryTracker;
 
 namespace memgraph::storage {
 
+class Storage;
+
 struct Indices {
   Indices(const Config &config, StorageMode storage_mode, utils::MemoryTracker *db_embedding_memory_tracker = nullptr,
           metrics::GaugeHandle active_label_indices = {}, metrics::GaugeHandle active_label_property_indices = {},
@@ -50,12 +52,13 @@ struct Indices {
   /// This function should be called from garbage collection to clean up the
   /// vertex indices.
   /// TODO: unused in disk indices
-  void RemoveObsoleteVertexEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) const;
+  void RemoveObsoleteVertexEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
+                                   std::stop_token token) const;
 
   /// This function should be called from garbage collection to clean up the
   /// edge indices.
   /// TODO: unused in disk indices
-  void RemoveObsoleteEdgeEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) const;
+  void RemoveObsoleteEdgeEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token) const;
 
   void DropGraphClearIndices();
 

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -331,12 +331,17 @@ std::vector<PropertyId> InMemoryEdgePropertyIndex::ActiveIndices::ListIndices(ui
   return ret;
 }
 
-void InMemoryEdgePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
+void InMemoryEdgePropertyIndex::RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
+                                                      std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
 
   CleanupAllIndicies();
 
   auto cpy = all_indices_.ReadCopy();
+  if (cpy->empty()) return;
+
+  // Pin the edge store while sweeping: the loop dereferences raw Edge* the epoch GC could free.
+  auto const edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
 
   for (auto &[property_id, index] : *cpy) {
     if (token.stop_requested()) return;

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -272,7 +272,7 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
       -> std::shared_ptr<IndividualIndex>;
   void RestoreIndex(PropertyId property, std::shared_ptr<IndividualIndex> evicted, ActiveIndicesUpdater const &updater);
 
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
+  void RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token);
 
   void DropGraphClearIndices() override;
 

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -263,12 +263,18 @@ std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::ActiveIndices::ListIndices(uint64
   return ret;
 }
 
-void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
+void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
+                                                  std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
 
   CleanupAllIndices();
 
   auto cpy = all_indices_.ReadCopy();
+  if (cpy->empty()) return;
+
+  // Pin the edge store while sweeping: the loop dereferences raw Edge* the epoch GC could free.
+  auto const edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
+
   for (auto &et_index : *cpy) {
     if (token.stop_requested()) return;
 

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -244,7 +244,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   void RestoreIndex(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> evicted,
                     ActiveIndicesUpdater const &updater);
 
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
+  void RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token);
 
   void DropGraphClearIndices() override;
 

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -328,11 +328,15 @@ std::vector<std::pair<EdgeTypeId, PropertyId>> InMemoryEdgeTypePropertyIndex::Ac
   return ret;
 }
 
-void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp,
+void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
                                                           std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
   CleanupAllIndices();
   auto all_indices = all_indices_.ReadCopy();
+  if (all_indices->empty()) return;
+
+  // Pin the edge store while sweeping: the loop dereferences raw Edge* the epoch GC could free.
+  auto const edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
 
   for (auto &[index, property] : *all_indices) {
     if (token.stop_requested()) return;

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -262,7 +262,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   void RestoreIndex(EdgeTypeId edge_type, PropertyId property, std::shared_ptr<IndividualIndex> evicted,
                     ActiveIndicesUpdater const &updater);
 
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
+  void RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token);
 
   void DropGraphClearIndices() override;
 

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -271,10 +271,15 @@ std::vector<LabelId> InMemoryLabelIndex::ActiveIndices::ListIndices(uint64_t sta
   return ret;
 }
 
-void InMemoryLabelIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
+void InMemoryLabelIndex::RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
+                                               std::stop_token token) {
   CleanupAllIndices();
   auto maybe_stop = utils::ResettableCounter(2048);
   auto index_container = all_indices_.ReadCopy();
+  if (index_container->empty()) return;
+
+  // Pin vertices_ while sweeping: the loop dereferences raw Vertex* the epoch GC could free.
+  auto const vertex_pin = static_cast<InMemoryStorage const *>(storage)->MakeVertexPin();
 
   for (auto &[index, label] : *index_container) {
     // before starting index, check if stop_requested

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -76,7 +76,7 @@ class InMemoryLabelIndex : public LabelIndex {
   [[nodiscard]] auto DropIndex(LabelId label, ActiveIndicesUpdater const &updater) -> std::shared_ptr<IndividualIndex>;
   void RestoreIndex(LabelId label, std::shared_ptr<IndividualIndex> evicted, ActiveIndicesUpdater const &updater);
 
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
+  void RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token);
 
   class Iterable {
    public:

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1065,7 +1065,8 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::ListIndicesImpl(uint64_t start_t
   return ret;
 }
 
-void InMemoryLabelPropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
+void InMemoryLabelPropertyIndex::RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp,
+                                                       std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
 
   CleanupAllIndices();
@@ -1110,6 +1111,11 @@ void InMemoryLabelPropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_st
   };
 
   auto data = all_indices_.ReadCopy();
+  if (data.asc->empty() && data.desc->empty()) return;
+
+  // Pin vertices_ while sweeping: the loop dereferences raw Vertex* the epoch GC could free.
+  auto const vertex_pin = static_cast<InMemoryStorage const *>(storage)->MakeVertexPin();
+
   data.ForEach(remove_from);
 }
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -501,7 +501,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
   auto GetActiveIndices() const -> std::shared_ptr<LabelPropertyIndex::ActiveIndices> override;
 
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
+  void RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token);
 
   // Captures the evicted asc/desc IndividualIndex shared_ptrs so the caller can
   // re-insert them on abort. Pair with RestoreIndex. The captured shared_ptrs

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3315,27 +3315,13 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // in every index every time.
   gc_progress_.SetPhase(GcPhase::INDEX_CLEANUP);
   if (auto token = stop_source.get_token(); !token.stop_requested()) {
-    // Pin the main object stores for the whole index-cleanup sweep.
-    // RemoveObsolete{Vertex,Edge}Entries dereference raw Vertex*/Edge* held in
-    // index skiplist entries (via AnyVersionHasLabelProperties /
-    // AnyVersionHasProperty, which read the object's PropertyStore buffer). Those
-    // objects are reclaimed by the SkipList accessor-epoch GC (run_gc), which can
-    // fire from any other thread's accessor destructor, or from a concurrent
-    // FreeMemory whose CollectGarbage early-returns on gc_lock_ but still calls
-    // {vertices_,edges_}.run_gc(). A live accessor here forbids reclaiming any
-    // object present at sweep start; combined with the invariant that an object's
-    // index entries are removed before the object leaves its store, every entry the
-    // sweep observes points at a still-live object. Without these pins the sweep
-    // reads a freed Edge -> SIGSEGV in HasExpectedProperty (issue #4473).
-    auto const vertices_gc_pin = vertices_.access();
-    auto const edges_gc_pin = edges_.access();
     if (index_cleanup_vertex_needed || index_cleanup_vertex_performance) {
-      indices_.RemoveObsoleteVertexEntries(oldest_active_start_timestamp, token);
+      indices_.RemoveObsoleteVertexEntries(this, oldest_active_start_timestamp, token);
       auto *mem_unique_constraints = static_cast<InMemoryUniqueConstraints *>(constraints_.unique_constraints_.get());
-      mem_unique_constraints->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
+      mem_unique_constraints->RemoveObsoleteEntries(this, oldest_active_start_timestamp, token);
     }
     if (index_cleanup_edge_needed || index_cleanup_edge_performance) {
-      indices_.RemoveObsoleteEdgeEntries(oldest_active_start_timestamp, token);
+      indices_.RemoveObsoleteEdgeEntries(this, oldest_active_start_timestamp, token);
     }
   }
   {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3315,6 +3315,20 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // in every index every time.
   gc_progress_.SetPhase(GcPhase::INDEX_CLEANUP);
   if (auto token = stop_source.get_token(); !token.stop_requested()) {
+    // Pin the main object stores for the whole index-cleanup sweep.
+    // RemoveObsolete{Vertex,Edge}Entries dereference raw Vertex*/Edge* held in
+    // index skiplist entries (via AnyVersionHasLabelProperties /
+    // AnyVersionHasProperty, which read the object's PropertyStore buffer). Those
+    // objects are reclaimed by the SkipList accessor-epoch GC (run_gc), which can
+    // fire from any other thread's accessor destructor, or from a concurrent
+    // FreeMemory whose CollectGarbage early-returns on gc_lock_ but still calls
+    // {vertices_,edges_}.run_gc(). A live accessor here forbids reclaiming any
+    // object present at sweep start; combined with the invariant that an object's
+    // index entries are removed before the object leaves its store, every entry the
+    // sweep observes points at a still-live object. Without these pins the sweep
+    // reads a freed Edge -> SIGSEGV in HasExpectedProperty (issue #4473).
+    auto const vertices_gc_pin = vertices_.access();
+    auto const edges_gc_pin = edges_.access();
     if (index_cleanup_vertex_needed || index_cleanup_vertex_performance) {
       indices_.RemoveObsoleteVertexEntries(oldest_active_start_timestamp, token);
       auto *mem_unique_constraints = static_cast<InMemoryUniqueConstraints *>(constraints_.unique_constraints_.get());

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -122,6 +122,7 @@ class InMemoryStorage final : public Storage {
   friend class InMemoryEdgeTypeIndex;
   friend class InMemoryEdgeTypePropertyIndex;
   friend class InMemoryEdgePropertyIndex;
+  friend class InMemoryUniqueConstraints;
 
  public:
   using free_mem_fn = std::function<void(std::unique_lock<utils::ResourceLock>, bool)>;
@@ -894,6 +895,10 @@ class InMemoryStorage final : public Storage {
     }
     return edges_.access();
   }
+
+  // Keeps vertices_ objects alive for the accessor's lifetime. Vertices are always
+  // heavy, so (unlike MakeEdgePin) there is no light-mode variant.
+  [[nodiscard]] auto MakeVertexPin() const { return vertices_.access(); }
 
   utils::SkipListDb<Edge> edges_;
   // Present iff salient.items.enable_edges_metadata && salient.items.properties_on_edges.

--- a/src/storage/v2/inmemory/unique_constraints.cpp
+++ b/src/storage/v2/inmemory/unique_constraints.cpp
@@ -21,6 +21,7 @@
 #include "storage/v2/constraints/utils.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 #include "storage/v2/transaction.hpp"
 #include "utils/counter.hpp"
@@ -639,10 +640,14 @@ auto InMemoryUniqueConstraints::Validate(const std::unordered_set<Vertex const *
   return {};
 }
 
-void InMemoryUniqueConstraints::RemoveObsoleteEntries(uint64_t const oldest_active_start_timestamp,
+void InMemoryUniqueConstraints::RemoveObsoleteEntries(Storage *storage, uint64_t const oldest_active_start_timestamp,
                                                       const std::stop_token &token) {
   auto container = container_.ReadCopy();
+  if (container->empty()) return;
   auto maybe_stop = utils::ResettableCounter(2048);
+
+  // Pin vertices_ while sweeping: the loop dereferences raw Vertex* the epoch GC could free.
+  auto const vertex_pin = static_cast<InMemoryStorage const *>(storage)->MakeVertexPin();
 
   for (const auto &[label, map] : *container) {
     for (const auto &[properties, individual_constraint] : map) {

--- a/src/storage/v2/inmemory/unique_constraints.hpp
+++ b/src/storage/v2/inmemory/unique_constraints.hpp
@@ -31,6 +31,7 @@
 namespace memgraph::storage {
 
 struct Transaction;
+class Storage;
 
 class InMemoryUniqueConstraints : public UniqueConstraints {
  public:
@@ -163,7 +164,7 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
                 uint64_t commit_timestamp) const -> std::expected<void, ConstraintViolation>;
 
   /// GC method that removes outdated entries from constraints' storages.
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, const std::stop_token &token);
+  void RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, const std::stop_token &token);
 
   void Clear() override;
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -4637,8 +4637,8 @@ TYPED_TEST(IndexTest, EdgePropertyIndexRemoveObsoleteEntriesWithActiveTransactio
   // because it's still visible to the old transaction
   {
     auto *mem_storage = static_cast<InMemoryStorage *>(this->storage.get());
-    mem_storage->indices_.RemoveObsoleteEdgeEntries(acc_old_transaction->GetTransaction()->start_timestamp,
-                                                    std::stop_token());
+    mem_storage->indices_.RemoveObsoleteEdgeEntries(
+        mem_storage, acc_old_transaction->GetTransaction()->start_timestamp, std::stop_token());
   }
 
   // The old transaction should still be able to see the edge
@@ -4697,8 +4697,8 @@ TYPED_TEST(IndexTest, EdgeTypeIndexRemoveObsoleteEntriesWithActiveTransaction) {
   // Call RemoveObsoleteEntries - this should NOT remove the edge from the index
   {
     auto *mem_storage = static_cast<InMemoryStorage *>(this->storage.get());
-    mem_storage->indices_.RemoveObsoleteEdgeEntries(acc_old_transaction->GetTransaction()->start_timestamp,
-                                                    std::stop_token());
+    mem_storage->indices_.RemoveObsoleteEdgeEntries(
+        mem_storage, acc_old_transaction->GetTransaction()->start_timestamp, std::stop_token());
   }
 
   // The old transaction should still be able to see the edge
@@ -4758,8 +4758,8 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexRemoveObsoleteEntriesWithActiveTransa
   // Call RemoveObsoleteEntries - this should NOT remove the edge from the index
   {
     auto *mem_storage = static_cast<InMemoryStorage *>(this->storage.get());
-    mem_storage->indices_.RemoveObsoleteEdgeEntries(acc_old_transaction->GetTransaction()->start_timestamp,
-                                                    std::stop_token());
+    mem_storage->indices_.RemoveObsoleteEdgeEntries(
+        mem_storage, acc_old_transaction->GetTransaction()->start_timestamp, std::stop_token());
   }
 
   // The old transaction should still be able to see the edge


### PR DESCRIPTION
The index and unique-constraint cleanup sweeps dereference the raw Vertex/Edge pointers in their entries while holding no accessor on vertices_/edges_. A concurrent accessor's run_gc can free an object mid-scan and crash the storage GC thread.

Each sweep now holds an accessor on its store for the scan: nothing present at scan start is reclaimed under it, and since an object's index entries are removed before it leaves the store, every entry the sweep sees is live. Edge sweeps pin via MakeEdgePin, which also covers light edges. The accessor is taken per-sweep at the dereference, only when there is an index or constraint to scan.

Existing skip-list GC tests cover the invariant; the index, constraint, and light-edge suites pass.
