### PR TITLE
feat(query): cache procedure query plans, scoped to module-dependent queries

### DIFF
--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -26,6 +26,7 @@
 #include "query/plan/rule_based_planner.hpp"
 #include "query/plan/used_index_checker.hpp"
 #include "query/plan/vertex_count_cache.hpp"
+#include "query/procedure/module.hpp"
 #include "utils/flag_validation.hpp"
 #include "utils/memory_tracker.hpp"
 #include "utils/string.hpp"
@@ -45,7 +46,8 @@ DEFINE_VALIDATED_int32(query_ast_cache_max_size, 1000,
                        FLAG_IN_RANGE(0, std::numeric_limits<int32_t>::max()));
 
 namespace memgraph::query {
-PlanWrapper::PlanWrapper(std::unique_ptr<LogicalPlan> plan) : plan_(std::move(plan)) {}
+PlanWrapper::PlanWrapper(std::unique_ptr<LogicalPlan> plan, uint64_t module_generation)
+    : plan_(std::move(plan)), module_generation_(module_generation) {}
 
 auto PrepareQueryParameters(frontend::StrippedQuery const &stripped_query, UserParameters const &user_parameters,
                             parameters::Parameters const *server_parameters, std::string_view database_uuid)
@@ -94,9 +96,10 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
 
   // Cache the query's AST if it isn't already.
   auto const &cache_key = stripped_query.stripped_query();
+  const auto module_generation = procedure::gModuleRegistry.ModuleGeneration();
   std::shared_ptr<const CachedQuery> cached;
   cache->WithLock([&](auto &lru) {
-    if (auto entry = lru.get(cache_key)) cached = *entry;
+    if (auto entry = lru.get(cache_key); entry && (*entry)->module_generation == module_generation) cached = *entry;
   });
   std::unique_ptr<frontend::opencypher::Parser> parser;
 
@@ -154,11 +157,14 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
                       .query = visitor.query(),
                       .required_privileges = query::GetRequiredPrivileges(visitor.query()),
                       .is_cypher_read = read_check(),
-                      .using_schema_assert = visitor.GetQueryInfo().has_schema_assert});
+                      .using_schema_assert = visitor.GetQueryInfo().has_schema_assert,
+                      .module_generation = module_generation});
       cache->WithLock([&](auto &lru) {
-        if (auto winner = lru.get(cache_key)) {
+        if (auto winner = lru.get(cache_key); winner && (*winner)->module_generation == module_generation) {
           cached_query = *winner;
         } else {
+          // put won't overwrite an existing key, so drop a stale-generation entry before inserting the fresh one
+          lru.invalidate(cache_key);
           lru.put(cache_key, cached_query);
         }
       });
@@ -187,6 +193,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
       .is_cypher_read = result.is_cypher_read,
       .using_schema_assert = result.using_schema_assert,
       .is_cacheable = is_cacheable,
+      .module_generation = module_generation,
       .user_parameters = user_parameters,
       .parameters = std::move(query_parameters),
   };
@@ -238,6 +245,7 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
                                                CypherQuery *query, const Parameters &parameters,
                                                PlanCacheLRU *plan_cache, DbAccessor *db_accessor,
                                                plan::v2::QueryPlannerContext &planner_context,
