### PR TITLE
feat: HA analytical mode

### DIFF
--- a/specs/ha-analytical-import.md
+++ b/specs/ha-analytical-import.md
@@ -1,0 +1,409 @@
+# HA analytical import — design
+
+**Status**: design interview complete; all ten questions resolved. Ready to implement.
+**Started**: 2026-08-03. **Completed**: 2026-08-04.
+
+## Target workload
+
+An HA cluster whose single data instance:
+
+1. switches to `IN_MEMORY_ANALYTICAL`,
+2. performs a bulk import,
+3. switches back to `IN_MEMORY_TRANSACTIONAL` — this writes the snapshot,
+4. has replicas registered back.
+
+A manual `CREATE SNAPSHOT` between the import and the switch back was in the original
+workload and was dropped by decision 8.
+
+Operator constraint stated up front: replica registration **and** unregistration must
+happen only while in transactional mode.
+
+## Decisions taken
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Precondition for an HA data instance to enter analytical | Instance holds the MAIN role **and** has zero registered replication clients |
+| 2 | Enforcement of "register only in transactional" | Reject up-front, before any replication state is mutated — both the coordinator RPC path and the user-facing `REGISTER REPLICA`; same for unregister |
+| 3 | Multi-tenancy scope of both gates | Instance-wide, all-or-nothing: any database in analytical blocks registration; entering analytical anywhere requires zero replicas instance-wide |
+| 4 | Replica state on re-registration | Originally **assumed empty**, with no recovery-path changes — the existing path is correct for an empty replica (finding 5). **Superseded by decision 9**: the assumption does not hold, because unregistering never wipes the replica (finding 7b), so recovery is fixed instead of assumed |
+| 5 | `--storage-mode=IN_MEMORY_ANALYTICAL` at startup for data instances | Stays forbidden; analytical is reachable only via the runtime query from a transactional start |
+| 6 | Observability when `REGISTER INSTANCE` lands while the main is analytical | Keep returning `SUCCESS`; the reconciliation loop heals it once the main is transactional again. The data instance logs the cause on reject. No `StateCheckRes` version bump, no new `SHOW INSTANCES` column. Operator docs state that registration belongs in transactional mode only |
+| 7 | Serialization of the two gates | Defence in depth **plus** a strict window close: friendly instance-wide check in `PrepareStorageModeQuery`, hard invariant inside `SetStorageMode` under UNIQUE, register-side check under the `repl_state_` lock — and both the final mode store and the client insert re-check under `replication_storage_clients_`' own lock, making "analytical with a live client" unrepresentable |
+| 8 | `CREATE SNAPSHOT` while analytical (step 3 of the workload) | Dropped from the recipe. The analytical→transactional switch already writes a correctly stamped snapshot; a manual one taken while analytical skips the digest check and is stamped with a pre-import timestamp |
+| 9 | Non-empty replica on re-registration | **Make recovery self-correct**, derived entirely from the durability files so it survives a main restart. Three parts: finalize the WAL when *entering* analytical; in `GetRecoverySteps`, treat "the latest snapshot's `durable_timestamp` lies inside no WAL file's `[from, to]` range" as proof the WAL chain cannot reproduce that data and force the snapshot path; keep a `snapshot_durable_ts > replica_commit` guard on that override. No refusal, no operator wipe, no in-memory flag, no persisted boundary, no snapshot format change. Supersedes an earlier "detect and refuse" choice, which was abandoned because its flag was in-memory and a main restart forgot it |
+| 10 | Test coverage | One new e2e file, `analytical_import.py`, with four scenarios: **A** nothing ingested anywhere before the switch, **B** data ingested on main *and* replica beforehand with the replica left strictly behind, **B2** B with a main restart before re-registration, **C** deferred registration. Plus unit tests pinning each gate, and a fires/does-not-fire pair for decision 9's override |
+
+## Work to do
+
+### Gates
+
+1. `PrepareStorageModeQuery` — replace the blanket `IsDataInstance()` rejection with the
+   decision-1 gate: MAIN role and zero registered replicas, instance-wide, with an error
+   message naming what blocks the switch. This is the operator-facing check; it is
+   advisory, since the state can change before the mode store lands.
+2. `InMemoryStorage::SetStorageMode` — under the UNIQUE hold it already takes, refuse the
+   transition to analytical when this storage has replication clients. It already throws
+   `BasicException` for active constraints and a non-idle async indexer, so this joins an
+   established rejection point.
+3. `RegisterReplica_` — reject before any replication state is mutated when any database is
+   analytical, under the `repl_state_` write lock it already holds. This is what makes the
+   permanent-`NAME_EXISTS` trap of finding 4 unreachable.
+4. The strict window close from decision 7: the `storage_mode_` store in `SetStorageMode`
+   and the client insert in `RegisterReplica_` both do their final check inside
+   `replication_storage_clients_`' own lock. Note the store currently sits *after* the
+   switch-back snapshot, at the end of the `if (storage_mode_ != new_storage_mode)` block.
+5. The same up-front rejection for the unregister paths.
+
+### Self-correcting recovery for a stale replica (decision 9)
+
+6. `InMemoryStorage::SetStorageMode`, transactional→analytical branch — finalize the WAL
+   (`wal_file_->FinalizeWal()`, `wal_file_.reset()`), placed **after** the two checks that
+   throw (active constraints, non-idle async indexer) so a rejected switch has no side
+   effect, and **under `engine_lock_`**: `GetRecoverySteps` holds that lock specifically to
+   read `wal_file_`, so finalizing without it races a replica-recovery reader. Lock order
+   `main_lock_ → engine_lock_` is respected, since the UNIQUE hold is `main_lock_`.
+   `InitializeWalFile` returns false in analytical mode, so no WAL is created during the
+   import, and the first post-switch commit opens a fresh file. Sequence numbering stays
+   contiguous — only *gaps* break the main's restart recovery, not rotations.
+7. `GetRecoverySteps` — override the WAL-only decision when the snapshot holds data no WAL
+   does:
+
+   ```cpp
+   // A snapshot timestamp inside no WAL file's range means its data was never written to a
+   // WAL (analytical-mode writes bypass it), so WAL-only recovery would silently skip it.
+   if (latest_snapshot && latest_snapshot->durable_timestamp > replica_commit &&
+       !SnapshotTsCoveredByAnyWal(wal_files, current_wal_from, current_wal_to,
+                                  latest_snapshot->durable_timestamp)) {
+     wal_chain_info.covered_by_wals = false;
+   }
+   ```
+
+   The check must consider the currently-open WAL as well as the finalized ones —
+   `WalFile::FromTimestamp()`/`ToTimestamp()` and `WalDurabilityInfo`'s from/to. The
+   `> replica_commit` guard is load-bearing, not decoration: without it a replica already
+   past the import takes the not-covered branch with `first_useful_wal` pointing at the
+   post-import file, and `MG_ASSERT(wal.from_timestamp <= snap_durable_ts || wal.seq_num == 0,
+   "Broken data chain.")` fires — an always-on assert, i.e. a crash.
+
+### Docs
+
+Operator-facing documentation must state that replica registration and unregistration
+belong in transactional mode only. A wiped data directory is **not** required —
+decision 9 makes a re-registered replica with stale data recover correctly.
+
+### Tests
+
+#### e2e — `tests/e2e/high_availability/analytical_import.py`
+
+New file, following the conventions of the existing HA tests (`interactive_mg_runner`,
+`MEMGRAPH_INSTANCES_DESCRIPTION`, `mg_sleep_and_assert`, `get_data_path`/`get_logs_path`
+from `common.py`). Register it in **both** `tests/e2e/high_availability/CMakeLists.txt`
+(`copy_e2e_python_files(high_availability analytical_import.py)`) and `workloads.yaml`.
+
+Replicas serve reads, so every assertion about replica contents is a plain
+`MATCH (n) RETURN count(n)` on the replica's own bolt cursor, wrapped in
+`mg_sleep_and_assert` because recovery is asynchronous. Assert the count *equals main's*,
+not just that it is non-zero.
+
+**Scenario A — nothing ingested anywhere before the switch.**
+
+1. Start a cluster with a coordinator, a main, and one replica. Write nothing.
+2. `UNREGISTER INSTANCE` the replica — required by decision 1's gate.
+3. On main: `STORAGE MODE IN_MEMORY_ANALYTICAL`, import N nodes,
+   `STORAGE MODE IN_MEMORY_TRANSACTIONAL`.
+4. `REGISTER INSTANCE` the replica back.
+5. Assert the replica holds N nodes and `SHOW INSTANCES` is healthy with the original main
+   still MAIN.
+
+This is the already-correct path from finding 5 — an empty replica reports timestamp 0 and
+takes the `add_snapshot()` branch. Its job is to prove the decision-1/2/3 gates work
+end-to-end and, critically, that the decision-9 override does **not** regress the empty
+case. It would pass without decision 9, so it must not be mistaken for that fix's guard.
+
+**Scenario B — data ingested on main *and* replica before the switch.**
+
+1. Start the same cluster. Write M nodes on main and wait until the replica reports M, so
+   it genuinely holds data.
+2. `UNREGISTER INSTANCE` the replica. It keeps its M nodes and its timestamp — see
+   finding 7b, nothing wipes it.
+3. **Write K more nodes on main.** See below; without this step the test does not exercise
+   the bug at all.
+4. main → analytical, import N nodes, → transactional.
+5. Re-register the replica **without wiping its data directory** — do not restart it clean,
+   and keep `keep_directories` semantics in mind when starting/stopping instances.
+6. Assert the replica holds M + K + N nodes and that this equals main's count.
+
+**Why step 3 is mandatory.** The bug needs `covered_by_wals == true`, which requires a
+finalized WAL chain that both extends past the replica's timestamp and reaches back to it.
+If the replica is re-registered while exactly in sync, `wal_files.back().to_timestamp ==
+replica_commit`, the WAL branch is skipped, the `else if` fires, and the snapshot is shipped
+anyway — the test would pass with the bug fully present. Writing K more nodes after the
+unregister leaves the replica **strictly behind** the end of the chain, which is the
+condition from the corrected reachability analysis in finding 6.
+
+**Why this is a genuine guard — and an implementation-ordering warning.** Part 1 of
+decision 9 (finalize the WAL when entering analytical) is what makes scenario B
+*deterministic*: it puts the pre-analytical file into `wal_files` with
+`to_timestamp > replica_commit`, so `covered_by_wals` becomes reliably true and part 2 is
+what saves the import. Remove part 2 and scenario B fails — which is exactly what a
+regression guard should do.
+
+The corollary matters: **part 1 alone makes things worse and the two must land together.**
+Today the pre-analytical WAL stays open, so it is excluded from `wal_files` and many layouts
+fall into the `else if` branch and ship the snapshot correctly *by accident*. Finalizing
+that file removes the accident. Do not merge part 1 without part 2.
+
+To reproduce the loss on a **pre-fix** build (useful to confirm the test is really testing
+something), force WAL rotation with a very small `--storage-wal-file-size-kib` so a
+finalized file covers the replica's position without part 1 in place.
+
+**Scenario B2 — main restart between the import and the re-registration.** Scenario B with
+the main restarted after step 4 and before step 5. This pins the requirement that rejected
+every in-memory-state design, and it is cheap: the assertion is identical to B.
+
+**Scenario C — deferred registration.** `REGISTER INSTANCE` while the main is analytical:
+assert it returns success, that the replica is not attached yet, and that it attaches by
+itself once the main is back in transactional mode — the reconciliation-loop behaviour of
+decision 6.
+
+#### Unit
+
+- `tests/unit/storage_v2_storage_mode.cpp` — switching to analytical with a replication
+  client attached is refused.
+- `tests/unit/storage_v2_replication.cpp` — registering while a database is analytical is
+  refused.
+- Decision 9 needs its own pair, because a false positive costs a needless full snapshot
+  transfer on every lagging replica: assert the override **does** fire after an analytical
+  episode, and **does not** fire for an ordinary periodic snapshot (finalized WALs ending
+  before the snapshot, whose timestamp the open WAL's range contains).
+- No race test for the decision-7 window: it is a few instructions wide, so a thread test
+  would pass with or without the fix.
+
+### Cleanup
+
+`storage/v2/replication/replication_client.cpp` justifies a guardrail with the comment
+"Data instances are barred from analytical at query time", which decision 1 makes false.
+
+## Deliberately out of scope
+
+- **Correctly stamped manual snapshots in analytical mode** (finding 3). Worth having — a
+  multi-hour import wants a mid-import checkpoint — but it is a durability fix affecting
+  any analytical instance, HA or not. File separately.
+Note that self-correcting recovery for a stale replica is **no longer** out of scope — it
+became decision 9. The hole is pre-existing and not HA-specific (nothing today stops a
+non-HA main with replicas from going analytical), so the fix benefits plain replication too.
+
+## Approaches ruled out on evidence
+
+Recorded so they are not re-proposed.
+
+- **Deliberate WAL sequence-number skip on switch-back.** Not merely risky — unusable. The
+  main's own restart recovery throws on *any* mid-chain gap, unconditionally, regardless of
+  snapshot coverage: `throw RecoveryFailure("You are missing a WAL file with the sequence
+  number {}!")` when `wal_file.seq_num - previous_seq_num > 1`. A deliberate skip means the
+  main will not restart (or, with `--storage-allow-recovery-failure`, the tenant goes
+  defunct).
+- **Deleting the pre-import WAL files instead.** Then `wal_files[0].seq_num != 0` and the
+  first WAL's `from_timestamp` exceeds the snapshot's, tripping the other check:
+  `RecoveryFailure("You must have at least one WAL file that contains at least one delta
+  that was created before the snapshot file!")`. The retention rule that always keeps one
+  pre-snapshot WAL exists to keep that check satisfiable.
+- **Rotating the epoch on a storage-mode switch.** The branching-point test fires only when
+  `recorded_ldt_for_epoch < replica_timestamp` — i.e. *"does the replica hold data I do
+  not?"* Our replica is **behind**, not divergent, so the test is false whether the epoch is
+  rotated before or after the switch-back's ldt bump. Recovery-step selection never consults
+  the epoch at all; its only influence is that one boolean. Rotating would also spend entries
+  in a bounded history (`kEpochHistoryRetention = 1000`, `pop_front`) and assert a lineage
+  change that did not happen — and `SaveLatestHistory()` early-returns when the ldt is
+  unchanged, so rotating before the bump would sometimes record nothing at all. Epochs
+  express *lineage*; the problem is *WAL coverage*, and no lineage marker can encode it.
+- **A boundary timestamp held in memory** (with or without a "has been analytical" flag).
+  Lost on a main restart, which is precisely the case that must work.
+- **Deriving the hole from WAL files without the forced rotation.** Nothing in
+  `SetStorageMode` finalizes the WAL today, so the pre-import file stays open across the
+  whole analytical episode and post-import commits append to it. Its `[from, to]` then spans
+  the gap and hides it inside a single file, so no file-level signature exists. Whether the
+  gap is even visible would otherwise depend on incidental size-based rotation.
+- **Comparing the snapshot against the end of the WAL chain** (`snapshot_ldt > max WAL
+  to_timestamp`). The open WAL's `ToTimestamp()` advances on *every* commit, so the first
+  post-import commit silences it; excluding the open WAL instead makes it fire for ordinary
+  periodic snapshots and forces needless full snapshot transfers. Containment — "is the
+  snapshot's timestamp inside some WAL's range?" — is the check that survives both.
+
+## Findings from the codebase
+
+Each of these was verified by reading the code, and several materially shaped the
+decisions above.
+
+### 1. There are two blockers, not one
+
+- `query/interpreter.cpp:6073-6078` throws `"Data instances cannot use analytical mode"`
+  for any `coordinator_state_->IsDataInstance()`.
+- `memgraph.cpp:613-615` `MG_ASSERT`s the same thing at startup, aborting the process.
+
+### 2. Startup mode permanently determines WAL capability
+
+`memgraph.cpp:606-608` sets `snapshot_wal_mode = DISABLED` for any non-transactional
+startup mode, and `InitializeWalFile` (`storage/v2/inmemory/storage.cpp:3635`) returns
+false unless the mode is `PERIODIC_SNAPSHOT_WITH_WAL`. That is creation-time config which
+`SetStorageMode` never touches, so an instance *started* analytical could never emit WAL
+even after switching to transactional — permanently breaking replication. This is the
+reason decision 5 keeps the startup assertion.
+
+Conversely the runtime mode is **not** persisted: `SetStorageMode` writes only the
+`storage_mode_` member, never `config_.salient.storage_mode` (confirmed by the comment at
+`dbms/dbms_handler.cpp:1067`). A restart mid-import therefore returns a healthy
+transactional instance with WAL config intact.
+
+### 3. The switch-back already writes a snapshot; the manual one is stale
+
+`SetStorageMode` on analytical→transactional (`storage/v2/inmemory/storage.cpp:2895-2917`)
+sets `txn->last_durable_ts_ = txn->start_timestamp` and then writes a snapshot with
+trigger `"storage_mode_change"`, synchronously, before `storage_mode_` is updated.
+
+A manual `CREATE SNAPSHOT` taken *while* analytical also **skips the digest check
+entirely** — the `last_snapshot_digest_` comparison is guarded on
+`transaction->storage_mode == IN_MEMORY_TRANSACTIONAL` — so it always writes, and it gets a
+**stale** durable timestamp:
+`storage.cpp:4263` states "In memory analytical doesn't update last_durable_ts so digest
+isn't valid", so the snapshot's `durable_timestamp` is the pre-analytical ldt and does not
+reflect the imported data. The later mode-change snapshot supersedes it. So step 3 of the
+workload is redundant and mildly misleading.
+
+`CREATE SNAPSHOT` itself is legal in analytical mode — only on-disk storage rejects it
+(`interpreter.cpp:6173`).
+
+### 4. The permanent-NAME_EXISTS trap (motivates decision 2)
+
+If `RegisterReplicaOnMainRpc` arrives while a database is analytical:
+
+- `ReplicationState::RegisterReplica` succeeds and **persists** the instance-level client, but
+- `RegisterReplica_` (`replication_handler/include/replication_handler/replication_handler.hpp:281`)
+  does `if (storage->storage_mode_ != IN_MEMORY_TRANSACTIONAL) return;` and creates no
+  per-database `ReplicationStorageClient`.
+
+Then `GetNumCommittedTxns` (`replication_handler/replication_handler.cpp:471`) enumerates
+*per-storage* clients, so the replica never appears in `replicas_num_txns`;
+`InstanceSuccessCallback` (`coordination/coordinator_instance.cpp:1188`) sees the gap and
+re-sends the RPC every ping; every retry now hits `NAME_EXISTS` → `DoRegisterReplica`
+returns false → `spdlog::warn` only. **The storage client is never created even after the
+switch back to transactional** — the replica is permanently dead with no error surfaced.
+
+Rejecting before mutating state makes this unreachable via this path.
+
+### 5. Empty replicas recover correctly through the existing path
+
+For `replica_commit = 0`, `GetWalChainInfo`
+(`storage/v2/inmemory/replication/recovery.cpp:199`) returns `covered_by_wals = false`
+because the oldest WAL's `from_timestamp > 1`, so `GetRecoverySteps` takes the
+`add_snapshot()` branch and the replica receives the mode-change snapshot. No changes
+needed. This is what makes decision 4 safe.
+
+### 6. Non-empty replicas would silently lose the import (why decision 4 is an assumption)
+
+`GetWalChainInfo` decides `covered_by_wals` from **seq-num contiguity** plus
+`from_timestamp`. The analytical import writes no WAL at all but does not disturb seq
+numbering, so it punches a *timestamp* hole into a chain that still looks seq-contiguous.
+A replica whose data predates the import gets recovered from WALs alone — pre-import WALs
+it already has, then post-import WALs — never the snapshot containing the import, and is
+then declared in sync.
+
+Two fixes were ruled out on evidence:
+
+- **Timestamp-gap-aware chain check is not viable**: `CreateTransaction`
+  (`storage.cpp:2835`) does `start_timestamp = timestamp_++` for *every* transaction
+  including read-only ones, so timestamp gaps between consecutive WAL files are normal and
+  the check would fire constantly.
+- **Snapshot retention will not clean up the stale WALs**: `DeleteOldWalFiles`
+  (`storage/v2/durability/snapshot.cpp:13827`) keys deletion on the *oldest retained*
+  snapshot's timestamp and always keeps one pre-snapshot WAL.
+
+Note this hole is pre-existing and not HA-specific: nothing today stops a non-HA MAIN with
+registered replicas from switching to analytical.
+
+**Corrected reachability.** An earlier draft of this finding claimed WAL-only recovery is
+unconditional. It is not — it depends on the WAL file layout at re-registration, because
+`GetWalFiles` **excludes the currently-open WAL** and the branch is entered only when
+`wal_files.back().to_timestamp > replica_commit`. Trace with a replica at 100 and a
+mode-change snapshot at 5000:
+
+- Finalized WALs end before the replica's position → the branch is skipped, the `else if`
+  sees `snapshot_durable_ts > replica_commit`, and the **snapshot is sent. Correct.** This
+  is the case of an exactly-in-sync replica re-registered with no post-import writes.
+- Replica at 90, last finalized WAL covers `[80,100]` → `100 > 90`, and that file's
+  `from_timestamp 80 <= 91` → covered → **snapshot skipped, import lost.** No post-import
+  traffic needed; a briefly-lagging or ASYNC replica suffices.
+- Any WAL holding post-switch commits gets finalized → `back().to_timestamp` exceeds every
+  replica's timestamp while the walk back still reaches `80 <= 101` → covered → **import
+  lost even for a replica that was perfectly in sync.**
+
+So correctness depended on incidental file layout rather than on whether the WALs hold the
+data — which is why the test in decision 10 must use a replica that is *behind*, and why a
+naive e2e test where nothing rotates would pass without the fix.
+
+### 6b. The main's ldt is not advanced by the switch-back snapshot
+
+`CreateSnapshot` writes `transaction->last_durable_ts_` into the snapshot header and never
+touches the storage's ldt. The ldt advances only on the transactional commit path
+(`ldt_ = durability_commit_timestamp`, with `DMG_ASSERT(durability_commit_timestamp >= prev,
+"LDT not monotonically increasing")`). Analytical commits never reach it, and the mode-change
+unique transaction is not committed through it either — `SetStorageMode` releases its guard
+via `FreeMemory`.
+
+So immediately after the switch back, **main's ldt is still the pre-analytical value while
+the newest snapshot's header carries the post-import timestamp**. A replica that loads that
+snapshot reports a timestamp *ahead of main*, and the `READY` check
+`replica_ts >= main_ldt` passes. This is what the three comments in
+`storage/v2/replication/replication_client.cpp` are documenting — *"ldt can be larger on
+replica due to snapshots"* — i.e. the anomaly has already been observed in practice. It is
+also why decision 9 keys on WAL containment rather than on any comparison against main's ldt.
+
+### 7. Epoch rotation alone would not help
+
+The HA branching-point path (`storage/v2/replication/replication_client.cpp:188-232`) does
+force a full reset — `RecoverReplica(0, ..., reset_needed=true)` — but only when the
+replica's epoch is absent from the main's history **or** the replica's timestamp for that
+epoch exceeds the main's recorded value. Rotating the epoch on switch-back would leave the
+history continuous, so `branching_point` stays false and the WAL-only path is taken again.
+See "Approaches ruled out on evidence" for the full walkthrough of both orderings.
+
+Note what the two roles do with a branching point, since it shaped decision 9: **non-HA**
+sets `DIVERGED_FROM_MAIN` and `RegisterReplica_` then unregisters the replica — registration
+fails and the operator must wipe. **HA** does not fail; it sets `RECOVERY` and calls
+`RecoverReplica(0, ..., reset_needed=true)`, healing itself. So refusing a registration would
+have been the only place in HA where an operator must manually wipe a data directory, which
+is why the self-correcting shape of decision 9 fits the surrounding design.
+
+### 7b. Unregistering a replica does not touch its data
+
+`UnregisterReplicationInstance` does exactly three things: removes the instance from the Raft
+cluster state, sends `UnregisterReplicaRpc` to the **main** so it drops its client, and erases
+the coordinator's in-memory connector. It **sends nothing to the instance being removed** —
+that process keeps running with its full data directory. On the way back in,
+`DemoteMainToReplicaHandler` only calls `SetReplicationRoleReplica`; no wipe, no reset.
+
+So "dropped the replica" means removed from the cluster, not emptied. Since decision 1's gate
+is what forces the operator to unregister before entering analytical, a re-registered replica
+carrying pre-import data is the natural path through the workload, not a corner case.
+
+### 8. HA lifecycle interactions
+
+- Replication topology is instance-wide: "NOTE Currently all databases are connected to
+  each replica" (`replication_handler.hpp:280`), and registered replicas live in
+  `RoleMainData::registered_replicas_`. `STORAGE MODE` is per-database. This mismatch is
+  what decision 3 resolves.
+- `UNREGISTER INSTANCE` refuses the current MAIN (`coordinator_instance.cpp:862`), so the
+  surviving single data instance must be the MAIN.
+- `REGISTER INSTANCE` returns `SUCCESS` even when `RegisterReplicaOnMainRpc` fails
+  (`coordinator_instance.cpp:817-825`) — the Raft commit is the success criterion, the RPC
+  is best-effort with reconciliation retry. This is why Q6 is about observability rather
+  than error propagation.
+- `PromoteToMainHandler` (`coordination/data_instance_management_server_handlers.cpp:315`)
+  calls `DoRegisterReplica` per replica and a failure there makes
+  `InstanceSuccessCallback` attempt `TryFailover()`. A healthy analytical main is not sent
+  `PromoteToMainRpc` in steady state (it is not a replica, writing is enabled, uuid
+  matches), so this is not triggered by the target workload — but it is the reason the
+  gates must not make promotion fail spuriously.
+- `StateCheckHandler` does not take `main_lock_` or `engine_lock_`, so a long import or the
+  UNIQUE-access mode switch cannot stall the coordinator's health checks into a false
+  failover.

--- a/specs/ha-analytical-import.md
+++ b/specs/ha-analytical-import.md
@@ -1,7 +1,13 @@
 # HA analytical import — design
 
-**Status**: design interview complete; all ten questions resolved. Ready to implement.
-**Started**: 2026-08-03. **Completed**: 2026-08-04.
+**Status**: implemented on `feat/ha-analytical-import`. All ten decisions are in code; the only
+outstanding item is the operator-facing documentation, which lives in `memgraph/documentation`.
+**Started**: 2026-08-03. **Design completed**: 2026-08-04. **Implemented**: 2026-08-04.
+
+Deviation from the plan worth recording: the "switching to analytical with a replication client
+attached is refused" unit test lives in `tests/unit/storage_v2_replication.cpp` rather than
+`storage_v2_storage_mode.cpp`, because only the former has the fixture that can produce a real
+`ReplicationStorageClient`.
 
 ## Target workload
 

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -228,6 +228,13 @@ auto DataInstanceManagementServerHandlers::DoRegisterReplica(replication::Replic
             config.instance_name);
         return false;
       }
