### PR TITLE
fix: Data race on cached dba during concurrent plan printing

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -9478,7 +9478,7 @@ UniqueCursorPtr ScanAllByPointDistance::MakeCursor(utils::MemoryResource *mem,
 std::string ScanAllByPointDistance::ToString(const DbAccessor *dba) const {
   auto const &name = output_symbol_.name();
   auto const &label = dba->LabelToName(label_);
-  auto const property = dba->PropertyToName(property_);
+  auto const &property = dba->PropertyToName(property_);
   return fmt::format("ScanAllByPointDistance ({0} :{1} {{{2}}})", name, label, property);
 }
 
@@ -9545,7 +9545,7 @@ UniqueCursorPtr ScanAllByPointWithinbbox::MakeCursor(utils::MemoryResource *mem,
 std::string ScanAllByPointWithinbbox::ToString(const DbAccessor *dba) const {
   auto const &name = output_symbol_.name();
   auto const &label = dba->LabelToName(label_);
-  auto const property = dba->PropertyToName(property_);
+  auto const &property = dba->PropertyToName(property_);
   return fmt::format("ScanAllByPointWithinbbox ({0} :{1} {{{2}}})", name, label, property);
 }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -692,7 +692,7 @@ std::vector<Symbol> CreateExpand::ModifiedSymbols(const SymbolTable &table) cons
   return symbols;
 }
 
-std::string CreateExpand::ToString() const {
+std::string CreateExpand::ToString(const DbAccessor *dba) const {
   const auto *maybe_edge_type_id = std::get_if<storage::EdgeTypeId>(&edge_info_.edge_type);
   const bool is_expansion_static = maybe_edge_type_id != nullptr;
   return fmt::format("{} ({}){}[{}:{}]{}({})",
@@ -700,7 +700,7 @@ std::string CreateExpand::ToString() const {
                      input_symbol_.name(),
                      edge_info_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
                      edge_info_.symbol.name(),
-                     is_expansion_static ? dba_->EdgeTypeToName(*maybe_edge_type_id) : "<DYNAMIC>",
+                     is_expansion_static ? dba->EdgeTypeToName(*maybe_edge_type_id) : "<DYNAMIC>",
                      edge_info_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
                      node_info_.symbol.name());
 }
@@ -1059,7 +1059,9 @@ std::vector<Symbol> ScanAll::ModifiedSymbols(const SymbolTable &table) const {
   return symbols;
 }
 
-std::string ScanAll::ToString() const { return fmt::format("ScanAll ({})", output_symbol_.name()); }
+std::string ScanAll::ToString(const DbAccessor * /*dba*/) const {
+  return fmt::format("ScanAll ({})", output_symbol_.name());
+}
 
 std::unique_ptr<LogicalOperator> ScanAll::Clone(AstStorage *storage) const {
   auto object = std::make_unique<ScanAll>();
@@ -1092,8 +1094,8 @@ UniqueCursorPtr ScanAllByLabel::MakeCursor(utils::MemoryResource *mem,
                                                                 "ScanAllByLabel");
 }
 
-std::string ScanAllByLabel::ToString() const {
-  return fmt::format("ScanAllByLabel ({} :{})", output_symbol_.name(), dba_->LabelToName(label_));
+std::string ScanAllByLabel::ToString(const DbAccessor *dba) const {
+  return fmt::format("ScanAllByLabel ({} :{})", output_symbol_.name(), dba->LabelToName(label_));
 }
 
 std::unique_ptr<LogicalOperator> ScanAllByLabel::Clone(AstStorage *storage) const {
@@ -1124,14 +1126,14 @@ std::vector<Symbol> ScanAllByEdge::ModifiedSymbols(const SymbolTable &table) con
   return symbols;
 }
 
-std::string ScanAllByEdge::ToString() const {
+std::string ScanAllByEdge::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "ScanAllByEdge ({}){}[{}{}]{}({})",
       common_.node1_symbol.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node2_symbol.name());
 }
@@ -1164,14 +1166,14 @@ UniqueCursorPtr ScanAllByEdgeType::MakeCursor(utils::MemoryResource *mem,
       mem, *this, input_->MakeCursor(mem, metric_handles), view_, std::move(edges), "ScanAllByEdgeType");
 }
 
-std::string ScanAllByEdgeType::ToString() const {
+std::string ScanAllByEdgeType::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "ScanAllByEdgeType ({}){}[{}{}]{}({})",
       common_.node1_symbol.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node2_symbol.name());
 }
@@ -1206,15 +1208,15 @@ UniqueCursorPtr ScanAllByEdgeTypeProperty::MakeCursor(utils::MemoryResource *mem
       mem, *this, input_->MakeCursor(mem, metric_handles), view_, std::move(get_edges), "ScanAllByEdgeTypeProperty");
 }
 
-std::string ScanAllByEdgeTypeProperty::ToString() const {
+std::string ScanAllByEdgeTypeProperty::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "ScanAllByEdgeTypeProperty ({0}){1}[{2}{3} {{{4}}}]{5}({6})",
       common_.node1_symbol.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
-      dba_->PropertyToName(property_),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
+      dba->PropertyToName(property_),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node2_symbol.name());
 }
@@ -1350,15 +1352,15 @@ UniqueCursorPtr ScanAllByEdgeTypePropertyValue::MakeCursor(utils::MemoryResource
                                                                        "ScanAllByEdgeTypePropertyValue");
 }
 
-std::string ScanAllByEdgeTypePropertyValue::ToString() const {
+std::string ScanAllByEdgeTypePropertyValue::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "ScanAllByEdgeTypePropertyValue ({0}){1}[{2}{3} {{{4}}}]{5}({6})",
       common_.node1_symbol.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
-      dba_->PropertyToName(property_),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
+      dba->PropertyToName(property_),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node2_symbol.name());
 }
@@ -1408,15 +1410,15 @@ UniqueCursorPtr ScanAllByEdgeTypePropertyRange::MakeCursor(utils::MemoryResource
                                                                        "ScanAllByEdgeTypePropertyRange");
 }
 
-std::string ScanAllByEdgeTypePropertyRange::ToString() const {
+std::string ScanAllByEdgeTypePropertyRange::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "ScanAllByEdgeTypePropertyRange ({0}){1}[{2}{3} {{{4}}}]{5}({6})",
       common_.node1_symbol.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
-      dba_->PropertyToName(property_),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
+      dba->PropertyToName(property_),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node2_symbol.name());
 }
@@ -1458,12 +1460,12 @@ UniqueCursorPtr ScanAllByEdgeProperty::MakeCursor(utils::MemoryResource *mem,
       mem, *this, input_->MakeCursor(mem, metric_handles), view_, std::move(get_edges), "ScanAllByEdgeProperty");
 }
 
-std::string ScanAllByEdgeProperty::ToString() const {
+std::string ScanAllByEdgeProperty::ToString(const DbAccessor *dba) const {
   return fmt::format("ScanAllByEdgeProperty ({0}){1}[{2} {{{3}}}]{4}({5})",
                      common_.node1_symbol.name(),
                      common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
                      common_.edge_symbol.name(),
-                     dba_->PropertyToName(property_),
+                     dba->PropertyToName(property_),
                      common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
                      common_.node2_symbol.name());
 }
@@ -1504,12 +1506,12 @@ UniqueCursorPtr ScanAllByEdgePropertyValue::MakeCursor(utils::MemoryResource *me
       mem, *this, input_->MakeCursor(mem, metric_handles), view_, std::move(get_edges), "ScanAllByEdgePropertyValue");
 }
 
-std::string ScanAllByEdgePropertyValue::ToString() const {
+std::string ScanAllByEdgePropertyValue::ToString(const DbAccessor *dba) const {
   return fmt::format("ScanAllByEdgePropertyValue ({0}){1}[{2} {{{3}}}]{4}({5})",
                      common_.node1_symbol.name(),
                      common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
                      common_.edge_symbol.name(),
-                     dba_->PropertyToName(property_),
+                     dba->PropertyToName(property_),
                      common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
                      common_.node2_symbol.name());
 }
@@ -1556,12 +1558,12 @@ UniqueCursorPtr ScanAllByEdgePropertyRange::MakeCursor(utils::MemoryResource *me
       mem, *this, input_->MakeCursor(mem, metric_handles), view_, std::move(get_edges), "ScanAllByEdgePropertyRange");
 }
 
-std::string ScanAllByEdgePropertyRange::ToString() const {
+std::string ScanAllByEdgePropertyRange::ToString(const DbAccessor *dba) const {
   return fmt::format("ScanAllByEdgePropertyRange ({0}){1}[{2} {{{3}}}]{4}({5})",
                      common_.node1_symbol.name(),
                      common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
                      common_.edge_symbol.name(),
-                     dba_->PropertyToName(property_),
+                     dba->PropertyToName(property_),
                      common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
                      common_.node2_symbol.name());
 }
@@ -1623,19 +1625,19 @@ UniqueCursorPtr ScanAllByLabelProperties::MakeCursor(utils::MemoryResource *mem,
                                                                 "ScanAllByLabelProperties");
 }
 
