### PR TITLE
fix(dbms): reclaim tenant memory synchronously on SUSPEND

### DIFF
--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -24,6 +24,7 @@
 #include "dbms/global.hpp"
 #include "dbms/rpc.hpp"
 #include "license/license.hpp"
+#include "memory/global_memory_control.hpp"  // memory::PurgeUnusedMemory (synchronous reclaim on suspend)
 #include "query/db_accessor.hpp"
 #include "query/exceptions.hpp"
 #include "spdlog/spdlog.h"
@@ -1227,6 +1228,19 @@ DbmsHandler::SuspendResult DbmsHandler::Suspend_(std::string_view name, system::
   // OUTSIDE lock_: value_.reset() -> ~Database (stop threads, FinalizeWal, NO exit snapshot).
   // The COLD shell stays in db_handler_ so a later resume can move-assign a fresh gatekeeper.
   gk->finish_suspend();
+
+  // ~Database above tears down the tenant's in-memory storage and force-purges its dedicated
+  // per-DB arenas (ArenaPool::~ArenaPool). But a large fraction of the tenant's freed pages lives
+  // in the SHARED/percpu arenas (query-execution allocations are not all routed to the DB arena),
+  // which the per-DB purge does not touch. Those pages are freed but only returned to the
+  // MemoryTracker asynchronously by jemalloc's decay (dirty->muzzy->clean, ~muzzy_decay_ms +
+  // dirty_decay_ms). Until decay lands, total_memory_tracker still counts them, so the memory
+  // ceiling that SUSPEND is meant to relieve stays elevated for several seconds. Force a global
+  // purge here so the reclaim is synchronous and observable the instant SUSPEND returns -- the
+  // contract callers rely on ("suspending a tenant returns its resident memory"). This is the same
+  // reclaim FREE MEMORY performs; SUSPEND is a rare, explicit give-back-memory operation, so the
+  // one-off cost of purging all arenas is acceptable.
+  memory::PurgeUnusedMemory();
 
   // The suspend is committed (tenant is COLD, in-memory storage and stream consumers dropped;
   // durable stream metadata persists for resume). Keep the streams stopped — do NOT run the undo guard.

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -1229,17 +1229,8 @@ DbmsHandler::SuspendResult DbmsHandler::Suspend_(std::string_view name, system::
   // The COLD shell stays in db_handler_ so a later resume can move-assign a fresh gatekeeper.
   gk->finish_suspend();
 
-  // ~Database above tears down the tenant's in-memory storage and force-purges its dedicated
-  // per-DB arenas (ArenaPool::~ArenaPool). But a large fraction of the tenant's freed pages lives
-  // in the SHARED/percpu arenas (query-execution allocations are not all routed to the DB arena),
-  // which the per-DB purge does not touch. Those pages are freed but only returned to the
-  // MemoryTracker asynchronously by jemalloc's decay (dirty->muzzy->clean, ~muzzy_decay_ms +
-  // dirty_decay_ms). Until decay lands, total_memory_tracker still counts them, so the memory
-  // ceiling that SUSPEND is meant to relieve stays elevated for several seconds. Force a global
-  // purge here so the reclaim is synchronous and observable the instant SUSPEND returns -- the
-  // contract callers rely on ("suspending a tenant returns its resident memory"). This is the same
-  // reclaim FREE MEMORY performs; SUSPEND is a rare, explicit give-back-memory operation, so the
-  // one-off cost of purging all arenas is acceptable.
+  // The database teardown frees its own arena, but many allocations remain in shared jemalloc arenas.
+  // Force a global purge so SUSPEND returns only after the tenant's memory has been reclaimed.
   memory::PurgeUnusedMemory();
 
   // The suspend is committed (tenant is COLD, in-memory storage and stream consumers dropped;


### PR DESCRIPTION
SUSPEND DATABASE tears down a tenant to return its resident memory under a memory ceiling, but only its dedicated per-DB arenas are force-purged by ArenaPool::~ArenaPool. A large fraction of a tenant's pages lives in the shared/percpu arenas (query-execution allocations are not all routed to the DB arena); those are freed on teardown but only returned to the MemoryTracker by jemalloc's decay (dirty_decay_ms + muzzy_decay_ms, ~10s). Until decay lands the memory ceiling stays elevated, so work that SUSPEND was meant to make room for keeps OOMing for several seconds.

Force a global purge (memory::PurgeUnusedMemory, same reclaim as FREE MEMORY) right after finish_suspend() so the reclaim is synchronous and observable the instant SUSPEND returns. Fixes the flaky e2e
test_suspend_reclaims_memory_under_ceiling (was ~1/30; 50/50 after).
