### PR TITLE
fix(query): correlate pattern comprehensions and scope CALL subquery variables

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -242,11 +242,13 @@ bool SymbolGenerator::PostVisit(CypherUnion &cypher_union) {
 
 bool SymbolGenerator::PreVisit(Create &) {
   scopes_.back().in_create = true;
+  create_clause_symbols_.clear();
   return true;
 }
 
 bool SymbolGenerator::PostVisit(Create &) {
   scopes_.back().in_create = false;
+  create_clause_symbols_.clear();
   return true;
 }
 
@@ -523,6 +525,10 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     // A shadowed outer name must not resolve to the enclosing query's symbol, so declare it in this scope.
     symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, type)
                                 : GetOrCreateSymbol(ident.name_, ident.user_declared_, type);
+    // An atom that was not already in scope is declared here, so this CREATE clause is what binds it.
+    if (scope.in_create && !name_in_scope) {
+      create_clause_symbols_.insert(symbol);
+    }
   } else if (scope.in_pattern && !scope.in_pattern_atom_identifier && scope.in_match) {
     if (scope.in_edge_range && scope.visiting_edge && scope.visiting_edge->identifier_ &&
         scope.visiting_edge->identifier_->name_ == ident.name_) {
@@ -549,6 +555,13 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
       throw UnboundVariableError(ident.name_);
     }
     symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::ANY);
+  }
+
+  // The operator that binds a symbol declared by this CREATE is the same one that reads the comprehension's result, so
+  // the frame slot is still unwritten when the clause needs it. There is no placement that works - reject instead.
+  if (scope.in_pattern_comprehension && create_clause_symbols_.contains(symbol)) {
+    throw SemanticException(
+        "Entity '{}' cannot be created and referenced by a pattern comprehension in the same clause.", ident.name_);
   }
 
   ident.MapTo(symbol);

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -507,8 +507,9 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     }
   } else if (scope.in_pattern && !(scope.in_node_atom || scope.visiting_edge)) {
     // If we are in the pattern, and outside of a node or an edge, the
-    // identifier is the pattern name.
-    symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::PATH);
+    // identifier is the pattern name. Shadowed: declare here, as for node and edge atoms below.
+    symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::PATH)
+                                : GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::PATH);
   } else if (scope.in_pattern && scope.in_pattern_atom_identifier) {
     //  Patterns used to create nodes and edges cannot redeclare already
     //  established bindings. Declaration only happens in single node
@@ -1064,7 +1065,9 @@ bool SymbolGenerator::PreVisit(PatternComprehension &pc) {
   // so in_pattern is not yet true when Visit(Identifier) is called for variable_.
   // Without this, Visit(Identifier) will throw UnboundVariableError.
   if (pc.variable_) {
-    auto path_symbol = GetOrCreateSymbol(pc.variable_->name_, pc.variable_->user_declared_, Symbol::Type::PATH);
+    // Always this comprehension's own declaration, so create it here: resolving outward would bind an outer path of
+    // the same name and overwrite its frame slot.
+    auto path_symbol = CreateSymbol(pc.variable_->name_, pc.variable_->user_declared_, Symbol::Type::PATH);
     pc.variable_->MapTo(path_symbol);
   }
 

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -242,12 +242,14 @@ bool SymbolGenerator::PostVisit(CypherUnion &cypher_union) {
 
 bool SymbolGenerator::PreVisit(Create &) {
   scopes_.back().in_create = true;
-  create_clause_symbols_.clear();
+  // Always empty: sibling CREATEs run in sequence and PostVisit clears, and a CREATE cannot nest inside one.
+  DMG_ASSERT(create_clause_symbols_.empty(), "a CREATE clause left its declared symbols behind");
   return true;
 }
 
 bool SymbolGenerator::PostVisit(Create &) {
   scopes_.back().in_create = false;
+  // A later clause reads these through a frame slot that is written by then, so it must not be rejected.
   create_clause_symbols_.clear();
   return true;
 }
@@ -471,13 +473,15 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     throw SemanticException("Variables are not allowed in {}.", scope.in_skip ? "SKIP" : "LIMIT");
   }
 
-  // An un-imported name of the enclosing query is out of scope inside a `CALL {}` subquery, so a pattern occurrence
-  // of it declares a fresh variable instead of referencing the outer one. Referencing it would resolve to the outer
-  // symbol and make the branch write through its frame slot, which the subquery shares with its caller.
-  const bool shadows_outer_name = scope.in_pattern && IsOutsideCallSubquery(ident.name_);
-  // Whether the name is in scope here. A shadowed outer name is not, so the rules below treat it as undeclared:
-  // patterns declare it afresh, while `exists()` - which may not introduce variables - rejects it.
-  const bool name_in_scope = HasSymbol(ident.name_) && !shadows_outer_name;
+  // Inside a `CALL {}` subquery only the scopes from its own outwards are visible; an un-imported name of the
+  // enclosing query is out of scope. A pattern occurrence of such a name declares a fresh variable rather than
+  // referencing the outer one, which would resolve to the outer symbol and make the branch write through its frame
+  // slot - the one the subquery shares with its caller.
+  auto const from = scope.in_pattern ? scope.call_subquery_base.value_or(0) : 0;
+  // A shadowed outer name is not in scope, so the rules below treat it as undeclared: patterns declare it afresh,
+  // while `exists()` - which may not introduce variables - rejects it.
+  const bool name_in_scope = HasSymbol(ident.name_, from);
+  const bool shadows_outer_name = !name_in_scope && from != 0 && HasSymbol(ident.name_);
 
   if (scope.in_exists_pattern && (scope.visiting_edge || scope.in_node_atom)) {
     if (!name_in_scope && !ConsumePredefinedIdentifier(ident.name_) && ident.user_declared_) {
@@ -1109,17 +1113,9 @@ void SymbolGenerator::VisitWithIdentifiers(std::vector<Expression *> exprs,
   }
 }
 
-bool SymbolGenerator::HasSymbol(const std::string &name) const {
-  return std::ranges::any_of(scopes_, [&name](const auto &scope) { return scope.symbols.contains(name); });
-}
-
-bool SymbolGenerator::IsOutsideCallSubquery(const std::string &name) const {
-  const auto base = scopes_.back().call_subquery_base;
-  if (!base) {
-    return false;
-  }
-  auto const inside = std::ranges::subrange(scopes_.begin() + static_cast<std::ptrdiff_t>(*base), scopes_.end());
-  return std::ranges::none_of(inside, [&name](const auto &scope) { return scope.symbols.contains(name); });
+bool SymbolGenerator::HasSymbol(const std::string &name, size_t from) const {
+  auto const visible = std::ranges::subrange(scopes_.begin() + static_cast<std::ptrdiff_t>(from), scopes_.end());
+  return std::ranges::any_of(visible, [&name](const auto &scope) { return scope.symbols.contains(name); });
 }
 
 bool SymbolGenerator::ConsumePredefinedIdentifier(const std::string &name) {

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -242,7 +242,7 @@ bool SymbolGenerator::PostVisit(CypherUnion &cypher_union) {
 
 bool SymbolGenerator::PreVisit(Create &) {
   scopes_.back().in_create = true;
-  // Always empty: sibling CREATEs run in sequence and PostVisit clears, and a CREATE cannot nest inside one.
+  // Always empty: siblings run in sequence and PostVisit clears, and a CREATE cannot nest.
   DMG_ASSERT(create_clause_symbols_.empty(), "a CREATE clause left its declared symbols behind");
   return true;
 }
@@ -473,13 +473,10 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     throw SemanticException("Variables are not allowed in {}.", scope.in_skip ? "SKIP" : "LIMIT");
   }
 
-  // Inside a `CALL {}` subquery only the scopes from its own outwards are visible; an un-imported name of the
-  // enclosing query is out of scope. A pattern occurrence of such a name declares a fresh variable rather than
-  // referencing the outer one, which would resolve to the outer symbol and make the branch write through its frame
-  // slot - the one the subquery shares with its caller.
+  // Inside a `CALL {}` subquery only its own scopes outwards are visible. A pattern occurrence of an un-imported
+  // outer name declares a fresh variable, rather than writing through the frame slot the caller shares.
   auto const from = scope.in_pattern ? scope.call_subquery_base.value_or(0) : 0;
-  // A shadowed outer name is not in scope, so the rules below treat it as undeclared: patterns declare it afresh,
-  // while `exists()` - which may not introduce variables - rejects it.
+  // Treated as undeclared below: patterns declare it afresh, `exists()` rejects it.
   const bool name_in_scope = HasSymbol(ident.name_, from);
   const bool shadows_outer_name = !name_in_scope && from != 0 && HasSymbol(ident.name_);
 
@@ -497,14 +494,12 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     if (!name_in_scope) {
       ident.user_declared_ = false;
       auto const type = scope.in_node_atom ? Symbol::Type::VERTEX : Symbol::Type::EDGE;
-      // A shadowed outer name is still found by GetOrCreateSymbol, so declare it here instead.
+      // Shadowed: GetOrCreateSymbol would find the outer symbol, so declare here.
       symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, type)
                                   : GetOrCreateSymbol(ident.name_, ident.user_declared_, type);
     } else {
-      // Resolving to the outer symbol is what correlates the pattern to the enclosing row, and for a node the planner
-      // can check the expansion reaches that node. For an edge it cannot - there is no `existing_edge` counterpart to
-      // `existing_node` - so reject here instead of building a plan that cannot be emitted. The same reuse spelled in
-      // an ORDER BY is already rejected below, by the `visiting_edge` branch.
+      // A bound node correlates: `Expand` can check the expansion reaches it. An edge has no `existing_edge`
+      // counterpart, so there is no operator to emit. The ORDER BY spelling is already rejected below.
       if (scope.in_pattern_atom_identifier && scope.visiting_edge) {
         throw SemanticException("Cannot use the already bound relationship '{}' in a pattern here.", ident.name_);
       }
@@ -533,10 +528,10 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
       }
       type = scope.visiting_edge->IsVariable() ? Symbol::Type::EDGE_LIST : Symbol::Type::EDGE;
     }
-    // A shadowed outer name must not resolve to the enclosing query's symbol, so declare it in this scope.
+    // Shadowed: must not resolve to the enclosing query's symbol.
     symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, type)
                                 : GetOrCreateSymbol(ident.name_, ident.user_declared_, type);
-    // An atom that was not already in scope is declared here, so this CREATE clause is what binds it.
+    // Not already in scope, so this CREATE is what binds it.
     if (scope.in_create && !name_in_scope) {
       create_clause_symbols_.insert(symbol);
     }
@@ -568,8 +563,7 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::ANY);
   }
 