+      case RegisterReplicaError::ANALYTICAL_MODE: {
+        spdlog::error(
+            "Error when registering instance {} as replica. A database on main is in analytical storage mode; "
+            "registration is retried once main is back in IN_MEMORY_TRANSACTIONAL.",
+            config.instance_name);
+        return false;
+      }
       default: {
         LOG_FATAL("Error in handling RegisterReplicaError. Unknown enum value.");
       }
@@ -397,6 +404,12 @@ void DataInstanceManagementServerHandlers::UnregisterReplicaHandler(
     }
     case NO_ACCESS: {
       spdlog::error("Couldn't get unique access to ReplicationState when unregistering replica.");
+      coordination::UnregisterReplicaRes const rpc_res{false};
+      rpc::SendFinalResponse(rpc_res, request_version, res_builder);
+      break;
+    }
+    case ANALYTICAL_MODE: {
+      spdlog::error("Couldn't unregister replica because a database is in analytical storage mode.");
       coordination::UnregisterReplicaRes const rpc_res{false};
       rpc::SendFinalResponse(rpc_res, request_version, res_builder);
       break;

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -382,6 +382,7 @@ void DataInstanceManagementServerHandlers::UnregisterReplicaHandler(
     case SUCCESS: {
       coordination::UnregisterReplicaRes const rpc_res{true};
       rpc::SendFinalResponse(rpc_res, request_version, res_builder);
+      spdlog::info("Replica {} successfully unregistered.", req.arg_);
       break;
     }
     case NOT_MAIN: {
@@ -415,7 +416,6 @@ void DataInstanceManagementServerHandlers::UnregisterReplicaHandler(
       break;
     }
   }
-  spdlog::info("Replica {} successfully unregistered.", req.arg_);
 }
 
 void DataInstanceManagementServerHandlers::UpdateDataInstanceConfigHandler(

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -470,6 +470,13 @@ class ReplQueryHandler {
         throw QueryRuntimeException("Replica can't register another replica!");
       }
 
+      if (error.error() == RegisterReplicaError::ANALYTICAL_MODE) {
+        throw QueryRuntimeException(
+            "Couldn't register replica {} because a database is in analytical storage mode. Switch every database back "
+            "to IN_MEMORY_TRANSACTIONAL and retry.",
+            name);
+      }
+
       throw QueryRuntimeException("Couldn't register replica {}. Error: {}", name, static_cast<uint8_t>(error.error()));
     }
   }
@@ -491,6 +498,11 @@ class ReplQueryHandler {
         [[fallthrough]];
       case CANNOT_UNREGISTER:
         throw QueryRuntimeException("Failed to unregister the replica {}.", replica_name);
+      case ANALYTICAL_MODE:
+        throw QueryRuntimeException(
+            "Couldn't unregister replica {} because a database is in analytical storage mode. Switch every database "
+            "back to IN_MEMORY_TRANSACTIONAL and retry.",
+            replica_name);
       case SUCCESS:
         break;
     }
