### PR TITLE
fix(tests): use Abort in Rpc.Abort instead of concurrent Shutdown

### DIFF
--- a/tests/unit/rpc.cpp
+++ b/tests/unit/rpc.cpp
@@ -74,8 +74,8 @@ TEST(Rpc, Abort) {
 
   std::thread thread([&client]() {
     std::this_thread::sleep_for(100ms);
-    spdlog::info("Shutting down the connection!");
-    client.Shutdown();
+    spdlog::info("Aborting the connection!");
+    client.Abort();
   });
 
   memgraph::utils::Timer const timer;
@@ -83,6 +83,7 @@ TEST(Rpc, Abort) {
   EXPECT_LT(timer.Elapsed(), 200ms);
 
   thread.join();
+  client.Shutdown();
 
   ASSERT_TRUE(server.Shutdown());
   server.AwaitShutdown();


### PR DESCRIPTION
The Rpc.Abort unit test triggers heap corruption during concurrent Client::Shutdown(). 

This is latent on Linux with glibc malloc (which does not validate freed metadata), but is caught by stricter allocators.