-  // The operator that binds a symbol declared by this CREATE is the same one that reads the comprehension's result, so
-  // the frame slot is still unwritten when the clause needs it. There is no placement that works - reject instead.
+  // The operator that binds the symbol is the one that reads the comprehension's result, so no placement works.
   if (scope.in_pattern_comprehension && create_clause_symbols_.contains(symbol)) {
     throw SemanticException(
         "Entity '{}' cannot be created and referenced by a pattern comprehension in the same clause.", ident.name_);
@@ -1057,8 +1051,7 @@ bool SymbolGenerator::PostVisit(EdgeAtom &) {
 }
 
 bool SymbolGenerator::PreVisit(PatternComprehension &pc) {
-  // Carry the subquery boundary in: a pattern inside the comprehension must not silently reach a variable of
-  // the enclosing query (see IsOutsideCallSubquery).
+  // Carry the subquery boundary in, so a pattern inside cannot reach an un-imported outer name.
   scopes_.emplace_back(
       Scope{.in_pattern_comprehension = true, .call_subquery_base = scopes_.back().call_subquery_base});
 

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -497,6 +497,13 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
       symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, type)
                                   : GetOrCreateSymbol(ident.name_, ident.user_declared_, type);
     } else {
+      // Resolving to the outer symbol is what correlates the pattern to the enclosing row, and for a node the planner
+      // can check the expansion reaches that node. For an edge it cannot - there is no `existing_edge` counterpart to
+      // `existing_node` - so reject here instead of building a plan that cannot be emitted. The same reuse spelled in
+      // an ORDER BY is already rejected below, by the `visiting_edge` branch.
+      if (scope.in_pattern_atom_identifier && scope.visiting_edge) {
+        throw SemanticException("Cannot use the already bound relationship '{}' in a pattern here.", ident.name_);
+      }
       symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::ANY);
     }
   } else if (scope.in_pattern && !(scope.in_node_atom || scope.visiting_edge)) {

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -208,6 +208,7 @@ bool SymbolGenerator::PreVisit(CypherUnion &) {
   // Currently only CALL and EXISTS subqueries can contain complete queries with UNION.
   next_scope.in_call_subquery = prev_scope.in_call_subquery;
   next_scope.in_exists_subquery = prev_scope.in_exists_subquery;
+  next_scope.call_subquery_base = prev_scope.call_subquery_base;
   // Carry over explicit `CALL (v1, v2) { ... }` imports so each UNION branch
   // within the subquery still sees the imported variables.
   next_scope.call_subquery_imports = prev_scope.call_subquery_imports;
@@ -271,6 +272,8 @@ bool SymbolGenerator::PostVisit(CallProcedure &call_proc) {
 
 bool SymbolGenerator::PreVisit(CallSubquery &call_sub) {
   Scope new_scope{.in_call_subquery = true};
+  // The scope about to be pushed is the subquery's outermost one; names below it need an explicit import.
+  new_scope.call_subquery_base = scopes_.size();
 
   if (call_sub.has_variable_scope_) {
     // `CALL (...) { ... }`: resolve imports against the current outer scope
@@ -444,8 +447,10 @@ bool SymbolGenerator::PostVisit(Match &) {
 
 bool SymbolGenerator::PreVisit(Foreach &for_each) {
   const auto &name = for_each.named_expression_->name_;
+  auto const call_subquery_base = scopes_.back().call_subquery_base;
   scopes_.emplace_back(Scope());
   scopes_.back().in_foreach = true;
+  scopes_.back().call_subquery_base = call_subquery_base;
   for_each.named_expression_->MapTo(
       CreateSymbol(name, true, Symbol::Type::ANY, for_each.named_expression_->token_position_));
   return true;
@@ -464,9 +469,16 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     throw SemanticException("Variables are not allowed in {}.", scope.in_skip ? "SKIP" : "LIMIT");
   }
 
+  // An un-imported name of the enclosing query is out of scope inside a `CALL {}` subquery, so a pattern occurrence
+  // of it declares a fresh variable instead of referencing the outer one. Referencing it would resolve to the outer
+  // symbol and make the branch write through its frame slot, which the subquery shares with its caller.
+  const bool shadows_outer_name = scope.in_pattern && IsOutsideCallSubquery(ident.name_);
+  // Whether the name is in scope here. A shadowed outer name is not, so the rules below treat it as undeclared:
+  // patterns declare it afresh, while `exists()` - which may not introduce variables - rejects it.
+  const bool name_in_scope = HasSymbol(ident.name_) && !shadows_outer_name;
+
   if (scope.in_exists_pattern && (scope.visiting_edge || scope.in_node_atom)) {
-    auto has_symbol = HasSymbol(ident.name_);
-    if (!has_symbol && !ConsumePredefinedIdentifier(ident.name_) && ident.user_declared_) {
+    if (!name_in_scope && !ConsumePredefinedIdentifier(ident.name_) && ident.user_declared_) {
       throw SemanticException("Unbounded variables are not allowed in exists!");
     }
   }
@@ -476,11 +488,12 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
 
   Symbol symbol;
   if ((scope.in_exists_subquery || is_in_pattern_comprehension_filter) && (scope.visiting_edge || scope.in_node_atom)) {
-    auto has_symbol = HasSymbol(ident.name_);
-    if (!has_symbol) {
+    if (!name_in_scope) {
       ident.user_declared_ = false;
-      symbol = GetOrCreateSymbol(
-          ident.name_, ident.user_declared_, scope.in_node_atom ? Symbol::Type::VERTEX : Symbol::Type::EDGE);
+      auto const type = scope.in_node_atom ? Symbol::Type::VERTEX : Symbol::Type::EDGE;
+      // A shadowed outer name is still found by GetOrCreateSymbol, so declare it here instead.
+      symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, type)
+                                  : GetOrCreateSymbol(ident.name_, ident.user_declared_, type);
     } else {
       symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::ANY);
     }
@@ -495,19 +508,21 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     //  `MATCH (n) CREATE (n)` should throw an error that `n` is already
     //  declared. While `MATCH (n) CREATE (n) -[:R]-> (n)` is allowed,
     //  since `n` now references the bound node instead of declaring it.
-    if ((scope.in_create_node || scope.in_create_edge) && HasSymbol(ident.name_)) {
+    if ((scope.in_create_node || scope.in_create_edge) && name_in_scope) {
       throw RedeclareVariableError(ident.name_);
     }
     auto type = Symbol::Type::VERTEX;
     if (scope.visiting_edge) {
       // Edge referencing is not allowed (like in Neo4j):
       // `MATCH (n) - [r] -> (n) - [r] -> (n) RETURN r` is not allowed.
-      if (HasSymbol(ident.name_)) {
+      if (name_in_scope) {
         throw RedeclareVariableError(ident.name_);
       }
       type = scope.visiting_edge->IsVariable() ? Symbol::Type::EDGE_LIST : Symbol::Type::EDGE;
     }
-    symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, type);
+    // A shadowed outer name must not resolve to the enclosing query's symbol, so declare it in this scope.
+    symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, type)
+                                : GetOrCreateSymbol(ident.name_, ident.user_declared_, type);
   } else if (scope.in_pattern && !scope.in_pattern_atom_identifier && scope.in_match) {
     if (scope.in_edge_range && scope.visiting_edge && scope.visiting_edge->identifier_ &&
         scope.visiting_edge->identifier_->name_ == ident.name_) {
@@ -702,7 +717,8 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
   }
 
   if (exists.HasSubquery()) {
-    scopes_.emplace_back(Scope{.in_exists_subquery = true});  // NOLINT(hicpp-use-emplace,modernize-use-emplace)
+    // NOLINTNEXTLINE(hicpp-use-emplace,modernize-use-emplace)
+    scopes_.emplace_back(Scope{.in_exists_subquery = true, .call_subquery_base = scope.call_subquery_base});
   }
 
   return true;
@@ -1017,7 +1033,10 @@ bool SymbolGenerator::PostVisit(EdgeAtom &) {
 }
 
 bool SymbolGenerator::PreVisit(PatternComprehension &pc) {
-  scopes_.emplace_back(Scope{.in_pattern_comprehension = true});
+  // Carry the subquery boundary in: a pattern inside the comprehension must not silently reach a variable of
+  // the enclosing query (see IsOutsideCallSubquery).
+  scopes_.emplace_back(
+      Scope{.in_pattern_comprehension = true, .call_subquery_base = scopes_.back().call_subquery_base});
 
   const auto &symbol = CreateAnonymousSymbol();
   pc.MapTo(symbol);
@@ -1072,6 +1091,15 @@ void SymbolGenerator::VisitWithIdentifiers(std::vector<Expression *> exprs,
 
 bool SymbolGenerator::HasSymbol(const std::string &name) const {
   return std::ranges::any_of(scopes_, [&name](const auto &scope) { return scope.symbols.contains(name); });
+}
+
+bool SymbolGenerator::IsOutsideCallSubquery(const std::string &name) const {
+  const auto base = scopes_.back().call_subquery_base;
+  if (!base) {
+    return false;
+  }
+  auto const inside = std::ranges::subrange(scopes_.begin() + static_cast<std::ptrdiff_t>(*base), scopes_.end());
+  return std::ranges::none_of(inside, [&name](const auto &scope) { return scope.symbols.contains(name); });
 }
 
 bool SymbolGenerator::ConsumePredefinedIdentifier(const std::string &name) {

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -187,11 +187,9 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
 
   static std::optional<Symbol> FindSymbolInScope(const std::string &name, const Scope &scope, Symbol::Type type);
 
-  bool HasSymbol(const std::string &name) const;
-
-  // True if @p name resolves only outside the innermost enclosing `CALL {}` subquery, i.e. it belongs to the
-  // enclosing query and was never imported. Always false when not inside a subquery.
-  bool IsOutsideCallSubquery(const std::string &name) const;
+  // Whether @p name resolves in any scope from index @p from outwards. `call_subquery_base` is the index to pass to
+  // ask only about what is visible inside a `CALL {}` subquery.
+  bool HasSymbol(const std::string &name, size_t from = 0) const;
 
   // @return true if it added a predefined identifier with that name
   bool ConsumePredefinedIdentifier(const std::string &name);

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -169,6 +169,9 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
     std::map<std::string, Symbol> symbols;
     // Symbols imported into a `CALL (v1, v2, ...) { ... }` subquery scope.
     std::map<std::string, Symbol> call_subquery_imports;
+    // Index into scopes_ of the scope that opened the innermost enclosing `CALL {}` subquery. A name that resolves
+    // only in a scope below it belongs to the enclosing query and is not visible here without an explicit import.
+    std::optional<size_t> call_subquery_base;
     // Identifiers found in property maps of patterns or as variable length path
     // bounds in a single Match clause. They need to be checked after visiting
     // Match. Identifiers created by naming vertices, edges and paths are *not*
@@ -185,6 +188,10 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   static std::optional<Symbol> FindSymbolInScope(const std::string &name, const Scope &scope, Symbol::Type type);
 
   bool HasSymbol(const std::string &name) const;
+
+  // True if @p name resolves only outside the innermost enclosing `CALL {}` subquery, i.e. it belongs to the
+  // enclosing query and was never imported. Always false when not inside a subquery.
+  bool IsOutsideCallSubquery(const std::string &name) const;
 
   // @return true if it added a predefined identifier with that name
   bool ConsumePredefinedIdentifier(const std::string &name);

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -169,8 +169,8 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
     std::map<std::string, Symbol> symbols;
     // Symbols imported into a `CALL (v1, v2, ...) { ... }` subquery scope.
     std::map<std::string, Symbol> call_subquery_imports;
-    // Index into scopes_ of the scope that opened the innermost enclosing `CALL {}` subquery. A name that resolves
-    // only in a scope below it belongs to the enclosing query and is not visible here without an explicit import.
+    // Index of the scope that opened the innermost enclosing `CALL {}`. A name resolving only below it belongs to
+    // the enclosing query and needs an explicit import.
     std::optional<size_t> call_subquery_base;
     // Identifiers found in property maps of patterns or as variable length path
     // bounds in a single Match clause. They need to be checked after visiting
@@ -187,8 +187,7 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
 
   static std::optional<Symbol> FindSymbolInScope(const std::string &name, const Scope &scope, Symbol::Type type);
 
-  // Whether @p name resolves in any scope from index @p from outwards. `call_subquery_base` is the index to pass to
-  // ask only about what is visible inside a `CALL {}` subquery.
+  // Whether @p name resolves in any scope from @p from outwards; pass `call_subquery_base` to ask about a subquery.
   bool HasSymbol(const std::string &name, size_t from = 0) const;
 
   // @return true if it added a predefined identifier with that name
@@ -217,8 +216,8 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   std::unordered_map<std::string, Identifier *> predefined_identifiers_;
   std::vector<Scope> scopes_;
   Scope global_scope_;
-  // Symbols declared by the CREATE clause currently being visited. A pattern comprehension inside that clause may not
-  // reference one of them - see the check in Visit(Identifier &). Empty outside a CREATE; CREATE cannot nest.
+  // Symbols the CREATE clause being visited declares. A pattern comprehension inside it may not reference one -
+  // see Visit(Identifier &). CREATE pushes no scope of its own, so this cannot be derived from `scopes_`.
   std::unordered_set<Symbol> create_clause_symbols_;
 };
 

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -219,6 +219,9 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   std::unordered_map<std::string, Identifier *> predefined_identifiers_;
   std::vector<Scope> scopes_;
   Scope global_scope_;
+  // Symbols declared by the CREATE clause currently being visited. A pattern comprehension inside that clause may not
+  // reference one of them - see the check in Visit(Identifier &). Empty outside a CREATE; CREATE cannot nest.
+  std::unordered_set<Symbol> create_clause_symbols_;
 };
 
 /// Visits the AST and assigns the evaluation mode for all the property lookups

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -9188,6 +9188,11 @@ std::vector<Symbol> RollUpApply::ModifiedSymbols(const SymbolTable &table) const
   return symbols;
 }
 
+std::vector<Symbol> RollUpApply::OutputSymbols(const SymbolTable &symbol_table) const {
+  // The result symbol is internal to expression evaluation, so only the input's output columns are propagated.
+  return input_->OutputSymbols(symbol_table);
+}
+
 bool RollUpApply::Accept(HierarchicalLogicalOperatorVisitor &visitor) {
   if (visitor.PreVisit(*this)) {
     if (!input_ || !list_collection_branch_) {

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -256,20 +256,19 @@ class LogicalOperator : public utils::Visitable<HierarchicalLogicalOperatorVisit
 
   /** Return @c Symbol vector where the query results will be stored.
    *
-   * Output symbols are the query's result columns, in order - not every symbol the operator writes
-   * (see @c ModifiedSymbols). Three kinds of operator answer:
+   * The query's result columns, in order - not every symbol the operator writes (see @c ModifiedSymbols).
+   * Three kinds of operator answer:
    *
-   * - those that define columns: @c Produce, @c Union, @c CallProcedure, @c LoadCsv, @c LoadParquet,
-   *   @c LoadJsonl, @c OutputTable and @c OutputTableStream;
-   * - those that sit above a column-defining operator and propagate its symbols: @c OrderBy,
-   *   @c OrderByParallel, @c Distinct, @c Skip, @c Limit, @c PeriodicCommit and @c RollUpApply;
-   * - @c EmptyResult, which suppresses them - it is how a query with no result columns is expressed.
+   * - column-defining: @c Produce, @c Union, @c CallProcedure, @c LoadCsv, @c LoadParquet, @c LoadJsonl,
+   *   @c OutputTable, @c OutputTableStream;
+   * - propagating from their input: @c OrderBy, @c OrderByParallel, @c Distinct, @c Skip, @c Limit,
+   *   @c PeriodicCommit, @c RollUpApply;
+   * - @c EmptyResult, which suppresses them.
    *
-   * Propagation is never automatic: the default below returns @c {} for every operator that does not
-   * override, whatever its input. So any operator inserted between the plan root and the
-   * column-defining operator must override and propagate, or the plan root reports no columns, gets
-   * wrapped in @c EmptyResult, and the query silently returns zero of them. That is why
-   * @c RollUpApply propagates, now that it may be spliced above the @c Produce.
+   * Propagation is never automatic - the default returns @c {} whatever the input - so an operator between
+   * the plan root and the column-defining one must override, or the root reports no columns, gets wrapped in
+   * @c EmptyResult, and the query silently returns none. @c Filter is the exception that does not override,
+   * safe only because a @c WITH ... @c WHERE is never a query's last clause.
    *
    *  @param SymbolTable used to find symbols for expressions.
    *  @return std::vector<Symbol> used for results.

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -257,18 +257,19 @@ class LogicalOperator : public utils::Visitable<HierarchicalLogicalOperatorVisit
   /** Return @c Symbol vector where the query results will be stored.
    *
    * Output symbols are the query's result columns, in order - not every symbol the operator writes
-   * (see @c ModifiedSymbols). Two kinds of operator answer:
+   * (see @c ModifiedSymbols). Three kinds of operator answer:
    *
    * - those that define columns: @c Produce, @c Union, @c CallProcedure, @c LoadCsv, @c LoadParquet,
    *   @c LoadJsonl, @c OutputTable and @c OutputTableStream;
    * - those that sit above a column-defining operator and propagate its symbols: @c OrderBy,
-   *   @c OrderByParallel, @c Distinct, @c Skip, @c Limit, @c PeriodicCommit and @c RollUpApply.
+   *   @c OrderByParallel, @c Distinct, @c Skip, @c Limit, @c PeriodicCommit and @c RollUpApply;
+   * - @c EmptyResult, which suppresses them - it is how a query with no result columns is expressed.
    *
-   * The default @c {} means "this query has no result columns", which is what wraps a plan in
-   * @c EmptyResult. So any operator inserted between the plan root and the column-defining operator
-   * must propagate, or the query silently returns zero columns. This is not automatic for a
-   * multi-input operator: @c HasSingleInput is false there, so it must override explicitly - as
-   * @c RollUpApply does, once it may be spliced above the @c Produce.
+   * Propagation is never automatic: the default below returns @c {} for every operator that does not
+   * override, whatever its input. So any operator inserted between the plan root and the
+   * column-defining operator must override and propagate, or the plan root reports no columns, gets
+   * wrapped in @c EmptyResult, and the query silently returns zero of them. That is why
+   * @c RollUpApply propagates, now that it may be spliced above the @c Produce.
    *
    *  @param SymbolTable used to find symbols for expressions.
    *  @return std::vector<Symbol> used for results.

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -3191,6 +3191,7 @@ class RollUpApply : public memgraph::query::plan::LogicalOperator {
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
   std::vector<Symbol> ModifiedSymbols(const SymbolTable &) const override;
+  std::vector<Symbol> OutputSymbols(const SymbolTable &) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -256,9 +256,19 @@ class LogicalOperator : public utils::Visitable<HierarchicalLogicalOperatorVisit
 
   /** Return @c Symbol vector where the query results will be stored.
    *
-   * Currently, output symbols are generated in @c Produce @c Union and
-   * @c CallProcedure operators. @c Skip, @c Limit, @c OrderBy and @c Distinct
-   * propagate the symbols from @c Produce (if it exists as input operator).
+   * Output symbols are the query's result columns, in order - not every symbol the operator writes
+   * (see @c ModifiedSymbols). Two kinds of operator answer:
+   *
+   * - those that define columns: @c Produce, @c Union, @c CallProcedure, @c LoadCsv, @c LoadParquet,
+   *   @c LoadJsonl, @c OutputTable and @c OutputTableStream;
+   * - those that sit above a column-defining operator and propagate its symbols: @c OrderBy,
+   *   @c OrderByParallel, @c Distinct, @c Skip, @c Limit, @c PeriodicCommit and @c RollUpApply.
+   *
+   * The default @c {} means "this query has no result columns", which is what wraps a plan in
+   * @c EmptyResult. So any operator inserted between the plan root and the column-defining operator
+   * must propagate, or the query silently returns zero columns. This is not automatic for a
+   * multi-input operator: @c HasSingleInput is false there, so it must override explicitly - as
+   * @c RollUpApply does, once it may be spliced above the @c Produce.
    *
    *  @param SymbolTable used to find symbols for expressions.
    *  @return std::vector<Symbol> used for results.

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -152,10 +152,8 @@ class UsedSymbolsCollector : public HierarchicalTreeVisitor {
 
  private:
   bool in_exists{false};
-  // A depth, not a flag: `PreVisit` above descends into the pattern itself, whose property maps and variable-length
-  // bounds may hold another comprehension. A flag would be cleared by the inner one's `PostVisit` and let the rest of
-  // the outer pattern collect anonymous symbols. (`filter_`/`resultExpr_` are not reached from here - `PreVisit`
-  // returns false - but `WhereReadSymbolsCollector` in the planner does visit them, which is the other way to nest.)
+  // A depth, not a flag: a pattern's property maps and variable-length bounds may hold another comprehension, whose
+  // `PostVisit` would clear a flag and let the rest of the outer pattern collect anonymous symbols.
   int in_pattern_comprehension_depth{0};
 };
 

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -84,7 +84,7 @@ class UsedSymbolsCollector : public HierarchicalTreeVisitor {
   }
 
   bool Visit(Identifier &ident) override {
-    const bool is_ordinary_flow = !in_exists && !in_pattern_comprehension;
+    const bool is_ordinary_flow = !in_exists && in_pattern_comprehension_depth == 0;
     if (is_ordinary_flow) {
       symbols_.insert(symbol_table_.at(ident));
     } else if (ident.user_declared_) {
@@ -130,14 +130,14 @@ class UsedSymbolsCollector : public HierarchicalTreeVisitor {
   }
 
   bool PreVisit(PatternComprehension &pc) override {
-    in_pattern_comprehension = true;
+    ++in_pattern_comprehension_depth;
     pc.pattern_->Accept(*this);
 
     return false;
   }
 
   bool PostVisit(PatternComprehension & /*pc*/) override {
-    in_pattern_comprehension = false;
+    --in_pattern_comprehension_depth;
     return true;
   }
 
@@ -152,7 +152,9 @@ class UsedSymbolsCollector : public HierarchicalTreeVisitor {
 
  private:
   bool in_exists{false};
-  bool in_pattern_comprehension{false};
+  // A depth, not a flag: a comprehension nested in another one's filter or result expression would otherwise clear
+  // it on the way out and let the rest of the outer traversal collect anonymous symbols.
+  int in_pattern_comprehension_depth{0};
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -152,8 +152,10 @@ class UsedSymbolsCollector : public HierarchicalTreeVisitor {
 
  private:
   bool in_exists{false};
-  // A depth, not a flag: a comprehension nested in another one's filter or result expression would otherwise clear
-  // it on the way out and let the rest of the outer traversal collect anonymous symbols.
+  // A depth, not a flag: `PreVisit` above descends into the pattern itself, whose property maps and variable-length
+  // bounds may hold another comprehension. A flag would be cleared by the inner one's `PostVisit` and let the rest of
+  // the outer pattern collect anonymous symbols. (`filter_`/`resultExpr_` are not reached from here - `PreVisit`
+  // returns false - but `WhereReadSymbolsCollector` in the planner does visit them, which is the other way to nest.)
   int in_pattern_comprehension_depth{0};
 };
 

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -36,22 +36,21 @@ bool IsConstantLiteral(const Expression *expression) {
   return utils::Downcast<const PrimitiveLiteral>(expression) || utils::Downcast<const ParameterLookup>(expression);
 }
 
-/// True if the comprehension's own pattern holds a variable-length edge. `ExpandVariable` can only read View::OLD, so
-/// such a comprehension must be planned with it. Only the top level - a nested comprehension is planned separately.
+/// Whether the comprehension's own pattern holds a variable-length edge. Top level only - a nested one is planned
+/// separately and gets its own view.
 bool HasVariableLengthExpansion(const PatternComprehensionMatching &pc) {
   return std::ranges::any_of(pc.expansions,
                              [](const auto &expansion) { return expansion.edge && expansion.edge->IsVariable(); });
 }
 
-/// Like UsedSymbolsCollector, but also descends into a comprehension's filter and result expression - everything the
-/// WHERE evaluates must survive an OrderBy below it. The base class stops at the pattern, as its other callers need.
+/// Like UsedSymbolsCollector but also descends into a comprehension's filter and result expression: everything the
+/// WHERE evaluates must survive an OrderBy below it. The base stops at the pattern, as its other callers need.
 class WhereReadSymbolsCollector : public UsedSymbolsCollector {
  public:
   using UsedSymbolsCollector::UsedSymbolsCollector;
 
   bool PreVisit(PatternComprehension &pc) override {
-    // Visits pc.pattern_ and enters the comprehension, which keeps anonymous symbols out. The base tracks a depth,
-    // so a comprehension nested in filter_/resultExpr_ below does not release us early.
+    // The base tracks a depth, so a comprehension nested below does not release us early.
     UsedSymbolsCollector::PreVisit(pc);
     if (pc.filter_) {
       pc.filter_->Accept(*this);
@@ -107,8 +106,8 @@ class PCSymbolCollector : public HierarchicalTreeVisitor {
 // aggregations and expressions used for group by.
 class ReturnBodyContext : public HierarchicalTreeVisitor {
  public:
-  // Where in the return body an expression sits, which determines where a pattern comprehension found in it must be
-  // spliced: the projection is evaluated by the Produce, ORDER BY below the OrderBy, and WHERE above it.
+  // Where in the return body an expression sits, hence where a comprehension in it is spliced: the projection below
+  // the Produce, ORDER BY below the OrderBy, WHERE above it.
   enum class BodyPosition : uint8_t { kProjection, kOrderBy, kWhere };
 
   ReturnBodyContext(const ReturnBody &body, SymbolTable &symbol_table, const std::unordered_set<Symbol> &bound_symbols,
@@ -141,8 +140,7 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       }
       group_by_used_symbols_ = collector.symbols_;
     }
-    // ORDER BY and WHERE are evaluated after the Produce, so a comprehension there also sees the named expression
-    // symbols - it must be planned against them and spliced in after the Produce.
+    // ORDER BY and WHERE run after the Produce, so a comprehension there also sees the named expression symbols.
     post_produce_bound_symbols_ = bound_symbols_;
     post_produce_bound_symbols_.insert(output_symbols_.begin(), output_symbols_.end());
     if (aggregations_.empty()) {
@@ -163,9 +161,8 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       }
       MG_ASSERT(aggregations_.empty(), "Unexpected aggregations in ORDER BY or WHERE");
     } else {
-      // With aggregations we must not visit ORDER BY and WHERE fully, or their expressions would pollute group_by_.
-      // Comprehensions in them still need planning, so only collect their symbols. Nested ones are collected too but
-      // are never pending - only top-level matchings are - so they drop out of the lookup.
+      // Visiting ORDER BY / WHERE fully would pollute group_by_, so only collect comprehension symbols. Nested ones
+      // are collected too but are never pending, so they drop out of the lookup.
       auto plan_comprehensions_in = [&](Expression &expr, BodyPosition position) {
         std::unordered_set<Symbol> pc_symbols;
         PCSymbolCollector collector(symbol_table_, pc_symbols);
@@ -567,8 +564,7 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     }
     has_aggregation_.emplace_back(has_aggr);
 
-    // Only plan top-level pattern comprehensions. Nested pattern comprehensions are handled inside their parent's
-    // operator tree.
+    // Nested comprehensions are planned inside their parent's operator tree.
     if (aggregations_start_index_stack_.empty()) {
       PlanPatternComprehensionOnDemand(symbol_table_.at(pattern_comprehension));
     }
@@ -642,14 +638,12 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     return pattern_comprehension_datas_;
   }
 
-  // Pattern comprehensions from ORDER BY, which read the named expression symbols and so must be planned after the
-  // Produce, but below the OrderBy that consumes them.
+  // From ORDER BY: planned after the Produce whose symbols they read, below the OrderBy that consumes them.
   std::unordered_map<Symbol, PatternComprehensionData> order_by_pattern_comprehension_data() const {
     return order_by_pattern_comprehension_datas_;
   }
 
-  // Pattern comprehensions from WHERE. OrderBy restores only its own output symbols, so these must be planned above
-  // it - directly below the Filter that consumes them.
+  // From WHERE: above the OrderBy, which restores only its own output symbols, and below the Filter.
   std::unordered_map<Symbol, PatternComprehensionData> where_pattern_comprehension_data() const {
     return where_pattern_comprehension_datas_;
   }
@@ -664,11 +658,9 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   const auto &pattern_comprehensions_in_aggregations() const { return pattern_comprehensions_in_aggregations_; }
 
  private:
-  // Plans the comprehension with result symbol @p result_sym if it is still pending, into the bucket matching its
-  // position in the return body.
+  // Plans @p result_sym's comprehension if still pending, into the bucket for its position in the body.
   void PlanPatternComprehensionOnDemand(const Symbol &result_sym) {
-    // Skip if we don't have a planning context (e.g. when analyzing bound symbols in GetSubqueryBoundSymbols) - the
-    // actual planning will handle them later.
+    // No planning context (e.g. GetSubqueryBoundSymbols); the real planning pass handles them later.
     if (!pc_ctx_ || !pc_ctx_->planner) {
       return;
     }
@@ -719,8 +711,6 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   std::unordered_map<Symbol, PatternComprehensionData> pattern_comprehension_datas_;
   std::unordered_map<Symbol, PatternComprehensionData> order_by_pattern_comprehension_datas_;
   std::unordered_map<Symbol, PatternComprehensionData> where_pattern_comprehension_datas_;
-  // Which part of the return body is currently being visited. ORDER BY and WHERE are both evaluated after the
-  // Produce, but at different points in the operator chain, so their comprehensions need separate splice points.
   BodyPosition position_ = BodyPosition::kProjection;
   // What a post-Produce comprehension may reference: the symbols bound before this clause plus its own output symbols.
   std::unordered_set<Symbol> post_produce_bound_symbols_;
@@ -813,7 +803,6 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
     last_op = std::make_unique<Aggregate>(std::move(last_op), body.aggregations(), body.group_by(), remember);
   }
 
-  // Splices a RollUpApply for each planned comprehension in @p pc_data onto last_op.
   auto splice_comprehensions = [&](auto &&pc_data) {
     for (auto &[result_symbol, list_collection_data] : pc_data) {
       if (list_collection_data.op) {
@@ -837,14 +826,12 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
   if (body.distinct()) {
     last_op = std::make_unique<Distinct>(std::move(last_op), body.output_symbols());
   }
-  // Comprehensions in ORDER BY reference the named expression symbols, so they can only be evaluated once Produce has
-  // written them. OrderBy reads them during its collection sweep, so they belong directly below it.
+  // They read the named expression symbols, and OrderBy reads them in its collection sweep - so directly below it.
   splice_comprehensions(body.order_by_pattern_comprehension_data());
   // Like Where, OrderBy can read from symbols established by named expressions
   // in Produce, so it must come after it.
   if (!body.order_by().empty()) {
-    // OrderBy restores only the symbols it is given, so anything an operator above it reads must be listed here.
-    // Filter(where) - and any comprehension branch feeding it - sits above OrderBy, so add what the WHERE reads.
+    // OrderBy restores only what it is given, and Filter(where) sits above it, so add what the WHERE reads.
     auto remember = body.output_symbols();
     if (body.where()) {
       WhereReadSymbolsCollector collector(body.symbol_table());
@@ -869,8 +856,7 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
   // Where may see new symbols so it comes after we generate Produce and in
   // general, comes after any OrderBy, Skip or Limit.
   if (body.where()) {
-    // Directly below the Filter, because OrderBy restores only its own output symbols: a comprehension spliced below
-    // an OrderBy would hand the Filter one frozen value for every replayed row.
+    // Below the Filter, not the OrderBy: spliced lower, it would hand the Filter one frozen value per replayed row.
     splice_comprehensions(body.where_pattern_comprehension_data());
     last_op = std::make_unique<Filter>(
         std::move(last_op), std::vector<std::shared_ptr<LogicalOperator>>{}, body.where()->expression_);

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -79,6 +79,10 @@ class PCSymbolCollector : public HierarchicalTreeVisitor {
 // aggregations and expressions used for group by.
 class ReturnBodyContext : public HierarchicalTreeVisitor {
  public:
+  // Where in the return body an expression sits, which determines where a pattern comprehension found in it must be
+  // spliced: the projection is evaluated by the Produce, ORDER BY below the OrderBy, and WHERE above it.
+  enum class BodyPosition : uint8_t { kProjection, kOrderBy, kWhere };
+
   ReturnBodyContext(const ReturnBody &body, SymbolTable &symbol_table, const std::unordered_set<Symbol> &bound_symbols,
                     AstStorage &storage, PatternComprehensionContext *pc_ctx, Where *where = nullptr)
       : body_(body),
@@ -112,7 +116,6 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     // ORDER BY and WHERE are evaluated after the Produce, so they see the named expression symbols. Pattern
     // comprehensions found there must be planned against those symbols and spliced in after the Produce.
     post_produce_bound_symbols_.insert(output_symbols_.begin(), output_symbols_.end());
-    in_post_produce_position_ = true;
     if (aggregations_.empty()) {
       // Visit order_by and where if we do not have aggregations. This way we
       // prevent collecting group_by expressions from order_by and where, which
@@ -120,11 +123,13 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       // only use new symbols (ensured in semantic analysis), so we don't care
       // about collecting used_symbols. Also, semantic analysis should
       // have prevented any aggregations from appearing here.
+      position_ = BodyPosition::kOrderBy;
       for (const auto &order_pair : body.order_by) {
         order_pair.expression->Accept(*this);
       }
 
       if (where) {
+        position_ = BodyPosition::kWhere;
         where->Accept(*this);
       }
       MG_ASSERT(aggregations_.empty(), "Unexpected aggregations in ORDER BY or WHERE");
@@ -132,14 +137,16 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       // With aggregations we must not visit ORDER BY and WHERE fully, or their expressions would pollute group_by_.
       // Pattern comprehensions in them still need planning, so discover them with a dedicated visitor.
       PostProduceComprehensionPlanner planner(*this);
+      position_ = BodyPosition::kOrderBy;
       for (const auto &order_pair : body.order_by) {
         order_pair.expression->Accept(planner);
       }
       if (where) {
+        position_ = BodyPosition::kWhere;
         where->Accept(planner);
       }
     }
-    in_post_produce_position_ = false;
+    position_ = BodyPosition::kProjection;
 
     // Handle pattern comprehensions in SKIP and LIMIT expressions
     // These are processed regardless of aggregation since SKIP/LIMIT come after aggregation
@@ -594,19 +601,21 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   // named_expressions.
   const auto &output_symbols() const { return output_symbols_; }
 
-  bool has_pattern_comprehension() const {
-    return !pattern_comprehension_datas_.empty() || !post_produce_pattern_comprehension_datas_.empty();
-  }
-
   // Pattern comprehensions from the named expressions, planned before the Produce.
   std::unordered_map<Symbol, PatternComprehensionData> pattern_comprehension_data() const {
     return pattern_comprehension_datas_;
   }
 
-  // Pattern comprehensions from ORDER BY / WHERE, which read the named expression symbols and so must be planned
-  // after the Produce.
-  std::unordered_map<Symbol, PatternComprehensionData> post_produce_pattern_comprehension_data() const {
-    return post_produce_pattern_comprehension_datas_;
+  // Pattern comprehensions from ORDER BY, which read the named expression symbols and so must be planned after the
+  // Produce, but below the OrderBy that consumes them.
+  std::unordered_map<Symbol, PatternComprehensionData> order_by_pattern_comprehension_data() const {
+    return order_by_pattern_comprehension_datas_;
+  }
+
+  // Pattern comprehensions from WHERE. OrderBy restores only its own output symbols, so these must be planned above
+  // it - directly below the Filter that consumes them.
+  std::unordered_map<Symbol, PatternComprehensionData> where_pattern_comprehension_data() const {
+    return where_pattern_comprehension_datas_;
   }
 
   // Symbols that were bound before this RETURN/WITH clause (from MATCH, CREATE, etc.)
@@ -660,11 +669,23 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     if (it == pending.end()) {
       return;
     }
-    auto op = in_post_produce_position_ ? pc_ctx_->planner->Plan(it->second, pc_ctx_->view, post_produce_bound_symbols_)
-                                        : pc_ctx_->planner->Plan(it->second, pc_ctx_->view);
-    auto &datas = in_post_produce_position_ ? post_produce_pattern_comprehension_datas_ : pattern_comprehension_datas_;
+    const auto &extra_bound_symbols =
+        position_ == BodyPosition::kProjection ? kNoExtraBoundSymbols : post_produce_bound_symbols_;
+    auto op = pc_ctx_->planner->Plan(it->second, pc_ctx_->view, extra_bound_symbols);
+    auto &datas = Bucket(position_);
     datas[result_sym] = PatternComprehensionData(std::move(op), result_sym, it->second.expansion_symbols);
     pending.erase(it);
+  }
+
+  std::unordered_map<Symbol, PatternComprehensionData> &Bucket(BodyPosition position) {
+    switch (position) {
+      case BodyPosition::kProjection:
+        return pattern_comprehension_datas_;
+      case BodyPosition::kOrderBy:
+        return order_by_pattern_comprehension_datas_;
+      case BodyPosition::kWhere:
+        return where_pattern_comprehension_datas_;
+    }
   }
 
   const ReturnBody &body_;
@@ -688,9 +709,11 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   std::list<bool> has_aggregation_;
   std::vector<NamedExpression *> named_expressions_;
   std::unordered_map<Symbol, PatternComprehensionData> pattern_comprehension_datas_;
-  std::unordered_map<Symbol, PatternComprehensionData> post_produce_pattern_comprehension_datas_;
-  // True while visiting ORDER BY / WHERE, whose expressions are evaluated after the Produce.
-  bool in_post_produce_position_ = false;
+  std::unordered_map<Symbol, PatternComprehensionData> order_by_pattern_comprehension_datas_;
+  std::unordered_map<Symbol, PatternComprehensionData> where_pattern_comprehension_datas_;
+  // Which part of the return body is currently being visited. ORDER BY and WHERE are both evaluated after the
+  // Produce, but at different points in the operator chain, so their comprehensions need separate splice points.
+  BodyPosition position_ = BodyPosition::kProjection;
   // The named expression symbols, which a post-Produce comprehension may reference.
   std::unordered_set<Symbol> post_produce_bound_symbols_;
   // Pattern comprehension symbols that appear inside aggregate expressions.
@@ -801,20 +824,37 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
   if (body.distinct()) {
     last_op = std::make_unique<Distinct>(std::move(last_op), body.output_symbols());
   }
-  // Pattern comprehensions from ORDER BY / WHERE reference the named expression symbols, so they can only be
-  // evaluated once Produce has written them.
-  auto post_produce_pc_data = body.post_produce_pattern_comprehension_data();
-  for (auto &[result_symbol, list_collection_data] : post_produce_pc_data) {
-    if (list_collection_data.op) {
-      auto list_collection_symbols = list_collection_data.op->ModifiedSymbols(body.symbol_table());
-      last_op = std::make_unique<RollUpApply>(
-          std::move(last_op), std::move(list_collection_data.op), list_collection_symbols, result_symbol);
+  // Splices a RollUpApply for each planned comprehension in @p pc_data onto last_op.
+  auto splice_comprehensions = [&](auto pc_data) {
+    for (auto &[result_symbol, list_collection_data] : pc_data) {
+      if (list_collection_data.op) {
+        auto list_collection_symbols = list_collection_data.op->ModifiedSymbols(body.symbol_table());
+        last_op = std::make_unique<RollUpApply>(
+            std::move(last_op), std::move(list_collection_data.op), list_collection_symbols, result_symbol);
+      }
     }
-  }
+  };
+
+  // Comprehensions in ORDER BY reference the named expression symbols, so they can only be evaluated once Produce has
+  // written them. OrderBy reads them during its collection sweep, so they belong directly below it.
+  splice_comprehensions(body.order_by_pattern_comprehension_data());
   // Like Where, OrderBy can read from symbols established by named expressions
   // in Produce, so it must come after it.
   if (!body.order_by().empty()) {
-    last_op = std::make_unique<OrderBy>(std::move(last_op), body.order_by(), body.output_symbols());
+    // OrderBy restores only the symbols it is given, so anything an operator above it reads must be listed here.
+    // Filter(where) - and any comprehension branch feeding it - sits above OrderBy, so add what the WHERE reads.
+    auto remember = body.output_symbols();
+    if (body.where()) {
+      UsedSymbolsCollector collector(body.symbol_table());
+      body.where()->expression_->Accept(collector);
+      for (const auto &symbol : collector.symbols_) {
+        // Only symbols bound before this clause; the rest are written above OrderBy anyway.
+        if (body.bound_symbols().contains(symbol) && !std::ranges::contains(remember, symbol)) {
+          remember.push_back(symbol);
+        }
+      }
+    }
+    last_op = std::make_unique<OrderBy>(std::move(last_op), body.order_by(), remember);
   }
   // Finally, Skip and Limit must come after OrderBy.
   if (body.skip()) {
@@ -827,6 +867,9 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
   // Where may see new symbols so it comes after we generate Produce and in
   // general, comes after any OrderBy, Skip or Limit.
   if (body.where()) {
+    // Directly below the Filter, because OrderBy restores only its own output symbols: a comprehension spliced below
+    // an OrderBy would hand the Filter one frozen value for every replayed row.
+    splice_comprehensions(body.where_pattern_comprehension_data());
     last_op = std::make_unique<Filter>(
         std::move(last_op), std::vector<std::shared_ptr<LogicalOperator>>{}, body.where()->expression_);
   }

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -903,6 +903,16 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
 
 namespace impl {
 
+std::unordered_set<Symbol> CollectPatternComprehensionSymbols(const std::vector<Clause *> &clauses,
+                                                              const SymbolTable &symbol_table) {
+  std::unordered_set<Symbol> symbols;
+  PCSymbolCollector collector(symbol_table, symbols);
+  for (auto *clause : clauses) {
+    clause->Accept(collector);
+  }
+  return symbols;
+}
+
 bool HasBoundFilterSymbols(const std::unordered_set<Symbol> &bound_symbols, const FilterInfo &filter) {
   return std::ranges::all_of(filter.used_symbols,
                              [&bound_symbols](const auto &symbol) { return bound_symbols.contains(symbol); });

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -18,6 +18,7 @@
 #include <ranges>
 #include <stack>
 #include <unordered_set>
+#include <utility>
 
 #include "query/frontend/ast/ast.hpp"
 #include "query/frontend/semantic/symbol_table.hpp"
@@ -42,7 +43,8 @@ class WhereReadSymbolsCollector : public UsedSymbolsCollector {
   using UsedSymbolsCollector::UsedSymbolsCollector;
 
   bool PreVisit(PatternComprehension &pc) override {
-    // Visits pc.pattern_ and sets the in-comprehension flag, which keeps anonymous symbols out.
+    // Visits pc.pattern_ and enters the comprehension, which keeps anonymous symbols out. The base tracks a depth,
+    // so a comprehension nested in filter_/resultExpr_ below does not release us early.
     UsedSymbolsCollector::PreVisit(pc);
     if (pc.filter_) {
       pc.filter_->Accept(*this);
@@ -705,6 +707,7 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       case BodyPosition::kWhere:
         return where_pattern_comprehension_datas_;
     }
+    std::unreachable();
   }
 
   const ReturnBody &body_;
@@ -844,7 +847,7 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
     last_op = std::make_unique<Distinct>(std::move(last_op), body.output_symbols());
   }
   // Splices a RollUpApply for each planned comprehension in @p pc_data onto last_op.
-  auto splice_comprehensions = [&](auto pc_data) {
+  auto splice_comprehensions = [&](auto &&pc_data) {
     for (auto &[result_symbol, list_collection_data] : pc_data) {
       if (list_collection_data.op) {
         auto list_collection_symbols = list_collection_data.op->ModifiedSymbols(body.symbol_table());

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -109,6 +109,10 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       }
       group_by_used_symbols_ = collector.symbols_;
     }
+    // ORDER BY and WHERE are evaluated after the Produce, so they see the named expression symbols. Pattern
+    // comprehensions found there must be planned against those symbols and spliced in after the Produce.
+    post_produce_bound_symbols_.insert(output_symbols_.begin(), output_symbols_.end());
+    in_post_produce_position_ = true;
     if (aggregations_.empty()) {
       // Visit order_by and where if we do not have aggregations. This way we
       // prevent collecting group_by expressions from order_by and where, which
@@ -124,7 +128,18 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
         where->Accept(*this);
       }
       MG_ASSERT(aggregations_.empty(), "Unexpected aggregations in ORDER BY or WHERE");
+    } else {
+      // With aggregations we must not visit ORDER BY and WHERE fully, or their expressions would pollute group_by_.
+      // Pattern comprehensions in them still need planning, so discover them with a dedicated visitor.
+      PostProduceComprehensionPlanner planner(*this);
+      for (const auto &order_pair : body.order_by) {
+        order_pair.expression->Accept(planner);
+      }
+      if (where) {
+        where->Accept(planner);
+      }
     }
+    in_post_produce_position_ = false;
 
     // Handle pattern comprehensions in SKIP and LIMIT expressions
     // These are processed regardless of aggregation since SKIP/LIMIT come after aggregation
@@ -509,20 +524,10 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     }
     has_aggregation_.emplace_back(has_aggr);
 
-    // Only add top-level pattern comprehensions to pattern_comprehension_datas_.
-    // Nested pattern comprehensions are handled inside their parent's operator tree.
-    // Also skip if we don't have a planning context (e.g., when analyzing bound
-    // symbols in GetSubqueryBoundSymbols) - the actual planning will handle them later.
-    if (aggregations_start_index_stack_.empty() && pc_ctx_ && pc_ctx_->planner) {
-      const auto result_sym = symbol_table_.at(pattern_comprehension);
-      // Find and plan this pattern comprehension on-demand
-      auto &pending = pc_ctx_->pending_comprehensions;
-      if (auto it = pending.find(result_sym); it != pending.end()) {
-        auto op = pc_ctx_->planner->Plan(it->second, pc_ctx_->view);
-        pattern_comprehension_datas_[result_sym] =
-            PatternComprehensionData(std::move(op), result_sym, it->second.expansion_symbols);
-        pending.erase(it);
-      }
+    // Only plan top-level pattern comprehensions. Nested pattern comprehensions are handled inside their parent's
+    // operator tree.
+    if (aggregations_start_index_stack_.empty()) {
+      PlanPatternComprehensionOnDemand(pattern_comprehension);
     }
     return true;
   }
@@ -589,10 +594,19 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   // named_expressions.
   const auto &output_symbols() const { return output_symbols_; }
 
-  bool has_pattern_comprehension() const { return !pattern_comprehension_datas_.empty(); }
+  bool has_pattern_comprehension() const {
+    return !pattern_comprehension_datas_.empty() || !post_produce_pattern_comprehension_datas_.empty();
+  }
 
+  // Pattern comprehensions from the named expressions, planned before the Produce.
   std::unordered_map<Symbol, PatternComprehensionData> pattern_comprehension_data() const {
     return pattern_comprehension_datas_;
+  }
+
+  // Pattern comprehensions from ORDER BY / WHERE, which read the named expression symbols and so must be planned
+  // after the Produce.
+  std::unordered_map<Symbol, PatternComprehensionData> post_produce_pattern_comprehension_data() const {
+    return post_produce_pattern_comprehension_datas_;
   }
 
   // Symbols that were bound before this RETURN/WITH clause (from MATCH, CREATE, etc.)
@@ -605,6 +619,54 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   const auto &pattern_comprehensions_in_aggregations() const { return pattern_comprehensions_in_aggregations_; }
 
  private:
+  // Finds pattern comprehensions in ORDER BY / WHERE without collecting aggregation or group-by information from
+  // those expressions. Used when the return body aggregates, where a full visit would pollute group_by_.
+  class PostProduceComprehensionPlanner : public HierarchicalTreeVisitor {
+   public:
+    explicit PostProduceComprehensionPlanner(ReturnBodyContext &context) : context_(context) {}
+
+    using HierarchicalTreeVisitor::PostVisit;
+    using HierarchicalTreeVisitor::PreVisit;
+    using HierarchicalTreeVisitor::Visit;
+
+    bool Visit(Identifier & /*unused*/) override { return true; }
+
+    bool Visit(PrimitiveLiteral & /*unused*/) override { return true; }
+
+    bool Visit(ParameterLookup & /*unused*/) override { return true; }
+
+    bool Visit(EnumValueAccess & /*unused*/) override { return true; }
+
+    bool PreVisit(PatternComprehension &pattern_comprehension) override {
+      context_.PlanPatternComprehensionOnDemand(pattern_comprehension);
+      return false;  // Nested comprehensions are planned within their parent's operator tree.
+    }
+
+   private:
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+    ReturnBodyContext &context_;
+  };
+
+  // Plans @p pattern_comprehension if it is still pending, into the bucket matching its position in the return body.
+  void PlanPatternComprehensionOnDemand(PatternComprehension &pattern_comprehension) {
+    // Skip if we don't have a planning context (e.g. when analyzing bound symbols in GetSubqueryBoundSymbols) - the
+    // actual planning will handle them later.
+    if (!pc_ctx_ || !pc_ctx_->planner) {
+      return;
+    }
+    const auto result_sym = symbol_table_.at(pattern_comprehension);
+    auto &pending = pc_ctx_->pending_comprehensions;
+    auto it = pending.find(result_sym);
+    if (it == pending.end()) {
+      return;
+    }
+    auto op = in_post_produce_position_ ? pc_ctx_->planner->Plan(it->second, pc_ctx_->view, post_produce_bound_symbols_)
+                                        : pc_ctx_->planner->Plan(it->second, pc_ctx_->view);
+    auto &datas = in_post_produce_position_ ? post_produce_pattern_comprehension_datas_ : pattern_comprehension_datas_;
+    datas[result_sym] = PatternComprehensionData(std::move(op), result_sym, it->second.expansion_symbols);
+    pending.erase(it);
+  }
+
   const ReturnBody &body_;
   SymbolTable &symbol_table_;
   const std::unordered_set<Symbol> &bound_symbols_;
@@ -626,6 +688,11 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   std::list<bool> has_aggregation_;
   std::vector<NamedExpression *> named_expressions_;
   std::unordered_map<Symbol, PatternComprehensionData> pattern_comprehension_datas_;
+  std::unordered_map<Symbol, PatternComprehensionData> post_produce_pattern_comprehension_datas_;
+  // True while visiting ORDER BY / WHERE, whose expressions are evaluated after the Produce.
+  bool in_post_produce_position_ = false;
+  // The named expression symbols, which a post-Produce comprehension may reference.
+  std::unordered_set<Symbol> post_produce_bound_symbols_;
   // Pattern comprehension symbols that appear inside aggregate expressions.
   // These must be planned BEFORE the Aggregate operator so their values are available.
   std::unordered_set<Symbol> pattern_comprehensions_in_aggregations_;
@@ -733,6 +800,16 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
   // Distinct in ReturnBody only makes Produce values unique, so plan after it.
   if (body.distinct()) {
     last_op = std::make_unique<Distinct>(std::move(last_op), body.output_symbols());
+  }
+  // Pattern comprehensions from ORDER BY / WHERE reference the named expression symbols, so they can only be
+  // evaluated once Produce has written them.
+  auto post_produce_pc_data = body.post_produce_pattern_comprehension_data();
+  for (auto &[result_symbol, list_collection_data] : post_produce_pc_data) {
+    if (list_collection_data.op) {
+      auto list_collection_symbols = list_collection_data.op->ModifiedSymbols(body.symbol_table());
+      last_op = std::make_unique<RollUpApply>(
+          std::move(last_op), std::move(list_collection_data.op), list_collection_symbols, result_symbol);
+    }
   }
   // Like Where, OrderBy can read from symbols established by named expressions
   // in Produce, so it must come after it.

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -36,6 +36,13 @@ bool IsConstantLiteral(const Expression *expression) {
   return utils::Downcast<const PrimitiveLiteral>(expression) || utils::Downcast<const ParameterLookup>(expression);
 }
 
+/// True if the comprehension's own pattern holds a variable-length edge. `ExpandVariable` can only read View::OLD, so
+/// such a comprehension must be planned with it. Only the top level - a nested comprehension is planned separately.
+bool HasVariableLengthExpansion(const PatternComprehensionMatching &pc) {
+  return std::ranges::any_of(pc.expansions,
+                             [](const auto &expansion) { return expansion.edge && expansion.edge->IsVariable(); });
+}
+
 /// Like UsedSymbolsCollector, but also descends into a comprehension's filter and result expression - everything the
 /// WHERE evaluates must survive an OrderBy below it. The base class stops at the pattern, as its other callers need.
 class WhereReadSymbolsCollector : public UsedSymbolsCollector {
@@ -911,6 +918,29 @@ std::unordered_set<Symbol> CollectPatternComprehensionSymbols(const std::vector<
     clause->Accept(collector);
   }
   return symbols;
+}
+
+bool ReferencesExternalSymbols(const PatternComprehensionMatching &pc,
+                               const std::unordered_set<Symbol> &bound_symbols) {
+  if (!pc.external_symbols.empty()) return true;
+  return std::ranges::any_of(pc.expansion_symbols, [&](const Symbol &sym) { return bound_symbols.contains(sym); });
+}
+
+storage::View PatternComprehensionView(const PatternComprehensionMatching &pc, storage::View preferred,
+                                       const std::unordered_set<Symbol> &bound_symbols,
+                                       const std::unordered_set<Symbol> &write_bound_symbols) {
+  if (!HasVariableLengthExpansion(pc)) return preferred;
+  // View::OLD cannot see a node a write clause of this query part bound, and View::NEW is not available here.
+  auto const unseeable = std::ranges::find_if(pc.expansion_symbols, [&](const Symbol &sym) {
+    return bound_symbols.contains(sym) && write_bound_symbols.contains(sym);
+  });
+  if (unseeable != pc.expansion_symbols.end()) {
+    throw QueryException(
+        "A variable-length pattern cannot expand from '{}', which a write clause of this query part binds. Close that "
+        "clause with a WITH before the pattern.",
+        unseeable->name());
+  }
+  return storage::View::OLD;
 }
 
 bool HasBoundFilterSymbols(const std::unordered_set<Symbol> &bound_symbols, const FilterInfo &filter) {

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -141,8 +141,9 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       }
       group_by_used_symbols_ = collector.symbols_;
     }
-    // ORDER BY and WHERE are evaluated after the Produce, so they see the named expression symbols. Pattern
-    // comprehensions found there must be planned against those symbols and spliced in after the Produce.
+    // ORDER BY and WHERE are evaluated after the Produce, so a comprehension there also sees the named expression
+    // symbols - it must be planned against them and spliced in after the Produce.
+    post_produce_bound_symbols_ = bound_symbols_;
     post_produce_bound_symbols_.insert(output_symbols_.begin(), output_symbols_.end());
     if (aggregations_.empty()) {
       // Visit order_by and where if we do not have aggregations. This way we
@@ -163,15 +164,22 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
       MG_ASSERT(aggregations_.empty(), "Unexpected aggregations in ORDER BY or WHERE");
     } else {
       // With aggregations we must not visit ORDER BY and WHERE fully, or their expressions would pollute group_by_.
-      // Pattern comprehensions in them still need planning, so discover them with a dedicated visitor.
-      PostProduceComprehensionPlanner planner(*this);
-      position_ = BodyPosition::kOrderBy;
+      // Comprehensions in them still need planning, so only collect their symbols. Nested ones are collected too but
+      // are never pending - only top-level matchings are - so they drop out of the lookup.
+      auto plan_comprehensions_in = [&](Expression &expr, BodyPosition position) {
+        std::unordered_set<Symbol> pc_symbols;
+        PCSymbolCollector collector(symbol_table_, pc_symbols);
+        expr.Accept(collector);
+        position_ = position;
+        for (const auto &sym : pc_symbols) {
+          PlanPatternComprehensionOnDemand(sym);
+        }
+      };
       for (const auto &order_pair : body.order_by) {
-        order_pair.expression->Accept(planner);
+        plan_comprehensions_in(*order_pair.expression, BodyPosition::kOrderBy);
       }
       if (where) {
-        position_ = BodyPosition::kWhere;
-        where->Accept(planner);
+        plan_comprehensions_in(*where->expression_, BodyPosition::kWhere);
       }
     }
     position_ = BodyPosition::kProjection;
@@ -562,7 +570,7 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     // Only plan top-level pattern comprehensions. Nested pattern comprehensions are handled inside their parent's
     // operator tree.
     if (aggregations_start_index_stack_.empty()) {
-      PlanPatternComprehensionOnDemand(pattern_comprehension);
+      PlanPatternComprehensionOnDemand(symbol_table_.at(pattern_comprehension));
     }
     return true;
   }
@@ -656,50 +664,21 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   const auto &pattern_comprehensions_in_aggregations() const { return pattern_comprehensions_in_aggregations_; }
 
  private:
-  // Finds pattern comprehensions in ORDER BY / WHERE without collecting aggregation or group-by information from
-  // those expressions. Used when the return body aggregates, where a full visit would pollute group_by_.
-  class PostProduceComprehensionPlanner : public HierarchicalTreeVisitor {
-   public:
-    explicit PostProduceComprehensionPlanner(ReturnBodyContext &context) : context_(context) {}
-
-    using HierarchicalTreeVisitor::PostVisit;
-    using HierarchicalTreeVisitor::PreVisit;
-    using HierarchicalTreeVisitor::Visit;
-
-    bool Visit(Identifier & /*unused*/) override { return true; }
-
-    bool Visit(PrimitiveLiteral & /*unused*/) override { return true; }
-
-    bool Visit(ParameterLookup & /*unused*/) override { return true; }
-
-    bool Visit(EnumValueAccess & /*unused*/) override { return true; }
-
-    bool PreVisit(PatternComprehension &pattern_comprehension) override {
-      context_.PlanPatternComprehensionOnDemand(pattern_comprehension);
-      return false;  // Nested comprehensions are planned within their parent's operator tree.
-    }
-
-   private:
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-    ReturnBodyContext &context_;
-  };
-
-  // Plans @p pattern_comprehension if it is still pending, into the bucket matching its position in the return body.
-  void PlanPatternComprehensionOnDemand(PatternComprehension &pattern_comprehension) {
+  // Plans the comprehension with result symbol @p result_sym if it is still pending, into the bucket matching its
+  // position in the return body.
+  void PlanPatternComprehensionOnDemand(const Symbol &result_sym) {
     // Skip if we don't have a planning context (e.g. when analyzing bound symbols in GetSubqueryBoundSymbols) - the
     // actual planning will handle them later.
     if (!pc_ctx_ || !pc_ctx_->planner) {
       return;
     }
-    const auto result_sym = symbol_table_.at(pattern_comprehension);
     auto &pending = pc_ctx_->pending_comprehensions;
     auto it = pending.find(result_sym);
     if (it == pending.end()) {
       return;
     }
-    const auto &extra_bound_symbols =
-        position_ == BodyPosition::kProjection ? kNoExtraBoundSymbols : post_produce_bound_symbols_;
-    auto op = pc_ctx_->planner->Plan(it->second, pc_ctx_->view, extra_bound_symbols);
+    const auto &bound_symbols = position_ == BodyPosition::kProjection ? bound_symbols_ : post_produce_bound_symbols_;
+    auto op = pc_ctx_->planner->Plan(it->second, pc_ctx_->view, bound_symbols);
     auto &datas = Bucket(position_);
     datas[result_sym] = PatternComprehensionData(std::move(op), result_sym, it->second.expansion_symbols);
     pending.erase(it);
@@ -743,7 +722,7 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   // Which part of the return body is currently being visited. ORDER BY and WHERE are both evaluated after the
   // Produce, but at different points in the operator chain, so their comprehensions need separate splice points.
   BodyPosition position_ = BodyPosition::kProjection;
-  // The named expression symbols, which a post-Produce comprehension may reference.
+  // What a post-Produce comprehension may reference: the symbols bound before this clause plus its own output symbols.
   std::unordered_set<Symbol> post_produce_bound_symbols_;
   // Pattern comprehension symbols that appear inside aggregate expressions.
   // These must be planned BEFORE the Aggregate operator so their values are available.
@@ -834,25 +813,6 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
     last_op = std::make_unique<Aggregate>(std::move(last_op), body.aggregations(), body.group_by(), remember);
   }
 
-  // Plan remaining pattern comprehensions AFTER Aggregate (or when no aggregations)
-  for (auto &[result_symbol, list_collection_data] : pc_data) {
-    if (list_collection_data.op) {
-      auto list_collection_symbols = list_collection_data.op->ModifiedSymbols(body.symbol_table());
-      last_op = std::make_unique<RollUpApply>(
-          std::move(last_op), std::move(list_collection_data.op), list_collection_symbols, result_symbol);
-    }
-  }
-
-  bool const has_periodic_commit = commit_frequency != nullptr;
-  if (has_periodic_commit) {
-    last_op = std::make_unique<PeriodicCommit>(std::move(last_op), commit_frequency);
-  }
-
-  last_op = std::make_unique<Produce>(std::move(last_op), body.named_expressions());
-  // Distinct in ReturnBody only makes Produce values unique, so plan after it.
-  if (body.distinct()) {
-    last_op = std::make_unique<Distinct>(std::move(last_op), body.output_symbols());
-  }
   // Splices a RollUpApply for each planned comprehension in @p pc_data onto last_op.
   auto splice_comprehensions = [&](auto &&pc_data) {
     for (auto &[result_symbol, list_collection_data] : pc_data) {
@@ -864,6 +824,19 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
     }
   };
 
+  // Plan remaining pattern comprehensions AFTER Aggregate (or when no aggregations)
+  splice_comprehensions(pc_data);
+
+  bool const has_periodic_commit = commit_frequency != nullptr;
+  if (has_periodic_commit) {
+    last_op = std::make_unique<PeriodicCommit>(std::move(last_op), commit_frequency);
+  }
+
+  last_op = std::make_unique<Produce>(std::move(last_op), body.named_expressions());
+  // Distinct in ReturnBody only makes Produce values unique, so plan after it.
+  if (body.distinct()) {
+    last_op = std::make_unique<Distinct>(std::move(last_op), body.output_symbols());
+  }
   // Comprehensions in ORDER BY reference the named expression symbols, so they can only be evaluated once Produce has
   // written them. OrderBy reads them during its collection sweep, so they belong directly below it.
   splice_comprehensions(body.order_by_pattern_comprehension_data());

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -35,6 +35,25 @@ bool IsConstantLiteral(const Expression *expression) {
   return utils::Downcast<const PrimitiveLiteral>(expression) || utils::Downcast<const ParameterLookup>(expression);
 }
 
+/// Like UsedSymbolsCollector, but also descends into a comprehension's filter and result expression - everything the
+/// WHERE evaluates must survive an OrderBy below it. The base class stops at the pattern, as its other callers need.
+class WhereReadSymbolsCollector : public UsedSymbolsCollector {
+ public:
+  using UsedSymbolsCollector::UsedSymbolsCollector;
+
+  bool PreVisit(PatternComprehension &pc) override {
+    // Visits pc.pattern_ and sets the in-comprehension flag, which keeps anonymous symbols out.
+    UsedSymbolsCollector::PreVisit(pc);
+    if (pc.filter_) {
+      pc.filter_->Accept(*this);
+    }
+    if (pc.resultExpr_) {
+      pc.resultExpr_->Accept(*this);
+    }
+    return false;
+  }
+};
+
 /// Visitor to collect pattern comprehension symbols from expressions.
 /// Used to track which pattern comprehensions appear inside aggregate expressions.
 class PCSymbolCollector : public HierarchicalTreeVisitor {
@@ -845,7 +864,7 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
     // Filter(where) - and any comprehension branch feeding it - sits above OrderBy, so add what the WHERE reads.
     auto remember = body.output_symbols();
     if (body.where()) {
-      UsedSymbolsCollector collector(body.symbol_table());
+      WhereReadSymbolsCollector collector(body.symbol_table());
       body.where()->expression_->Accept(collector);
       for (const auto &symbol : collector.symbols_) {
         // Only symbols bound before this clause; the rest are written above OrderBy anyway.

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -45,7 +45,11 @@ struct PatternComprehensionData {
 /// Interface for planning pattern comprehensions, avoiding std::function overhead.
 struct PatternComprehensionPlanner {
   virtual ~PatternComprehensionPlanner() = default;
-  virtual std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view) = 0;
+  /// @param extra_bound_symbols Symbols bound by an operator the comprehension will be planned after, but which are
+  /// not yet in the planning context (the output symbols of a WITH/RETURN whose WHERE or ORDER BY holds the
+  /// comprehension).
+  virtual std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
+                                                const std::unordered_set<Symbol> &extra_bound_symbols = {}) = 0;
 };
 
 /// Context for on-demand pattern comprehension planning in RETURN/WITH bodies.
@@ -204,8 +208,14 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   explicit RuleBasedPlanner(TPlanningContext *context) : context_(context) {}
 
   /// Implements PatternComprehensionPlanner interface
-  std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view) override {
-    return PlanPatternComprehension(matching, *context_->symbol_table, context_->bound_symbols, view);
+  std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
+                                        const std::unordered_set<Symbol> &extra_bound_symbols = {}) override {
+    if (extra_bound_symbols.empty()) {
+      return PlanPatternComprehension(matching, *context_->symbol_table, context_->bound_symbols, view);
+    }
+    auto bound_symbols = context_->bound_symbols;
+    bound_symbols.insert(extra_bound_symbols.begin(), extra_bound_symbols.end());
+    return PlanPatternComprehension(matching, *context_->symbol_table, bound_symbols, view);
   }
 
   /// @brief The result of plan generation is the root of the generated operator

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -1329,7 +1329,9 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   }
 
   /// True once every symbol the comprehension references that this query part binds elsewhere is bound. Symbols from
-  /// an earlier query part are not waited for. Every site draining `pending_comprehensions` must use this.
+  /// an earlier query part are not waited for. Every *early* drain must use this - the on-demand path in
+  /// `ReturnBodyContext` needs no check, because a WITH/RETURN is the last clause of its query part, so a
+  /// comprehension reaching there is already at the clause that owns it.
   static bool DepsSatisfied(const PatternComprehensionMatching &pc,
                             const std::unordered_set<Symbol> &symbols_bound_by_query_part,
                             const std::unordered_set<Symbol> &bound_symbols) {
@@ -1360,18 +1362,28 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     return std::ranges::any_of(pc.expansion_symbols, [&](const Symbol &sym) { return bound_symbols.contains(sym); });
   }
 
-  /// The view a comprehension must be planned with. Every site draining `pending_comprehensions` must use this: a
-  /// comprehension planned after a write, over a symbol that write bound, sees nothing under View::OLD.
+  /// The view a comprehension must be planned with: one planned after a write, over a symbol that write bound, sees
+  /// nothing under View::OLD.
+  ///
+  /// Not every site draining `pending_comprehensions` uses this. The on-demand path in `ReturnBodyContext` passes
+  /// `PatternComprehensionContext::view` straight through, and `HasVariableLengthExpansion` inspects only the
+  /// top-level expansions although the view propagates into nested comprehensions - so a variable-length comprehension
+  /// can still reach `ExpandVariable` with View::NEW, which it cannot service. That is rejected there rather than
+  /// silently mis-planned; the rejection is the backstop, not the routing.
   static storage::View PatternComprehensionView(const PatternComprehensionMatching &pc, bool write_occurred,
                                                 const std::unordered_set<Symbol> &bound_symbols) {
     if (HasVariableLengthExpansion(pc)) return storage::View::OLD;
     return write_occurred && ReferencesExternalSymbols(pc, bound_symbols) ? storage::View::NEW : storage::View::OLD;
   }
 
-  /// The one place a pending comprehension turns into a `RollUpApply`. Every operator chain that can evaluate one
-  /// drains through here - the main clause chain, a FOREACH body, and each MERGE branch - because a comprehension
-  /// must be spliced onto the chain that *reads* it, not merely the one its clause sits on. Both defects this file
-  /// has had came from that: a drain site whose dependency check had drifted, and a chain with no drain site at all.
+  /// The one place a pending comprehension turns into a `RollUpApply`, because a comprehension must be spliced onto
+  /// the chain that *reads* it, not merely the one its clause sits on. Both defects this file has had came from that:
+  /// a drain site whose dependency check had drifted, and a chain with no drain site at all.
+  ///
+  /// Four chains can evaluate a comprehension. Three drain through here - the main clause chain, a FOREACH body, and
+  /// each MERGE branch. The fourth, `CALL ... YIELD ... WHERE`, has no drain at all: `CallProcedure` is a query-part
+  /// boundary, so nothing downstream can drain it either and the matching is collected then abandoned. Known gap -
+  /// which is also why `pending_comprehensions` cannot yet be asserted empty at the end of a query part.
   ///
   /// @param bound_symbols what is bound on @p chain, used for the dependency check and the view.
   /// @param only when non-null, restricts the drain to these result symbols - a MERGE branch takes only what its own

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -310,27 +310,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         // need to use View::NEW to see the newly created/modified data.
         bool write_occurred = false;
 
-        // Helper to check if a comprehension's dependencies are satisfied.
-        // A comprehension is ready to be planned when ALL its external dependencies are bound:
-        // 1. Explicit external_symbols (from filter/result expressions)
-        // 2. Expansion symbols that reference already-declared variables (e.g., `a` in `[(a)-->(x)|...]`
-        //    when `a` comes from CREATE)
         auto deps_satisfied = [&](const PatternComprehensionMatching &pc) {
-          // Check explicit external symbols
-          bool external_ok = std::all_of(pc.external_symbols.begin(), pc.external_symbols.end(), [&](const Symbol &s) {
-            if (!symbols_bound_by_query_part.contains(s)) return true;
-            return context.bound_symbols.contains(s);
-          });
-          if (!external_ok) return false;
-
-          // Check expansion symbols that should be externally bound (i.e., they're in symbols_bound_by_query_part,
-          // meaning they're declared elsewhere in this query part and we should wait for them to be bound)
-          for (const auto &sym : pc.expansion_symbols) {
-            if (symbols_bound_by_query_part.contains(sym) && !context.bound_symbols.contains(sym)) {
-              return false;  // This symbol will be bound later, wait for it
-            }
-          }
-          return true;
+          return DepsSatisfied(pc, symbols_bound_by_query_part, context.bound_symbols);
         };
 
         // Helper to check if a pattern comprehension has variable-length paths.
@@ -489,7 +470,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                            context.bound_symbols,
                                            single_query_part,
                                            merge_id,
-                                           pending_comprehensions);
+                                           pending_comprehensions,
+                                           symbols_bound_by_query_part);
           } else if (auto *call_sub = utils::Downcast<query::CallSubquery>(clause)) {
             auto scoped_variables = std::invoke([&]() -> std::optional<std::unordered_set<Symbol>> {
               if (!call_sub->has_variable_scope_) {
@@ -1348,10 +1330,34 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     return last_op;
   }
 
+  /// True when a comprehension is ready to be planned, i.e. every symbol it references that this query part binds
+  /// elsewhere is already bound. A symbol absent from @p symbols_bound_by_query_part comes from an earlier query part
+  /// and is not waited for.
+  ///
+  /// Every site that drains `pending_comprehensions` must use this - the main clause loop and FOREACH both do. They
+  /// used to carry separate copies, and FOREACH's checked only `external_symbols`, which is empty for a comprehension
+  /// whose sole reference is its pattern's start node, so it drained and planned such a comprehension uncorrelated.
+  static bool DepsSatisfied(const PatternComprehensionMatching &pc,
+                            const std::unordered_set<Symbol> &symbols_bound_by_query_part,
+                            const std::unordered_set<Symbol> &bound_symbols) {
+    // Symbols referenced from the filter or result expression.
+    const bool external_ok = std::ranges::all_of(pc.external_symbols, [&](const Symbol &s) {
+      return !symbols_bound_by_query_part.contains(s) || bound_symbols.contains(s);
+    });
+    if (!external_ok) return false;
+
+    // Symbols the pattern itself references but that are declared elsewhere in this query part, e.g. `a` in
+    // `[(a)-->(x)|...]` when `a` comes from a CREATE or a later WITH. Those must be bound first.
+    return std::ranges::all_of(pc.expansion_symbols, [&](const Symbol &sym) {
+      return !symbols_bound_by_query_part.contains(sym) || bound_symbols.contains(sym);
+    });
+  }
+
   std::unique_ptr<LogicalOperator> HandleForeachClause(
       query::Foreach *foreach, std::unique_ptr<LogicalOperator> input_op, const SymbolTable &symbol_table,
       std::unordered_set<Symbol> &bound_symbols, const SingleQueryPart &query_part, uint64_t &merge_id,
-      std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions) {
+      std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
+      const std::unordered_set<Symbol> &symbols_bound_by_query_part) {
     const auto &symbol = symbol_table.at(*foreach->named_expression_);
     bound_symbols.insert(symbol);
     std::unique_ptr<LogicalOperator> op = std::make_unique<plan::Once>();
@@ -1360,11 +1366,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     auto plan_satisfied_comprehensions = [&]() {
       for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
         const auto &[sym, pc] = *it;
-        // Check if all external symbols are now bound
-        bool deps_satisfied = std::all_of(pc.external_symbols.begin(), pc.external_symbols.end(), [&](const Symbol &s) {
-          return bound_symbols.contains(s);
-        });
-        if (deps_satisfied) {
+        if (DepsSatisfied(pc, symbols_bound_by_query_part, bound_symbols)) {
           auto pc_op = Plan(pc, storage::View::OLD, kNoExtraBoundSymbols);
           auto symbols = pc_op->ModifiedSymbols(symbol_table);
           op = std::make_unique<RollUpApply>(std::move(op), std::move(pc_op), symbols, sym);
@@ -1380,8 +1382,14 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
     for (auto *clause : foreach->clauses_) {
       if (auto *nested_for_each = utils::Downcast<query::Foreach>(clause)) {
-        op = HandleForeachClause(
-            nested_for_each, std::move(op), symbol_table, bound_symbols, query_part, merge_id, pending_comprehensions);
+        op = HandleForeachClause(nested_for_each,
+                                 std::move(op),
+                                 symbol_table,
+                                 bound_symbols,
+                                 query_part,
+                                 merge_id,
+                                 pending_comprehensions,
+                                 symbols_bound_by_query_part);
       } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
         op = GenMerge(*merge, std::move(op), query_part.merge_matching[merge_id++]);
       } else {

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -24,6 +24,7 @@
 #include "query/plan/rewrite/range.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/logging.hpp"
+#include "utils/on_scope_exit.hpp"
 #include "utils/typeinfo.hpp"
 
 namespace memgraph::query::plan {
@@ -61,6 +62,8 @@ inline const std::unordered_set<Symbol> kNoExtraBoundSymbols{};
 struct PatternComprehensionContext {
   std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions;
   PatternComprehensionPlanner *planner;
+  /// The view this query part has reached: View::NEW once one of its write clauses has been planned. Only a
+  /// *preference* - @c RuleBasedPlanner::PlanPatternComprehension filters it, see @c impl::PatternComprehensionView.
   storage::View view;
 };
 
@@ -207,6 +210,29 @@ Expression *BoolJoin(AstStorage &storage, Expression *expr1, Expression *expr2) 
 std::unordered_set<Symbol> CollectPatternComprehensionSymbols(const std::vector<Clause *> &clauses,
                                                               const SymbolTable &symbol_table);
 
+/// True if the comprehension reads something bound outside it: either from its filter or result expression, or a
+/// pattern symbol that is already bound, e.g. `a` in `[(a)-->(x)|x]` when `a` comes from a CREATE.
+bool ReferencesExternalSymbols(const PatternComprehensionMatching &pc, const std::unordered_set<Symbol> &bound_symbols);
+
+/// Applies the variable-length rule to the view a drain site would otherwise use. Called from exactly one place,
+/// @c RuleBasedPlanner::PlanPatternComprehension, which every comprehension - nested ones included - passes through.
+///
+/// `ExpandVariable` can only read View::OLD, so a variable-length pattern cannot have @p preferred when that is
+/// View::NEW. View::OLD is still correct for it as long as the pattern's root exists in that view. When the root is a
+/// node a write clause of this same query part bound, neither view works: this throws rather than emit a plan that
+/// fails at runtime with a storage-level message.
+///
+/// A fixed-length pattern keeps @p preferred untouched. Sites legitimately differ in how they pick it - the early
+/// drains require the comprehension to reference an externally bound symbol before choosing View::NEW, while a return
+/// body uses the query part's current view directly - so that choice stays with the caller.
+///
+/// @param preferred the view the site would use if the pattern were fixed-length.
+/// @param bound_symbols what is bound on the chain the comprehension will be spliced onto.
+/// @param write_bound_symbols symbols bound by a write clause of this query part, which View::OLD cannot see.
+storage::View PatternComprehensionView(const PatternComprehensionMatching &pc, storage::View preferred,
+                                       const std::unordered_set<Symbol> &bound_symbols,
+                                       const std::unordered_set<Symbol> &write_bound_symbols);
+
 }  // namespace impl
 
 /// @brief Planner which uses hardcoded rules to produce operators.
@@ -266,6 +292,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         // Compute all symbols that will be bound by this query part (from MATCH, CREATE, MERGE, etc.)
         // This is used to determine which comprehension symbols are external references vs. internal.
         std::unordered_set<Symbol> symbols_bound_by_query_part;
+        // The subset of the above that a *write* clause of this query part is what *first* binds. View::OLD cannot see
+        // those, which is what makes a variable-length comprehension over one of them unplannable - see
+        // `impl::PatternComprehensionView`. Restored on the way out because a subquery re-enters this function.
+        auto const restore_write_bound = utils::OnScopeExit{
+            [this, saved = std::move(write_bound_symbols_)]() mutable { write_bound_symbols_ = std::move(saved); }};
+        write_bound_symbols_.clear();
         // Add symbols from MATCH
         symbols_bound_by_query_part.insert(single_query_part.matching.expansion_symbols.begin(),
                                            single_query_part.matching.expansion_symbols.end());
@@ -274,10 +306,11 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
           symbols_bound_by_query_part.insert(opt_matching.expansion_symbols.begin(),
                                              opt_matching.expansion_symbols.end());
         }
-        // Add symbols from merge matchings
+        // Add symbols from merge matchings. MERGE may create its pattern, so View::OLD may not see it either.
         for (const auto &merge_matching : single_query_part.merge_matching) {
           symbols_bound_by_query_part.insert(merge_matching.expansion_symbols.begin(),
                                              merge_matching.expansion_symbols.end());
+          write_bound_symbols_.insert(merge_matching.expansion_symbols.begin(), merge_matching.expansion_symbols.end());
         }
         auto collect_return_body_symbols = [&](const ReturnBody &body) {
           for (const auto *named_expr : body.named_expressions) {
@@ -290,6 +323,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
             for (const auto *pattern : create->patterns_) {
               for (const PatternAtom *atom : pattern->atoms_) {
                 symbols_bound_by_query_part.insert(context.symbol_table->at(*atom->identifier_));
+                write_bound_symbols_.insert(context.symbol_table->at(*atom->identifier_));
               }
             }
           } else if (auto *foreach_clause = utils::Downcast<query::Foreach>(clause)) {
@@ -309,6 +343,20 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         };
         for (const auto &clause : single_query_part.remaining_clauses) {
           collect_clause_symbols(clause);
+        }
+        // A CREATE or MERGE pattern re-uses the names it does not declare, e.g. `a` in
+        // `MATCH (a) CREATE (a)-[:R]->(b)`. Those were bound before the write and View::OLD does see them, so drop
+        // everything already bound on entry or bound by a MATCH of this query part.
+        for (const auto &sym : context.bound_symbols) {
+          write_bound_symbols_.erase(sym);
+        }
+        for (const auto &sym : single_query_part.matching.expansion_symbols) {
+          write_bound_symbols_.erase(sym);
+        }
+        for (const auto &opt_matching : single_query_part.optional_matching) {
+          for (const auto &sym : opt_matching.expansion_symbols) {
+            write_bound_symbols_.erase(sym);
+          }
         }
 
         // Track whether a write operation has occurred - comprehensions planned after writes
@@ -502,11 +550,14 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   /// @brief Recursively plans a pattern comprehension including any nested pattern comprehensions.
   /// For nested pattern comprehensions (e.g., [()--() | [()--() | 1]]), the inner pattern
   /// comprehension is planned first and wrapped with RollUpApply before the outer one's Produce.
-  /// @param view The storage view to use - View::NEW if planned after write clauses, View::OLD otherwise.
+  /// @param view The view the calling site would like - View::NEW if planned after write clauses, View::OLD otherwise.
+  /// Only a preference: this is the one place every comprehension, nested ones included, passes through, so the
+  /// variable-length rule is applied here once rather than at each drain site.
   std::unique_ptr<LogicalOperator> PlanPatternComprehension(const PatternComprehensionMatching &matching,
                                                             const SymbolTable &symbol_table,
                                                             std::unordered_set<Symbol> &bound_symbols,
                                                             storage::View view = storage::View::OLD) {
+    view = impl::PatternComprehensionView(matching, view, bound_symbols, write_bound_symbols_);
     std::unique_ptr<LogicalOperator> new_input;
     // Create a copy of bound_symbols and add external symbols from the pattern comprehension.
     // External symbols are references to variables from outer scope (e.g., FOREACH variable `x`
@@ -524,6 +575,10 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   }
 
   TPlanningContext *context_;
+  /// Symbols a write clause of the query part being planned is the first to bind; see
+  /// `impl::PatternComprehensionView`. Scoped to one query part, and saved/restored around it because a subquery
+  /// re-enters `PlanQueryPart` on this same object.
+  std::unordered_set<Symbol> write_bound_symbols_;
 
   storage::LabelId GetLabel(const LabelIx &label) { return context_->db->NameToLabel(label.name); }
 
@@ -724,6 +779,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
       std::unique_ptr<LogicalOperator> input_op, const std::vector<PatternComprehensionMatching> &nested_comprehensions,
       const SymbolTable &symbol_table, std::unordered_set<Symbol> &bound_symbols, storage::View view) {
     for (const auto &nested : nested_comprehensions) {
+      // The parent's view is a preference for the nested one too: a nested pattern has its own edges, so a
+      // variable-length one must read View::OLD even under a View::NEW parent. PlanPatternComprehension applies that.
       auto nested_op = PlanPatternComprehension(nested, symbol_table, bound_symbols, view);
       auto nested_symbols = nested_op->ModifiedSymbols(symbol_table);
       input_op = std::make_unique<RollUpApply>(
@@ -1254,8 +1311,10 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         bound_symbols.insert(*total_weight);
       }
 
-      // ExpandVariable can only read View::OLD, so a variable-length pattern that must see writes from its own
-      // query part has no valid plan. Reject the query instead of asserting, which would abort the process.
+      // ExpandVariable can only read View::OLD. Nothing should reach here with another view: every comprehension is
+      // filtered through `impl::PatternComprehensionView`, a MERGE pattern cannot hold a variable-length edge (semantic
+      // analysis rejects that), and MATCH plans with View::OLD. This is the backstop for a routing mistake - reject
+      // rather than assert, because an assert on the planning path aborts the process and `EXPLAIN` alone reaches it.
       if (view != storage::View::OLD) {
         throw QueryException(
             "A variable-length pattern cannot be evaluated after a write in the same query part. Separate them with a "
@@ -1336,7 +1395,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   /// True once every symbol the comprehension references that this query part binds elsewhere is bound. Symbols from
   /// an earlier query part are not waited for. Every *early* drain must use this - the on-demand path in
   /// `ReturnBodyContext` needs no check, because a WITH/RETURN is the last clause of its query part, so a
-  /// comprehension reaching there is already at the clause that owns it.
+  /// comprehension reaching there is already at the clause that owns it. (It does share the view rule; see
+  /// `impl::PatternComprehensionView`.)
   static bool DepsSatisfied(const PatternComprehensionMatching &pc,
                             const std::unordered_set<Symbol> &symbols_bound_by_query_part,
                             const std::unordered_set<Symbol> &bound_symbols) {
@@ -1353,42 +1413,17 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     });
   }
 
-  /// ExpandVariable requires View::OLD, so a comprehension whose pattern has a variable-length edge must use it.
-  static bool HasVariableLengthExpansion(const PatternComprehensionMatching &pc) {
-    return std::ranges::any_of(pc.expansions,
-                               [](const auto &expansion) { return expansion.edge && expansion.edge->IsVariable(); });
-  }
-
-  /// True if the comprehension reads something bound outside it: either from its filter or result expression, or a
-  /// pattern symbol that is already bound, e.g. `a` in `[(a)-->(x)|x]` when `a` comes from a CREATE.
-  static bool ReferencesExternalSymbols(const PatternComprehensionMatching &pc,
-                                        const std::unordered_set<Symbol> &bound_symbols) {
-    if (!pc.external_symbols.empty()) return true;
-    return std::ranges::any_of(pc.expansion_symbols, [&](const Symbol &sym) { return bound_symbols.contains(sym); });
-  }
-
-  /// The view a comprehension must be planned with: one planned after a write, over a symbol that write bound, sees
-  /// nothing under View::OLD.
+  /// The one *early* place a pending comprehension turns into a `RollUpApply`, because a comprehension must be spliced
+  /// onto the chain that *reads* it, not merely the one its clause sits on. Both defects this file has had came from
+  /// that: a drain site whose dependency check had drifted, and a chain with no drain site at all.
   ///
-  /// Not every site draining `pending_comprehensions` uses this. The on-demand path in `ReturnBodyContext` passes
-  /// `PatternComprehensionContext::view` straight through, and `HasVariableLengthExpansion` inspects only the
-  /// top-level expansions although the view propagates into nested comprehensions - so a variable-length comprehension
-  /// can still reach `ExpandVariable` with View::NEW, which it cannot service. That is rejected there rather than
-  /// silently mis-planned; the rejection is the backstop, not the routing.
-  static storage::View PatternComprehensionView(const PatternComprehensionMatching &pc, bool write_occurred,
-                                                const std::unordered_set<Symbol> &bound_symbols) {
-    if (HasVariableLengthExpansion(pc)) return storage::View::OLD;
-    return write_occurred && ReferencesExternalSymbols(pc, bound_symbols) ? storage::View::NEW : storage::View::OLD;
-  }
-
-  /// The one place a pending comprehension turns into a `RollUpApply`, because a comprehension must be spliced onto
-  /// the chain that *reads* it, not merely the one its clause sits on. Both defects this file has had came from that:
-  /// a drain site whose dependency check had drifted, and a chain with no drain site at all.
-  ///
-  /// Four chains can evaluate a comprehension. Three drain through here - the main clause chain, a FOREACH body, and
-  /// each MERGE branch. The fourth, `CALL ... YIELD ... WHERE`, has no drain at all: `CallProcedure` is a query-part
-  /// boundary, so nothing downstream can drain it either and the matching is collected then abandoned. Known gap -
-  /// which is also why `pending_comprehensions` cannot yet be asserted empty at the end of a query part.
+  /// Five chains can evaluate a comprehension. Three drain through here - the main clause chain, a FOREACH body, and
+  /// each MERGE branch. The fourth is a WITH/RETURN return body, which drains on demand in `ReturnBodyContext` because
+  /// it needs a different splice point per position in the body; it shares this function's view rule through
+  /// `impl::PatternComprehensionView` and needs no dependency check (see `DepsSatisfied`). The fifth, a
+  /// `CallProcedure` clause - its arguments as much as its `YIELD ... WHERE` - has no drain at all: `CallProcedure` is
+  /// a query-part boundary, so nothing downstream can drain it either and the matching is collected then abandoned.
+  /// Known gap, and the reason `pending_comprehensions` cannot yet be asserted empty at the end of a query part.
   ///
   /// @param bound_symbols what is bound on @p chain, used for the dependency check and the view.
   /// @param only when non-null, restricts the drain to these result symbols - a MERGE branch takes only what its own
@@ -1408,7 +1443,9 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         ++it;
         continue;
       }
-      auto pc_op = Plan(pc, PatternComprehensionView(pc, write_occurred, bound_symbols), extra_bound_symbols);
+      auto const preferred = write_occurred && impl::ReferencesExternalSymbols(pc, bound_symbols) ? storage::View::NEW
+                                                                                                  : storage::View::OLD;
+      auto pc_op = Plan(pc, preferred, extra_bound_symbols);
       auto symbols = pc_op->ModifiedSymbols(*context_->symbol_table);
       chain = std::make_unique<RollUpApply>(std::move(chain), std::move(pc_op), symbols, sym);
       it = pending_comprehensions.erase(it);

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -1330,13 +1330,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     return last_op;
   }
 
-  /// True when a comprehension is ready to be planned, i.e. every symbol it references that this query part binds
-  /// elsewhere is already bound. A symbol absent from @p symbols_bound_by_query_part comes from an earlier query part
-  /// and is not waited for.
-  ///
-  /// Every site that drains `pending_comprehensions` must use this - the main clause loop and FOREACH both do. They
-  /// used to carry separate copies, and FOREACH's checked only `external_symbols`, which is empty for a comprehension
-  /// whose sole reference is its pattern's start node, so it drained and planned such a comprehension uncorrelated.
+  /// True once every symbol the comprehension references that this query part binds elsewhere is bound. Symbols from
+  /// an earlier query part are not waited for. Every site draining `pending_comprehensions` must use this.
   static bool DepsSatisfied(const PatternComprehensionMatching &pc,
                             const std::unordered_set<Symbol> &symbols_bound_by_query_part,
                             const std::unordered_set<Symbol> &bound_symbols) {

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -46,17 +46,12 @@ struct PatternComprehensionData {
 /// Interface for planning pattern comprehensions, avoiding std::function overhead.
 struct PatternComprehensionPlanner {
   virtual ~PatternComprehensionPlanner() = default;
-  /// @param extra_bound_symbols Symbols bound by an operator the comprehension will be planned after, but which are
-  /// not yet in the planning context (the output symbols of a WITH/RETURN whose WHERE or ORDER BY holds the
-  /// comprehension). Has no default: a default argument on a virtual function is bound statically, so it would mean
-  /// something different depending on whether the call goes through this interface or through RuleBasedPlanner.
+  /// @param bound_symbols Everything bound on the chain the comprehension will be spliced onto. The caller owns this
+  /// because it varies: a MERGE branch binds its pattern into a copy the planning context does not share, and a
+  /// WHERE/ORDER BY comprehension also sees the output symbols of the WITH/RETURN it sits in.
   virtual std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
-                                                const std::unordered_set<Symbol> &extra_bound_symbols) = 0;
+                                                const std::unordered_set<Symbol> &bound_symbols) = 0;
 };
-
-/// Passed as @c PatternComprehensionPlanner::Plan's @c extra_bound_symbols when the comprehension is planned in the
-/// position its own clause binds, so the planning context's bound symbols are already complete.
-inline const std::unordered_set<Symbol> kNoExtraBoundSymbols{};
 
 /// Context for on-demand pattern comprehension planning in RETURN/WITH bodies.
 struct PatternComprehensionContext {
@@ -245,12 +240,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
   /// Implements PatternComprehensionPlanner interface
   std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
-                                        const std::unordered_set<Symbol> &extra_bound_symbols) override {
-    if (extra_bound_symbols.empty()) {
-      return PlanPatternComprehension(matching, *context_->symbol_table, context_->bound_symbols, view);
-    }
-    auto bound_symbols = context_->bound_symbols;
-    bound_symbols.insert_range(extra_bound_symbols);
+                                        const std::unordered_set<Symbol> &bound_symbols) override {
     return PlanPatternComprehension(matching, *context_->symbol_table, bound_symbols, view);
   }
 
@@ -306,11 +296,21 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
           symbols_bound_by_query_part.insert(opt_matching.expansion_symbols.begin(),
                                              opt_matching.expansion_symbols.end());
         }
+        // A write clause re-uses the names it does not declare, e.g. `a` in `MATCH (a) CREATE (a)-[:R]->(b)`; those
+        // were bound before the write and View::OLD does see them. Only a name the clause *first* binds counts, and
+        // every MATCH symbol is already collected above, so testing at insertion is enough.
+        auto note_write_bound = [&](const Symbol &sym) {
+          if (!context.bound_symbols.contains(sym) && !symbols_bound_by_query_part.contains(sym)) {
+            write_bound_symbols_.insert(sym);
+          }
+        };
         // Add symbols from merge matchings. MERGE may create its pattern, so View::OLD may not see it either.
         for (const auto &merge_matching : single_query_part.merge_matching) {
+          for (const auto &sym : merge_matching.expansion_symbols) {
+            note_write_bound(sym);
+          }
           symbols_bound_by_query_part.insert(merge_matching.expansion_symbols.begin(),
                                              merge_matching.expansion_symbols.end());
-          write_bound_symbols_.insert(merge_matching.expansion_symbols.begin(), merge_matching.expansion_symbols.end());
         }
         auto collect_return_body_symbols = [&](const ReturnBody &body) {
           for (const auto *named_expr : body.named_expressions) {
@@ -322,8 +322,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
           if (auto *create = utils::Downcast<Create>(clause)) {
             for (const auto *pattern : create->patterns_) {
               for (const PatternAtom *atom : pattern->atoms_) {
+                note_write_bound(context.symbol_table->at(*atom->identifier_));
                 symbols_bound_by_query_part.insert(context.symbol_table->at(*atom->identifier_));
-                write_bound_symbols_.insert(context.symbol_table->at(*atom->identifier_));
               }
             }
           } else if (auto *foreach_clause = utils::Downcast<query::Foreach>(clause)) {
@@ -344,21 +344,6 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         for (const auto &clause : single_query_part.remaining_clauses) {
           collect_clause_symbols(clause);
         }
-        // A CREATE or MERGE pattern re-uses the names it does not declare, e.g. `a` in
-        // `MATCH (a) CREATE (a)-[:R]->(b)`. Those were bound before the write and View::OLD does see them, so drop
-        // everything already bound on entry or bound by a MATCH of this query part.
-        for (const auto &sym : context.bound_symbols) {
-          write_bound_symbols_.erase(sym);
-        }
-        for (const auto &sym : single_query_part.matching.expansion_symbols) {
-          write_bound_symbols_.erase(sym);
-        }
-        for (const auto &opt_matching : single_query_part.optional_matching) {
-          for (const auto &sym : opt_matching.expansion_symbols) {
-            write_bound_symbols_.erase(sym);
-          }
-        }
-
         // Track whether a write operation has occurred - comprehensions planned after writes
         // need to use View::NEW to see the newly created/modified data.
         bool write_occurred = false;
@@ -555,8 +540,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   /// variable-length rule is applied here once rather than at each drain site.
   std::unique_ptr<LogicalOperator> PlanPatternComprehension(const PatternComprehensionMatching &matching,
                                                             const SymbolTable &symbol_table,
-                                                            std::unordered_set<Symbol> &bound_symbols,
-                                                            storage::View view = storage::View::OLD) {
+                                                            const std::unordered_set<Symbol> &bound_symbols,
+                                                            storage::View view) {
     view = impl::PatternComprehensionView(matching, view, bound_symbols, write_bound_symbols_);
     std::unique_ptr<LogicalOperator> new_input;
     // Create a copy of bound_symbols and add external symbols from the pattern comprehension.
@@ -1407,17 +1392,13 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   static bool DepsSatisfied(const PatternComprehensionMatching &pc,
                             const std::unordered_set<Symbol> &symbols_bound_by_query_part,
                             const std::unordered_set<Symbol> &bound_symbols) {
-    // Symbols referenced from the filter or result expression.
-    const bool external_ok = std::ranges::all_of(pc.external_symbols, [&](const Symbol &s) {
-      return !symbols_bound_by_query_part.contains(s) || bound_symbols.contains(s);
-    });
-    if (!external_ok) return false;
-
-    // Symbols the pattern itself references but that are declared elsewhere in this query part, e.g. `a` in
-    // `[(a)-->(x)|...]` when `a` comes from a CREATE or a later WITH. Those must be bound first.
-    return std::ranges::all_of(pc.expansion_symbols, [&](const Symbol &sym) {
+    // A symbol this query part binds elsewhere must be bound already; one from an earlier part never waits.
+    auto ready = [&](const Symbol &sym) {
       return !symbols_bound_by_query_part.contains(sym) || bound_symbols.contains(sym);
-    });
+    };
+    // external_symbols come from the filter or result expression; expansion_symbols from the pattern, e.g. `a` in
+    // `[(a)-->(x)|...]` when `a` comes from a CREATE or a later WITH.
+    return std::ranges::all_of(pc.external_symbols, ready) && std::ranges::all_of(pc.expansion_symbols, ready);
   }
 
   /// The one *early* place a pending comprehension turns into a `RollUpApply`, because a comprehension must be spliced
@@ -1435,14 +1416,11 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   /// @param bound_symbols what is bound on @p chain, used for the dependency check and the view.
   /// @param only when non-null, restricts the drain to these result symbols - a MERGE branch takes only what its own
   ///        SET clauses read, so the two branches cannot steal each other's.
-  /// @param extra_bound_symbols symbols bound on @p chain that the planning context does not share, e.g. MERGE's
-  ///        ON MATCH, which binds its pattern into a copy. Omitting them plans an uncorrelated scan.
   std::unique_ptr<LogicalOperator> SpliceSatisfiedComprehensions(
       std::unique_ptr<LogicalOperator> chain,
       std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
       const std::unordered_set<Symbol> &symbols_bound_by_query_part, const std::unordered_set<Symbol> &bound_symbols,
-      bool write_occurred, const std::unordered_set<Symbol> *only = nullptr,
-      const std::unordered_set<Symbol> &extra_bound_symbols = kNoExtraBoundSymbols) {
+      bool write_occurred, const std::unordered_set<Symbol> *only = nullptr) {
     for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
       const auto &[sym, pc] = *it;
       const bool wanted = only == nullptr || only->contains(sym);
@@ -1452,7 +1430,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
       }
       auto const preferred = write_occurred && impl::ReferencesExternalSymbols(pc, bound_symbols) ? storage::View::NEW
                                                                                                   : storage::View::OLD;
-      auto pc_op = Plan(pc, preferred, extra_bound_symbols);
+      auto pc_op = Plan(pc, preferred, bound_symbols);
       auto symbols = pc_op->ModifiedSymbols(*context_->symbol_table);
       chain = std::make_unique<RollUpApply>(std::move(chain), std::move(pc_op), symbols, sym);
       it = pending_comprehensions.erase(it);

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -46,9 +46,9 @@ struct PatternComprehensionData {
 /// Interface for planning pattern comprehensions, avoiding std::function overhead.
 struct PatternComprehensionPlanner {
   virtual ~PatternComprehensionPlanner() = default;
-  /// @param bound_symbols Everything bound on the chain the comprehension will be spliced onto. The caller owns this
-  /// because it varies: a MERGE branch binds its pattern into a copy the planning context does not share, and a
-  /// WHERE/ORDER BY comprehension also sees the output symbols of the WITH/RETURN it sits in.
+  /// @param bound_symbols Everything bound on the chain it will be spliced onto. The caller owns this because it
+  /// varies: a MERGE branch binds its pattern into a copy, and a WHERE/ORDER BY comprehension also sees the
+  /// WITH/RETURN's output symbols.
   virtual std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
                                                 const std::unordered_set<Symbol> &bound_symbols) = 0;
 };
@@ -58,7 +58,7 @@ struct PatternComprehensionContext {
   std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions;
   PatternComprehensionPlanner *planner;
   /// The view this query part has reached: View::NEW once one of its write clauses has been planned. Only a
-  /// *preference* - @c RuleBasedPlanner::PlanPatternComprehension filters it, see @c impl::PatternComprehensionView.
+  /// preference; @c impl::PatternComprehensionView filters it.
   storage::View view;
 };
 
@@ -200,30 +200,26 @@ Expression *BoolJoin(AstStorage &storage, Expression *expr1, Expression *expr2) 
   return expr1 ? expr1 : expr2;
 }
 
-/// Result symbols of the top-level pattern comprehensions @p clauses evaluate. Used to splice a comprehension into
-/// the operator branch that actually reads it, rather than the chain its clause happens to sit on.
+/// Result symbols of the top-level comprehensions @p clauses evaluate, so each is spliced into the branch that reads
+/// it rather than the chain its clause sits on.
 std::unordered_set<Symbol> CollectPatternComprehensionSymbols(const std::vector<Clause *> &clauses,
                                                               const SymbolTable &symbol_table);
 
-/// True if the comprehension reads something bound outside it: either from its filter or result expression, or a
-/// pattern symbol that is already bound, e.g. `a` in `[(a)-->(x)|x]` when `a` comes from a CREATE.
+/// Whether the comprehension reads something bound outside it - from its filter or result expression, or an already
+/// bound pattern symbol, e.g. `a` in `[(a)-->(x)|x]` when a CREATE bound it.
 bool ReferencesExternalSymbols(const PatternComprehensionMatching &pc, const std::unordered_set<Symbol> &bound_symbols);
 
-/// Applies the variable-length rule to the view a drain site would otherwise use. Called from exactly one place,
-/// @c RuleBasedPlanner::PlanPatternComprehension, which every comprehension - nested ones included - passes through.
+/// Applies the variable-length rule to the view a drain site would otherwise use, from the single place every
+/// comprehension - nested ones included - passes through, @c RuleBasedPlanner::PlanPatternComprehension.
 ///
-/// `ExpandVariable` can only read View::OLD, so a variable-length pattern cannot have @p preferred when that is
-/// View::NEW. View::OLD is still correct for it as long as the pattern's root exists in that view. When the root is a
-/// node a write clause of this same query part bound, neither view works: this throws rather than emit a plan that
-/// fails at runtime with a storage-level message.
+/// `ExpandVariable` can only read View::OLD, so a variable-length pattern cannot take a View::NEW @p preferred.
+/// View::OLD serves it as long as its root exists there; when a write clause of this query part bound that root,
+/// neither view works and this throws rather than emit a plan that fails at runtime.
 ///
-/// A fixed-length pattern keeps @p preferred untouched. Sites legitimately differ in how they pick it - the early
-/// drains require the comprehension to reference an externally bound symbol before choosing View::NEW, while a return
-/// body uses the query part's current view directly - so that choice stays with the caller.
+/// A fixed-length pattern keeps @p preferred, because sites legitimately differ in how they pick it.
 ///
 /// @param preferred the view the site would use if the pattern were fixed-length.
-/// @param bound_symbols what is bound on the chain the comprehension will be spliced onto.
-/// @param write_bound_symbols symbols bound by a write clause of this query part, which View::OLD cannot see.
+/// @param write_bound_symbols symbols a write clause of this query part bound, which View::OLD cannot see.
 storage::View PatternComprehensionView(const PatternComprehensionMatching &pc, storage::View preferred,
                                        const std::unordered_set<Symbol> &bound_symbols,
                                        const std::unordered_set<Symbol> &write_bound_symbols);
@@ -293,9 +289,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
           symbols_bound_by_query_part.insert(opt_matching.expansion_symbols.begin(),
                                              opt_matching.expansion_symbols.end());
         }
-        // A write clause re-uses the names it does not declare, e.g. `a` in `MATCH (a) CREATE (a)-[:R]->(b)`; those
-        // were bound before the write and View::OLD does see them. Only a name the clause *first* binds counts, and
-        // every MATCH symbol is already collected above, so testing at insertion is enough.
+        // A write clause re-uses names it does not declare, e.g. `a` in `MATCH (a) CREATE (a)-[:R]->(b)`, which
+        // View::OLD does see. Only a name it *first* binds counts; MATCH symbols are already collected above.
         auto note_write_bound = [&](const Symbol &sym) {
           if (!context.bound_symbols.contains(sym) && !symbols_bound_by_query_part.contains(sym)) {
             query_part_symbols_.write_bound.insert(sym);
@@ -331,8 +326,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
               collect_clause_symbols(nested);
             }
           } else if (auto *ret = utils::Downcast<Return>(clause)) {
-            // A WITH/RETURN re-declares its projected names. A comprehension in its WHERE or ORDER BY resolves to
-            // those new symbols, so it must not be drained before the clause that binds them - see deps_satisfied.
+            // A WITH/RETURN re-declares its projected names, so a comprehension in its WHERE or ORDER BY resolves to
+            // those and must not drain before the clause that binds them - see DepsSatisfied.
             collect_return_body_symbols(ret->body_);
           } else if (auto *with = utils::Downcast<query::With>(clause)) {
             collect_return_body_symbols(with->body_);
@@ -523,9 +518,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   /// @brief Recursively plans a pattern comprehension including any nested pattern comprehensions.
   /// For nested pattern comprehensions (e.g., [()--() | [()--() | 1]]), the inner pattern
   /// comprehension is planned first and wrapped with RollUpApply before the outer one's Produce.
-  /// @param view The view the calling site would like - View::NEW if planned after write clauses, View::OLD otherwise.
-  /// Only a preference: this is the one place every comprehension, nested ones included, passes through, so the
-  /// variable-length rule is applied here once rather than at each drain site.
+  /// @param view Only a preference: this is the one place every comprehension, nested ones included, passes through,
+  /// so @c impl::PatternComprehensionView is applied here once rather than at each drain site.
   std::unique_ptr<LogicalOperator> PlanPatternComprehension(const PatternComprehensionMatching &matching,
                                                             const SymbolTable &symbol_table,
                                                             const std::unordered_set<Symbol> &bound_symbols,
@@ -554,8 +548,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   struct QueryPartSymbols {
     /// Everything the part binds, wherever in it. A comprehension waits for these - see `DepsSatisfied`.
     std::unordered_set<Symbol> all;
-    /// The subset a *write* clause of the part is the first to bind, which View::OLD cannot see - see
-    /// `impl::PatternComprehensionView`.
+    /// The subset a *write* clause first binds, which View::OLD cannot see - see `impl::PatternComprehensionView`.
     std::unordered_set<Symbol> write_bound;
   };
 
@@ -760,8 +753,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
       std::unique_ptr<LogicalOperator> input_op, const std::vector<PatternComprehensionMatching> &nested_comprehensions,
       const SymbolTable &symbol_table, std::unordered_set<Symbol> &bound_symbols, storage::View view) {
     for (const auto &nested : nested_comprehensions) {
-      // The parent's view is a preference for the nested one too: a nested pattern has its own edges, so a
-      // variable-length one must read View::OLD even under a View::NEW parent. PlanPatternComprehension applies that.
+      // A preference for the nested one too: its own edges decide, so a variable-length nested pattern reads
+      // View::OLD even under a View::NEW parent.
       auto nested_op = PlanPatternComprehension(nested, symbol_table, bound_symbols, view);
       auto nested_symbols = nested_op->ModifiedSymbols(symbol_table);
       input_op = std::make_unique<RollUpApply>(
@@ -866,10 +859,9 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     auto once_with_symbols = std::make_unique<Once>(bound_symbols);
     auto on_match = PlanMatching(match_ctx, std::move(once_with_symbols));
 
-    // ON CREATE / ON MATCH run inside their own branch, so a comprehension one of them reads has to be spliced into
-    // that branch. Splicing it onto the chain the MERGE itself sits on would evaluate it above the Merge, leaving the
-    // frame slot unwritten when the SET below reads it. Only the comprehensions that branch actually evaluates are
-    // taken, so the two branches cannot steal each other's.
+    // ON CREATE / ON MATCH run in their own branch, so a comprehension one reads is spliced there: on the MERGE's own
+    // chain it would evaluate above the Merge, leaving the slot unwritten when the SET reads it. Each branch takes
+    // only what it evaluates, so they cannot steal each other's.
     auto splice_branch_comprehensions = [&](std::unique_ptr<LogicalOperator> branch,
                                             const std::vector<query::Clause *> &sets,
                                             const std::unordered_set<Symbol> &branch_bound_symbols) {
@@ -879,8 +871,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     };
 
     {
-      // ON MATCH runs only when the pattern was found, so View::OLD does see its symbols - unlike ON CREATE's, and
-      // unlike the chain below the Merge, where the planner cannot know which branch ran.
+      // ON MATCH runs only when the pattern was found, so View::OLD sees its symbols - unlike ON CREATE's, or the
+      // chain below the Merge, where the planner cannot know which branch ran.
       auto const restore = utils::OnScopeExit{[this, saved = query_part_symbols_.write_bound]() mutable {
         query_part_symbols_.write_bound = std::move(saved);
       }};
@@ -1206,9 +1198,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
     auto existing_node = bound_symbols.contains(node_symbol);
     const auto &edge_symbol = symbol_table.at(*edge->identifier_);
-    // `Expand` can check that an already bound *node* is the one the pattern reaches, but it has no equivalent for an
-    // edge, so there is no operator to emit here. Semantic analysis rejects the spellings that get this far, but reject
-    // rather than assert: an assert on the planning path aborts the process, and `EXPLAIN` alone reaches it.
+    // No `existing_edge` counterpart to `existing_node`, so there is no operator to emit. Semantic analysis rejects
+    // the spellings that reach here; throw rather than assert, which would abort the process from `EXPLAIN` alone.
     if (bound_symbols.contains(edge_symbol)) {
       throw QueryException("Expanding over the already bound relationship '{}' is not supported.", edge_symbol.name());
     }
@@ -1295,10 +1286,9 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         bound_symbols.insert(*total_weight);
       }
 
-      // ExpandVariable can only read View::OLD. Nothing should reach here with another view: every comprehension is
-      // filtered through `impl::PatternComprehensionView`, a MERGE pattern cannot hold a variable-length edge (semantic
-      // analysis rejects that), and MATCH plans with View::OLD. This is the backstop for a routing mistake - reject
-      // rather than assert, because an assert on the planning path aborts the process and `EXPLAIN` alone reaches it.
+      // Unreachable today: comprehensions are filtered through `impl::PatternComprehensionView`, a MERGE pattern
+      // cannot hold a variable-length edge, and MATCH plans View::OLD. Backstop for a routing mistake - throw rather
+      // than assert, which would abort the process from `EXPLAIN` alone.
       if (view != storage::View::OLD) {
         throw QueryException(
             "A variable-length pattern cannot be evaluated after a write in the same query part. Separate them with a "
@@ -1376,37 +1366,30 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     return last_op;
   }
 
-  /// True once every symbol the comprehension references that this query part binds elsewhere is bound. Symbols from
-  /// an earlier query part are not waited for. Every *early* drain must use this - the on-demand path in
-  /// `ReturnBodyContext` needs no check, because a WITH/RETURN is the last clause of its query part, so a
-  /// comprehension reaching there is already at the clause that owns it. (It does share the view rule; see
-  /// `impl::PatternComprehensionView`.)
+  /// True once every symbol the comprehension references that this query part binds elsewhere is bound; symbols from
+  /// an earlier part are not waited for. Every *early* drain must use this. The on-demand path in `ReturnBodyContext`
+  /// needs no check, because a WITH/RETURN is the last clause of its query part.
   bool DepsSatisfied(const PatternComprehensionMatching &pc, const std::unordered_set<Symbol> &bound_symbols) const {
     const auto &symbols_bound_by_query_part = query_part_symbols_.all;
-    // A symbol this query part binds elsewhere must be bound already; one from an earlier part never waits.
+    // A symbol this part binds elsewhere must be bound already; one from an earlier part never waits.
     auto ready = [&](const Symbol &sym) {
       return !symbols_bound_by_query_part.contains(sym) || bound_symbols.contains(sym);
     };
-    // external_symbols come from the filter or result expression; expansion_symbols from the pattern, e.g. `a` in
-    // `[(a)-->(x)|...]` when `a` comes from a CREATE or a later WITH.
+    // external_symbols come from the filter or result expression, expansion_symbols from the pattern.
     return std::ranges::all_of(pc.external_symbols, ready) && std::ranges::all_of(pc.expansion_symbols, ready);
   }
 
-  /// The one *early* place a pending comprehension turns into a `RollUpApply`, because a comprehension must be spliced
-  /// onto the chain that *reads* it, not merely the one its clause sits on. Both defects this file has had came from
-  /// that: a drain site whose dependency check had drifted, and a chain with no drain site at all.
+  /// The one *early* place a pending comprehension becomes a `RollUpApply`. It must be spliced onto the chain that
+  /// *reads* it, not merely the one its clause sits on; both defects this file has had came from that.
   ///
-  /// Five chains can evaluate a comprehension. Three drain through here - the main clause chain, a FOREACH body, and
-  /// each MERGE branch. The fourth is a WITH/RETURN return body, which drains on demand in `ReturnBodyContext` because
-  /// it needs a different splice point per position in the body; it shares this function's view rule through
-  /// `impl::PatternComprehensionView` and needs no dependency check (see `DepsSatisfied`). The fifth, a
-  /// `CallProcedure` clause - its arguments as much as its `YIELD ... WHERE` - has no drain at all: `CallProcedure` is
-  /// a query-part boundary, so nothing downstream can drain it either and the matching is collected then abandoned.
-  /// Known gap, and the reason `pending_comprehensions` cannot yet be asserted empty at the end of a query part.
+  /// Five chains can evaluate a comprehension. Three drain here: the main clause chain, a FOREACH body, each MERGE
+  /// branch. A WITH/RETURN body drains on demand in `ReturnBodyContext`, needing a splice point per position. A
+  /// `CallProcedure` clause - arguments as much as `YIELD ... WHERE` - has **no** drain: it is a query-part boundary,
+  /// so nothing downstream can drain it either. Known gap, and why `pending_comprehensions` cannot be asserted empty.
   ///
-  /// @param bound_symbols what is bound on @p chain, used for the dependency check and the view.
-  /// @param only when non-null, restricts the drain to these result symbols - a MERGE branch takes only what its own
-  ///        SET clauses read, so the two branches cannot steal each other's.
+  /// @param bound_symbols what is bound on @p chain, for the dependency check and the view.
+  /// @param only when non-null, restricts the drain to these result symbols, so MERGE branches cannot steal each
+  ///        other's.
   std::unique_ptr<LogicalOperator> SpliceSatisfiedComprehensions(
       std::unique_ptr<LogicalOperator> chain,
       std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
@@ -1437,7 +1420,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     bound_symbols.insert(symbol);
     std::unique_ptr<LogicalOperator> op = std::make_unique<plan::Once>();
 
-    // Every clause a FOREACH body may hold is a write, so anything planned after the first one must read View::NEW.
+    // Every clause a FOREACH body may hold is a write, so anything planned after the first reads View::NEW.
     bool write_occurred = false;
 
     // Plan comprehensions whose dependencies are now satisfied, onto the body's own chain.
@@ -1457,8 +1440,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
       } else {
         op = HandleWriteClause(clause, op, symbol_table, bound_symbols);
       }
-      // A body clause can bind the very symbol a pending comprehension expands from, so drain again after each one -
-      // exactly as the main clause loop does. Without this the comprehension stays pending and is never planned.
+      // A body clause can bind the symbol a pending comprehension expands from, so drain after each one, as the main
+      // clause loop does. Without this it stays pending and is never planned.
       write_occurred = true;
       plan_satisfied_comprehensions();
     }

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -893,18 +893,25 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     auto splice_branch_comprehensions = [&](std::unique_ptr<LogicalOperator> branch,
                                             const std::vector<query::Clause *> &sets,
                                             const std::unordered_set<Symbol> &branch_bound_symbols) {
-      if (sets.empty() || pending_comprehensions.empty()) return branch;
       const auto wanted = impl::CollectPatternComprehensionSymbols(sets, *context_->symbol_table);
       return SpliceSatisfiedComprehensions(std::move(branch),
                                            pending_comprehensions,
                                            symbols_bound_by_query_part,
                                            branch_bound_symbols,
                                            /*write_occurred=*/true,
-                                           &wanted,
-                                           branch_bound_symbols);
+                                           &wanted);
     };
 
-    on_match = splice_branch_comprehensions(std::move(on_match), merge.on_match_, bound_symbols_copy);
+    {
+      // ON MATCH runs only when the pattern was found, so View::OLD does see its symbols - unlike ON CREATE's, and
+      // unlike the chain below the Merge, where the planner cannot know which branch ran.
+      auto const restore = utils::OnScopeExit{
+          [this, saved = write_bound_symbols_]() mutable { write_bound_symbols_ = std::move(saved); }};
+      for (const auto &sym : matching.expansion_symbols) {
+        write_bound_symbols_.erase(sym);
+      }
+      on_match = splice_branch_comprehensions(std::move(on_match), merge.on_match_, bound_symbols_copy);
+    }
 
     once_with_symbols = std::make_unique<Once>(std::move(bound_symbols));
     // Use the original bound_symbols, so we fill it with new symbols.

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -1165,7 +1165,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
     auto existing_node = bound_symbols.contains(node_symbol);
     const auto &edge_symbol = symbol_table.at(*edge->identifier_);
-    MG_ASSERT(!bound_symbols.contains(edge_symbol), "Existing edges are not supported");
+    // `Expand` can check that an already bound *node* is the one the pattern reaches, but it has no equivalent for an
+    // edge, so there is no operator to emit here. Semantic analysis rejects the spellings that get this far, but reject
+    // rather than assert: an assert on the planning path aborts the process, and `EXPLAIN` alone reaches it.
+    if (bound_symbols.contains(edge_symbol)) {
+      throw QueryException("Expanding over the already bound relationship '{}' is not supported.", edge_symbol.name());
+    }
 
     auto edge_types = GetEdgeTypes(edge->edge_types_);
     if (edge->IsVariable()) {

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -202,6 +202,11 @@ Expression *BoolJoin(AstStorage &storage, Expression *expr1, Expression *expr2) 
   return expr1 ? expr1 : expr2;
 }
 
+/// Result symbols of the top-level pattern comprehensions @p clauses evaluate. Used to splice a comprehension into
+/// the operator branch that actually reads it, rather than the chain its clause happens to sit on.
+std::unordered_set<Symbol> CollectPatternComprehensionSymbols(const std::vector<Clause *> &clauses,
+                                                              const SymbolTable &symbol_table);
+
 }  // namespace impl
 
 /// @brief Planner which uses hardcoded rules to produce operators.
@@ -349,7 +354,11 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                        context.in_exists_subquery);
           } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
             plan_and_apply_comprehensions();
-            input_op = GenMerge(*merge, std::move(input_op), single_query_part.merge_matching[merge_id++]);
+            input_op = GenMerge(*merge,
+                                std::move(input_op),
+                                single_query_part.merge_matching[merge_id++],
+                                pending_comprehensions,
+                                symbols_bound_by_query_part);
             // Treat MERGE clause as write, because we do not know if it will create anything.
             context.is_write_query = true;
             write_occurred = true;
@@ -818,7 +827,9 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     return last_op;
   }
 
-  auto GenMerge(query::Merge &merge, std::unique_ptr<LogicalOperator> input_op, const Matching &matching) {
+  auto GenMerge(query::Merge &merge, std::unique_ptr<LogicalOperator> input_op, const Matching &matching,
+                std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
+                const std::unordered_set<Symbol> &symbols_bound_by_query_part) {
     // Copy the bound symbol set, because we don't want to use the updated
     // version when generating the create part.
     std::unordered_set<Symbol> bound_symbols_copy(context_->bound_symbols);
@@ -829,10 +840,39 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     auto once_with_symbols = std::make_unique<Once>(bound_symbols);
     auto on_match = PlanMatching(match_ctx, std::move(once_with_symbols));
 
+    // ON CREATE / ON MATCH run inside their own branch, so a comprehension one of them reads has to be spliced into
+    // that branch. Splicing it onto the chain the MERGE itself sits on would evaluate it above the Merge, leaving the
+    // frame slot unwritten when the SET below reads it. Only the comprehensions that branch actually evaluates are
+    // taken, so the two branches cannot steal each other's.
+    auto splice_branch_comprehensions = [&](std::unique_ptr<LogicalOperator> branch,
+                                            const std::vector<query::Clause *> &sets,
+                                            const std::unordered_set<Symbol> &branch_bound_symbols) {
+      if (sets.empty() || pending_comprehensions.empty()) return branch;
+      const auto wanted = impl::CollectPatternComprehensionSymbols(sets, *context_->symbol_table);
+      for (const auto &sym : wanted) {
+        auto it = pending_comprehensions.find(sym);
+        if (it == pending_comprehensions.end()) continue;
+        const auto &pc = it->second;
+        if (!DepsSatisfied(pc, symbols_bound_by_query_part, branch_bound_symbols)) continue;
+        // The branch has just written the nodes the comprehension expands from, so it must read View::NEW. The
+        // branch's own symbols go in as extras: ON MATCH binds the pattern into a copy of the bound set the planning
+        // context does not share, and without them the branch would be planned uncorrelated.
+        auto pc_op =
+            Plan(pc, PatternComprehensionView(pc, /*write_occurred=*/true, branch_bound_symbols), branch_bound_symbols);
+        auto symbols = pc_op->ModifiedSymbols(*context_->symbol_table);
+        branch = std::make_unique<RollUpApply>(std::move(branch), std::move(pc_op), symbols, sym);
+        pending_comprehensions.erase(it);
+      }
+      return branch;
+    };
+
+    on_match = splice_branch_comprehensions(std::move(on_match), merge.on_match_, bound_symbols_copy);
+
     once_with_symbols = std::make_unique<Once>(std::move(bound_symbols));
     // Use the original bound_symbols, so we fill it with new symbols.
     auto on_create = GenCreateForPattern(
         *merge.pattern_, std::move(once_with_symbols), *context_->symbol_table, context_->bound_symbols);
+    on_create = splice_branch_comprehensions(std::move(on_create), merge.on_create_, context_->bound_symbols);
     for (auto &set : merge.on_create_) {
       on_create = HandleWriteClause(set, on_create, *context_->symbol_table, context_->bound_symbols);
       MG_ASSERT(on_create, "Expected SET in MERGE ... ON CREATE");
@@ -1381,7 +1421,11 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                  pending_comprehensions,
                                  symbols_bound_by_query_part);
       } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
-        op = GenMerge(*merge, std::move(op), query_part.merge_matching[merge_id++]);
+        op = GenMerge(*merge,
+                      std::move(op),
+                      query_part.merge_matching[merge_id++],
+                      pending_comprehensions,
+                      symbols_bound_by_query_part);
       } else {
         op = HandleWriteClause(clause, op, symbol_table, bound_symbols);
       }

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -263,6 +263,11 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
       context.is_write_query = false;
       for (const auto &single_query_part : query_part.single_query_parts) {
+        // Installed before HandleMatching, which plans MATCH-clause comprehensions through the same member.
+        auto const restore_symbols = utils::OnScopeExit{
+            [this, saved = std::move(query_part_symbols_)]() mutable { query_part_symbols_ = std::move(saved); }};
+        query_part_symbols_ = {};
+
         input_op = HandleMatching(std::move(input_op), single_query_part, *context.symbol_table, context.bound_symbols);
 
         uint64_t merge_id = 0;
@@ -277,9 +282,6 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
         // Compute all symbols that will be bound by this query part (from MATCH, CREATE, MERGE, etc.)
         // This is used to determine which comprehension symbols are external references vs. internal.
-        auto const restore_symbols = utils::OnScopeExit{
-            [this, saved = std::move(query_part_symbols_)]() mutable { query_part_symbols_ = std::move(saved); }};
-        query_part_symbols_ = {};
         auto &symbols_bound_by_query_part = query_part_symbols_.all;
         // Add symbols from MATCH
         symbols_bound_by_query_part.insert(single_query_part.matching.expansion_symbols.begin(),
@@ -365,8 +367,11 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                        context.in_exists_subquery);
           } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
             plan_and_apply_comprehensions();
-            input_op = GenMerge(
-                *merge, std::move(input_op), single_query_part.merge_matching[merge_id++], pending_comprehensions);
+            input_op = GenMerge(*merge,
+                                std::move(input_op),
+                                single_query_part.merge_matching[merge_id++],
+                                pending_comprehensions,
+                                write_occurred);
             // Treat MERGE clause as write, because we do not know if it will create anything.
             context.is_write_query = true;
             write_occurred = true;
@@ -847,8 +852,9 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     return last_op;
   }
 
+  /// @param write_occurred whether a clause earlier in this query part has already written.
   auto GenMerge(query::Merge &merge, std::unique_ptr<LogicalOperator> input_op, const Matching &matching,
-                std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions) {
+                std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions, bool write_occurred) {
     // Copy the bound symbol set, because we don't want to use the updated
     // version when generating the create part.
     std::unordered_set<Symbol> bound_symbols_copy(context_->bound_symbols);
@@ -872,12 +878,16 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
     {
       // ON MATCH runs only when the pattern was found, so View::OLD sees its symbols - unlike ON CREATE's, or the
-      // chain below the Merge, where the planner cannot know which branch ran.
+      // chain below the Merge, where the planner cannot know which branch ran. Only once nothing has written earlier
+      // in this part, though: the match branch reads View::NEW, so it can find a node such a write created, which
+      // View::OLD cannot see.
       auto const restore = utils::OnScopeExit{[this, saved = query_part_symbols_.write_bound]() mutable {
         query_part_symbols_.write_bound = std::move(saved);
       }};
-      for (const auto &sym : matching.expansion_symbols) {
-        query_part_symbols_.write_bound.erase(sym);
+      if (!write_occurred) {
+        for (const auto &sym : matching.expansion_symbols) {
+          query_part_symbols_.write_bound.erase(sym);
+        }
       }
       on_match = splice_branch_comprehensions(std::move(on_match), merge.on_match_, bound_symbols_copy);
     }
@@ -1436,7 +1446,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         op = HandleForeachClause(
             nested_for_each, std::move(op), symbol_table, bound_symbols, query_part, merge_id, pending_comprehensions);
       } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
-        op = GenMerge(*merge, std::move(op), query_part.merge_matching[merge_id++], pending_comprehensions);
+        op = GenMerge(
+            *merge, std::move(op), query_part.merge_matching[merge_id++], pending_comprehensions, write_occurred);
       } else {
         op = HandleWriteClause(clause, op, symbol_table, bound_symbols);
       }

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -281,13 +281,10 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
         // Compute all symbols that will be bound by this query part (from MATCH, CREATE, MERGE, etc.)
         // This is used to determine which comprehension symbols are external references vs. internal.
-        std::unordered_set<Symbol> symbols_bound_by_query_part;
-        // The subset of the above that a *write* clause of this query part is what *first* binds. View::OLD cannot see
-        // those, which is what makes a variable-length comprehension over one of them unplannable - see
-        // `impl::PatternComprehensionView`. Restored on the way out because a subquery re-enters this function.
-        auto const restore_write_bound = utils::OnScopeExit{
-            [this, saved = std::move(write_bound_symbols_)]() mutable { write_bound_symbols_ = std::move(saved); }};
-        write_bound_symbols_.clear();
+        auto const restore_symbols = utils::OnScopeExit{
+            [this, saved = std::move(query_part_symbols_)]() mutable { query_part_symbols_ = std::move(saved); }};
+        query_part_symbols_ = {};
+        auto &symbols_bound_by_query_part = query_part_symbols_.all;
         // Add symbols from MATCH
         symbols_bound_by_query_part.insert(single_query_part.matching.expansion_symbols.begin(),
                                            single_query_part.matching.expansion_symbols.end());
@@ -301,7 +298,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         // every MATCH symbol is already collected above, so testing at insertion is enough.
         auto note_write_bound = [&](const Symbol &sym) {
           if (!context.bound_symbols.contains(sym) && !symbols_bound_by_query_part.contains(sym)) {
-            write_bound_symbols_.insert(sym);
+            query_part_symbols_.write_bound.insert(sym);
           }
         };
         // Add symbols from merge matchings. MERGE may create its pattern, so View::OLD may not see it either.
@@ -350,11 +347,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
         // Plan and apply all satisfiable comprehensions before write clauses.
         auto plan_and_apply_comprehensions = [&]() {
-          input_op = SpliceSatisfiedComprehensions(std::move(input_op),
-                                                   pending_comprehensions,
-                                                   symbols_bound_by_query_part,
-                                                   context.bound_symbols,
-                                                   write_occurred);
+          input_op = SpliceSatisfiedComprehensions(
+              std::move(input_op), pending_comprehensions, context.bound_symbols, write_occurred);
         };
 
         for (const auto &clause : single_query_part.remaining_clauses) {
@@ -376,11 +370,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                        context.in_exists_subquery);
           } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
             plan_and_apply_comprehensions();
-            input_op = GenMerge(*merge,
-                                std::move(input_op),
-                                single_query_part.merge_matching[merge_id++],
-                                pending_comprehensions,
-                                symbols_bound_by_query_part);
+            input_op = GenMerge(
+                *merge, std::move(input_op), single_query_part.merge_matching[merge_id++], pending_comprehensions);
             // Treat MERGE clause as write, because we do not know if it will create anything.
             context.is_write_query = true;
             write_occurred = true;
@@ -471,8 +462,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                            context.bound_symbols,
                                            single_query_part,
                                            merge_id,
-                                           pending_comprehensions,
-                                           symbols_bound_by_query_part);
+                                           pending_comprehensions);
           } else if (auto *call_sub = utils::Downcast<query::CallSubquery>(clause)) {
             auto scoped_variables = std::invoke([&]() -> std::optional<std::unordered_set<Symbol>> {
               if (!call_sub->has_variable_scope_) {
@@ -494,8 +484,6 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                       single_query_part.subqueries[subquery_id++],
                                       *context.symbol_table,
                                       *context_->ast_storage,
-                                      pending_comprehensions,
-                                      write_occurred,
                                       call_sub->cypher_query_->pre_query_directives_.commit_frequency_,
                                       scoped_variables);
             if (context.is_write_query && !has_periodic_commit) {
@@ -542,7 +530,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                                             const SymbolTable &symbol_table,
                                                             const std::unordered_set<Symbol> &bound_symbols,
                                                             storage::View view) {
-    view = impl::PatternComprehensionView(matching, view, bound_symbols, write_bound_symbols_);
+    view = impl::PatternComprehensionView(matching, view, bound_symbols, query_part_symbols_.write_bound);
     std::unique_ptr<LogicalOperator> new_input;
     // Create a copy of bound_symbols and add external symbols from the pattern comprehension.
     // External symbols are references to variables from outer scope (e.g., FOREACH variable `x`
@@ -560,10 +548,18 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   }
 
   TPlanningContext *context_;
-  /// Symbols a write clause of the query part being planned is the first to bind; see
-  /// `impl::PatternComprehensionView`. Scoped to one query part, and saved/restored around it because a subquery
-  /// re-enters `PlanQueryPart` on this same object.
-  std::unordered_set<Symbol> write_bound_symbols_;
+
+  /// What the query part being planned binds. Scoped to one query part and saved/restored around it, because a
+  /// subquery re-enters `PlanQueryPart` on this same object.
+  struct QueryPartSymbols {
+    /// Everything the part binds, wherever in it. A comprehension waits for these - see `DepsSatisfied`.
+    std::unordered_set<Symbol> all;
+    /// The subset a *write* clause of the part is the first to bind, which View::OLD cannot see - see
+    /// `impl::PatternComprehensionView`.
+    std::unordered_set<Symbol> write_bound;
+  };
+
+  QueryPartSymbols query_part_symbols_;
 
   storage::LabelId GetLabel(const LabelIx &label) { return context_->db->NameToLabel(label.name); }
 
@@ -859,8 +855,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   }
 
   auto GenMerge(query::Merge &merge, std::unique_ptr<LogicalOperator> input_op, const Matching &matching,
-                std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
-                const std::unordered_set<Symbol> &symbols_bound_by_query_part) {
+                std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions) {
     // Copy the bound symbol set, because we don't want to use the updated
     // version when generating the create part.
     std::unordered_set<Symbol> bound_symbols_copy(context_->bound_symbols);
@@ -879,21 +874,18 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                             const std::vector<query::Clause *> &sets,
                                             const std::unordered_set<Symbol> &branch_bound_symbols) {
       const auto wanted = impl::CollectPatternComprehensionSymbols(sets, *context_->symbol_table);
-      return SpliceSatisfiedComprehensions(std::move(branch),
-                                           pending_comprehensions,
-                                           symbols_bound_by_query_part,
-                                           branch_bound_symbols,
-                                           /*write_occurred=*/true,
-                                           &wanted);
+      return SpliceSatisfiedComprehensions(
+          std::move(branch), pending_comprehensions, branch_bound_symbols, /*write_occurred=*/true, &wanted);
     };
 
     {
       // ON MATCH runs only when the pattern was found, so View::OLD does see its symbols - unlike ON CREATE's, and
       // unlike the chain below the Merge, where the planner cannot know which branch ran.
-      auto const restore = utils::OnScopeExit{
-          [this, saved = write_bound_symbols_]() mutable { write_bound_symbols_ = std::move(saved); }};
+      auto const restore = utils::OnScopeExit{[this, saved = query_part_symbols_.write_bound]() mutable {
+        query_part_symbols_.write_bound = std::move(saved);
+      }};
       for (const auto &sym : matching.expansion_symbols) {
-        write_bound_symbols_.erase(sym);
+        query_part_symbols_.write_bound.erase(sym);
       }
       on_match = splice_branch_comprehensions(std::move(on_match), merge.on_match_, bound_symbols_copy);
     }
@@ -1389,9 +1381,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   /// `ReturnBodyContext` needs no check, because a WITH/RETURN is the last clause of its query part, so a
   /// comprehension reaching there is already at the clause that owns it. (It does share the view rule; see
   /// `impl::PatternComprehensionView`.)
-  static bool DepsSatisfied(const PatternComprehensionMatching &pc,
-                            const std::unordered_set<Symbol> &symbols_bound_by_query_part,
-                            const std::unordered_set<Symbol> &bound_symbols) {
+  bool DepsSatisfied(const PatternComprehensionMatching &pc, const std::unordered_set<Symbol> &bound_symbols) const {
+    const auto &symbols_bound_by_query_part = query_part_symbols_.all;
     // A symbol this query part binds elsewhere must be bound already; one from an earlier part never waits.
     auto ready = [&](const Symbol &sym) {
       return !symbols_bound_by_query_part.contains(sym) || bound_symbols.contains(sym);
@@ -1419,12 +1410,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   std::unique_ptr<LogicalOperator> SpliceSatisfiedComprehensions(
       std::unique_ptr<LogicalOperator> chain,
       std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
-      const std::unordered_set<Symbol> &symbols_bound_by_query_part, const std::unordered_set<Symbol> &bound_symbols,
-      bool write_occurred, const std::unordered_set<Symbol> *only = nullptr) {
+      const std::unordered_set<Symbol> &bound_symbols, bool write_occurred,
+      const std::unordered_set<Symbol> *only = nullptr) {
     for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
       const auto &[sym, pc] = *it;
       const bool wanted = only == nullptr || only->contains(sym);
-      if (!wanted || !DepsSatisfied(pc, symbols_bound_by_query_part, bound_symbols)) {
+      if (!wanted || !DepsSatisfied(pc, bound_symbols)) {
         ++it;
         continue;
       }
@@ -1441,8 +1432,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
   std::unique_ptr<LogicalOperator> HandleForeachClause(
       query::Foreach *foreach, std::unique_ptr<LogicalOperator> input_op, const SymbolTable &symbol_table,
       std::unordered_set<Symbol> &bound_symbols, const SingleQueryPart &query_part, uint64_t &merge_id,
-      std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
-      const std::unordered_set<Symbol> &symbols_bound_by_query_part) {
+      std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions) {
     const auto &symbol = symbol_table.at(*foreach->named_expression_);
     bound_symbols.insert(symbol);
     std::unique_ptr<LogicalOperator> op = std::make_unique<plan::Once>();
@@ -1452,8 +1442,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
     // Plan comprehensions whose dependencies are now satisfied, onto the body's own chain.
     auto plan_satisfied_comprehensions = [&]() {
-      op = SpliceSatisfiedComprehensions(
-          std::move(op), pending_comprehensions, symbols_bound_by_query_part, bound_symbols, write_occurred);
+      op = SpliceSatisfiedComprehensions(std::move(op), pending_comprehensions, bound_symbols, write_occurred);
     };
 
     // Plan any comprehensions whose dependencies are now satisfied (e.g., referencing the FOREACH variable)
@@ -1461,20 +1450,10 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
     for (auto *clause : foreach->clauses_) {
       if (auto *nested_for_each = utils::Downcast<query::Foreach>(clause)) {
-        op = HandleForeachClause(nested_for_each,
-                                 std::move(op),
-                                 symbol_table,
-                                 bound_symbols,
-                                 query_part,
-                                 merge_id,
-                                 pending_comprehensions,
-                                 symbols_bound_by_query_part);
+        op = HandleForeachClause(
+            nested_for_each, std::move(op), symbol_table, bound_symbols, query_part, merge_id, pending_comprehensions);
       } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
-        op = GenMerge(*merge,
-                      std::move(op),
-                      query_part.merge_matching[merge_id++],
-                      pending_comprehensions,
-                      symbols_bound_by_query_part);
+        op = GenMerge(*merge, std::move(op), query_part.merge_matching[merge_id++], pending_comprehensions);
       } else {
         op = HandleWriteClause(clause, op, symbol_table, bound_symbols);
       }
@@ -1489,8 +1468,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
   std::unique_ptr<LogicalOperator> HandleSubquery(
       std::unique_ptr<LogicalOperator> last_op, std::shared_ptr<QueryParts> subquery, SymbolTable &symbol_table,
-      AstStorage &storage, std::unordered_map<Symbol, PatternComprehensionMatching> & /*pending_comprehensions*/,
-      bool /*write_occurred*/, Expression *commit_frequency,
+      AstStorage &storage, Expression *commit_frequency,
       const std::optional<std::unordered_set<Symbol>> &scoped_variables = std::nullopt) {
     std::unordered_set<Symbol> outer_scope_bound_symbols;
     outer_scope_bound_symbols.insert(std::make_move_iterator(context_->bound_symbols.begin()),

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -47,10 +47,15 @@ struct PatternComprehensionPlanner {
   virtual ~PatternComprehensionPlanner() = default;
   /// @param extra_bound_symbols Symbols bound by an operator the comprehension will be planned after, but which are
   /// not yet in the planning context (the output symbols of a WITH/RETURN whose WHERE or ORDER BY holds the
-  /// comprehension).
+  /// comprehension). Has no default: a default argument on a virtual function is bound statically, so it would mean
+  /// something different depending on whether the call goes through this interface or through RuleBasedPlanner.
   virtual std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
-                                                const std::unordered_set<Symbol> &extra_bound_symbols = {}) = 0;
+                                                const std::unordered_set<Symbol> &extra_bound_symbols) = 0;
 };
+
+/// Passed as @c PatternComprehensionPlanner::Plan's @c extra_bound_symbols when the comprehension is planned in the
+/// position its own clause binds, so the planning context's bound symbols are already complete.
+inline const std::unordered_set<Symbol> kNoExtraBoundSymbols{};
 
 /// Context for on-demand pattern comprehension planning in RETURN/WITH bodies.
 struct PatternComprehensionContext {
@@ -209,12 +214,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
 
   /// Implements PatternComprehensionPlanner interface
   std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
-                                        const std::unordered_set<Symbol> &extra_bound_symbols = {}) override {
+                                        const std::unordered_set<Symbol> &extra_bound_symbols) override {
     if (extra_bound_symbols.empty()) {
       return PlanPatternComprehension(matching, *context_->symbol_table, context_->bound_symbols, view);
     }
     auto bound_symbols = context_->bound_symbols;
-    bound_symbols.insert(extra_bound_symbols.begin(), extra_bound_symbols.end());
+    bound_symbols.insert_range(extra_bound_symbols);
     return PlanPatternComprehension(matching, *context_->symbol_table, bound_symbols, view);
   }
 
@@ -269,7 +274,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
           symbols_bound_by_query_part.insert(merge_matching.expansion_symbols.begin(),
                                              merge_matching.expansion_symbols.end());
         }
-        // Add symbols from CREATE and FOREACH clauses
+        auto collect_return_body_symbols = [&](const ReturnBody &body) {
+          for (const auto *named_expr : body.named_expressions) {
+            symbols_bound_by_query_part.insert(context.symbol_table->at(*named_expr));
+          }
+        };
+        // Add symbols from CREATE, FOREACH and WITH/RETURN clauses
         std::function<void(Clause *)> collect_clause_symbols = [&](Clause *clause) {
           if (auto *create = utils::Downcast<Create>(clause)) {
             for (const auto *pattern : create->patterns_) {
@@ -284,6 +294,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
             for (auto *nested : foreach_clause->clauses_) {
               collect_clause_symbols(nested);
             }
+          } else if (auto *ret = utils::Downcast<Return>(clause)) {
+            // A WITH/RETURN re-declares its projected names. A comprehension in its WHERE or ORDER BY resolves to
+            // those new symbols, so it must not be drained before the clause that binds them - see deps_satisfied.
+            collect_return_body_symbols(ret->body_);
+          } else if (auto *with = utils::Downcast<query::With>(clause)) {
+            collect_return_body_symbols(with->body_);
           }
         };
         for (const auto &clause : single_query_part.remaining_clauses) {
@@ -353,7 +369,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                   has_variable_length_expansion(pc)
                       ? storage::View::OLD
                       : ((write_occurred && references_external_symbols(pc)) ? storage::View::NEW : storage::View::OLD);
-              auto op = Plan(pc, view);
+              auto op = Plan(pc, view, kNoExtraBoundSymbols);
               auto symbols = op->ModifiedSymbols(*context.symbol_table);
               input_op = std::make_unique<RollUpApply>(std::move(input_op), std::move(op), symbols, sym);
               it = pending_comprehensions.erase(it);
@@ -1349,7 +1365,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
           return bound_symbols.contains(s);
         });
         if (deps_satisfied) {
-          auto pc_op = Plan(pc, storage::View::OLD);
+          auto pc_op = Plan(pc, storage::View::OLD, kNoExtraBoundSymbols);
           auto symbols = pc_op->ModifiedSymbols(symbol_table);
           op = std::make_unique<RollUpApply>(std::move(op), std::move(pc_op), symbols, sym);
           it = pending_comprehensions.erase(it);

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -315,24 +315,13 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         // need to use View::NEW to see the newly created/modified data.
         bool write_occurred = false;
 
-        auto deps_satisfied = [&](const PatternComprehensionMatching &pc) {
-          return DepsSatisfied(pc, symbols_bound_by_query_part, context.bound_symbols);
-        };
-
-        // Helper to plan and apply all satisfiable comprehensions before write clauses
+        // Plan and apply all satisfiable comprehensions before write clauses.
         auto plan_and_apply_comprehensions = [&]() {
-          for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
-            const auto &[sym, pc] = *it;
-            if (deps_satisfied(pc)) {
-              auto view = PatternComprehensionView(pc, write_occurred, context.bound_symbols);
-              auto op = Plan(pc, view, kNoExtraBoundSymbols);
-              auto symbols = op->ModifiedSymbols(*context.symbol_table);
-              input_op = std::make_unique<RollUpApply>(std::move(input_op), std::move(op), symbols, sym);
-              it = pending_comprehensions.erase(it);
-            } else {
-              ++it;
-            }
-          }
+          input_op = SpliceSatisfiedComprehensions(std::move(input_op),
+                                                   pending_comprehensions,
+                                                   symbols_bound_by_query_part,
+                                                   context.bound_symbols,
+                                                   write_occurred);
         };
 
         for (const auto &clause : single_query_part.remaining_clauses) {
@@ -849,21 +838,13 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                             const std::unordered_set<Symbol> &branch_bound_symbols) {
       if (sets.empty() || pending_comprehensions.empty()) return branch;
       const auto wanted = impl::CollectPatternComprehensionSymbols(sets, *context_->symbol_table);
-      for (const auto &sym : wanted) {
-        auto it = pending_comprehensions.find(sym);
-        if (it == pending_comprehensions.end()) continue;
-        const auto &pc = it->second;
-        if (!DepsSatisfied(pc, symbols_bound_by_query_part, branch_bound_symbols)) continue;
-        // The branch has just written the nodes the comprehension expands from, so it must read View::NEW. The
-        // branch's own symbols go in as extras: ON MATCH binds the pattern into a copy of the bound set the planning
-        // context does not share, and without them the branch would be planned uncorrelated.
-        auto pc_op =
-            Plan(pc, PatternComprehensionView(pc, /*write_occurred=*/true, branch_bound_symbols), branch_bound_symbols);
-        auto symbols = pc_op->ModifiedSymbols(*context_->symbol_table);
-        branch = std::make_unique<RollUpApply>(std::move(branch), std::move(pc_op), symbols, sym);
-        pending_comprehensions.erase(it);
-      }
-      return branch;
+      return SpliceSatisfiedComprehensions(std::move(branch),
+                                           pending_comprehensions,
+                                           symbols_bound_by_query_part,
+                                           branch_bound_symbols,
+                                           /*write_occurred=*/true,
+                                           &wanted,
+                                           branch_bound_symbols);
     };
 
     on_match = splice_branch_comprehensions(std::move(on_match), merge.on_match_, bound_symbols_copy);
@@ -1380,6 +1361,37 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     return write_occurred && ReferencesExternalSymbols(pc, bound_symbols) ? storage::View::NEW : storage::View::OLD;
   }
 
+  /// The one place a pending comprehension turns into a `RollUpApply`. Every operator chain that can evaluate one
+  /// drains through here - the main clause chain, a FOREACH body, and each MERGE branch - because a comprehension
+  /// must be spliced onto the chain that *reads* it, not merely the one its clause sits on. Both defects this file
+  /// has had came from that: a drain site whose dependency check had drifted, and a chain with no drain site at all.
+  ///
+  /// @param bound_symbols what is bound on @p chain, used for the dependency check and the view.
+  /// @param only when non-null, restricts the drain to these result symbols - a MERGE branch takes only what its own
+  ///        SET clauses read, so the two branches cannot steal each other's.
+  /// @param extra_bound_symbols symbols bound on @p chain that the planning context does not share, e.g. MERGE's
+  ///        ON MATCH, which binds its pattern into a copy. Omitting them plans an uncorrelated scan.
+  std::unique_ptr<LogicalOperator> SpliceSatisfiedComprehensions(
+      std::unique_ptr<LogicalOperator> chain,
+      std::unordered_map<Symbol, PatternComprehensionMatching> &pending_comprehensions,
+      const std::unordered_set<Symbol> &symbols_bound_by_query_part, const std::unordered_set<Symbol> &bound_symbols,
+      bool write_occurred, const std::unordered_set<Symbol> *only = nullptr,
+      const std::unordered_set<Symbol> &extra_bound_symbols = kNoExtraBoundSymbols) {
+    for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
+      const auto &[sym, pc] = *it;
+      const bool wanted = only == nullptr || only->contains(sym);
+      if (!wanted || !DepsSatisfied(pc, symbols_bound_by_query_part, bound_symbols)) {
+        ++it;
+        continue;
+      }
+      auto pc_op = Plan(pc, PatternComprehensionView(pc, write_occurred, bound_symbols), extra_bound_symbols);
+      auto symbols = pc_op->ModifiedSymbols(*context_->symbol_table);
+      chain = std::make_unique<RollUpApply>(std::move(chain), std::move(pc_op), symbols, sym);
+      it = pending_comprehensions.erase(it);
+    }
+    return chain;
+  }
+
   std::unique_ptr<LogicalOperator> HandleForeachClause(
       query::Foreach *foreach, std::unique_ptr<LogicalOperator> input_op, const SymbolTable &symbol_table,
       std::unordered_set<Symbol> &bound_symbols, const SingleQueryPart &query_part, uint64_t &merge_id,
@@ -1392,19 +1404,10 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     // Every clause a FOREACH body may hold is a write, so anything planned after the first one must read View::NEW.
     bool write_occurred = false;
 
-    // Helper to plan comprehensions whose dependencies are now satisfied
+    // Plan comprehensions whose dependencies are now satisfied, onto the body's own chain.
     auto plan_satisfied_comprehensions = [&]() {
-      for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
-        const auto &[sym, pc] = *it;
-        if (DepsSatisfied(pc, symbols_bound_by_query_part, bound_symbols)) {
-          auto pc_op = Plan(pc, PatternComprehensionView(pc, write_occurred, bound_symbols), kNoExtraBoundSymbols);
-          auto symbols = pc_op->ModifiedSymbols(symbol_table);
-          op = std::make_unique<RollUpApply>(std::move(op), std::move(pc_op), symbols, sym);
-          it = pending_comprehensions.erase(it);
-        } else {
-          ++it;
-        }
-      }
+      op = SpliceSatisfiedComprehensions(
+          std::move(op), pending_comprehensions, symbols_bound_by_query_part, bound_symbols, write_occurred);
     };
 
     // Plan any comprehensions whose dependencies are now satisfied (e.g., referencing the FOREACH variable)

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -314,42 +314,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
           return DepsSatisfied(pc, symbols_bound_by_query_part, context.bound_symbols);
         };
 
-        // Helper to check if a pattern comprehension has variable-length paths.
-        // ExpandVariable requires View::OLD, so comprehensions with VLE must use OLD.
-        auto has_variable_length_expansion = [](const PatternComprehensionMatching &pc) {
-          for (const auto &expansion : pc.expansions) {
-            if (expansion.edge && expansion.edge->IsVariable()) {
-              return true;
-            }
-          }
-          return false;
-        };
-
-        // Helper to check if a pattern comprehension references externally bound symbols.
-        // This includes both explicit external_symbols AND expansion_symbols that were already bound
-        // before the comprehension (e.g., `a` in `[(a)-->(x) | x.id]` when `a` comes from CREATE).
-        auto references_external_symbols = [&](const PatternComprehensionMatching &pc) {
-          // Check explicit external symbols (from filter/result expressions)
-          if (!pc.external_symbols.empty()) return true;
-          // Check if any expansion symbol was already bound (external reference in pattern)
-          for (const auto &sym : pc.expansion_symbols) {
-            if (context.bound_symbols.contains(sym)) return true;
-          }
-          return false;
-        };
-
         // Helper to plan and apply all satisfiable comprehensions before write clauses
         auto plan_and_apply_comprehensions = [&]() {
           for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
             const auto &[sym, pc] = *it;
             if (deps_satisfied(pc)) {
-              // Use View::OLD for variable-length paths (ExpandVariable requires it).
-              // Use View::NEW after writes if the comprehension references externally bound symbols,
-              // so it can see newly created edges/properties on those nodes.
-              auto view =
-                  has_variable_length_expansion(pc)
-                      ? storage::View::OLD
-                      : ((write_occurred && references_external_symbols(pc)) ? storage::View::NEW : storage::View::OLD);
+              auto view = PatternComprehensionView(pc, write_occurred, context.bound_symbols);
               auto op = Plan(pc, view, kNoExtraBoundSymbols);
               auto symbols = op->ModifiedSymbols(*context.symbol_table);
               input_op = std::make_unique<RollUpApply>(std::move(input_op), std::move(op), symbols, sym);
@@ -1348,6 +1318,28 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     });
   }
 
+  /// ExpandVariable requires View::OLD, so a comprehension whose pattern has a variable-length edge must use it.
+  static bool HasVariableLengthExpansion(const PatternComprehensionMatching &pc) {
+    return std::ranges::any_of(pc.expansions,
+                               [](const auto &expansion) { return expansion.edge && expansion.edge->IsVariable(); });
+  }
+
+  /// True if the comprehension reads something bound outside it: either from its filter or result expression, or a
+  /// pattern symbol that is already bound, e.g. `a` in `[(a)-->(x)|x]` when `a` comes from a CREATE.
+  static bool ReferencesExternalSymbols(const PatternComprehensionMatching &pc,
+                                        const std::unordered_set<Symbol> &bound_symbols) {
+    if (!pc.external_symbols.empty()) return true;
+    return std::ranges::any_of(pc.expansion_symbols, [&](const Symbol &sym) { return bound_symbols.contains(sym); });
+  }
+
+  /// The view a comprehension must be planned with. Every site draining `pending_comprehensions` must use this: a
+  /// comprehension planned after a write, over a symbol that write bound, sees nothing under View::OLD.
+  static storage::View PatternComprehensionView(const PatternComprehensionMatching &pc, bool write_occurred,
+                                                const std::unordered_set<Symbol> &bound_symbols) {
+    if (HasVariableLengthExpansion(pc)) return storage::View::OLD;
+    return write_occurred && ReferencesExternalSymbols(pc, bound_symbols) ? storage::View::NEW : storage::View::OLD;
+  }
+
   std::unique_ptr<LogicalOperator> HandleForeachClause(
       query::Foreach *foreach, std::unique_ptr<LogicalOperator> input_op, const SymbolTable &symbol_table,
       std::unordered_set<Symbol> &bound_symbols, const SingleQueryPart &query_part, uint64_t &merge_id,
@@ -1357,12 +1349,15 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     bound_symbols.insert(symbol);
     std::unique_ptr<LogicalOperator> op = std::make_unique<plan::Once>();
 
+    // Every clause a FOREACH body may hold is a write, so anything planned after the first one must read View::NEW.
+    bool write_occurred = false;
+
     // Helper to plan comprehensions whose dependencies are now satisfied
     auto plan_satisfied_comprehensions = [&]() {
       for (auto it = pending_comprehensions.begin(); it != pending_comprehensions.end();) {
         const auto &[sym, pc] = *it;
         if (DepsSatisfied(pc, symbols_bound_by_query_part, bound_symbols)) {
-          auto pc_op = Plan(pc, storage::View::OLD, kNoExtraBoundSymbols);
+          auto pc_op = Plan(pc, PatternComprehensionView(pc, write_occurred, bound_symbols), kNoExtraBoundSymbols);
           auto symbols = pc_op->ModifiedSymbols(symbol_table);
           op = std::make_unique<RollUpApply>(std::move(op), std::move(pc_op), symbols, sym);
           it = pending_comprehensions.erase(it);
@@ -1390,6 +1385,10 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
       } else {
         op = HandleWriteClause(clause, op, symbol_table, bound_symbols);
       }
+      // A body clause can bind the very symbol a pending comprehension expands from, so drain again after each one -
+      // exactly as the main clause loop does. Without this the comprehension stays pending and is never planned.
+      write_occurred = true;
+      plan_satisfied_comprehensions();
     }
     return std::make_unique<plan::Foreach>(
         std::move(input_op), std::move(op), foreach->named_expression_->expression_, symbol);

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -1249,8 +1249,15 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         bound_symbols.insert(*total_weight);
       }
 
+      // ExpandVariable can only read View::OLD, so a variable-length pattern that must see writes from its own
+      // query part has no valid plan. Reject the query instead of asserting, which would abort the process.
+      if (view != storage::View::OLD) {
+        throw QueryException(
+            "A variable-length pattern cannot be evaluated after a write in the same query part. Separate them with a "
+            "WITH clause.");
+      }
+
       // TODO: Pass weight lambda.
-      MG_ASSERT(view == storage::View::OLD, "ExpandVariable should only be planned with storage::View::OLD");
       last_op = std::make_unique<ExpandVariable>(std::move(last_op),
                                                  node1_symbol,
                                                  node_symbol,

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -826,3 +826,70 @@ Feature: Pattern comprehensions
         Then the result should be:
             | outer_sum | inners |
             | 1         | [0]    |
+
+    Scenario: Pattern comprehension in MERGE ON CREATE correlates to the merged node
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            MERGE (q:Marker {id: 1})
+              ON CREATE SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m])
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN count(q) AS n, collect(q.cnt) AS counts
+            """
+        Then the result should be:
+            | n | counts |
+            | 1 | [0]    |
+
+    Scenario: Pattern comprehension in MERGE ON MATCH correlates to the matched node
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            MERGE (q:Person {name: 'Zoe'})
+              ON MATCH SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m])
+            """
+        When executing query:
+            """
+            MATCH (q:Person {name: 'Zoe'})
+            RETURN q.cnt AS cnt
+            """
+        Then the result should be:
+            | cnt |
+            | 1   |
+
+    Scenario: Pattern comprehension in a MERGE ON CREATE inside a FOREACH body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] |
+              MERGE (q:Marker {id: 1})
+                ON CREATE SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m]))
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN count(q) AS n, collect(q.cnt) AS counts
+            """
+        Then the result should be:
+            | n | counts |
+            | 1 | [0]    |

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -421,3 +421,122 @@ Feature: Pattern comprehensions
         Then the result should be:
             | cnt | edges  |
             | 2   | [1, 1] |
+
+    Scenario: Pattern comprehension in the WHERE of a WITH filters on the bound variable
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be:
+            | name     |
+            | 'Regina' |
+
+    Scenario: Pattern comprehension in the WHERE of a WITH DISTINCT filters on the bound variable
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH DISTINCT p
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be:
+            | name     |
+            | 'Regina' |
+
+    Scenario: Pattern comprehension in the ORDER BY of a WITH sorts on the bound variable
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p
+            ORDER BY size([(p)-[:ACTED_IN]->(m) | m]) DESC
+            RETURN p.name AS name
+            """
+        Then the result should be, in order:
+            | name     |
+            | 'Zoe'    |
+            | 'Regina' |
+            | 'Bob'    |
+
+    Scenario: Pattern comprehension in the WHERE of an aggregating WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p, count(*) AS c
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name, c
+            """
+        Then the result should be:
+            | name     | c |
+            | 'Regina' | 1 |
+
+    Scenario: Pattern comprehension in the ORDER BY of an aggregating WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p, count(*) AS c
+            ORDER BY size([(p)-[:ACTED_IN]->(m) | m]) DESC
+            RETURN p.name AS name
+            """
+        Then the result should be, in order:
+            | name     |
+            | 'Zoe'    |
+            | 'Regina' |
+            | 'Bob'    |
+
+    Scenario: Pattern comprehension in the ORDER BY of a RETURN sorts on the bound variable
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            RETURN p.name AS name
+            ORDER BY size([(p)-[:ACTED_IN]->(m) | m]) DESC
+            """
+        Then the result should be, in order:
+            | name     |
+            | 'Zoe'    |
+            | 'Regina' |
+            | 'Bob'    |

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -918,3 +918,41 @@ Feature: Pattern comprehensions
         Then the result should be:
             | ids    |
             | [2, 9] |
+
+    Scenario: A pattern comprehension's own path variable does not overwrite an outer path
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Hop {id: 10})-[:S]->(b:Hop {id: 11})
+            CREATE (b)-[:S]->(:Hop {id: 12})
+            CREATE (:Side {id: 1})-[:R]->(:Side {id: 4})
+            """
+        When executing query:
+            """
+            MATCH p = (:Hop {id: 10})-[:S*2]->(:Hop {id: 12})
+            RETURN [n IN nodes(p) | n.id] AS ids, [p = (:Side)-[:R]->(y:Side) | y.id] AS inner
+            """
+        Then the result should be:
+            | ids          | inner |
+            | [10, 11, 12] | [4]   |
+
+    Scenario: A named path inside a CALL subquery does not overwrite the caller's
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Hop {id: 10})-[:S]->(b:Hop {id: 11})
+            CREATE (b)-[:S]->(:Hop {id: 12})
+            CREATE (:Side {id: 1})-[:R]->(:Side {id: 4})
+            """
+        When executing query:
+            """
+            MATCH p = (:Hop {id: 10})-[:S*2]->(:Hop {id: 12})
+            CALL {
+              MATCH p = (:Side)-[:R]->(y:Side)
+              RETURN y
+            }
+            RETURN [n IN nodes(p) | n.id] AS ids, y.id AS yid
+            """
+        Then the result should be:
+            | ids          | yid |
+            | [10, 11, 12] | 4   |

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -898,3 +898,102 @@ Feature: Pattern comprehensions
         Then the result should be:
             | n | counts |
             | 1 | [0]    |
+
+    Scenario: Variable-length pattern comprehension in the WHERE of a WITH preceded by a write clause
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {id: 1})-[:FRIEND]->(b:Person {id: 2})
+            CREATE (b)-[:FRIEND]->(:Person {id: 9})
+            """
+        When executing query:
+            """
+            MATCH (p:Person) SET p.seen = 1
+            WITH p AS q WHERE size([(q)-[:FRIEND*1..2]->(m) | m]) > 0
+            RETURN q.id AS id ORDER BY id
+            """
+        Then the result should be:
+            | id |
+            | 1  |
+            | 2  |
+
+    Scenario: Variable-length pattern comprehension in the ORDER BY of a WITH preceded by a write clause
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {id: 1})-[:FRIEND]->(b:Person {id: 2})
+            CREATE (b)-[:FRIEND]->(:Person {id: 9})
+            """
+        When executing query:
+            """
+            MATCH (p:Person) SET p.seen = 1
+            WITH p AS q ORDER BY size([(q)-[:FRIEND*1..2]->(m) | m]) DESC, q.id
+            RETURN q.id AS id
+            """
+        Then the result should be, in order:
+            | id |
+            | 1  |
+            | 2  |
+            | 9  |
+
+    Scenario: Nested variable-length pattern comprehension inside a FOREACH body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {id: 1})
+            CREATE (:Person {id: 2})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] |
+              CREATE (q:Marker)
+              SET q.cnt = size([(q)-[:FRIEND]->(x) | size([(x)-[:FRIEND*1..2]->(y) | y])]))
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN count(q) AS n, collect(q.cnt) AS counts
+            """
+        Then the result should be:
+            | n | counts |
+            | 2 | [0, 0] |
+
+    Scenario: Variable-length pattern comprehension over a node its own query part creates is rejected
+        Given an empty graph
+        When executing query:
+            """
+            CREATE (a:Person)-[:FRIEND]->(:Person)
+            RETURN [(a)-[:FRIEND*1..2]->(x) | x] AS reachable
+            """
+        Then an error should be raised
+
+    Scenario: Pattern comprehension may not reuse an already bound relationship variable
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {id: 1})-[:FRIEND]->(:Person {id: 2})
+            """
+        When executing query:
+            """
+            MATCH (a:Person)-[r:FRIEND]->(b:Person)
+            WITH a, r WHERE size([(a)-[r]->(y) | y]) > 0
+            RETURN a.id AS id
+            """
+        Then an error should be raised
+
+    Scenario: Variable-length pattern comprehension over a matched node a write clause reuses
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {id: 1})-[:FRIEND]->(b:Person {id: 2})
+            CREATE (b)-[:FRIEND]->(:Person {id: 9})
+            """
+        When executing query:
+            """
+            MATCH (a:Person {id: 1}) CREATE (a)-[:SEEN]->(:Marker)
+            RETURN [(a)-[:FRIEND*1..2]->(x) | x.id] AS ids
+            """
+        Then the result should be:
+            | ids    |
+            | [2, 9] |

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -540,3 +540,154 @@ Feature: Pattern comprehensions
             | 'Zoe'    |
             | 'Regina' |
             | 'Bob'    |
+
+    Scenario: Pattern comprehension in the WHERE of a WITH that also has an ORDER BY
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p
+            ORDER BY p.name
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be, in order:
+            | name     |
+            | 'Regina' |
+            | 'Zoe'    |
+
+    Scenario: Pattern comprehension in the WHERE of an aggregating WITH that also has an ORDER BY
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p, count(*) AS c
+            ORDER BY p.name
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be, in order:
+            | name     |
+            | 'Regina' |
+            | 'Zoe'    |
+
+    Scenario: Pattern comprehensions in both the ORDER BY and the WHERE of a WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p
+            ORDER BY size([(p)-[:ACTED_IN]->(m) | m]) DESC
+            WHERE size([(p)-[:ACTED_IN]->(x) | x]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be, in order:
+            | name     |
+            | 'Zoe'    |
+            | 'Regina' |
+
+    Scenario: Pattern comprehension in the WHERE of a WITH that renames the variable it references
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p AS q
+            ORDER BY q.name
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN q.name AS name
+            """
+        Then the result should be, in order:
+            | name     |
+            | 'Regina' |
+            | 'Zoe'    |
+
+    Scenario: Pattern comprehension in the WHERE of a WITH preceded by a write clause
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            SET p.seen = 1
+            WITH p
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be:
+            | name     |
+            | 'Zoe'    |
+            | 'Regina' |
+
+    Scenario: Pattern comprehension in the WHERE of a WITH preceded by a CREATE
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            CREATE (:Marker)
+            WITH p
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be:
+            | name     |
+            | 'Zoe'    |
+            | 'Regina' |
+
+    Scenario: WITH ORDER BY LIMIT still filters after the limit
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p
+            ORDER BY p.name
+            LIMIT 2
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be:
+            | name     |
+            | 'Regina' |

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -440,24 +440,6 @@ Feature: Pattern comprehensions
             | name     |
             | 'Regina' |
 
-    Scenario: Pattern comprehension in the WHERE of a WITH DISTINCT filters on the bound variable
-        Given an empty graph
-        And having executed:
-            """
-            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
-            CREATE (:Person {name: 'Bob'})
-            """
-        When executing query:
-            """
-            MATCH (p:Person)
-            WITH DISTINCT p
-            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
-            RETURN p.name AS name
-            """
-        Then the result should be:
-            | name     |
-            | 'Regina' |
-
     Scenario: Pattern comprehension in the ORDER BY of a WITH sorts on the bound variable
         Given an empty graph
         # Created fewest-edges-first, so the expected order is the reverse of the scan order: a sort key that is the
@@ -566,28 +548,6 @@ Feature: Pattern comprehensions
             | 'Regina' |
             | 'Zoe'    |
 
-    Scenario: Pattern comprehension in the WHERE of an aggregating WITH that also has an ORDER BY
-        Given an empty graph
-        And having executed:
-            """
-            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
-            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
-            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
-            CREATE (:Person {name: 'Bob'})
-            """
-        When executing query:
-            """
-            MATCH (p:Person)
-            WITH p, count(*) AS c
-            ORDER BY p.name
-            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
-            RETURN p.name AS name
-            """
-        Then the result should be, in order:
-            | name     |
-            | 'Regina' |
-            | 'Zoe'    |
-
     Scenario: Pattern comprehensions in both the ORDER BY and the WHERE of a WITH
         Given an empty graph
         And having executed:
@@ -674,27 +634,6 @@ Feature: Pattern comprehensions
             | 'Zoe'    |
             | 'Regina' |
 
-    Scenario: Pattern comprehension in the WHERE of a WITH preceded by a CREATE
-        Given an empty graph
-        And having executed:
-            """
-            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
-            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
-            CREATE (:Person {name: 'Bob'})
-            """
-        When executing query:
-            """
-            MATCH (p:Person)
-            CREATE (:Marker)
-            WITH p
-            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
-            RETURN p.name AS name
-            """
-        Then the result should be:
-            | name     |
-            | 'Zoe'    |
-            | 'Regina' |
-
     Scenario: WITH ORDER BY LIMIT still filters after the limit
         Given an empty graph
         And having executed:
@@ -738,28 +677,6 @@ Feature: Pattern comprehensions
         Then the result should be:
             | created | counts |
             | 2       | [0]    |
-
-    Scenario: Pattern comprehension over a node merged inside the same FOREACH body
-        Given an empty graph
-        And having executed:
-            """
-            CREATE (:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
-            """
-        And having executed:
-            """
-            MATCH (p:Person)
-            FOREACH (i IN [1] |
-              MERGE (q:Marker {id: 1})
-              SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m]))
-            """
-        When executing query:
-            """
-            MATCH (q:Marker)
-            RETURN count(q) AS merged, collect(DISTINCT q.cnt) AS counts
-            """
-        Then the result should be:
-            | merged | counts |
-            | 1      | [0]    |
 
     Scenario: Pattern comprehension over a node created by an enclosing FOREACH body
         Given an empty graph
@@ -921,8 +838,8 @@ Feature: Pattern comprehensions
         Given an empty graph
         And having executed:
             """
-            CREATE (a:Person {id: 1})-[:FRIEND]->(b:Person {id: 2})
-            CREATE (b)-[:FRIEND]->(:Person {id: 9})
+            CREATE (a:Person {id: 9})-[:FRIEND]->(b:Person {id: 2})
+            CREATE (b)-[:FRIEND]->(:Person {id: 1})
             """
         When executing query:
             """
@@ -930,34 +847,38 @@ Feature: Pattern comprehensions
             WITH p AS q ORDER BY size([(q)-[:FRIEND*1..2]->(m) | m]) DESC, q.id
             RETURN q.id AS id
             """
+        # Ids run opposite to reachability on purpose: an uncorrelated key ties every row and the
+        # q.id tie-break would give 1, 2, 9.
         Then the result should be, in order:
             | id |
-            | 1  |
-            | 2  |
             | 9  |
+            | 2  |
+            | 1  |
 
     Scenario: Nested variable-length pattern comprehension inside a FOREACH body
         Given an empty graph
         And having executed:
             """
-            CREATE (:Person {id: 1})
-            CREATE (:Person {id: 2})
+            CREATE (h:Hub {id: 1})-[:FRIEND]->(m:Hub {id: 2})
+            CREATE (m)-[:FRIEND]->(:Hub {id: 3})
             """
         And having executed:
             """
-            MATCH (p:Person)
+            MATCH (h:Hub {id: 1})
             FOREACH (i IN [1] |
               CREATE (q:Marker)
-              SET q.cnt = size([(q)-[:FRIEND]->(x) | size([(x)-[:FRIEND*1..2]->(y) | y])]))
+              SET q.cnt = [(h)-[:FRIEND]->(x) | size([(x)-[:FRIEND*1..2]->(y) | y])])
             """
         When executing query:
             """
             MATCH (q:Marker)
             RETURN count(q) AS n, collect(q.cnt) AS counts
             """
+        # The nested variable-length branch must actually run: h reaches one node, which reaches one
+        # more. Planning this used to abort the process.
         Then the result should be:
             | n | counts |
-            | 2 | [0, 0] |
+            | 1 | [[1]]  |
 
     Scenario: Variable-length pattern comprehension over a node its own query part creates is rejected
         Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -460,12 +460,14 @@ Feature: Pattern comprehensions
 
     Scenario: Pattern comprehension in the ORDER BY of a WITH sorts on the bound variable
         Given an empty graph
+        # Created fewest-edges-first, so the expected order is the reverse of the scan order: a sort key that is the
+        # same for every row - an uncorrelated whole-graph count - cannot produce it.
         And having executed:
             """
+            CREATE (:Person {name: 'Bob'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
             CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
             CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
-            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
-            CREATE (:Person {name: 'Bob'})
             """
         When executing query:
             """
@@ -522,12 +524,13 @@ Feature: Pattern comprehensions
 
     Scenario: Pattern comprehension in the ORDER BY of a RETURN sorts on the bound variable
         Given an empty graph
+        # As above: fewest edges created first, so the scan order is the reverse of the expected one.
         And having executed:
             """
+            CREATE (:Person {name: 'Bob'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
             CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
             CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
-            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
-            CREATE (:Person {name: 'Bob'})
             """
         When executing query:
             """
@@ -786,6 +789,7 @@ Feature: Pattern comprehensions
         And having executed:
             """
             CREATE (:Person {name: 'Zoe'})
+            CREATE (:Extra)-[:ACTED_IN]->(:Movie {title: 'Old'})
             """
         And having executed:
             """
@@ -854,7 +858,8 @@ Feature: Pattern comprehensions
         And having executed:
             """
             CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
-            CREATE (:Person {name: 'Regina'})
+            CREATE (b:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'J1'})
+            CREATE (b)-[:ACTED_IN]->(:Movie {title: 'J2'})
             """
         And having executed:
             """

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -712,3 +712,117 @@ Feature: Pattern comprehensions
         Then the result should be:
             | name     |
             | 'Regina' |
+
+    Scenario: Pattern comprehension over a node created inside the same FOREACH body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] |
+              CREATE (q:Marker)
+              SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m]))
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN count(q) AS created, collect(DISTINCT q.cnt) AS counts
+            """
+        Then the result should be:
+            | created | counts |
+            | 2       | [0]    |
+
+    Scenario: Pattern comprehension over a node merged inside the same FOREACH body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] |
+              MERGE (q:Marker {id: 1})
+              SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m]))
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN count(q) AS merged, collect(DISTINCT q.cnt) AS counts
+            """
+        Then the result should be:
+            | merged | counts |
+            | 1      | [0]    |
+
+    Scenario: Pattern comprehension over a node created by an enclosing FOREACH body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] |
+              CREATE (q:Marker)
+              FOREACH (j IN [1] |
+                SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m])))
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN count(q) AS created, collect(DISTINCT q.cnt) AS counts
+            """
+        Then the result should be:
+            | created | counts |
+            | 1       | [0]    |
+
+    Scenario: Pattern comprehension in a FOREACH body sees edges created in that body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Zoe'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] |
+              CREATE (q:Marker)-[:ACTED_IN]->(:Movie {title: 'New'})
+              SET q.cnt = size([(q)-[:ACTED_IN]->(m) | m]))
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN collect(q.cnt) AS counts
+            """
+        Then the result should be:
+            | counts |
+            | [1]    |
+
+    Scenario: A comprehension on a pre-FOREACH symbol is unaffected by one bound inside the body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})
+            """
+        And having executed:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] |
+              CREATE (q:Marker)
+              SET q.outer = size([(p)-[:ACTED_IN]->(m) | m]),
+                  q.inner = size([(q)-[:ACTED_IN]->(m2) | m2]))
+            """
+        When executing query:
+            """
+            MATCH (q:Marker)
+            RETURN sum(q.outer) AS outer_sum, collect(DISTINCT q.inner) AS inners
+            """
+        Then the result should be:
+            | outer_sum | inners |
+            | 1         | [0]    |

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -650,6 +650,27 @@ Feature: Pattern comprehensions
             | 'Zoe'    |
             | 'Regina' |
 
+    Scenario: Pattern comprehension in the WHERE of a WITH preceded by a FOREACH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (:Person {name: 'Regina'})-[:ACTED_IN]->(:Movie {title: 'Jerry'})
+            CREATE (:Person {name: 'Bob'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            FOREACH (i IN [1] | SET p.seen = 1)
+            WITH p
+            WHERE size([(p)-[:ACTED_IN]->(m) | m]) > 0
+            RETURN p.name AS name
+            """
+        Then the result should be:
+            | name     |
+            | 'Zoe'    |
+            | 'Regina' |
+
     Scenario: Pattern comprehension in the WHERE of a WITH preceded by a CREATE
         Given an empty graph
         And having executed:

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -847,3 +847,28 @@ Feature: Subqueries
         Then the result should be:
             | playerName | cnt |
             | 'Player A' | 1   |
+
+    Scenario: A plain MATCH in a CALL subquery declares a fresh variable, not the un-imported outer one
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Zoe'})-[:ACTED_IN]->(:Movie {title: 'M1'})
+            CREATE (a)-[:ACTED_IN]->(:Movie {title: 'M2'})
+            CREATE (:Person {name: 'Regina'})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            CALL {
+              MATCH (p)-[:ACTED_IN]->(x)
+              RETURN x
+            }
+            RETURN p.name AS name, x.title AS title
+            ORDER BY name, title
+            """
+        Then the result should be, in order:
+            | name       | title |
+            | 'Regina'   | 'M1'  |
+            | 'Regina'   | 'M2'  |
+            | 'Zoe'      | 'M1'  |
+            | 'Zoe'      | 'M2'  |

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -796,28 +796,6 @@ Feature: Subqueries
             | 'Player E' | 5   |
             | 'Player F' | 5   |
 
-    Scenario: Pattern comprehension in an aggregating WHERE of a CALL subquery declares a fresh variable
-        Given graph "subqueries"
-        When executing query:
-            """
-            MATCH (p:Player)
-            CALL {
-              MATCH (t:Team)
-              WITH t, count(*) AS c
-              WHERE size([(p)-[:PLAYS_FOR]->(x) | x]) > 0
-              RETURN t
-            }
-            RETURN DISTINCT p.name AS playerName
-            """
-        Then the result should be:
-            | playerName |
-            | 'Player A' |
-            | 'Player B' |
-            | 'Player C' |
-            | 'Player D' |
-            | 'Player E' |
-            | 'Player F' |
-
     Scenario: EXISTS pattern in a CALL subquery cannot see an un-imported outer variable
         Given graph "subqueries"
         When executing query:

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -774,3 +774,76 @@ Feature: Subqueries
             RETURN playerName
             """
         Then an error should be raised
+
+    Scenario: Pattern comprehension in a CALL subquery declares a fresh variable, not the un-imported outer one
+        Given graph "subqueries"
+        When executing query:
+            """
+            MATCH (p:Player)
+            CALL {
+              MATCH (t:Team)
+              WITH t, size([(p)-[:PLAYS_FOR]->(x) | x]) AS cnt
+              RETURN t, cnt
+            }
+            RETURN DISTINCT p.name AS playerName, cnt
+            """
+        Then the result should be:
+            | playerName | cnt |
+            | 'Player A' | 5   |
+            | 'Player B' | 5   |
+            | 'Player C' | 5   |
+            | 'Player D' | 5   |
+            | 'Player E' | 5   |
+            | 'Player F' | 5   |
+
+    Scenario: Pattern comprehension in an aggregating WHERE of a CALL subquery declares a fresh variable
+        Given graph "subqueries"
+        When executing query:
+            """
+            MATCH (p:Player)
+            CALL {
+              MATCH (t:Team)
+              WITH t, count(*) AS c
+              WHERE size([(p)-[:PLAYS_FOR]->(x) | x]) > 0
+              RETURN t
+            }
+            RETURN DISTINCT p.name AS playerName
+            """
+        Then the result should be:
+            | playerName |
+            | 'Player A' |
+            | 'Player B' |
+            | 'Player C' |
+            | 'Player D' |
+            | 'Player E' |
+            | 'Player F' |
+
+    Scenario: EXISTS pattern in a CALL subquery cannot see an un-imported outer variable
+        Given graph "subqueries"
+        When executing query:
+            """
+            MATCH (p:Player)
+            CALL {
+              MATCH (t:Team)
+              WHERE exists((p)-[:PLAYS_FOR]->(t))
+              RETURN t
+            }
+            RETURN p.name AS playerName
+            """
+        Then an error should be raised
+
+    Scenario: Pattern comprehension in a CALL subquery may use an explicitly imported outer variable
+        Given graph "subqueries"
+        When executing query:
+            """
+            MATCH (p:Player {name: 'Player A'})
+            CALL (p) {
+              MATCH (t:Team)
+              WITH t, size([(p)-[:PLAYS_FOR]->(x) | x]) AS cnt
+              RETURN t, cnt
+            }
+            RETURN DISTINCT p.name AS playerName, cnt
+            """
+        Then the result should be:
+            | playerName | cnt |
+            | 'Player A' | 1   |

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -796,20 +796,6 @@ Feature: Subqueries
             | 'Player E' | 5   |
             | 'Player F' | 5   |
 
-    Scenario: EXISTS pattern in a CALL subquery cannot see an un-imported outer variable
-        Given graph "subqueries"
-        When executing query:
-            """
-            MATCH (p:Player)
-            CALL {
-              MATCH (t:Team)
-              WHERE exists((p)-[:PLAYS_FOR]->(t))
-              RETURN t
-            }
-            RETURN p.name AS playerName
-            """
-        Then an error should be raised
-
     Scenario: Pattern comprehension in a CALL subquery may use an explicitly imported outer variable
         Given graph "subqueries"
         When executing query:

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -836,3 +836,159 @@ Feature: Subqueries
             | 'Regina'   | 'M2'  |
             | 'Zoe'      | 'M1'  |
             | 'Zoe'      | 'M2'  |
+
+    Scenario: A CALL subquery may not return a variable that shadows an outer one
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'p1'})
+            CREATE (:Parent {name: 'x1'})
+            """
+        When executing query:
+            """
+            MATCH (n:Person)
+            CALL {
+              MATCH (n:Parent)
+              RETURN n
+            }
+            RETURN n.name AS name
+            """
+        Then an error should be raised
+
+    Scenario: A nested CALL subquery may not return a variable that shadows the outermost one
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'p1'})
+            CREATE (:Parent {name: 'x1'})
+            """
+        # The inner return merges into the outer subquery's scope, which is empty, so the collision is only
+        # caught when that scope is merged into the main query's.
+        When executing query:
+            """
+            MATCH (n:Person)
+            CALL {
+              CALL {
+                MATCH (n:Parent)
+                RETURN n
+              }
+              RETURN n
+            }
+            RETURN n.name AS name
+            """
+        Then an error should be raised
+
+    Scenario: A CALL subquery may not return a shadowing variable through a UNION either
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'p1'})
+            CREATE (:Parent {name: 'x1'})
+            """
+        When executing query:
+            """
+            MATCH (n:Person)
+            CALL {
+              MATCH (n:Parent) RETURN n
+              UNION
+              MATCH (n:Parent) RETURN n
+            }
+            RETURN n.name AS name
+            """
+        Then an error should be raised
+
+    Scenario: A shadowing variable may be returned under a different name
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'p1'})
+            CREATE (:Person {name: 'p2'})
+            CREATE (:Parent {name: 'x1'})
+            """
+        When executing query:
+            """
+            MATCH (n:Person)
+            CALL {
+              CALL {
+                MATCH (n:Parent)
+                RETURN n
+              }
+              RETURN n AS m
+            }
+            RETURN n.name AS person, m.name AS shadowed
+            ORDER BY person
+            """
+        Then the result should be, in order:
+            | person | shadowed |
+            | 'p1'   | 'x1'     |
+            | 'p2'   | 'x1'     |
+
+    Scenario: A subquery may use a shadowing variable as long as the name does not escape
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'p1'})
+            CREATE (:Person {name: 'p2'})
+            CREATE (:Parent {name: 'x1'})
+            """
+        # Deliberately no aggregation in the subquery: that shape hits a pre-existing parallel-executor bug, and this
+        # suite also runs with USING PARALLEL EXECUTION.
+        When executing query:
+            """
+            MATCH (n:Person)
+            CALL {
+              MATCH (n:Parent)
+              RETURN n.name AS shadowed
+            }
+            RETURN n.name AS person, shadowed
+            ORDER BY person
+            """
+        Then the result should be, in order:
+            | person | shadowed |
+            | 'p1'   | 'x1'     |
+            | 'p2'   | 'x1'     |
+
+    Scenario: A pattern comprehension correlates through a legacy importing WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Node {id: 1})-[:R]->(b:Node {id: 2})
+            CREATE (b)-[:R]->(a)
+            """
+        When executing query:
+            """
+            MATCH (p:Node)
+            CALL {
+              WITH p
+              RETURN size([(p)-[:R]->(x) | 1]) AS c
+            }
+            RETURN p.id AS id, c
+            ORDER BY id
+            """
+        Then the result should be, in order:
+            | id | c |
+            | 1  | 1 |
+            | 2  | 1 |
+
+    Scenario: A leading WITH that does not import the outer variable still shadows it
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Node {id: 1})-[:R]->(b:Node {id: 2})
+            CREATE (b)-[:R]->(a)
+            """
+        # `c` is 2, the whole-graph count, because `p` inside the comprehension is a fresh variable.
+        When executing query:
+            """
+            MATCH (p:Node)
+            CALL {
+              WITH 1 AS k
+              RETURN size([(p)-[:R]->(x) | 1]) AS c
+            }
+            RETURN p.id AS id, c
+            ORDER BY id
+            """
+        Then the result should be, in order:
+            | id | c |
+            | 1  | 2 |
+            | 2  | 2 |

--- a/tests/gql_behave/tests/memgraph_V1/features/with.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/with.feature
@@ -448,3 +448,23 @@ Feature: With
             MERGE ()-[r:edge_type.value.edge_type]->();
             """
         Then an error should be raised
+
+    Scenario: With test 29 (WHERE after ORDER BY reads a symbol the projection did not output):
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Person {name: 'Zoe', age: 10})
+            CREATE (:Person {name: 'Regina', age: 20})
+            CREATE (:Person {name: 'Bob', age: 30})
+            """
+        When executing query:
+            """
+            MATCH (p:Person)
+            WITH p.name AS n
+            ORDER BY n
+            WHERE p.age > 25
+            RETURN n
+            """
+        Then the result should be:
+            | n     |
+            | 'Bob' |

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5231,6 +5231,144 @@ TOp *FindOpOfType(memgraph::query::plan::LogicalOperator *root) {
 
 }  // namespace
 
+TYPED_TEST(TestPlanner, VariableLengthComprehensionAfterWriteFallsBackToViewOld) {
+  // Test MATCH (n) SET n.prop = 1 WITH n WHERE [(n)-[*1..2]->(m) | 1] = [] RETURN n
+  // The query part has written, so it has reached View::NEW - but `ExpandVariable` can only read View::OLD. `n` comes
+  // from the MATCH, so View::OLD does see it and a correct plan exists. Handing the query part's View::NEW straight
+  // through rejected the query instead, which is worse than what master answered.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("n"), EDGE_VARIABLE("anon1", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("m")),
+      nullptr,
+      LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                   SET(PROPERTY_LOOKUP(dba, "n", prop), LITERAL(1)),
+                                   WITH("n"),
+                                   WHERE(EQ(pattern_comp, LIST())),
+                                   RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  auto *filter = FindOpOfType<Filter>(&plan);
+  ASSERT_NE(filter, nullptr) << "the WHERE should still be planned as a Filter";
+  auto *rollup = dynamic_cast<RollUpApply *>(filter->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply belongs directly below the Filter that reads it";
+
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr);
+  // The discriminator is Once-not-ScanAll below the expansion: an uncorrelated plan also has an ExpandVariable.
+  auto *expand = dynamic_cast<ExpandVariable *>(branch_produce->input_.get());
+  ASSERT_NE(expand, nullptr) << "the branch should expand the variable-length pattern";
+  EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr)
+      << "the expansion must start from the `n` the WITH projected, not re-scan the graph";
+}
+
+TYPED_TEST(TestPlanner, NestedVariableLengthComprehensionReadsViewOldUnderAViewNewParent) {
+  // Test MATCH (p) FOREACH (i IN [1] | CREATE (q) SET q.prop = [(q)-->(x) | [(x)-[*1..2]->(y) | 1]])
+  // The outer comprehension expands from the just-created `q`, so it needs View::NEW. The nested one holds the
+  // variable-length edge and must read View::OLD - its own root `x` is bound by the outer expansion, not by the write.
+  // Forwarding the parent's view verbatim handed `ExpandVariable` a View::NEW it cannot service.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *nested_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("x"), EDGE_VARIABLE("anon2", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("y")),
+      nullptr,
+      LITERAL(1));
+  auto *outer_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("q"), EDGE("anon1", EdgeAtom::Direction::OUT), NODE("x")), nullptr, nested_comp);
+  auto *foreach_clause = FOREACH(NEXPR("i", LIST(LITERAL(1))),
+                                 {CREATE(PATTERN(NODE("q"))), SET(PROPERTY_LOOKUP(dba, "q", prop), outer_comp)});
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("p"))), foreach_clause));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  auto *foreach_op = FindOpOfType<Foreach>(&planner.plan());
+  ASSERT_NE(foreach_op, nullptr) << "expected a Foreach operator";
+  auto *set_property = dynamic_cast<SetProperty *>(foreach_op->update_clauses_.get());
+  ASSERT_NE(set_property, nullptr) << "the body should end with SetProperty";
+  auto *outer_rollup = dynamic_cast<RollUpApply *>(set_property->input_.get());
+  ASSERT_NE(outer_rollup, nullptr) << "the outer comprehension belongs below the SetProperty that reads it";
+
+  auto *outer_branch = dynamic_cast<Produce *>(outer_rollup->list_collection_branch_.get());
+  ASSERT_NE(outer_branch, nullptr);
+  auto *nested_rollup = dynamic_cast<RollUpApply *>(outer_branch->input_.get());
+  ASSERT_NE(nested_rollup, nullptr) << "the nested comprehension is rolled up inside its parent's branch";
+
+  auto *outer_expand = dynamic_cast<Expand *>(nested_rollup->input_.get());
+  ASSERT_NE(outer_expand, nullptr) << "the outer expansion sits below the nested RollUpApply";
+  EXPECT_EQ(outer_expand->view_, memgraph::storage::View::NEW)
+      << "`q` was created in this command, so the parent must read View::NEW";
+
+  auto *nested_branch = dynamic_cast<Produce *>(nested_rollup->list_collection_branch_.get());
+  ASSERT_NE(nested_branch, nullptr);
+  auto *nested_expand = dynamic_cast<ExpandVariable *>(nested_branch->input_.get());
+  ASSERT_NE(nested_expand, nullptr) << "the nested branch should hold the variable-length expansion";
+  EXPECT_NE(dynamic_cast<Once *>(nested_expand->input_.get()), nullptr)
+      << "the nested expansion must start from the `x` its parent bound";
+}
+
+TYPED_TEST(TestPlanner, VariableLengthComprehensionOverANodeAWriteBindsIsRejected) {
+  // Test CREATE (a) RETURN [(a)-[*1..2]->(x) | 1]
+  // `a` does not exist under View::OLD and `ExpandVariable` cannot read View::NEW, so no plan can serve this. Reject at
+  // planning time with a message naming the variable, rather than emit a plan that fails at runtime with
+  // "Trying to get relationships from a node that doesn't exist" - or, before that, abort the process.
+  FakeDbAccessor dba;
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("a"), EDGE_VARIABLE("anon1", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("x")),
+      nullptr,
+      LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(NODE("a"))), RETURN(pattern_comp, AS("l"))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  try {
+    MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    FAIL() << "expected the query to be rejected";
+  } catch (const memgraph::query::QueryException &e) {
+    // Naming the variable is what distinguishes this rejection from the `ExpandVariable` backstop, which cannot say
+    // which symbol is at fault. If this ever catches the backstop instead, the routing has regressed.
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("'a'")) << "the rejection should name the variable, got: " << e.what();
+  }
+}
+
+TYPED_TEST(TestPlanner, VariableLengthComprehensionOverAMatchedNodeAWriteReusesIsAccepted) {
+  // Test MATCH (a) CREATE (a)-[:R]->(b) RETURN [(a)-[*1..2]->(x) | 1]
+  // The positive control for the rejection above, and it has to use `a` *inside* the CREATE pattern: a write clause
+  // re-uses the names it does not declare, so collecting its pattern atoms wholesale marks the MATCH's `a` write-bound
+  // and rejects a query View::OLD serves perfectly. `CREATE (b)` as a separate pattern would not discriminate.
+  FakeDbAccessor dba;
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("a"), EDGE_VARIABLE("anon1", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("x")),
+      nullptr,
+      LITERAL(1));
+  auto *query =
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("a"))),
+                         CREATE(PATTERN(NODE("a"), EDGE("anon2", EdgeAtom::Direction::OUT, {"R"}), NODE("b"))),
+                         RETURN(pattern_comp, AS("l"))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  auto *rollup = FindOpOfType<RollUpApply>(&planner.plan());
+  ASSERT_NE(rollup, nullptr) << "the comprehension should still be planned";
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr);
+  auto *expand = dynamic_cast<ExpandVariable *>(branch_produce->input_.get());
+  ASSERT_NE(expand, nullptr) << "the branch should expand the variable-length pattern";
+  EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr) << "and stay correlated to the matched `a`";
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInMergeOnCreateIsPlannedInsideBranch) {
   // Test MERGE (q) ON CREATE SET q.prop = [(q)-->() | 1]
   // `q` is bound by the MERGE pattern, and the SET runs inside the Merge's create branch, so the comprehension must

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3061,6 +3061,93 @@ TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithWhereWithAggregation
   auto *rollup = dynamic_cast<RollUpApply *>(filter->input_.get());
   ASSERT_NE(rollup, nullptr) << "RollUpApply should be planned for the comprehension in WHERE";
   EXPECT_NE(dynamic_cast<Produce *>(rollup->input_.get()), nullptr) << "RollUpApply must come after the WITH's Produce";
+
+  // The branch must expand from the bound `n` rather than re-scanning it. Without this the test would still pass if
+  // the aggregating path stopped passing the return body's output symbols as extra bound symbols.
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr) << "Branch root should be Produce";
+  auto *branch_expand = dynamic_cast<Expand *>(branch_produce->input_.get());
+  ASSERT_NE(branch_expand, nullptr) << "Branch should expand from the correlated `n`";
+  EXPECT_NE(dynamic_cast<Once *>(branch_expand->input_.get()), nullptr)
+      << "Correlated branch must start at Once, not ScanAll";
+}
+
+TYPED_TEST(TestPlanner, PatternComprehensionInWithWhereWithOrderBy) {
+  // Test MATCH (n) WITH n ORDER BY n.prop WHERE [(n)--(m) | 1] = [] RETURN n
+  // OrderBy restores only its own output symbols, so a comprehension feeding the WHERE must be planned ABOVE it -
+  // below it, the Filter would read one frozen value for every row OrderBy replays.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                   WITH("n", ORDER_BY(PROPERTY_LOOKUP(dba, "n", prop))),
+                                   WHERE(EQ(pattern_comp, LIST())),
+                                   RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  // Produce (RETURN) -> Filter (WHERE) -> RollUpApply -> OrderBy -> Produce (WITH)
+  auto *produce = dynamic_cast<Produce *>(&plan);
+  ASSERT_NE(produce, nullptr) << "Root should be Produce";
+  auto *filter = dynamic_cast<Filter *>(produce->input_.get());
+  ASSERT_NE(filter, nullptr) << "Filter should be directly under Produce";
+  auto *rollup = dynamic_cast<RollUpApply *>(filter->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply should be planned for the comprehension in WHERE";
+  EXPECT_NE(dynamic_cast<OrderBy *>(rollup->input_.get()), nullptr)
+      << "RollUpApply for a WHERE comprehension must sit above OrderBy";
+}
+
+TYPED_TEST(TestPlanner, PatternComprehensionInWithOrderByStaysBelowOrderBy) {
+  // Test MATCH (n) WITH n ORDER BY length([(n)--(m) | 1]) RETURN n
+  // A comprehension the ORDER BY itself reads must stay BELOW the OrderBy, which evaluates its sort keys during the
+  // collection sweep.
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  FakeDbAccessor dba;
+  auto *query =
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WITH("n", ORDER_BY(FN("length", pattern_comp))), RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  // Produce (RETURN) -> OrderBy -> RollUpApply -> Produce (WITH)
+  auto *produce = dynamic_cast<Produce *>(&plan);
+  ASSERT_NE(produce, nullptr) << "Root should be Produce";
+  auto *order_by = dynamic_cast<OrderBy *>(produce->input_.get());
+  ASSERT_NE(order_by, nullptr) << "OrderBy should be directly under Produce";
+  auto *rollup = dynamic_cast<RollUpApply *>(order_by->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply for an ORDER BY comprehension must sit below OrderBy";
+  EXPECT_NE(dynamic_cast<Produce *>(rollup->input_.get()), nullptr) << "RollUpApply must come after the WITH's Produce";
+}
+
+TYPED_TEST(TestPlanner, OrderByRemembersSymbolsUsedByWhere) {
+  // Test MATCH (n) WITH n.prop AS x ORDER BY x WHERE n.prop2 = 1 RETURN x
+  // Filter(where) is planned above OrderBy, so every symbol the WHERE reads must be in OrderBy's remember set -
+  // otherwise `n` is frozen at the last row pulled during the collection sweep.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+  auto prop2 = dba.Property("prop2");
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                   WITH(PROPERTY_LOOKUP(dba, "n", prop), AS("x"), ORDER_BY(IDENT("x"))),
+                                   WHERE(EQ(PROPERTY_LOOKUP(dba, "n", prop2), LITERAL(1))),
+                                   RETURN("x")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  auto *produce = dynamic_cast<Produce *>(&plan);
+  ASSERT_NE(produce, nullptr) << "Root should be Produce";
+  auto *filter = dynamic_cast<Filter *>(produce->input_.get());
+  ASSERT_NE(filter, nullptr) << "Filter should be directly under Produce";
+  auto *order_by = dynamic_cast<OrderBy *>(filter->input_.get());
+  ASSERT_NE(order_by, nullptr) << "OrderBy should be under the Filter";
+  EXPECT_TRUE(std::ranges::any_of(order_by->output_symbols_, [](const auto &sym) { return sym.name() == "n"; }))
+      << "OrderBy must remember `n`, which the WHERE above it reads";
 }
 
 TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInWithWhere) {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3189,30 +3189,6 @@ TYPED_TEST(TestPlanner, PatternComprehensionInWithWhereWithOrderBy) {
       << "RollUpApply for a WHERE comprehension must sit above OrderBy";
 }
 
-TYPED_TEST(TestPlanner, PatternComprehensionInWithOrderByStaysBelowOrderBy) {
-  // Test MATCH (n) WITH n ORDER BY length([(n)--(m) | 1]) RETURN n
-  // A comprehension the ORDER BY itself reads must stay BELOW the OrderBy, which evaluates its sort keys during the
-  // collection sweep.
-  auto *pattern_comp = PATTERN_COMPREHENSION(
-      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
-  FakeDbAccessor dba;
-  auto *query =
-      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WITH("n", ORDER_BY(FN("length", pattern_comp))), RETURN("n")));
-
-  auto symbol_table = memgraph::query::MakeSymbolTable(query);
-  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
-  auto &plan = planner.plan();
-
-  // Produce (RETURN) -> OrderBy -> RollUpApply -> Produce (WITH)
-  auto *produce = dynamic_cast<Produce *>(&plan);
-  ASSERT_NE(produce, nullptr) << "Root should be Produce";
-  auto *order_by = dynamic_cast<OrderBy *>(produce->input_.get());
-  ASSERT_NE(order_by, nullptr) << "OrderBy should be directly under Produce";
-  auto *rollup = dynamic_cast<RollUpApply *>(order_by->input_.get());
-  ASSERT_NE(rollup, nullptr) << "RollUpApply for an ORDER BY comprehension must sit below OrderBy";
-  EXPECT_NE(dynamic_cast<Produce *>(rollup->input_.get()), nullptr) << "RollUpApply must come after the WITH's Produce";
-}
-
 TYPED_TEST(TestPlanner, OrderByRemembersSymbolsUsedByWhere) {
   // Test MATCH (n) WITH n.prop AS x ORDER BY x WHERE n.prop2 = 1 RETURN x
   // Filter(where) is planned above OrderBy, so every symbol the WHERE reads must be in OrderBy's remember set -
@@ -5218,6 +5194,21 @@ TYPED_TEST(TestPlanner, PatternComprehensionOverSymbolBoundInsideForeachBody) {
 
 namespace {
 
+/// Asserts @p rollup's comprehension branch expands from a bound symbol rather than re-scanning: `Once` below the
+/// expansion, never merely the presence of one, since an uncorrelated plan has an expansion too.
+template <class TExpand>
+TExpand *ExpectCorrelatedBranch(RollUpApply *rollup) {
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  EXPECT_NE(branch_produce, nullptr) << "comprehension branch should end with Produce";
+  if (!branch_produce) return nullptr;
+  auto *expand = dynamic_cast<TExpand *>(branch_produce->input_.get());
+  EXPECT_NE(expand, nullptr) << "comprehension branch should expand, not re-scan";
+  if (!expand) return nullptr;
+  EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr)
+      << "the expansion must start from the bound symbol on the frame, not a ScanAll";
+  return expand;
+}
+
 /// Walks down the single-input chain from @p root and returns the first operator of type TOp, or nullptr.
 template <class TOp>
 TOp *FindOpOfType(memgraph::query::plan::LogicalOperator *root) {
@@ -5369,6 +5360,30 @@ TYPED_TEST(TestPlanner, VariableLengthComprehensionOverAMatchedNodeAWriteReusesI
   EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr) << "and stay correlated to the matched `a`";
 }
 
+TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInAggregatingWithOrderBy) {
+  // Test MATCH (n) WITH n, count(*) AS c ORDER BY [(n)--(m) | 1] RETURN n
+  // The aggregating path discovers ORDER BY comprehensions separately, so the ORDER BY bucket needs its own coverage
+  // here: the behave scenario for this shape can only discriminate through Aggregate's unordered group emission.
+  FakeDbAccessor dba;
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                   WITH(IDENT("n"), AS("n"), COUNT(nullptr, false), AS("c"), ORDER_BY(pattern_comp)),
+                                   RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  auto *order_by = FindOpOfType<OrderBy>(&plan);
+  ASSERT_NE(order_by, nullptr) << "expected an OrderBy";
+  auto *rollup = dynamic_cast<RollUpApply *>(order_by->input_.get());
+  ASSERT_NE(rollup, nullptr) << "the ORDER BY bucket belongs directly below the OrderBy that reads it";
+  EXPECT_NE(dynamic_cast<Produce *>(rollup->input_.get()), nullptr) << "and above the WITH's Produce";
+  ExpectCorrelatedBranch<Expand>(rollup);
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInMergeOnCreateIsPlannedInsideBranch) {
   // Test MERGE (q) ON CREATE SET q.prop = [(q)-->() | 1]
   // `q` is bound by the MERGE pattern, and the SET runs inside the Merge's create branch, so the comprehension must
@@ -5437,8 +5452,6 @@ TYPED_TEST(TestPlanner, PatternComprehensionInMergeOnMatchCorrelatesToMatchedNod
   ASSERT_NE(branch_produce, nullptr);
   auto *expand = dynamic_cast<Expand *>(branch_produce->input_.get());
   ASSERT_NE(expand, nullptr) << "the comprehension must expand from the matched `q`, not re-scan the whole graph";
-  EXPECT_EQ(dynamic_cast<ScanAll *>(expand->input_.get()), nullptr)
-      << "a ScanAll below the Expand means `q` was not treated as bound, so the branch counts the whole graph";
   EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr)
       << "the expansion must start from the `q` the branch already has on the frame";
 }

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3150,6 +3150,38 @@ TYPED_TEST(TestPlanner, OrderByRemembersSymbolsUsedByWhere) {
       << "OrderBy must remember `n`, which the WHERE above it reads";
 }
 
+TYPED_TEST(TestPlanner, OrderByRemembersSymbolsReadOnlyInsideComprehension) {
+  // MATCH (n), (q) WITH n.prop AS x ORDER BY x WHERE size([(n)-->(m) WHERE q.prop2 = 1 | m]) > 0 RETURN x
+  // `q` is read only from the comprehension's own filter, which the WHERE-bucket RollUpApply evaluates above
+  // OrderBy. It must therefore be remembered too, or `q` is frozen at the last row of the collection sweep.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+  auto prop2 = dba.Property("prop2");
+  auto *comprehension = PATTERN_COMPREHENSION(nullptr,
+                                              PATTERN(NODE("n"), EDGE("anon1"), NODE("m")),
+                                              WHERE(EQ(PROPERTY_LOOKUP(dba, "q", prop2), LITERAL(1))),
+                                              IDENT("m"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n")), PATTERN(NODE("q"))),
+                                   WITH(PROPERTY_LOOKUP(dba, "n", prop), AS("x"), ORDER_BY(IDENT("x"))),
+                                   WHERE(GREATER(FN("size", comprehension), LITERAL(0))),
+                                   RETURN("x")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  auto *produce = dynamic_cast<Produce *>(&plan);
+  ASSERT_NE(produce, nullptr) << "Root should be Produce";
+  auto *filter = dynamic_cast<Filter *>(produce->input_.get());
+  ASSERT_NE(filter, nullptr) << "Filter should be directly under Produce";
+  auto *rollup = dynamic_cast<RollUpApply *>(filter->input_.get());
+  ASSERT_NE(rollup, nullptr) << "The WHERE's comprehension branch should sit directly below the Filter";
+  auto *order_by = dynamic_cast<OrderBy *>(rollup->input_.get());
+  ASSERT_NE(order_by, nullptr) << "OrderBy should be below the comprehension branch";
+  EXPECT_TRUE(std::ranges::any_of(order_by->output_symbols_, [](const auto &sym) { return sym.name() == "q"; }))
+      << "OrderBy must remember `q`, which the comprehension's filter reads above it";
+}
+
 TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInWithWhere) {
   // Test WITH 1 AS a WHERE [()--() | 1] = [()--() | 1] RETURN *
   // This tests that multiple pattern comprehensions in WHERE clauses are handled correctly

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5384,6 +5384,33 @@ TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInAggregatingWithOrderBy) 
   ExpectCorrelatedBranch<Expand>(rollup);
 }
 
+TYPED_TEST(TestPlanner, QueryPartSymbolsSurviveASubquery) {
+  // Test CREATE (a) CALL { MATCH (z) RETURN count(z) AS c } RETURN [(a)-[*1..2]->(m) | 1]
+  // A CALL subquery is not a query-part boundary, so the write and the comprehension are in the same part - but
+  // planning the subquery re-enters PlanQueryPart on this same planner. Without the save/restore around
+  // `query_part_symbols_`, the subquery's sets replace the caller's, `a` stops looking write-bound, and the rejection
+  // silently degrades into a plan that fails at runtime with "Trying to get relationships from a node that doesn't
+  // exist".
+  FakeDbAccessor dba;
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("a"), EDGE_VARIABLE("anon1", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("m")),
+      nullptr,
+      LITERAL(1));
+  auto *subquery = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("z"))), RETURN(COUNT(IDENT("z"), false), AS("c"))));
+  auto *query = QUERY(SINGLE_QUERY(
+      CREATE(PATTERN(NODE("a"))), CALL_SUBQUERY(subquery), RETURN(pattern_comp, AS("l"), IDENT("c"), AS("c"))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  try {
+    MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    FAIL() << "expected the query to be rejected";
+  } catch (const memgraph::query::QueryException &e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("'a'")) << "the caller's write-bound symbols must survive the subquery";
+  }
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInMergeOnCreateIsPlannedInsideBranch) {
   // Test MERGE (q) ON CREATE SET q.prop = [(q)-->() | 1]
   // `q` is bound by the MERGE pattern, and the SET runs inside the Merge's create branch, so the comprehension must

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5064,6 +5064,67 @@ TYPED_TEST(TestPlanner, PatternComprehensionInForeachBodyWithExternalReference) 
   ASSERT_NE(once, nullptr) << "Foreach input should be Once";
 }
 
+TYPED_TEST(TestPlanner, PatternComprehensionOverSymbolBoundInsideForeachBody) {
+  // Test FOREACH (i IN [1] | CREATE (q) SET q.prop = [(q)-->() | 1])
+  // `q` is bound by a CREATE inside the body, so the comprehension can only be planned once that CREATE has run.
+  // The body is drained after every clause, so the RollUpApply lands between CreateNode and SetProperty. Draining
+  // only on entry - as before - left the comprehension pending forever and its frame slot unwritten.
+  //
+  // Expected plan structure:
+  //   EmptyResult
+  //   Foreach
+  //   |\
+  //   | SetProperty
+  //   | RollUpApply
+  //   | |\
+  //   | | Produce {anon_result}
+  //   | | Expand (q)-[anon_edge]->(anon_node)
+  //   | | Once
+  //   | CreateNode (q)
+  //   | Once
+  //   Once
+
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("q"), EDGE("anon_edge", EdgeAtom::Direction::OUT), NODE("anon_node")), nullptr, LITERAL(1));
+
+  auto *foreach_clause = FOREACH(NEXPR("i", LIST(LITERAL(1))),
+                                 {CREATE(PATTERN(NODE("q"))), SET(PROPERTY_LOOKUP(dba, "q", prop), pattern_comp)});
+
+  auto *query = QUERY(SINGLE_QUERY(foreach_clause));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  auto &plan = planner.plan();
+  auto *empty_result = dynamic_cast<EmptyResult *>(&plan);
+  ASSERT_NE(empty_result, nullptr) << "Root should be EmptyResult";
+
+  auto *foreach_op = dynamic_cast<Foreach *>(empty_result->input_.get());
+  ASSERT_NE(foreach_op, nullptr) << "Should have Foreach operator";
+
+  auto *set_property = dynamic_cast<SetProperty *>(foreach_op->update_clauses_.get());
+  ASSERT_NE(set_property, nullptr) << "Foreach update branch should end with SetProperty";
+
+  auto *rollup = dynamic_cast<RollUpApply *>(set_property->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply must sit between CreateNode and SetProperty; without the per-clause "
+                                "drain the comprehension is never planned at all";
+
+  // The comprehension must expand from the just-created `q`, not re-scan, and must read View::NEW - `q` does not
+  // exist under View::OLD, which surfaces as "Trying to get relationships from a node that doesn't exist".
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr) << "Comprehension branch should end with Produce";
+  auto *expand = dynamic_cast<Expand *>(branch_produce->input_.get());
+  ASSERT_NE(expand, nullptr) << "Comprehension branch should expand from the bound `q`, not ScanAll";
+  EXPECT_EQ(expand->common_.existing_node, false);
+  EXPECT_EQ(expand->view_, memgraph::storage::View::NEW)
+      << "A comprehension planned after a write it depends on must read View::NEW";
+
+  auto *create_node = dynamic_cast<CreateNode *>(rollup->input_.get());
+  ASSERT_NE(create_node, nullptr) << "CreateNode should be below the RollUpApply";
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInsideCountAggregate) {
   // Test MATCH (n) RETURN count([(n)-[e]->(m) | m]) AS c
   // The pattern comprehension is inside count(), so RollUpApply must come BEFORE Aggregate.

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5411,6 +5411,83 @@ TYPED_TEST(TestPlanner, QueryPartSymbolsSurviveASubquery) {
   }
 }
 
+TYPED_TEST(TestPlanner, MergeOnMatchPlansAVariableLengthComprehensionWithViewOld) {
+  // Test MERGE (a) ON MATCH SET a.prop = [(a)-[*1..2]->(x) | 1]
+  // ON MATCH runs only when the pattern was found, so View::OLD does see `a` and the comprehension is plannable.
+  // Treating every MERGE symbol as write-bound rejected this outright.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("a"), EDGE_VARIABLE("anon1", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("x")),
+      nullptr,
+      LITERAL(1));
+  auto *query =
+      QUERY(SINGLE_QUERY(MERGE(PATTERN(NODE("a")), ON_MATCH(SET(PROPERTY_LOOKUP(dba, "a", prop), pattern_comp)))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  auto *merge = FindOpOfType<Merge>(&planner.plan());
+  ASSERT_NE(merge, nullptr);
+  auto *set_property = dynamic_cast<SetProperty *>(merge->merge_match_.get());
+  ASSERT_NE(set_property, nullptr) << "the match branch should end with SetProperty";
+  auto *rollup = dynamic_cast<RollUpApply *>(set_property->input_.get());
+  ASSERT_NE(rollup, nullptr) << "the comprehension belongs inside the ON MATCH branch";
+  ExpectCorrelatedBranch<ExpandVariable>(rollup);
+}
+
+TYPED_TEST(TestPlanner, MergeOnMatchAfterAWriteStillRejectsAVariableLengthComprehension) {
+  // Test CREATE (x) MERGE (b) ON MATCH SET b.prop = [(b)-[*1..2]->(m) | 1]
+  // MERGE's match branch reads View::NEW, so with a write earlier in the query part it can match a node that write
+  // created - which View::OLD cannot see. Narrowing unconditionally turned the rejection into a runtime failure.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("b"), EDGE_VARIABLE("anon1", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("m")),
+      nullptr,
+      LITERAL(1));
+  auto *query =
+      QUERY(SINGLE_QUERY(CREATE(PATTERN(NODE("x"))),
+                         MERGE(PATTERN(NODE("b")), ON_MATCH(SET(PROPERTY_LOOKUP(dba, "b", prop), pattern_comp)))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  try {
+    MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    FAIL() << "expected the query to be rejected";
+  } catch (const memgraph::query::QueryException &e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("'b'"));
+  }
+}
+
+TYPED_TEST(TestPlanner, MergeRestoresTheWriteBoundSymbolsItNarrowed) {
+  // Test MERGE (b) ON MATCH SET b.prop = 1 RETURN [(b)-[*1..2]->(m) | 1]
+  // The ON MATCH narrowing is scoped to that branch. If it leaked, `b` would no longer look write-bound and the
+  // RETURN's comprehension would be planned instead of rejected.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(NODE("b"), EDGE_VARIABLE("anon1", EdgeAtom::Type::DEPTH_FIRST, EdgeAtom::Direction::OUT), NODE("m")),
+      nullptr,
+      LITERAL(1));
+  auto *query =
+      QUERY(SINGLE_QUERY(MERGE(PATTERN(NODE("b")), ON_MATCH(SET(PROPERTY_LOOKUP(dba, "b", prop), LITERAL(1)))),
+                         RETURN(pattern_comp, AS("l"))));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  try {
+    MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    FAIL() << "expected the query to be rejected";
+  } catch (const memgraph::query::QueryException &e) {
+    EXPECT_THAT(e.what(), ::testing::HasSubstr("'b'"));
+  }
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInMergeOnCreateIsPlannedInsideBranch) {
   // Test MERGE (q) ON CREATE SET q.prop = [(q)-->() | 1]
   // `q` is bound by the MERGE pattern, and the SET runs inside the Merge's create branch, so the comprehension must

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3015,6 +3015,95 @@ TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithWhere) {
       query, this->storage, ExpectRollUpApply(input_ops, pattern_comp_branch_ops), ExpectFilter(), ExpectProduce());
 }
 
+TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithWhereAfterWriteClause) {
+  // Test MATCH (n) SET n.prop = 1 WITH n WHERE [(n)--(m) | 1] = [] RETURN n
+  // A write clause drains the pending comprehensions before it is planned, and `n` is bound there - but the
+  // comprehension resolves to the symbol the later WITH re-binds, not to the MATCH's `n`. Only because
+  // `symbols_bound_by_query_part` is seeded with the output symbols of every WITH/RETURN still ahead does the drain
+  // wait; otherwise the SET takes it, plans it uncorrelated, and the WHERE machinery never sees it at all.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                   SET(PROPERTY_LOOKUP(dba, "n", prop), LITERAL(1)),
+                                   WITH("n"),
+                                   WHERE(EQ(pattern_comp, LIST())),
+                                   RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  // Produce (RETURN) -> Filter (WHERE) -> RollUpApply -> Produce (WITH) -> Accumulate -> SetProperty -> ScanAll
+  auto *produce = dynamic_cast<Produce *>(&plan);
+  ASSERT_NE(produce, nullptr) << "Root should be Produce";
+  auto *filter = dynamic_cast<Filter *>(produce->input_.get());
+  ASSERT_NE(filter, nullptr) << "Filter should be directly under Produce";
+  auto *rollup = dynamic_cast<RollUpApply *>(filter->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply belongs below the Filter; if the SET drained it early it sits under the "
+                                "SetProperty instead and the WHERE reads an unwritten slot";
+  auto *with_produce = dynamic_cast<Produce *>(rollup->input_.get());
+  ASSERT_NE(with_produce, nullptr) << "RollUpApply must come after the WITH's Produce";
+  auto *accumulate = dynamic_cast<Accumulate *>(with_produce->input_.get());
+  ASSERT_NE(accumulate, nullptr) << "a WITH after a write accumulates";
+  EXPECT_NE(dynamic_cast<SetProperty *>(accumulate->input_.get()), nullptr) << "SetProperty belongs below the WITH";
+
+  // The discriminator: a ScanAll below the Expand means the branch was planned before `n` was bound, so it counts the
+  // whole graph instead of this row's node.
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr) << "Branch root should be Produce";
+  auto *branch_expand = dynamic_cast<Expand *>(branch_produce->input_.get());
+  ASSERT_NE(branch_expand, nullptr) << "Branch should expand from the correlated `n`";
+  EXPECT_NE(dynamic_cast<Once *>(branch_expand->input_.get()), nullptr)
+      << "Correlated branch must start at Once, not ScanAll";
+}
+
+TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithWhereAfterForeach) {
+  // Test MATCH (n) FOREACH (i IN [1] | SET n.prop = 1) WITH n WHERE [(n)--(m) | 1] = [] RETURN n
+  // FOREACH drains onto its own body chain, and it must apply the same dependency check as the main clause loop. Its
+  // own copy tested only `external_symbols`, which is empty here - the comprehension's sole free reference is its
+  // pattern's start node - so it drained on entry to the FOREACH and was planned uncorrelated inside the body.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  auto *foreach_clause = FOREACH(NEXPR("i", LIST(LITERAL(1))), {SET(PROPERTY_LOOKUP(dba, "n", prop), LITERAL(1))});
+  auto *query = QUERY(
+      SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), foreach_clause, WITH("n"), WHERE(EQ(pattern_comp, LIST())), RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  // Produce (RETURN) -> Filter (WHERE) -> RollUpApply -> Produce (WITH) -> Accumulate -> Foreach -> ScanAll
+  auto *produce = dynamic_cast<Produce *>(&plan);
+  ASSERT_NE(produce, nullptr) << "Root should be Produce";
+  auto *filter = dynamic_cast<Filter *>(produce->input_.get());
+  ASSERT_NE(filter, nullptr) << "Filter should be directly under Produce";
+  auto *rollup = dynamic_cast<RollUpApply *>(filter->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply belongs below the Filter; if the FOREACH drained it early it sits on the "
+                                "body's chain instead, where the WHERE cannot read it";
+  auto *with_produce = dynamic_cast<Produce *>(rollup->input_.get());
+  ASSERT_NE(with_produce, nullptr) << "RollUpApply must come after the WITH's Produce";
+  auto *accumulate = dynamic_cast<Accumulate *>(with_produce->input_.get());
+  ASSERT_NE(accumulate, nullptr) << "a WITH after a write accumulates";
+  auto *foreach_op = dynamic_cast<Foreach *>(accumulate->input_.get());
+  ASSERT_NE(foreach_op, nullptr) << "Foreach belongs below the WITH";
+  auto *body_set = dynamic_cast<SetProperty *>(foreach_op->update_clauses_.get());
+  ASSERT_NE(body_set, nullptr) << "the FOREACH body should be just the SetProperty";
+  EXPECT_NE(dynamic_cast<Once *>(body_set->input_.get()), nullptr)
+      << "the FOREACH body must not have taken the WITH's comprehension";
+
+  // Same discriminator as above: Once, not ScanAll, below the Expand.
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr) << "Branch root should be Produce";
+  auto *branch_expand = dynamic_cast<Expand *>(branch_produce->input_.get());
+  ASSERT_NE(branch_expand, nullptr) << "Branch should expand from the correlated `n`";
+  EXPECT_NE(dynamic_cast<Once *>(branch_expand->input_.get()), nullptr)
+      << "Correlated branch must start at Once, not ScanAll";
+}
+
 TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithOrderBy) {
   // Test MATCH (n) WITH n ORDER BY length([(n)--(m) | 1]) RETURN n
   // As above, but for ORDER BY: the sort key must be computed per row from the bound `n`.

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2975,10 +2975,11 @@ TYPED_TEST(TestPlanner, PatternComprehensionInWithWhere) {
 
   auto *query = QUERY(SINGLE_QUERY(WITH(NEXPR("a", LITERAL(1))), WHERE(where_expr), RETURN("a")));
 
-  // Plan structure: Once -> RollUpApply -> Produce (WITH) -> Filter (WHERE) -> Produce (RETURN)
-  // The RollUpApply evaluates the pattern comprehension in the WHERE clause
+  // Plan structure: Once -> Produce (WITH) -> RollUpApply -> Filter (WHERE) -> Produce (RETURN)
+  // The comprehension is in WHERE, which is evaluated after the WITH's Produce, so the RollUpApply follows it.
   std::list<std::unique_ptr<BaseOpChecker>> input_ops;
   input_ops.push_back(std::make_unique<ExpectOnce>());
+  input_ops.push_back(std::make_unique<ExpectProduce>());
 
   // Pattern comprehension branch operations (bottom-up: Once -> ScanAll -> Expand -> Produce)
   std::list<std::unique_ptr<BaseOpChecker>> pattern_comp_branch_ops;
@@ -2987,12 +2988,79 @@ TYPED_TEST(TestPlanner, PatternComprehensionInWithWhere) {
   pattern_comp_branch_ops.push_back(std::make_unique<ExpectExpand>());
   pattern_comp_branch_ops.push_back(std::make_unique<ExpectProduce>());
 
-  CheckPlan<TypeParam>(query,
-                       this->storage,
-                       ExpectRollUpApply(input_ops, pattern_comp_branch_ops),
-                       ExpectProduce(),
-                       ExpectFilter(),
-                       ExpectProduce());
+  CheckPlan<TypeParam>(
+      query, this->storage, ExpectRollUpApply(input_ops, pattern_comp_branch_ops), ExpectFilter(), ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithWhere) {
+  // Test MATCH (n) WITH n WHERE [(n)--(m) | 1] = [] RETURN n
+  // The comprehension expands from `n`, which WITH re-declares. Its branch must expand from the bound `n` rather
+  // than re-scanning it, which is only possible if the RollUpApply is planned after the WITH's Produce.
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WITH("n"), WHERE(EQ(pattern_comp, LIST())), RETURN("n")));
+
+  std::list<std::unique_ptr<BaseOpChecker>> input_ops;
+  input_ops.push_back(std::make_unique<ExpectOnce>());
+  input_ops.push_back(std::make_unique<ExpectScanAll>());
+  input_ops.push_back(std::make_unique<ExpectProduce>());
+
+  // No ScanAll in the branch: `n` is bound, so the expansion starts from it.
+  std::list<std::unique_ptr<BaseOpChecker>> pattern_comp_branch_ops;
+  pattern_comp_branch_ops.push_back(std::make_unique<ExpectOnce>());
+  pattern_comp_branch_ops.push_back(std::make_unique<ExpectExpand>());
+  pattern_comp_branch_ops.push_back(std::make_unique<ExpectProduce>());
+
+  CheckPlan<TypeParam>(
+      query, this->storage, ExpectRollUpApply(input_ops, pattern_comp_branch_ops), ExpectFilter(), ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithOrderBy) {
+  // Test MATCH (n) WITH n ORDER BY length([(n)--(m) | 1]) RETURN n
+  // As above, but for ORDER BY: the sort key must be computed per row from the bound `n`.
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  auto *query =
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WITH("n", ORDER_BY(FN("length", pattern_comp))), RETURN("n")));
+
+  std::list<std::unique_ptr<BaseOpChecker>> input_ops;
+  input_ops.push_back(std::make_unique<ExpectOnce>());
+  input_ops.push_back(std::make_unique<ExpectScanAll>());
+  input_ops.push_back(std::make_unique<ExpectProduce>());
+
+  std::list<std::unique_ptr<BaseOpChecker>> pattern_comp_branch_ops;
+  pattern_comp_branch_ops.push_back(std::make_unique<ExpectOnce>());
+  pattern_comp_branch_ops.push_back(std::make_unique<ExpectExpand>());
+  pattern_comp_branch_ops.push_back(std::make_unique<ExpectProduce>());
+
+  CheckPlan<TypeParam>(
+      query, this->storage, ExpectRollUpApply(input_ops, pattern_comp_branch_ops), ExpectOrderBy(), ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, CorrelatedPatternComprehensionInWithWhereWithAggregation) {
+  // Test MATCH (n) WITH n, count(*) AS c WHERE [(n)--(m) | 1] = [] RETURN n
+  // With an aggregation present, ORDER BY / WHERE are not visited for group-by collection. The comprehension there
+  // must still be planned, and after the Produce - otherwise it is never planned at all and its frame slot is null.
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("anon1", EdgeAtom::Direction::BOTH), NODE("m")), nullptr, LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                   WITH(IDENT("n"), AS("n"), COUNT(nullptr, false), AS("c")),
+                                   WHERE(EQ(pattern_comp, LIST())),
+                                   RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  FakeDbAccessor dba;
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+  auto &plan = planner.plan();
+
+  // Produce (RETURN) -> Filter (WHERE) -> RollUpApply -> Produce (WITH) -> Aggregate
+  auto *produce = dynamic_cast<Produce *>(&plan);
+  ASSERT_NE(produce, nullptr) << "Root should be Produce";
+  auto *filter = dynamic_cast<Filter *>(produce->input_.get());
+  ASSERT_NE(filter, nullptr) << "Filter should be directly under Produce";
+  auto *rollup = dynamic_cast<RollUpApply *>(filter->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply should be planned for the comprehension in WHERE";
+  EXPECT_NE(dynamic_cast<Produce *>(rollup->input_.get()), nullptr) << "RollUpApply must come after the WITH's Produce";
 }
 
 TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInWithWhere) {
@@ -3008,10 +3076,12 @@ TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInWithWhere) {
 
   auto *query = QUERY(SINGLE_QUERY(WITH(NEXPR("a", LITERAL(1))), WHERE(where_expr), RETURN("a")));
 
-  // Plan structure: Once -> RollUpApply (first PC) -> RollUpApply (second PC) -> Produce (WITH) -> Filter (WHERE) ->
-  // Produce (RETURN) First RollUpApply
+  // Plan structure: Once -> Produce (WITH) -> RollUpApply (first PC) -> RollUpApply (second PC) -> Filter (WHERE) ->
+  // Produce (RETURN). Both comprehensions are in WHERE, so both follow the WITH's Produce.
+  // First RollUpApply
   std::list<std::unique_ptr<BaseOpChecker>> input_ops1;
   input_ops1.push_back(std::make_unique<ExpectOnce>());
+  input_ops1.push_back(std::make_unique<ExpectProduce>());
 
   std::list<std::unique_ptr<BaseOpChecker>> pattern_comp_branch_ops1;
   pattern_comp_branch_ops1.push_back(std::make_unique<ExpectOnce>());
@@ -3029,12 +3099,8 @@ TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInWithWhere) {
   pattern_comp_branch_ops2.push_back(std::make_unique<ExpectExpand>());
   pattern_comp_branch_ops2.push_back(std::make_unique<ExpectProduce>());
 
-  CheckPlan<TypeParam>(query,
-                       this->storage,
-                       ExpectRollUpApply(input_ops2, pattern_comp_branch_ops2),
-                       ExpectProduce(),
-                       ExpectFilter(),
-                       ExpectProduce());
+  CheckPlan<TypeParam>(
+      query, this->storage, ExpectRollUpApply(input_ops2, pattern_comp_branch_ops2), ExpectFilter(), ExpectProduce());
 }
 
 TYPED_TEST(TestPlanner, NestedPatternComprehensionInMatchWhere) {
@@ -3162,10 +3228,11 @@ TYPED_TEST(TestPlanner, SinglePatternComprehensionInOrderBy) {
 
   auto *query = QUERY(SINGLE_QUERY(RETURN(NEXPR("x", LITERAL(1)), ORDER_BY(length_call))));
 
-  // Plan structure: Once -> RollUpApply -> Produce -> OrderBy
-  // The RollUpApply evaluates the pattern comprehension in the ORDER BY clause
+  // Plan structure: Once -> Produce -> RollUpApply -> OrderBy
+  // ORDER BY is evaluated after the Produce, so the RollUpApply follows it.
   std::list<std::unique_ptr<BaseOpChecker>> input_ops;
   input_ops.push_back(std::make_unique<ExpectOnce>());
+  input_ops.push_back(std::make_unique<ExpectProduce>());
 
   // Pattern comprehension branch operations (bottom-up: Once -> ScanAll -> Expand -> Produce)
   std::list<std::unique_ptr<BaseOpChecker>> pattern_comp_branch_ops;
@@ -3174,8 +3241,7 @@ TYPED_TEST(TestPlanner, SinglePatternComprehensionInOrderBy) {
   pattern_comp_branch_ops.push_back(std::make_unique<ExpectExpand>());
   pattern_comp_branch_ops.push_back(std::make_unique<ExpectProduce>());
 
-  CheckPlan<TypeParam>(
-      query, this->storage, ExpectRollUpApply(input_ops, pattern_comp_branch_ops), ExpectProduce(), ExpectOrderBy());
+  CheckPlan<TypeParam>(query, this->storage, ExpectRollUpApply(input_ops, pattern_comp_branch_ops), ExpectOrderBy());
 }
 
 TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInOrderBy) {
@@ -3190,10 +3256,11 @@ TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInOrderBy) {
 
   auto *query = QUERY(SINGLE_QUERY(RETURN(NEXPR("x", LITERAL(1)), ORDER_BY(length_call))));
 
-  // Plan structure: Once -> RollUpApply (first PC) -> RollUpApply (second PC) -> Produce -> OrderBy
+  // Plan structure: Once -> Produce -> RollUpApply (first PC) -> RollUpApply (second PC) -> OrderBy
   // First RollUpApply
   std::list<std::unique_ptr<BaseOpChecker>> input_ops1;
   input_ops1.push_back(std::make_unique<ExpectOnce>());
+  input_ops1.push_back(std::make_unique<ExpectProduce>());
 
   std::list<std::unique_ptr<BaseOpChecker>> pattern_comp_branch_ops1;
   pattern_comp_branch_ops1.push_back(std::make_unique<ExpectOnce>());
@@ -3211,8 +3278,7 @@ TYPED_TEST(TestPlanner, MultiplePatternComprehensionsInOrderBy) {
   pattern_comp_branch_ops2.push_back(std::make_unique<ExpectExpand>());
   pattern_comp_branch_ops2.push_back(std::make_unique<ExpectProduce>());
 
-  CheckPlan<TypeParam>(
-      query, this->storage, ExpectRollUpApply(input_ops2, pattern_comp_branch_ops2), ExpectProduce(), ExpectOrderBy());
+  CheckPlan<TypeParam>(query, this->storage, ExpectRollUpApply(input_ops2, pattern_comp_branch_ops2), ExpectOrderBy());
 }
 
 // Note: Nested pattern comprehensions (e.g., RETURN [()--() | [()--() | 1]] AS x) are supported.

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5117,12 +5117,103 @@ TYPED_TEST(TestPlanner, PatternComprehensionOverSymbolBoundInsideForeachBody) {
   ASSERT_NE(branch_produce, nullptr) << "Comprehension branch should end with Produce";
   auto *expand = dynamic_cast<Expand *>(branch_produce->input_.get());
   ASSERT_NE(expand, nullptr) << "Comprehension branch should expand from the bound `q`, not ScanAll";
+  EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr)
+      << "the expansion must start from the `q` on the frame, not re-scan the graph";
   EXPECT_EQ(expand->common_.existing_node, false);
   EXPECT_EQ(expand->view_, memgraph::storage::View::NEW)
       << "A comprehension planned after a write it depends on must read View::NEW";
 
   auto *create_node = dynamic_cast<CreateNode *>(rollup->input_.get());
   ASSERT_NE(create_node, nullptr) << "CreateNode should be below the RollUpApply";
+}
+
+namespace {
+
+/// Walks down the single-input chain from @p root and returns the first operator of type TOp, or nullptr.
+template <class TOp>
+TOp *FindOpOfType(memgraph::query::plan::LogicalOperator *root) {
+  for (auto *op = root; op != nullptr;) {
+    if (auto *found = dynamic_cast<TOp *>(op)) return found;
+    if (!op->HasSingleInput()) return nullptr;
+    op = op->input().get();
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TYPED_TEST(TestPlanner, PatternComprehensionInMergeOnCreateIsPlannedInsideBranch) {
+  // Test MERGE (q) ON CREATE SET q.prop = [(q)-->() | 1]
+  // `q` is bound by the MERGE pattern, and the SET runs inside the Merge's create branch, so the comprehension must
+  // be spliced into that branch - between CreateNode and SetProperty. Splicing it onto the chain the MERGE sits on
+  // would leave the frame slot unwritten when the SET reads it.
+  //
+  // Expected create branch (bottom-up): Once -> CreateNode (q) -> RollUpApply -> SetProperty
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("q"), EDGE("anon_edge", EdgeAtom::Direction::OUT), NODE("anon_node")), nullptr, LITERAL(1));
+
+  auto *query =
+      QUERY(SINGLE_QUERY(MERGE(PATTERN(NODE("q")), ON_CREATE(SET(PROPERTY_LOOKUP(dba, "q", prop), pattern_comp)))));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  auto *merge = FindOpOfType<Merge>(&planner.plan());
+  ASSERT_NE(merge, nullptr) << "expected a Merge operator";
+
+  auto *set_property = dynamic_cast<SetProperty *>(merge->merge_create_.get());
+  ASSERT_NE(set_property, nullptr) << "the create branch should end with SetProperty";
+
+  auto *rollup = dynamic_cast<RollUpApply *>(set_property->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply must sit inside the create branch, below the SetProperty that reads it";
+
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr);
+  auto *expand = dynamic_cast<Expand *>(branch_produce->input_.get());
+  ASSERT_NE(expand, nullptr) << "the comprehension must expand from the merged `q`, not re-scan";
+  EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr)
+      << "the expansion must start from the just-created `q` on the frame, not a ScanAll";
+  EXPECT_EQ(expand->view_, memgraph::storage::View::NEW)
+      << "`q` was created in this command, so it is invisible under View::OLD";
+
+  EXPECT_NE(dynamic_cast<CreateNode *>(rollup->input_.get()), nullptr) << "CreateNode belongs below the RollUpApply";
+}
+
+TYPED_TEST(TestPlanner, PatternComprehensionInMergeOnMatchCorrelatesToMatchedNode) {
+  // Test MERGE (q) ON MATCH SET q.prop = [(q)-->() | 1]
+  // ON MATCH binds the pattern into a *copy* of the bound symbol set that the planning context does not share, so the
+  // branch's symbols have to be handed to the comprehension planner explicitly. Without that the branch is planned
+  // uncorrelated - a ScanAll - and the query silently returns a whole-graph count instead of `q`'s own.
+  FakeDbAccessor dba;
+  auto prop = dba.Property("prop");
+
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("q"), EDGE("anon_edge", EdgeAtom::Direction::OUT), NODE("anon_node")), nullptr, LITERAL(1));
+
+  auto *query =
+      QUERY(SINGLE_QUERY(MERGE(PATTERN(NODE("q")), ON_MATCH(SET(PROPERTY_LOOKUP(dba, "q", prop), pattern_comp)))));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  auto *merge = FindOpOfType<Merge>(&planner.plan());
+  ASSERT_NE(merge, nullptr) << "expected a Merge operator";
+
+  auto *set_property = dynamic_cast<SetProperty *>(merge->merge_match_.get());
+  ASSERT_NE(set_property, nullptr) << "the match branch should end with SetProperty";
+
+  auto *rollup = dynamic_cast<RollUpApply *>(set_property->input_.get());
+  ASSERT_NE(rollup, nullptr) << "RollUpApply must sit inside the match branch, below the SetProperty that reads it";
+
+  auto *branch_produce = dynamic_cast<Produce *>(rollup->list_collection_branch_.get());
+  ASSERT_NE(branch_produce, nullptr);
+  auto *expand = dynamic_cast<Expand *>(branch_produce->input_.get());
+  ASSERT_NE(expand, nullptr) << "the comprehension must expand from the matched `q`, not re-scan the whole graph";
+  EXPECT_EQ(dynamic_cast<ScanAll *>(expand->input_.get()), nullptr)
+      << "a ScanAll below the Expand means `q` was not treated as bound, so the branch counts the whole graph";
+  EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr)
+      << "the expansion must start from the `q` the branch already has on the frame";
 }
 
 TYPED_TEST(TestPlanner, PatternComprehensionInsideCountAggregate) {

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1604,3 +1604,165 @@ TYPED_TEST(TestSymbolGenerator, ListComprehensionInWith) {
   // 0, we erase the x symbol as it is only mentioned in the list comprehension
   ASSERT_EQ(collector.symbols_.size(), 0);
 }
+
+// Shadowing of un-imported outer variables inside a `CALL {}` subquery. Such a name is out of scope in the subquery,
+// so a pattern occurrence of it declares a fresh variable rather than referencing the outer one. Referencing it would
+// resolve to the outer symbol and make the branch write through its frame slot, which the subquery shares with its
+// caller. `SUBQUERY_COMPREHENSION(name)` builds `[(<name>)-->() | 1]`.
+//
+// Note the subquery RETURNs below list two NamedExpressions rather than a bare name plus one: `RETURN("t", NEXPR(...))`
+// selects the `RETURN(expr, AS(name))` overload, which would overwrite the comprehension with an identifier.
+#define SUBQUERY_COMPREHENSION(name)                                                                                   \
+  PATTERN_COMPREHENSION(                                                                                               \
+      nullptr,                                                                                                         \
+      PATTERN(                                                                                                         \
+          NODE(name), EDGE("anon_edge", EdgeAtom::Direction::OUT, {}, false), NODE("anon_node", std::nullopt, false)), \
+      nullptr,                                                                                                         \
+      LITERAL(1))
+
+namespace {
+
+const Identifier &ComprehensionStartNode(PatternComprehension *pc) {
+  auto *node = dynamic_cast<NodeAtom *>(pc->pattern_->atoms_[0]);
+  MG_ASSERT(node, "expected the comprehension's first atom to be a node");
+  return *node->identifier_;
+}
+
+// A subquery's RETURN rejects an unaliased expression, and the NEXPR helper does not set the flag.
+NamedExpression *Aliased(NamedExpression *named_expr) {
+  named_expr->is_aliased_ = true;
+  return named_expr;
+}
+
+}  // namespace
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryShadowsUnimportedOuterVariable) {
+  // MATCH (p) CALL { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN p, k
+  auto *outer_p = NODE("p");
+  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
+                                RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), CALL_SUBQUERY(subquery), RETURN("p", "k")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  const auto outer_symbol = symbol_table.at(*outer_p->identifier_);
+  const auto inner_symbol = symbol_table.at(ComprehensionStartNode(comprehension));
+  EXPECT_NE(outer_symbol, inner_symbol) << "the un-imported name must be declared afresh, not bound to the outer `p`";
+  EXPECT_EQ(outer_symbol.name(), inner_symbol.name());
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesExplicitlyImportedVariable) {
+  // MATCH (p) CALL (p) { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN p, k
+  auto *outer_p = NODE("p");
+  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
+                                RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
+  auto *call_sub = CALL_SUBQUERY(subquery);
+  call_sub->has_variable_scope_ = true;
+  call_sub->scoped_variables_.push_back(NEXPR("p", IDENT("p")));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), call_sub, RETURN("p", "k")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_EQ(symbol_table.at(*outer_p->identifier_), symbol_table.at(ComprehensionStartNode(comprehension)))
+      << "an explicitly imported name is in scope, so it must still correlate";
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesWithCallStar) {
+  // MATCH (p) CALL (*) { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN p, k
+  auto *outer_p = NODE("p");
+  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
+                                RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
+  auto *call_sub = CALL_SUBQUERY(subquery);
+  call_sub->has_variable_scope_ = true;
+  call_sub->all_variables_scoped_ = true;
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), call_sub, RETURN("p", "k")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_EQ(symbol_table.at(*outer_p->identifier_), symbol_table.at(ComprehensionStartNode(comprehension)))
+      << "CALL (*) imports every user-declared outer variable";
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionInNestedSubqueryReshadowsImportedVariable) {
+  // MATCH (p) CALL (p) { CALL { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN t, k } RETURN p, k
+  // The inner `CALL {}` imports nothing, so `p` is out of scope again even though the outer subquery imported it.
+  auto *outer_p = NODE("p");
+  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *inner_subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
+                                      RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
+  auto *outer_subquery = SINGLE_QUERY(CALL_SUBQUERY(inner_subquery), RETURN("t", "k"));
+  auto *call_sub = CALL_SUBQUERY(outer_subquery);
+  call_sub->has_variable_scope_ = true;
+  call_sub->scoped_variables_.push_back(NEXPR("p", IDENT("p")));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), call_sub, RETURN("p", "k")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_NE(symbol_table.at(*outer_p->identifier_), symbol_table.at(ComprehensionStartNode(comprehension)))
+      << "the innermost CALL {} imported nothing, so `p` is out of scope there too";
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesItsOwnScopeVariable) {
+  // MATCH (p) CALL { MATCH (t) RETURN t, [(t)-->() | 1] AS k } RETURN t, k
+  // `t` is declared inside the subquery, so it is in scope there and must correlate, not be shadowed.
+  auto *inner_t = NODE("t");
+  auto *comprehension = SUBQUERY_COMPREHENSION("t");
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(inner_t)),
+                                RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("p"))), CALL_SUBQUERY(subquery), RETURN("t", "k")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_EQ(symbol_table.at(*inner_t->identifier_), symbol_table.at(ComprehensionStartNode(comprehension)))
+      << "a name declared inside the subquery is in scope there, so shadowing must not fire";
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionAtTopLevelDeclaresUndeclaredNameAfresh) {
+  // MATCH (t) RETURN [(zz)-->() | 1] AS k -- no CALL {} anywhere, so the rule must not fire differently here
+  auto *comprehension = SUBQUERY_COMPREHENSION("zz");
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("t"))), RETURN(NEXPR("k", comprehension))));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_EQ(symbol_table.at(ComprehensionStartNode(comprehension)).name(), "zz");
+}
+
+TYPED_TEST(TestSymbolGenerator, CreateInSubqueryMayRedeclareUnimportedOuterVariable) {
+  // MATCH (p) CALL { CREATE (p) RETURN p AS q } RETURN q
+  // `p` is out of scope in the subquery, so the CREATE declares a fresh node instead of raising a redeclaration
+  // error, and the outer `p` keeps its own frame slot.
+  auto *outer_p = NODE("p");
+  auto *created_p = NODE("p");
+  auto *subquery = SINGLE_QUERY(CREATE(PATTERN(created_p)), RETURN(IDENT("p"), AS("q")));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), CALL_SUBQUERY(subquery), RETURN("q")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_NE(symbol_table.at(*outer_p->identifier_), symbol_table.at(*created_p->identifier_))
+      << "the created node must be a fresh symbol, so the outer `p` survives the subquery";
+}
+
+TYPED_TEST(TestSymbolGenerator, SubqueryReturningShadowingNameStillCollidesWithOuterScope) {
+  // MATCH (p) CALL { CREATE (p) RETURN p } RETURN p
+  // Returning the shadowing name under its own name would collide with the caller's `p`; still rejected.
+  auto *subquery = SINGLE_QUERY(CREATE(PATTERN(NODE("p"))), RETURN("p"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("p"))), CALL_SUBQUERY(subquery), RETURN("p")));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
+TYPED_TEST(TestSymbolGenerator, ExistsPatternInSubqueryRejectsUnimportedOuterVariable) {
+  // MATCH (p) CALL { MATCH (t) WHERE exists((p)-->()) RETURN t } RETURN t
+  // A pattern expression may not introduce variables, so the out-of-scope `p` is an unbound reference.
+  auto *exists = EXISTS(PATTERN(
+      NODE("p"), EDGE("anon_edge", EdgeAtom::Direction::OUT, {}, false), NODE("anon_node", std::nullopt, false)));
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))), WHERE(exists), RETURN("t"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("p"))), CALL_SUBQUERY(subquery), RETURN("t")));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
+#undef SUBQUERY_COMPREHENSION

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1608,11 +1608,11 @@ TYPED_TEST(TestSymbolGenerator, ListComprehensionInWith) {
 // Shadowing of un-imported outer variables inside a `CALL {}` subquery. Such a name is out of scope in the subquery,
 // so a pattern occurrence of it declares a fresh variable rather than referencing the outer one. Referencing it would
 // resolve to the outer symbol and make the branch write through its frame slot, which the subquery shares with its
-// caller. `SUBQUERY_COMPREHENSION(name)` builds `[(<name>)-->() | 1]`.
+// caller. `COMPREHENSION_OVER(name)` builds `[(<name>)-->() | 1]`.
 //
 // Note the subquery RETURNs below list two NamedExpressions rather than a bare name plus one: `RETURN("t", NEXPR(...))`
 // selects the `RETURN(expr, AS(name))` overload, which would overwrite the comprehension with an identifier.
-#define SUBQUERY_COMPREHENSION(name)                                                                                   \
+#define COMPREHENSION_OVER(name)                                                                                       \
   PATTERN_COMPREHENSION(                                                                                               \
       nullptr,                                                                                                         \
       PATTERN(                                                                                                         \
@@ -1639,7 +1639,7 @@ NamedExpression *Aliased(NamedExpression *named_expr) {
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryShadowsUnimportedOuterVariable) {
   // MATCH (p) CALL { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN p, k
   auto *outer_p = NODE("p");
-  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *comprehension = COMPREHENSION_OVER("p");
   auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
                                 RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), CALL_SUBQUERY(subquery), RETURN("p", "k")));
@@ -1655,7 +1655,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryShadowsUnimportedO
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesExplicitlyImportedVariable) {
   // MATCH (p) CALL (p) { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN p, k
   auto *outer_p = NODE("p");
-  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *comprehension = COMPREHENSION_OVER("p");
   auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
                                 RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
   auto *call_sub = CALL_SUBQUERY(subquery);
@@ -1672,7 +1672,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesExplicit
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesWithCallStar) {
   // MATCH (p) CALL (*) { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN p, k
   auto *outer_p = NODE("p");
-  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *comprehension = COMPREHENSION_OVER("p");
   auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
                                 RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
   auto *call_sub = CALL_SUBQUERY(subquery);
@@ -1690,7 +1690,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionInNestedSubqueryReshadowsImp
   // MATCH (p) CALL (p) { CALL { MATCH (t) RETURN t, [(p)-->() | 1] AS k } RETURN t, k } RETURN p, k
   // The inner `CALL {}` imports nothing, so `p` is out of scope again even though the outer subquery imported it.
   auto *outer_p = NODE("p");
-  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *comprehension = COMPREHENSION_OVER("p");
   auto *inner_subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
                                       RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
   auto *outer_subquery = SINGLE_QUERY(CALL_SUBQUERY(inner_subquery), RETURN("t", "k"));
@@ -1709,7 +1709,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesItsOwnSc
   // MATCH (p) CALL { MATCH (t) RETURN t, [(t)-->() | 1] AS k } RETURN t, k
   // `t` is declared inside the subquery, so it is in scope there and must correlate, not be shadowed.
   auto *inner_t = NODE("t");
-  auto *comprehension = SUBQUERY_COMPREHENSION("t");
+  auto *comprehension = COMPREHENSION_OVER("t");
   auto *subquery = SINGLE_QUERY(MATCH(PATTERN(inner_t)),
                                 RETURN(Aliased(NEXPR("t", IDENT("t"))), Aliased(NEXPR("k", comprehension))));
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("p"))), CALL_SUBQUERY(subquery), RETURN("t", "k")));
@@ -1720,37 +1720,24 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesItsOwnSc
       << "a name declared inside the subquery is in scope there, so shadowing must not fire";
 }
 
-TYPED_TEST(TestSymbolGenerator, PatternComprehensionAtTopLevelDeclaresUndeclaredNameAfresh) {
-  // MATCH (t) RETURN [(zz)-->() | 1] AS k -- no CALL {} anywhere, so the rule must not fire differently here
-  auto *comprehension = SUBQUERY_COMPREHENSION("zz");
-  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("t"))), RETURN(NEXPR("k", comprehension))));
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionAtTopLevelCorrelatesToABoundName) {
+  // MATCH (zz) RETURN [(zz)-->() | 1] AS k
+  // Outside a subquery there is no boundary to shadow against, so a bound name in a comprehension pattern must resolve
+  // to the same symbol. Asserting the symbol's *name* would pass either way - both branches name it "zz".
+  auto *outer = NODE("zz");
+  auto *comprehension = COMPREHENSION_OVER("zz");
+  auto *query =
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(outer)), RETURN(NEXPR("k", static_cast<Expression *>(comprehension)))));
 
   auto symbol_table = MakeSymbolTable(query);
 
-  EXPECT_EQ(symbol_table.at(ComprehensionStartNode(comprehension)).name(), "zz");
+  EXPECT_EQ(symbol_table.at(ComprehensionStartNode(comprehension)), symbol_table.at(*outer->identifier_))
+      << "at top level the shadowing rule must not fire";
 }
 
 // Moved here from `subqueries.feature` because that suite also runs with `USING PARALLEL EXECUTION`, and this shape
 // (an aggregation inside a `CALL {}`) hits a pre-existing parallel-executor bug that nulls every outer variable --
 // unrelated to what the scenario is checking. Asserting the symbol identity pins the rule directly instead.
-TYPED_TEST(TestSymbolGenerator, PatternComprehensionInAggregatingSubqueryWhereShadowsUnimportedOuterVariable) {
-  // MATCH (p) CALL { MATCH (t) WITH t, count(*) AS c WHERE size([(p)-->() | 1]) > 0 RETURN t } RETURN p
-  auto *outer_p = NODE("p");
-  auto *comprehension = SUBQUERY_COMPREHENSION("p");
-  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
-                                WITH(IDENT("t"), AS("t"), COUNT(LITERAL(1), false), AS("c")),
-                                WHERE(GREATER(comprehension, LITERAL(0))),
-                                RETURN(Aliased(NEXPR("t", IDENT("t")))));
-  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), CALL_SUBQUERY(subquery), RETURN("p")));
-
-  auto symbol_table = MakeSymbolTable(query);
-
-  const auto outer_symbol = symbol_table.at(*outer_p->identifier_);
-  const auto inner_symbol = symbol_table.at(ComprehensionStartNode(comprehension));
-  EXPECT_NE(outer_symbol, inner_symbol) << "an aggregating WHERE must not correlate the un-imported outer `p` either";
-  EXPECT_EQ(outer_symbol.name(), inner_symbol.name());
-}
-
 TYPED_TEST(TestSymbolGenerator, PlainMatchInSubqueryShadowsUnimportedOuterVariable) {
   // MATCH (a) CALL { MATCH (a)-[:R]->(x) RETURN x } RETURN a, x
   // The subquery's own MATCH pattern is the same case as the comprehension: `a` is out of scope, so the pattern
@@ -1795,7 +1782,8 @@ TYPED_TEST(TestSymbolGenerator, ComprehensionInWhereRejectsAlreadyBoundRelations
                                    WHERE(EQ(pattern_comp, LIST())),
                                    RETURN("a")));
 
-  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+  EXPECT_THAT([&] { MakeSymbolTable(query); },
+              ThrowsMessage<SemanticException>(::testing::HasSubstr("already bound relationship 'r'")));
 }
 
 TYPED_TEST(TestSymbolGenerator, ComprehensionInWhereStillCorrelatesAnAlreadyBoundNode) {
@@ -1850,8 +1838,6 @@ TYPED_TEST(TestSymbolGenerator, ExistsPatternInSubqueryRejectsUnimportedOuterVar
   EXPECT_THROW(MakeSymbolTable(query), SemanticException);
 }
 
-#undef SUBQUERY_COMPREHENSION
-
 // A pattern comprehension may not reference a symbol the same CREATE clause declares. The operator that binds the
 // symbol is the one that reads the comprehension's result, so the frame slot is unwritten no matter where the
 // RollUpApply is spliced. A comprehension over a symbol bound by an *earlier* clause is fine and must keep working -
@@ -1867,18 +1853,9 @@ NodeAtom *WithProperty(AstStorage &storage, NodeAtom *node, const std::string &n
 
 }  // namespace
 
-// `[(<name>)-->() | 1]`
-#define SELF_COMPREHENSION(name)                                                                                       \
-  PATTERN_COMPREHENSION(                                                                                               \
-      nullptr,                                                                                                         \
-      PATTERN(                                                                                                         \
-          NODE(name), EDGE("anon_edge", EdgeAtom::Direction::OUT, {}, false), NODE("anon_node", std::nullopt, false)), \
-      nullptr,                                                                                                         \
-      LITERAL(1))
-
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedBySameClauseIsRejected) {
   // CREATE (q:L {c: [(q)-->() | 1]})
-  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("q"));
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", COMPREHENSION_OVER("q"));
   auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(created))));
 
   EXPECT_THROW(MakeSymbolTable(query), SemanticException);
@@ -1888,7 +1865,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedBySameClauseI
   // FOREACH (i IN [1] | CREATE (q:L {c: [(q)-->() | 1]}))
   // The FOREACH-wrapped form is the one that regressed: before the fix the merge-base planned it with an uncorrelated
   // scan and completed with a wrong count, and afterwards it failed with an internal error.
-  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("q"));
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", COMPREHENSION_OVER("q"));
   auto *query = QUERY(SINGLE_QUERY(FOREACH(NEXPR("i", LIST(LITERAL(1))), {CREATE(PATTERN(created))})));
 
   EXPECT_THROW(MakeSymbolTable(query), SemanticException);
@@ -1896,7 +1873,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedBySameClauseI
 
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedByEarlierPatternInSameClauseIsRejected) {
   // CREATE (a:L), (q:L {c: [(a)-->() | 1]})
-  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("a"));
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", COMPREHENSION_OVER("a"));
   auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(NODE("a", "L")), PATTERN(created))));
 
   EXPECT_THROW(MakeSymbolTable(query), SemanticException);
@@ -1921,7 +1898,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionReferencingCreatedNodeOnlyIn
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedByAnEarlierCreateClauseIsAccepted) {
   // CREATE (a:L) CREATE (q:L {c: [(a)-->() | 1]})
   // A separate clause binds `a`, so the comprehension is drained after it and correlates normally.
-  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("a"));
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", COMPREHENSION_OVER("a"));
   auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(NODE("a", "L"))), CREATE(PATTERN(created))));
 
   EXPECT_NO_THROW(MakeSymbolTable(query));
@@ -1929,7 +1906,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedByAnEarlierCr
 
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverMatchedNodeInsideCreateIsAccepted) {
   // MATCH (p) CREATE (q:L {c: [(p)-->() | 1]})
-  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("p"));
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", COMPREHENSION_OVER("p"));
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("p"))), CREATE(PATTERN(created))));
 
   EXPECT_NO_THROW(MakeSymbolTable(query));
@@ -1938,7 +1915,7 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverMatchedNodeInsideCreateI
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverItsOwnNodesInsideCreateIsAccepted) {
   // CREATE (q:L {c: [(z)-->() | 1]})
   // Nothing the CREATE binds is referenced, so the comprehension stands alone.
-  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("z"));
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", COMPREHENSION_OVER("z"));
   auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(created))));
 
   EXPECT_NO_THROW(MakeSymbolTable(query));

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1921,4 +1921,4 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverItsOwnNodesInsideCreateI
   EXPECT_NO_THROW(MakeSymbolTable(query));
 }
 
-#undef SELF_COMPREHENSION
+#undef COMPREHENSION_OVER

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1730,6 +1730,27 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionAtTopLevelDeclaresUndeclared
   EXPECT_EQ(symbol_table.at(ComprehensionStartNode(comprehension)).name(), "zz");
 }
 
+// Moved here from `subqueries.feature` because that suite also runs with `USING PARALLEL EXECUTION`, and this shape
+// (an aggregation inside a `CALL {}`) hits a pre-existing parallel-executor bug that nulls every outer variable --
+// unrelated to what the scenario is checking. Asserting the symbol identity pins the rule directly instead.
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionInAggregatingSubqueryWhereShadowsUnimportedOuterVariable) {
+  // MATCH (p) CALL { MATCH (t) WITH t, count(*) AS c WHERE size([(p)-->() | 1]) > 0 RETURN t } RETURN p
+  auto *outer_p = NODE("p");
+  auto *comprehension = SUBQUERY_COMPREHENSION("p");
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("t"))),
+                                WITH(IDENT("t"), AS("t"), COUNT(LITERAL(1), false), AS("c")),
+                                WHERE(GREATER(comprehension, LITERAL(0))),
+                                RETURN(Aliased(NEXPR("t", IDENT("t")))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_p)), CALL_SUBQUERY(subquery), RETURN("p")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  const auto outer_symbol = symbol_table.at(*outer_p->identifier_);
+  const auto inner_symbol = symbol_table.at(ComprehensionStartNode(comprehension));
+  EXPECT_NE(outer_symbol, inner_symbol) << "an aggregating WHERE must not correlate the un-imported outer `p` either";
+  EXPECT_EQ(outer_symbol.name(), inner_symbol.name());
+}
+
 TYPED_TEST(TestSymbolGenerator, PlainMatchInSubqueryShadowsUnimportedOuterVariable) {
   // MATCH (a) CALL { MATCH (a)-[:R]->(x) RETURN x } RETURN a, x
   // The subquery's own MATCH pattern is the same case as the comprehension: `a` is out of scope, so the pattern

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1730,6 +1730,23 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionAtTopLevelDeclaresUndeclared
   EXPECT_EQ(symbol_table.at(ComprehensionStartNode(comprehension)).name(), "zz");
 }
 
+TYPED_TEST(TestSymbolGenerator, PlainMatchInSubqueryShadowsUnimportedOuterVariable) {
+  // MATCH (a) CALL { MATCH (a)-[:R]->(x) RETURN x } RETURN a, x
+  // The subquery's own MATCH pattern is the same case as the comprehension: `a` is out of scope, so the pattern
+  // declares it afresh. Binding it to the outer symbol made the branch's scan overwrite the caller's frame slot,
+  // which dropped every outer row but the last.
+  auto *outer_a = NODE("a");
+  auto *inner_a = NODE("a");
+  auto *subquery = SINGLE_QUERY(
+      MATCH(PATTERN(inner_a, EDGE("anon_edge", EdgeAtom::Direction::OUT, {}, false), NODE("x"))), RETURN("x"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_a)), CALL_SUBQUERY(subquery), RETURN("a", "x")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_NE(symbol_table.at(*outer_a->identifier_), symbol_table.at(*inner_a->identifier_))
+      << "a subquery MATCH pattern must declare the un-imported name afresh, leaving the outer `a` intact";
+}
+
 TYPED_TEST(TestSymbolGenerator, CreateInSubqueryMayRedeclareUnimportedOuterVariable) {
   // MATCH (p) CALL { CREATE (p) RETURN p AS q } RETURN q
   // `p` is out of scope in the subquery, so the CREATE declares a fresh node instead of raising a redeclaration

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1783,6 +1783,53 @@ TYPED_TEST(TestSymbolGenerator, CreateInSubqueryMayRedeclareUnimportedOuterVaria
       << "the created node must be a fresh symbol, so the outer `p` survives the subquery";
 }
 
+TYPED_TEST(TestSymbolGenerator, ComprehensionInWhereRejectsAlreadyBoundRelationship) {
+  // MATCH (a)-[r]->(b) WITH a, r WHERE [(a)-[r]->(y) | 1] = [] RETURN a
+  // Reusing a bound *node* correlates the comprehension; reusing a bound *relationship* has no operator behind it -
+  // `Expand` has no `existing_edge` counterpart to `existing_node`. Left to resolve to the outer symbol, the planner
+  // received an already-bound edge symbol and tripped an assertion that aborted the process, reachable from EXPLAIN.
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("a"), EDGE("r", EdgeAtom::Direction::OUT), NODE("y")), nullptr, LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("a"), EDGE("r", EdgeAtom::Direction::OUT), NODE("b"))),
+                                   WITH(IDENT("a"), AS("a"), IDENT("r"), AS("r")),
+                                   WHERE(EQ(pattern_comp, LIST())),
+                                   RETURN("a")));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
+TYPED_TEST(TestSymbolGenerator, ComprehensionInWhereStillCorrelatesAnAlreadyBoundNode) {
+  // MATCH (a)-[r]->(b) WITH a AS a, b AS b WHERE [(a)-[]->(b) | 1] = [] RETURN a
+  // The positive control for the rejection above: a bound *node* in the same position must keep resolving to the symbol
+  // already in scope - here the one the WITH projects, which is what the comprehension has to correlate to.
+  auto *with_a = NEXPR("a", IDENT("a"));
+  auto *inner_a = NODE("a");
+  auto *pattern_comp = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(inner_a, EDGE("anon1", EdgeAtom::Direction::OUT), NODE("b")), nullptr, LITERAL(1));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("a"), EDGE("r", EdgeAtom::Direction::OUT), NODE("b"))),
+                                   WITH(with_a, NEXPR("b", IDENT("b"))),
+                                   WHERE(EQ(pattern_comp, LIST())),
+                                   RETURN("a")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_EQ(symbol_table.at(*inner_a->identifier_), symbol_table.at(*with_a))
+      << "a bound node in a comprehension pattern must correlate to the WITH's output symbol, not declare a fresh one";
+}
+
+TYPED_TEST(TestSymbolGenerator, ExistsSubqueryRejectsAlreadyBoundRelationship) {
+  // MATCH (a)-[r]->(b) WHERE EXISTS { MATCH (a)-[r]->(y) RETURN y } RETURN a
+  // Same planner limitation reached through the other spelling that resolves pattern names against the outer scope.
+  // This one aborted the process on master too.
+  auto *subquery =
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("a"), EDGE("r", EdgeAtom::Direction::OUT), NODE("y"))), RETURN("y")));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("a"), EDGE("r", EdgeAtom::Direction::OUT), NODE("b"))),
+                                   WHERE(EXISTS_SUBQUERY(subquery)),
+                                   RETURN("a")));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
 TYPED_TEST(TestSymbolGenerator, SubqueryReturningShadowingNameStillCollidesWithOuterScope) {
   // MATCH (p) CALL { CREATE (p) RETURN p } RETURN p
   // Returning the shadowing name under its own name would collide with the caller's `p`; still rejected.

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1783,3 +1783,97 @@ TYPED_TEST(TestSymbolGenerator, ExistsPatternInSubqueryRejectsUnimportedOuterVar
 }
 
 #undef SUBQUERY_COMPREHENSION
+
+// A pattern comprehension may not reference a symbol the same CREATE clause declares. The operator that binds the
+// symbol is the one that reads the comprehension's result, so the frame slot is unwritten no matter where the
+// RollUpApply is spliced. A comprehension over a symbol bound by an *earlier* clause is fine and must keep working -
+// that is the whole point of correlating them.
+namespace {
+
+// NODE() has no properties overload, so set the map directly. The variant's first alternative is the map, which is
+// what a default-constructed NodeAtom holds.
+NodeAtom *WithProperty(AstStorage &storage, NodeAtom *node, const std::string &name, Expression *value) {
+  std::get<std::unordered_map<PropertyIx, Expression *>>(node->properties_)[storage.GetPropertyIx(name)] = value;
+  return node;
+}
+
+}  // namespace
+
+// `[(<name>)-->() | 1]`
+#define SELF_COMPREHENSION(name)                                                                                       \
+  PATTERN_COMPREHENSION(                                                                                               \
+      nullptr,                                                                                                         \
+      PATTERN(                                                                                                         \
+          NODE(name), EDGE("anon_edge", EdgeAtom::Direction::OUT, {}, false), NODE("anon_node", std::nullopt, false)), \
+      nullptr,                                                                                                         \
+      LITERAL(1))
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedBySameClauseIsRejected) {
+  // CREATE (q:L {c: [(q)-->() | 1]})
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("q"));
+  auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(created))));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedBySameClauseInForeachIsRejected) {
+  // FOREACH (i IN [1] | CREATE (q:L {c: [(q)-->() | 1]}))
+  // The FOREACH-wrapped form is the one that regressed: before the fix the merge-base planned it with an uncorrelated
+  // scan and completed with a wrong count, and afterwards it failed with an internal error.
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("q"));
+  auto *query = QUERY(SINGLE_QUERY(FOREACH(NEXPR("i", LIST(LITERAL(1))), {CREATE(PATTERN(created))})));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedByEarlierPatternInSameClauseIsRejected) {
+  // CREATE (a:L), (q:L {c: [(a)-->() | 1]})
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("a"));
+  auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(NODE("a", "L")), PATTERN(created))));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionReferencingCreatedNodeOnlyInItsFilterIsRejected) {
+  // CREATE (q:L {c: [(z)-->() WHERE z = q | 1]})
+  // The reference is outside the comprehension's pattern, so it resolves through a different branch of
+  // Visit(Identifier) than the cases above.
+  auto *comprehension = PATTERN_COMPREHENSION(
+      nullptr,
+      PATTERN(
+          NODE("z"), EDGE("anon_edge", EdgeAtom::Direction::OUT, {}, false), NODE("anon_node", std::nullopt, false)),
+      WHERE(EQ(IDENT("z"), IDENT("q"))),
+      LITERAL(1));
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", comprehension);
+  auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(created))));
+
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverNodeCreatedByAnEarlierCreateClauseIsAccepted) {
+  // CREATE (a:L) CREATE (q:L {c: [(a)-->() | 1]})
+  // A separate clause binds `a`, so the comprehension is drained after it and correlates normally.
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("a"));
+  auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(NODE("a", "L"))), CREATE(PATTERN(created))));
+
+  EXPECT_NO_THROW(MakeSymbolTable(query));
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverMatchedNodeInsideCreateIsAccepted) {
+  // MATCH (p) CREATE (q:L {c: [(p)-->() | 1]})
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("p"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("p"))), CREATE(PATTERN(created))));
+
+  EXPECT_NO_THROW(MakeSymbolTable(query));
+}
+
+TYPED_TEST(TestSymbolGenerator, PatternComprehensionOverItsOwnNodesInsideCreateIsAccepted) {
+  // CREATE (q:L {c: [(z)-->() | 1]})
+  // Nothing the CREATE binds is referenced, so the comprehension stands alone.
+  auto *created = WithProperty(this->storage, NODE("q", "L"), "c", SELF_COMPREHENSION("z"));
+  auto *query = QUERY(SINGLE_QUERY(CREATE(PATTERN(created))));
+
+  EXPECT_NO_THROW(MakeSymbolTable(query));
+}
+
+#undef SELF_COMPREHENSION


### PR DESCRIPTION
A pattern comprehension in the `WHERE` or `ORDER BY` of a `WITH` did not correlate with the bound variable — it re-scanned it, so `size([(p)-->(m)|m])` silently meant *"every edge in the graph"*. Filters admitted rows they should have excluded, `ORDER BY` did not sort, and with an aggregation in the same `WITH` the comprehension was never planned at all (`Pattern Comprehension expected a list, got null`). Eight reported issues are this one defect in different shapes.

## How

`VisitReturnBody` mints the `WITH`'s output symbols *after* the named expressions but *before* `order_by`/`where`, so a comprehension there binds to those symbols — while `GenReturnBody` spliced every `RollUpApply` *below* the `Produce` that writes them. Unbound at planning time ⇒ uncorrelated `ScanAll`.

`ReturnBodyContext` now records each comprehension's position and splices per position. `OrderByCursor` restores only its `output_symbols_`, and `Filter(where)` sits above it, so one splice point cannot serve both:

```
Filter(where) → RollUpApply(where) → Limit → Skip → OrderBy → RollUpApply(orderby) → Distinct → Produce
```

Five chains can evaluate a comprehension. Three drain through one helper (main clause chain, FOREACH body, each MERGE branch); a WITH/RETURN body drains on demand, sharing the same view rule; a `CallProcedure` clause has no drain — a known gap. `ExpandVariable` can only read `View::OLD`, so one rule at the single planning funnel forces that for variable-length patterns, rejecting only when the pattern's root is a node a write clause of the same query part binds.

## Crash fixes

Two `MG_ASSERT`s on the planning path — unconditional in every build, so a whole-process abort dropping every session, and reachable from **`EXPLAIN` alone** without write permission. Both fired on `master`; both are now `QueryException`s, with the shapes that reached them rejected earlier by name.

- `EXPLAIN CREATE (a)-[:R]->(b)-[:R]->(c) RETURN [(a)-[*1..2]->(x) | x.name]`
- `EXPLAIN MATCH (a)-[r]->(b) WHERE EXISTS { MATCH (a)-[r]->(y) RETURN y } RETURN a`

## Fixes with no comprehension involved

An un-imported name of the enclosing query is now out of scope inside a `CALL {}` subquery, and a named path no longer escapes into an outer one. Each measured against a merge-base binary and a reference implementation:

- **Silent wrong answers for a plain `MATCH`.** `MATCH (n) CALL { MATCH (n)-[:R]->(x) RETURN count(x) AS c } RETURN n.id, c` returned `n.id` as `null` in *every* row — the subquery's scan resolved `n` to the caller's symbol and wrote through the frame slot they share. Closes #4394, #4388, #3955, #4160.
- **A named path was overwritten by an inner one of the same name**, in a subquery or in a comprehension's own path variable — the latter needs no subquery at all.
- **A `WITH` with both `ORDER BY` and `WHERE` could return wrong rows.** `OrderBy` restores only the symbols it is given and the `WHERE` sits above it, so a symbol the projection dropped was frozen at the last input row. `MATCH (p) WITH p.name AS n ORDER BY n WHERE p.age > 25 RETURN n` returned every row.

## Breaking changes

1. **Silent results change.** Inside a `CALL {}`, a *pattern* mentioning an un-imported variable of the enclosing query declares that name afresh instead of reusing the caller's, so such a query returns **different results with no error**. A bare `CALL {}` now matches its documented scope, identical to `CALL () {}`; every non-pattern reference was already rejected as unbound. Import explicitly — `CALL (n) {`, `CALL (*) {`, or a leading `WITH n`. The `exists()` *pattern* form raises instead.
2. `CREATE (q:T {c: size([(q)-->(m)|m])})` → `Entity 'q' cannot be created and referenced by a pattern comprehension in the same clause`. No placement works: the operator that binds the symbol is the one that reads the result.
3. Reusing an **already bound relationship** in a comprehension or `EXISTS {}` pattern → `Cannot use the already bound relationship 'r' in a pattern here`. `Expand` has no `existing_edge` counterpart, so there is no operator to emit. Bound *nodes* still correlate. Previously a process abort.
4. A **variable-length** comprehension expanding from a node a write clause of the same query part binds → `A variable-length pattern cannot expand from 'a', …`. Closing the write clause with a `WITH` works. Previously a process abort, or a runtime storage error.

Also: `CALL { CREATE (p) … }` over an un-imported outer `p` now succeeds (unlabelled form only); `EXPLAIN` output changes.

## Verification

Measured against a binary built at the merge base and against a reference implementation.

- `query_plan` **231/231**, `query_semantic` **238/238**, plus six neighbouring `query_*` suites.
- `gql_behave memgraph_V1` with `USING PARALLEL EXECUTION`: **1158 of 1227, zero regressions** — the residual 69 are `text_*`/`vector_*` needing experimental flags. `openCypher_M09`: 113 failures, identical on both binaries.
- Every fix's test was verified to **fail when its own hunk is reverted**.

## Known gaps, deliberately not fixed here

Each is pre-existing and behaves identically on the merge-base binary.

- A `CallProcedure` clause never drains its comprehensions — arguments as much as `YIELD … WHERE`. Also why `pending_comprehensions` cannot yet be asserted empty.
- `MakePatternComprehensionFilter` is a second planning path, so a comprehension in a `MATCH … WHERE` bypasses the variable-length rule.
- `Accumulate` does not restore a comprehension's anonymous result symbol, so a write clause followed by a non-reprojected symbol freezes it.
- The main clause chain drains before a write clause, so `MATCH (p) CREATE (p)-[:R]->(x) RETURN size([(p)-[:R]->(m)|m])` counts pre-existing edges only. A FOREACH body likewise splices at the earliest satisfying clause rather than the reading one.
- Comprehension in `SKIP`/`LIMIT`; the CREATE rejection is order-dependent; `MERGE` has no counterpart to it.
- Same scoping family, still open: `check_node_semantic` uses raw `HasSymbol`, so `CREATE (p)` shadows but `CREATE (p:L)` errors; a comprehension's *filter* still reaches an un-imported outer name; `CALL (v) { WITH … MATCH (v) … }` still resolves to the caller's symbol.
- One scenario lives in `query_semantic.cpp` rather than `subqueries.feature`: an aggregation inside a `CALL {}` trips a pre-existing parallel-executor bug, filed separately.

Closes #4394
Closes #4388
Closes #4378
Closes #4376
Closes #4365
Closes #4364
Closes #4350
Closes #4339
Closes #4180
Closes #4161
Closes #4160
Closes #3955