@@ -6430,7 +6442,24 @@ PreparedQuery PrepareStorageModeQuery(ParsedQuery parsed_query, const bool in_ex
 #ifdef MG_ENTERPRISE
   if (interpreter_context->coordinator_state_ && interpreter_context->coordinator_state_->IsDataInstance() &&
       requested_mode == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
-    throw QueryRuntimeException("Data instances cannot use analytical mode");
+    // Analytical writes bypass the WAL, so a data instance may only enter analytical mode when it is the
+    // MAIN and nothing replicates from it. Instance-wide and advisory: replicas can still appear before
+    // SetStorageMode stores the mode, which is why that store re-checks under the clients' own lock.
+    auto const locked_repl_state = interpreter_context->repl_state->ReadLock();
+    if (!locked_repl_state->IsMain()) {
+      throw QueryRuntimeException(
+          "Only the MAIN data instance can use analytical mode. A REPLICA receives replicated writes, which analytical "
+          "mode cannot apply.");
+    }
+    if (auto const &replicas = locked_repl_state->GetMainRole().registered_replicas_; !replicas.empty()) {
+      auto const names = replicas | std::views::transform([](auto const &replica) { return replica.name_; }) |
+                         std::ranges::to<std::vector<std::string>>();
+      throw QueryRuntimeException(
+          "Cannot switch to analytical mode while replicas are registered ({}). Analytical writes are not replicated, "
+          "so unregister every replica from the cluster first and register them back after switching to "
+          "IN_MEMORY_TRANSACTIONAL.",
+          utils::Join(names, ", "));
+    }
   }
 #endif
 

--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -33,7 +33,10 @@ enum class RegisterReplicaError : uint8_t {
   CONNECTION_FAILED,
   COULD_NOT_BE_PERSISTED,
   ERROR_ACCEPTING_MAIN,
-  NO_ACCESS
+  NO_ACCESS,
+  // Some database is in IN_MEMORY_ANALYTICAL; analytical writes bypass the WAL, so a replica
+  // attached now would silently miss them.
+  ANALYTICAL_MODE
 };
 
 enum class UnregisterReplicaResult : uint8_t {
@@ -41,7 +44,8 @@ enum class UnregisterReplicaResult : uint8_t {
   COULD_NOT_BE_PERSISTED,
   CANNOT_UNREGISTER,
   SUCCESS,
-  NO_ACCESS
+  NO_ACCESS,
+  ANALYTICAL_MODE
 };
 
 enum class ShowReplicaError : uint8_t {

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -235,9 +235,17 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
     spdlog::trace("Replication storage clients destroyed.");
   }
 
+  using LockedReplState = utils::Synchronized<ReplicationState, utils::RWSpinLock>::LockedPtr;
+
   // UnregisterReplica without the analytical-mode gate, for the rollback of a failed registration:
   // that rollback must succeed precisely when a database did turn analytical mid-registration.
   auto UnregisterReplica_(std::string_view name) -> query::UnregisterReplicaResult;
+
+  // The same, driven by a hold the caller already owns. repl_state_ is not recursive, so a rollback
+  // running inside RegisterReplica_ cannot reacquire it: UnregisterReplica_ fails its TryLock every time
+  // and reports NO_ACCESS while leaving the replica registered.
+  auto UnregisterReplicaLocked_(LockedReplState &locked_repl_state, std::string_view name)
+      -> query::UnregisterReplicaResult;
 
   // Name of the first database found in analytical mode, if any. Registration and unregistration are
   // instance-wide operations, so a single analytical database blocks both.
@@ -305,6 +313,10 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
     // Add database specific clients (NOTE Currently all databases are connected to each replica)
     bool all_clients_good{true};
     dbms_handler_.ForEach([&](dbms::DatabaseAccess db_acc) {
+      // One failed database rolls the whole registration back, and the Shutdown below has already torn the
+      // instance client down, so every further Start would only block on an aborted RPC client.
+      if (!all_clients_good) return;
+
       auto *storage = db_acc->storage();
       // Disk storage never participates in replication, so it is skipped rather than failed. Analytical
       // does fail: silently skipping it is what leaves the replica permanently unattached. The up-front
@@ -320,36 +332,43 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
       auto client = std::make_unique<storage::ReplicationStorageClient>(*instance_client_ptr, main_uuid);
       client->Start(storage, protector);
 
-      all_clients_good &= storage->repl_storage_state_.replication_storage_clients_.WithLock(
-          [storage, client = std::move(client)](auto &storage_clients) mutable {  // NOLINT
+      // Start runs the heartbeat synchronously but may leave a recovery task queued on the instance
+      // client's thread pool, holding a raw pointer to this client. A rejected client therefore must not be
+      // destroyed under the lock: ownership is handed back so it outlives the drain below.
+      auto rejected = storage->repl_storage_state_.replication_storage_clients_.WithLock(
+          [storage, client = std::move(client)](
+              auto &storage_clients) mutable -> storage::ReplicationStorageState::ReplicationStorageClientPtr {
             // Re-read the mode under this lock. SetStorageMode stores IN_MEMORY_ANALYTICAL under the very
             // same lock, so "analytical with a live client" is unrepresentable rather than merely unlikely.
-            if (storage->storage_mode_ != storage::StorageMode::IN_MEMORY_TRANSACTIONAL) return false;
+            if (storage->storage_mode_ != storage::StorageMode::IN_MEMORY_TRANSACTIONAL) return std::move(client);
 
-            bool const success = std::invoke([state = client->State()]() {
-              // We force sync replicas in other situation
-              // DIVERGED_FROM_MAIN is only valid state in enterprise and community replication. HA will immediately
-              // set the state to RECOVERY
-              return state != storage::replication::ReplicaState::DIVERGED_FROM_MAIN;
-            });
+            // We force sync replicas in other situation
+            // DIVERGED_FROM_MAIN is only valid state in enterprise and community replication. HA will immediately
+            // set the state to RECOVERY
+            if (client->State() == storage::replication::ReplicaState::DIVERGED_FROM_MAIN) return std::move(client);
 
-            if (success) {
-              storage_clients.push_back(std::move(client));
-            }
-            return success;
+            storage_clients.push_back(std::move(client));
+            return nullptr;
           });
+
+      if (rejected) {
+        all_clients_good = false;
+        // Aborts the in-flight RPC, drops the queue and joins the worker, so no task can outlive `rejected`,
+        // which is destroyed at the end of this iteration. Must run with the clients' lock released: the
+        // task can be inside GetRecoverySteps waiting on engine_lock_, which a committing thread holds
+        // while waiting for that very lock.
+        instance_client_ptr->Shutdown();
+      }
     });
 
     if (!all_clients_good) {
       spdlog::error("Failed to register all databases for the replica {}. Started unregistering replica.", config.name);
-      switch (UnregisterReplica_(config.name)) {
+      switch (UnregisterReplicaLocked_(locked_repl_state, config.name)) {
         using query::UnregisterReplicaResult;
         case UnregisterReplicaResult::ANALYTICAL_MODE:
-          LOG_FATAL("UnregisterReplica_ must not apply the analytical-mode gate.");
+          LOG_FATAL("UnregisterReplicaLocked_ must not apply the analytical-mode gate.");
         case UnregisterReplicaResult::NO_ACCESS:
-          spdlog::trace("Failed to unregister replica {} since we couldn't get unique access to ReplicationState.",
-                        config.name);
-          break;
+          LOG_FATAL("UnregisterReplicaLocked_ must not acquire ReplicationState; the caller already holds it.");
         case UnregisterReplicaResult::NOT_MAIN:
           spdlog::trace(
               "Failed to unregister replica {} after failed registration process since the instance isn't main "

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -235,11 +235,36 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
     spdlog::trace("Replication storage clients destroyed.");
   }
 
+  // UnregisterReplica without the analytical-mode gate, for the rollback of a failed registration:
+  // that rollback must succeed precisely when a database did turn analytical mid-registration.
+  auto UnregisterReplica_(std::string_view name) -> query::UnregisterReplicaResult;
+
+  // Name of the first database found in analytical mode, if any. Registration and unregistration are
+  // instance-wide operations, so a single analytical database blocks both.
+  auto AnalyticalDatabase() const -> std::optional<std::string> {
+    std::optional<std::string> analytical_db;
+    dbms_handler_.ForEach([&analytical_db](dbms::DatabaseAccess db_acc) {
+      if (!analytical_db && db_acc->storage()->storage_mode_ == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
+        analytical_db = db_acc->name();
+      }
+    });
+    return analytical_db;
+  }
+
   template <bool SendSwapUUID>
   auto RegisterReplica_(auto &locked_repl_state, const ReplicationClientConfig &config)
       -> std::expected<void, query::RegisterReplicaError> {
     using query::RegisterReplicaError;
     using ClientRegisterReplicaStatus = RegisterReplicaStatus;
+
+    // Reject before any replication state is mutated: persisting the instance-level client while no
+    // per-database client can be created leaves the replica permanently unattached, since every retry
+    // then fails with NAME_EXISTS.
+    if (auto const analytical_db = AnalyticalDatabase(); analytical_db.has_value()) {
+      spdlog::error(
+          "Cannot register replica {} while database \"{}\" is in analytical mode.", config.name, *analytical_db);
+      return std::unexpected{RegisterReplicaError::ANALYTICAL_MODE};
+    }
 
     auto maybe_client = locked_repl_state->RegisterReplica(config);
     if (!maybe_client) {
@@ -281,7 +306,14 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
     bool all_clients_good{true};
     dbms_handler_.ForEach([&](dbms::DatabaseAccess db_acc) {
       auto *storage = db_acc->storage();
-      if (storage->storage_mode_ != storage::StorageMode::IN_MEMORY_TRANSACTIONAL) return;
+      // Disk storage never participates in replication, so it is skipped rather than failed. Analytical
+      // does fail: silently skipping it is what leaves the replica permanently unattached. The up-front
+      // gate above already rejected that, so getting here means the mode flipped in between.
+      if (storage->storage_mode_ == storage::StorageMode::ON_DISK_TRANSACTIONAL) return;
+      if (storage->storage_mode_ != storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
+        all_clients_good = false;
+        return;
+      }
 
       auto protector = dbms::DatabaseProtector{db_acc};
 
@@ -289,7 +321,11 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
       client->Start(storage, protector);
 
       all_clients_good &= storage->repl_storage_state_.replication_storage_clients_.WithLock(
-          [client = std::move(client)](auto &storage_clients) mutable {  // NOLINT
+          [storage, client = std::move(client)](auto &storage_clients) mutable {  // NOLINT
+            // Re-read the mode under this lock. SetStorageMode stores IN_MEMORY_ANALYTICAL under the very
+            // same lock, so "analytical with a live client" is unrepresentable rather than merely unlikely.
+            if (storage->storage_mode_ != storage::StorageMode::IN_MEMORY_TRANSACTIONAL) return false;
+
             bool const success = std::invoke([state = client->State()]() {
               // We force sync replicas in other situation
               // DIVERGED_FROM_MAIN is only valid state in enterprise and community replication. HA will immediately
@@ -306,8 +342,10 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
 
     if (!all_clients_good) {
       spdlog::error("Failed to register all databases for the replica {}. Started unregistering replica.", config.name);
-      switch (UnregisterReplica(config.name)) {
+      switch (UnregisterReplica_(config.name)) {
         using query::UnregisterReplicaResult;
+        case UnregisterReplicaResult::ANALYTICAL_MODE:
+          LOG_FATAL("UnregisterReplica_ must not apply the analytical-mode gate.");
         case UnregisterReplicaResult::NO_ACCESS:
           spdlog::trace("Failed to unregister replica {} since we couldn't get unique access to ReplicationState.",
                         config.name);

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -23,6 +23,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+
 namespace memgraph::replication {
 
 using namespace std::chrono_literals;
@@ -364,36 +366,48 @@ auto ReplicationHandler::UnregisterReplica(std::string_view name) -> query::Unre
 auto ReplicationHandler::UnregisterReplica_(std::string_view name) -> query::UnregisterReplicaResult {
   try {
     auto locked_repl_state = repl_state_.TryLock();
-
-    auto const replica_handler = [](RoleReplicaData const &) -> query::UnregisterReplicaResult {
-      return query::UnregisterReplicaResult::NOT_MAIN;
-    };
-    auto const main_handler =
-        [this, name, &locked_repl_state](RoleMainData &mainData) -> query::UnregisterReplicaResult {
-      if (!locked_repl_state->TryPersistUnregisterReplica(name)) {
-        return query::UnregisterReplicaResult::COULD_NOT_BE_PERSISTED;
-      }
-      // Remove database specific clients
-      dbms_handler_.ForEach([name](dbms::DatabaseAccess db_acc) {
-        db_acc->storage()->repl_storage_state_.replication_storage_clients_.WithLock([&name](auto &clients) {
-          std::erase_if(clients, [name](const auto &client) { return client->Name() == name; });
-        });
-      });
-      // Remove instance level clients
-      auto const n_unregistered =
-          std::erase_if(mainData.registered_replicas_, [name](auto const &client) { return client.name_ == name; });
-
-      // Drop the per-instance replication throughput series so the metric maps don't grow unbounded.
-      metrics::Metrics().RemoveReplicationThroughput(name);
-
-      return n_unregistered != 0 ? query::UnregisterReplicaResult::SUCCESS
-                                 : query::UnregisterReplicaResult::CANNOT_UNREGISTER;
-    };
-
-    return std::visit(utils::Overloaded{main_handler, replica_handler}, locked_repl_state->ReplicationData());
+    return UnregisterReplicaLocked_(locked_repl_state, name);
   } catch (const utils::TryLockException & /* unused */) {
     return query::UnregisterReplicaResult::NO_ACCESS;
   }
+}
+
+auto ReplicationHandler::UnregisterReplicaLocked_(LockedReplState &locked_repl_state, std::string_view name)
+    -> query::UnregisterReplicaResult {
+  auto const replica_handler = [](RoleReplicaData const &) -> query::UnregisterReplicaResult {
+    return query::UnregisterReplicaResult::NOT_MAIN;
+  };
+  auto const main_handler = [this, name, &locked_repl_state](RoleMainData &mainData) -> query::UnregisterReplicaResult {
+    if (!locked_repl_state->TryPersistUnregisterReplica(name)) {
+      return query::UnregisterReplicaResult::COULD_NOT_BE_PERSISTED;
+    }
+    // Stop the instance-level client before destroying any storage client below. Its thread pool holds raw
+    // pointers to them, and only Shutdown aborts the in-flight recovery, drops the queue and joins the
+    // worker; the destructor further down would do it after the storage clients are already gone.
+    // ClientsShutdown observes the same order for the role transition.
+    auto const client_it = std::ranges::find_if(mainData.registered_replicas_,
+                                                [name](auto const &client) { return client.name_ == name; });
+    if (client_it != mainData.registered_replicas_.end()) {
+      client_it->Shutdown();
+    }
+    // Remove database specific clients
+    dbms_handler_.ForEach([name](dbms::DatabaseAccess db_acc) {
+      db_acc->storage()->repl_storage_state_.replication_storage_clients_.WithLock([&name](auto &clients) {
+        std::erase_if(clients, [name](const auto &client) { return client->Name() == name; });
+      });
+    });
+    // Remove instance level clients
+    auto const n_unregistered =
+        std::erase_if(mainData.registered_replicas_, [name](auto const &client) { return client.name_ == name; });
+
+    // Drop the per-instance replication throughput series so the metric maps don't grow unbounded.
+    metrics::Metrics().RemoveReplicationThroughput(name);
+
+    return n_unregistered != 0 ? query::UnregisterReplicaResult::SUCCESS
+                               : query::UnregisterReplicaResult::CANNOT_UNREGISTER;
+  };
+
+  return std::visit(utils::Overloaded{main_handler, replica_handler}, locked_repl_state->ReplicationData());
 }
 
 auto ReplicationHandler::GetRole() const -> replication_coordination_glue::ReplicationRole {

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -352,6 +352,16 @@ auto ReplicationHandler::RegisterReplica(const ReplicationClientConfig &config)
 }
 
 auto ReplicationHandler::UnregisterReplica(std::string_view name) -> query::UnregisterReplicaResult {
+  // Reject before any replication state is mutated, mirroring the registration gate. Analytical mode
+  // implies there are no per-database clients to erase, so this would silently half-unregister.
+  if (auto const analytical_db = AnalyticalDatabase(); analytical_db.has_value()) {
+    spdlog::error("Cannot unregister replica {} while database \"{}\" is in analytical mode.", name, *analytical_db);
+    return query::UnregisterReplicaResult::ANALYTICAL_MODE;
+  }
+  return UnregisterReplica_(name);
+}
+
+auto ReplicationHandler::UnregisterReplica_(std::string_view name) -> query::UnregisterReplicaResult {
   try {
     auto locked_repl_state = repl_state_.TryLock();
 

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -387,24 +387,24 @@ auto ReplicationHandler::UnregisterReplicaLocked_(LockedReplState &locked_repl_s
     // ClientsShutdown observes the same order for the role transition.
     auto const client_it = std::ranges::find_if(mainData.registered_replicas_,
                                                 [name](auto const &client) { return client.name_ == name; });
-    if (client_it != mainData.registered_replicas_.end()) {
-      client_it->Shutdown();
+    if (client_it == mainData.registered_replicas_.end()) {
+      return query::UnregisterReplicaResult::CANNOT_UNREGISTER;
     }
+    client_it->Shutdown();
+
     // Remove database specific clients
     dbms_handler_.ForEach([name](dbms::DatabaseAccess db_acc) {
       db_acc->storage()->repl_storage_state_.replication_storage_clients_.WithLock([&name](auto &clients) {
         std::erase_if(clients, [name](const auto &client) { return client->Name() == name; });
       });
     });
-    // Remove instance level clients
-    auto const n_unregistered =
-        std::erase_if(mainData.registered_replicas_, [name](auto const &client) { return client.name_ == name; });
+    // Remove instance level client
+    mainData.registered_replicas_.erase(client_it);
 
     // Drop the per-instance replication throughput series so the metric maps don't grow unbounded.
     metrics::Metrics().RemoveReplicationThroughput(name);
 
-    return n_unregistered != 0 ? query::UnregisterReplicaResult::SUCCESS
-                               : query::UnregisterReplicaResult::CANNOT_UNREGISTER;
+    return query::UnregisterReplicaResult::SUCCESS;
   };
 
   return std::visit(utils::Overloaded{main_handler, replica_handler}, locked_repl_state->ReplicationData());

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -13,27 +13,55 @@
 
 namespace memgraph::rpc {
 
+Connection::Connection(io::network::Endpoint endpoint, communication::ClientContext *context,
+                       std::chrono::milliseconds const connect_timeout_ms)
+    : endpoint_(std::move(endpoint)), context_(context), connect_timeout_ms_(connect_timeout_ms) {}
+
+void Connection::Interrupt() {
+  if (!client_) return;
+  client_->Shutdown();
+}
+
+void Connection::Abort() {
+  // Latch first so any thread that subsequently tries to open a stream fails fast instead of reconnecting, then break
+  // the in-flight RPC. Nothing is destroyed, so this is safe with an RPC in flight.
+  aborted_.store(true, std::memory_order_release);
+  Interrupt();
+}
+
+void Connection::Shutdown() {
+  // Retire the socket rather than destroy it: the in-flight RPC owns mutex_ and has to be the one that finishes with
+  // it. EnsureConnected replaces it on the next stream, under that same lock.
+  needs_reconnect_.store(true, std::memory_order_release);
+  Interrupt();
+}
+
+void Connection::EnsureConnected() {
+  // Retired by Shutdown, or broken while idle (a long-unused connection whose server has since died). IsConnected
+  // gates ErrorStatus because the latter is a getsockopt on the raw descriptor and asserts on a closed socket.
+  if (needs_reconnect_.exchange(false, std::memory_order_acq_rel) ||
+      (client_ && (!client_->IsConnected() || client_->ErrorStatus()))) {
+    client_ = std::nullopt;
+  }
+
+  if (client_) return;
+
+  client_.emplace(context_, connect_timeout_ms_);
+  if (!client_->Connect(endpoint_)) {
+    spdlog::error("Couldn't connect to remote address {}", endpoint_.SocketAddress());
+    client_ = std::nullopt;
+    throw RpcFailedToConnectException();
+  }
+}
+
 Client::Client(io::network::Endpoint endpoint, communication::ClientContext *context,
                std::unordered_map<std::string_view, int> const &rpc_timeouts_ms,
                std::chrono::milliseconds const connect_timeout_ms)
-    : endpoint_(std::move(endpoint)),
-      context_(context),
-      rpc_timeouts_ms_(rpc_timeouts_ms),
-      connect_timeout_ms_(connect_timeout_ms) {}
+    : conn_(std::make_shared<Connection>(std::move(endpoint), context, connect_timeout_ms)),
+      rpc_timeouts_ms_(rpc_timeouts_ms) {}
 
-void Client::Abort() {
-  // Latch the aborted flag first so any thread that subsequently tries to open a stream fails fast instead of
-  // reconnecting. Then shut down the socket to abort any pending read, write, or connect operations on another thread.
-  // Does NOT destroy the client object, so it is safe to call concurrently with an in-flight RPC.
-  aborted_.store(true, std::memory_order_release);
-  if (!client_) return;
-  client_->Shutdown();
-}
+void Client::Abort() { conn_->Abort(); }
 
-void Client::Shutdown() {
-  if (!client_) return;
-  client_->Shutdown();
-  client_ = std::nullopt;
-}
+void Client::Shutdown() { conn_->Shutdown(); }
 
 }  // namespace memgraph::rpc

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -18,8 +18,12 @@ Connection::Connection(io::network::Endpoint endpoint, communication::ClientCont
     : endpoint_(std::move(endpoint)), context_(context), connect_timeout_ms_(connect_timeout_ms) {}
 
 void Connection::Interrupt() {
-  if (!client_) return;
-  client_->Shutdown();
+  // The load pins the socket, so a concurrent reconnect cannot destroy it while we shut it down. That it
+  // is the *right* socket comes from mutex_ rather than from the pin: a thread blocked in an RPC holds
+  // mutex_, so EnsureConnected cannot run and client_ cannot change under it. Once that thread has
+  // released the lock a reconnect may intervene and this interrupts the newer socket instead, which is
+  // harmless -- nobody is blocked on the older one by then.
+  if (auto const sock = client_.load(std::memory_order_acquire)) sock->Shutdown();
 }
 
 void Connection::Abort() {
@@ -36,22 +40,30 @@ void Connection::Shutdown() {
   Interrupt();
 }
 
-void Connection::EnsureConnected() {
+auto Connection::EnsureConnected() -> std::shared_ptr<communication::Client> {
+  auto sock = client_.load(std::memory_order_acquire);
+
   // Retired by Shutdown, or broken while idle (a long-unused connection whose server has since died). IsConnected
   // gates ErrorStatus because the latter is a getsockopt on the raw descriptor and asserts on a closed socket.
   if (needs_reconnect_.exchange(false, std::memory_order_acq_rel) ||
-      (client_ && (!client_->IsConnected() || client_->ErrorStatus()))) {
-    client_ = std::nullopt;
+      (sock && (!sock->IsConnected() || sock->ErrorStatus()))) {
+    sock.reset();
   }
 
-  if (client_) return;
+  if (sock) return sock;
 
-  client_.emplace(context_, connect_timeout_ms_);
-  if (!client_->Connect(endpoint_)) {
+  sock = std::make_shared<communication::Client>(context_, connect_timeout_ms_);
+  if (!sock->Connect(endpoint_)) {
     spdlog::error("Couldn't connect to remote address {}", endpoint_.SocketAddress());
-    client_ = std::nullopt;
+    // Retire the previous socket too: whatever it was, it is not what the next attempt should reuse.
+    client_.store(nullptr, std::memory_order_release);
     throw RpcFailedToConnectException();
   }
+
+  // Publishing drops the caller's share of the old socket, but not any share an in-flight RPC or a
+  // concurrent Interrupt still holds -- those keep it alive until they are done with it.
+  client_.store(sock, std::memory_order_release);
+  return sock;
 }
 
 Client::Client(io::network::Endpoint endpoint, communication::ClientContext *context,

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <storage/v2/replication/rpc.hpp>
@@ -34,6 +35,71 @@
 namespace memgraph::rpc {
 
 using namespace std::string_view_literals;
+
+/// Everything a StreamHandler needs in order to outlive the Client that produced it: the socket, the
+/// lock serializing it, and the endpoint. Held by shared_ptr so a handler that is still unwinding
+/// keeps them alive after the owning Client is gone -- which is what lets teardown interrupt an
+/// in-flight RPC without waiting for it and without destroying anything underneath it.
+///
+/// The invariant that makes that safe: client_ is written only under mutex_, and a live StreamHandler
+/// holds mutex_ for its whole lifetime, so the socket a handler is using can be neither replaced nor
+/// destroyed while it runs. Abort() and Shutdown() therefore only interrupt; they never destroy.
+class Connection {
+ public:
+  Connection(io::network::Endpoint endpoint, communication::ClientContext *context,
+             std::chrono::milliseconds connect_timeout_ms);
+
+  Connection(Connection const &) = delete;
+  Connection &operator=(Connection const &) = delete;
+  Connection(Connection &&) = delete;
+  Connection &operator=(Connection &&) = delete;
+  ~Connection() = default;
+
+  /// Latch the connection as aborted and break any in-flight RPC. No further stream can be opened,
+  /// so no queued task, heartbeat or commit can revive the connection once teardown has begun.
+  void Abort();
+
+  /// Retire the current socket and break any in-flight RPC, so the next stream reconnects. Used both
+  /// on teardown and to poison a connection whose request was only half written.
+  void Shutdown();
+
+  auto endpoint() const -> io::network::Endpoint const & { return endpoint_; }
+
+ private:
+  // StreamHandler is nested in Client and so shares its access rights.
+  friend class Client;
+
+  /// shutdown(2) on the current socket: aborts a pending read, write or connect on another thread
+  /// without destroying anything, so it is safe to call with an RPC in flight.
+  ///
+  /// Reads client_ without mutex_, which is a benign race against the reconnect below: the reader
+  /// never destroys, and the only caller that does not already hold mutex_ runs after Abort() has
+  /// latched aborted_, which stops any reconnect from starting. This is the same exposure Abort()
+  /// has always had; the destructive variant is what used to be unsound.
+  void Interrupt();
+
+  /// Replace a retired or broken socket and connect. Caller must hold mutex_.
+  /// @throws RpcFailedToConnectException
+  void EnsureConnected();
+
+  io::network::Endpoint endpoint_;
+  communication::ClientContext *context_;
+  std::chrono::milliseconds connect_timeout_ms_;
+
+  // Written only under mutex_. See the class comment.
+  std::optional<communication::Client> client_;
+
+  mutable utils::ResourceLock mutex_;
+
+  // Set once by Abort() during shutdown. Latches permanently: an aborted connection never opens
+  // another stream, so no in-flight or queued task can reconnect after teardown begins.
+  std::atomic<bool> aborted_{false};
+
+  // Set by Shutdown() to retire the current socket. A bare shutdown(2) leaves SO_ERROR clear, so the
+  // ErrorStatus() probe in EnsureConnected cannot observe it on its own; without this flag the next
+  // stream would reuse a connection that already carries a half-written request.
+  std::atomic<bool> needs_reconnect_{false};
+};
 
 /** Client is thread safe, but it is recommended to use thread_local clients.
  * This class represents a communication link from the client's side. It is something between a fair-loss link (fll)
@@ -120,39 +186,47 @@ class Client {
          std::unordered_map<std::string_view, int> const &rpc_timeouts_ms = Client::default_rpc_timeouts_ms,
          std::chrono::milliseconds connect_timeout_ms = std::chrono::milliseconds{5000});
 
+  // Holding the connection by shared_ptr would otherwise make Client copyable, where it used to be
+  // pinned by its ResourceLock member. Two Clients sharing one socket is not a meaningful state.
+  Client(Client const &) = delete;
+  Client &operator=(Client const &) = delete;
+  Client(Client &&) = delete;
+  Client &operator=(Client &&) = delete;
+  ~Client() = default;
+
   /// Object used to handle streaming of request data to the RPC server.
   template <class TRequestResponse>
   class StreamHandler {
    private:
     friend class Client;
 
-    StreamHandler(Client *self, std::unique_lock<utils::ResourceLock> &&guard,
+    StreamHandler(std::shared_ptr<Connection> conn, std::unique_lock<utils::ResourceLock> &&guard,
                   std::function<typename TRequestResponse::Response(slk::Reader *)> res_load,
                   std::optional<int> timeout_ms)
-        : self_(self),
+        : conn_(std::move(conn)),
           timeout_ms_(timeout_ms),
           guard_(std::move(guard)),
-          req_builder_(GenBuilderCallback(self, this, timeout_ms_)),
+          req_builder_(GenBuilderCallback(conn_.get(), this, timeout_ms_)),
           res_load_(res_load) {}
 
    public:
     // NOLINTNEXTLINE
     StreamHandler(StreamHandler &&other) noexcept
-        : self_{std::exchange(other.self_, nullptr)},
+        : conn_{std::exchange(other.conn_, nullptr)},
           timeout_ms_{other.timeout_ms_},
           defunct_{std::exchange(other.defunct_, true)},
           guard_{std::move(other.guard_)},
-          req_builder_{std::move(other.req_builder_), GenBuilderCallback(self_, this, timeout_ms_)},
+          req_builder_{std::move(other.req_builder_), GenBuilderCallback(conn_.get(), this, timeout_ms_)},
           res_load_{std::move(other.res_load_)} {}
 
     // NOLINTNEXTLINE
     StreamHandler &operator=(StreamHandler &&other) noexcept {
       if (&other != this) {
-        self_ = std::exchange(other.self_, nullptr);
+        conn_ = std::exchange(other.conn_, nullptr);
         timeout_ms_ = other.timeout_ms_;
         defunct_ = std::exchange(other.defunct_, true);
         guard_ = std::move(other.guard_);
-        req_builder_ = slk::Builder(std::move(other.req_builder_), GenBuilderCallback(self_, this, timeout_ms_));
+        req_builder_ = slk::Builder(std::move(other.req_builder_), GenBuilderCallback(conn_.get(), this, timeout_ms_));
         res_load_ = std::move(other.res_load_);
       }
       return *this;
@@ -177,14 +251,14 @@ class Client {
       spdlog::trace("[RpcClient] sent {}, version {}, to {}",
                     req_type_name,
                     TRequestResponse::Request::kVersion,
-                    self_->client_->endpoint().SocketAddress());
+                    conn_->client_->endpoint().SocketAddress());
 
       while (true) {
         // Receive the response.
         uint64_t response_data_size = 0;
         while (true) {
           // Even if in progress RPC message was sent, the stream will be complete
-          auto const ret = slk::CheckStreamStatus(self_->client_->GetData(), self_->client_->GetDataSize());
+          auto const ret = slk::CheckStreamStatus(conn_->client_->GetData(), conn_->client_->GetDataSize());
           if (ret.status == slk::StreamStatus::INVALID) {
             // Logically invalid state, connection is still up, defunct stream and release
             defunct_ = true;
@@ -192,13 +266,13 @@ class Client {
             throw GenericRpcFailedException();
           }
           if (ret.status == slk::StreamStatus::PARTIAL) {
-            if (auto const res = self_->client_->Read(ret.stream_size - self_->client_->GetDataSize(),
+            if (auto const res = conn_->client_->Read(ret.stream_size - conn_->client_->GetDataSize(),
                                                       /* exactly_len = */ false,
                                                       /* timeout_ms = */ timeout_ms_);
                 !res.has_value()) {
               // Failed connection, abort and let somebody retry in the future.
               defunct_ = true;
-              self_->Shutdown();
+              conn_->Shutdown();
               guard_.unlock();
               if (res.error() == io::network::ClientCommunicationError::TIMEOUT_ERROR) {
                 throw RpcTimeoutException();
@@ -213,7 +287,7 @@ class Client {
         }
 
         // Load the response.
-        slk::Reader res_reader(self_->client_->GetData(), response_data_size);
+        slk::Reader res_reader(conn_->client_->GetData(), response_data_size);
 
         auto const maybe_message_header = std::invoke([&res_reader]() -> std::optional<ProtocolMessageHeader> {
           try {
@@ -224,7 +298,7 @@ class Client {
         });
 
         if (!maybe_message_header) {
-          self_->client_->ShiftData(response_data_size);
+          conn_->client_->ShiftData(response_data_size);
           throw SlkRpcFailedException();
           ;
         }
@@ -232,10 +306,10 @@ class Client {
         if (maybe_message_header->message_id == utils::TypeId::REP_IN_PROGRESS_RES) {
           // Continue holding the lock
           spdlog::info("[RpcClient] Received InProgressRes RPC message from {}:{}. Waiting for {}.",
-                       self_->endpoint_.GetAddress(),
-                       self_->endpoint_.GetPort(),
+                       conn_->endpoint_.GetAddress(),
+                       conn_->endpoint_.GetPort(),
                        final_res_type_name);
-          self_->client_->ShiftData(response_data_size);
+          conn_->client_->ShiftData(response_data_size);
           continue;
         }
 
@@ -245,16 +319,16 @@ class Client {
           // Logically invalid state, connection is still up, defunct stream and release
           defunct_ = true;
           guard_.unlock();
-          self_->client_->ShiftData(response_data_size);
+          conn_->client_->ShiftData(response_data_size);
           throw GenericRpcFailedException();
         }
 
         spdlog::trace("[RpcClient] received {}, version {}, from endpoint {}:{}.",
                       final_res_type_name,
                       maybe_message_header->message_version,
-                      self_->endpoint_.GetAddress(),
-                      self_->endpoint_.GetPort());
-        self_->client_->ShiftData(response_data_size);
+                      conn_->endpoint_.GetAddress(),
+                      conn_->endpoint_.GetPort());
+        conn_->client_->ShiftData(response_data_size);
         return res_load_(&res_reader);
       }
     }
@@ -272,12 +346,12 @@ class Client {
       spdlog::trace("[RpcClient] sent {}, version {}, to {}",
                     req_type_name,
                     TRequestResponse::Request::kVersion,
-                    self_->client_->endpoint().SocketAddress());
+                    conn_->client_->endpoint().SocketAddress());
 
       // Receive the response.
       uint64_t response_data_size = 0;
       while (true) {
-        auto ret = slk::CheckStreamStatus(self_->client_->GetData(), self_->client_->GetDataSize());
+        auto ret = slk::CheckStreamStatus(conn_->client_->GetData(), conn_->client_->GetDataSize());
         if (ret.status == slk::StreamStatus::INVALID) {
           // Logically invalid state, connection is still up, defunct stream and release
           defunct_ = true;
@@ -285,13 +359,13 @@ class Client {
           throw GenericRpcFailedException();
         }
         if (ret.status == slk::StreamStatus::PARTIAL) {
-          if (auto const res = self_->client_->Read(ret.stream_size - self_->client_->GetDataSize(),
+          if (auto const res = conn_->client_->Read(ret.stream_size - conn_->client_->GetDataSize(),
                                                     /* exactly_len = */ false,
                                                     /* timeout_ms = */ timeout_ms_);
               !res.has_value()) {
             // Failed connection, abort and let somebody retry in the future.
             defunct_ = true;
-            self_->Shutdown();
+            conn_->Shutdown();
             guard_.unlock();
             if (res.error() == io::network::ClientCommunicationError::TIMEOUT_ERROR) {
               throw RpcTimeoutException();
@@ -306,8 +380,8 @@ class Client {
       }
 
       // Load the response.
-      slk::Reader res_reader(self_->client_->GetData(), response_data_size);
-      utils::OnScopeExit res_cleanup([&, response_data_size] { self_->client_->ShiftData(response_data_size); });
+      slk::Reader res_reader(conn_->client_->GetData(), response_data_size);
+      utils::OnScopeExit res_cleanup([&, response_data_size] { conn_->client_->ShiftData(response_data_size); });
 
       auto const maybe_message_header = std::invoke([&res_reader]() -> std::optional<ProtocolMessageHeader> {
         try {
@@ -337,8 +411,8 @@ class Client {
       spdlog::trace("[RpcClient] received {}, version {} from endpoint {}:{}.",
                     res_type_name,
                     maybe_message_header->message_version,
-                    self_->endpoint_.GetAddress(),
-                    self_->endpoint_.GetPort());
+                    conn_->endpoint_.GetAddress(),
+                    conn_->endpoint_.GetPort());
 
       return res_load_(&res_reader);
     }
@@ -346,12 +420,14 @@ class Client {
     bool IsDefunct() const { return defunct_; }
 
    private:
-    static auto GenBuilderCallback(Client *client, StreamHandler *self, std::optional<int> timeout_ms) {
-      return [client, self, timeout_ms](const uint8_t *data, size_t size, bool have_more) {
+    // Raw pointer, not a shared_ptr copy: the callback lives inside req_builder_, which is a member of
+    // the same handler that owns conn_, so the connection outlives every invocation.
+    static auto GenBuilderCallback(Connection *conn, StreamHandler *self, std::optional<int> timeout_ms) {
+      return [conn, self, timeout_ms](const uint8_t *data, size_t size, bool have_more) {
         if (self->defunct_) throw GenericRpcFailedException();
-        if (auto const res = client->client_->Write(data, size, have_more, timeout_ms); !res.has_value()) {
+        if (auto const res = conn->client_->Write(data, size, have_more, timeout_ms); !res.has_value()) {
           self->defunct_ = true;
-          client->Shutdown();
+          conn->Shutdown();
           self->guard_.unlock();
           if (res.error() == io::network::ClientCommunicationError::TIMEOUT_ERROR) {
             throw RpcTimeoutException();
@@ -362,7 +438,9 @@ class Client {
       };
     }
 
-    Client *self_;
+    // Must be declared before guard_: members are destroyed in reverse order, so guard_ releases
+    // conn_->mutex_ while the connection holding it is still alive.
+    std::shared_ptr<Connection> conn_;
     std::optional<int> timeout_ms_;
     bool defunct_ = false;
     std::unique_lock<utils::ResourceLock> guard_;
@@ -452,7 +530,7 @@ class Client {
         return std::move(*guard_arg);
       }
       // New stream, new lock, maybe use try_lock_timeout
-      auto local_guard = std::unique_lock{mutex_, std::defer_lock};
+      auto local_guard = std::unique_lock{conn_->mutex_, std::defer_lock};
       if (!try_lock_timeout) {
         local_guard.lock();
       } else if (!local_guard.try_lock_for(*try_lock_timeout)) {
@@ -463,25 +541,11 @@ class Client {
 
     // The client has been aborted as part of shutdown. Refuse to open (or reconnect) a stream so a queued recovery
     // task, heartbeat, or commit can't revive the connection after Abort() already tore it down.
-    if (aborted_.load(std::memory_order_acquire)) {
+    if (conn_->aborted_.load(std::memory_order_acquire)) {
       throw GenericRpcFailedException();
     }
 
-    // Check if the connection is broken (if we haven't used the client for a
-    // long time the server could have died).
-    if (client_ && client_->ErrorStatus()) {
-      client_ = std::nullopt;
-    }
-
-    // Connect to the remote server.
-    if (!client_) {
-      client_.emplace(context_, connect_timeout_ms_);
-      if (!client_->Connect(endpoint_)) {
-        spdlog::error("Couldn't connect to remote address {}", endpoint_.SocketAddress());
-        client_ = std::nullopt;
-        throw RpcFailedToConnectException();
-      }
-    }
+    conn_->EnsureConnected();
 
     std::optional<int> timeout_ms{std::nullopt};
 
@@ -491,8 +555,9 @@ class Client {
       timeout_ms.emplace(maybe_timeout->second);
     }
 
-    // Create the stream handler.
-    StreamHandler<TRequestResponse> handler(this, std::move(guard), res_load, timeout_ms);
+    // Create the stream handler. It takes a share of the connection, so it stays usable even if this
+    // Client is destroyed while the RPC is still unwinding.
+    StreamHandler<TRequestResponse> handler(conn_, std::move(guard), res_load, timeout_ms);
 
     ProtocolMessageHeader const message_header{.protocol_version = current_protocol_version,
                                                .message_id = req_type.id,
@@ -527,29 +592,24 @@ class Client {
     return stream.SendAndWait();
   }
 
-  /// Call this function from another thread to abort a pending RPC call.
-  /// Unlike Shutdown(), this does not destroy the client object, making it
-  /// safe to call while another thread is using the client.
+  /// Abort a pending RPC call and latch the client so no further stream can be opened. Safe to call
+  /// from any thread, including one that owns a live stream: it interrupts, it does not destroy.
   void Abort();
 
-  /// Shut down and destroy the underlying connection. Not safe to call
-  /// concurrently with in-flight RPCs — call Abort() first, then join
-  /// the worker thread, then call Shutdown().
+  /// Abort a pending RPC call and retire the connection, so the next stream reconnects. Safe to call
+  /// concurrently with in-flight RPCs, and from a thread that owns a live stream -- the socket is only
+  /// replaced later, under the lock that such a thread already holds.
+  ///
+  /// Note this returns before the socket is closed: the last StreamHandler to finish with the
+  /// connection is the one that destroys it. Teardown therefore never waits on an in-flight RPC.
   void Shutdown();
 
-  auto Endpoint() const -> io::network::Endpoint const & { return endpoint_; }
+  auto Endpoint() const -> io::network::Endpoint const & { return conn_->endpoint(); }
 
  private:
-  io::network::Endpoint endpoint_;
-  communication::ClientContext *context_;
-  std::optional<communication::Client> client_;
+  // Shared, not owned: a StreamHandler outliving this Client keeps the connection alive.
+  std::shared_ptr<Connection> conn_;
   std::unordered_map<std::string_view, int> rpc_timeouts_ms_;
-  std::chrono::milliseconds connect_timeout_ms_;
-
-  mutable utils::ResourceLock mutex_;
-  // Set once by Abort() during shutdown. Latches permanently: an aborted client never opens another stream, so no
-  // in-flight or queued task can reconnect after teardown begins.
-  std::atomic<bool> aborted_{false};
 };
 
 }  // namespace memgraph::rpc

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -41,9 +41,21 @@ using namespace std::string_view_literals;
 /// keeps them alive after the owning Client is gone -- which is what lets teardown interrupt an
 /// in-flight RPC without waiting for it and without destroying anything underneath it.
 ///
-/// The invariant that makes that safe: client_ is written only under mutex_, and a live StreamHandler
-/// holds mutex_ for its whole lifetime, so the socket a handler is using can be neither replaced nor
-/// destroyed while it runs. Abort() and Shutdown() therefore only interrupt; they never destroy.
+/// The socket is shared once more, one level down. Two separate guarantees make that safe, and they
+/// come from different places -- conflating them is the easy mistake here:
+///
+///   lifetime -- client_ is an atomic shared_ptr, so a load() pins whatever socket it returns. A
+///               concurrent reconnect publishes a replacement and drops the container's share, but it
+///               can never destroy a socket somebody else is still holding.
+///   identity -- EnsureConnected, the only writer of client_, runs solely under mutex_, and a handler
+///               holds mutex_ for as long as its RPC is in flight. So while a thread is blocked in
+///               Read/Write, client_ cannot change, and Interrupt() necessarily loads the very socket
+///               that thread is blocked on.
+///
+/// The pin alone would keep a socket alive but say nothing about which one you got; the lock alone
+/// would fix which one is current but not stop it being destroyed by a thread that does not hold it.
+/// Abort() and Shutdown() therefore only ever interrupt; nothing here destroys a socket another thread
+/// can still reach.
 class Connection {
  public:
   Connection(io::network::Endpoint endpoint, communication::ClientContext *context,
@@ -70,24 +82,23 @@ class Connection {
   friend class Client;
 
   /// shutdown(2) on the current socket: aborts a pending read, write or connect on another thread
-  /// without destroying anything, so it is safe to call with an RPC in flight.
-  ///
-  /// Reads client_ without mutex_, which is a benign race against the reconnect below: the reader
-  /// never destroys, and the only caller that does not already hold mutex_ runs after Abort() has
-  /// latched aborted_, which stops any reconnect from starting. This is the same exposure Abort()
-  /// has always had; the destructive variant is what used to be unsound.
+  /// without destroying anything, so it is safe to call with an RPC in flight and without mutex_.
   void Interrupt();
 
-  /// Replace a retired or broken socket and connect. Caller must hold mutex_.
+  /// Return the socket to run the next RPC on, replacing a retired or broken one first. Caller must
+  /// hold mutex_: being the sole writer of client_, and being reachable only under that lock, is what
+  /// gives every in-flight RPC a stable identity for the socket it is using.
   /// @throws RpcFailedToConnectException
-  void EnsureConnected();
+  auto EnsureConnected() -> std::shared_ptr<communication::Client>;
 
   io::network::Endpoint endpoint_;
   communication::ClientContext *context_;
   std::chrono::milliseconds connect_timeout_ms_;
 
-  // Written only under mutex_. See the class comment.
-  std::optional<communication::Client> client_;
+  // Replaced only under mutex_, but loaded without it by Interrupt. See the lifetime/identity split in
+  // the class comment: the atomic gives a loader a socket that stays alive, mutex_ gives an in-flight
+  // RPC the socket it started on.
+  std::atomic<std::shared_ptr<communication::Client>> client_;
 
   mutable utils::ResourceLock mutex_;
 
@@ -200,10 +211,12 @@ class Client {
    private:
     friend class Client;
 
-    StreamHandler(std::shared_ptr<Connection> conn, std::unique_lock<utils::ResourceLock> &&guard,
+    StreamHandler(std::shared_ptr<Connection> conn, std::shared_ptr<communication::Client> sock,
+                  std::unique_lock<utils::ResourceLock> &&guard,
                   std::function<typename TRequestResponse::Response(slk::Reader *)> res_load,
                   std::optional<int> timeout_ms)
         : conn_(std::move(conn)),
+          sock_(std::move(sock)),
           timeout_ms_(timeout_ms),
           guard_(std::move(guard)),
           req_builder_(GenBuilderCallback(conn_.get(), this, timeout_ms_)),
@@ -213,6 +226,7 @@ class Client {
     // NOLINTNEXTLINE
     StreamHandler(StreamHandler &&other) noexcept
         : conn_{std::exchange(other.conn_, nullptr)},
+          sock_{std::exchange(other.sock_, nullptr)},
           timeout_ms_{other.timeout_ms_},
           defunct_{std::exchange(other.defunct_, true)},
           guard_{std::move(other.guard_)},
@@ -223,6 +237,7 @@ class Client {
     StreamHandler &operator=(StreamHandler &&other) noexcept {
       if (&other != this) {
         conn_ = std::exchange(other.conn_, nullptr);
+        sock_ = std::exchange(other.sock_, nullptr);
         timeout_ms_ = other.timeout_ms_;
         defunct_ = std::exchange(other.defunct_, true);
         guard_ = std::move(other.guard_);
@@ -251,14 +266,14 @@ class Client {
       spdlog::trace("[RpcClient] sent {}, version {}, to {}",
                     req_type_name,
                     TRequestResponse::Request::kVersion,
-                    conn_->client_->endpoint().SocketAddress());
+                    sock_->endpoint().SocketAddress());
 
       while (true) {
         // Receive the response.
         uint64_t response_data_size = 0;
         while (true) {
           // Even if in progress RPC message was sent, the stream will be complete
-          auto const ret = slk::CheckStreamStatus(conn_->client_->GetData(), conn_->client_->GetDataSize());
+          auto const ret = slk::CheckStreamStatus(sock_->GetData(), sock_->GetDataSize());
           if (ret.status == slk::StreamStatus::INVALID) {
             // Logically invalid state, connection is still up, defunct stream and release
             defunct_ = true;
@@ -266,9 +281,9 @@ class Client {
             throw GenericRpcFailedException();
           }
           if (ret.status == slk::StreamStatus::PARTIAL) {
-            if (auto const res = conn_->client_->Read(ret.stream_size - conn_->client_->GetDataSize(),
-                                                      /* exactly_len = */ false,
-                                                      /* timeout_ms = */ timeout_ms_);
+            if (auto const res = sock_->Read(ret.stream_size - sock_->GetDataSize(),
+                                             /* exactly_len = */ false,
+                                             /* timeout_ms = */ timeout_ms_);
                 !res.has_value()) {
               // Failed connection, abort and let somebody retry in the future.
               defunct_ = true;
@@ -287,7 +302,7 @@ class Client {
         }
 
         // Load the response.
-        slk::Reader res_reader(conn_->client_->GetData(), response_data_size);
+        slk::Reader res_reader(sock_->GetData(), response_data_size);
 
         auto const maybe_message_header = std::invoke([&res_reader]() -> std::optional<ProtocolMessageHeader> {
           try {
@@ -298,9 +313,8 @@ class Client {
         });
 
         if (!maybe_message_header) {
-          conn_->client_->ShiftData(response_data_size);
+          sock_->ShiftData(response_data_size);
           throw SlkRpcFailedException();
-          ;
         }
 
         if (maybe_message_header->message_id == utils::TypeId::REP_IN_PROGRESS_RES) {
@@ -309,7 +323,7 @@ class Client {
                        conn_->endpoint_.GetAddress(),
                        conn_->endpoint_.GetPort(),
                        final_res_type_name);
-          conn_->client_->ShiftData(response_data_size);
+          sock_->ShiftData(response_data_size);
           continue;
         }
 
@@ -318,8 +332,10 @@ class Client {
                         static_cast<uint64_t>(maybe_message_header->message_id));
           // Logically invalid state, connection is still up, defunct stream and release
           defunct_ = true;
+          // Consume the response before dropping the lock: afterwards another thread can start its own
+          // RPC on this same socket, and shifting then would corrupt the framing it is reading.
+          sock_->ShiftData(response_data_size);
           guard_.unlock();
-          conn_->client_->ShiftData(response_data_size);
           throw GenericRpcFailedException();
         }
 
@@ -328,7 +344,7 @@ class Client {
                       maybe_message_header->message_version,
                       conn_->endpoint_.GetAddress(),
                       conn_->endpoint_.GetPort());
-        conn_->client_->ShiftData(response_data_size);
+        sock_->ShiftData(response_data_size);
         return res_load_(&res_reader);
       }
     }
@@ -346,12 +362,12 @@ class Client {
       spdlog::trace("[RpcClient] sent {}, version {}, to {}",
                     req_type_name,
                     TRequestResponse::Request::kVersion,
-                    conn_->client_->endpoint().SocketAddress());
+                    sock_->endpoint().SocketAddress());
 
       // Receive the response.
       uint64_t response_data_size = 0;
       while (true) {
-        auto ret = slk::CheckStreamStatus(conn_->client_->GetData(), conn_->client_->GetDataSize());
+        auto ret = slk::CheckStreamStatus(sock_->GetData(), sock_->GetDataSize());
         if (ret.status == slk::StreamStatus::INVALID) {
           // Logically invalid state, connection is still up, defunct stream and release
           defunct_ = true;
@@ -359,9 +375,9 @@ class Client {
           throw GenericRpcFailedException();
         }
         if (ret.status == slk::StreamStatus::PARTIAL) {
-          if (auto const res = conn_->client_->Read(ret.stream_size - conn_->client_->GetDataSize(),
-                                                    /* exactly_len = */ false,
-                                                    /* timeout_ms = */ timeout_ms_);
+          if (auto const res = sock_->Read(ret.stream_size - sock_->GetDataSize(),
+                                           /* exactly_len = */ false,
+                                           /* timeout_ms = */ timeout_ms_);
               !res.has_value()) {
             // Failed connection, abort and let somebody retry in the future.
             defunct_ = true;
@@ -380,8 +396,8 @@ class Client {
       }
 
       // Load the response.
-      slk::Reader res_reader(conn_->client_->GetData(), response_data_size);
-      utils::OnScopeExit res_cleanup([&, response_data_size] { conn_->client_->ShiftData(response_data_size); });
+      slk::Reader res_reader(sock_->GetData(), response_data_size);
+      utils::OnScopeExit res_cleanup([&, response_data_size] { sock_->ShiftData(response_data_size); });
 
       auto const maybe_message_header = std::invoke([&res_reader]() -> std::optional<ProtocolMessageHeader> {
         try {
@@ -404,6 +420,10 @@ class Client {
                       static_cast<uint64_t>(res_type.id));
         // Logically invalid state, connection is still up, defunct stream and release
         defunct_ = true;
+        // Same ordering as above. res_cleanup would otherwise run during unwinding, by which point
+        // another thread can already have started its own RPC on this socket.
+        sock_->ShiftData(response_data_size);
+        res_cleanup.Disable();
         guard_.unlock();
         throw GenericRpcFailedException();
       }
@@ -425,7 +445,7 @@ class Client {
     static auto GenBuilderCallback(Connection *conn, StreamHandler *self, std::optional<int> timeout_ms) {
       return [conn, self, timeout_ms](const uint8_t *data, size_t size, bool have_more) {
         if (self->defunct_) throw GenericRpcFailedException();
-        if (auto const res = conn->client_->Write(data, size, have_more, timeout_ms); !res.has_value()) {
+        if (auto const res = self->sock_->Write(data, size, have_more, timeout_ms); !res.has_value()) {
           self->defunct_ = true;
           conn->Shutdown();
           self->guard_.unlock();
@@ -441,6 +461,10 @@ class Client {
     // Must be declared before guard_: members are destroyed in reverse order, so guard_ releases
     // conn_->mutex_ while the connection holding it is still alive.
     std::shared_ptr<Connection> conn_;
+    // The socket this RPC was opened on. Not strictly required -- guard_ already pins client_'s identity
+    // for every access below -- but it is one load instead of one per use, and it lets each access read
+    // as "the socket this stream opened" rather than having to re-derive that from the lock.
+    std::shared_ptr<communication::Client> sock_;
     std::optional<int> timeout_ms_;
     bool defunct_ = false;
     std::unique_lock<utils::ResourceLock> guard_;
@@ -545,7 +569,7 @@ class Client {
       throw GenericRpcFailedException();
     }
 
-    conn_->EnsureConnected();
+    auto sock = conn_->EnsureConnected();
 
     std::optional<int> timeout_ms{std::nullopt};
 
@@ -555,9 +579,9 @@ class Client {
       timeout_ms.emplace(maybe_timeout->second);
     }
 
-    // Create the stream handler. It takes a share of the connection, so it stays usable even if this
-    // Client is destroyed while the RPC is still unwinding.
-    StreamHandler<TRequestResponse> handler(conn_, std::move(guard), res_load, timeout_ms);
+    // Create the stream handler. It takes a share of both the connection and the socket, so it stays
+    // usable even if this Client is destroyed, or the socket replaced, while the RPC is unwinding.
+    StreamHandler<TRequestResponse> handler(conn_, std::move(sock), std::move(guard), res_load, timeout_ms);
 
     ProtocolMessageHeader const message_header{.protocol_version = current_protocol_version,
                                                .message_id = req_type.id,
@@ -607,8 +631,10 @@ class Client {
   auto Endpoint() const -> io::network::Endpoint const & { return conn_->endpoint(); }
 
  private:
-  // Shared, not owned: a StreamHandler outliving this Client keeps the connection alive.
-  std::shared_ptr<Connection> conn_;
+  // Shared, not owned: a StreamHandler outliving this Client keeps the connection alive. const because
+  // it is never swapped -- that is what makes a plain shared_ptr here sufficient. Reconnecting replaces
+  // the socket inside the Connection, not the Connection, so mutex_ stays a fixed serialization point.
+  std::shared_ptr<Connection> const conn_;
   std::unordered_map<std::string_view, int> rpc_timeouts_ms_;
 };
 

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -83,6 +83,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   // This lock is also necessary to force the missed transaction to finish.
   std::optional<uint64_t> current_wal_seq_num;
   std::optional<uint64_t> current_wal_timestamp;
+  std::optional<uint64_t> current_wal_from_timestamp;
   uint64_t last_durable_timestamp{kTimestampInitialId};
 
   std::unique_lock transaction_guard(
@@ -96,6 +97,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
 
   if (main_storage->wal_file_) {
     current_wal_timestamp.emplace(main_storage->wal_file_->ToTimestamp());
+    current_wal_from_timestamp.emplace(main_storage->wal_file_->FromTimestamp());
     current_wal_seq_num.emplace(main_storage->wal_file_->SequenceNumber());
     // No need to hold the lock since the current WAL is present
     transaction_guard.unlock();
@@ -136,6 +138,23 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
       maybe_wal_files->back().to_timestamp > replica_commit) {
     auto const &wal_files = *maybe_wal_files;
     auto wal_chain_info = GetWalChainInfo(wal_files, replica_commit);
+
+    // A snapshot timestamp inside no WAL file's range means its data was never written to a WAL
+    // (analytical-mode writes bypass it), so WAL-only recovery would silently skip it. The chain looks
+    // intact because an analytical episode punches a timestamp hole without disturbing seq numbering.
+    // The > replica_commit guard is load-bearing: a replica already past the snapshot would otherwise
+    // enter the branch below with first_useful_wal pointing past the snapshot and trip its
+    // "Broken data chain" assert.
+    if (latest_snapshot && latest_snapshot->durable_timestamp > replica_commit &&
+        !SnapshotTsCoveredByAnyWal(
+            wal_files, current_wal_from_timestamp, current_wal_timestamp, latest_snapshot->durable_timestamp)) {
+      spdlog::info(
+          "Snapshot with durable timestamp {} is not covered by any WAL file; forcing snapshot-based recovery for a "
+          "replica at {}.",
+          latest_snapshot->durable_timestamp,
+          replica_commit);
+      wal_chain_info.covered_by_wals = false;
+    }
 
     // Finished the WAL chain, but still missing some data
     if (!wal_chain_info.covered_by_wals) {
@@ -244,6 +263,17 @@ auto FirstWalAfterSnapshot(std::vector<durability::WalDurabilityInfo> const &wal
          std::cmp_less_equal(wal_files[first_useful_wal].to_timestamp, snap_durable_ts))
     ++first_useful_wal;
   return first_useful_wal;
+}
+
+auto SnapshotTsCoveredByAnyWal(std::vector<durability::WalDurabilityInfo> const &wal_files,
+                               std::optional<uint64_t> const current_wal_from,
+                               std::optional<uint64_t> const current_wal_to, uint64_t const snapshot_ts) -> bool {
+  if (current_wal_from && current_wal_to && *current_wal_from <= snapshot_ts && snapshot_ts <= *current_wal_to) {
+    return true;
+  }
+  return std::ranges::any_of(wal_files, [snapshot_ts](auto const &wal) {
+    return wal.from_timestamp <= snapshot_ts && snapshot_ts <= wal.to_timestamp;
+  });
 }
 
 auto GetRecoveryWalFiles(utils::FileRetainer::FileLockerAccessor *locker_acc,

--- a/src/storage/v2/inmemory/replication/recovery.hpp
+++ b/src/storage/v2/inmemory/replication/recovery.hpp
@@ -148,6 +148,13 @@ auto GetWalChainInfo(std::vector<durability::WalDurabilityInfo> const &wal_files
 auto FirstWalAfterSnapshot(std::vector<durability::WalDurabilityInfo> const &wal_files, uint64_t snap_durable_ts,
                            uint64_t first_useful_wal) -> uint64_t;
 
+// True when some WAL file's [from, to] range contains snapshot_ts, i.e. a WAL holds the commits around
+// the snapshot's position and the WAL chain can reproduce its contents. The currently-open WAL is
+// considered too, since for an ordinary periodic snapshot that is the file whose range contains it.
+auto SnapshotTsCoveredByAnyWal(std::vector<durability::WalDurabilityInfo> const &wal_files,
+                               std::optional<uint64_t> current_wal_from, std::optional<uint64_t> current_wal_to,
+                               uint64_t snapshot_ts) -> bool;
+
 // Copy and lock the chain part we need, from oldest to newest
 auto GetRecoveryWalFiles(utils::FileRetainer::FileLockerAccessor *locker_acc,
                          std::vector<durability::WalDurabilityInfo> const &wal_files, uint64_t first_useful_wal)

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -78,6 +78,10 @@ namespace rv = r::views;
 namespace memgraph::storage {
 namespace {
 
+// Sub-directory holding durability files superseded by a new base state. Kept in sync with the name
+// utils::GetFilesFromDir filters out, so archived files are invisible to every directory scan.
+constexpr std::string_view kOldDurabilityDir = ".old";
+
 constexpr auto ActionToStorageOperation(MetadataDelta::Action const action) -> durability::StorageMetadataOperation {
   // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define add_case(E)              \
@@ -2954,6 +2958,25 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
                                            return CommitTsInfo{.ldt_ = std::max(old_info.ldt_, ldt),
                                                                .num_committed_txns_ = old_info.num_committed_txns_};
                                          });
+
+      // The switch-back snapshot is a new durability base, not an increment on the old one: an analytical
+      // episode leaves a timestamp hole no WAL can fill, so nothing written before it can be chained onto
+      // it. Archive the superseded files and restart the WAL numbering at 0 -- the two go together.
+      // Wiping alone would break recovery, since a chain whose first file has a non-zero sequence number
+      // is accepted only when some WAL predates the snapshot, and every such WAL is what was just wiped.
+      // Restarting alone would be worse: the surviving files carry this same UUID, so the new numbers
+      // would collide with theirs, and a duplicate sequence number is caught by no check anywhere.
+      if (snapshot_path) {
+        DMG_ASSERT(!wal_file_, "Analytical mode must not leave an open WAL file.");
+        if (ArchiveSupersededDurabilityFiles(*snapshot_path)) {
+          wal_seq_num_ = 0;
+        } else {
+          spdlog::warn(
+              "Superseded WAL files could not be archived, so WAL sequence numbering continues from {} to stay "
+              "collision-free.",
+              wal_seq_num_);
+        }
+      }
       snapshot_runner_.Resume();
       // Under the clients' lock for symmetry with the analytical store above, so replica registration's
       // in-lock read of storage_mode_ is serialized against every mode change, not just one direction.
@@ -3711,6 +3734,65 @@ void InMemoryStorage::FinalizeWalFile() {
     // reading thread EnabledFlushing)
     wal_file_->TryFlushing();
   }
+}
+
+bool InMemoryStorage::ArchiveSupersededDurabilityFiles(std::filesystem::path const &keep_snapshot) {
+  auto const use_old_dir = FLAGS_storage_backup_dir_enabled;
+
+  // A leftover .old from an earlier archival describes a state even older than the one being archived
+  // now, so it is dropped rather than merged; keeping both would let the directory grow without bound.
+  auto const prepare_old_dir = [](std::filesystem::path const &parent) -> bool {
+    auto const target = parent / kOldDurabilityDir;
+    std::error_code ec;
+    std::filesystem::remove_all(target, ec);
+    if (ec) {
+      spdlog::warn("Failed to clear backup directory {}. Err: {}", target, ec.message());
+      return false;
+    }
+    std::filesystem::create_directory(target, ec);
+    if (ec) {
+      spdlog::warn("Failed to create backup directory {}. Err: {}", target, ec.message());
+      return false;
+    }
+    return true;
+  };
+
+  // Archival is best-effort: it is housekeeping, not part of making the new snapshot durable. A failure
+  // degrades to "superseded files stay where they are", which the return value reports.
+  auto const archive_dir = [&](std::filesystem::path const &dir, std::filesystem::path const *keep) {
+    if (!utils::DirExists(dir)) return;  // durability off entirely; nothing was ever written here
+
+    // With backups enabled, a backup directory that cannot be created means the files stay where they
+    // are. Falling back to deleting them would turn a filesystem hiccup into unrecoverable data loss.
+    std::optional<std::filesystem::path> backup_dir;
+    if (use_old_dir) {
+      if (!prepare_old_dir(dir)) return;
+      backup_dir = dir / kOldDurabilityDir;
+    }
+
+    for (auto const &path : utils::GetFilesFromDir(dir)) {  // already skips the .old sub-directory
+      if (keep && path.filename() == keep->filename()) continue;
+      if (!backup_dir) {
+        file_retainer_.DeleteFile(path);
+        continue;
+      }
+      auto const new_path = *backup_dir / path.filename();
+      spdlog::trace("Archiving durability file {} to {}", path, new_path);
+      file_retainer_.RenameFile(path, new_path);
+    }
+
+    if (backup_dir) {
+      std::error_code ec;
+      std::filesystem::remove(*backup_dir, ec);  // no-op unless nothing needed archiving
+    }
+  };
+
+  archive_dir(recovery_.snapshot_directory_, &keep_snapshot);
+  archive_dir(recovery_.wal_directory_, nullptr);
+
+  // Deletions and renames are deferred while a file is locked (SHOW SNAPSHOTS, a replica recovery), so
+  // the directory is re-read rather than assumed empty.
+  return !utils::DirExists(recovery_.wal_directory_) || utils::GetFilesFromDir(recovery_.wal_directory_).empty();
 }
 
 auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
@@ -4501,7 +4583,7 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
     SetBroken(false);
 
     auto const use_old_dir = FLAGS_storage_backup_dir_enabled;
-    constexpr std::string_view old_dir = ".old";
+    auto const &old_dir = kOldDurabilityDir;
 
     // Move all previous snapshots and WAL files to .old dir
     if (use_old_dir) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2942,6 +2942,18 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
                                                             &abort_snapshot_,
                                                             &snapshot_progress_,
                                                             "storage_mode_change");
+      // Publish the snapshot's timestamp as the cached ldt. Analytical writes never reach
+      // FinalizeCommitPhase, so without this main keeps advertising the pre-analytical ldt and a replica
+      // registered afterwards is judged up to date by the heartbeat comparison -- recovery would never
+      // run and the imported data would never reach it. num_committed_txns_ is deliberately left alone:
+      // the snapshot records the same unchanged counter, so main and a recovering replica stay
+      // consistent. Advance-only, since concurrent commits are barred by the UNIQUE main_lock_ hold but
+      // the field is shared with the replication clients.
+      atomic_struct_update<CommitTsInfo>(repl_storage_state_.commit_ts_info_,
+                                         [ldt = txn->last_durable_ts_](CommitTsInfo const &old_info) {
+                                           return CommitTsInfo{.ldt_ = std::max(old_info.ldt_, ldt),
+                                                               .num_committed_txns_ = old_info.num_committed_txns_};
+                                         });
       snapshot_runner_.Resume();
       // Under the clients' lock for symmetry with the analytical store above, so replica registration's
       // in-lock read of storage_mode_ is serialized against every mode change, not just one direction.

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2950,7 +2950,7 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
       // consistent. Advance-only, since concurrent commits are barred by the UNIQUE main_lock_ hold but
       // the field is shared with the replication clients.
       atomic_struct_update<CommitTsInfo>(repl_storage_state_.commit_ts_info_,
-                                         [ldt = txn->last_durable_ts_](CommitTsInfo const &old_info) {
+                                         [ldt = *txn->last_durable_ts_](CommitTsInfo const &old_info) {
                                            return CommitTsInfo{.ldt_ = std::max(old_info.ldt_, ldt),
                                                                .num_committed_txns_ = old_info.num_committed_txns_};
                                          });

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2891,6 +2891,34 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
             "or ENABLE TTL) was enqueued concurrently with the storage mode change. Wait for pending "
             "index creation to finish and retry.");
       }
+      // Analytical writes are never appended to the WAL, so a replica attached across the switch would
+      // silently miss the whole episode. Refuse and store the mode under the clients' own lock, which is
+      // the same lock replica registration inserts under: "analytical with a live client" is then
+      // unrepresentable rather than merely a narrow race.
+      repl_storage_state_.replication_storage_clients_.WithLock([this](auto const &clients) {
+        if (!clients.empty()) {
+          throw utils::BasicException(
+              "Cannot switch to IN_MEMORY_ANALYTICAL while {} replica(s) replicate from this database. Analytical "
+              "writes are not replicated; unregister every replica first.",
+              clients.size());
+        }
+        storage_mode_ = StorageMode::IN_MEMORY_ANALYTICAL;
+      });
+
+      // Finalize the WAL so the episode leaves a file-level signature: the pre-import file's [from, to]
+      // range then ends before the switch-back snapshot's timestamp, which is how GetRecoverySteps
+      // detects that no WAL can reproduce the imported data. Placed after every check that throws, so a
+      // rejected switch has no side effect, and under engine_lock_ because GetRecoverySteps holds that
+      // lock specifically to read wal_file_. Lock order main_lock_ -> engine_lock_ is respected, since
+      // the UNIQUE hold above is on main_lock_.
+      {
+        std::unique_lock engine_guard(engine_lock_);
+        if (wal_file_) {
+          wal_file_->FinalizeWal();
+          wal_file_.reset();
+          wal_unsynced_transactions_ = 0;
+        }
+      }
       snapshot_runner_.Pause();
     } else {
       // No need to resume async indexer, it is always running.
@@ -2915,8 +2943,11 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
                                                             &snapshot_progress_,
                                                             "storage_mode_change");
       snapshot_runner_.Resume();
+      // Under the clients' lock for symmetry with the analytical store above, so replica registration's
+      // in-lock read of storage_mode_ is serialized against every mode change, not just one direction.
+      repl_storage_state_.replication_storage_clients_.WithLock(
+          [this](auto const & /*clients*/) { storage_mode_ = StorageMode::IN_MEMORY_TRANSACTIONAL; });
     }
-    storage_mode_ = new_storage_mode;
     // Hand off the same lock unique_accessor already holds; adopting main_lock_ into a second
     // lock would give the one hold two owners and release it twice.
     FreeMemory(unique_accessor->ReleaseGuard(), false);

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2916,7 +2916,7 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
       // lock specifically to read wal_file_. Lock order main_lock_ -> engine_lock_ is respected, since
       // the UNIQUE hold above is on main_lock_.
       {
-        std::unique_lock engine_guard(engine_lock_);
+        std::unique_lock const engine_guard(engine_lock_);
         if (wal_file_) {
           wal_file_->FinalizeWal();
           wal_file_.reset();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2946,6 +2946,17 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
                                                             &abort_snapshot_,
                                                             &snapshot_progress_,
                                                             "storage_mode_change");
+      if (!snapshot_path) {
+        // Analytical writes never reached a WAL, so this snapshot is the only durable record the episode
+        // will ever have. Completing the switch without it would leave the data live in memory but absent
+        // from durability, and the next recovery would silently drop it. Stay analytical instead: the
+        // mode, the cached ldt and every durability file are still untouched at this point, so the user
+        // can fix the cause and retry. CreateSnapshot has already removed whatever partial file it wrote.
+        throw utils::BasicException(
+            "Failed to create the snapshot required to leave IN_MEMORY_ANALYTICAL. The database is still in "
+            "analytical mode and its data is unchanged; check the logs for the cause and retry.");
+      }
+
       // Publish the snapshot's timestamp as the cached ldt. Analytical writes never reach
       // FinalizeCommitPhase, so without this main keeps advertising the pre-analytical ldt and a replica
       // registered afterwards is judged up to date by the heartbeat comparison -- recovery would never
@@ -2966,16 +2977,14 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
       // is accepted only when some WAL predates the snapshot, and every such WAL is what was just wiped.
       // Restarting alone would be worse: the surviving files carry this same UUID, so the new numbers
       // would collide with theirs, and a duplicate sequence number is caught by no check anywhere.
-      if (snapshot_path) {
-        DMG_ASSERT(!wal_file_, "Analytical mode must not leave an open WAL file.");
-        if (ArchiveSupersededDurabilityFiles(*snapshot_path)) {
-          wal_seq_num_ = 0;
-        } else {
-          spdlog::warn(
-              "Superseded WAL files could not be archived, so WAL sequence numbering continues from {} to stay "
-              "collision-free.",
-              wal_seq_num_);
-        }
+      DMG_ASSERT(!wal_file_, "Analytical mode must not leave an open WAL file.");
+      if (ArchiveSupersededDurabilityFiles(*snapshot_path)) {
+        wal_seq_num_ = 0;
+      } else {
+        spdlog::warn(
+            "Superseded WAL files could not be archived, so WAL sequence numbering continues from {} to stay "
+            "collision-free.",
+            wal_seq_num_);
       }
       snapshot_runner_.Resume();
       // Under the clients' lock for symmetry with the analytical store above, so replica registration's

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -837,6 +837,12 @@ class InMemoryStorage final : public Storage {
   bool InitializeWalFile(std::string_view epoch_id);
   void FinalizeWalFile();
 
+  // Archives every durability file superseded by `keep_snapshot` into a `.old` sub-directory of its own
+  // directory, or deletes it when --storage-backup-dir-enabled=false. Leaves `keep_snapshot` as the only
+  // snapshot and the WAL directory empty. Returns whether the WAL directory really did end up empty:
+  // restarting the WAL sequence numbering is only safe once no pre-existing file can collide with it.
+  bool ArchiveSupersededDurabilityFiles(std::filesystem::path const &keep_snapshot);
+
   StorageInfo GetBaseInfo() override;
   StorageInfo GetInfo() override;
 

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -669,8 +669,9 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
   auto const &main_db_name = main_storage->name();
 
   // A guardrail, not a decision point: read without a hold, so the mode could flip right after.
-  // Data instances are barred from analytical at query time, and taking main_lock_ on this
-  // background task would risk deadlocking against the commits it is recovering.
+  // A storage with replication clients cannot enter analytical mode (SetStorageMode refuses under the
+  // clients' lock), and taking main_lock_ on this background task would risk deadlocking against the
+  // commits it is recovering.
   if (main_storage->storage_mode_ != StorageMode::IN_MEMORY_TRANSACTIONAL) {
     throw utils::BasicException("Only InMemoryTransactional mode supports replication!");
   }

--- a/tests/e2e/analytical_mode/analytical_data_instance.py
+++ b/tests/e2e/analytical_mode/analytical_data_instance.py
@@ -16,13 +16,24 @@ import pytest
 from common import execute_and_fetch_all
 
 
-def test_data_instance_cannot_switch_analytical():
+def storage_mode(cursor):
+    rows = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
+    return {row[0]: row[1] for row in rows}["storage_mode"]
+
+
+def test_data_instance_switches_analytical_without_replicas():
+    # A MAIN data instance with no registered replicas may enter analytical mode: nothing replicates
+    # from it, so no replica can miss the writes that analytical mode keeps out of the WAL. Registering
+    # replicas back is what the operator does after switching to transactional again.
     connection = mgclient.connect(host="localhost", port=7687)
     connection.autocommit = True
     cursor = connection.cursor()
-    with pytest.raises(mgclient.DatabaseError) as e:
-        execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL")
-    assert "Data instances cannot use analytical mode" in str(e.value)
+
+    execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL")
+    assert storage_mode(cursor) == "IN_MEMORY_ANALYTICAL"
+
+    execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL")
+    assert storage_mode(cursor) == "IN_MEMORY_TRANSACTIONAL"
 
 
 if __name__ == "__main__":

--- a/tests/e2e/high_availability/CMakeLists.txt
+++ b/tests/e2e/high_availability/CMakeLists.txt
@@ -20,6 +20,7 @@ copy_e2e_python_files(high_availability coordinator_dummy_sso_module.py)
 copy_e2e_python_files(high_availability large_cluster.py)
 copy_e2e_python_files(high_availability instance_metrics.py)
 copy_e2e_python_files(high_availability tls_cluster.py)
+copy_e2e_python_files(high_availability analytical_import.py)
 copy_e2e_python_files(high_availability workloads.yaml)
 
 

--- a/tests/e2e/high_availability/analytical_import.py
+++ b/tests/e2e/high_availability/analytical_import.py
@@ -21,6 +21,7 @@ import mgclient
 import pytest
 from common import (
     connect,
+    count_files,
     execute_and_fetch_all,
     get_data_path,
     get_logs_path,
@@ -54,6 +55,16 @@ CLUSTER_WITHOUT_REPLICA = [
     ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
     ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
 ]
+
+CLUSTER_WITH_REPLICA_DOWN = [
+    ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
+    ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+    ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+]
+
+# The import's three phases, kept separate so a restart that loses one of them cannot be masked by a
+# total that happens to match.
+EXPECTED_LABEL_COUNTS = {"Before": 10, "AfterUnregister": 5, "Imported": 100}
 
 
 @pytest.fixture
@@ -132,6 +143,21 @@ def start_cluster(test_name: str):
     return instances, coord_cursor, connect(host="localhost", port=7687).cursor()
 
 
+def get_label_counts(cursor):
+    return {
+        label: execute_and_fetch_all(cursor, f"MATCH (n:{label}) RETURN count(n);")[0][0]
+        for label in EXPECTED_LABEL_COUNTS
+    }
+
+
+def durability_dirs(test_name: str, instance: str):
+    """The snapshot and WAL directories of an instance, as (snapshots, wal)."""
+    data_dir = os.path.join(
+        interactive_mg_runner.PROJECT_DIR, "build", "e2e", "data", get_data_path(file, test_name), instance
+    )
+    return os.path.join(data_dir, "snapshots"), os.path.join(data_dir, "wal")
+
+
 def import_while_analytical(main_cursor, count: int):
     """The target workload: analytical for the duration of the import, transactional again afterwards.
 
@@ -204,7 +230,12 @@ def test_analytical_import_with_stale_replica_and_main_restart(test_name):
     """Scenario B2: scenario B with the main restarted between the import and the re-registration.
 
     This pins the requirement that ruled out every design keyed on in-memory state: the recovery
-    decision has to be derivable from the durability files alone.
+    decision has to be derivable from the durability files alone. The whole cluster is then restarted
+    once more at the end, which is what exercises the durability layout the switch back leaves behind:
+    the switch-back snapshot is the only file left in place, every file it supersedes is archived into
+    .old, and the WAL numbering restarts at 0. Recovering from that layout is only valid because of the
+    restart -- a chain whose first file has a non-zero sequence number is accepted only when some WAL
+    predates the snapshot, and archiving removed every such WAL from view.
     """
     instances, coord_cursor, main_cursor = start_cluster(test_name)
     replica_cursor = connect(host="localhost", port=7688).cursor()
@@ -217,6 +248,14 @@ def test_analytical_import_with_stale_replica_and_main_restart(test_name):
 
     execute_and_fetch_all(main_cursor, "UNWIND RANGE(1, 5) AS i CREATE (:AfterUnregister {id: i});")
     import_while_analytical(main_cursor, 100)
+
+    # The switch back left exactly one snapshot behind and moved the pre-import WAL chain out of the way.
+    main_snapshot_dir, main_wal_dir = durability_dirs(test_name, "instance_1")
+    assert count_files(main_snapshot_dir) == 1
+    assert count_files(main_wal_dir) == 0
+    main_wal_archive_dir = os.path.join(main_wal_dir, ".old")
+    assert os.path.isdir(main_wal_archive_dir), "the pre-import WAL chain was not archived"
+    assert count_files(main_wal_archive_dir) >= 1
 
     interactive_mg_runner.kill(instances, "instance_1")
     interactive_mg_runner.start(instances, "instance_1")
@@ -231,6 +270,25 @@ def test_analytical_import_with_stale_replica_and_main_restart(test_name):
     replica_cursor = connect(host="localhost", port=7688).cursor()
     mg_sleep_and_assert(115, partial(get_vertex_count, replica_cursor))
     assert get_vertex_count(replica_cursor) == get_vertex_count(main_cursor)
+
+    # Restart both data instances. The replica goes down first and is confirmed down before the main
+    # follows, so the coordinator has no promotion candidate and instance_1 comes back as MAIN.
+    interactive_mg_runner.kill(instances, "instance_2")
+    mg_sleep_and_assert(CLUSTER_WITH_REPLICA_DOWN, partial(show_instances, coord_cursor))
+    interactive_mg_runner.kill(instances, "instance_1")
+
+    interactive_mg_runner.start(instances, "instance_1")
+    interactive_mg_runner.start(instances, "instance_2")
+    mg_sleep_and_assert(CLUSTER_WITH_REPLICA, partial(show_instances, coord_cursor))
+
+    # Both instances recovered the full dataset from their own durability files, the imported vertices
+    # included -- those live only in the switch-back snapshot, in no WAL on either side.
+    main_cursor = connect(host="localhost", port=7687).cursor()
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert(115, partial(get_vertex_count, main_cursor))
+    mg_sleep_and_assert(115, partial(get_vertex_count, replica_cursor))
+    assert get_label_counts(main_cursor) == EXPECTED_LABEL_COUNTS
+    assert get_label_counts(replica_cursor) == EXPECTED_LABEL_COUNTS
 
 
 def test_register_instance_while_main_is_analytical(test_name):

--- a/tests/e2e/high_availability/analytical_import.py
+++ b/tests/e2e/high_availability/analytical_import.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+# Bulk import on an HA data instance: switch the single MAIN to IN_MEMORY_ANALYTICAL, import, switch
+# back (which writes the snapshot), then register the replicas again. See specs/ha-analytical-import.md.
+
+import os
+import sys
+from functools import partial
+
+import interactive_mg_runner
+import mgclient
+import pytest
+from common import (
+    connect,
+    execute_and_fetch_all,
+    get_data_path,
+    get_logs_path,
+    get_vertex_count,
+    show_instances,
+    show_replicas,
+)
+from mg_utils import mg_sleep_and_assert
+
+interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+interactive_mg_runner.PROJECT_DIR = os.path.normpath(
+    os.path.join(interactive_mg_runner.SCRIPT_DIR, "..", "..", "..", "..")
+)
+interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
+interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
+
+file = "analytical_import"
+
+REGISTER_INSTANCE_2 = (
+    "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', "
+    "'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};"
+)
+
+CLUSTER_WITH_REPLICA = [
+    ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
+    ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+    ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+]
+
+CLUSTER_WITHOUT_REPLICA = [
+    ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
+    ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+]
+
+
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    interactive_mg_runner.kill_all(keep_directories=False)
+
+
+def get_instances_description(test_name: str):
+    return {
+        "instance_1": {
+            "args": [
+                "--bolt-port",
+                "7687",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10011",
+                "--replication-restore-state-on-startup=true",
+                "--data-recovery-on-startup=true",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
+            "setup_queries": [],
+        },
+        "instance_2": {
+            "args": [
+                "--bolt-port",
+                "7688",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10012",
+                "--replication-restore-state-on-startup=true",
+                "--data-recovery-on-startup=true",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
+            "setup_queries": [],
+        },
+        "coordinator_1": {
+            "args": [
+                "--bolt-port",
+                "7690",
+                "--log-level=TRACE",
+                "--coordinator-id=1",
+                "--coordinator-port=10111",
+                "--coordinator-hostname=localhost",
+                "--management-port=10121",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
+            "setup_queries": [
+                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                REGISTER_INSTANCE_2,
+                "SET INSTANCE instance_1 TO MAIN",
+            ],
+        },
+    }
+
+
+def start_cluster(test_name: str):
+    """Starts a coordinator, a MAIN (instance_1) and one replica (instance_2) and returns their cursors."""
+    instances = get_instances_description(test_name)
+    interactive_mg_runner.start_all(instances, keep_directories=False)
+
+    coord_cursor = connect(host="localhost", port=7690).cursor()
+    mg_sleep_and_assert(CLUSTER_WITH_REPLICA, partial(show_instances, coord_cursor))
+
+    return instances, coord_cursor, connect(host="localhost", port=7687).cursor()
+
+
+def import_while_analytical(main_cursor, count: int):
+    """The target workload: analytical for the duration of the import, transactional again afterwards.
+
+    No manual CREATE SNAPSHOT in between -- the switch back writes one that is stamped with a
+    post-import timestamp, whereas a manual snapshot taken while analytical carries a stale one.
+    """
+    execute_and_fetch_all(main_cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL")
+    execute_and_fetch_all(main_cursor, f"UNWIND RANGE(1, {count}) AS i CREATE (:Imported {{id: i}});")
+    execute_and_fetch_all(main_cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL")
+
+
+def test_analytical_import_with_empty_replica(test_name):
+    """Scenario A: nothing was ingested anywhere before the switch.
+
+    An empty replica reports timestamp 0 and already took the snapshot path before decision 9, so this
+    is not the guard for that fix -- its job is to prove the gates work end to end and that the
+    recovery override does not regress the empty case.
+    """
+    instances, coord_cursor, main_cursor = start_cluster(test_name)
+
+    # Decision 1: entering analytical requires zero registered replicas, instance-wide.
+    execute_and_fetch_all(coord_cursor, "UNREGISTER INSTANCE instance_2")
+    mg_sleep_and_assert(CLUSTER_WITHOUT_REPLICA, partial(show_instances, coord_cursor))
+
+    import_while_analytical(main_cursor, 100)
+    assert get_vertex_count(main_cursor) == 100
+
+    execute_and_fetch_all(coord_cursor, REGISTER_INSTANCE_2)
+    mg_sleep_and_assert(CLUSTER_WITH_REPLICA, partial(show_instances, coord_cursor))
+
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert(100, partial(get_vertex_count, replica_cursor))
+
+
+def test_analytical_import_with_stale_replica(test_name):
+    """Scenario B: the replica already holds data and is left strictly behind before the switch.
+
+    Unregistering never wipes the replica, so this is the natural path through the workload rather than
+    a corner case. The extra writes after the unregister are mandatory: they leave the replica strictly
+    behind the end of the finalized WAL chain, which is the only layout in which WAL-only recovery is
+    chosen and the import would be lost. Without them the snapshot is shipped by accident and the test
+    would pass even with the fix removed.
+    """
+    instances, coord_cursor, main_cursor = start_cluster(test_name)
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+
+    execute_and_fetch_all(main_cursor, "UNWIND RANGE(1, 10) AS i CREATE (:Before {id: i});")
+    mg_sleep_and_assert(10, partial(get_vertex_count, replica_cursor))
+
+    execute_and_fetch_all(coord_cursor, "UNREGISTER INSTANCE instance_2")
+    mg_sleep_and_assert(CLUSTER_WITHOUT_REPLICA, partial(show_instances, coord_cursor))
+
+    # Leaves the replica behind the end of the WAL chain while still inside its range.
+    execute_and_fetch_all(main_cursor, "UNWIND RANGE(1, 5) AS i CREATE (:AfterUnregister {id: i});")
+
+    import_while_analytical(main_cursor, 100)
+    assert get_vertex_count(main_cursor) == 115
+
+    # Re-registered without wiping its data directory: recovery has to notice that the snapshot holds
+    # data no WAL file does and ship the snapshot.
+    execute_and_fetch_all(coord_cursor, REGISTER_INSTANCE_2)
+    mg_sleep_and_assert(CLUSTER_WITH_REPLICA, partial(show_instances, coord_cursor))
+
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert(115, partial(get_vertex_count, replica_cursor))
+    assert get_vertex_count(replica_cursor) == get_vertex_count(main_cursor)
+
+
+def test_analytical_import_with_stale_replica_and_main_restart(test_name):
+    """Scenario B2: scenario B with the main restarted between the import and the re-registration.
+
+    This pins the requirement that ruled out every design keyed on in-memory state: the recovery
+    decision has to be derivable from the durability files alone.
+    """
+    instances, coord_cursor, main_cursor = start_cluster(test_name)
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+
+    execute_and_fetch_all(main_cursor, "UNWIND RANGE(1, 10) AS i CREATE (:Before {id: i});")
+    mg_sleep_and_assert(10, partial(get_vertex_count, replica_cursor))
+
+    execute_and_fetch_all(coord_cursor, "UNREGISTER INSTANCE instance_2")
+    mg_sleep_and_assert(CLUSTER_WITHOUT_REPLICA, partial(show_instances, coord_cursor))
+
+    execute_and_fetch_all(main_cursor, "UNWIND RANGE(1, 5) AS i CREATE (:AfterUnregister {id: i});")
+    import_while_analytical(main_cursor, 100)
+
+    interactive_mg_runner.kill(instances, "instance_1")
+    interactive_mg_runner.start(instances, "instance_1")
+    mg_sleep_and_assert(CLUSTER_WITHOUT_REPLICA, partial(show_instances, coord_cursor))
+
+    main_cursor = connect(host="localhost", port=7687).cursor()
+    mg_sleep_and_assert(115, partial(get_vertex_count, main_cursor))
+
+    execute_and_fetch_all(coord_cursor, REGISTER_INSTANCE_2)
+    mg_sleep_and_assert(CLUSTER_WITH_REPLICA, partial(show_instances, coord_cursor))
+
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert(115, partial(get_vertex_count, replica_cursor))
+    assert get_vertex_count(replica_cursor) == get_vertex_count(main_cursor)
+
+
+def test_register_instance_while_main_is_analytical(test_name):
+    """Scenario C: REGISTER INSTANCE lands while the main is analytical.
+
+    The Raft commit is the success criterion, so the query still returns success; the main rejects the
+    registration RPC without mutating any replication state, and the coordinator's reconciliation loop
+    heals the cluster once the main is transactional again.
+    """
+    instances, coord_cursor, main_cursor = start_cluster(test_name)
+
+    execute_and_fetch_all(coord_cursor, "UNREGISTER INSTANCE instance_2")
+    mg_sleep_and_assert(CLUSTER_WITHOUT_REPLICA, partial(show_instances, coord_cursor))
+
+    execute_and_fetch_all(main_cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL")
+    execute_and_fetch_all(main_cursor, "UNWIND RANGE(1, 100) AS i CREATE (:Imported {id: i});")
+
+    # Succeeds on the coordinator ...
+    execute_and_fetch_all(coord_cursor, REGISTER_INSTANCE_2)
+    # ... but nothing is attached on the main, and the rejection left no half-registered client behind.
+    assert show_replicas(main_cursor) == []
+
+    execute_and_fetch_all(main_cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL")
+
+    # The reconciliation loop retries the registration RPC on every ping.
+    mg_sleep_and_assert(1, lambda: len(show_replicas(main_cursor)))
+    mg_sleep_and_assert(CLUSTER_WITH_REPLICA, partial(show_instances, coord_cursor))
+
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert(100, partial(get_vertex_count, replica_cursor))
+
+
+def test_cannot_enter_analytical_with_registered_replica(test_name):
+    """Decision 1's gate is operator-facing: the error names what blocks the switch."""
+    instances, coord_cursor, main_cursor = start_cluster(test_name)
+
+    with pytest.raises(mgclient.DatabaseError) as e:
+        execute_and_fetch_all(main_cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL")
+    assert "Cannot switch to analytical mode while replicas are registered" in str(e.value)
+    assert "instance_2" in str(e.value)
+
+    # The rejected switch left the instance untouched.
+    execute_and_fetch_all(main_cursor, "CREATE (:StillTransactional)")
+    replica_cursor = connect(host="localhost", port=7688).cursor()
+    mg_sleep_and_assert(1, partial(get_vertex_count, replica_cursor))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/high_availability/analytical_import.py
+++ b/tests/e2e/high_availability/analytical_import.py
@@ -59,7 +59,7 @@ CLUSTER_WITHOUT_REPLICA = [
 CLUSTER_WITH_REPLICA_DOWN = [
     ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
     ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-    ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+    ("instance_2", "localhost:7688", "", "localhost:10012", "down", "replica"),
 ]
 
 # The import's three phases, kept separate so a restart that loses one of them cannot be masked by a

--- a/tests/e2e/high_availability/workloads.yaml
+++ b/tests/e2e/high_availability/workloads.yaml
@@ -70,3 +70,7 @@ workloads:
   - name: "HA TLS cluster"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["high_availability/tls_cluster.py"]
+
+  - name: "HA analytical import"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["high_availability/analytical_import.py"]

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -737,7 +737,7 @@ add_unit_test(storage_v2_decoder_encoder
 
 add_unit_test(storage_v2_durability_inmemory
     SOURCES storage_v2_durability_inmemory.cpp
-    LINK_TARGETS mg::storage mg-dbms
+    LINK_TARGETS mg::storage mg-dbms storage_test_utils
 )
 
 add_unit_test(storage_v2_create_snapshot

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -1402,6 +1402,16 @@ class DurabilityTest : public ::testing::TestWithParam<DurabilityParam> {
                         memgraph::storage::durability::kWalDirectory);
   }
 
+  // Files superseded by a new durability base (a storage mode switch, RECOVER SNAPSHOT) are archived
+  // into a .old sub-directory of the directory they came from, not into kBackupDirectory.
+  std::vector<std::filesystem::path> GetArchivedSnapshotsList() {
+    return GetFilesList(storage_directory / memgraph::storage::durability::kSnapshotDirectory / ".old");
+  }
+
+  std::vector<std::filesystem::path> GetArchivedWalsList() {
+    return GetFilesList(storage_directory / memgraph::storage::durability::kWalDirectory / ".old");
+  }
+
   void RestoreBackups() {
     {
       auto backup_snapshots = GetBackupSnapshotsList();
@@ -1429,6 +1439,9 @@ class DurabilityTest : public ::testing::TestWithParam<DurabilityParam> {
     for (auto &item : std::filesystem::directory_iterator(path, ec)) {
       // Parallel snapshot creation creates additional temporary files; these need to be ignored for the test
       if (item.path().filename().string().find("_part_") != std::string::npos) continue;
+      // A durability file is never a directory; this skips the .old archive sub-directory, which is
+      // listed through GetArchived*List instead.
+      if (item.is_directory()) continue;
       ret.push_back(item.path());
     }
     std::sort(ret.begin(), ret.end());
@@ -2588,6 +2601,86 @@ TEST_P(DurabilityTest, WalBackup) {
   ASSERT_EQ(GetBackupSnapshotsList().size(), 0);
   ASSERT_EQ(GetWalsList().size(), 0);
   ASSERT_EQ(GetBackupWalsList().size(), num_wals);
+}
+
+// The snapshot taken when leaving analytical mode is a new durability base: the analytical writes are in
+// no WAL, so nothing written before it can be chained onto it. Everything superseded is archived and the
+// WAL numbering restarts, which together keep the resulting directory recoverable.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST_P(DurabilityTest, StorageModeSwitchBackArchivesSupersededFilesAndRestartsWalSeqNum) {
+  static constexpr size_t kNumTransactionalVertices = 100;
+  static constexpr size_t kNumAnalyticalVertices = 50;
+
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory,
+                     .snapshot_wal_mode =
+                         memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                     .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
+                     // One vertex per transaction with a 1 KiB cap gives several WAL files to archive.
+                     .wal_file_size_kibibytes = 1},
+      .salient = {.items = {.properties_on_edges = GetParam(), .storage_light_edge = GetParam().light_edge}},
+  };
+
+  {
+    memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+    auto const create_vertices = [&](size_t count) {
+      for (size_t i = 0; i < count; ++i) {
+        auto acc = db.Access(memgraph::storage::WRITE);
+        acc->CreateVertex();
+        ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+      }
+    };
+
+    // A pre-analytical history: WAL files, with a snapshot on top of them.
+    create_vertices(kNumTransactionalVertices);
+    ASSERT_TRUE(mem_storage->CreateSnapshot({}).has_value());
+
+    auto const num_pre_switch_snapshots = GetSnapshotsList().size();
+    auto const num_pre_switch_wals = GetWalsList().size();
+    ASSERT_EQ(num_pre_switch_snapshots, 1);
+    ASSERT_GT(num_pre_switch_wals, 1);
+    ASSERT_EQ(GetArchivedSnapshotsList().size(), 0);
+    ASSERT_EQ(GetArchivedWalsList().size(), 0);
+
+    // Bulk import under analytical mode: none of it reaches a WAL.
+    mem_storage->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+    create_vertices(kNumAnalyticalVertices);
+    ASSERT_EQ(GetWalsList().size(), num_pre_switch_wals);
+
+    mem_storage->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+    // The switch-back snapshot is the only file left in place; the rest moved into .old.
+    ASSERT_EQ(GetSnapshotsList().size(), 1);
+    ASSERT_EQ(GetWalsList().size(), 0);
+    ASSERT_EQ(GetArchivedSnapshotsList().size(), num_pre_switch_snapshots);
+    ASSERT_EQ(GetArchivedWalsList().size(), num_pre_switch_wals);
+
+    // One more commit, so the restarted numbering shows up in a file.
+    create_vertices(1);
+  }
+
+  // Recovery accepts a WAL chain whose first file has a non-zero sequence number only when some WAL
+  // predates the snapshot -- and every such WAL was just archived. Restarting at 0 is what keeps the
+  // chain valid, and it cannot collide with the archived files' numbers now that they are out of the way.
+  auto const wals = GetWalsList();
+  ASSERT_EQ(wals.size(), 1);
+  ASSERT_EQ(memgraph::storage::durability::ReadWalInfo(wals.front()).seq_num, 0);
+
+  // The analytical writes survive, via the snapshot alone.
+  {
+    memgraph::storage::Config recovery_config{
+        .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = GetParam(), .storage_light_edge = GetParam().light_edge}},
+    };
+    memgraph::dbms::Database db{recovery_config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    auto acc = db.Access(memgraph::storage::READ);
+    ASSERT_EQ(CountVertices(*acc, memgraph::storage::View::OLD),
+              kNumTransactionalVertices + kNumAnalyticalVertices + 1);
+  }
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -9,11 +9,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <thread>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gmock/gmock.h>
@@ -32,14 +34,17 @@
 #include "replication/config.hpp"
 #include "replication/state.hpp"
 #include "replication_handler/replication_handler.hpp"
+#include "storage/v2/durability/durability.hpp"
 #include "storage/v2/durability/paths.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
+#include "storage/v2/inmemory/replication/recovery.hpp"
 #include "storage/v2/replication/recovery.hpp"
 #include "storage/v2/storage.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
 #include "tests/unit/storage_test_utils.hpp"
+#include "utils/exceptions.hpp"
 
 using testing::UnorderedElementsAre;
 
@@ -1545,6 +1550,204 @@ TEST_F(ReplicationTest, RecoverySteps) {
     ASSERT_TRUE(std::holds_alternative<memgraph::storage::RecoveryWals>(recovery_steps[1]));
     ASSERT_TRUE(std::holds_alternative<memgraph::storage::RecoveryCurrentWal>(recovery_steps[2]));
   }
+}
+
+// A WAL whose [from, to] range contains the snapshot's timestamp proves the chain can reproduce the
+// snapshot's contents. The pair below pins both verdicts, because a false positive costs a full
+// snapshot transfer on every lagging replica.
+TEST(SnapshotWalCoverage, CoveredAndUncovered) {
+  using memgraph::storage::SnapshotTsCoveredByAnyWal;
+  auto const wal = [](uint64_t const seq_num, uint64_t const from, uint64_t const to) {
+    return memgraph::storage::durability::WalDurabilityInfo{seq_num, from, to, "uuid", "epoch", "path"};
+  };
+  std::vector const finalized{wal(0, 1, 100), wal(1, 101, 200)};
+
+  // Ordinary periodic snapshot: its timestamp sits inside the still-open WAL's range.
+  EXPECT_TRUE(SnapshotTsCoveredByAnyWal(finalized, 201, 300, 250));
+  // ... or inside a finalized one, if the snapshot predates the current WAL.
+  EXPECT_TRUE(SnapshotTsCoveredByAnyWal(finalized, 201, 300, 150));
+  // Range ends are inclusive: a snapshot stamped exactly at a WAL boundary is covered.
+  EXPECT_TRUE(SnapshotTsCoveredByAnyWal(finalized, std::nullopt, std::nullopt, 100));
+
+  // After an analytical episode: the pre-import WAL was finalized at 200 and the post-import WAL
+  // starts after the snapshot, so nothing holds the imported data.
+  EXPECT_FALSE(SnapshotTsCoveredByAnyWal(finalized, 5001, 5100, 5000));
+  // No open WAL at all, snapshot past the end of the chain.
+  EXPECT_FALSE(SnapshotTsCoveredByAnyWal(finalized, std::nullopt, std::nullopt, 5000));
+}
+
+// Decision 9 of specs/ha-analytical-import.md. Entering analytical finalizes the WAL and the import
+// writes none, so the switch-back snapshot holds data no WAL can reproduce. A replica sitting strictly
+// behind the end of the finalized chain would otherwise be recovered from WALs alone and declared in
+// sync while silently missing the whole import.
+TEST_F(ReplicationTest, RecoveryStepsAfterAnalyticalEpisode) {
+  auto config = main_conf;
+  config.durability.wal_file_size_kibibytes = 1;  // Easy way to control when a new WAL is created
+  MinMemgraph main(config);
+  auto *in_mem = static_cast<InMemoryStorage *>(main.db.storage());
+
+  memgraph::utils::FileRetainer file_retainer;
+  auto file_locker = file_retainer.AddLocker();
+
+  auto const p = in_mem->NameToProperty("p1");
+  const auto large_property = PropertyValue{PropertyValue::list_t{1024 / sizeof(int64_t), PropertyValue{int64_t{}}}};
+
+  auto large_write_to_finalize_wal = [&]() {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = in_mem->Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    ASSERT_TRUE(v.SetProperty(p, large_property).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  };
+  auto create_vertices_and_commit = [&](int const n) {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = in_mem->Access(memgraph::storage::WRITE);
+    for (int i = 0; i < n; ++i) acc->CreateVertex();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  };
+
+  // A finalized chain of two files, the newest of which spans several commits so a replica can sit
+  // strictly inside it.
+  large_write_to_finalize_wal();
+  create_vertices_and_commit(1);
+  create_vertices_and_commit(1);
+  large_write_to_finalize_wal();
+
+  auto const wal_dir = in_mem->config_.durability.storage_directory / memgraph::storage::durability::kWalDirectory;
+  auto const chain = memgraph::storage::durability::GetWalFiles(wal_dir, std::string{in_mem->uuid()});
+  ASSERT_TRUE(chain.has_value());
+  ASSERT_FALSE(chain->empty());
+  ASSERT_GT(chain->back().to_timestamp, chain->back().from_timestamp);
+  // Strictly behind the end of the chain, but inside the newest file's range: exactly the layout in
+  // which the pre-fix code takes the WAL-only path.
+  auto const replica_commit = chain->back().to_timestamp - 1;
+
+  in_mem->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+  create_vertices_and_commit(10);
+  in_mem->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+  // First post-switch commit opens a fresh WAL, so the current WAL starts after the snapshot.
+  create_vertices_and_commit(1);
+
+  {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto const steps = GetRecoverySteps(replica_commit, &file_locker, in_mem);
+    ASSERT_TRUE(steps.has_value());
+    EXPECT_TRUE(std::ranges::any_of(*steps, [](auto const &step) {
+      return std::holds_alternative<memgraph::storage::RecoverySnapshot>(step);
+    })) << "the mode-change snapshot is the only source of the imported data";
+  }
+}
+
+// The negative half of the pair: an ordinary periodic snapshot must not force a snapshot transfer for
+// a lagging replica, since its timestamp lies inside the open WAL's range.
+TEST_F(ReplicationTest, RecoveryStepsAfterPeriodicSnapshot) {
+  auto config = main_conf;
+  config.durability.wal_file_size_kibibytes = 1;
+  MinMemgraph main(config);
+  auto *in_mem = static_cast<InMemoryStorage *>(main.db.storage());
+
+  memgraph::utils::FileRetainer file_retainer;
+  auto file_locker = file_retainer.AddLocker();
+
+  auto const p = in_mem->NameToProperty("p1");
+  const auto large_property = PropertyValue{PropertyValue::list_t{1024 / sizeof(int64_t), PropertyValue{int64_t{}}}};
+
+  auto large_write_to_finalize_wal = [&]() {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = in_mem->Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    ASSERT_TRUE(v.SetProperty(p, large_property).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  };
+  auto create_vertex_and_commit = [&]() {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = in_mem->Access(memgraph::storage::WRITE);
+    acc->CreateVertex();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  };
+
+  large_write_to_finalize_wal();
+  create_vertex_and_commit();
+  create_vertex_and_commit();
+  large_write_to_finalize_wal();
+
+  auto const wal_dir = in_mem->config_.durability.storage_directory / memgraph::storage::durability::kWalDirectory;
+  auto const chain = memgraph::storage::durability::GetWalFiles(wal_dir, std::string{in_mem->uuid()});
+  ASSERT_TRUE(chain.has_value());
+  ASSERT_FALSE(chain->empty());
+  ASSERT_GT(chain->back().to_timestamp, chain->back().from_timestamp);
+  auto const replica_commit = chain->back().to_timestamp - 1;
+
+  create_vertex_and_commit();  // opens the current WAL the snapshot's timestamp will fall inside
+  ASSERT_TRUE(in_mem->CreateSnapshot().has_value());
+
+  {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto const steps = GetRecoverySteps(replica_commit, &file_locker, in_mem);
+    ASSERT_TRUE(steps.has_value());
+    EXPECT_FALSE(std::ranges::any_of(*steps, [](auto const &step) {
+      return std::holds_alternative<memgraph::storage::RecoverySnapshot>(step);
+    })) << "the WAL chain reproduces everything, so shipping the snapshot is pure waste";
+  }
+}
+
+// Analytical writes are never appended to the WAL, so a storage that replicates must not be allowed to
+// enter analytical mode; registration in the other order must be refused too.
+TEST_F(ReplicationTest, AnalyticalModeAndReplicationAreMutuallyExclusive) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+
+  auto replica_store_handler = replica.repl_handler;
+  replica_store_handler.TrySetReplicationRoleReplica(
+      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])});
+
+  auto const reg = main.repl_handler.TryRegisterReplica(ReplicationClientConfig{
+      .name = "REPLICA",
+      .mode = ReplicationMode::SYNC,
+      .repl_server_endpoint = Endpoint(local_host, ports[0]),
+  });
+  ASSERT_TRUE(reg.has_value()) << static_cast<int>(reg.error());
+
+  auto *in_mem = static_cast<InMemoryStorage *>(main.db.storage());
+  ASSERT_THROW(in_mem->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL),
+               memgraph::utils::BasicException);
+  ASSERT_EQ(in_mem->GetStorageMode(), memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+  ASSERT_EQ(main.repl_handler.UnregisterReplica("REPLICA"), UnregisterReplicaResult::SUCCESS);
+  ASSERT_NO_THROW(in_mem->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL));
+
+  // Now the other direction: registering while analytical is rejected before any state is mutated, so
+  // it does not leave a persisted instance-level client that every retry then trips over.
+  auto const reg_while_analytical = main.repl_handler.TryRegisterReplica(ReplicationClientConfig{
+      .name = "REPLICA",
+      .mode = ReplicationMode::SYNC,
+      .repl_server_endpoint = Endpoint(local_host, ports[0]),
+  });
+  ASSERT_FALSE(reg_while_analytical.has_value());
+  ASSERT_EQ(reg_while_analytical.error(), RegisterReplicaError::ANALYTICAL_MODE);
+
+  // Rejected up-front means the name is still free once the instance is transactional again.
+  in_mem->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+  ASSERT_TRUE(main.repl_handler
+                  .TryRegisterReplica(ReplicationClientConfig{
+                      .name = "REPLICA",
+                      .mode = ReplicationMode::SYNC,
+                      .repl_server_endpoint = Endpoint(local_host, ports[0]),
+                  })
+                  .has_value());
+}
+
+// Unregistering while analytical would erase the persisted client while leaving the per-database
+// clients untouched, so it is refused up-front too -- before the name is even looked up.
+TEST_F(ReplicationTest, UnregisterReplicaRefusedWhileAnalytical) {
+  MinMemgraph main(main_conf);
+  auto *in_mem = static_cast<InMemoryStorage *>(main.db.storage());
+
+  in_mem->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+  ASSERT_EQ(main.repl_handler.UnregisterReplica("REPLICA"), UnregisterReplicaResult::ANALYTICAL_MODE);
+
+  in_mem->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+  ASSERT_EQ(main.repl_handler.UnregisterReplica("REPLICA"), UnregisterReplicaResult::CANNOT_UNREGISTER);
 }
 
 TEST_F(ReplicationTest, SchemaReplication) {


### PR DESCRIPTION
## What

Enables the analytical bulk-import workflow on an HA data instance: switch to `IN_MEMORY_ANALYTICAL`, bulk import, switch back to `IN_MEMORY_TRANSACTIONAL`, register replicas back. Previously this was a flat refusal — `Data instances cannot use analytical mode`.

Design and the evidence behind each choice are in `specs/ha-analytical-import.md`.

## Why removing the check wasn't enough

Two independent blockers, not one:

1. **Analytical writes never reach the WAL.** A replica attached across the episode silently misses the entire import.
2. **Unregistering a replica does not wipe it.** So a re-registered replica is non-empty and stale, and its WAL chain still looks intact — an analytical episode punches a timestamp hole without disturbing sequence numbering. Recovery would walk the chain, find no gap, skip the snapshot, and never deliver the imported data.

The first is fixed by gating. The second needed recovery itself to change.

## What changed

**Gates.** Analytical is reachable only when the instance holds MAIN and has zero registered replication clients; registration and unregistration are rejected up front while any database is analytical. Instance-wide and all-or-nothing. Rejection happens before any replication state is mutated — persisting the instance-level client while no per-database client can be created would leave the replica permanently unattached, since every retry then fails with `NAME_EXISTS`.

Enforced in depth, ending with a hard window close: both the final mode store and the replica client insert re-check under `replication_storage_clients_`' own lock, which makes "analytical with a live client" unrepresentable rather than merely unlikely.

**Self-correcting recovery.** The WAL is finalized when *entering* analytical, so the episode leaves a file-level signature. `GetRecoverySteps` then treats "the latest snapshot's `durable_timestamp` lies inside no WAL file's `[from, to]` range" as proof that no WAL can reproduce that data, and forces snapshot-based recovery. Derived entirely from the durability files, so it survives a main restart — an earlier in-memory flag did not.

**Switch-back durability.** The switch-back snapshot is a new durability base, not an increment on the old one. Superseded snapshots and WALs are archived to `.old` (or deleted when `--storage-backup-dir-enabled=false`) and WAL sequence numbering restarts at 0. The two are inseparable: wiping alone breaks recovery, since a chain whose first file has a non-zero sequence number is only accepted when some WAL predates the snapshot — and those are exactly the files just wiped. Restarting alone is worse, because surviving files share this UUID and the new numbers would collide with theirs, which no check anywhere catches.

If the snapshot fails, the switch now aborts and throws with the mode, the cached `ldt`, `wal_seq_num_` and every durability file untouched. Previously it carried on and published a timestamp for data that had no durable record, which the next recovery dropped silently.

**RPC client lifetime.** Came out of reviewing the teardown reordering above. `rpc::Client`'s socket, serialization lock and endpoint now live in a shared `Connection`, so a `StreamHandler` can outlive the `Client` that produced it — which it genuinely can, because `~TransactionReplication` releases the storage-clients read lock before destroying its streams. The socket is published through an `atomic<shared_ptr>` so a reconnect never destroys one that an interrupt or an in-flight RPC still holds.

This closes a use-after-free where unregistering a replica destroyed the shared `rpc_client_` under a live SYNC commit on another database. `Shutdown()` is now safe to call with an RPC in flight, and its declaration says so — the old contract ("call `Abort()`, then join the worker thread") was unsatisfiable on the SYNC path, where the RPC runs inline on the committing thread and there is no thread to join.

## Notes for reviewers

- `--storage-mode=IN_MEMORY_ANALYTICAL` at startup stays forbidden for data instances; analytical is reachable only via the runtime query from a transactional start.
- `REGISTER INSTANCE` against an analytical main still returns `SUCCESS` and is healed by the reconciliation loop. The data instance logs the cause on reject. No `StateCheckRes` version bump, no new `SHOW INSTANCES` column.
- A manual `CREATE SNAPSHOT` between import and switch-back was dropped from the recipe: the switch-back already writes a correctly stamped snapshot, while a manual one taken while analytical skips the digest check and carries a pre-import timestamp.
- Operator constraint, stated in the docs: register and unregister replicas only while in transactional mode.
