### PR TITLE
fix: prevent SIGSEGV for RETURN-only EXISTS subqueries

### DIFF
--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -102,9 +102,12 @@ class UsedSymbolsCollector : public HierarchicalTreeVisitor {
         atom->Accept(*this);
       }
     } else if (exists.HasSubquery()) {
-      // For subqueries, we need to collect symbols from the subquery
-      auto *single_query = exists.GetSubquery()->single_query_;
-      if (single_query) {
+      // Collect free (outer) symbols referenced by the subquery. Newly introduced MATCH
+      // variables are marked user_declared_=false by SymbolGenerator and are skipped by Visit.
+      // RETURN/WITH expressions must also be visited so that e.g. EXISTS { RETURN n } waits for
+      // outer `n` to be bound (and does not crash / mis-order the filter). See #4485.
+      auto collect_from_single_query = [this](SingleQuery *single_query) {
+        if (!single_query) return;
         for (auto *clause : single_query->clauses_) {
           if (auto *match = utils::Downcast<Match>(clause)) {
             for (auto *pattern : match->patterns_) {
@@ -112,8 +115,34 @@ class UsedSymbolsCollector : public HierarchicalTreeVisitor {
                 atom->Accept(*this);
               }
             }
+            if (match->where_) {
+              match->where_->expression_->Accept(*this);
+            }
+          } else if (auto *ret = utils::Downcast<Return>(clause)) {
+            for (auto *named_expr : ret->body_.named_expressions) {
+              if (named_expr->expression_) {
+                named_expr->expression_->Accept(*this);
+              }
+            }
+          } else if (auto *with = utils::Downcast<With>(clause)) {
+            for (auto *named_expr : with->body_.named_expressions) {
+              if (named_expr->expression_) {
+                named_expr->expression_->Accept(*this);
+              }
+            }
+            if (with->where_) {
+              with->where_->expression_->Accept(*this);
+            }
+          } else if (auto *where = utils::Downcast<Where>(clause)) {
+            where->expression_->Accept(*this);
           }
         }
+      };
+
+      auto *cypher_query = exists.GetSubquery();
+      collect_from_single_query(cypher_query->single_query_);
+      for (auto *cypher_union : cypher_query->cypher_unions_) {
+        collect_from_single_query(cypher_union->single_query_);
       }
     } else {
       throw SemanticException(

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -839,8 +839,15 @@ std::unique_ptr<LogicalOperator> GenReturn(Return &ret, std::unique_ptr<LogicalO
                                            const std::unordered_set<Symbol> &bound_symbols, AstStorage &storage,
                                            PatternComprehensionContext &pc_ctx, Expression *commit_frequency,
                                            bool in_exists_subquery) {
-  // In existential subqueries, we should omit any return clauses as per Neo4j documentation
+  // In existential subqueries, we should omit any return clauses as per Neo4j documentation.
+  // EXISTS only cares whether the subquery produces a row, not what it returns.
+  // When the subquery is RETURN-only (no MATCH/WITH/etc.), there is no input operator yet —
+  // supply Once so the plan is valid and EXISTS can evaluate to true when outer symbols exist.
+  // See: https://github.com/memgraph/memgraph/issues/4485
   if (in_exists_subquery) {
+    if (!input_op) {
+      return std::make_unique<Once>(std::vector<Symbol>(bound_symbols.begin(), bound_symbols.end()));
+    }
     return input_op;
   }
 

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -499,8 +499,15 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         }
       }
 
+      // EXISTS subqueries may end with a null plan if they only had an omitted RETURN and no
+      // prior clauses produced an operator (defensive; GenReturn should already supply Once).
+      if (!input_op && context.in_exists_subquery) {
+        input_op = std::make_unique<Once>(
+            std::vector<Symbol>(context.bound_symbols.begin(), context.bound_symbols.end()));
+      }
+
       // Is this the only situation that should be covered
-      if (input_op->OutputSymbols(*context.symbol_table).empty() && !context.in_exists_subquery) {
+      if (input_op && input_op->OutputSymbols(*context.symbol_table).empty() && !context.in_exists_subquery) {
         if (has_periodic_commit && is_root_query) {
           // this periodic commit is from USING PERIODIC COMMIT
           input_op = std::make_unique<PeriodicCommit>(std::move(input_op), query_parts.commit_frequency);
@@ -1525,6 +1532,12 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
             context_->bound_symbols.clear();
             context_->bound_symbols.insert(std::make_move_iterator(outer_scope_bound_symbols.begin()),
                                            std::make_move_iterator(outer_scope_bound_symbols.end()));
+
+            // RETURN-only EXISTS subqueries must still produce a row source (Once).
+            // Guard against a null plan so Limit/EvaluatePatternFilter never see nullptr.
+            if (!last_op) {
+              last_op = std::make_unique<Once>(std::vector<Symbol>(bound_symbols.begin(), bound_symbols.end()));
+            }
 
             // Add a Limit operator to ensure we only need one result
             last_op = std::make_unique<Limit>(std::move(last_op), storage.Create<PrimitiveLiteral>(1));

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -595,6 +595,43 @@ Feature: WHERE exists
           | name   |
           | 'John' |
 
+  # Regression for https://github.com/memgraph/memgraph/issues/4485
+  Scenario: Test EXISTS subquery with RETURN only
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Person {name: 'John'})
+          CREATE (:Person {name: 'Alice'})
+          """
+      When executing query:
+          """
+          MATCH (n) WHERE exists { RETURN n } RETURN n.name AS name ORDER BY name;
+          """
+      Then the result should be:
+          | name    |
+          | 'Alice' |
+          | 'John'  |
+
+  # Regression for https://github.com/memgraph/memgraph/issues/4485 — empty database must not crash
+  Scenario: Test EXISTS subquery with RETURN only on empty graph
+      Given an empty graph
+      When executing query:
+          """
+          MATCH (n) WHERE exists { RETURN n } RETURN n;
+          """
+      Then the result should be empty
+
+  # Regression for https://github.com/memgraph/memgraph/issues/4478
+  Scenario: Test EXISTS RETURN-only subquery inside pattern comprehension filter
+      Given an empty graph
+      When executing query:
+          """
+          RETURN [p = ()-[]->() WHERE EXISTS { RETURN 1 } | p] AS paths;
+          """
+      Then the result should be:
+          | paths |
+          | []    |
+
   Scenario: Test nested EXISTS subqueries
       Given an empty graph
       And having executed:

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -4569,6 +4569,45 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
   DeleteListContent(&exists_union_plan);
 }
 
+// Regression: EXISTS { RETURN n } (RETURN-only subquery) must not crash during planning.
+// Previously Plan() left input_op as nullptr and dereferenced it (SIGSEGV). See #4485.
+TYPED_TEST(TestPlanner, ExistsSubqueryReturnOnly) {
+  FakeDbAccessor dba;
+
+  auto *exists_subquery = QUERY(SINGLE_QUERY(RETURN("n")));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EXISTS_SUBQUERY(exists_subquery)), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  // RETURN is omitted in EXISTS; Once (implicit, not checked) supplies the single row.
+  std::list<BaseOpChecker *> filter_tree{new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectScanAll(),
+            ExpectFilter(std::vector<std::list<BaseOpChecker *>>{filter_tree}),
+            ExpectProduce());
+
+  DeleteListContent(&filter_tree);
+}
+
+// Regression: EXISTS { RETURN 1 } inside a pattern comprehension filter (#4478).
+TYPED_TEST(TestPlanner, ExistsSubqueryReturnOnlyInPatternComprehension) {
+  FakeDbAccessor dba;
+
+  auto *exists_subquery = QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("x"))));
+  // RETURN [(n)-[r]->(m) WHERE EXISTS { RETURN 1 } | m]
+  auto *pc = PATTERN_COMPREHENSION(
+      nullptr, PATTERN(NODE("n"), EDGE("r"), NODE("m")), WHERE(EXISTS_SUBQUERY(exists_subquery)), IDENT("m"));
+  auto *query = QUERY(SINGLE_QUERY(RETURN(pc, AS("result"))));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  // Planning must succeed without SIGSEGV / null dereference.
+  EXPECT_NO_THROW({
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    (void)planner.plan();
+  });
+}
+
 TYPED_TEST(TestPlanner, MatchKShortest) {
   // Test MATCH (n), (m) WITH n, m MATCH (n) -[r:type *kshortest..10]-> (m) RETURN r
   FakeDbAccessor dba;


### PR DESCRIPTION
## Summary

Fixes a segmentation fault when planning Cypher queries that use an `EXISTS` subquery with only a `RETURN` clause (no `MATCH`), for example:

```cypher
MATCH (n) WHERE exists { RETURN n } RETURN n
```

### Root cause

In existential subqueries, `RETURN` is intentionally omitted (EXISTS only cares whether a row is produced). For **RETURN-only** subqueries that left `input_op` as `nullptr`, the planner then called `input_op->OutputSymbols(...)`, which null-dereferenced and terminated Memgraph with SIGSEGV (exit code 139).

The same path affected pattern-comprehension filters such as:

```cypher
RETURN [p = ()-[]->() WHERE EXISTS { RETURN 1 } | p];
```

### Fix

1. **GenReturn**: when inside an EXISTS subquery and there is no prior operator, create a `Once` with outer bound symbols so the subquery still has a valid row source.
2. **Plan / ExtractPatternFilters**: null-guard and defensive `Once` so a null plan cannot reach `OutputSymbols` / `Limit` / `EvaluatePatternFilter`.
3. **UsedSymbolsCollector**: also collect free symbols from `RETURN` / `WITH` / `WHERE` inside EXISTS subqueries so e.g. `EXISTS { RETURN n }` waits for outer `n` to be bound before the filter is applied.

### Tests

- Unit planner tests: `ExistsSubqueryReturnOnly`, `ExistsSubqueryReturnOnlyInPatternComprehension`
- GQL Behave scenarios in `memgraph_exists.feature` for RETURN-only EXISTS (with data, empty graph) and EXISTS inside a pattern comprehension filter

## Related issues

- Fixes https://github.com/memgraph/memgraph/issues/4485
- Related to https://github.com/memgraph/memgraph/issues/4478

## Test plan

- [ ] `memgraph__unit__query_plan` — filter `*ExistsSubqueryReturnOnly*`
- [ ] Behave: `memgraph_exists.feature` RETURN-only / pattern comprehension scenarios
- [ ] Manual: `MATCH (n) WHERE exists { RETURN n } RETURN n` does not crash (empty and non-empty DB)
- [ ] Manual: `RETURN [p = ()-[]->() WHERE EXISTS { RETURN 1 } | p]` does not crash