### PR TITLE
fix(storage): resolve edge-type+property index entries by gid

### DIFF
--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -12,6 +12,8 @@
 #include "storage/v2/inmemory/edge_type_property_index.hpp"
 #include <range/v3/all.hpp>
 
+#include <variant>
+
 #include "metrics/prometheus_metrics.hpp"
 #include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/edge_info_helpers.hpp"
@@ -46,7 +48,7 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       continue;
     }
 
-    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, 0});
+    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, edge_ref.ptr->gid, 0});
     if (snapshot_info) {
       snapshot_info->Update(UpdateType::EDGES);
     }
@@ -118,7 +120,8 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       continue;
     }
 
-    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, tx.start_timestamp});
+    index_accessor.insert(
+        {std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, edge_ref.ptr->gid, tx.start_timestamp});
     if (snapshot_info) {
       snapshot_info->Update(UpdateType::EDGES);
     }
@@ -126,10 +129,24 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
 }
 
 // Free function which advances the given iterator until the next valid entry is found.
+//
+// `edge_pin` is the iterable's own pin, threaded down so this loop can re-resolve
+// each entry's edge through it. Holding the pin is NOT by itself enough to make
+// `Entry::edge` dereferenceable: the pin protects nodes reachable through the
+// skiplist from the moment its accessor id was allocated, whereas an Entry holds
+// an Edge* captured when the entry was indexed. A node the epoch GC already
+// collected -- tagged with an older accessor id -- before this pin existed is
+// freed underneath the scan, and every touch of it is a use-after-free. Observed
+// in the field as `SkipListGc<Edge>::Run()` freeing the node from a concurrent
+// `CreateEdge` while this loop reads it.
 void AdvanceUntilValid_(auto &index_iterator, const auto &end, EdgeRef &current_edge, EdgeAccessor &current_accessor,
                         PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                         const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
-                        Transaction *transaction, EdgeTypeId edge_type, Gid max_gid) {
+                        Transaction *transaction, EdgeTypeId edge_type, Gid max_gid, EdgePin const &edge_pin) {
+  // Light mode keeps no edge skiplist to resolve against, so it retains the
+  // previous behaviour; the reported crashes are all heavy-edge.
+  auto const *edge_store = std::get_if<utils::SkipListDb<Edge>::ConstAccessor>(&edge_pin);
+
   for (; index_iterator != end; ++index_iterator) {
     if (index_iterator->edge == current_edge.ptr) {
       continue;
@@ -147,12 +164,32 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, EdgeRef &current_
     // Visibility filters run after the value-bounds check: bounds depend only on the
     // entry value, so checking them first lets the scan stop at the bound instead of
     // walking past entries invisible to this transaction.
-    if (index_iterator->edge->gid >= max_gid) {
+    //
+    // Read the gid off the ENTRY, not through `entry.edge->gid`. That dereference
+    // was the first touch of the edge in this loop and needed the edge to still be
+    // alive just to discover its own identity -- the exact circularity the entry's
+    // own gid removes.
+    if (index_iterator->gid >= max_gid) {
       continue;
     }
 
     if (!CanSeeEntityWithTimestamp(index_iterator->timestamp, transaction, view)) {
       continue;
+    }
+
+    // Everything below dereferences the edge, so establish first that the entry's
+    // pointer still names a live edge under our pin. Resolving the gid through the
+    // pinned store and requiring the SAME address answers both failure modes at
+    // once: a miss means the edge was reclaimed, and a hit at a different address
+    // means the gid was reused by a newer edge. Either way this entry refers to a
+    // dead edge and is stale by definition, which a scan must skip rather than
+    // yield. A hit at the same address is the only case where `entry.edge` is
+    // provably alive for as long as the pin is held.
+    if (edge_store != nullptr) {
+      auto const found = edge_store->find(index_iterator->gid);
+      if (found == edge_store->end() || &*found != index_iterator->edge) {
+        continue;
+      }
     }
 
     if (!CurrentVersionHasProperty(*index_iterator->edge, property, index_iterator->value, transaction, view)) {
@@ -337,6 +374,16 @@ uint64_t InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(Storage *storage, 
 
   // Pin the edge store while sweeping: the loop dereferences raw Edge* the epoch GC could free.
   auto const edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
+  // ...but the pin ALONE is not sufficient, for the same reason spelled out above
+  // AdvanceUntilValid_: it protects nodes reachable through the skiplist from the
+  // moment its accessor id was allocated, whereas an Entry holds an Edge* captured
+  // when the entry was indexed. A node already collected before this pin existed is
+  // freed underneath it, and the first touch is fatal -- AnyVersionHasProperty takes
+  // `std::shared_lock{edge.lock}`, so the use-after-free is a WRITE and no amount of
+  // locking discipline can help. Re-resolve the entry's gid through the pinned
+  // accessor instead; a miss means the edge is gone and the entry is stale by
+  // definition, which is precisely what this sweep removes.
+  auto const *edge_store = std::get_if<utils::SkipListDb<Edge>::ConstAccessor>(&edge_pin);
 
   uint64_t swept = 0;
   for (auto &[index, property] : *all_indices) {
@@ -366,8 +413,14 @@ uint64_t InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(Storage *storage, 
       const bool redundant_duplicate = has_next && it->value == next_it->value &&
                                        it->from_vertex == next_it->from_vertex && it->to_vertex == next_it->to_vertex &&
                                        it->edge == next_it->edge;
-      if (redundant_duplicate ||
-          !AnyVersionHasProperty(*it->edge, property, it->value, oldest_active_start_timestamp)) {
+      Edge const *live_edge = it->edge;
+      if (edge_store != nullptr) {
+        auto const found = edge_store->find(it->gid);
+        live_edge = found == edge_store->end() ? nullptr : &*found;
+      }
+
+      if (redundant_duplicate || live_edge == nullptr ||
+          !AnyVersionHasProperty(*live_edge, property, it->value, oldest_active_start_timestamp)) {
         edges_acc.remove(*it);
       }
 
@@ -388,7 +441,11 @@ void InMemoryEdgeTypePropertyIndex::ActiveIndices::AbortEntries(
 
   auto acc = it->second->skiplist.access();
   for (const auto &[from_vertex, to_vertex, edge, value] : edges) {
-    acc.remove(Entry{value, from_vertex, to_vertex, edge, exact_start_timestamp});
+    // Dereferencing `edge` is safe HERE, unlike in a GC-concurrent read: this is
+    // the abort path for a transaction that still owns the edge it is undoing, so
+    // nothing can have reclaimed it yet. `gid` is not part of `operator<`, so it
+    // does not affect which entry `remove` finds.
+    acc.remove(Entry{value, from_vertex, to_vertex, edge, edge->gid, exact_start_timestamp});
   }
 }
 
@@ -405,7 +462,7 @@ void InMemoryEdgeTypePropertyIndex::ActiveIndices::UpdateOnSetProperty(Vertex *f
     return;
 
   auto acc = it->second->skiplist.access();
-  acc.insert({value, from_vertex, to_vertex, edge, timestamp});
+  acc.insert({value, from_vertex, to_vertex, edge, edge->gid, timestamp});
 }
 
 uint64_t InMemoryEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(EdgeTypeId edge_type,
@@ -504,7 +561,8 @@ void InMemoryEdgeTypePropertyIndex::Iterable::Iterator::AdvanceUntilValid() {
                      self_->storage_,
                      self_->transaction_,
                      self_->edge_type_,
-                     self_->max_gid_);
+                     self_->max_gid_,
+                     self_->pin_accessor_edge_);
 }
 
 void InMemoryEdgeTypePropertyIndex::RunGC() {
@@ -592,7 +650,7 @@ void InMemoryEdgeTypePropertyIndex::ActiveIndices::AbortEntries(EdgeTypeProperty
 
     auto acc = it->second->skiplist.access();
     for (const auto &[from_vertex, to_vertex, edge, value] : edges) {
-      acc.remove(Entry{std::move(value), from_vertex, to_vertex, edge, start_timestamp});
+      acc.remove(Entry{std::move(value), from_vertex, to_vertex, edge, edge->gid, start_timestamp});
     }
   }
 }
@@ -661,7 +719,8 @@ void InMemoryEdgeTypePropertyIndex::ChunkedIterable::Iterator::AdvanceUntilValid
                      self_->storage_,
                      self_->transaction_,
                      self_->edge_type_,
-                     self_->max_gid_);
+                     self_->max_gid_,
+                     self_->pin_accessor_edge_);
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -43,6 +43,13 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     Vertex *from_vertex;
     Vertex *to_vertex;
     Edge *edge;
+    // The `edge` pointer above is a borrowed reference into the edge store and
+    // cannot be dereferenced to discover its own identity once the edge GC has
+    // reclaimed it. Carrying the gid lets a reader re-resolve the edge through a
+    // pinned accessor instead. Deliberately NOT part of `operator<`: the index
+    // ordering, and the adjacency the duplicate check relies on, must stay
+    // exactly as they were.
+    Gid gid;
 
     uint64_t timestamp;
 


### PR DESCRIPTION
Fixes #4523.

An index `Entry` in `InMemoryEdgeTypePropertyIndex` stores a raw `Edge *`
captured when the entry was indexed. The epoch GC can free that `Edge` while the
index still holds the pointer, and both the GC sweep and query-time scans then
dereference it.

Free stack, from an ASAN build — a concurrent `MERGE`/`CREATE` drives the edge GC
while a scan walks the index:

```
SkipListGc<Edge, DbAwareAllocator<char>>::Run()
 ← InMemoryStorage::InMemoryAccessor::CreateEdge(...)
 ← plan::CreateExpand::CreateExpandCursor::Pull()
 ← plan::Merge::MergeCursor::Pull()
```

### Why the existing pin doesn't cover it

`Iterable`/`ChunkedIterable` already hold `pin_accessor_edge_` for the iterator's
lifetime, and it still faults. The pin protects nodes reachable through the
skiplist from the moment its accessor id was allocated, whereas an `Entry` holds
a pointer captured when the entry was *indexed*. A node already collected before
the pin existed is freed underneath a scan that holds one.

### The change

Carry the edge's `gid` on the `Entry` and re-resolve through the pinned edge
store rather than dereferencing the stored pointer. `gid` is deliberately **not**
part of `operator<`, so index ordering — and the adjacency the duplicate check in
the sweep relies on — is unchanged.

- **`RemoveObsoleteEntries`** (background sweep): re-resolve; a miss means the
  edge is gone and the entry is stale, which is what the sweep removes anyway.
- **`AdvanceUntilValid_`** (query scans, shared by `Iterable` and
  `ChunkedIterable`): re-resolve and require the **same address** before any
  dereference. A miss means the edge was reclaimed; a hit at a different address
  means the gid was reused. Either way the entry names a dead edge and the scan
  skips it. `max_gid` is also now compared against the entry's own gid — that
  dereference was the first touch of the edge, requiring it alive merely to learn
  its identity.

Light mode keeps no edge skiplist to resolve against and retains the previous
behaviour.

### Why both sites

Fixing only the sweep **moves** the crash rather than removing it. Measured on
our CI under ASAN, same commit and suite across all three arms:

| engine | jobs | ASAN aborts | faulting site |
|---|---|---|---|
| unpatched | — | 3 | `RemoveObsoleteEntries` |
| sweep only | 96 | 20 (~21%) | `AdvanceUntilValid` |
| **both sites** | **72** | **0** | — |

Zero aborts across 1,166 completed jobs on all shards. At the middle arm's rate
72 jobs should have produced ~15.

### Scope

This shows the reproducer is dead, not that the `Edge` lifetime problem is gone
generally — only this index was exercised. If you would rather fix it at the root
(make the pin cover entries captured before it, so no consumer needs to
re-resolve), I'd happily drop this in favour of that; the arms above give a way
to measure a candidate.

No test is included: the race needs concurrent `MERGE`/`CREATE` against an
edge-type+property index under a sanitizer to be observable, which I did not see
a natural home for in `tests/unit`. Happy to add one wherever you'd want it.
