### PR TITLE
fix: add retry_install function for build dependencies

### DIFF
--- a/environment/os/debian-12-arm.sh
+++ b/environment/os/debian-12-arm.sh
@@ -199,7 +199,7 @@ install() {
     for pkg in "${custom_packages[@]}"; do
         case "$pkg" in
             dotnet-sdk-8.0)
-                install_dotnet_sdk "8.0"
+                retry_install install_dotnet_sdk "8.0"
                 ;;
             *)
                 # Skip packages that don't need special handling

--- a/environment/os/debian-13-arm.sh
+++ b/environment/os/debian-13-arm.sh
@@ -192,7 +192,7 @@ install() {
     for pkg in "${custom_packages[@]}"; do
         case "$pkg" in
             dotnet-sdk-8.0)
-                install_dotnet_sdk "8.0"
+                retry_install install_dotnet_sdk "8.0"
                 ;;
             *)
                 # Skip packages that don't need special handling

--- a/environment/util.sh
+++ b/environment/util.sh
@@ -225,7 +225,8 @@ function install_custom_golang() {
     GOINSTALLDIR="/opt/go$GOVERSION"
     GOROOT="$GOINSTALLDIR/go" # GOPATH=$HOME/go
     if [ ! -f "$GOROOT/bin/go" ]; then
-      curl -LO https://go.dev/dl/go$GOVERSION.linux-$GOARCH.tar.gz \
+      curl -fLO --proto '=https' --proto-redir '=https' \
+      https://go.dev/dl/go$GOVERSION.linux-$GOARCH.tar.gz \
         && mkdir -p "$GOINSTALLDIR" \
         && tar -C "$GOINSTALLDIR" -xzf go$GOVERSION.linux-$GOARCH.tar.gz
     fi
@@ -242,7 +243,7 @@ function install_custom_maven() {
   MVNURL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/maven/apache-maven-$MVNVERSION-bin.tar.gz"
   if [ ! -f "$MVNINSTALLDIR/bin/mvn" ]; then
     echo "Downloading maven from $MVNURL"
-    curl -LO "$MVNURL" \
+    curl -fLO --proto '=https' --proto-redir '=https' "$MVNURL" \
       && tar -C "/opt" -xzf "apache-maven-$MVNVERSION-bin.tar.gz"
   fi
   if [ ! -f "$MVNINSTALLDIR/bin/mvn" ]; then
@@ -282,7 +283,7 @@ function install_rust () {
 
 function install_node () {
   NODE_VERSION="$1"
-  curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash \
+  curl -f --proto '=https' --proto-redir '=https' https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash \
       && . ~/.nvm/nvm.sh \
       && nvm install ${NODE_VERSION} \
       && nvm use ${NODE_VERSION}

--- a/environment/util.sh
+++ b/environment/util.sh
@@ -129,6 +129,8 @@ function retry_install() {
     local attempt=1
     local status
 
+    echo "retry_install: installing '$*' (up to $attempts attempt(s))"
+
     while true; do
         # `|| status=$?` also suspends `set -e` for the duration of the call, so
         # a failing step inside the callee returns here instead of killing the

--- a/environment/util.sh
+++ b/environment/util.sh
@@ -132,9 +132,11 @@ function retry_install() {
     echo "retry_install: installing '$*' (up to $attempts attempt(s))"
 
     while true; do
-        # `|| status=$?` also suspends `set -e` for the duration of the call, so
-        # a failing step inside the callee returns here instead of killing the
-        # whole script before we get a chance to retry.
+        # Left side of `||`, so errexit is suspended for the whole call - even
+        # inside the callee, which carries on past a failing step and returns its
+        # last command's status. Hence the `&&` chains and postcondition checks
+        # in the install_* functions: one ending in a plain `echo` always looks
+        # like a success and would never be retried.
         status=0
         "$@" || status=$?
         if [[ "$status" -eq 0 ]]; then

--- a/environment/util.sh
+++ b/environment/util.sh
@@ -118,13 +118,6 @@ function check_custom_package() {
 # RETRY_INSTALL_DELAY seconds (default 5) after a failure and doubling the delay
 # on each subsequent one. Returns the exit status of the last attempt, so a
 # caller running under `set -e` still aborts once the retries are exhausted.
-#
-# NOTE: the command runs in the CURRENT shell, not a subshell, because
-# install_rust/install_node source their environment (`. $HOME/.cargo/env`,
-# `. ~/.nvm/nvm.sh`) and callers rely on those changes surviving. Re-running a
-# partially completed install is safe: every install_* function here is
-# idempotent (rustup-init/nvm's installer both no-op on an existing install, and
-# the maven/golang/dotnet helpers are guarded by a binary existence check).
 function retry_install() {
     if [ "$#" -eq 0 ]; then
         echo "retry_install: no command given" >&2
@@ -236,9 +229,6 @@ function install_custom_golang() {
         && mkdir -p "$GOINSTALLDIR" \
         && tar -C "$GOINSTALLDIR" -xzf go$GOVERSION.linux-$GOARCH.tar.gz
     fi
-    # NOTE: check the postcondition rather than falling through to the echo
-    # below. retry_install suspends `set -e` inside this function, so a swallowed
-    # download/extract failure would otherwise be reported as a success.
     if [ ! -f "$GOROOT/bin/go" ]; then
       echo "go $GOVERSION installation failed, $GOROOT/bin/go is missing" >&2
       return 1
@@ -255,8 +245,6 @@ function install_custom_maven() {
     curl -LO "$MVNURL" \
       && tar -C "/opt" -xzf "apache-maven-$MVNVERSION-bin.tar.gz"
   fi
-  # NOTE: see the comment in install_custom_golang - the postcondition has to be
-  # checked explicitly so retry_install can tell a failed install from a good one.
   if [ ! -f "$MVNINSTALLDIR/bin/mvn" ]; then
     echo "maven $MVNVERSION installation failed, $MVNINSTALLDIR/bin/mvn is missing" >&2
     return 1
@@ -278,11 +266,6 @@ function install_dotnet_sdk ()
       && rm dotnet-install.sh \
       && ln -sf $DOTNETSDKINSTALLDIR/dotnet /usr/bin/dotnet
   fi
-  # NOTE: see the comment in install_custom_golang - the postcondition has to be
-  # checked explicitly so retry_install can tell a failed install from a good one.
-  # This checks $DOTNETSDKINSTALLDIR/dotnet, which is where dotnet-install.sh
-  # actually puts the binary (and what the symlink above points at), not the
-  # .dotnet/dotnet path the guard above uses.
   if [ ! -f "$DOTNETSDKINSTALLDIR/dotnet" ]; then
     echo "dotnet sdk $DOTNETSDKVERSION installation failed, $DOTNETSDKINSTALLDIR/dotnet is missing" >&2
     return 1

--- a/environment/util.sh
+++ b/environment/util.sh
@@ -109,22 +109,72 @@ function check_custom_package() {
     return 0
 }
 
+# Retry wrapper for the network-dependent install_* functions below.
+#
+# Usage: retry_install <command> [args...]
+#   e.g. retry_install install_rust "1.85"
+#
+# Retries up to RETRY_INSTALL_ATTEMPTS times (default 3), sleeping
+# RETRY_INSTALL_DELAY seconds (default 5) after a failure and doubling the delay
+# on each subsequent one. Returns the exit status of the last attempt, so a
+# caller running under `set -e` still aborts once the retries are exhausted.
+#
+# NOTE: the command runs in the CURRENT shell, not a subshell, because
+# install_rust/install_node source their environment (`. $HOME/.cargo/env`,
+# `. ~/.nvm/nvm.sh`) and callers rely on those changes surviving. Re-running a
+# partially completed install is safe: every install_* function here is
+# idempotent (rustup-init/nvm's installer both no-op on an existing install, and
+# the maven/golang/dotnet helpers are guarded by a binary existence check).
+function retry_install() {
+    if [ "$#" -eq 0 ]; then
+        echo "retry_install: no command given" >&2
+        return 2
+    fi
+
+    local attempts="${RETRY_INSTALL_ATTEMPTS:-3}"
+    local delay="${RETRY_INSTALL_DELAY:-5}"
+    local attempt=1
+    local status
+
+    while true; do
+        # `|| status=$?` also suspends `set -e` for the duration of the call, so
+        # a failing step inside the callee returns here instead of killing the
+        # whole script before we get a chance to retry.
+        status=0
+        "$@" || status=$?
+        if [ "$status" -eq 0 ]; then
+            if [ "$attempt" -gt 1 ]; then
+                echo "retry_install: '$*' succeeded on attempt $attempt/$attempts"
+            fi
+            return 0
+        fi
+        if [ "$attempt" -ge "$attempts" ]; then
+            echo "retry_install: '$*' failed after $attempts attempt(s), last exit status $status" >&2
+            return "$status"
+        fi
+        echo "retry_install: '$*' failed with exit status $status, retrying in ${delay}s (attempt $((attempt + 1))/$attempts)" >&2
+        sleep "$delay"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+}
+
 function install_custom_packages() {
     local packages=("$@")
 
     for pkg in "${packages[@]}"; do
         case "$pkg" in
             custom-maven*)
-                install_custom_maven "3.9.3"
+                retry_install install_custom_maven "3.9.3"
                 ;;
             custom-golang*)
-                install_custom_golang "1.18.9"
+                retry_install install_custom_golang "1.18.9"
                 ;;
             custom-rust)
-                install_rust "1.85"
+                retry_install install_rust "1.89"
                 ;;
             custom-node)
-                install_node "20"
+                retry_install install_node "20"
                 ;;
         esac
     done
@@ -182,9 +232,16 @@ function install_custom_golang() {
     GOINSTALLDIR="/opt/go$GOVERSION"
     GOROOT="$GOINSTALLDIR/go" # GOPATH=$HOME/go
     if [ ! -f "$GOROOT/bin/go" ]; then
-      curl -LO https://go.dev/dl/go$GOVERSION.linux-$GOARCH.tar.gz
-      mkdir -p "$GOINSTALLDIR"
-      tar -C "$GOINSTALLDIR" -xzf go$GOVERSION.linux-$GOARCH.tar.gz
+      curl -LO https://go.dev/dl/go$GOVERSION.linux-$GOARCH.tar.gz \
+        && mkdir -p "$GOINSTALLDIR" \
+        && tar -C "$GOINSTALLDIR" -xzf go$GOVERSION.linux-$GOARCH.tar.gz
+    fi
+    # NOTE: check the postcondition rather than falling through to the echo
+    # below. retry_install suspends `set -e` inside this function, so a swallowed
+    # download/extract failure would otherwise be reported as a success.
+    if [ ! -f "$GOROOT/bin/go" ]; then
+      echo "go $GOVERSION installation failed, $GOROOT/bin/go is missing" >&2
+      return 1
     fi
     echo "go $GOVERSION installed under $GOROOT"
 }
@@ -195,8 +252,14 @@ function install_custom_maven() {
   MVNURL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/maven/apache-maven-$MVNVERSION-bin.tar.gz"
   if [ ! -f "$MVNINSTALLDIR/bin/mvn" ]; then
     echo "Downloading maven from $MVNURL"
-    curl -LO "$MVNURL"
-    tar -C "/opt" -xzf "apache-maven-$MVNVERSION-bin.tar.gz"
+    curl -LO "$MVNURL" \
+      && tar -C "/opt" -xzf "apache-maven-$MVNVERSION-bin.tar.gz"
+  fi
+  # NOTE: see the comment in install_custom_golang - the postcondition has to be
+  # checked explicitly so retry_install can tell a failed install from a good one.
+  if [ ! -f "$MVNINSTALLDIR/bin/mvn" ]; then
+    echo "maven $MVNVERSION installation failed, $MVNINSTALLDIR/bin/mvn is missing" >&2
+    return 1
   fi
   echo "maven $MVNVERSION installed under $MVNINSTALLDIR"
 }
@@ -209,11 +272,20 @@ function install_dotnet_sdk ()
     mkdir -p $DOTNETSDKINSTALLDIR
   fi
   if [ ! -f "$DOTNETSDKINSTALLDIR/.dotnet/dotnet" ]; then
-    wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
-    chmod +x ./dotnet-install.sh
-    ./dotnet-install.sh --channel 8.0 --install-dir $DOTNETSDKINSTALLDIR
-    rm dotnet-install.sh
-    ln -sf $DOTNETSDKINSTALLDIR/dotnet /usr/bin/dotnet
+    wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
+      && chmod +x ./dotnet-install.sh \
+      && ./dotnet-install.sh --channel 8.0 --install-dir $DOTNETSDKINSTALLDIR \
+      && rm dotnet-install.sh \
+      && ln -sf $DOTNETSDKINSTALLDIR/dotnet /usr/bin/dotnet
+  fi
+  # NOTE: see the comment in install_custom_golang - the postcondition has to be
+  # checked explicitly so retry_install can tell a failed install from a good one.
+  # This checks $DOTNETSDKINSTALLDIR/dotnet, which is where dotnet-install.sh
+  # actually puts the binary (and what the symlink above points at), not the
+  # .dotnet/dotnet path the guard above uses.
+  if [ ! -f "$DOTNETSDKINSTALLDIR/dotnet" ]; then
+    echo "dotnet sdk $DOTNETSDKVERSION installation failed, $DOTNETSDKINSTALLDIR/dotnet is missing" >&2
+    return 1
   fi
   echo "dotnet sdk $DOTNETSDKVERSION installed under $DOTNETSDKINSTALLDIR"
 }

--- a/environment/util.sh
+++ b/environment/util.sh
@@ -112,7 +112,7 @@ function check_custom_package() {
 # Retry wrapper for the network-dependent install_* functions below.
 #
 # Usage: retry_install <command> [args...]
-#   e.g. retry_install install_rust "1.85"
+#   e.g. retry_install install_rust "1.89"
 #
 # Retries up to RETRY_INSTALL_ATTEMPTS times (default 3), sleeping
 # RETRY_INSTALL_DELAY seconds (default 10) after a failure and doubling the delay
@@ -260,7 +260,7 @@ function install_dotnet_sdk ()
   if [ ! -d $DOTNETSDKINSTALLDIR ]; then
     mkdir -p $DOTNETSDKINSTALLDIR
   fi
-  if [ ! -f "$DOTNETSDKINSTALLDIR/.dotnet/dotnet" ]; then
+  if [ ! -f "$DOTNETSDKINSTALLDIR/dotnet" ]; then
     wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
       && chmod +x ./dotnet-install.sh \
       && ./dotnet-install.sh --channel 8.0 --install-dir $DOTNETSDKINSTALLDIR \

--- a/environment/util.sh
+++ b/environment/util.sh
@@ -115,7 +115,7 @@ function check_custom_package() {
 #   e.g. retry_install install_rust "1.85"
 #
 # Retries up to RETRY_INSTALL_ATTEMPTS times (default 3), sleeping
-# RETRY_INSTALL_DELAY seconds (default 5) after a failure and doubling the delay
+# RETRY_INSTALL_DELAY seconds (default 10) after a failure and doubling the delay
 # on each subsequent one. Returns the exit status of the last attempt, so a
 # caller running under `set -e` still aborts once the retries are exhausted.
 function retry_install() {
@@ -125,7 +125,7 @@ function retry_install() {
     fi
 
     local attempts="${RETRY_INSTALL_ATTEMPTS:-3}"
-    local delay="${RETRY_INSTALL_DELAY:-5}"
+    local delay="${RETRY_INSTALL_DELAY:-10}"
     local attempt=1
     local status
 
@@ -137,13 +137,11 @@ function retry_install() {
         # whole script before we get a chance to retry.
         status=0
         "$@" || status=$?
-        if [ "$status" -eq 0 ]; then
-            if [ "$attempt" -gt 1 ]; then
-                echo "retry_install: '$*' succeeded on attempt $attempt/$attempts"
-            fi
+        if [[ "$status" -eq 0 ]]; then
+            echo "retry_install: '$*' succeeded on attempt $attempt/$attempts"
             return 0
         fi
-        if [ "$attempt" -ge "$attempts" ]; then
+        if [[ "$attempt" -ge "$attempts" ]]; then
             echo "retry_install: '$*' failed after $attempts attempt(s), last exit status $status" >&2
             return "$status"
         fi

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -708,7 +708,7 @@ build_memgraph () {
   docker exec -u root "$build_container" bash -c "$MGBUILD_ROOT_DIR/environment/os/$os.sh check MEMGRAPH_BUILD_DEPS || $MGBUILD_ROOT_DIR/environment/os/$os.sh install MEMGRAPH_BUILD_DEPS"
 
   echo "Installing Rust $DEFAULT_RUST_VERSION..."
-  docker exec -u mg "$build_container" bash -c "source $MGBUILD_ROOT_DIR/environment/util.sh && install_rust $DEFAULT_RUST_VERSION"
+  docker exec -u mg "$build_container" bash -c "source $MGBUILD_ROOT_DIR/environment/util.sh && retry_install install_rust $DEFAULT_RUST_VERSION"
 
   # Install the requested build-time Python (--python-build-version) from deadsnakes
   # and point libpython3.so at it, so the build links against exactly that
@@ -2418,7 +2418,7 @@ test_mage() {
       echo -e "${GREEN_BOLD}Running tests in container: $build_container${RESET}"
 
       echo -e "${GREEN_BOLD}Installing Rust $DEFAULT_RUST_VERSION${RESET}"
-      docker exec -i -u mg $build_container bash -c "source \$HOME/memgraph/environment/util.sh && install_rust $DEFAULT_RUST_VERSION"
+      docker exec -i -u mg $build_container bash -c "source \$HOME/memgraph/environment/util.sh && retry_install install_rust $DEFAULT_RUST_VERSION"
 
       echo -e "${GREEN_BOLD}Running Rust tests${RESET}"
       docker exec -i -u mg $build_container bash -c "$ACTIVATE_TOOLCHAIN && source \$HOME/.cargo/env && cd \$HOME/memgraph/src/mage/rust/rsmgp-sys && cargo fmt -- --check && RUST_BACKTRACE=1 cargo test"

--- a/tools/ci/container-test-mage.sh
+++ b/tools/ci/container-test-mage.sh
@@ -58,7 +58,7 @@ trap exit_handler ERR EXIT
 echo -e "${GREEN_BOLD}Running tests in container: $CONTAINER_NAME${RESET}"
 
 echo -e "${GREEN_BOLD}Installing Rust${RESET}"
-docker exec -i -u mg $CONTAINER_NAME bash -c "source \$HOME/memgraph/environment/util.sh && install_rust $RUST_VERSION"
+docker exec -i -u mg $CONTAINER_NAME bash -c "source \$HOME/memgraph/environment/util.sh && retry_install install_rust $RUST_VERSION"
 
 echo -e "${GREEN_BOLD}Running Rust tests${RESET}"
 docker exec -i -u mg $CONTAINER_NAME bash -c "source /opt/toolchain-v7/activate && source \$HOME/.cargo/env && cd \$HOME/memgraph/src/mage/rust/rsmgp-sys && cargo fmt -- --check && RUST_BACKTRACE=1 cargo test"


### PR DESCRIPTION
Added `retry_install` function to allow retries on some build dependencies (rust, dotnet, node, maven) to reduce CI failures due to network flakiness.

