### PR TITLE
fix(storage): hold vector-search pins for the lifetime of their results

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -5177,8 +5177,13 @@ std::vector<std::tuple<VertexAccessor, double, double>> InMemoryStorage::InMemor
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
   std::vector<std::tuple<VertexAccessor, double, double>> result;
 
-  // we have to take vertices accessor to be sure no vertex is deleted while we are searching
-  auto acc = mem_storage->vertices_.access();
+  // The pin has to outlive the search, not just cover it. SearchNodes hands
+  // back raw Vertex*, we wrap them in VertexAccessors, and the caller reads
+  // through those long after this function has returned — while a pin scoped to
+  // this call is already gone and vertices_ is free to reclaim a node the
+  // moment its last accessor drops. Hold it on the storage accessor instead, so
+  // it covers the whole window in which the results are usable.
+  if (!vector_search_vertex_pin_) vector_search_vertex_pin_.emplace(mem_storage->MakeVertexPin());
   const auto search_results = storage_->indices_.vector_index_.SearchNodes(
       index_name, number_of_results, vector, mem_storage->name_id_mapper_.get());
   std::transform(search_results.begin(), search_results.end(), std::back_inserter(result), [&](const auto &item) {
@@ -5194,8 +5199,15 @@ std::vector<std::tuple<EdgeAccessor, double, double>> InMemoryStorage::InMemoryA
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
   std::vector<std::tuple<EdgeAccessor, double, double>> result;
 
-  // we have to take edges accessor to be sure no edge is deleted while we are searching
-  auto acc = mem_storage->edges_.access();
+  // Same lifetime rule as the node search above. Both pins are needed: the
+  // EdgeAccessor holds the Edge and its two endpoint Vertex*, so pinning only
+  // edges_ would still let the endpoints be reclaimed underneath it. Take the
+  // edge pin via MakeEdgePin rather than edges_.access(): under
+  // storage_light_edge the edges are not in edges_ at all, and an accessor on
+  // it pins nothing — the graveyard drain frees light edges on the epoch the
+  // pin acquires.
+  if (!vector_search_edge_pin_) vector_search_edge_pin_.emplace(mem_storage->MakeEdgePin());
+  if (!vector_search_vertex_pin_) vector_search_vertex_pin_.emplace(mem_storage->MakeVertexPin());
   const auto search_results = storage_->indices_.vector_edge_index_.SearchEdges(index_name, number_of_results, vector);
   std::transform(search_results.begin(), search_results.end(), std::back_inserter(result), [&](const auto &item) {
     const auto &[entry, distance, score] = item;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -731,6 +731,15 @@ class InMemoryStorage final : public Storage {
                              IndexPerformanceTracker &impact_tracker);
     SalientConfig::Items config_;
 
+    // Vector search is the one read path that hands raw Vertex*/Edge* out of
+    // storage and lets the caller dereference them after the call returns, so
+    // its pins live here rather than in the search's own scope. Taken lazily on
+    // the first search of each kind and released with the accessor: an object a
+    // search returned stays reachable for as long as the accessors wrapping it
+    // can be used. Transactions that never search hold nothing.
+    std::optional<utils::SkipListDb<Vertex>::ConstAccessor> vector_search_vertex_pin_;
+    std::optional<EdgePin> vector_search_edge_pin_;
+
     // Bookkeeping
     durability::WalTxnDataPos wal_txn_positions_;
     bool needs_wal_update_{false};

--- a/tests/unit/vector_index.cpp
+++ b/tests/unit/vector_index.cpp
@@ -165,6 +165,32 @@ TEST_F(VectorIndexTest, DeleteVertexTest) {
   }
 }
 
+TEST_F(VectorIndexTest, SearchResultsSurviveGcWhileAccessorIsAliveTest) {
+  // The accessors a vector search returns wrap raw Vertex*, and the caller reads
+  // through them after the search call has returned. Pinning only for the
+  // duration of the search leaves that read unprotected, so the pin is held on
+  // the storage accessor instead. Read the results back with a GC pass in
+  // between: the reads must still be valid while the searching accessor lives.
+  this->CreateIndex(2, 10);
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    auto properties = MakeVectorIndexProperty(acc.get(), memgraph::utils::small_vector<float>{1.0F, 1.0F});
+    this->CreateVertex(acc.get(), test_property, properties, test_label);
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  auto acc = this->storage->Access(memgraph::storage::READ);
+  std::vector<float> query = {1.0F, 1.0F};
+  const auto results = acc->VectorIndexSearchOnNodes(test_index.data(), 1, query);
+  ASSERT_EQ(results.size(), 1);
+
+  this->storage->FreeMemory();
+
+  const auto &vertex = std::get<0>(results[0]);
+  const auto property = acc->NameToProperty(test_property.data());
+  EXPECT_TRUE(vertex.GetProperty(property, View::OLD).has_value());
+}
+
 TEST_F(VectorIndexTest, SimpleAbortTest) {
   this->CreateIndex(2, 10);
   auto acc = this->storage->Access(memgraph::storage::WRITE);


### PR DESCRIPTION
Follow-on to #4475, same class of defect: an index hands out a raw pointer whose lifetime is not covered by anything the reader holds.

## The gap

`VectorIndexSearchOnNodes` / `VectorIndexSearchOnEdges` pin the object store for the duration of the **search call**, then return raw `Vertex*` / `Edge*` wrapped in accessors:

```cpp
// we have to take vertices accessor to be sure no vertex is deleted while we are searching
auto acc = mem_storage->vertices_.access();
const auto search_results = ...SearchNodes(...);
// ... wrap raw Vertex* into VertexAccessors ...
return result;   // ← pin dies here; the caller reads through the pointers afterwards
```

The comment states the intent, but the scoping does not deliver it: it is the *results*, not the lookup, that outlive the pin. Every other index read path in the tree gets this right — `InMemoryEdgeTypePropertyIndex::Iterable` and friends keep `EdgePin pin_accessor_edge_` and a `SkipListDb<Vertex>::ConstAccessor` as **members**, so the pin lives exactly as long as anything the caller can iterate. Vector search is the outlier.

This moves the pins onto the storage accessor, taken lazily on the first search of each kind. An object a search returned then stays reachable for as long as the accessors wrapping it can be used, and a transaction that never searches holds nothing.

## Two further problems in the edge search

- It took `edges_.access()` directly rather than `MakeEdgePin()`. Under `storage_light_edge` that pins **nothing relevant**: light edges are not skiplist nodes, and their memory is released by the graveyard drain against the epoch `MakeEdgePin()` acquires. The header says as much where `MakeEdgePin` is defined.
- It never pinned `vertices_` at all, although the `EdgeAccessor` it constructs carries both endpoint `Vertex*` next to the edge.

## Scope — what this is not

**I am not claiming this fixes #4517.** That crash is an engine SIGSEGV in a query-executor thread reading a freed `PropertyStore`, and I have only frame #0 — the release build will not unwind further, so the call path is unknown. This change is in the right family and touches a read path that hands out raw pointers, but I have not demonstrated that it is *that* path, and I would rather send you a correctly-scoped hardening change than a guess wearing a "Fixes" tag.

Specifically, it does **not** rescue the case where the index still holds an entry for a vertex freed before the reading transaction began; no pin taken at search time can help there. If that turns out to be #4517, the fix belongs in index cleanup, not here.

We are switching our CI to an unstripped build so the next occurrence yields a full symbolized stack, and I will attach it to #4517.

## Testing

Added `VectorIndexTest.SearchResultsSurviveGcWhileAccessorIsAliveTest`, which searches, runs `FreeMemory()`, and then reads a property back through the returned accessor — the pattern the scoping above left unprotected.

In fairness: I have not been able to build memgraph locally (no toolchain), so this has not been compiled on my side and the test has not been executed — your CI will be the first to do both. Happy to iterate on anything it turns up.
