### PR TITLE
feat(coordination): enable SHOW VERSION on coordinators

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1311,7 +1311,8 @@ auth::Permission RequiredCoordinatorPermission(Query *query) {
     return setting_query->action_ == SettingQuery::Action::SET_SETTING ? auth::Permission::COORDINATOR_WRITE
                                                                        : auth::Permission::COORDINATOR_READ;
   }
-  if (utils::Downcast<ShowConfigQuery>(query) || utils::Downcast<SystemInfoQuery>(query)) {
+  if (utils::Downcast<ShowConfigQuery>(query) || utils::Downcast<SystemInfoQuery>(query) ||
+      utils::Downcast<VersionQuery>(query)) {
     return auth::Permission::COORDINATOR_READ;
   }
   if (auto *auth_query = utils::Downcast<AuthQuery>(query)) {
@@ -10492,7 +10493,8 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     if (interpreter_context_->coordinator_state_ && interpreter_context_->coordinator_state_->IsCoordinator() &&
         !utils::Downcast<CoordinatorQuery>(parsed_query.query) && !utils::Downcast<SettingQuery>(parsed_query.query) &&
         !utils::Downcast<ReloadSSLQuery>(parsed_query.query) && !utils::Downcast<ShowConfigQuery>(parsed_query.query) &&
-        !utils::Downcast<SystemInfoQuery>(parsed_query.query) && !is_coordinator_auth_query(parsed_query.query)) {
+        !utils::Downcast<SystemInfoQuery>(parsed_query.query) && !utils::Downcast<VersionQuery>(parsed_query.query) &&
+        !is_coordinator_auth_query(parsed_query.query)) {
       throw QueryRuntimeException("Coordinator can run only coordinator queries!");
     }
 

--- a/tests/e2e/high_availability/auth.py
+++ b/tests/e2e/high_availability/auth.py
@@ -1369,6 +1369,7 @@ def test_sso_privilege_enforcement(test_name):
         "reader",
         "writer",
     ]
+    assert len(sso_run(leader_port, "oidc", "reader", "SHOW VERSION")) == 1
     # ... but every mutating query is denied.
     try:
         sso_run(leader_port, "oidc", "reader", "CREATE ROLE from_reader")

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -140,6 +140,13 @@ def test_enable_show_config_queries(test_name):
     execute_and_fetch_all(cursor, "SHOW CONFIG")
 
 
+def test_enable_show_version_queries(test_name):
+    cursor = setup_test(test_name=test_name)
+    results = execute_and_fetch_all(cursor, "SHOW VERSION")
+    assert len(results) == 1
+    assert results[0][0]
+
+
 def test_disable_cypher_queries(test_name):
     cursor = setup_test(test_name=test_name)
 


### PR DESCRIPTION
### Description

`SHOW VERSION` was rejected on coordinators with `Coordinator can run only coordinator queries!`, even though it reads nothing but the build's version string. This adds it to the coordinator allow-list.

- `VersionQuery` is added to the coordinator query allow-list in `Interpreter::Prepare`.
- It is classified as `COORDINATOR_READ` in `RequiredCoordinatorPermission`, alongside the other read-only introspection queries (`SHOW CONFIG`, `SHOW ... INFO`).

Nothing else was required: `PrepareVersionQuery` reads only `gflags::VersionString()`, takes no storage accessor (its `QueryTransactionRequirements` visit is a no-op), and is not a system query, so it never touches the replication state a coordinator lacks. Coordinator sessions carry no `QueryUserOrRole`, so the `STATS` privilege check is skipped and the coordinator mask governs — exactly as for `SHOW CONFIG`.

### Tests

- `tests/e2e/high_availability/coordinator.py` — `test_enable_show_version_queries` asserts a single non-empty row from a coordinator.
- `tests/e2e/high_availability/auth.py` — `test_sso_privilege_enforcement` also runs `SHOW VERSION` on the `COORDINATOR_READ`-only SSO session, pinning the read-privilege classification.