### PR TITLE
feat: Allow usage of --coordinator-id=0

### DIFF
--- a/src/flags/coord_flag_env_handler.cpp
+++ b/src/flags/coord_flag_env_handler.cpp
@@ -41,17 +41,18 @@ std::string CoordinationSetup::ToString() {
       "coordinator_hostname: {}",
       management_port,
       coordinator_port,
-      coordinator_id,
+      coordinator_id == kUnsetCoordinatorId ? "not set" : std::to_string(coordinator_id),
       nuraft_log_file,
       coordinator_hostname);
 }
 
 [[nodiscard]] auto CoordinationSetup::IsDataInstanceManagedByCoordinator() const -> bool {
-  return management_port != 0 && coordinator_port == 0 && coordinator_id == 0;
+  return management_port != 0 && coordinator_port == 0 && coordinator_id == kUnsetCoordinatorId;
 }
 
 [[nodiscard]] auto CoordinationSetup::IsCoordinator() const -> bool {
-  return coordinator_id != 0 && coordinator_port != 0 && !coordinator_hostname.empty() && management_port != 0;
+  return coordinator_id != kUnsetCoordinatorId && coordinator_port != 0 && !coordinator_hostname.empty() &&
+         management_port != 0;
 }
 
 auto CoordinationSetupInstance() -> CoordinationSetup & {
@@ -73,7 +74,7 @@ void SetFinalCoordinationSetup() {
   auto const is_flag_set = []<typename T>(T const &flag) { return flag != T{}; };
 
   bool const any_flags_set = is_flag_set(FLAGS_management_port) || is_flag_set(FLAGS_coordinator_port) ||
-                             is_flag_set(FLAGS_coordinator_id) || is_flag_set(FLAGS_nuraft_log_file) ||
+                             FLAGS_coordinator_id != kUnsetCoordinatorId || is_flag_set(FLAGS_nuraft_log_file) ||
                              is_flag_set(FLAGS_coordinator_hostname);
 
   if (any_flags_set && any_envs_set) {
@@ -103,12 +104,12 @@ void SetFinalCoordinationSetup() {
 
     if (any_envs_set) {
       spdlog::trace("Coordinator will be initialized using environment variables.");
-      return CoordinationSetup{
-          .management_port = coord_envs[0] ? std::stoi(coord_envs[0].value()) : 0,
-          .coordinator_port = coord_envs[1] ? std::stoi(coord_envs[1].value()) : 0,
-          .coordinator_id = coord_envs[2] ? static_cast<int32_t>(std::stoul(coord_envs[2].value())) : 0,
-          .nuraft_log_file = coord_envs[3] ? coord_envs[3].value() : "",
-          .coordinator_hostname = coord_envs[4] ? coord_envs[4].value() : ""};
+      return CoordinationSetup{.management_port = coord_envs[0] ? std::stoi(coord_envs[0].value()) : 0,
+                               .coordinator_port = coord_envs[1] ? std::stoi(coord_envs[1].value()) : 0,
+                               .coordinator_id = coord_envs[2] ? static_cast<int32_t>(std::stoul(coord_envs[2].value()))
+                                                               : kUnsetCoordinatorId,
+                               .nuraft_log_file = coord_envs[3] ? coord_envs[3].value() : "",
+                               .coordinator_hostname = coord_envs[4] ? coord_envs[4].value() : ""};
     }
 
     spdlog::trace("Coordinator will be initialized using flags.");

--- a/src/flags/coord_flag_env_handler.hpp
+++ b/src/flags/coord_flag_env_handler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,9 +11,14 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <string>
 
 namespace memgraph::flags {
+
+// coordinator_id defaults to this sentinel, meaning "not provided". 0 is a valid coordinator id, so it cannot be used
+// to detect an unset value.
+inline constexpr int32_t kUnsetCoordinatorId{std::numeric_limits<int32_t>::max()};
 
 constexpr auto kMgManagementPort = "MEMGRAPH_MANAGEMENT_PORT";
 constexpr auto kMgCoordinatorPort = "MEMGRAPH_COORDINATOR_PORT";
@@ -26,7 +31,7 @@ constexpr auto kMgCoordinatorHostname = "MEMGRAPH_COORDINATOR_HOSTNAME";
 struct CoordinationSetup {
   int management_port{0};
   int coordinator_port{0};
-  int32_t coordinator_id{0};
+  int32_t coordinator_id{kUnsetCoordinatorId};
   std::string nuraft_log_file;
   std::string coordinator_hostname;
 

--- a/src/flags/coordination.cpp
+++ b/src/flags/coordination.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <limits>
 
+#include "flags/coord_flag_env_handler.hpp"
 #include "utils/flag_validation.hpp"
 
 #ifdef MG_ENTERPRISE
@@ -26,7 +27,7 @@ DEFINE_VALIDATED_int32(coordinator_port, 0, "Port on which raft servers will be 
                        FLAG_IN_RANGE(0, std::numeric_limits<uint16_t>::max()));  // NOLINT
 // NOLINTEND(performance-avoid-endl)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_int32(coordinator_id, 0, "Unique ID of the raft server.");
+DEFINE_int32(coordinator_id, memgraph::flags::kUnsetCoordinatorId, "Unique ID of the raft server.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_string(nuraft_log_file, "", "Path to the file where NuRaft logs are saved.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -328,7 +328,7 @@ int main(int argc, char **argv) {
   memgraph::flags::SetFinalCoordinationSetup();
   auto const &coordination_setup = memgraph::flags::CoordinationSetupInstance();
   bool const is_coordinator_instance = coordination_setup.management_port && coordination_setup.coordinator_port &&
-                                       coordination_setup.coordinator_id &&
+                                       coordination_setup.coordinator_id != memgraph::flags::kUnsetCoordinatorId &&
                                        !coordination_setup.coordinator_hostname.empty();
 
 #else
@@ -721,15 +721,15 @@ int main(int argc, char **argv) {
   // but DataInstanceManagementServer must be explicitly shut down before repl_state destruction (done in shutdown
   // lambda)
   std::shared_ptr<CoordinatorState> coordinator_state{};
-  auto const is_valid_data_instance =
-      coordination_setup.management_port && !coordination_setup.coordinator_port && !coordination_setup.coordinator_id;
+  auto const is_valid_data_instance = coordination_setup.management_port && !coordination_setup.coordinator_port &&
+                                      coordination_setup.coordinator_id == memgraph::flags::kUnsetCoordinatorId;
 
   auto try_init_coord_state = [&coordinator_state,
                                &extracted_bolt_port,
                                &is_valid_data_instance,
                                &is_coordinator_instance](auto const &coordination_setup) {
     if (!(coordination_setup.management_port || coordination_setup.coordinator_port ||
-          coordination_setup.coordinator_id)) {
+          coordination_setup.coordinator_id != memgraph::flags::kUnsetCoordinatorId)) {
       spdlog::trace("Aborting coordinator initialization.");
       return;
     }

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -74,7 +74,7 @@ startup_config_dict = {
     "cluster_key_file": ("", "", "Key file used for intra-cluster TLS communication."),
     "management_port": ("0", "0", "Port on which coordinator servers will be started."),
     "coordinator_port": ("0", "0", "Port on which raft servers will be started."),
-    "coordinator_id": ("0", "0", "Unique ID of the raft server."),
+    "coordinator_id": ("2147483647", "2147483647", "Unique ID of the raft server."),
     "coordinator_hostname": ("", "", "Instance's hostname. Used as output of SHOW INSTANCES query."),
     "data_directory": ("mg_data", "mg_data", "Path to directory in which to save all permanent data."),
     "data_dir_lock_acquisition_timeout_sec": (


### PR DESCRIPTION
Users will now be able to use 0 as valid coordinator id. Motivation is the future K8s operator. 