### PR TITLE
fix(coordination): reject instance_health_check_frequency_sec = 0

### DIFF
--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -13,6 +13,7 @@
 
 #include "coordination/coordinator_cluster_state.hpp"
 
+#include <spdlog/spdlog.h>
 #include <algorithm>
 #include <libnuraft/buffer.hxx>
 #include <libnuraft/buffer_serializer.hxx>
@@ -41,6 +42,25 @@ auto DedupCoordinatorInstances(std::vector<CoordinatorInstanceContext> instances
     }
   }
   return result;
+}
+
+// Older versions accepted instance_health_check_frequency_sec = 0, so persisted state can contain a value the read
+// side treats as fatal: StartStateCheck() MG_ASSERTs on it, aborting every coordinator that recovers it, on every
+// restart. Clamping on the way in is a deterministic function of the log, so all coordinators running this version
+// still agree, and it lets a cluster that is already crash-looping come back up. An unpatched peer derives 0 instead
+// and keeps aborting — but that is what it does today regardless, so there is no divergence this creates.
+auto ClampInstanceHealthCheckFreqSec(uint32_t const check_freq_sec) -> uint32_t {
+  if (check_freq_sec >= kMinInstanceHealthCheckFreqSec) {
+    return check_freq_sec;
+  }
+  spdlog::warn(
+      "Recovered {}={}, which is below the supported minimum; using {} instead. Persist a valid value with "
+      "SET COORDINATOR SETTING '{}' TO '<value>'.",
+      kInstanceHealthCheckFreqSec,
+      check_freq_sec,
+      kMinInstanceHealthCheckFreqSec,
+      kInstanceHealthCheckFreqSec);
+  return kMinInstanceHealthCheckFreqSec;
 }
 }  // namespace
 
