### PR TITLE
fix(ttl): wake scheduler after SetInterval so TTL updates

### DIFF
--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -53,7 +53,9 @@ RpcInfoSpecialize(UpdateDataInstanceConfigRpc, update_data_instance_config_rpc_s
 auto ReplicationInstanceClient::InstanceName() const -> std::string const & { return instance_name_; }
 
 void ReplicationInstanceClient::UpdateHealthCheckFrequencySec(std::chrono::seconds const &new_config) const {
-  instance_checker_.SetInterval(new_config);
+  // instance_checker_ is already running (runtime setting change), so wake it: a plain SetInterval would
+  // leave the new frequency lagging by up to one old interval before the next tick picks it up.
+  instance_checker_.SetIntervalAndWake(new_config);
 }
 
 void ReplicationInstanceClient::StartStateCheck() {

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -53,8 +53,7 @@ RpcInfoSpecialize(UpdateDataInstanceConfigRpc, update_data_instance_config_rpc_s
 auto ReplicationInstanceClient::InstanceName() const -> std::string const & { return instance_name_; }
 
 void ReplicationInstanceClient::UpdateHealthCheckFrequencySec(std::chrono::seconds const &new_config) const {
-  // instance_checker_ is already running (runtime setting change), so wake it: a plain SetInterval would
-  // leave the new frequency lagging by up to one old interval before the next tick picks it up.
+  // Called on an already-running checker (runtime setting change), so wake it rather than SetInterval.
   instance_checker_.SetIntervalAndWake(new_config);
 }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -246,10 +246,7 @@ class PeriodicSnapshotObserver : public memgraph::utils::Observer<memgraph::util
   explicit PeriodicSnapshotObserver(memgraph::utils::Scheduler &scheduler) : scheduler_{&scheduler} {}
 
   // String HAS to be a valid cron expr
-  void Update(const memgraph::utils::SchedulerInterval &in) override {
-    scheduler_->SetInterval(in);
-    scheduler_->SpinOnce();
-  }
+  void Update(const memgraph::utils::SchedulerInterval &in) override { scheduler_->SetIntervalAndWake(in); }
 
  private:
   memgraph::utils::Scheduler *scheduler_;

--- a/src/storage/v2/ttl.cpp
+++ b/src/storage/v2/ttl.cpp
@@ -157,7 +157,9 @@ void TTL::SetInterval(std::optional<std::chrono::microseconds> period,
   info_.period = actual_period;
   info_.start_time = start_time;
 
-  ttl_.SetInterval(actual_period, start_time);
+  // Wake the worker: TTL sets its schedule after the scheduler thread starts, and a plain SetInterval won't
+  // wake a thread already parked on the default (infinite) wait, so without this it could silently never fire.
+  ttl_.SetIntervalAndWake(actual_period, start_time);
 }
 
 void TTL::Configure(bool should_run_edge_ttl) {

--- a/src/storage/v2/ttl.cpp
+++ b/src/storage/v2/ttl.cpp
@@ -157,8 +157,8 @@ void TTL::SetInterval(std::optional<std::chrono::microseconds> period,
   info_.period = actual_period;
   info_.start_time = start_time;
 
-  // Wake the worker: TTL sets its schedule after the scheduler thread starts, and a plain SetInterval won't
-  // wake a thread already parked on the default (infinite) wait, so without this it could silently never fire.
+  // TTL's schedule is set after the worker thread is already running (Configure() starts it first),
+  // so without waking it here the worker could stay parked and TTL would silently never fire.
   ttl_.SetIntervalAndWake(actual_period, start_time);
 }
 

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -77,6 +77,20 @@ class Scheduler {
 
   void SetInterval(std::string cron_expr) { SetInterval(SchedulerInterval{cron_expr}); }
 
+  // Reconfigure the schedule and wake a running worker so the new interval applies immediately. Plain
+  // SetInterval does not wake a parked worker (contract pinned by Scheduler.SetupAndSpinOnce), so callers
+  // reconfiguring an already-running scheduler use this.
+  void SetIntervalAndWake(const SchedulerInterval &setup) {
+    SetInterval(setup);
+    SpinOnce();
+  }
+
+  template <typename TRep, typename TPeriod>
+  void SetIntervalAndWake(const std::chrono::duration<TRep, TPeriod> &period,
+                          std::optional<std::chrono::system_clock::time_point> start_time = {}) {
+    SetIntervalAndWake(SchedulerInterval{period, start_time});
+  }
+
   void Resume();
 
   void Pause();

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -77,9 +77,8 @@ class Scheduler {
 
   void SetInterval(std::string cron_expr) { SetInterval(SchedulerInterval{cron_expr}); }
 
-  // Reconfigure the schedule and wake a running worker so the new interval applies immediately. Plain
-  // SetInterval does not wake a parked worker (contract pinned by Scheduler.SetupAndSpinOnce), so callers
-  // reconfiguring an already-running scheduler use this.
+  // Wakes a running worker so the new interval applies immediately — plain SetInterval leaves a parked
+  // worker on its old wait until timeout (contract verified by Scheduler.SetupAndSpinOnce).
   void SetIntervalAndWake(const SchedulerInterval &setup) {
     SetInterval(setup);
     SpinOnce();

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -111,9 +111,8 @@ bool WaitForVertexCount(DbAccess &db, size_t expected_count,
   return WaitForCondition([&]() { return CountVisibleVertices(db) == expected_count; }, timeout);
 }
 
-// Wait until the visible vertex count drops to at most `expected_count`. Under TTL the count is monotone
-// non-increasing, so don't poll for exact equality with a transient value: two vertices can expire close
-// together and a single batch takes the count straight past the intermediate, which == would miss.
+// Poll for <=, not ==: a single reap batch can delete several expired vertices at once and skip
+// straight past an intermediate count that WaitForVertexCount would wait for forever.
 template <typename DbAccess>
 bool WaitForVertexCountAtMost(DbAccess &db, size_t expected_count,
                               std::chrono::milliseconds timeout = std::chrono::seconds(3)) {

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -111,6 +111,15 @@ bool WaitForVertexCount(DbAccess &db, size_t expected_count,
   return WaitForCondition([&]() { return CountVisibleVertices(db) == expected_count; }, timeout);
 }
 
+// Wait until the visible vertex count drops to at most `expected_count`. Under TTL the count is monotone
+// non-increasing, so don't poll for exact equality with a transient value: two vertices can expire close
+// together and a single batch takes the count straight past the intermediate, which == would miss.
+template <typename DbAccess>
+bool WaitForVertexCountAtMost(DbAccess &db, size_t expected_count,
+                              std::chrono::milliseconds timeout = std::chrono::seconds(3)) {
+  return WaitForCondition([&]() { return CountVisibleVertices(db) <= expected_count; }, timeout);
+}
+
 // Helper function to wait for specific vertex and edge counts
 template <typename DbAccess>
 bool WaitForVertexAndEdgeCount(DbAccess &db, size_t expected_vertices, size_t expected_edges,
@@ -403,12 +412,15 @@ TYPED_TEST(TTLFixture, StartTime) {
       << "TTL ran before the configured start time (expected to wait 3 seconds)";
 
   // After 3 seconds, TTL should start running (interval is 100ms)
-  // Wait for first deletion
-  ASSERT_TRUE(WaitForVertexCount(this->db_, 5, std::chrono::milliseconds(1500)))
+  // Wait for first deletion. Use <= because v5 (already expired) and v6 (expires ~1s later) can both be
+  // reaped by a single batch if the scheduler starts late, taking the count 6 -> 4 without pausing at 5.
+  ASSERT_TRUE(WaitForVertexCountAtMost(this->db_, 5, std::chrono::milliseconds(1500)))
       << "Failed to observe first TTL deletion after start time";
 
-  // Wait for second deletion (newer timestamp is 4s in future from test start)
-  ASSERT_TRUE(WaitForVertexCount(this->db_, 4, std::chrono::seconds(2))) << "Failed to observe second TTL deletion";
+  // Wait for second deletion (newer timestamp is 4s in future from test start). 4 is the terminal steady
+  // state (v1-v4 are never eligible), so <= 4 is exact here.
+  ASSERT_TRUE(WaitForVertexCountAtMost(this->db_, 4, std::chrono::seconds(2)))
+      << "Failed to observe second TTL deletion";
 }
 
 TYPED_TEST(TTLFixture, Edge) {


### PR DESCRIPTION
TTL sets its schedule after the scheduler thread is already running: ConfigureTtl calls Configure (which does Pause+Run to spawn the worker), then SetInterval; enabling TTL separately calls Resume. utils::Scheduler::SetInterval deliberately doesn't wake a worker parked on the old wait — a contract pinned by Scheduler.SetupAndSpinOnce. So if the freshly-spawned thread reads the default time_point::max() before SetInterval reconfigures find_next_, it parks in wait_until(max, [spin_once_]) forever: Resume's notify is swallowed (spin_once_ is false, and the thread never reaches the is_paused_ wait Resume targets), and TTL silently never fires. Reproduces under concurrency.

Fix: add Scheduler::SetIntervalAndWake (SetInterval + SpinOnce) and route TTL::SetInterval through it, covering every TTL path (configure, replica WAL, snapshot restore, disk). The snapshot observer's two-call site folds into the same helper. SetInterval stays untouched, so the pinned contract and the "set before Run" init pattern still hold.