-std::string ScanAllByLabelProperties::ToString() const {
+std::string ScanAllByLabelProperties::ToString(const DbAccessor *dba) const {
   // TODO: better diagnostics...info about expression_ranges_?
   auto const property_names =
       properties_ | rv::transform([&](storage::PropertyPath const &property_path) {
         return utils::Join(
-            property_path | rv::transform([&](storage::PropertyId prop) { return dba_->PropertyToName(prop); }), ".");
+            property_path | rv::transform([&](storage::PropertyId prop) { return dba->PropertyToName(prop); }), ".");
       }) |
       ranges::to_vector;
   auto const properties_stringified = utils::Join(property_names, ", ");
   std::string_view suffix = index_order_ == storage::IndexOrder::DESC ? " (DESC)" : "";
   return fmt::format("ScanAllByLabelProperties ({0} :{1} {{{2}}}){3}",
                      output_symbol_.name(),
-                     dba_->LabelToName(label_),
+                     dba->LabelToName(label_),
                      properties_stringified,
                      suffix);
 }
@@ -1706,7 +1708,9 @@ UniqueCursorPtr ScanAllById::MakeCursor(utils::MemoryResource *mem,
       mem, *this, output_symbol_, input_->MakeCursor(mem, metric_handles), view_, std::move(vertices), "ScanAllById");
 }
 
-std::string ScanAllById::ToString() const { return fmt::format("ScanAllById ({})", output_symbol_.name()); }
+std::string ScanAllById::ToString(const DbAccessor * /*dba*/) const {
+  return fmt::format("ScanAllById ({})", output_symbol_.name());
+}
 
 std::unique_ptr<LogicalOperator> ScanAllById::Clone(AstStorage *storage) const {
   auto object = std::make_unique<ScanAllById>();
@@ -1748,7 +1752,7 @@ UniqueCursorPtr ScanAllByEdgeId::MakeCursor(utils::MemoryResource *mem,
       mem, *this, input_->MakeCursor(mem, metric_handles), view_, std::move(edges), "ScanAllByEdgeId");
 }
 
-std::string ScanAllByEdgeId::ToString() const {
+std::string ScanAllByEdgeId::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("ScanAllByEdgeId ({})", common_.edge_symbol.name());
 }
 
@@ -1816,14 +1820,14 @@ std::vector<Symbol> Expand::ModifiedSymbols(const SymbolTable &table) const {
   return symbols;
 }
 
-std::string Expand::ToString() const {
+std::string Expand::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "Expand ({}){}[{}{}]{}({})",
       input_symbol_.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node_symbol.name());
 }
@@ -4216,7 +4220,7 @@ UniqueCursorPtr ExpandVariable::MakeCursor(utils::MemoryResource *mem,
   }
 }  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-std::string ExpandVariable::ToString() const {
+std::string ExpandVariable::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "{} ({}){}[{}{}]{}({})",
       OperatorName(),
@@ -4224,7 +4228,7 @@ std::string ExpandVariable::ToString() const {
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node_symbol.name());
 }
@@ -4517,7 +4521,7 @@ std::string Filter::SingleFilterName(FilterInfo const &single_filter) {
   }
 }
 