+                                               uint64_t module_generation,
                                                const std::vector<Identifier *> &predefined_identifiers) {
   // Enforce the global memory limit during query preparation. Without this,
   // MemoryTrackerCanThrow() is false here (the per-cursor
@@ -262,7 +270,7 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
       const_cast<plan::LogicalOperator &>(plan).Accept(checker);
 
       auto const all_satisfied = db_accessor->CheckIndicesAreReady(checker.required_indices_);
-      if (all_satisfied) {
+      if (all_satisfied && ptr->module_generation() == module_generation) {
         return ptr;
       } else {
         plan_cache->WithLock([&](PlanCache_t &cache) { cache.invalidate(stripped_query.stripped_query()); });
@@ -272,7 +280,7 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
 
   auto logical_plan =
       MakeLogicalPlan(std::move(ast_storage), query, parameters, db_accessor, predefined_identifiers, planner_context);
-  auto plan = std::make_shared<PlanWrapper>(std::move(logical_plan));
+  auto plan = std::make_shared<PlanWrapper>(std::move(logical_plan), module_generation);
 
   if (use_plan_cache) {
     plan_cache->WithLock([&](auto &cache) { cache.put(stripped_query.stripped_query(), plan); });

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -96,9 +96,11 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
 
   // Cache the query's AST if it isn't already.
   auto const &cache_key = stripped_query.stripped_query();
-  const auto module_generation = procedure::gModuleRegistry.ModuleGeneration();
+  // sample the module generation under the cache lock so a reload while waiting for the lock isn't missed
+  uint64_t module_generation = 0;
   std::shared_ptr<const CachedQuery> cached;
   cache->WithLock([&](auto &lru) {
+    module_generation = procedure::gModuleRegistry.ModuleGeneration();
     if (auto entry = lru.get(cache_key); entry && (*entry)->module_generation == module_generation) cached = *entry;
   });
   std::unique_ptr<frontend::opencypher::Parser> parser;

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -46,6 +46,17 @@ DEFINE_VALIDATED_int32(query_ast_cache_max_size, 1000,
                        FLAG_IN_RANGE(0, std::numeric_limits<int32_t>::max()));
 
 namespace memgraph::query {
+namespace {
+
+/// A cached artifact is generation-checked only when building its AST read the query-module
+/// registry. A query naming no procedure and no user-defined function bakes in nothing that a
+/// module reload can invalidate, so it survives one untouched.
+bool IsFresh(AstStorage const &ast_storage, uint64_t stamped_generation, uint64_t current_generation) {
+  return !ast_storage.DependsOnModules() || stamped_generation == current_generation;
+}
+
+}  // namespace
+
 PlanWrapper::PlanWrapper(std::unique_ptr<LogicalPlan> plan, uint64_t module_generation)
     : plan_(std::move(plan)), module_generation_(module_generation) {}
 
@@ -101,7 +112,14 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
   std::shared_ptr<const CachedQuery> cached;
   cache->WithLock([&](auto &lru) {
     module_generation = procedure::gModuleRegistry.ModuleGeneration();
-    if (auto entry = lru.get(cache_key); entry && (*entry)->module_generation == module_generation) cached = *entry;
+    auto entry = lru.get(cache_key);
+    if (!entry) return;
+    if (IsFresh((*entry)->ast_storage, (*entry)->module_generation, module_generation)) {
+      cached = *entry;
+    } else {
+      // known dead: drop it now rather than leave it holding an AstStorage until the insert path replaces it
+      lru.invalidate(cache_key);
+    }
   });
   std::unique_ptr<frontend::opencypher::Parser> parser;
 
@@ -114,6 +132,7 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
     result.ast_storage.labels_ = cached_query.ast_storage.labels_;
     result.ast_storage.edge_types_ = cached_query.ast_storage.edge_types_;
     result.ast_storage.user_functions_ = cached_query.ast_storage.user_functions_;
+    result.ast_storage.call_procedures_ = cached_query.ast_storage.call_procedures_;
 
     result.query = cached_query.query->Clone(&result.ast_storage);
     result.required_privileges = cached_query.required_privileges;
@@ -162,7 +181,8 @@ ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const
                       .using_schema_assert = visitor.GetQueryInfo().has_schema_assert,
                       .module_generation = module_generation});
       cache->WithLock([&](auto &lru) {
-        if (auto winner = lru.get(cache_key); winner && (*winner)->module_generation == module_generation) {
+        auto winner = lru.get(cache_key);
+        if (winner && IsFresh((*winner)->ast_storage, (*winner)->module_generation, module_generation)) {
           cached_query = *winner;
         } else {
           // put won't overwrite an existing key, so drop a stale-generation entry before inserting the fresh one
@@ -272,7 +292,7 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
       const_cast<plan::LogicalOperator &>(plan).Accept(checker);
 
       auto const all_satisfied = db_accessor->CheckIndicesAreReady(checker.required_indices_);
-      if (all_satisfied && ptr->module_generation() == module_generation) {
+      if (all_satisfied && IsFresh(ptr->ast_storage(), ptr->module_generation(), module_generation)) {
         return ptr;
       } else {
         plan_cache->WithLock([&](PlanCache_t &cache) { cache.invalidate(stripped_query.stripped_query()); });

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -58,7 +58,13 @@ bool IsFresh(AstStorage const &ast_storage, uint64_t stamped_generation, uint64_
 }  // namespace
 
 PlanWrapper::PlanWrapper(std::unique_ptr<LogicalPlan> plan, uint64_t module_generation)
-    : plan_(std::move(plan)), module_generation_(module_generation) {}
+    : plan_(std::move(plan)), module_generation_(module_generation) {
+  auto checker = plan::UsedIndexChecker{};
+  // G_Lloyd: I am so SORRY, const_cast is BAD, but I'm not fixing Visitable and HierarchicalLogicalOperatorVisitor
+  //          ATM to work with a const visitor. This maybe addressed when the planner is redone.
+  const_cast<plan::LogicalOperator &>(plan_->GetRoot()).Accept(checker);
+  required_indices_ = std::move(checker.required_indices_);
+}
 
 auto PrepareQueryParameters(frontend::StrippedQuery const &stripped_query, UserParameters const &user_parameters,
                             parameters::Parameters const *server_parameters, std::string_view database_uuid)
@@ -284,14 +290,8 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
     if (existing_plan) {
       // validate the index usage
       auto &ptr = existing_plan.value();
-      auto &plan = ptr->plan();
 
-      auto checker = plan::UsedIndexChecker{};
-      // G_Lloyd: I am so SORRY, const_cast is BAD, but I'm not fixing Visitable and HierarchicalLogicalOperatorVisitor
-      //          ATM to work with a const visitor. This maybe addressed when the planner is redone.
-      const_cast<plan::LogicalOperator &>(plan).Accept(checker);
-
-      auto const all_satisfied = db_accessor->CheckIndicesAreReady(checker.required_indices_);
+      auto const all_satisfied = db_accessor->CheckIndicesAreReady(ptr->required_indices());
       if (all_satisfied && IsFresh(ptr->ast_storage(), ptr->module_generation(), module_generation)) {
         return ptr;
       } else {

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "parameters/parameters.hpp"
@@ -75,7 +76,7 @@ auto PrepareQueryParameters(frontend::StrippedQuery const &stripped_query, UserP
 
 class PlanWrapper {
  public:
-  explicit PlanWrapper(std::unique_ptr<LogicalPlan> plan);
+  explicit PlanWrapper(std::unique_ptr<LogicalPlan> plan, uint64_t module_generation = 0);
 
   auto plan() const -> plan::LogicalOperator const & { return plan_->GetRoot(); }
 
@@ -87,8 +88,11 @@ class PlanWrapper {
 
   auto rw_type() const { return plan_->RWType(); }
 
+  uint64_t module_generation() const { return module_generation_; }
+
  private:
   std::unique_ptr<LogicalPlan> plan_;
+  uint64_t module_generation_;
 };
 
 struct CachedQuery {
@@ -97,6 +101,7 @@ struct CachedQuery {
   std::vector<AuthQuery::Privilege> required_privileges;
   bool is_cypher_read{false};
   bool using_schema_assert{false};
+  uint64_t module_generation{0};
 };
 
 // keyed by text, not hash, so a hash collision can't return another query's
@@ -116,6 +121,7 @@ struct ParsedQuery {
   bool is_cypher_read{false};
   bool using_schema_assert{false};
   bool is_cacheable{true};
+  uint64_t module_generation{0};
   UserParameters user_parameters;
   Parameters parameters;
 };
@@ -166,6 +172,7 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
                                                CypherQuery *query, const Parameters &parameters,
                                                PlanCacheLRU *plan_cache, DbAccessor *db_accessor,
                                                plan::v2::QueryPlannerContext &planner_context,
+                                               uint64_t module_generation,
                                                const std::vector<Identifier *> &predefined_identifiers = {});
 
 }  // namespace memgraph::query

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -21,6 +21,7 @@
 #include "query/frontend/semantic/symbol_table.hpp"
 #include "query/frontend/stripped.hpp"
 #include "query/parameters.hpp"
+#include "storage/v2/indices/active_indices.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/lru_cache.hpp"
 #include "utils/rw_spin_lock.hpp"
@@ -90,9 +91,14 @@ class PlanWrapper {
 
   uint64_t module_generation() const { return module_generation_; }
 
+  /// A pure function of the plan, so it is derived once at construction and reused for the
+  /// readiness check every time this plan is served.
+  auto required_indices() const -> storage::IndicesCollection const & { return required_indices_; }
+
  private:
   std::unique_ptr<LogicalPlan> plan_;
   uint64_t module_generation_;
+  storage::IndicesCollection required_indices_;
 };
 
 struct CachedQuery {

--- a/src/query/frontend/ast/ast_storage.hpp
+++ b/src/query/frontend/ast/ast_storage.hpp
@@ -109,11 +109,19 @@ class AstStorage {
 
   int64_t FindOrAddUserFunction(const std::string &name) { return FindOrAddName(name, &user_functions_); }
 
+  int64_t FindOrAddCallProcedure(const std::string &name) { return FindOrAddName(name, &call_procedures_); }
+
+  /// True when building this AST read the query-module registry, so facts taken from it
+  /// (a procedure's result fields, is_write and required privilege; whether a function
+  /// name resolves at all) are baked in here and go stale when a module is reloaded.
+  bool DependsOnModules() const { return !user_functions_.empty() || !call_procedures_.empty(); }
+
   // TODO: would be good if these were stable memory locations, then *Ix could have string_view rather than stringq
   std::vector<std::string> labels_;
   std::vector<std::string> edge_types_;
   std::vector<std::string> properties_;
   std::vector<std::string> user_functions_;
+  std::vector<std::string> call_procedures_;
 
   // Public only for serialization access
   std::vector<std::unique_ptr<Tree>> storage_;

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2135,14 +2135,6 @@ antlrcpp::Any CypherMainVisitor::visitCreate(MemgraphCypher::CreateContext *ctx)
 }
 
 antlrcpp::Any CypherMainVisitor::visitCallProcedure(MemgraphCypher::CallProcedureContext *ctx) {
-  // Don't cache queries which call procedures because the
-  // procedure definition can affect the behaviour of the visitor and
-  // the execution of the query.
-  // If a user recompiles and reloads the procedure with different result
-  // names, because of the cache, old result names will be expected while the
-  // procedure will return results mapped to new names.
-  query_info_.is_cacheable = false;
-
   auto *call_proc = storage_->Create<CallProcedure>();
   MG_ASSERT(!ctx->procedureName()->symbolicName().empty());
   call_proc->procedure_name_ = JoinSymbolicNames(this, ctx->procedureName()->symbolicName());

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2159,6 +2159,10 @@ antlrcpp::Any CypherMainVisitor::visitCallProcedure(MemgraphCypher::CallProcedur
     throw SemanticException("There is no procedure named '{}'.", call_proc->procedure_name_);
   }
 
+  // Record the dependency before reading the signature below: is_write, void-ness and the
+  // YIELD * expansion all come from it and are baked into the AST from here on.
+  storage_->FindOrAddCallProcedure(call_proc->procedure_name_);
+
   call_proc->is_write_ = maybe_found->second->info.is_write;
   if (maybe_found->second->results.empty()) {
     call_proc->void_procedure_ = true;

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -63,10 +63,14 @@ inline SelectedFunction SelectFunctionImpl(const Function &function, const Evalu
   const auto &resolved = ctx.resolved_user_functions;
   if (resolved && function.user_function_id_ >= 0) {
     const auto slot = static_cast<size_t>(function.user_function_id_);
-    MG_ASSERT(slot < resolved->functions.size(),
-              "user_function_id_ {} out of range for resolved table of size {}",
-              function.user_function_id_,
-              resolved->functions.size());
+    if (slot >= resolved->functions.size()) [[unlikely]] {
+      // The plan's AstStorage is not the one these Function nodes were indexed into, so some
+      // clone path failed to carry user_functions_ across. Fail the query, not the process.
+      throw QueryRuntimeException("Function '{}' resolved to slot {}, outside a table of {} resolved functions.",
+                                  function.function_name_,
+                                  function.user_function_id_,
+                                  resolved->functions.size());
+    }
     return {&resolved->functions[slot].first};
   }
   return {ResolveUserFunction(function.function_name_)};

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3593,7 +3593,8 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                 parsed_query.parameters,
                                 plan_cache,
                                 dba,
-                                interpreter.query_planner_context());
+                                interpreter.query_planner_context(),
+                                parsed_query.module_generation);
 
   auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
   for (const auto &hint : hints) {
@@ -3725,7 +3726,8 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::vector<Notifica
                                              parsed_inner_query.parameters,
                                              plan_cache,
                                              dba,
-                                             interpreter.query_planner_context());
+                                             interpreter.query_planner_context(),
+                                             parsed_inner_query.module_generation);
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
   for (const auto &hint : hints) {
@@ -3835,7 +3837,8 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                                              parsed_inner_query.parameters,
                                              plan_cache,
                                              dba,
-                                             interpreter.query_planner_context());
+                                             interpreter.query_planner_context(),
+                                             parsed_inner_query.module_generation);
 
 #ifdef MG_ENTERPRISE
   CheckParallelExecution(parallel_execution, cypher_query_plan->plan(), interpreter_context, notifications, dba);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -8116,6 +8116,11 @@ class CallProcedureCursor : public Cursor {
     for (size_t i = 0UZ; i < self_->result_fields_.size(); ++i) {
       auto signature_it =
           proc_->results.find(memgraph::utils::pmr::string{self_->result_fields_[i], proc_->results.get_allocator()});
+      if (signature_it == proc_->results.end()) {
+        throw QueryRuntimeException("The procedure named '{}' has no result field named '{}'.",
+                                    self_->procedure_name_,
+                                    self_->result_fields_[i]);
+      }
       result_.signature.emplace(
           self_->result_fields_[i],
           ResultsMetadata{signature_it->second.first, signature_it->second.second, static_cast<uint32_t>(i)});

--- a/src/query/procedure/module.cpp
+++ b/src/query/procedure/module.cpp
@@ -1336,6 +1336,7 @@ bool ModuleRegistry::TryEraseModule(std::string_view name) {
   }
 
   modules_.erase(it);
+  ++generation_;
   return true;
 }
 
@@ -1348,6 +1349,7 @@ bool ModuleRegistry::TryEraseAllModules() {
   }
 
   modules_.clear();
+  ++generation_;
   return true;
 }
 
@@ -1365,6 +1367,7 @@ bool ModuleRegistry::RegisterModule(const std::string_view name, std::unique_ptr
   }
 
   modules_.emplace(std::string(name), std::move(module));
+  ++generation_;
   return true;
 }
 

--- a/src/query/procedure/module.hpp
+++ b/src/query/procedure/module.hpp
@@ -21,6 +21,8 @@
 #include "utils/rw_lock.hpp"
 
 #include <dlfcn.h>
+#include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -63,6 +65,7 @@ class ModuleRegistry final {
 
  private:
   std::map<std::string, std::shared_ptr<Module>, std::less<>> modules_;
+  std::atomic<std::uint64_t> generation_{0};
   mutable utils::RWLock lock_{utils::RWLock::Priority::WRITE};
   std::unique_ptr<utils::MemoryResource> shared_{std::make_unique<utils::ResourceWithOutOfMemoryException>()};
 
@@ -114,6 +117,9 @@ class ModuleRegistry final {
   /// Find a module with given name or return nullptr.
   /// Takes a read lock.
   auto GetModuleNamed(std::string_view name) const -> std::shared_ptr<Module>;
+
+  /// Monotonically bumped whenever the set of loaded modules changes; cached query plans compare against it.
+  auto ModuleGeneration() const noexcept -> std::uint64_t { return generation_.load(); }
 
   /// Remove all loaded (non-builtin) modules.
   /// Takes a write lock.

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -198,6 +198,7 @@ std::shared_ptr<Trigger::TriggerPlan> Trigger::GetPlan(DbAccessor *db_accessor, 
     ast_storage.labels_ = parsed_statements_.ast_storage.labels_;
     ast_storage.edge_types_ = parsed_statements_.ast_storage.edge_types_;
     ast_storage.user_functions_ = parsed_statements_.ast_storage.user_functions_;
+    ast_storage.call_procedures_ = parsed_statements_.ast_storage.call_procedures_;
 
     std::vector<Identifier *> predefined_identifiers;
     predefined_identifiers.reserve(identifiers.size());

--- a/tests/e2e/python_query_modules_reloading/procedures/CMakeLists.txt
+++ b/tests/e2e/python_query_modules_reloading/procedures/CMakeLists.txt
@@ -1,6 +1,7 @@
 copy_query_modules_reloading_procedures_e2e_python_files(test_module.py)
 copy_query_modules_reloading_procedures_e2e_python_files(new_test_module.py)
 copy_query_modules_reloading_procedures_e2e_python_files(reload_func_module.py)
+copy_query_modules_reloading_procedures_e2e_python_files(reload_proc_module.py)
 
 add_subdirectory(mage)
 add_subdirectory(new_test_module_utils)

--- a/tests/e2e/python_query_modules_reloading/procedures/reload_proc_module.py
+++ b/tests/e2e/python_query_modules_reloading/procedures/reload_proc_module.py
@@ -1,0 +1,6 @@
+import mgp
+
+
+@mgp.read_proc
+def compute(ctx: mgp.ProcCtx, a: mgp.Number, b: mgp.Number) -> mgp.Record(result=mgp.Number):
+    return mgp.Record(result=a + b)

--- a/tests/e2e/python_query_modules_reloading/test_reload_query_module.py
+++ b/tests/e2e/python_query_modules_reloading/test_reload_query_module.py
@@ -45,6 +45,22 @@ FUNC4_PATH = os.path.join(
 )
 
 RELOAD_FUNC_MODULE_PATH = os.path.join(os.path.dirname(__file__), "procedures", "reload_func_module.py")
+RELOAD_PROC_MODULE_PATH = os.path.join(os.path.dirname(__file__), "procedures", "reload_proc_module.py")
+
+BASELINE_PROC = """@mgp.read_proc
+def compute(ctx: mgp.ProcCtx, a: mgp.Number, b: mgp.Number) -> mgp.Record(result=mgp.Number):
+    return mgp.Record(result=a + b)
+"""
+
+WRITE_PROC = """@mgp.write_proc
+def compute(ctx: mgp.ProcCtx, a: mgp.Number, b: mgp.Number) -> mgp.Record(result=mgp.Number):
+    return mgp.Record(result=a + b)
+"""
+
+
+def write_proc_module(body: str):
+    with open(RELOAD_PROC_MODULE_PATH, "w") as proc_file:
+        proc_file.write("import mgp\n\n\n" + body)
 
 
 def write_combine_function(op: str):
@@ -295,6 +311,129 @@ def test_trigger_using_magic_function_reload(switch):
             pass
         write_combine_function("+")
         execute_and_fetch_all(cursor, "CALL mg.load('reload_func_module');")
+
+
+def test_mg_load_reload_procedure_impl():
+    cursor = connect().cursor()
+    write_proc_module(BASELINE_PROC)
+    execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+    q = "CALL reload_proc_module.compute(2, 3) YIELD result RETURN result;"
+    try:
+        assert execute_and_fetch_all(cursor, q)[0][0] == 5
+        assert execute_and_fetch_all(cursor, q)[0][0] == 5
+        write_proc_module(
+            "@mgp.read_proc\n"
+            "def compute(ctx: mgp.ProcCtx, a: mgp.Number, b: mgp.Number) -> mgp.Record(result=mgp.Number):\n"
+            "    return mgp.Record(result=a * b)\n"
+        )
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+        assert execute_and_fetch_all(cursor, q)[0][0] == 6
+    finally:
+        write_proc_module(BASELINE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+
+
+def test_mg_load_reload_procedure_yield_star_reexpands():
+    cursor = connect().cursor()
+    write_proc_module(BASELINE_PROC)
+    execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+    q = "CALL reload_proc_module.compute(2, 3) YIELD * RETURN *;"
+    try:
+        row = execute_and_fetch_all(cursor, q)[0]
+        assert len(row) == 1 and row[0] == 5
+        write_proc_module(
+            "@mgp.read_proc\n"
+            "def compute(ctx: mgp.ProcCtx, a: mgp.Number, b: mgp.Number) -> "
+            "mgp.Record(result=mgp.Number, doubled=mgp.Number):\n"
+            "    return mgp.Record(result=a + b, doubled=2 * (a + b))\n"
+        )
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+        row = execute_and_fetch_all(cursor, q)[0]
+        assert len(row) == 2 and 10 in row
+    finally:
+        write_proc_module(BASELINE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+
+
+def test_mg_load_reload_procedure_read_to_write_self_heals():
+    cursor = connect().cursor()
+    write_proc_module(BASELINE_PROC)
+    execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+    q = "CALL reload_proc_module.compute(2, 3) YIELD result RETURN result;"
+    try:
+        assert execute_and_fetch_all(cursor, q)[0][0] == 5
+        write_proc_module(WRITE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+        assert execute_and_fetch_all(cursor, q)[0][0] == 5
+    finally:
+        write_proc_module(BASELINE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+
+
+def test_mg_load_reload_procedure_write_to_read_self_heals():
+    cursor = connect().cursor()
+    write_proc_module(WRITE_PROC)
+    execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+    q = "CALL reload_proc_module.compute(2, 3) YIELD result RETURN result;"
+    try:
+        assert execute_and_fetch_all(cursor, q)[0][0] == 5
+        write_proc_module(BASELINE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+        assert execute_and_fetch_all(cursor, q)[0][0] == 5
+    finally:
+        write_proc_module(BASELINE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+
+
+def test_mg_load_reload_procedure_removed_field_errors():
+    cursor = connect().cursor()
+    write_proc_module(BASELINE_PROC)
+    execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+    q = "CALL reload_proc_module.compute(2, 3) YIELD result RETURN result;"
+    try:
+        assert execute_and_fetch_all(cursor, q)[0][0] == 5
+        write_proc_module(
+            "@mgp.read_proc\n"
+            "def compute(ctx: mgp.ProcCtx, a: mgp.Number, b: mgp.Number) -> mgp.Record(total=mgp.Number):\n"
+            "    return mgp.Record(total=a + b)\n"
+        )
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(cursor, q)
+    finally:
+        write_proc_module(BASELINE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+
+
+def test_mg_load_reload_procedure_trigger():
+    cursor = connect().cursor()
+    write_proc_module(BASELINE_PROC)
+    execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+    try:
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+        execute_and_fetch_all(
+            cursor,
+            "CREATE TRIGGER proc_trigger ON () CREATE BEFORE COMMIT "
+            "EXECUTE UNWIND createdVertices AS v "
+            "CALL reload_proc_module.compute(2, 3) YIELD result SET v.r = result;",
+        )
+        execute_and_fetch_all(cursor, "CREATE (:A);")
+        assert execute_and_fetch_all(cursor, "MATCH (n:A) RETURN n.r;")[0][0] == 5
+        write_proc_module(
+            "@mgp.read_proc\n"
+            "def compute(ctx: mgp.ProcCtx, a: mgp.Number, b: mgp.Number) -> mgp.Record(result=mgp.Number):\n"
+            "    return mgp.Record(result=a * b)\n"
+        )
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
+        execute_and_fetch_all(cursor, "CREATE (:B);")
+        assert execute_and_fetch_all(cursor, "MATCH (n:B) RETURN n.r;")[0][0] == 6
+    finally:
+        try:
+            execute_and_fetch_all(cursor, "DROP TRIGGER proc_trigger;")
+        except mgclient.DatabaseError:
+            pass
+        write_proc_module(BASELINE_PROC)
+        execute_and_fetch_all(cursor, "CALL mg.load('reload_proc_module');")
 
 
 if __name__ == "__main__":

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1119,6 +1119,17 @@ TEST_P(CypherMainVisitorTest, MagicFunctionCacheable) {
   EXPECT_EQ(storage.user_functions_[0], "mock_module.get");
 }
 
+TEST_P(CypherMainVisitorTest, CallProcedureCacheable) {
+  AddProc(*mock_module, "proc", {}, {"res"}, ProcedureType::READ);
+  ParsingContext context;
+  AstStorage storage;
+  Parameters parameters;
+  CypherMainVisitor visitor(context, &storage, &parameters);
+  ::frontend::opencypher::Parser parser("CALL mock_module.proc() YIELD res RETURN res");
+  visitor.visit(parser.tree());
+  EXPECT_TRUE(visitor.GetQueryInfo().is_cacheable);
+}
+
 TEST_P(CypherMainVisitorTest, StringLiteralDoubleQuotes) {
   auto &ast_generator = *GetParam();
   auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN \"mi'rko\""));

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1128,6 +1128,33 @@ TEST_P(CypherMainVisitorTest, CallProcedureCacheable) {
   ::frontend::opencypher::Parser parser("CALL mock_module.proc() YIELD res RETURN res");
   visitor.visit(parser.tree());
   EXPECT_TRUE(visitor.GetQueryInfo().is_cacheable);
+  ASSERT_EQ(storage.call_procedures_.size(), 1U);
+  EXPECT_EQ(storage.call_procedures_[0], "mock_module.proc");
+  EXPECT_TRUE(storage.DependsOnModules());
+}
+
+TEST_P(CypherMainVisitorTest, ModuleFreeQueryDependsOnNoModules) {
+  ParsingContext context;
+  AstStorage storage;
+  Parameters parameters;
+  CypherMainVisitor visitor(context, &storage, &parameters);
+  ::frontend::opencypher::Parser parser("MATCH (n) RETURN n");
+  visitor.visit(parser.tree());
+  EXPECT_TRUE(storage.user_functions_.empty());
+  EXPECT_TRUE(storage.call_procedures_.empty());
+  EXPECT_FALSE(storage.DependsOnModules());
+}
+
+TEST_P(CypherMainVisitorTest, MagicFunctionDependsOnModules) {
+  AddFunc(*mock_module, "get", {});
+  ParsingContext context;
+  AstStorage storage;
+  Parameters parameters;
+  CypherMainVisitor visitor(context, &storage, &parameters);
+  ::frontend::opencypher::Parser parser("RETURN mock_module.get()");
+  visitor.visit(parser.tree());
+  EXPECT_TRUE(storage.call_procedures_.empty());
+  EXPECT_TRUE(storage.DependsOnModules());
 }
 
 TEST_P(CypherMainVisitorTest, StringLiteralDoubleQuotes) {

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1133,6 +1133,60 @@ TEST_P(CypherMainVisitorTest, CallProcedureCacheable) {
   EXPECT_TRUE(storage.DependsOnModules());
 }
 
+// Two occurrences of one module function are one dependency and one resolved callable, so both
+// call sites share a slot in the table resolved for an execution.
+TEST_P(CypherMainVisitorTest, RepeatedMagicFunctionSharesOneSlot) {
+  AddFunc(*mock_module, "get", {});
+  ParsingContext context;
+  AstStorage storage;
+  Parameters parameters;
+  CypherMainVisitor visitor(context, &storage, &parameters);
+  ::frontend::opencypher::Parser parser("RETURN mock_module.get() AS a, mock_module.get() AS b");
+  visitor.visit(parser.tree());
+
+  ASSERT_EQ(storage.user_functions_.size(), 1U);
+  EXPECT_EQ(storage.user_functions_[0], "mock_module.get");
+
+  auto *query = dynamic_cast<CypherQuery *>(visitor.query());
+  ASSERT_TRUE(query);
+  auto *return_clause = dynamic_cast<Return *>(query->single_query_->clauses_[0]);
+  ASSERT_EQ(return_clause->body_.named_expressions.size(), 2);
+  auto *first = dynamic_cast<Function *>(return_clause->body_.named_expressions[0]->expression_);
+  auto *second = dynamic_cast<Function *>(return_clause->body_.named_expressions[1]->expression_);
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+  EXPECT_EQ(first->user_function_id_, second->user_function_id_);
+}
+
+// Distinct module functions get distinct slots, so one resolution cannot stand in for the other.
+TEST_P(CypherMainVisitorTest, DistinctMagicFunctionsGetDistinctSlots) {
+  AddFunc(*mock_module, "get", {});
+  AddFunc(*mock_module, "put", {});
+  ParsingContext context;
+  AstStorage storage;
+  Parameters parameters;
+  CypherMainVisitor visitor(context, &storage, &parameters);
+  ::frontend::opencypher::Parser parser("RETURN mock_module.get() AS a, mock_module.put() AS b");
+  visitor.visit(parser.tree());
+
+  EXPECT_EQ(storage.user_functions_.size(), 2U);
+}
+
+// The same procedure called twice is recorded once; the list names dependencies, not call sites.
+TEST_P(CypherMainVisitorTest, RepeatedCallProcedureRecordedOnce) {
+  AddProc(*mock_module, "proc", {}, {"res"}, ProcedureType::READ);
+  ParsingContext context;
+  AstStorage storage;
+  Parameters parameters;
+  CypherMainVisitor visitor(context, &storage, &parameters);
+  ::frontend::opencypher::Parser parser(
+      "CALL mock_module.proc() YIELD res AS a CALL mock_module.proc() YIELD res AS b RETURN a, b");
+  visitor.visit(parser.tree());
+
+  ASSERT_EQ(storage.call_procedures_.size(), 1U);
+  EXPECT_EQ(storage.call_procedures_[0], "mock_module.proc");
+}
+
 TEST_P(CypherMainVisitorTest, ModuleFreeQueryDependsOnNoModules) {
   ParsingContext context;
   AstStorage storage;

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -29,6 +29,7 @@
 #include "query/auth_checker.hpp"
 #include "query/config.hpp"
 #include "query/exceptions.hpp"
+#include "query/frontend/stripped.hpp"
 #include "query/interpreter.hpp"
 #include "query/interpreter_context.hpp"
 #include "query/metadata.hpp"
@@ -1515,13 +1516,33 @@ TYPED_TEST(InterpreterTest, CacheableQueries) {
   }
 
   {
-    SCOPED_TRACE("Uncacheable query");
-    // Queries which are calling procedure should not be cached because the
-    // result signature could be changed
-    this->Interpret("CALL mg.load_all()");
-    EXPECT_EQ(this->AstCacheSize(), 1U);
-    EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 1U);
+    SCOPED_TRACE("Cacheable procedure query");
+    this->Interpret("CALL mg.procedures() YIELD name RETURN name");
+    EXPECT_EQ(this->AstCacheSize(), 2U);
+    EXPECT_EQ(this->db->plan_cache()->WithLock([&](auto &cache) { return cache.size(); }), 2U);
   }
+}
+
+TYPED_TEST(InterpreterTest, ProcedurePlanReuseAndGenerationInvalidation) {
+  const std::string query = "CALL mg.procedures() YIELD name RETURN name";
+  const auto key = memgraph::query::frontend::StrippedQuery{query}.stripped_query();
+  auto cached_plan = [&] {
+    return this->db->plan_cache()->WithLock([&](auto &cache) {
+      auto entry = cache.get(key);
+      return entry ? *entry : nullptr;
+    });
+  };
+
+  this->Interpret(query);
+  auto first = cached_plan();
+  ASSERT_NE(first, nullptr);
+
+  this->Interpret(query);
+  EXPECT_EQ(cached_plan(), first);
+
+  this->Interpret("CALL mg.load_all()");
+  this->Interpret(query);
+  EXPECT_NE(cached_plan(), first);
 }
 
 TYPED_TEST(InterpreterTest, AllowLoadCsvConfig) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1545,6 +1545,27 @@ TYPED_TEST(InterpreterTest, ProcedurePlanReuseAndGenerationInvalidation) {
   EXPECT_NE(cached_plan(), first);
 }
 
+// A query that names no procedure and no user-defined function bakes in nothing a module reload
+// can invalidate, so a reload must leave its cached plan and AST alone.
+TYPED_TEST(InterpreterTest, ModuleFreePlanSurvivesModuleReload) {
+  const std::string query = "MATCH (n) RETURN n";
+  const auto key = memgraph::query::frontend::StrippedQuery{query}.stripped_query();
+  auto cached_plan = [&] {
+    return this->db->plan_cache()->WithLock([&](auto &cache) {
+      auto entry = cache.get(key);
+      return entry ? *entry : nullptr;
+    });
+  };
+
+  this->Interpret(query);
+  auto first = cached_plan();
+  ASSERT_NE(first, nullptr);
+
+  this->Interpret("CALL mg.load_all()");
+  this->Interpret(query);
+  EXPECT_EQ(cached_plan(), first);
+}
+
 TYPED_TEST(InterpreterTest, AllowLoadCsvConfig) {
   const auto check_load_csv_queries = [&](const bool allow_load_csv) {
     TmpDirManager directory_manager{"allow_load_csv"};

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1831,6 +1831,18 @@ class FunctionTest : public ExpressionEvaluatorTest<StorageType> {
 
 TYPED_TEST_SUITE(FunctionTest, StorageTypes);
 
+// A slot outside the resolved table means the plan's AstStorage is not the one its Function
+// nodes were indexed into. That is a broken invariant, and it is contained to the query.
+TYPED_TEST(FunctionTest, OutOfRangeUserFunctionSlotThrows) {
+  auto *op = this->storage.template Create<Function>("SIZE", std::vector<Expression *>{});
+  op->is_user_defined_ = true;
+  op->user_function_id_ = 0;
+  // Non-null but empty, so slot 0 is out of range rather than falling back to resolution by name.
+  this->ctx.resolved_user_functions = std::make_shared<memgraph::query::ResolvedUserFunctions>();
+
+  EXPECT_THROW(this->Eval(op), QueryRuntimeException);
+}
+
 template <class... TArgs>
 static TypedValue MakeTypedValueList(TArgs &&...args) {
   return TypedValue(std::vector<TypedValue>{TypedValue(args)...});


### PR DESCRIPTION
## Problem

`CALL mod.proc() YIELD ...` queries were non-cacheable, so every execution re-parsed and re-planned. Parsing a `CALL` bakes the procedure's result fields (including `YIELD *`), its `is_write` classification and its `required_privilege` into the AST. The last two are consumed before execution starts, to pick the storage accessor and to authorize, so a reload needs a re-parse, not just a re-plan.

Procedure counterpart to #4461, which made query-module functions cacheable via per-execution binding.

## Changes

- **Cache procedure queries.** `ModuleRegistry` gains an atomic generation counter, bumped on any change to the loaded module set. Cached ASTs and plans are stamped at build and rebuilt when stale, so a reload re-parses and re-plans on next execution. The plan inherits the AST's generation, so a reload between parse and prepare cannot stamp a stale plan as fresh.

- **Scope invalidation to dependent queries.** A global stamp invalidated every cached AST and plan on any module load, including queries naming no module. `AstStorage` now records `call_procedures_` next to `user_functions_`, and `DependsOnModules()` gates the check. Queries touching no module survive a reload untouched, and procedures and module functions end up under one rule.

- **Two crash paths closed.** `CallProcedureCursor` dereferenced a past-the-end iterator when a yielded field was missing. The user-function slot bounds check was an unconditional assert, aborting the process in release. Both now throw.

- **Derive a plan's required indices once**, at construction, instead of re-walking the plan on every cache hit. Benefits all cached queries.

## Not addressed

Triggers have no generation check and never re-parse, so a signature or privilege change is picked up only on recreate. Pre-existing; needs trigger re-parse, which touches durability.