@@ -178,7 +198,8 @@ auto CoordinatorClusterState::DoAction(CoordinatorClusterStateDelta delta_state)
   }
 
   if (delta_state.instance_health_check_frequency_sec_.has_value()) {
-    instance_health_check_frequency_sec_ = *delta_state.instance_health_check_frequency_sec_;
+    instance_health_check_frequency_sec_ =
+        ClampInstanceHealthCheckFreqSec(*delta_state.instance_health_check_frequency_sec_);
   }
 
   if (delta_state.global_read_only_.has_value()) {
@@ -325,7 +346,7 @@ void CoordinatorClusterState::SetInstanceDownTimeoutSec(uint32_t const timeout_s
 
 void CoordinatorClusterState::SetInstanceHealthCheckFreqSec(uint32_t const check_freq_sec) {
   auto lock = std::lock_guard{app_lock_};
-  instance_health_check_frequency_sec_ = check_freq_sec;
+  instance_health_check_frequency_sec_ = ClampInstanceHealthCheckFreqSec(check_freq_sec);
 }
 
 void CoordinatorClusterState::SetGlobalReadOnly(bool const global_read_only) {
@@ -404,7 +425,9 @@ void from_json(nlohmann::json const &j, CoordinatorClusterState &instance_state)
   }
 
   {
-    uint32_t const check_freq_sec = j.value(kInstanceHealthCheckFreqSec.data(), 1);
+    // The default covers a snapshot serialized before this key existed; an explicit out-of-range value is clamped by
+    // the setter, not by this default.
+    uint32_t const check_freq_sec = j.value(kInstanceHealthCheckFreqSec.data(), kMinInstanceHealthCheckFreqSec);
     instance_state.SetInstanceHealthCheckFreqSec(check_freq_sec);
   }
 

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1144,7 +1144,14 @@ auto CoordinatorInstance::SetCoordinatorSetting(std::string_view const setting_n
     } else if (setting_name == kInstanceDownTimeoutSec) {
       delta_state.instance_down_timeout_sec_ = utils::ParseStringToUint<uint32_t>(setting_value);
     } else if (setting_name == kInstanceHealthCheckFreqSec) {
-      delta_state.instance_health_check_frequency_sec_ = utils::ParseStringToUint<uint32_t>(setting_value);
+      auto const freq_sec = utils::ParseStringToUint<uint32_t>(setting_value);
+      // Unlike other scheduler-backed settings (e.g. storage_snapshot_interval_sec), 0 has no "disabled"
+      // meaning here: StartStateCheck() asserts freq > 0, so a committed 0 aborts the coordinator on the
+      // next REGISTER INSTANCE or reconcile, and — since Raft replicates it — keeps doing so on restart.
+      if (freq_sec == 0) {
+        throw std::invalid_argument{"Value must be greater than 0."};
+      }
+      delta_state.instance_health_check_frequency_sec_ = freq_sec;
     } else if (setting_name == kGlobalReadOnly) {
       delta_state.global_read_only_ = parse_bool(setting_value);
     }

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1146,10 +1146,15 @@ auto CoordinatorInstance::SetCoordinatorSetting(std::string_view const setting_n
     } else if (setting_name == kInstanceHealthCheckFreqSec) {
       auto const freq_sec = utils::ParseStringToUint<uint32_t>(setting_value);
       // Unlike other scheduler-backed settings (e.g. storage_snapshot_interval_sec), 0 has no "disabled"
-      // meaning here: StartStateCheck() asserts freq > 0, so a committed 0 aborts the coordinator on the
-      // next REGISTER INSTANCE or reconcile, and — since Raft replicates it — keeps doing so on restart.
-      if (freq_sec == 0) {
-        throw std::invalid_argument{"Value must be greater than 0."};
+      // meaning here: StartStateCheck() rejects freq < kMinInstanceHealthCheckFreqSec, so a committed 0 aborts
+      // the coordinator on the next REGISTER INSTANCE or reconcile, and — since Raft replicates it — keeps
+      // doing so on restart.
+      if (freq_sec < kMinInstanceHealthCheckFreqSec) {
+        spdlog::error("Error occurred while trying to update {} to {}. Error: value must be >= {}.",
+                      setting_name,
+                      setting_value,
+                      kMinInstanceHealthCheckFreqSec);
+        return SetCoordinatorSettingStatus::INVALID_ARGUMENT;
       }
       delta_state.instance_health_check_frequency_sec_ = freq_sec;
     } else if (setting_name == kGlobalReadOnly) {

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1146,9 +1146,10 @@ auto CoordinatorInstance::SetCoordinatorSetting(std::string_view const setting_n
     } else if (setting_name == kInstanceHealthCheckFreqSec) {
       auto const freq_sec = utils::ParseStringToUint<uint32_t>(setting_value);
       // Unlike other scheduler-backed settings (e.g. storage_snapshot_interval_sec), 0 has no "disabled"
-      // meaning here: StartStateCheck() rejects freq < kMinInstanceHealthCheckFreqSec, so a committed 0 aborts
-      // the coordinator on the next REGISTER INSTANCE or reconcile, and — since Raft replicates it — keeps
-      // doing so on restart.
+      // meaning here: StartStateCheck() MG_ASSERTs on freq < kMinInstanceHealthCheckFreqSec, so a committed 0
+      // aborts the coordinator on the next REGISTER INSTANCE or reconcile, and — since Raft replicates it —
+      // keeps doing so on restart. This guard only stops new 0s; a 0 already in the log or a snapshot is still
+      // applied verbatim on recovery.
       if (freq_sec < kMinInstanceHealthCheckFreqSec) {
         spdlog::error("Error occurred while trying to update {} to {}. Error: value must be >= {}.",
                       setting_name,

--- a/src/coordination/include/coordination/constants.hpp
+++ b/src/coordination/include/coordination/constants.hpp
@@ -61,6 +61,10 @@ constexpr auto kInstanceDownTimeoutSec = "instance_down_timeout_sec"sv;
 constexpr auto kInstanceHealthCheckFreqSec = "instance_health_check_frequency_sec"sv;
 constexpr auto kGlobalReadOnly = "global_read_only"sv;
 
+// Lower bound for instance_health_check_frequency_sec. There is no gflag for this setting (it lives only in the
+// Raft-replicated cluster state), so this stands in for the FLAG_IN_RANGE validator a startup flag would carry.
+constexpr uint32_t kMinInstanceHealthCheckFreqSec = 1;
+
 // cluster state
 constexpr int MAX_SNAPSHOTS = 3;
 constexpr auto kUuid = "uuid"sv;

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -61,8 +61,9 @@ void ReplicationInstanceClient::StartStateCheck() {
     return;
   }
 
-  MG_ASSERT(instance_health_check_frequency_sec_ > std::chrono::seconds(0),
-            "Health check frequency must be greater than 0");
+  MG_ASSERT(instance_health_check_frequency_sec_ >= std::chrono::seconds{kMinInstanceHealthCheckFreqSec},
+            "Health check frequency must be at least {}s",
+            kMinInstanceHealthCheckFreqSec);
 
   instance_checker_.SetInterval(instance_health_check_frequency_sec_);
   instance_checker_.Run(instance_name_, [this] {

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -2654,6 +2654,17 @@ def test_coord_settings(test_name):
     assert settings[instance_down_timeout_sec] == "15"
     assert settings[instance_health_check_frequency_sec] == "3"
 
+    # 0 is not the usual "disable the scheduler" value here: a coordinator that never health-checks cannot detect
+    # failure, and StartStateCheck() aborts on it. The rejection happens before the Raft commit, so the previously
+    # committed value must still be readable afterwards.
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(coord_cursor_3, "SET COORDINATOR SETTING 'instance_health_check_frequency_sec' to '0'")
+    assert "Invalid argument detected while trying to update setting instance_health_check_frequency_sec" in str(
+        e.value
+    )
+    settings = dict(execute_and_fetch_all(coord_cursor_3, "SHOW COORDINATOR SETTINGS"))
+    assert settings[instance_health_check_frequency_sec] == "3"
+
 
 def test_update_config(test_name):
     inner_instances_description = get_instances_description_no_setup(test_name=test_name)

--- a/tests/unit/coordinator_cluster_state.cpp
+++ b/tests/unit/coordinator_cluster_state.cpp
@@ -446,3 +446,49 @@ TEST_F(CoordinatorClusterStateTest, DedupCoordinatorsOnDeserialize) {
   };
   ASSERT_EQ(deserialized_cluster_state.GetCoordinatorInstancesContext(), expected_coord_instances);
 }
+
+// A 0 committed by a version that still accepted it is fatal on the read side: StartStateCheck() MG_ASSERTs on it, so
+// without clamping every coordinator recovering this state aborts, on every restart.
+TEST_F(CoordinatorClusterStateTest, ClampZeroHealthCheckFreqOnDoAction) {
+  CoordinatorClusterState cluster_state;
+
+  // NOLINTNEXTLINE
+  CoordinatorClusterStateDelta const zero_delta{.instance_health_check_frequency_sec_ = 0};
+  cluster_state.DoAction(zero_delta);
+  ASSERT_EQ(cluster_state.GetInstanceHealthCheckFrequencySec(),
+            std::chrono::seconds{memgraph::coordination::kMinInstanceHealthCheckFreqSec});
+
+  // A valid value is applied verbatim, so the clamp is not just pinning everything to the minimum.
+  // NOLINTNEXTLINE
+  CoordinatorClusterStateDelta const valid_delta{.instance_health_check_frequency_sec_ = 7};
+  cluster_state.DoAction(valid_delta);
+  ASSERT_EQ(cluster_state.GetInstanceHealthCheckFrequencySec(), std::chrono::seconds{7});
+}
+
+TEST_F(CoordinatorClusterStateTest, ClampZeroHealthCheckFreqOnDeserialize) {
+  auto const serialize = [](nlohmann::json json) {
+    auto const log = json.dump();
+    ptr<buffer> data = buffer::alloc(sizeof(uint32_t) + log.size());
+    nuraft::buffer_serializer bs(data);
+    bs.put_str(log);
+    return CoordinatorClusterState::Deserialize(*data);
+  };
+
+  auto const base =
+      nlohmann::json{{memgraph::coordination::kDataInstances.data(), std::vector<DataInstanceContext>{}},
+                     {memgraph::coordination::kMainUUID.data(), UUID{}},
+                     {memgraph::coordination::kCoordinatorInstances.data(), std::vector<CoordinatorInstanceContext>{}}};
+
+  auto zero = base;
+  zero[memgraph::coordination::kInstanceHealthCheckFreqSec.data()] = 0;
+  ASSERT_EQ(serialize(zero).GetInstanceHealthCheckFrequencySec(),
+            std::chrono::seconds{memgraph::coordination::kMinInstanceHealthCheckFreqSec});
+
+  auto valid = base;
+  valid[memgraph::coordination::kInstanceHealthCheckFreqSec.data()] = 7;
+  ASSERT_EQ(serialize(valid).GetInstanceHealthCheckFrequencySec(), std::chrono::seconds{7});
+
+  // A snapshot written before the key existed must still land on the default, not on 0.
+  ASSERT_EQ(serialize(base).GetInstanceHealthCheckFrequencySec(),
+            std::chrono::seconds{memgraph::coordination::kMinInstanceHealthCheckFreqSec});
+}


### PR DESCRIPTION
## Issue

`SET COORDINATOR SETTING 'instance_health_check_frequency_sec' TO '0'` is accepted and committed to
the Raft log, but `0` is fatal: every coordinator that later constructs a `ReplicationInstanceClient`
(on `REGISTER INSTANCE`, leader-election reconcile, or startup) hits `MG_ASSERT(freq > 0)` in
`StartStateCheck` and `SIGABRT`s. Raft replicates the setting, so each new leader crashes the same
way — restart included.

Root cause: `0` is the codebase's "disable a periodic scheduler" convention, which `Scheduler`
honours but `StartStateCheck` rejects.

## Reproduce (1 coordinator + 1 instance, RelWithDebInfo)

```
SET COORDINATOR SETTING 'instance_health_check_frequency_sec' TO '0';  -- accepted, SHOW reports 0
REGISTER INSTANCE ...;                                                 -- coordinator SIGABRT
-- restart -> SIGABRT again at replication_instance_client.cpp:67
--   'instance_health_check_frequency_sec_ > std::chrono::seconds(0)'
```

## Fix

Reject `0` in `SetCoordinatorSetting` before the Raft commit, reusing the existing `try/catch` that
maps to `INVALID_ARGUMENT`. A coordinator that can't health-check can't detect failure, so "disabled"
isn't a meaningful state for this setting.