-std::string Filter::ToString() const {
+std::string Filter::ToString(const DbAccessor * /*dba*/) const {
   std::set<std::string, std::less<>> filter_names;
   for (const auto &filter : all_filters_) {
     filter_names.insert(SingleFilterName(filter));
@@ -4650,7 +4654,7 @@ std::unique_ptr<LogicalOperator> Produce::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string Produce::ToString() const {
+std::string Produce::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("Produce {{{}}}",
                      utils::IterableToString(named_expressions_, ", ", [](const auto &nexpr) { return nexpr->name_; }));
 }
@@ -6019,7 +6023,7 @@ std::unique_ptr<LogicalOperator> EdgeUniquenessFilter::Clone(AstStorage *storage
   return object;
 }
 
-std::string EdgeUniquenessFilter::ToString() const {
+std::string EdgeUniquenessFilter::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("EdgeUniquenessFilter {{{0} : {1}}}",
                      utils::IterableToString(previous_symbols_, ", ", [](const auto &sym) { return sym.name(); }),
                      expand_symbol_.name());
@@ -6936,7 +6940,7 @@ std::unique_ptr<LogicalOperator> Aggregate::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string Aggregate::ToString() const {
+std::string Aggregate::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("Aggregate {{{0}}} {{{1}}}",
                      utils::IterableToString(
                          aggregations_,
@@ -7099,7 +7103,7 @@ std::unique_ptr<LogicalOperator> OrderBy::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string OrderBy::ToString() const {
+std::string OrderBy::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("OrderBy {{{}}}",
                      utils::IterableToString(output_symbols_, ", ", [](const auto &sym) { return sym.name(); }));
 }
@@ -7642,7 +7646,7 @@ std::unique_ptr<LogicalOperator> Union::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string Union::ToString() const {
+std::string Union::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("Union {{{0} : {1}}}",
                      utils::IterableToString(left_symbols_, ", ", [](const auto &sym) { return sym.name(); }),
                      utils::IterableToString(right_symbols_, ", ", [](const auto &sym) { return sym.name(); }));
@@ -8271,7 +8275,7 @@ std::unique_ptr<LogicalOperator> CallProcedure::Clone(AstStorage *storage) const
   return object;
 }
 
-std::string CallProcedure::ToString() const {
+std::string CallProcedure::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("CallProcedure<{0}> {{{1}}}",
                      procedure_name_,
                      utils::IterableToString(result_symbols_, ", ", [](const auto &sym) { return sym.name(); }));
@@ -8476,7 +8480,9 @@ std::unique_ptr<LogicalOperator> LoadCsv::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string LoadCsv::ToString() const { return fmt::format("LoadCsv {{{}}}", row_var_.name()); };
+std::string LoadCsv::ToString(const DbAccessor * /*dba*/) const {
+  return fmt::format("LoadCsv {{{}}}", row_var_.name());
+};
 
 LoadParquet::LoadParquet(std::shared_ptr<LogicalOperator> input, Expression *file,
                          std::unordered_map<Expression *, Expression *> config_map, Symbol row_var)
@@ -8592,7 +8598,9 @@ std::unique_ptr<LogicalOperator> LoadParquet::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string LoadParquet::ToString() const { return fmt::format("LoadParquet {{{}}}", row_var_.name()); }
+std::string LoadParquet::ToString(const DbAccessor * /*dba*/) const {
+  return fmt::format("LoadParquet {{{}}}", row_var_.name());
+}
 
 LoadJsonl::LoadJsonl(std::shared_ptr<LogicalOperator> input, Expression *file,
                      std::unordered_map<Expression *, Expression *> config_map, Symbol row_var)
@@ -8701,7 +8709,9 @@ std::unique_ptr<LogicalOperator> LoadJsonl::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string LoadJsonl::ToString() const { return fmt::format("LoadJsonl {{{}}}", row_var_.name()); }
+std::string LoadJsonl::ToString(const DbAccessor * /*dba*/) const {
+  return fmt::format("LoadJsonl {{{}}}", row_var_.name());
+}
 
 class ForeachCursor : public Cursor {
  public:
@@ -9099,7 +9109,7 @@ std::unique_ptr<LogicalOperator> HashJoin::Clone(AstStorage *storage) const {
   return object;
 }
 
-std::string HashJoin::ToString() const {
+std::string HashJoin::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("HashJoin {{{} : {}}}",
                      utils::IterableToString(left_symbols_, ", ", [](const auto &sym) { return sym.name(); }),
                      utils::IterableToString(right_symbols_, ", ", [](const auto &sym) { return sym.name(); }));
@@ -9465,10 +9475,10 @@ UniqueCursorPtr ScanAllByPointDistance::MakeCursor(utils::MemoryResource *mem,
                                                                 "ScanAllByPointDistance");
 }
 
-std::string ScanAllByPointDistance::ToString() const {
+std::string ScanAllByPointDistance::ToString(const DbAccessor *dba) const {
   auto const &name = output_symbol_.name();
-  auto const &label = dba_->LabelToName(label_);
-  auto const property = dba_->PropertyToName(property_);
+  auto const &label = dba->LabelToName(label_);
+  auto const property = dba->PropertyToName(property_);
   return fmt::format("ScanAllByPointDistance ({0} :{1} {{{2}}})", name, label, property);
 }
 
@@ -9532,10 +9542,10 @@ UniqueCursorPtr ScanAllByPointWithinbbox::MakeCursor(utils::MemoryResource *mem,
                                                                 "ScanAllByPointWithinbbox");
 }
 
-std::string ScanAllByPointWithinbbox::ToString() const {
+std::string ScanAllByPointWithinbbox::ToString(const DbAccessor *dba) const {
   auto const &name = output_symbol_.name();
-  auto const &label = dba_->LabelToName(label_);
-  auto const property = dba_->PropertyToName(property_);
+  auto const &label = dba->LabelToName(label_);
+  auto const property = dba->PropertyToName(property_);
   return fmt::format("ScanAllByPointWithinbbox ({0} :{1} {{{2}}})", name, label, property);
 }
 
@@ -9573,7 +9583,7 @@ query::plan::NodeCreationInfo query::plan::NodeCreationInfo::Clone(query::AstSto
   return object;
 }
 
-std::string query::plan::LogicalOperator::ToString() const { return GetTypeInfo().name; }
+std::string query::plan::LogicalOperator::ToString(const DbAccessor * /*dba*/) const { return GetTypeInfo().name; }
 
 query::plan::EdgeCreationInfo query::plan::EdgeCreationInfo::Clone(query::AstStorage *storage) const {
   EdgeCreationInfo object;
@@ -9639,7 +9649,9 @@ UniqueCursorPtr ScanChunk::MakeCursor(utils::MemoryResource *mem,
       mem, *this, output_symbol_, input_->MakeCursor(mem, metric_handles), view_, std::move(vertices), "ScanChunk");
 }
 
-std::string ScanChunk::ToString() const { return fmt::format("ScanChunk ({})", output_symbol_.name()); }
+std::string ScanChunk::ToString(const DbAccessor * /*dba*/) const {
+  return fmt::format("ScanChunk ({})", output_symbol_.name());
+}
 
 std::unique_ptr<LogicalOperator> ScanChunk::Clone(AstStorage *storage) const {
   auto object = std::make_unique<ScanChunk>();
@@ -9682,14 +9694,14 @@ std::vector<Symbol> ScanChunkByEdge::ModifiedSymbols(const SymbolTable &table) c
   return symbols;
 }
 
-std::string ScanChunkByEdge::ToString() const {
+std::string ScanChunkByEdge::ToString(const DbAccessor *dba) const {
   return fmt::format(
       "ScanChunkByEdge ({}){}[{}{}]{}({})",
       common_.node1_symbol.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
       utils::IterableToString(
-          common_.edge_types, "|", [this](const auto &edge_type) { return ":" + dba_->EdgeTypeToName(edge_type); }),
+          common_.edge_types, "|", [dba](const auto &edge_type) { return ":" + dba->EdgeTypeToName(edge_type); }),
       common_.direction == query::EdgeAtom::Direction::OUT ? "->" : "-",
       common_.node2_symbol.name());
 }
@@ -9805,7 +9817,9 @@ ScanParallel::ScanParallel(const std::shared_ptr<LogicalOperator> &input, storag
 
 ACCEPT_WITH_INPUT(ScanParallel)
 
-std::string ScanParallel::ToString() const { return fmt::format("ScanParallel (threads: {})", num_threads_); }
+std::string ScanParallel::ToString(const DbAccessor * /*dba*/) const {
+  return fmt::format("ScanParallel (threads: {})", num_threads_);
+}
 
 std::unique_ptr<LogicalOperator> ScanParallel::Clone(AstStorage *storage) const {
   auto object = std::make_unique<ScanParallel>();
@@ -9838,8 +9852,8 @@ UniqueCursorPtr ScanParallelByLabel::MakeCursor(utils::MemoryResource *mem,
 #endif
 }
 
-std::string ScanParallelByLabel::ToString() const {
-  return fmt::format("ScanParallelByLabel (threads: {}, :{})", num_threads_, dba_->LabelToName(label_));
+std::string ScanParallelByLabel::ToString(const DbAccessor *dba) const {
+  return fmt::format("ScanParallelByLabel (threads: {}, :{})", num_threads_, dba->LabelToName(label_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByLabel::Clone(AstStorage *storage) const {
@@ -9874,8 +9888,8 @@ UniqueCursorPtr ScanParallelByEdgeType::MakeCursor(utils::MemoryResource *mem,
 #endif
 }
 
-std::string ScanParallelByEdgeType::ToString() const {
-  return fmt::format("ScanParallelByEdgeType (threads: {}, -[:{}]-)", num_threads_, dba_->EdgeTypeToName(edge_type_));
+std::string ScanParallelByEdgeType::ToString(const DbAccessor *dba) const {
+  return fmt::format("ScanParallelByEdgeType (threads: {}, -[:{}]-)", num_threads_, dba->EdgeTypeToName(edge_type_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByEdgeType::Clone(AstStorage *storage) const {
@@ -9928,18 +9942,18 @@ UniqueCursorPtr ScanParallelByLabelProperties::MakeCursor(utils::MemoryResource 
 #endif
 }
 
-std::string ScanParallelByLabelProperties::ToString() const {
+std::string ScanParallelByLabelProperties::ToString(const DbAccessor *dba) const {
   auto const property_names =
       properties_ | rv::transform([&](storage::PropertyPath const &property_path) {
         return utils::Join(
-            property_path | rv::transform([&](storage::PropertyId prop) { return dba_->PropertyToName(prop); }), ".");
+            property_path | rv::transform([&](storage::PropertyId prop) { return dba->PropertyToName(prop); }), ".");
       }) |
       ranges::to_vector;
   auto const properties_stringified = utils::Join(property_names, ", ");
   std::string_view suffix = index_order_ == storage::IndexOrder::DESC ? " (DESC)" : "";
   return fmt::format("ScanParallelByLabelProperties (threads: {0}, :{1} {{{2}}}){3}",
                      num_threads_,
-                     dba_->LabelToName(label_),
+                     dba->LabelToName(label_),
                      properties_stringified,
                      suffix);
 }
@@ -9983,11 +9997,11 @@ UniqueCursorPtr ScanParallelByEdgeTypeProperty::MakeCursor(utils::MemoryResource
 #endif
 }
 
-std::string ScanParallelByEdgeTypeProperty::ToString() const {
+std::string ScanParallelByEdgeTypeProperty::ToString(const DbAccessor *dba) const {
   return fmt::format("ScanParallelByEdgeTypeProperty (threads: {}, -[:{}]- {{{}}})",
                      num_threads_,
-                     dba_->EdgeTypeToName(edge_type_),
-                     dba_->PropertyToName(property_));
+                     dba->EdgeTypeToName(edge_type_),
+                     dba->PropertyToName(property_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByEdgeTypeProperty::Clone(AstStorage *storage) const {
@@ -10032,11 +10046,11 @@ UniqueCursorPtr ScanParallelByEdgeTypePropertyRange::MakeCursor(utils::MemoryRes
 #endif
 }
 
-std::string ScanParallelByEdgeTypePropertyRange::ToString() const {
+std::string ScanParallelByEdgeTypePropertyRange::ToString(const DbAccessor *dba) const {
   return fmt::format("ScanParallelByEdgeTypePropertyRange (threads: {}, -[:{}]- {{{}}})",
                      num_threads_,
-                     dba_->EdgeTypeToName(edge_type_),
-                     dba_->PropertyToName(property_));
+                     dba->EdgeTypeToName(edge_type_),
+                     dba->PropertyToName(property_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByEdgeTypePropertyRange::Clone(AstStorage *storage) const {
@@ -10081,9 +10095,9 @@ UniqueCursorPtr ScanParallelByEdgeProperty::MakeCursor(utils::MemoryResource *me
 #endif
 }
 
-std::string ScanParallelByEdgeProperty::ToString() const {
+std::string ScanParallelByEdgeProperty::ToString(const DbAccessor *dba) const {
   return fmt::format(
-      "ScanParallelByEdgeProperty (threads: {}, -[]- {{{}}})", num_threads_, dba_->PropertyToName(property_));
+      "ScanParallelByEdgeProperty (threads: {}, -[]- {{{}}})", num_threads_, dba->PropertyToName(property_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByEdgeProperty::Clone(AstStorage *storage) const {
@@ -10121,9 +10135,9 @@ UniqueCursorPtr ScanParallelByEdgePropertyValue::MakeCursor(utils::MemoryResourc
 #endif
 }
 
-std::string ScanParallelByEdgePropertyValue::ToString() const {
+std::string ScanParallelByEdgePropertyValue::ToString(const DbAccessor *dba) const {
   return fmt::format(
-      "ScanParallelByEdgePropertyValue (threads: {}, -[]- {{{}}})", num_threads_, dba_->PropertyToName(property_));
+      "ScanParallelByEdgePropertyValue (threads: {}, -[]- {{{}}})", num_threads_, dba->PropertyToName(property_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByEdgePropertyValue::Clone(AstStorage *storage) const {
@@ -10168,9 +10182,9 @@ UniqueCursorPtr ScanParallelByEdgePropertyRange::MakeCursor(utils::MemoryResourc
 #endif
 }
 
-std::string ScanParallelByEdgePropertyRange::ToString() const {
+std::string ScanParallelByEdgePropertyRange::ToString(const DbAccessor *dba) const {
   return fmt::format(
-      "ScanParallelByEdgePropertyRange (threads: {}, -[]- {{{}}})", num_threads_, dba_->PropertyToName(property_));
+      "ScanParallelByEdgePropertyRange (threads: {}, -[]- {{{}}})", num_threads_, dba->PropertyToName(property_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByEdgePropertyRange::Clone(AstStorage *storage) const {
@@ -10211,7 +10225,7 @@ UniqueCursorPtr ScanParallelByEdge::MakeCursor(utils::MemoryResource * /*mem*/,
 #endif
 }
 
-std::string ScanParallelByEdge::ToString() const {
+std::string ScanParallelByEdge::ToString(const DbAccessor * /*dba*/) const {
   return fmt::format("ScanParallelByEdge (threads: {}, ({}){}[{}]{}({}))",
                      num_threads_,
                      node1_symbol_.name(),
@@ -10269,11 +10283,11 @@ UniqueCursorPtr ScanParallelByEdgeTypePropertyValue::MakeCursor(utils::MemoryRes
 #endif
 }
 
-std::string ScanParallelByEdgeTypePropertyValue::ToString() const {
+std::string ScanParallelByEdgeTypePropertyValue::ToString(const DbAccessor *dba) const {
   return fmt::format("ScanParallelByEdgeTypePropertyValue (threads: {}, -[:{}]- {{{}}})",
                      num_threads_,
-                     dba_->EdgeTypeToName(edge_type_),
-                     dba_->PropertyToName(property_));
+                     dba->EdgeTypeToName(edge_type_),
+                     dba->PropertyToName(property_));
 }
 
 std::unique_ptr<LogicalOperator> ScanParallelByEdgeTypePropertyValue::Clone(AstStorage *storage) const {
@@ -10296,7 +10310,7 @@ ParallelMerge::ParallelMerge(const std::shared_ptr<LogicalOperator> &input) : in
 
 ACCEPT_WITH_INPUT(ParallelMerge)
 
-std::string ParallelMerge::ToString() const { return "ParallelMerge"; }
+std::string ParallelMerge::ToString(const DbAccessor * /*dba*/) const { return "ParallelMerge"; }
 
 std::unique_ptr<LogicalOperator> ParallelMerge::Clone(AstStorage *storage) const {
   auto object = std::make_unique<ParallelMerge>();

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -220,8 +220,7 @@ class HierarchicalLogicalOperatorVisitor : public LogicalOperatorCompositeVisito
 
 class NamedLogicalOperator {
  public:
-  mutable const DbAccessor *dba_{nullptr};
-  virtual std::string ToString() const = 0;
+  virtual std::string ToString(const DbAccessor *dba) const = 0;
   virtual ~NamedLogicalOperator() = default;
 
  protected:
@@ -314,7 +313,7 @@ class LogicalOperator : public utils::Visitable<HierarchicalLogicalOperatorVisit
     std::vector<std::shared_ptr<LogicalOperator>> loaded_ops;
   };
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   virtual std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const = 0;
 
@@ -519,7 +518,7 @@ class CreateExpand : public memgraph::query::plan::LogicalOperator {
   /// if the given node atom refers to an existing node (either matched or created)
   bool existing_node_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
@@ -583,7 +582,7 @@ class ScanAll : public memgraph::query::plan::LogicalOperator {
   /// transaction sees along with their modifications.
   storage::View view_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -607,7 +606,7 @@ class ScanAllByLabel : public memgraph::query::plan::ScanAll {
 
   storage::LabelId label_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -644,7 +643,7 @@ class ScanAllByEdge : public memgraph::query::plan::ScanAll {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::EdgeTypeId GetEdgeType() { return common_.edge_types[0]; }
 
@@ -672,7 +671,7 @@ class ScanAllByEdgeType : public memgraph::query::plan::ScanAllByEdge {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -696,7 +695,7 @@ class ScanAllByEdgeTypeProperty : public memgraph::query::plan::ScanAllByEdge {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::PropertyId property_;
 
@@ -723,7 +722,7 @@ class ScanAllByEdgeTypePropertyValue : public memgraph::query::plan::ScanAllByEd
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::PropertyId property_;
   Expression *expression_;
@@ -754,7 +753,7 @@ class ScanAllByEdgeTypePropertyRange : public memgraph::query::plan::ScanAllByEd
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::PropertyId property_;
   std::optional<Bound> lower_bound_;
@@ -782,7 +781,7 @@ class ScanAllByEdgeProperty : public memgraph::query::plan::ScanAllByEdge {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::PropertyId property_;
 
@@ -808,7 +807,7 @@ class ScanAllByEdgePropertyValue : public memgraph::query::plan::ScanAllByEdge {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::PropertyId property_;
   Expression *expression_;
@@ -839,7 +838,7 @@ class ScanAllByEdgePropertyRange : public memgraph::query::plan::ScanAllByEdge {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::PropertyId property_;
   std::optional<Bound> lower_bound_;
@@ -882,7 +881,7 @@ class ScanAllByLabelProperties : public memgraph::query::plan::ScanAll {
   std::vector<ExpressionRange> expression_ranges_;
   storage::IndexOrder index_order_{storage::IndexOrder::ASC};
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -905,7 +904,7 @@ class ScanAllById : public memgraph::query::plan::ScanAll {
   /// True if the id value is a string (elementId) rather than a number (id).
   bool expects_string_id_{false};
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -929,7 +928,7 @@ class ScanAllByEdgeId : public memgraph::query::plan::ScanAllByEdge {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   Expression *expression_;
   /// True if the id value is a string (elementId) rather than a number (id).
@@ -951,7 +950,7 @@ class ScanAllByPointDistance : public memgraph::query::plan::ScanAll {
 
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::LabelId label_;
   storage::PropertyId property_;
@@ -975,7 +974,7 @@ class ScanAllByPointWithinbbox : public memgraph::query::plan::ScanAll {
 
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   storage::LabelId label_;
   storage::PropertyId property_;
@@ -1097,7 +1096,7 @@ class Expand : public memgraph::query::plan::LogicalOperator {
   /// State from which the input node should get expanded.
   storage::View view_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -1206,7 +1205,7 @@ class ExpandVariable : public memgraph::query::plan::LogicalOperator {
 
   std::string_view OperatorName() const;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
@@ -1284,7 +1283,7 @@ class Filter : public memgraph::query::plan::LogicalOperator {
 
   static std::string SingleFilterName(const query::plan::FilterInfo &single_filter);
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
@@ -1335,7 +1334,7 @@ class Produce : public memgraph::query::plan::LogicalOperator {
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
   std::vector<NamedExpression *> named_expressions_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
@@ -1753,7 +1752,7 @@ class EdgeUniquenessFilter : public memgraph::query::plan::LogicalOperator {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
   Symbol expand_symbol_;
@@ -1917,7 +1916,7 @@ class Aggregate : public memgraph::query::plan::LogicalOperator {
   std::vector<Expression *> group_by_;
   std::vector<Symbol> remember_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -1942,7 +1941,7 @@ class ParallelMerge : public memgraph::query::plan::LogicalOperator {
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *mem, metrics::DatabaseMetricHandles &metric_handles) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   std::shared_ptr<LogicalOperator> input_;
@@ -1973,7 +1972,7 @@ class AggregateParallel : public memgraph::query::plan::LogicalOperator {
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
   size_t num_threads_;
 
-  std::string ToString() const override { return "AggregateParallel"; }
+  std::string ToString(const DbAccessor * /*dba*/) const override { return "AggregateParallel"; }
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override {
     auto object = std::make_unique<AggregateParallel>();
@@ -2010,7 +2009,7 @@ class OrderByParallel : public memgraph::query::plan::LogicalOperator {
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
   size_t num_threads_;
 
-  std::string ToString() const override { return "OrderByParallel"; }
+  std::string ToString(const DbAccessor * /*dba*/) const override { return "OrderByParallel"; }
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override {
     auto object = std::make_unique<OrderByParallel>();
@@ -2046,7 +2045,7 @@ class ScanParallel : public memgraph::query::plan::LogicalOperator {
 #endif
   }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   std::shared_ptr<LogicalOperator> input_;
@@ -2068,7 +2067,7 @@ class ScanParallelByLabel : public memgraph::query::plan::ScanParallel {
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::LabelId label_;
@@ -2087,7 +2086,7 @@ class ScanParallelByEdgeType : public memgraph::query::plan::ScanParallel {
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::EdgeTypeId edge_type_;
@@ -2109,7 +2108,7 @@ class ScanParallelByLabelProperties : public memgraph::query::plan::ScanParallel
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::LabelId label_;
@@ -2131,7 +2130,7 @@ class ScanParallelByEdgeTypeProperty : public memgraph::query::plan::ScanParalle
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::EdgeTypeId edge_type_;
@@ -2154,7 +2153,7 @@ class ScanParallelByEdgeTypePropertyRange : public memgraph::query::plan::ScanPa
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::EdgeTypeId edge_type_;
@@ -2176,7 +2175,7 @@ class ScanParallelByEdgeProperty : public memgraph::query::plan::ScanParallel {
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::PropertyId property_;
@@ -2195,7 +2194,7 @@ class ScanParallelByEdgePropertyValue : public memgraph::query::plan::ScanParall
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::PropertyId property_;
@@ -2217,7 +2216,7 @@ class ScanParallelByEdgePropertyRange : public memgraph::query::plan::ScanParall
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::PropertyId property_;
@@ -2239,7 +2238,7 @@ class ScanParallelByEdge : public memgraph::query::plan::ScanParallel {
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   Symbol edge_symbol_;
@@ -2262,7 +2261,7 @@ class ScanParallelByEdgeTypePropertyValue : public memgraph::query::plan::ScanPa
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   storage::EdgeTypeId edge_type_;
@@ -2282,7 +2281,7 @@ class ScanChunk : public memgraph::query::plan::ScanAll {
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
  private:
@@ -2309,7 +2308,7 @@ class ScanChunkByEdge : public memgraph::query::plan::ScanAllByEdge {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
  private:
@@ -2508,7 +2507,7 @@ class OrderBy : public memgraph::query::plan::LogicalOperator {
   std::vector<Symbol> output_symbols_;
   bool parallel_execution_{false};  // When true, OrderByCursor keeps order_by_cache_ for OrderByParallel merge
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -2722,7 +2721,7 @@ class Union : public memgraph::query::plan::LogicalOperator {
   std::vector<Symbol> left_symbols_;
   std::vector<Symbol> right_symbols_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
@@ -2872,7 +2871,7 @@ class CallProcedure : public memgraph::query::plan::LogicalOperator {
   int64_t procedure_id_;
   bool void_procedure_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
@@ -2911,7 +2910,7 @@ class LoadCsv : public memgraph::query::plan::LogicalOperator {
   Symbol row_var_;
   std::unordered_map<Expression *, Expression *> config_map_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };
@@ -2936,7 +2935,7 @@ class LoadParquet : public memgraph::query::plan::LogicalOperator {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
@@ -2965,7 +2964,7 @@ class LoadJsonl : public memgraph::query::plan::LogicalOperator {
 
   void set_input(std::shared_ptr<LogicalOperator> input) override { input_ = input; }
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
@@ -3122,7 +3121,7 @@ class HashJoin : public memgraph::query::plan::LogicalOperator {
   std::vector<Symbol> right_symbols_;
   EqualOperator *hash_join_condition_;
 
-  std::string ToString() const override;
+  std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -356,18 +356,10 @@ PlanPrinter::PlanPrinter(const DbAccessor *dba, std::ostream *out) : dba_(dba), 
     return true;                                                             \
   }
 
-#define PRE_VISIT_TS(TOp)                                                                  \
-  bool PlanPrinter::PreVisit(TOp &op) {                                                    \
-    WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(); }); \
-    return true;                                                                           \
-  }
-
-#define PRE_VISIT_DBA_TS(TOp)                                                              \
-  bool PlanPrinter::PreVisit(TOp &op) {                                                    \
-    op.dba_ = dba_;                                                                        \
-    WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(); }); \
-    op.dba_ = nullptr;                                                                     \
-    return true;                                                                           \
+#define PRE_VISIT_TS(TOp)                                                                      \
+  bool PlanPrinter::PreVisit(TOp &op) {                                                        \
+    WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(dba_); }); \
+    return true;                                                                               \
   }
 
 #define PRE_VISIT_IGNORE(TOp) \
@@ -375,24 +367,24 @@ PlanPrinter::PlanPrinter(const DbAccessor *dba, std::ostream *out) : dba_(dba), 
 // NOLINTEND(bugprone-macro-parentheses,cppcoreguidelines-macro-usage)
 
 PRE_VISIT(CreateNode);
-PRE_VISIT_DBA_TS(CreateExpand);
+PRE_VISIT_TS(CreateExpand);
 PRE_VISIT(Delete);
 
 PRE_VISIT_TS(ScanAll);
-PRE_VISIT_DBA_TS(ScanAllByLabel);
-PRE_VISIT_DBA_TS(ScanAllByLabelProperties);
+PRE_VISIT_TS(ScanAllByLabel);
+PRE_VISIT_TS(ScanAllByLabelProperties);
 PRE_VISIT_TS(ScanAllById);
-PRE_VISIT_DBA_TS(ScanAllByEdge);
-PRE_VISIT_DBA_TS(ScanAllByEdgeType);
-PRE_VISIT_DBA_TS(ScanAllByEdgeTypeProperty);
-PRE_VISIT_DBA_TS(ScanAllByEdgeTypePropertyValue);
-PRE_VISIT_DBA_TS(ScanAllByEdgeTypePropertyRange);
-PRE_VISIT_DBA_TS(ScanAllByEdgeProperty);
-PRE_VISIT_DBA_TS(ScanAllByEdgePropertyValue);
-PRE_VISIT_DBA_TS(ScanAllByEdgePropertyRange);
-PRE_VISIT_DBA_TS(ScanAllByEdgeId);
-PRE_VISIT_DBA_TS(ScanAllByPointDistance);
-PRE_VISIT_DBA_TS(ScanAllByPointWithinbbox);
+PRE_VISIT_TS(ScanAllByEdge);
+PRE_VISIT_TS(ScanAllByEdgeType);
+PRE_VISIT_TS(ScanAllByEdgeTypeProperty);
+PRE_VISIT_TS(ScanAllByEdgeTypePropertyValue);
+PRE_VISIT_TS(ScanAllByEdgeTypePropertyRange);
+PRE_VISIT_TS(ScanAllByEdgeProperty);
+PRE_VISIT_TS(ScanAllByEdgePropertyValue);
+PRE_VISIT_TS(ScanAllByEdgePropertyRange);
+PRE_VISIT_TS(ScanAllByEdgeId);
+PRE_VISIT_TS(ScanAllByPointDistance);
+PRE_VISIT_TS(ScanAllByPointWithinbbox);
 
 namespace {
 std::string ScanChunkToString(const auto &op, const DbAccessor *dba) {
@@ -402,9 +394,7 @@ std::string ScanChunkToString(const auto &op, const DbAccessor *dba) {
   if (!node) {
     throw std::runtime_error("ScanChunk must be connected to a ScanParallel variant");
   }
-  node->dba_ = dba;
-  auto name = node->ToString();
-  node->dba_ = nullptr;
+  auto name = node->ToString(dba);
   name.replace(name.find("Parallel"), strlen("Parallel"), "All");
   name.insert(name.find('(') + 1, op.output_symbol_.name() + ", ");
   return name;
@@ -453,8 +443,8 @@ bool PlanPrinter::PreVisit(ParallelMerge & /*unused*/) {
   return true;
 }
 
-PRE_VISIT_DBA_TS(Expand);
-PRE_VISIT_DBA_TS(ExpandVariable);
+PRE_VISIT_TS(Expand);
+PRE_VISIT_TS(ExpandVariable);
 PRE_VISIT_TS(Produce);
 
 PRE_VISIT(ConstructNamedPath);
@@ -495,14 +485,14 @@ PRE_VISIT(Unwind);
 PRE_VISIT(Distinct);
 
 bool PlanPrinter::PreVisit(query::plan::Union &op) {
-  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(); });
+  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(dba_); });
   Branch(*op.right_op_);
   op.left_op_->Accept(*this);
   return false;
 }
 
 bool PlanPrinter::PreVisit(query::plan::RollUpApply &op) {
-  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(); });
+  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(dba_); });
   Branch(*op.list_collection_branch_);
   op.input_->Accept(*this);
   return false;
@@ -517,7 +507,7 @@ PRE_VISIT_TS(LoadCsv);
 PRE_VISIT_TS(LoadParquet);
 
 bool PlanPrinter::PreVisit(query::plan::LoadJsonl &op) {
-  WithPrintLn([&op](auto &out) { out << "* " << op.ToString(); });
+  WithPrintLn([this, &op](auto &out) { out << "* " << op.ToString(dba_); });
   return true;
 }
 
@@ -540,7 +530,7 @@ bool PlanPrinter::PreVisit(query::plan::Cartesian &op) {
 }
 
 bool PlanPrinter::PreVisit(query::plan::HashJoin &op) {
-  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(); });
+  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(dba_); });
   Branch(*op.right_op_);
   op.left_op_->Accept(*this);
   return false;
@@ -554,7 +544,7 @@ bool PlanPrinter::PreVisit(query::plan::Foreach &op) {
 }
 
 bool PlanPrinter::PreVisit(query::plan::Filter &op) {
-  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(); });
+  WithPrintLn([this, &op](auto &out) { out << StartSymbol() << " " << op.ToString(dba_); });
   for (const auto &pattern_filter : op.pattern_filters_) {
     Branch(*pattern_filter);
   }
@@ -587,7 +577,6 @@ bool PlanPrinter::PreVisit(query::plan::IndexedJoin &op) {
 
 #undef PRE_VISIT
 #undef PRE_VISIT_TS
-#undef PRE_VISIT_DBA_TS
 #undef PRE_VISIT_IGNORE
 
 bool PlanPrinter::DefaultPreVisit() {

--- a/src/query/plan/rewrite/parallel_rewrite.hpp
+++ b/src/query/plan/rewrite/parallel_rewrite.hpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <memory>
 #include <set>
+#include <string>
 #include <vector>
 #include "context.hpp"
 #include "flags/bolt.hpp"
@@ -354,7 +355,7 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
       } else if (dynamic_cast<OutputTableStream *>(scan_parent) != nullptr) {
         return failure("OutputTableStream operator cannot be a parent of a scan");
       } else {
-        return failure("Unsupported operator in parallel chain" + scan_parent->ToString());
+        return failure(std::string{"Unsupported operator in parallel chain: "} + scan_parent->GetTypeInfo().name);
       }
     }
 
@@ -370,7 +371,7 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
       } else if (auto *distinct_op = dynamic_cast<Distinct *>(update_op)) {
         distinct_op->parallel_execution_.emplace(num_threads_);
       } else {
-        return failure("Unsupported operator in parallel chain " + update_op->ToString());
+        return failure(std::string{"Unsupported operator in parallel chain: "} + update_op->GetTypeInfo().name);
       }
     }
 
@@ -427,7 +428,8 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
         } else if (cartesian_op->right_op_.get() == original_op) {
           cartesian_op->right_op_ = create_parallel_op(cartesian_op->right_op_);
         } else {
-          throw std::runtime_error("Unsupported operator in operator chain: " + current->ToString());
+          throw std::runtime_error(std::string{"Unsupported operator in operator chain: "} +
+                                   current->GetTypeInfo().name);
         }
       } else if (auto *hash_join_op = dynamic_cast<HashJoin *>(current)) {
         if (hash_join_op->left_op_.get() == original_op) {
@@ -435,7 +437,8 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
         } else if (hash_join_op->right_op_.get() == original_op) {
           hash_join_op->right_op_ = create_parallel_op(hash_join_op->right_op_);
         } else {
-          throw std::runtime_error("Unsupported operator in operator chain: " + current->ToString());
+          throw std::runtime_error(std::string{"Unsupported operator in operator chain: "} +
+                                   current->GetTypeInfo().name);
         }
       } else if (auto *indexed_join_op = dynamic_cast<IndexedJoin *>(current)) {
         if (indexed_join_op->main_branch_.get() == original_op) {
@@ -443,7 +446,8 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
         } else if (indexed_join_op->sub_branch_.get() == original_op) {
           indexed_join_op->sub_branch_ = create_parallel_op(indexed_join_op->sub_branch_);
         } else {
-          throw std::runtime_error("Unsupported operator in operator chain: " + current->ToString());
+          throw std::runtime_error(std::string{"Unsupported operator in operator chain: "} +
+                                   current->GetTypeInfo().name);
         }
       } else if (auto *rollup_apply_op = dynamic_cast<RollUpApply *>(current)) {
         if (rollup_apply_op->input_.get() == original_op) {
@@ -451,10 +455,11 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
         } else if (rollup_apply_op->list_collection_branch_.get() == original_op) {
           rollup_apply_op->list_collection_branch_ = create_parallel_op(rollup_apply_op->list_collection_branch_);
         } else {
-          throw std::runtime_error("Unsupported operator in operator chain: " + current->ToString());
+          throw std::runtime_error(std::string{"Unsupported operator in operator chain: "} +
+                                   current->GetTypeInfo().name);
         }
       } else {
-        throw std::runtime_error("Unsupported operator in operator chain: " + current->ToString());
+        throw std::runtime_error(std::string{"Unsupported operator in operator chain: "} + current->GetTypeInfo().name);
       }
     }
   }
@@ -725,7 +730,7 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
         spdlog::error(
             "Unsupported operator in operator chain: {}. Please contact Memgraph support as this scenario should not "
             "happen!",
-            current->ToString());
+            current->GetTypeInfo().name);
         return false;
       }
     }
@@ -868,7 +873,7 @@ class ParallelRewriter final : public HierarchicalLogicalOperatorVisitor {
           spdlog::error(
               "Unsupported operator in operator chain: {}. Please contact Memgraph support as this scenario should not "
               "happen!",
-              current->ToString());
+              current->GetTypeInfo().name);
           return false;
         }
 

--- a/src/query/plan/scoped_profile.hpp
+++ b/src/query/plan/scoped_profile.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -36,9 +36,7 @@ class ScopedProfile {
     if (!root_) {
       stats_ = &context_->stats;
       stats_->key = key;
-      op.dba_ = context->db_accessor;
-      stats_->name = op.ToString();
-      op.dba_ = nullptr;
+      stats_->name = op.ToString(context->db_accessor);
     } else {
       stats_ = nullptr;
 
@@ -50,9 +48,7 @@ class ScopedProfile {
         root_->children.emplace_back();
         stats_ = &root_->children.back();
         stats_->key = key;
-        op.dba_ = context->db_accessor;
-        stats_->name = op.ToString();
-        op.dba_ = nullptr;
+        stats_->name = op.ToString(context->db_accessor);
       } else {
         stats_ = &(*it);
       }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -269,6 +269,11 @@ add_unit_test(transaction_queue_multiple
     LINK_TARGETS mg-communication mg-query mg-glue disk_test_utils
 )
 
+add_unit_test(query_plan_printer_race
+    SOURCES query_plan_printer_race.cpp
+    LINK_TARGETS mg-communication mg-query mg-glue disk_test_utils
+)
+
 
 # Test query functions
 add_unit_test(query_function_mgp_module

--- a/tests/unit/query_plan_operator_to_string.cpp
+++ b/tests/unit/query_plan_operator_to_string.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(OperatorToStringTest, Once) {
   last_op = std::make_shared<Once>();
 
   std::string expected_string{"Once"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, CreateNode) {
@@ -79,7 +79,7 @@ TYPED_TEST(OperatorToStringTest, CreateNode) {
                                                      {this->dba.NameToProperty("prop2"), LITERAL("some cool stuff")}}});
 
   std::string expected_string{"CreateNode"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, CreateExpand) {
@@ -97,10 +97,9 @@ TYPED_TEST(OperatorToStringTest, CreateExpand) {
       last_op,
       node1_sym,
       false);
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"CreateExpand (node1)-[edge:edge_type]->(node2)"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAll) {
@@ -108,16 +107,15 @@ TYPED_TEST(OperatorToStringTest, ScanAll) {
   last_op = std::make_shared<ScanAll>(nullptr, this->GetSymbol("node"));
 
   std::string expected_string{"ScanAll (node)"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabel) {
   std::shared_ptr<LogicalOperator> last_op;
   last_op = std::make_shared<ScanAllByLabel>(nullptr, this->GetSymbol("node"), this->dba.NameToLabel("Label"));
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabel (node :Label)"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelProperties_OverARange) {
@@ -129,10 +127,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelProperties_OverARange) {
       std::vector{ms::PropertyPath{this->dba.NameToProperty("prop")}},
       std::vector{ExpressionRange::Range(memgraph::utils::MakeBoundInclusive<Expression *>(LITERAL(1)),
                                          memgraph::utils::MakeBoundExclusive<Expression *>(LITERAL(20)))});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {prop})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelProperties_Value) {
@@ -143,10 +140,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelProperties_Value) {
                                                  this->dba.NameToLabel("Label"),
                                                  std::vector{ms::PropertyPath{this->dba.NameToProperty("prop")}},
                                                  std::vector{ExpressionRange::Equal(ADD(LITERAL(21), LITERAL(21)))});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {prop})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelProperty) {
@@ -156,10 +152,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelProperty) {
                                                        this->dba.NameToLabel("Label"),
                                                        std::vector{ms::PropertyPath{this->dba.NameToProperty("prop")}},
                                                        std::vector{ExpressionRange::IsNotNull()});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {prop})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelCompositeProperties_OverARange) {
@@ -173,10 +168,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelCompositeProperties_OverARange) {
                   ms::PropertyPath{this->dba.NameToProperty("third")}},
       std::vector{ExpressionRange::Range(memgraph::utils::MakeBoundInclusive<Expression *>(LITERAL(1)),
                                          memgraph::utils::MakeBoundExclusive<Expression *>(LITERAL(20)))});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {first, second, third})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelCompositeProperties_Value) {
@@ -189,10 +183,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelCompositeProperties_Value) {
                                                              ms::PropertyPath{this->dba.NameToProperty("second")},
                                                              ms::PropertyPath{this->dba.NameToProperty("third")}},
                                                  std::vector{ExpressionRange::Equal(ADD(LITERAL(21), LITERAL(21)))});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {first, second, third})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelCompositeProperty) {
@@ -204,10 +197,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelCompositeProperty) {
                                                                    ms::PropertyPath{this->dba.NameToProperty("second")},
                                                                    ms::PropertyPath{this->dba.NameToProperty("third")}},
                                                        std::vector{ExpressionRange::IsNotNull()});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {first, second, third})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelNestedProperties_OverARange) {
@@ -220,10 +212,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelNestedProperties_OverARange) {
           this->dba.NameToProperty("first"), this->dba.NameToProperty("second"), this->dba.NameToProperty("third")}},
       std::vector{ExpressionRange::Range(memgraph::utils::MakeBoundInclusive<Expression *>(LITERAL(1)),
                                          memgraph::utils::MakeBoundExclusive<Expression *>(LITERAL(20)))});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {first.second.third})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelNestedProperties_Value) {
@@ -235,10 +226,9 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelNestedProperties_Value) {
       std::vector{ms::PropertyPath{
           this->dba.NameToProperty("first"), this->dba.NameToProperty("second"), this->dba.NameToProperty("third")}},
       std::vector{ExpressionRange::Equal(ADD(LITERAL(21), LITERAL(21)))});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {first.second.third})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllByLabelNestedProperty) {
@@ -250,19 +240,17 @@ TYPED_TEST(OperatorToStringTest, ScanAllByLabelNestedProperty) {
       std::vector{ms::PropertyPath{
           this->dba.NameToProperty("first"), this->dba.NameToProperty("second"), this->dba.NameToProperty("third")}},
       std::vector{ExpressionRange::IsNotNull()});
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllByLabelProperties (node :Label {first.second.third})"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ScanAllById) {
   std::shared_ptr<LogicalOperator> last_op;
   last_op = std::make_shared<ScanAllById>(nullptr, this->GetSymbol("node"), ADD(LITERAL(21), LITERAL(21)));
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"ScanAllById (node)"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Expand) {
@@ -277,10 +265,9 @@ TYPED_TEST(OperatorToStringTest, Expand) {
                                                                                 this->dba.NameToEdgeType("EdgeType2")},
                                      false,
                                      memgraph::storage::View::OLD);
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"Expand (node1)-[edge:EdgeType1|:EdgeType2]-(node2)"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ExpandVariable) {
@@ -305,10 +292,9 @@ TYPED_TEST(OperatorToStringTest, ExpandVariable) {
       std::nullopt,
       std::nullopt,
       nullptr);
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"BFSExpand (node1)-[edge:EdgeType1|:EdgeType2]->(node2)"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, KShortestExpand) {
@@ -336,10 +322,9 @@ TYPED_TEST(OperatorToStringTest, KShortestExpand) {
       std::nullopt,
       std::nullopt,
       nullptr);
-  last_op->dba_ = &this->dba;
 
   std::string expected_string{"KShortest (node1)-[edge:EdgeType1|:EdgeType2]->(node2)"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, ConstructNamedPath) {
@@ -370,7 +355,7 @@ TYPED_TEST(OperatorToStringTest, ConstructNamedPath) {
       last_op, this->GetSymbol("path"), std::vector<Symbol>{node1_sym, edge1_sym, node2_sym, edge2_sym, node3_sym});
 
   std::string expected_string{"ConstructNamedPath"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Filter) {
@@ -411,7 +396,7 @@ TYPED_TEST(OperatorToStringTest, Filter) {
 
   std::string expected_string{
       "Filter (:Customer:Visitor), (person :Customer:Visitor), Generic {person}, Pattern, id(person), {person.name}"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, FilterORExpressionsOnLabels1) {
@@ -430,7 +415,7 @@ TYPED_TEST(OperatorToStringTest, FilterORExpressionsOnLabels1) {
       last_op, std::vector<std::shared_ptr<LogicalOperator>>{}, LABELS_TEST(node_ident, labels), filters);
 
   std::string expected_string{"Filter (person :Customer|Visitor)"};
-  auto op_string = last_op->ToString();
+  auto op_string = last_op->ToString(&this->dba);
   EXPECT_EQ(op_string, expected_string);
 }
 
@@ -453,7 +438,7 @@ TYPED_TEST(OperatorToStringTest, FilterORExpressionsOnLabels2) {
   last_op = std::make_shared<Filter>(last_op, std::vector<std::shared_ptr<LogicalOperator>>{}, labels_test, filters);
 
   std::string expected_string{"Filter (person :Label1:Label2:(Label3|Label4))"};
-  auto op_string = last_op->ToString();
+  auto op_string = last_op->ToString(&this->dba);
   EXPECT_EQ(op_string, expected_string);
 }
 
@@ -476,7 +461,7 @@ TYPED_TEST(OperatorToStringTest, FilterORExpressionsOnLabels3) {
   last_op = std::make_shared<Filter>(last_op, std::vector<std::shared_ptr<LogicalOperator>>{}, labels_test, filters);
 
   std::string expected_string{"Filter (person :(Label1|Label2):(Label3|Label4))"};
-  auto op_string = last_op->ToString();
+  auto op_string = last_op->ToString(&this->dba);
   EXPECT_EQ(op_string, expected_string);
 }
 
@@ -485,7 +470,7 @@ TYPED_TEST(OperatorToStringTest, Produce) {
       nullptr, std::vector<NamedExpression *>{NEXPR("pet", LITERAL(5)), NEXPR("string", LITERAL("string"))});
 
   std::string expected_string{"Produce {pet, string}"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Delete) {
@@ -502,7 +487,7 @@ TYPED_TEST(OperatorToStringTest, Delete) {
   last_op = std::make_shared<plan::Delete>(last_op, std::vector<Expression *>{IDENT("node2")}, true);
 
   std::string expected_string{"Delete"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, SetProperty) {
@@ -515,7 +500,7 @@ TYPED_TEST(OperatorToStringTest, SetProperty) {
                                                 ADD(PROPERTY_LOOKUP(this->dba, "node", prop), LITERAL(1)));
 
   std::string expected_string{"SetProperty"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, SetProperties) {
@@ -528,7 +513,7 @@ TYPED_TEST(OperatorToStringTest, SetProperties) {
                                                   plan::SetProperties::Op::REPLACE);
 
   std::string expected_string{"SetProperties"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, SetLabels) {
@@ -540,7 +525,7 @@ TYPED_TEST(OperatorToStringTest, SetLabels) {
   last_op = std::make_shared<plan::SetLabels>(last_op, node_sym, labels);
 
   std::string expected_string{"SetLabels"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, RemoveProperty) {
@@ -550,7 +535,7 @@ TYPED_TEST(OperatorToStringTest, RemoveProperty) {
       last_op, this->dba.NameToProperty("prop"), PROPERTY_LOOKUP(this->dba, "node", this->dba.NameToProperty("prop")));
 
   std::string expected_string{"RemoveProperty"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, RemoveLabels) {
@@ -562,7 +547,7 @@ TYPED_TEST(OperatorToStringTest, RemoveLabels) {
   last_op = std::make_shared<plan::RemoveLabels>(last_op, node_sym, labels);
 
   std::string expected_string{"RemoveLabels"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, EdgeUniquenessFilter) {
@@ -595,7 +580,7 @@ TYPED_TEST(OperatorToStringTest, EdgeUniquenessFilter) {
   last_op = std::make_shared<EdgeUniquenessFilter>(last_op, edge2_sym, std::vector<Symbol>{edge1_sym});
 
   std::string expected_string{"EdgeUniquenessFilter {edge1 : edge2}"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Accumulate) {
@@ -609,7 +594,7 @@ TYPED_TEST(OperatorToStringTest, Accumulate) {
   last_op = std::make_shared<plan::Accumulate>(last_op, std::vector<Symbol>{node_sym}, true);
 
   std::string expected_string{"Accumulate"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Aggregate) {
@@ -631,7 +616,7 @@ TYPED_TEST(OperatorToStringTest, Aggregate) {
       std::vector<Symbol>{node_sym});
 
   std::string expected_string{"Aggregate {sum, map, count} {node}"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Skip) {
@@ -639,7 +624,7 @@ TYPED_TEST(OperatorToStringTest, Skip) {
   last_op = std::make_shared<Skip>(last_op, LITERAL(42));
 
   std::string expected_string{"Skip"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Limit) {
@@ -647,7 +632,7 @@ TYPED_TEST(OperatorToStringTest, Limit) {
   last_op = std::make_shared<Limit>(last_op, LITERAL(42));
 
   std::string expected_string{"Limit"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, OrderBy) {
@@ -662,7 +647,7 @@ TYPED_TEST(OperatorToStringTest, OrderBy) {
                                       std::vector<Symbol>{person_sym, pet_sym});
 
   std::string expected_string{"OrderBy {person, pet}"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Merge) {
@@ -677,7 +662,7 @@ TYPED_TEST(OperatorToStringTest, Merge) {
   std::shared_ptr<LogicalOperator> last_op = std::make_shared<plan::Merge>(nullptr, match, create);
 
   std::string expected_string{"Merge"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Optional) {
@@ -700,7 +685,7 @@ TYPED_TEST(OperatorToStringTest, Optional) {
       std::make_shared<Optional>(input, expand, std::vector<Symbol>{node2_sym, edge_sym});
 
   std::string expected_string{"Optional"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Unwind) {
@@ -708,7 +693,7 @@ TYPED_TEST(OperatorToStringTest, Unwind) {
       std::make_shared<plan::Unwind>(nullptr, LIST(LITERAL(1), LITERAL(2), LITERAL(3)), this->GetSymbol("x"));
 
   std::string expected_string{"Unwind"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Distinct) {
@@ -718,7 +703,7 @@ TYPED_TEST(OperatorToStringTest, Distinct) {
   last_op = std::make_shared<Distinct>(last_op, std::vector<Symbol>{x});
 
   std::string expected_string{"Distinct"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Union) {
@@ -733,7 +718,7 @@ TYPED_TEST(OperatorToStringTest, Union) {
       lhs, rhs, std::vector<Symbol>{this->GetSymbol("x")}, std::vector<Symbol>{x}, std::vector<Symbol>{node});
 
   std::string expected_string{"Union {x : x}"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, CallProcedure) {
@@ -749,7 +734,7 @@ TYPED_TEST(OperatorToStringTest, CallProcedure) {
                              this->GetSymbol("signature")};
 
   std::string expected_string{"CallProcedure<mg.procedures> {is_editable, is_write, name, path, signature}"};
-  EXPECT_EQ(call_op.ToString(), expected_string);
+  EXPECT_EQ(call_op.ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, LoadCsv) {
@@ -758,7 +743,7 @@ TYPED_TEST(OperatorToStringTest, LoadCsv) {
   last_op.row_var_ = this->GetSymbol("transaction");
 
   std::string expected_string{"LoadCsv {transaction}"};
-  EXPECT_EQ(last_op.ToString(), expected_string);
+  EXPECT_EQ(last_op.ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, LoadParquet) {
@@ -767,7 +752,7 @@ TYPED_TEST(OperatorToStringTest, LoadParquet) {
   last_op.row_var_ = this->GetSymbol("transaction");
 
   std::string const expected_string{"LoadParquet {transaction}"};
-  EXPECT_EQ(last_op.ToString(), expected_string);
+  EXPECT_EQ(last_op.ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Foreach) {
@@ -778,28 +763,28 @@ TYPED_TEST(OperatorToStringTest, Foreach) {
       std::make_shared<plan::Foreach>(nullptr, std::move(create), LIST(LITERAL(1)), x);
 
   std::string expected_string{"Foreach"};
-  EXPECT_EQ(foreach->ToString(), expected_string);
+  EXPECT_EQ(foreach->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, EmptyResult) {
   std::shared_ptr<LogicalOperator> last_op = std::make_shared<EmptyResult>(nullptr);
 
   std::string expected_string{"EmptyResult"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, EvaluatePatternFilter) {
   std::shared_ptr<LogicalOperator> last_op = std::make_shared<EvaluatePatternFilter>(nullptr, this->GetSymbol("node"));
 
   std::string expected_string{"EvaluatePatternFilter"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, Apply) {
   memgraph::query::plan::Apply last_op(nullptr, nullptr, false);
 
   std::string expected_string{"Apply"};
-  EXPECT_EQ(last_op.ToString(), expected_string);
+  EXPECT_EQ(last_op.ToString(&this->dba), expected_string);
 }
 
 TYPED_TEST(OperatorToStringTest, HashJoin) {
@@ -812,5 +797,5 @@ TYPED_TEST(OperatorToStringTest, HashJoin) {
       lhs_match, std::vector<Symbol>{lhs_sym}, rhs_match, std::vector<Symbol>{rhs_sym}, nullptr);
 
   std::string expected_string{"HashJoin {node1 : node2}"};
-  EXPECT_EQ(last_op->ToString(), expected_string);
+  EXPECT_EQ(last_op->ToString(&this->dba), expected_string);
 }

--- a/tests/unit/query_plan_printer_race.cpp
+++ b/tests/unit/query_plan_printer_race.cpp
@@ -1,0 +1,131 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <atomic>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "interpreter_faker.hpp"
+#include "query/interpreter_context.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+
+// Concurrent EXPLAIN of one plan-cache entry.
+//
+// CypherQueryToPlan returns the cached shared_ptr, so every session prints the
+// same LogicalOperator tree. Plan printing must therefore treat that tree as
+// read-only and carry the DbAccessor itself; an operator that stores the
+// accessor lets one session's teardown strand another session mid-print.
+//
+// The label index is required: without it MATCH (n:Node) plans to ScanAll plus
+// Filter, whose printing needs no accessor at all.
+
+namespace {
+constexpr int kThreads = 4;
+constexpr int kExplainsPerThread = 5000;
+constexpr char kExplainQuery[] = "EXPLAIN MATCH (n:Node) RETURN n;";
+}  // namespace
+
+class PlanPrinterRaceTest : public ::testing::Test {
+ protected:
+  std::filesystem::path data_directory{std::filesystem::temp_directory_path() / "MG_tests_unit_plan_printer_race"};
+
+  memgraph::storage::Config config{
+      [&]() {
+        memgraph::storage::Config config{};
+        config.durability.storage_directory = data_directory;
+        config.disk.main_storage_directory = config.durability.storage_directory / "disk";
+        return config;
+      }()  // iile
+  };
+
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::utils::Gatekeeper<memgraph::dbms::Database> db_gk{config};
+  memgraph::dbms::DatabaseAccess db{
+      [&]() {
+        auto db_acc_opt = db_gk.access();
+        MG_ASSERT(db_acc_opt, "Failed to access db");
+        return *db_acc_opt;
+      }()  // iile
+  };
+
+  memgraph::system::System system_state;
+  memgraph::query::InterpreterContext interpreter_context{{},
+                                                          nullptr,
+                                                          nullptr,
+                                                          nullptr,
+                                                          &repl_state,
+                                                          system_state,
+                                                          nullptr
+#ifdef MG_ENTERPRISE
+                                                          ,
+                                                          nullptr,
+                                                          nullptr
+#endif
+  };
+
+  void TearDown() override { std::filesystem::remove_all(data_directory); }
+
+  static bool PlanMentions(const ResultStreamFaker &stream, std::string_view needle) {
+    for (const auto &row : stream.GetResults()) {
+      if (row.front().ValueString().find(needle) != std::string::npos) return true;
+    }
+    return false;
+  }
+
+  size_t PlanCacheSize() {
+    return db->plan_cache()->WithLock([](auto &cache) { return cache.size(); });
+  }
+};
+
+TEST_F(PlanPrinterRaceTest, ConcurrentExplainOfSharedCachedPlan) {
+  InterpreterFaker setup{&interpreter_context, db};
+  setup.Interpret("CREATE INDEX ON :Node;");
+
+  // Prime the cache, and confirm the plan really is an indexed scan. Without
+  // this the cached tree could contain no operator that reads dba_, and the
+  // test would pass while exercising nothing.
+  auto primed = setup.Interpret(kExplainQuery);
+  ASSERT_TRUE(PlanMentions(primed, "ScanAllByLabel (n :Node)"))
+      << "expected an indexed scan; the label index was not picked up";
+  ASSERT_EQ(PlanCacheSize(), 1U);
+
+  // One interpreter per thread: each supplies its own DbAccessor, so the
+  // threads write different pointers into the same shared node.
+  std::vector<std::unique_ptr<InterpreterFaker>> interpreters;
+  interpreters.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    interpreters.push_back(std::make_unique<InterpreterFaker>(&interpreter_context, db));
+  }
+
+  std::atomic<int> label_missing{0};
+  auto hammer = [&](int index) {
+    for (int i = 0; i < kExplainsPerThread; ++i) {
+      auto stream = interpreters[index]->Interpret(kExplainQuery);
+      if (!PlanMentions(stream, ":Node")) label_missing.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) threads.emplace_back(hammer, i);
+  for (auto &thread : threads) thread.join();
+
+  EXPECT_EQ(label_missing.load(), 0) << "a plan was printed without the label name";
+  EXPECT_EQ(PlanCacheSize(), 1U) << "the plan was not shared across sessions";
+}


### PR DESCRIPTION
Data race on cached dba when multiple sessions are printing plan.
There is no way to mitigate this issue when using explain or profile.
For other queries,
```
set session trace off;
```
and 
```
--log-query-plan=false
```
should help.