### PR TITLE
fix(storage): retire edge-index entries before the edge is unlinked

### DIFF
--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -342,6 +342,7 @@ uint64_t InMemoryEdgePropertyIndex::RemoveObsoleteEntries(Storage *storage, uint
 
   // Pin the edge store while sweeping: the loop dereferences raw Edge* the epoch GC could free.
   auto const edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
+  auto const *mem_storage = static_cast<InMemoryStorage const *>(storage);
 
   uint64_t swept = 0;
   for (auto &[property_id, index] : *cpy) {
@@ -356,6 +357,17 @@ uint64_t InMemoryEdgePropertyIndex::RemoveObsoleteEntries(Storage *storage, uint
 
       auto next_it = it;
       ++next_it;
+
+      // An edge the in-flight GC pass is about to unlink takes its entries with
+      // it, ahead of every other test in this loop: identity against the doomed
+      // set, O(1), no dereference. Both tests below can `continue` past an entry,
+      // and an entry that survives while its edge is unlinked is a dangling
+      // pointer left in the index. See InMemoryStorage::IsEdgeDyingThisGcPass.
+      if (mem_storage->IsEdgeDyingThisGcPass(it->edge)) {
+        edges_acc.remove(*it);
+        it = next_it;
+        continue;
+      }
 
       if (it->timestamp >= oldest_active_start_timestamp) {
         it = next_it;

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -277,6 +277,7 @@ uint64_t InMemoryEdgeTypeIndex::RemoveObsoleteEntries(Storage *storage, uint64_t
 
   // Pin the edge store while sweeping: the loop dereferences raw Edge* the epoch GC could free.
   auto const edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
+  auto const *mem_storage = static_cast<InMemoryStorage const *>(storage);
 
   uint64_t swept = 0;
   for (auto &et_index : *cpy) {
@@ -289,6 +290,17 @@ uint64_t InMemoryEdgeTypeIndex::RemoveObsoleteEntries(Storage *storage, uint64_t
 
       auto next_it = it;
       ++next_it;
+
+      // An edge the in-flight GC pass is about to unlink takes its entries with
+      // it, ahead of every other test in this loop: identity against the doomed
+      // set, O(1), no dereference. Both tests below can `continue` past an entry,
+      // and an entry that survives while its edge is unlinked is a dangling
+      // pointer left in the index. See InMemoryStorage::IsEdgeDyingThisGcPass.
+      if (mem_storage->IsEdgeDyingThisGcPass(it->edge)) {
+        edges_acc.remove(*it);
+        it = next_it;
+        continue;
+      }
 
       if (it->timestamp >= oldest_active_start_timestamp) {
         it = next_it;

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -46,7 +46,7 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       continue;
     }
 
-    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, 0});
+    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, edge_ref.ptr->gid, 0});
     if (snapshot_info) {
       snapshot_info->Update(UpdateType::EDGES);
     }
@@ -118,7 +118,8 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       continue;
     }
 
-    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, tx.start_timestamp});
+    index_accessor.insert(
+        {std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, edge_ref.ptr->gid, tx.start_timestamp});
     if (snapshot_info) {
       snapshot_info->Update(UpdateType::EDGES);
     }
@@ -126,6 +127,13 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
 }
 
 // Free function which advances the given iterator until the next valid entry is found.
