### PR TITLE
feat(query): terminate all transactions with TERMINATE TRANSACTIONS "*"

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7328,6 +7328,14 @@ std::vector<TypedValue> BuildGcTransactionRow(storage::GcRunInfoView const &info
 }
 
 namespace {
+// TERMINATE TRANSACTIONS "*" terminates every transaction the caller may kill. Matched
+// exactly: near-misses are rejected by ParseTransactionId rather than silently ignored.
+constexpr std::string_view kTerminateAllWildcard = "*";
+
+bool IsTerminateAllWildcard(TypedValue const &value) {
+  return value.IsString() && std::string_view{value.ValueString()} == kTerminateAllWildcard;
+}
+
 // Transaction ids arrive as string literals, so the whole string must parse; a partial
 // parse would silently target a different transaction than the one named.
 uint64_t ParseTransactionId(TypedValue const &value) {
@@ -7347,7 +7355,7 @@ uint64_t ParseTransactionId(TypedValue const &value) {
 
 Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                                      std::shared_ptr<QueryUserOrRole> user_or_role, const Parameters &parameters,
-                                     InterpreterContext *interpreter_context) {
+                                     InterpreterContext *interpreter_context, Interpreter const *self) {
   auto privilege_checker = [](QueryUserOrRole *user_or_role, std::string const &db_name) {
     return user_or_role &&
            user_or_role->IsAuthorized(
@@ -7390,12 +7398,34 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
     case TransactionQueueQuery::Action::TERMINATE_TRANSACTIONS: {
       auto evaluation_context = EvaluationContext{.timestamp = QueryTimestamp(), .parameters = parameters};
       auto evaluator = PrimitiveLiteralExpressionEvaluator{evaluation_context};
-      std::vector<uint64_t> maybe_kill_transaction_ids;
-      std::ranges::transform(
-          transaction_query->transaction_id_list_,
-          std::back_inserter(maybe_kill_transaction_ids),
-          [&evaluator](Expression *expression) { return ParseTransactionId(expression->Accept(evaluator)); });
+      std::vector<TypedValue> id_values;
+      std::ranges::transform(transaction_query->transaction_id_list_,
+                             std::back_inserter(id_values),
+                             [&evaluator](Expression *expression) { return expression->Accept(evaluator); });
+
       callback.header = {"transaction_id", "killed"};
+
+      if (std::ranges::any_of(id_values, IsTerminateAllWildcard)) {
+        // Mixing would make the wildcard's meaning depend on the rest of the list: a named id
+        // that the wildcard skips (the caller's own) would silently not be terminated.
+        if (id_values.size() != 1) {
+          throw QueryRuntimeException("The '{}' wildcard cannot be combined with transaction ids.",
+                                      kTerminateAllWildcard);
+        }
+        callback.fn = [interpreter_context,
+                       self,
+                       user_or_role = std::move(user_or_role),
+                       privilege_checker = std::move(privilege_checker)]() mutable {
+          return interpreter_context->interpreters.WithLock([&](auto &interpreters) mutable {
+            return interpreter_context->TerminateAllTransactions(
+                interpreters, self, user_or_role.get(), std::move(privilege_checker));
+          });
+        };
+        break;
+      }
+
+      std::vector<uint64_t> maybe_kill_transaction_ids;
+      std::ranges::transform(id_values, std::back_inserter(maybe_kill_transaction_ids), ParseTransactionId);
       callback.fn = [interpreter_context,
                      maybe_kill_transaction_ids = std::move(maybe_kill_transaction_ids),
                      user_or_role = std::move(user_or_role),
@@ -7413,11 +7443,11 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
 }
 
 PreparedQuery PrepareTransactionQueueQuery(ParsedQuery parsed_query, std::shared_ptr<QueryUserOrRole> user_or_role,
-                                           InterpreterContext *interpreter_context) {
+                                           InterpreterContext *interpreter_context, Interpreter const *self) {
   auto *transaction_queue_query = utils::Downcast<TransactionQueueQuery>(parsed_query.query);
   MG_ASSERT(transaction_queue_query);
   auto callback = HandleTransactionQueueQuery(
-      transaction_queue_query, std::move(user_or_role), parsed_query.parameters, interpreter_context);
+      transaction_queue_query, std::move(user_or_role), parsed_query.parameters, interpreter_context, self);
 
   return PreparedQuery{
       .header = std::move(callback.header),
@@ -10830,7 +10860,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
       if (in_explicit_transaction_) {
         throw TransactionQueueInMulticommandTxException();
       }
-      prepared_query = PrepareTransactionQueueQuery(std::move(parsed_query), user_or_role_, interpreter_context_);
+      prepared_query = PrepareTransactionQueueQuery(std::move(parsed_query), user_or_role_, interpreter_context_, this);
     } else if (utils::Downcast<MultiDatabaseQuery>(parsed_query.query)) {
       if (in_explicit_transaction_) {
         throw MultiDatabaseQueryInMulticommandTxException();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <charconv>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -7326,6 +7327,24 @@ std::vector<TypedValue> BuildGcTransactionRow(storage::GcRunInfoView const &info
       "gc", "GARBAGE COLLECTION", std::move(metadata), info.start_time_us, info.start_steady_ms);
 }
 
+namespace {
+// Transaction ids arrive as string literals, so the whole string must parse; a partial
+// parse would silently target a different transaction than the one named.
+uint64_t ParseTransactionId(TypedValue const &value) {
+  if (!value.IsString()) {
+    throw QueryRuntimeException("Transaction id must be a string.");
+  }
+  auto const &id_string = value.ValueString();
+  auto const *const end = id_string.data() + id_string.size();
+  uint64_t transaction_id{};
+  auto const [parse_end, ec] = std::from_chars(id_string.data(), end, transaction_id);
+  if (ec != std::errc{} || parse_end != end) {
+    throw QueryRuntimeException("'{}' is not a valid transaction id.", std::string_view{id_string});
+  }
+  return transaction_id;
+}
+}  // namespace
+
 Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                                      std::shared_ptr<QueryUserOrRole> user_or_role, const Parameters &parameters,
                                      InterpreterContext *interpreter_context) {
@@ -7372,16 +7391,10 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
       auto evaluation_context = EvaluationContext{.timestamp = QueryTimestamp(), .parameters = parameters};
       auto evaluator = PrimitiveLiteralExpressionEvaluator{evaluation_context};
       std::vector<uint64_t> maybe_kill_transaction_ids;
-      std::ranges::transform(transaction_query->transaction_id_list_,
-                             std::back_inserter(maybe_kill_transaction_ids),
-                             [&evaluator](Expression *expression) {
-                               try {
-                                 auto value = expression->Accept(evaluator);
-                                 return std::stoul(value.ValueString().c_str());  // NOLINT
-                               } catch (std::exception & /* unused */) {
-                                 return std::numeric_limits<uint64_t>::max();
-                               }
-                             });
+      std::ranges::transform(
+          transaction_query->transaction_id_list_,
+          std::back_inserter(maybe_kill_transaction_ids),
+          [&evaluator](Expression *expression) { return ParseTransactionId(expression->Accept(evaluator)); });
       callback.header = {"transaction_id", "killed"};
       callback.fn = [interpreter_context,
                      maybe_kill_transaction_ids = std::move(maybe_kill_transaction_ids),

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7417,7 +7417,7 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                        user_or_role = std::move(user_or_role),
                        privilege_checker = std::move(privilege_checker)]() mutable {
           return interpreter_context->interpreters.WithLock([&](auto &interpreters) mutable {
-            return interpreter_context->TerminateAllTransactions(
+            return InterpreterContext::TerminateAllTransactions(
                 interpreters, self, user_or_role.get(), std::move(privilege_checker));
           });
         };

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -9,8 +9,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <algorithm>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <utility>
+#include <vector>
 
 #include "query/interpreter_context.hpp"
 
@@ -56,6 +60,53 @@ InterpreterContext::InterpreterContext(InterpreterConfig interpreter_config, mem
       worker_pool(worker_pool) {
 }
 
+namespace {
+
+/// Pins `interpreter`'s transaction so it can neither commit nor abort, hands its id to
+/// `should_kill`, and marks it TERMINATED if the predicate accepts. Only an ACTIVE
+/// transaction can be pinned, so one already committing, aborting or terminated is left
+/// alone. Returns whether the transaction was terminated.
+template <typename ShouldKill>
+bool TryTerminateInterpreter(Interpreter *interpreter, ShouldKill &&should_kill) {
+  TransactionStatus alive_status = TransactionStatus::ACTIVE;
+  // if it is just checking kill, commit and abort should wait for the end of the check
+  // The only way to start checking if the transaction will get killed is if the transaction_status is
+  // active
+  if (!interpreter->transaction_status_.compare_exchange_strong(alive_status, TransactionStatus::VERIFYING)) {
+    return false;
+  }
+  bool killed = false;
+  const utils::OnScopeExit clean_status([interpreter, &killed]() {
+    if (killed) {
+      interpreter->transaction_status_.store(TransactionStatus::TERMINATED, std::memory_order_release);
+    } else {
+      interpreter->transaction_status_.store(TransactionStatus::ACTIVE, std::memory_order_release);
+    }
+  });
+  std::optional<uint64_t> intr_trans = interpreter->GetTransactionId();
+  if (!intr_trans) return false;
+
+  killed = should_kill(*intr_trans);  // Note: this is used by the above `clean_status` (OnScopeExit)
+  return killed;
+}
+
+/// A caller may kill a transaction it owns, or any transaction on a database it holds
+/// TRANSACTION_MANAGEMENT for.
+bool MayTerminate(Interpreter const *interpreter, QueryUserOrRole *user_or_role,
+                  std::function<bool(QueryUserOrRole *, std::string const &)> const &privilege_checker) {
+  auto same_user = [](const auto &lv, const auto &rv) {
+    if (lv.get() == rv) return true;
+    if (lv && rv) return *lv == *rv;
+    return false;
+  };
+  if (same_user(interpreter->user_or_role_, user_or_role)) return true;
+
+  auto const db_name = interpreter->current_db_.db_acc_ ? interpreter->current_db_.db_acc_->get()->name() : "";
+  return privilege_checker(user_or_role, db_name);
+}
+
+}  // namespace
+
 std::vector<std::vector<TypedValue>> InterpreterContext::TerminateTransactions(
     const std::unordered_set<Interpreter *> &interpreters, std::vector<uint64_t> maybe_kill_transaction_ids,
     QueryUserOrRole *user_or_role, std::function<bool(QueryUserOrRole *, std::string const &)> privilege_checker) {
@@ -64,50 +115,21 @@ std::vector<std::vector<TypedValue>> InterpreterContext::TerminateTransactions(
   // Multiple simultaneous TERMINATE TRANSACTIONS aren't allowed
   // TERMINATE and SHOW TRANSACTIONS are mutually exclusive
   for (Interpreter *interpreter : interpreters) {
-    TransactionStatus alive_status = TransactionStatus::ACTIVE;
-    // if it is just checking kill, commit and abort should wait for the end of the check
-    // The only way to start checking if the transaction will get killed is if the transaction_status is
-    // active
-    if (!interpreter->transaction_status_.compare_exchange_strong(alive_status, TransactionStatus::VERIFYING)) {
-      continue;
-    }
-    bool killed = false;
-    const utils::OnScopeExit clean_status([interpreter, &killed]() {
-      if (killed) {
-        interpreter->transaction_status_.store(TransactionStatus::TERMINATED, std::memory_order_release);
-      } else {
-        interpreter->transaction_status_.store(TransactionStatus::ACTIVE, std::memory_order_release);
-      }
-    });
-    std::optional<uint64_t> intr_trans = interpreter->GetTransactionId();
-    if (!intr_trans) continue;
+    TryTerminateInterpreter(interpreter, [&](uint64_t transaction_id) {
+      auto it = std::find(maybe_kill_transaction_ids.begin(), not_found_midpoint, transaction_id);
+      if (it == not_found_midpoint) return false;
 
-    auto transaction_id = intr_trans.value();
-
-    auto it = std::find(maybe_kill_transaction_ids.begin(), not_found_midpoint, transaction_id);
-    if (it != not_found_midpoint) {
-      auto get_interpreter_db_name = [&]() -> std::string {
-        return interpreter->current_db_.db_acc_ ? interpreter->current_db_.db_acc_->get()->name() : "";
-      };
-
-      auto same_user = [](const auto &lv, const auto &rv) {
-        if (lv.get() == rv) return true;
-        if (lv && rv) return *lv == *rv;
-        return false;
-      };
-
-      if (same_user(interpreter->user_or_role_, user_or_role) ||
-          privilege_checker(user_or_role, get_interpreter_db_name())) {
-        // Only authorized kills join the killed partition. An unauthorized match stays in the
-        // not-found partition so it reports killed=false and its existence isn't leaked.
-        --not_found_midpoint;
-        std::iter_swap(it, not_found_midpoint);
-        killed = true;  // Note: this is used by the above `clean_status` (OnScopeExit)
-        spdlog::warn("Transaction {} successfully killed", transaction_id);
-      } else {
+      if (!MayTerminate(interpreter, user_or_role, privilege_checker)) {
         spdlog::warn("Not enough rights to kill the transaction");
+        return false;
       }
-    }
+      // Only authorized kills join the killed partition. An unauthorized match stays in the
+      // not-found partition so it reports killed=false and its existence isn't leaked.
+      --not_found_midpoint;
+      std::iter_swap(it, not_found_midpoint);
+      spdlog::warn("Transaction {} successfully killed", transaction_id);
+      return true;
+    });
   }
 
   std::vector<std::vector<TypedValue>> results;
@@ -117,6 +139,40 @@ std::vector<std::vector<TypedValue>> InterpreterContext::TerminateTransactions(
   }
   for (auto it = not_found_midpoint; it != maybe_kill_transaction_ids.end(); ++it) {
     results.push_back({TypedValue(std::to_string(*it)), TypedValue(true)});
+  }
+
+  return results;
+}
+
+std::vector<std::vector<TypedValue>> InterpreterContext::TerminateAllTransactions(
+    const std::unordered_set<Interpreter *> &interpreters, Interpreter const *self, QueryUserOrRole *user_or_role,
+    std::function<bool(QueryUserOrRole *, std::string const &)> privilege_checker) {
+  std::vector<uint64_t> killed_transaction_ids;
+
+  for (Interpreter *interpreter : interpreters) {
+    // Terminating the issuing transaction would make its own commit throw, so the caller would
+    // never see which transactions it killed.
+    if (interpreter == self) continue;
+
+    TryTerminateInterpreter(interpreter, [&](uint64_t transaction_id) {
+      if (!MayTerminate(interpreter, user_or_role, privilege_checker)) {
+        spdlog::warn("Not enough rights to kill the transaction");
+        return false;
+      }
+      killed_transaction_ids.push_back(transaction_id);
+      spdlog::warn("Transaction {} successfully killed", transaction_id);
+      return true;
+    });
+  }
+
+  // Ids are handed out monotonically, so ascending id is oldest transaction first. Sort the
+  // numbers rather than the formatted strings, which would order lexicographically.
+  std::ranges::sort(killed_transaction_ids);
+
+  std::vector<std::vector<TypedValue>> results;
+  results.reserve(killed_transaction_ids.size());
+  for (auto const transaction_id : killed_transaction_ids) {
+    results.push_back({TypedValue(std::to_string(transaction_id)), TypedValue(true)});
   }
 
   return results;

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -86,9 +86,6 @@ std::vector<std::vector<TypedValue>> InterpreterContext::TerminateTransactions(
 
     auto it = std::find(maybe_kill_transaction_ids.begin(), not_found_midpoint, transaction_id);
     if (it != not_found_midpoint) {
-      // update the maybe_kill_transaction_ids (partitioning not found + killed)
-      --not_found_midpoint;
-      std::iter_swap(it, not_found_midpoint);
       auto get_interpreter_db_name = [&]() -> std::string {
         return interpreter->current_db_.db_acc_ ? interpreter->current_db_.db_acc_->get()->name() : "";
       };
@@ -101,6 +98,10 @@ std::vector<std::vector<TypedValue>> InterpreterContext::TerminateTransactions(
 
       if (same_user(interpreter->user_or_role_, user_or_role) ||
           privilege_checker(user_or_role, get_interpreter_db_name())) {
+        // Only authorized kills join the killed partition. An unauthorized match stays in the
+        // not-found partition so it reports killed=false and its existence isn't leaked.
+        --not_found_midpoint;
+        std::iter_swap(it, not_found_midpoint);
         killed = true;  // Note: this is used by the above `clean_status` (OnScopeExit)
         spdlog::warn("Transaction {} successfully killed", transaction_id);
       } else {

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -107,7 +107,7 @@ struct InterpreterContext {
   /// `self` is the issuing interpreter and is skipped: terminating it would make its own
   /// commit throw, so the caller would never see which transactions it killed. Returns one
   /// row per terminated transaction, ordered by ascending transaction id.
-  std::vector<std::vector<TypedValue>> TerminateAllTransactions(
+  static std::vector<std::vector<TypedValue>> TerminateAllTransactions(
       const std::unordered_set<Interpreter *> &interpreters, Interpreter const *self, QueryUserOrRole *user_or_role,
       std::function<bool(QueryUserOrRole *, std::string const &)> privilege_checker);
 

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -103,6 +103,14 @@ struct InterpreterContext {
       const std::unordered_set<Interpreter *> &interpreters, std::vector<uint64_t> maybe_kill_transaction_ids,
       QueryUserOrRole *user_or_role, std::function<bool(QueryUserOrRole *, std::string const &)> privilege_checker);
 
+  /// Terminates every transaction the caller is authorized to kill, across all databases.
+  /// `self` is the issuing interpreter and is skipped: terminating it would make its own
+  /// commit throw, so the caller would never see which transactions it killed. Returns one
+  /// row per terminated transaction, ordered by ascending transaction id.
+  std::vector<std::vector<TypedValue>> TerminateAllTransactions(
+      const std::unordered_set<Interpreter *> &interpreters, Interpreter const *self, QueryUserOrRole *user_or_role,
+      std::function<bool(QueryUserOrRole *, std::string const &)> privilege_checker);
+
   static std::vector<uint64_t> ShowTransactionsUsingDBName(const std::unordered_set<Interpreter *> &interpreters,
                                                            std::string_view db_name);
 

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -52,11 +52,13 @@ def show_transactions_test(cursor, expected_num_results: int):
 def wait_for_transaction_count(cursor, expected_num_results: int, timeout_s: int = 10):
     """Polls SHOW TRANSACTIONS until the expected number of transactions is visible."""
     deadline = time.time() + timeout_s
-    while time.time() < deadline:
-        if len(execute_and_fetch_all(cursor, "SHOW TRANSACTIONS")) == expected_num_results:
+    while True:
+        results = execute_and_fetch_all(cursor, "SHOW TRANSACTIONS")
+        if len(results) == expected_num_results:
             return
+        if time.time() >= deadline:
+            assert False, f"Timed out waiting for {expected_num_results} transactions, saw {results}"
         time.sleep(0.1)
-    assert False, f"Timed out waiting for {expected_num_results} transactions"
 
 
 def process_function(cursor, queries: List[str]):
@@ -377,6 +379,8 @@ def test_wildcard_admin_kills_all(request):
     # Only the sweeping session is left.
     wait_for_transaction_count(admin_cursor, 1)
 
+    for process in processes:
+        process.join()
     for connection in victim_connections:
         connection.close()
 
@@ -443,6 +447,13 @@ def test_wildcard_unprivileged_kills_only_own(request):
     wait_for_transaction_count(admin_observer_cursor, 2)
     assert admin_long_query_id() == admin_transaction_id
 
+    # The survivor has to be killed here: the long query runs in a forked child, so closing the
+    # connection from this process would leave it running and later tests would count it.
+    execute_and_fetch_all(admin_observer_cursor, f"TERMINATE TRANSACTIONS '{admin_transaction_id}'")
+    wait_for_transaction_count(admin_observer_cursor, 1)
+
+    admin_process.join()
+    user_process.join()
     admin_connection.close()
     user_victim_connection.close()
 
@@ -487,6 +498,9 @@ def test_wildcard_across_databases(request):
     assert all(result[1] == True for result in results)
     wait_for_transaction_count(admin_cursor, 1)
 
+    # The victim sessions have to be gone before the databases they used can be dropped.
+    for process in processes:
+        process.join()
     for connection in victim_connections:
         connection.close()
 
@@ -503,12 +517,21 @@ def test_wildcard_rejects_mixed_list():
             execute_and_fetch_all(cursor, query)
 
 
-def test_wildcard_as_parameter():
-    """Query stripping turns the literal into a parameter, so a parameterized wildcard is the
-    same statement and must behave identically."""
+def test_wildcard_and_id_share_the_cached_query():
+    """Query stripping replaces the id literal with a parameter, so the wildcard and a named id
+    strip to the same query and share one cached AST. Each execution must follow its own literal
+    instead of the one that populated the cache."""
     cursor = connect().cursor()
-    cursor.execute("TERMINATE TRANSACTIONS $id", {"id": "*"})
-    assert len(cursor.fetchall()) == 0
+    assert len(execute_and_fetch_all(cursor, 'TERMINATE TRANSACTIONS "*"')) == 0
+
+    # Same cache entry, different parameter: read as a named id, not as a sweep.
+    results = execute_and_fetch_all(cursor, "TERMINATE TRANSACTIONS '1'")
+    assert len(results) == 1
+    assert results[0][0] == "1"
+    assert results[0][1] == False
+
+    # And back, so a wildcard decision cached from the first execution would show up here.
+    assert len(execute_and_fetch_all(cursor, 'TERMINATE TRANSACTIONS "*"')) == 0
 
 
 def test_unauthorized_terminate_reports_not_killed(request):
@@ -551,6 +574,7 @@ def test_unauthorized_terminate_reports_not_killed(request):
     # The admin can still kill it.
     results = execute_and_fetch_all(admin_observer_cursor, f"TERMINATE TRANSACTIONS '{admin_transaction_id}'")
     assert results[0][1] == True
+    wait_for_transaction_count(admin_observer_cursor, 1)
 
     admin_connection.close()
     user_connection.close()

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -33,6 +33,8 @@ def suppress_builtin_roles():
 # Utility functions
 # -------------------------
 
+LONG_QUERY = "CALL infinite_query.long_query() YIELD my_id RETURN my_id"
+
 
 def get_non_show_transaction_id(results):
     """Returns transaction id of the first transaction that is not SHOW TRANSACTIONS;"""
@@ -338,6 +340,177 @@ def test_user_cannot_see_admin_transaction(request):
     user_connection.close()
 
 
+def test_wildcard_admin_kills_all(request):
+    """An admin's TERMINATE TRANSACTIONS "*" kills every other transaction it can see."""
+    superadmin_cursor = connect().cursor()
+    execute_and_fetch_all(superadmin_cursor, "CREATE USER admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT TRANSACTION_MANAGEMENT TO admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT DATABASE * TO admin")
+
+    def on_exit():
+        execute_and_fetch_all(superadmin_cursor, "DROP USER admin")
+
+    request.addfinalizer(on_exit)
+
+    victim_connections = [connect(username="admin", password="") for _ in range(2)]
+    processes = [
+        multiprocessing.Process(
+            target=process_function,
+            args=(connection.cursor(), [LONG_QUERY]),
+        )
+        for connection in victim_connections
+    ]
+    for process in processes:
+        process.start()
+
+    admin_cursor = connect(username="admin", password="").cursor()
+    wait_for_transaction_count(admin_cursor, 3)  # two victims plus the SHOW itself
+
+    results = execute_and_fetch_all(admin_cursor, 'TERMINATE TRANSACTIONS "*"')
+    assert len(results) == 2
+    assert all(result[1] == True for result in results)
+    # Rows come back ordered by ascending transaction id, one row per distinct victim.
+    reported_ids = [result[0] for result in results]
+    assert reported_ids == sorted(reported_ids, key=int)
+    assert len(set(reported_ids)) == 2
+
+    # Only the sweeping session is left.
+    wait_for_transaction_count(admin_cursor, 1)
+
+    for connection in victim_connections:
+        connection.close()
+
+
+def test_wildcard_no_transactions_returns_empty():
+    """With nothing else running the sweep returns no rows, and the statement still succeeds
+    (its own transaction is excluded, so its commit is not aborted)."""
+    cursor = connect().cursor()
+    results = execute_and_fetch_all(cursor, 'TERMINATE TRANSACTIONS "*"')
+    assert len(results) == 0
+    # The session survived its own sweep.
+    assert len(execute_and_fetch_all(cursor, "SHOW TRANSACTIONS")) == 1
+
+
+def test_wildcard_unprivileged_kills_only_own(request):
+    """An unprivileged user's wildcard reaches only its own transactions, never anyone else's."""
+    superadmin_cursor = connect().cursor()
+    execute_and_fetch_all(superadmin_cursor, "CREATE USER admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT TRANSACTION_MANAGEMENT TO admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT DATABASE * TO admin")
+    execute_and_fetch_all(superadmin_cursor, "CREATE USER user")
+    execute_and_fetch_all(superadmin_cursor, "REVOKE ALL PRIVILEGES FROM user")
+
+    def on_exit():
+        execute_and_fetch_all(superadmin_cursor, "DROP USER admin")
+        execute_and_fetch_all(superadmin_cursor, "DROP USER user")
+
+    request.addfinalizer(on_exit)
+
+    admin_connection = connect(username="admin", password="")
+    user_victim_connection = connect(username="user", password="")
+    admin_process = multiprocessing.Process(
+        target=process_function,
+        args=(admin_connection.cursor(), [LONG_QUERY]),
+    )
+    user_process = multiprocessing.Process(
+        target=process_function,
+        args=(user_victim_connection.cursor(), [LONG_QUERY]),
+    )
+    admin_process.start()
+    user_process.start()
+
+    admin_observer_cursor = connect(username="admin", password="").cursor()
+    wait_for_transaction_count(admin_observer_cursor, 3)  # both victims plus the SHOW itself
+
+    def admin_long_query_id():
+        """The admin's long query, told apart from the observer's own SHOW row by its query text."""
+        return next(
+            result[1]
+            for result in execute_and_fetch_all(admin_observer_cursor, "SHOW TRANSACTIONS")
+            if result[0] == "admin" and result[2] == [LONG_QUERY]
+        )
+
+    admin_transaction_id = admin_long_query_id()
+
+    # The user sweeps: it kills its own long query and cannot touch the admin's.
+    user_cursor = connect(username="user", password="").cursor()
+    results = execute_and_fetch_all(user_cursor, 'TERMINATE TRANSACTIONS "*"')
+    assert len(results) == 1
+    assert results[0][1] == True
+    assert results[0][0] != admin_transaction_id
+
+    # The admin's transaction is untouched and still visible to the admin.
+    wait_for_transaction_count(admin_observer_cursor, 2)
+    assert admin_long_query_id() == admin_transaction_id
+
+    admin_connection.close()
+    user_victim_connection.close()
+
+
+def test_wildcard_across_databases(request):
+    """The wildcard is not scoped to the caller's database: one sweep kills transactions on
+    every database the caller has TRANSACTION_MANAGEMENT for."""
+    superadmin_cursor = connect().cursor()
+    execute_and_fetch_all(superadmin_cursor, "CREATE DATABASE wildcard_db_a")
+    execute_and_fetch_all(superadmin_cursor, "CREATE DATABASE wildcard_db_b")
+    execute_and_fetch_all(superadmin_cursor, "CREATE USER admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT TRANSACTION_MANAGEMENT TO admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT DATABASE * TO admin")
+
+    def on_exit():
+        execute_and_fetch_all(superadmin_cursor, "DROP USER admin")
+        execute_and_fetch_all(superadmin_cursor, "DROP DATABASE wildcard_db_a")
+        execute_and_fetch_all(superadmin_cursor, "DROP DATABASE wildcard_db_b")
+
+    request.addfinalizer(on_exit)
+
+    victim_connections = [connect(username="admin", password="") for _ in range(2)]
+    processes = [
+        multiprocessing.Process(
+            target=process_function,
+            args=(
+                connection.cursor(),
+                [f"USE DATABASE {db_name}", LONG_QUERY],
+            ),
+        )
+        for connection, db_name in zip(victim_connections, ["wildcard_db_a", "wildcard_db_b"])
+    ]
+    for process in processes:
+        process.start()
+
+    # The sweeping session stays on the default database.
+    admin_cursor = connect(username="admin", password="").cursor()
+    wait_for_transaction_count(admin_cursor, 3)
+
+    results = execute_and_fetch_all(admin_cursor, 'TERMINATE TRANSACTIONS "*"')
+    assert len(results) == 2
+    assert all(result[1] == True for result in results)
+    wait_for_transaction_count(admin_cursor, 1)
+
+    for connection in victim_connections:
+        connection.close()
+
+
+def test_wildcard_rejects_mixed_list():
+    """The wildcard must be the sole argument, so its meaning never depends on the rest."""
+    cursor = connect().cursor()
+    for query in [
+        "TERMINATE TRANSACTIONS \"*\", '1'",
+        "TERMINATE TRANSACTIONS '1', \"*\"",
+        'TERMINATE TRANSACTIONS "*", "*"',
+    ]:
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(cursor, query)
+
+
+def test_wildcard_as_parameter():
+    """Query stripping turns the literal into a parameter, so a parameterized wildcard is the
+    same statement and must behave identically."""
+    cursor = connect().cursor()
+    cursor.execute("TERMINATE TRANSACTIONS $id", {"id": "*"})
+    assert len(cursor.fetchall()) == 0
+
+
 def test_unauthorized_terminate_reports_not_killed(request):
     """An unprivileged user naming someone else's transaction id gets killed=false, and the
     transaction survives. Reporting killed=true would both lie and confirm the id exists."""
@@ -360,9 +533,7 @@ def test_unauthorized_terminate_reports_not_killed(request):
     user_cursor = user_connection.cursor()
 
     # Admin runs a long query; the admin's own second session reads its id.
-    process = multiprocessing.Process(
-        target=process_function, args=(admin_cursor, ["CALL infinite_query.long_query() YIELD my_id RETURN my_id"])
-    )
+    process = multiprocessing.Process(target=process_function, args=(admin_cursor, [LONG_QUERY]))
     process.start()
     admin_observer_cursor = connect(username="admin", password="").cursor()
     wait_for_transaction_count(admin_observer_cursor, 2)

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -47,6 +47,16 @@ def show_transactions_test(cursor, expected_num_results: int):
     return results
 
 
+def wait_for_transaction_count(cursor, expected_num_results: int, timeout_s: int = 10):
+    """Polls SHOW TRANSACTIONS until the expected number of transactions is visible."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if len(execute_and_fetch_all(cursor, "SHOW TRANSACTIONS")) == expected_num_results:
+            return
+        time.sleep(0.1)
+    assert False, f"Timed out waiting for {expected_num_results} transactions"
+
+
 def process_function(cursor, queries: List[str]):
     try:
         for query in queries:
@@ -326,6 +336,61 @@ def test_user_cannot_see_admin_transaction(request):
     admin_connection_1.close()
     admin_connection_2.close()
     user_connection.close()
+
+
+def test_unauthorized_terminate_reports_not_killed(request):
+    """An unprivileged user naming someone else's transaction id gets killed=false, and the
+    transaction survives. Reporting killed=true would both lie and confirm the id exists."""
+    superadmin_cursor = connect().cursor()
+    execute_and_fetch_all(superadmin_cursor, "CREATE USER admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT TRANSACTION_MANAGEMENT TO admin")
+    execute_and_fetch_all(superadmin_cursor, "GRANT DATABASE * TO admin")
+    execute_and_fetch_all(superadmin_cursor, "CREATE USER user")
+    execute_and_fetch_all(superadmin_cursor, "REVOKE ALL PRIVILEGES FROM user")
+
+    def on_exit():
+        execute_and_fetch_all(superadmin_cursor, "DROP USER admin")
+        execute_and_fetch_all(superadmin_cursor, "DROP USER user")
+
+    request.addfinalizer(on_exit)
+
+    admin_connection = connect(username="admin", password="")
+    admin_cursor = admin_connection.cursor()
+    user_connection = connect(username="user", password="")
+    user_cursor = user_connection.cursor()
+
+    # Admin runs a long query; the admin's own second session reads its id.
+    process = multiprocessing.Process(
+        target=process_function, args=(admin_cursor, ["CALL infinite_query.long_query() YIELD my_id RETURN my_id"])
+    )
+    process.start()
+    admin_observer_cursor = connect(username="admin", password="").cursor()
+    wait_for_transaction_count(admin_observer_cursor, 2)
+    admin_transaction_id = get_non_show_transaction_id(show_transactions_test(admin_observer_cursor, 2))
+
+    # The unprivileged user cannot kill it, and must not be told it exists.
+    results = execute_and_fetch_all(user_cursor, f"TERMINATE TRANSACTIONS '{admin_transaction_id}'")
+    assert len(results) == 1
+    assert results[0][0] == admin_transaction_id
+    assert results[0][1] == False  # not killed, indistinguishable from a missing id
+
+    # The transaction survived and is still visible to the admin.
+    assert get_non_show_transaction_id(show_transactions_test(admin_observer_cursor, 2)) == admin_transaction_id
+
+    # The admin can still kill it.
+    results = execute_and_fetch_all(admin_observer_cursor, f"TERMINATE TRANSACTIONS '{admin_transaction_id}'")
+    assert results[0][1] == True
+
+    admin_connection.close()
+    user_connection.close()
+
+
+def test_terminate_rejects_malformed_ids():
+    """Ids must parse in full; a numeric prefix must not silently target another transaction."""
+    cursor = connect().cursor()
+    for bad_id in ["'1abc'", "'ALL'", "''", "'0x10'", "'1 '", "123"]:
+        with pytest.raises(mgclient.DatabaseError):
+            execute_and_fetch_all(cursor, f"TERMINATE TRANSACTIONS {bad_id}")
 
 
 def test_killing_non_existing_transaction():

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -265,10 +265,26 @@ TYPED_TEST(TransactionQueueSimpleTest, StrictIdParsing) {
   // Non-string literals are rejected rather than degrading to a bogus id. A real id can't be
   // used unquoted here: ids start at 1<<63, which overflows an integer literal.
   EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS 123"), memgraph::query::QueryRuntimeException);
+  // Ids are unsigned, so a sign is never part of a valid id — whether it leads or is embedded.
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS '-" + tx_id + "'"),
+               memgraph::query::QueryRuntimeException);
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS '+" + tx_id + "'"),
+               memgraph::query::QueryRuntimeException);
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS '" + tx_id + "+1'"),
+               memgraph::query::QueryRuntimeException);
+  // 2^64, the first value that no longer fits an id, is rejected instead of wrapping.
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS '18446744073709551616'"),
+               memgraph::query::QueryRuntimeException);
 
   // The victim survived every rejected attempt.
   auto show_stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
   ASSERT_EQ(show_stream.GetResults().size(), 2U);
+
+  // Leading zeros are digits, so the id still parses in full and names the same transaction.
+  auto terminate_stream = this->main_interpreter.Interpret("TERMINATE TRANSACTIONS '00" + tx_id + "'");
+  ASSERT_EQ(terminate_stream.GetResults().size(), 1U);
+  EXPECT_EQ(terminate_stream.GetResults()[0][0].ValueString(), tx_id);
+  EXPECT_TRUE(terminate_stream.GetResults()[0][1].ValueBool());
 
   this->running_interpreter.Abort();
 }

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -9,10 +9,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <algorithm>
 #include <chrono>
+#include <memory>
 #include <stop_token>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include "gmock/gmock.h"
@@ -266,6 +269,90 @@ TYPED_TEST(TransactionQueueSimpleTest, StrictIdParsing) {
   // The victim survived every rejected attempt.
   auto show_stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
   ASSERT_EQ(show_stream.GetResults().size(), 2U);
+
+  this->running_interpreter.Abort();
+}
+
+TYPED_TEST(TransactionQueueSimpleTest, WildcardTerminatesOther) {
+  this->running_interpreter.Interpret("BEGIN");
+  this->running_interpreter.Interpret("CREATE (:Person {prop: 1})");
+  std::string const victim_id = std::to_string(this->running_interpreter.interpreter.GetTransactionId().value());
+
+  auto terminate_stream = this->main_interpreter.Interpret("TERMINATE TRANSACTIONS \"*\"");
+  ASSERT_EQ(terminate_stream.GetResults().size(), 1U);
+  EXPECT_EQ(terminate_stream.GetResults()[0][0].ValueString(), victim_id);
+  EXPECT_TRUE(terminate_stream.GetResults()[0][1].ValueBool());
+  EXPECT_EQ(this->running_interpreter.interpreter.transaction_status_.load(std::memory_order_acquire),
+            memgraph::query::TransactionStatus::TERMINATED);
+
+  this->running_interpreter.Abort();
+}
+
+TYPED_TEST(TransactionQueueSimpleTest, WildcardExcludesSelf) {
+  // Nothing else is running, so the sweep finds nothing. Crucially the statement itself
+  // succeeds: had it terminated its own transaction, its commit would have thrown and the
+  // caller would never learn what it killed.
+  auto terminate_stream = this->main_interpreter.Interpret("TERMINATE TRANSACTIONS \"*\"");
+  EXPECT_EQ(terminate_stream.GetResults().size(), 0U);
+
+  // The issuing interpreter is still usable.
+  auto show_stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
+  EXPECT_EQ(show_stream.GetResults().size(), 1U);
+}
+
+TYPED_TEST(TransactionQueueSimpleTest, WildcardRowsSortedAscending) {
+  auto victim_2 = std::make_unique<InterpreterFaker>(&this->interpreter_context, this->db);
+  auto victim_3 = std::make_unique<InterpreterFaker>(&this->interpreter_context, this->db);
+
+  this->running_interpreter.Interpret("BEGIN");
+  victim_2->Interpret("BEGIN");
+  victim_3->Interpret("BEGIN");
+
+  auto terminate_stream = this->main_interpreter.Interpret("TERMINATE TRANSACTIONS \"*\"");
+  ASSERT_EQ(terminate_stream.GetResults().size(), 3U);
+
+  std::vector<uint64_t> reported_ids;
+  for (const auto &row : terminate_stream.GetResults()) {
+    EXPECT_TRUE(row[1].ValueBool());
+    reported_ids.push_back(std::stoull(row[0].ValueString()));
+  }
+  EXPECT_TRUE(std::ranges::is_sorted(reported_ids));
+
+  this->running_interpreter.Abort();
+  victim_2->Abort();
+  victim_3->Abort();
+}
+
+TYPED_TEST(TransactionQueueSimpleTest, WildcardSkipsCommitting) {
+  this->running_interpreter.Interpret("BEGIN");
+  this->running_interpreter.Interpret("CREATE (:Person {prop: 1})");
+
+  // Only an ACTIVE transaction can be pinned for termination, so a committing one is skipped.
+  this->running_interpreter.interpreter.transaction_status_.store(
+      memgraph::query::TransactionStatus::STARTED_COMMITTING, std::memory_order_release);
+
+  auto terminate_stream = this->main_interpreter.Interpret("TERMINATE TRANSACTIONS \"*\"");
+  EXPECT_EQ(terminate_stream.GetResults().size(), 0U);
+
+  this->running_interpreter.interpreter.transaction_status_.store(memgraph::query::TransactionStatus::IDLE,
+                                                                  std::memory_order_release);
+}
+
+TYPED_TEST(TransactionQueueSimpleTest, WildcardRejectsMixedList) {
+  this->running_interpreter.Interpret("BEGIN");
+  std::string const victim_id = std::to_string(this->running_interpreter.interpreter.GetTransactionId().value());
+
+  // Mixing is rejected in either order, and a repeated wildcard is still a list.
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS \"*\", '" + victim_id + "'"),
+               memgraph::query::QueryRuntimeException);
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS '" + victim_id + "', \"*\""),
+               memgraph::query::QueryRuntimeException);
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS \"*\", \"*\""),
+               memgraph::query::QueryRuntimeException);
+
+  // The victim survived every rejected attempt.
+  EXPECT_EQ(this->running_interpreter.interpreter.transaction_status_.load(std::memory_order_acquire),
+            memgraph::query::TransactionStatus::ACTIVE);
 
   this->running_interpreter.Abort();
 }

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -20,6 +20,7 @@
 #include "disk_test_utils.hpp"
 #include "interpreter_faker.hpp"
 #include "query/context.hpp"
+#include "query/exceptions.hpp"
 #include "query/interpreter_context.hpp"
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
@@ -244,6 +245,29 @@ TYPED_TEST(TransactionQueueSimpleTest, TerminateCommittingTransactionNotFound) {
   // Restore to IDLE
   this->running_interpreter.interpreter.transaction_status_.store(memgraph::query::TransactionStatus::IDLE,
                                                                   std::memory_order_release);
+}
+
+TYPED_TEST(TransactionQueueSimpleTest, StrictIdParsing) {
+  // A transaction id must parse in full. Previously a trailing-garbage id parsed as its
+  // numeric prefix and silently terminated a different transaction, while an unparseable
+  // id reported a kill attempt on a bogus UINT64_MAX id.
+  this->running_interpreter.Interpret("BEGIN");
+  std::string const tx_id = std::to_string(this->running_interpreter.interpreter.GetTransactionId().value());
+
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS '" + tx_id + "abc'"),
+               memgraph::query::QueryRuntimeException);
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS 'ALL'"),
+               memgraph::query::QueryRuntimeException);
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS ''"), memgraph::query::QueryRuntimeException);
+  // Non-string literals are rejected rather than degrading to a bogus id. A real id can't be
+  // used unquoted here: ids start at 1<<63, which overflows an integer literal.
+  EXPECT_THROW(this->main_interpreter.Interpret("TERMINATE TRANSACTIONS 123"), memgraph::query::QueryRuntimeException);
+
+  // The victim survived every rejected attempt.
+  auto show_stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
+  ASSERT_EQ(show_stream.GetResults().size(), 2U);
+
+  this->running_interpreter.Abort();
 }
 
 TYPED_TEST(TransactionQueueSimpleTest, ShowTransactionsAfterCommit) {


### PR DESCRIPTION
### Description

Adds `TERMINATE TRANSACTIONS "*"`, which terminates every transaction the caller is authorized to kill, so an operator no longer has to copy 19-digit ids out of `SHOW TRANSACTIONS` one at a time.

**No grammar or AST change.** `transactionId : literal` already accepts a quoted string, so the wildcard is detected in `HandleTransactionQueueQuery` and handled by a new `InterpreterContext::TerminateAllTransactions`, which shares its per-victim core (CAS `ACTIVE → VERIFYING`, status restore, authorization) with the existing id-list path. `DROP DATABASE ... FORCE`'s call site is untouched.

#### Semantics

| Decision | Behavior |
| --- | --- |
| Candidate set | The `SHOW TRANSACTIONS` set — all databases, not scoped to the caller's current database |
| Authorization | Per victim, identical to the id-list form: owns it, **or** holds `TRANSACTION_MANAGEMENT` on the victim's database |
| Unprivileged caller | Reaches only its own transactions; never errors on authorization, just returns fewer rows |
| Unauthorized victims | Absent from the output rather than reported, matching `SHOW` — no id is leaked |
| Self | Skipped |
| Output | Existing `{transaction_id, killed}` header, one row per terminated transaction, ascending id, zero rows when nothing matched |
| Mixing | `"*"` must be the sole argument; `TERMINATE TRANSACTIONS "*", '123'` is an error |
| Non-`ACTIVE` victims | Skipped, as today — a committing or aborting transaction cannot be pinned |

Self is skipped because terminating the issuing transaction makes its own `Commit()` throw, so the caller would get an error instead of the rows and would never learn what it killed. Two sessions sweeping concurrently can each kill the other; the `ACTIVE → VERIFYING` CAS serializes them and the loser sees fewer victims.

Query stripping turns the literal into a `ParameterLookup`, so a parameterized wildcard is indistinguishable from a literal one — `TERMINATE TRANSACTIONS $id` with `$id = "*"` is the same statement, and is covered by a test.

### Behavior changes to existing `TERMINATE TRANSACTIONS '<id>'` (for release notes)

Both in the first commit, both cases where the statement reported an outcome that did not happen:

1. **A matched-but-unauthorized victim now reports `killed: false` instead of `true`.** The authorization check ran *after* the id had been moved into the killed partition, so an unprivileged user naming someone else's id got `killed: true` back while the transaction kept running — a false positive that also confirmed the id existed. An unauthorized match now stays in the not-found partition, indistinguishable from a missing id.

2. **Ids must parse in full.** `std::stoul` accepted a numeric prefix, so `TERMINATE TRANSACTIONS '9223372036854775809abc'` silently terminated transaction `9223372036854775809`; anything unparseable degraded to `UINT64_MAX` and was reported as a kill attempt on `18446744073709551615`, an id the user never typed. Malformed ids now raise an error. This is what gives `"*"` an unambiguous home — exact wildcard match first, strict parse second, no sentinel.

### Known wart (pre-existing, unchanged)

An in-flight **system transaction** (`CREATE DATABASE`, `GRANT`) is swept and reported `killed: true`, but system transactions are not abortable — `Interpreter::Commit()` says so explicitly — so it runs to completion. Reachable today by naming such a transaction's id; the wildcard makes it routine. Not fixed here: `system_transaction_` is assigned *after* the release-store that publishes `ACTIVE`, so probing it from the terminating thread is a data race, and excluding these would need new synchronized state on `Interpreter` to produce a more honest report about a transaction we still cannot kill. Making the kill real is a separate feature with an existing TODO.

Out of scope: `SHOW TRANSACTIONS ON *` / `ON 'db1'` database scoping. `SHOW` already returns everything the caller can see, so the wildcard needs nothing there, and explicit scoping composes cleanly with this later.