+//
+// Dereferencing `Entry::edge` here is safe because of an ordering the GC upholds,
+// not because of anything this loop checks: an entry is removed from the index
+// before its edge is unlinked from the edge store, and the iterable's own pin
+// covers every edge unlinked after the scan began. The caller must therefore hold
+// that pin (Iterable/ChunkedIterable keep it in `pin_accessor_edge_`) for as long
+// as the returned accessor is used.
 void AdvanceUntilValid_(auto &index_iterator, const auto &end, EdgeRef &current_edge, EdgeAccessor &current_accessor,
                         PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                         const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
@@ -147,7 +155,12 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, EdgeRef &current_
     // Visibility filters run after the value-bounds check: bounds depend only on the
     // entry value, so checking them first lets the scan stop at the bound instead of
     // walking past entries invisible to this transaction.
-    if (index_iterator->edge->gid >= max_gid) {
+    //
+    // Read the gid off the ENTRY, not through `entry.edge->gid`. That dereference
+    // was the first touch of the edge in this loop and needed the edge to still be
+    // alive just to discover its own identity -- the exact circularity the entry's
+    // own gid removes.
+    if (index_iterator->gid >= max_gid) {
       continue;
     }
 
@@ -155,6 +168,13 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, EdgeRef &current_
       continue;
     }
 
+    // No liveness re-resolution here: the scan does not need one. An entry is
+    // removed from the index before its edge is unlinked (RemoveObsoleteEntries,
+    // against the doomed set the GC pass publishes), so an entry reachable from
+    // this iterator names an edge that is still linked, or one unlinked after our
+    // pin was taken -- which the pin then keeps alive for the whole scan. Both
+    // cases are dereferenceable, so the dereference below is the first and only
+    // touch, at no lookup cost.
     if (!CurrentVersionHasProperty(*index_iterator->edge, property, index_iterator->value, transaction, view)) {
       continue;
     }
@@ -337,6 +357,13 @@ uint64_t InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(Storage *storage, 
 
   // Pin the edge store while sweeping: the loop dereferences raw Edge* the epoch GC could free.
   auto const edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
+  // The pin stops an edge deleted from now on from being freed under us. It cannot
+  // speak for an edge that was already gone when the pin was taken -- it protects
+  // nodes from the moment its accessor id was allocated, and an Entry holds an
+  // Edge* captured when the entry was indexed. That gap is closed on the other
+  // side instead: this sweep is what removes an entry before its edge is unlinked,
+  // so no entry ever outlives its edge and the gap has nothing to leak through.
+  auto const *mem_storage = static_cast<InMemoryStorage const *>(storage);
 
   uint64_t swept = 0;
   for (auto &[index, property] : *all_indices) {
@@ -352,6 +379,20 @@ uint64_t InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(Storage *storage, 
       auto next_it = it;
       ++next_it;
 
+      // FIRST, ahead of every other test in this loop. An edge the in-flight GC
+      // pass is about to unlink takes its entries with it, unconditionally and
+      // without the edge being consulted at all: identity against the doomed set,
+      // O(1), no dereference. It has to come first because both tests below can
+      // `continue` past an entry -- the timestamp guard skips young entries
+      // outright, and AnyVersionHasProperty can answer `true` -- and an entry that
+      // survives this pass while its edge is unlinked is precisely a dangling
+      // pointer left in the index for a later scan to dereference.
+      if (mem_storage->IsEdgeDyingThisGcPass(it->edge)) {
+        edges_acc.remove(*it);
+        it = next_it;
+        continue;
+      }
+
       if (it->timestamp >= oldest_active_start_timestamp) {
         it = next_it;
         continue;
@@ -366,6 +407,8 @@ uint64_t InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(Storage *storage, 
       const bool redundant_duplicate = has_next && it->value == next_it->value &&
                                        it->from_vertex == next_it->from_vertex && it->to_vertex == next_it->to_vertex &&
                                        it->edge == next_it->edge;
+      // Every entry reaching here names an edge that is still linked (the doomed
+      // set was checked at the top of the loop), so dereferencing it is safe.
       if (redundant_duplicate ||
           !AnyVersionHasProperty(*it->edge, property, it->value, oldest_active_start_timestamp)) {
         edges_acc.remove(*it);
@@ -388,7 +431,11 @@ void InMemoryEdgeTypePropertyIndex::ActiveIndices::AbortEntries(
 
   auto acc = it->second->skiplist.access();
   for (const auto &[from_vertex, to_vertex, edge, value] : edges) {
-    acc.remove(Entry{value, from_vertex, to_vertex, edge, exact_start_timestamp});
+    // Dereferencing `edge` is safe HERE, unlike in a GC-concurrent read: this is
+    // the abort path for a transaction that still owns the edge it is undoing, so
+    // nothing can have reclaimed it yet. `gid` is not part of `operator<`, so it
+    // does not affect which entry `remove` finds.
+    acc.remove(Entry{value, from_vertex, to_vertex, edge, edge->gid, exact_start_timestamp});
   }
 }
 
@@ -405,7 +452,7 @@ void InMemoryEdgeTypePropertyIndex::ActiveIndices::UpdateOnSetProperty(Vertex *f
     return;
 
   auto acc = it->second->skiplist.access();
-  acc.insert({value, from_vertex, to_vertex, edge, timestamp});
+  acc.insert({value, from_vertex, to_vertex, edge, edge->gid, timestamp});
 }
 
 uint64_t InMemoryEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(EdgeTypeId edge_type,
@@ -592,7 +639,7 @@ void InMemoryEdgeTypePropertyIndex::ActiveIndices::AbortEntries(EdgeTypeProperty
 
     auto acc = it->second->skiplist.access();
     for (const auto &[from_vertex, to_vertex, edge, value] : edges) {
-      acc.remove(Entry{std::move(value), from_vertex, to_vertex, edge, start_timestamp});
+      acc.remove(Entry{std::move(value), from_vertex, to_vertex, edge, edge->gid, start_timestamp});
     }
   }
 }

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -43,6 +43,13 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     Vertex *from_vertex;
     Vertex *to_vertex;
     Edge *edge;
+    // The `edge` pointer above is a borrowed reference into the edge store and
+    // cannot be dereferenced to discover its own identity once the edge GC has
+    // reclaimed it. Carrying the gid lets a reader re-resolve the edge through a
+    // pinned accessor instead. Deliberately NOT part of `operator<`: the index
+    // ordering, and the adjacency the duplicate check relies on, must stay
+    // exactly as they were.
+    Gid gid;
 
     uint64_t timestamp;
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1813,20 +1813,12 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                                   *transaction_.active_indices_,
                                   transaction_.start_timestamp,
                                   mem_storage->name_id_mapper_.get());
-    // EDGES METADATA (has ptr to Vertices, must be before removing verticies).
-    // Heavy edges are removed from the edges_ skiplist below and never re-enter
-    // GC, so abort is their single metadata-removal site. Light edges instead
-    // ride deleted_edges_ into CollectGarbage, which is THEIR single removal site
-    // (OnEdgesDeleted at the transactional GC light arm) — calling OnEdgesDeleted
-    // here too would double-remove the gid and trip the MG_ASSERT in
-    // EdgeMetadataIndex::OnEdgesDeleted. So gate this to heavy only.
-    // my_deleted_edges holds Edge* for edges this aborting txn created (abort-of-create);
-    // they remain in `edges_` until the remove loop below, so reading ->gid here is safe.
-    if (!my_deleted_edges.empty() && !mem_storage->config_.salient.items.storage_light_edge) {
-      if (auto &idx = mem_storage->edges_metadata_index_) {
-        idx->OnEdgesDeleted(my_deleted_edges | std::ranges::views::transform(&Edge::gid));
-      }
-    }
+    // EDGES METADATA: nothing to do here for either edge kind. Both now ride
+    // deleted_edges_ into CollectGarbage, which is the single site that removes an
+    // edge from `edges_` and therefore the single site that must retire its index
+    // entries first; OnEdgesDeleted runs there, for heavy and light alike. Doing it
+    // here as well would double-remove the gid and trip the MG_ASSERT in
+    // EdgeMetadataIndex::OnEdgesDeleted.
 
     // VERTICES (has ptr to Edges, must be before removing edges)
     if (!my_deleted_vertices.empty()) {
@@ -1837,33 +1829,29 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     }
 
     // EDGES / LIGHT EDGES
-    // Both heavy and light edges defer to deleted_edges_ here. Light edges must
-    // NOT be pushed to the light_edge_graveyard_ at abort time: the graveyard
-    // watermark (guard_epoch) is snapped at GC-COLLECTION time so that any
-    // post-abort reader is ordered before it. Riding deleted_edges_ into
-    // CollectGarbage also runs the index cleanup (OnEdgesDeleted +
-    // RemoveEdgesFromVectorEdgeIndices) before the graveyard push, exactly like
-    // heavy. Light edges have no skiplist node, so the heavy edges_acc.remove
-    // call is skipped for them; only the deleted_edges_ routing applies.
-    // Heavy behaviour is unchanged.
     if (!my_deleted_edges.empty()) {
-      if (mem_storage->config_.salient.items.storage_light_edge) {
-        // Do NOT push to light_edge_graveyard_ here: snapping guard_epoch at abort
-        // time, before any post-commit index iterable opens, would let
-        // DrainLightEdgeGraveyard free the Edge* under a live iterable (UAF). Mirror
-        // the heavy deferral (the skiplist GC frees a marked node only once its
-        // accessor watermark clears) by routing light edges through deleted_edges_
-        // into CollectGarbage, which snaps the graveyard watermark at GC-collection
-        // time.
-        // O(1) splice under the SpinLock — never an O(batch) copy while locked.
-        mem_storage->deleted_edges_.WithLock(
-            [&](auto &deleted_edges) { deleted_edges.splice(deleted_edges.end(), my_deleted_edges); });
-      } else {
-        auto edges_acc = mem_storage->edges_.access();
-        for (auto *edge : my_deleted_edges) {
-          edges_acc.remove(edge->gid);
-        }
-      }
+      // Both kinds defer to deleted_edges_; neither is unlinked here. Riding it
+      // into CollectGarbage is what puts them through the index cleanup
+      // (OnEdgesDeleted + RemoveEdgesFromVectorEdgeIndices + the edge-index sweep)
+      // before anything reclaims them.
+      //
+      // Light edges must not be pushed to light_edge_graveyard_ at abort time:
+      // snapping guard_epoch before any post-commit index iterable opens would let
+      // DrainLightEdgeGraveyard free the Edge* under a live iterable (UAF).
+      //
+      // Heavy edges used to be removed from `edges_` right here, which made abort a
+      // SECOND unlink site — one that runs no index sweep. Any index entry naming
+      // one of these edges that AbortEntries did not match exactly (it removes by
+      // exact key: value, endpoints, timestamp) outlived its edge, and the entry was
+      // then a dangling pointer for the next scan or sweep to dereference. Deferring
+      // to deleted_edges_ makes CollectGarbage the only unlink site for both kinds,
+      // which is what lets the sweep there retire every entry BEFORE the edge goes
+      // (see InMemoryStorage::IsEdgeDyingThisGcPass) and lets readers dereference
+      // Entry::edge under nothing but their pin.
+      //
+      // O(1) splice under the SpinLock — never an O(batch) copy while locked.
+      mem_storage->deleted_edges_.WithLock(
+          [&](auto &deleted_edges) { deleted_edges.splice(deleted_edges.end(), my_deleted_edges); });
     }
   }
 
@@ -3454,6 +3442,19 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
   // This operation is very expensive as it traverses through all of the items
   // in every index every time.
   gc_progress_.SetPhase(GcPhase::INDEX_CLEANUP);
+
+  // Publish the edges this pass will unlink, so the sweep below can drop their
+  // index entries by pointer identity instead of inferring staleness from each
+  // edge's MVCC state. The window closes after the unlink loop further down; an
+  // OnScopeExit rather than a plain clear() because everything between here and
+  // there can throw, and a set left published would make a later sweep discard
+  // live entries for edges that were never unlinked.
+  auto const unpublish_dying_edges = utils::OnScopeExit{[this] { gc_dying_edges_.clear(); }};
+  if (!current_deleted_edges.empty() && !config_.salient.items.storage_light_edge) {
+    gc_dying_edges_.reserve(current_deleted_edges.size());
+    gc_dying_edges_.insert(current_deleted_edges.begin(), current_deleted_edges.end());
+  }
+
   if (auto token = stop_source.get_token(); !token.stop_requested()) {
     uint64_t swept = 0;
     if (index_cleanup_vertex_needed || index_cleanup_vertex_performance) {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -16,6 +16,9 @@
 #include <optional>
 #include <string_view>
 #include <utility>
+
+#include <absl/container/flat_hash_set.h>
+
 #include "memory/db_arena_fwd.hpp"
 #include "replication_coordination_glue/role.hpp"
 #include "storage/v2/commit_log.hpp"
@@ -921,7 +924,28 @@ class InMemoryStorage final : public Storage {
   // heavy, so (unlike MakeEdgePin) there is no light-mode variant.
   [[nodiscard]] auto MakeVertexPin() const { return vertices_.access(); }
 
+  // The edges the in-flight GC pass is about to unlink from `edges_`, published
+  // for the duration of that pass's index sweep and empty at every other moment.
+  //
+  // An index Entry holds a borrowed Edge*, so the only thing that keeps it
+  // dereferenceable is that no entry ever outlives its edge. CollectGarbage is
+  // the single site that unlinks an edge, and it sweeps the indices immediately
+  // beforehand -- so publishing the doomed set across that sweep lets the sweep
+  // recognise those entries by POINTER IDENTITY and drop them unconditionally,
+  // without deciding their fate from the edge's own MVCC state and without
+  // re-resolving anything. That is what makes the ordering an invariant rather
+  // than a consequence of AnyVersionHasProperty happening to say `false`.
+  //
+  // Written and read only from the GC pass, which is serialised against itself
+  // by the caller of CollectGarbage; hence a plain set, no lock.
+  [[nodiscard]] bool IsEdgeDyingThisGcPass(Edge const *edge) const noexcept {
+    return !gc_dying_edges_.empty() && gc_dying_edges_.contains(edge);
+  }
+
   utils::SkipListDb<Edge> edges_;
+  // See IsEdgeDyingThisGcPass. Populated by CollectGarbage immediately before the
+  // index sweep and cleared once the unlink loop below it has run.
+  absl::flat_hash_set<Edge const *> gc_dying_edges_;
   // Present iff salient.items.enable_edges_metadata && salient.items.properties_on_edges.
   std::optional<EdgeMetadataIndex> edges_metadata_index_;
 


### PR DESCRIPTION
@Ignition — an alternative to #4525 that has no `find` on either path, in response to your comment that the `O(log n)` lookup is problematic. Opened as a separate PR so the two approaches can be compared side by side; if you prefer this one, #4525 should be closed in its favour (and vice versa).

**Please read the caveat at the bottom before spending much time on it: this is not tested.**

## The idea

The `find` in #4525 exists to answer "is this `Edge*` still alive?". The alternative is to make the question unaskable — guarantee that no index entry ever outlives its edge, and then readers need nothing but the pin they already hold.

`CollectGarbage` almost does this already: it sweeps the edge indices immediately before it unlinks edges, and the comment there says as much ("we need to remove entries from indexes to avoid dangling raw pointers"). What is missing is that the sweep decides each entry's fate from *the edge's own MVCC state*, and two paths let an entry survive regardless:

- `it->timestamp >= oldest_active_start_timestamp` skips the entry outright, before any liveness question is asked;
- `AnyVersionHasProperty` can answer `true`.

Either way the entry is still in the index when the unlink loop below runs, and from that moment it is a dangling pointer waiting for the next scan or sweep.

So: `CollectGarbage` publishes the set of edges it is about to unlink for the duration of its sweep, and the sweep drops those entries **by pointer identity, ahead of every other test in the loop**. O(1), no dereference, and not a judgement the edge's state gets to make.

```cpp
if (mem_storage->IsEdgeDyingThisGcPass(it->edge)) {
  edges_acc.remove(*it);
  it = next_it;
  continue;
}
```

The set is a plain member, written and read only from the GC pass, which is serialised against itself — the same treatment `claimed_index_arming_` already gets a few lines above.

With the ordering enforced, `AdvanceUntilValid_` needs no liveness check at all: an entry reachable from the iterator names an edge that is either still linked, or one unlinked after the pin was taken — and the pin covers that second case for the whole scan. It therefore drops the `find` **and** the `EdgePin` parameter #4525 threaded into it. The hot path ends up cheaper than it is on `master` today, because `Entry::gid` (kept from #4525, and the part of it I think is worth keeping regardless) lets the `max_gid` bound read the gid off the entry instead of dereferencing the edge to discover its own identity.

## The second unlink site

Tracing this turned up something that may be the actual source of the dangling entries, rather than just a way to prevent them.

`Abort()` removed heavy edges from `edges_` itself, with no index sweep — only `AbortEntries`, which removes by exact key (value, endpoints, timestamp). Any entry it did not match exactly outlived its edge. Light edges already defer to `deleted_edges_` and ride into `CollectGarbage`; this makes heavy do the same, so there is one unlink site instead of two and the heavy/light special case goes away.

I want to be careful about how strongly I put that: it is a hypothesis that fits the evidence, not something I have reproduced in isolation.

The same doomed-set guard is also applied to the edge-type and edge-property indices, which borrow `Edge*` the same way and have the same exposure.

## What this has NOT had

**It is not tested.** Specifically:

- it has not been compiled — I have no Memgraph toolchain to hand, so there may be trivial build breakage;
- it has not been run against the workload that produced the numbers on #4523. Those came from an ASAN build under a parallel integration suite; the discriminator there is sharp (20 aborts / 96 jobs on the one-site arm vs 0 / 72 on the two-site one), so the same harness would give a clear verdict on this approach too.

I did not want to spend that cycle before knowing whether the direction is one you would take. **If you like the approach, I am happy to do the validation afterwards** — build it, run it through the same ASAN arm, and report the numbers here the way I did on the issue.

One residual I deliberately left: the analytical-mode full-scan arm removes edges that never enter the doomed set. Those are selected by `delta() == nullptr && deleted()`, which is exactly the case where `AnyVersionHasProperty` returns `false`, so they are covered by the same reasoning `master` already relies on — but that is an argument, not an enforcement, and you are better placed than I am to say whether it is good enough.

Refs #4523. Alternative to #4525.
