### PR TITLE
fix: fully clean conan cache with LRU

### DIFF
--- a/tools/ci/clean_conan.sh
+++ b/tools/ci/clean_conan.sh
@@ -20,5 +20,5 @@ if ! command -v conan &> /dev/null; then
 fi
 
 # remove all conan packages older than 1 week
-conan remove "*#*:*#*" --lru=$LRU_PERIOD -c # stale binaries first
-conan remove "*#*" --lru=$LRU_PERIOD -c # unused recipes second
+conan remove "*#*:*#*" --lru="$LRU_PERIOD" -c # stale binaries first
+conan remove "*#*" --lru="$LRU_PERIOD" -c # unused recipes second

--- a/tools/ci/clean_conan.sh
+++ b/tools/ci/clean_conan.sh
@@ -20,4 +20,5 @@ if ! command -v conan &> /dev/null; then
 fi
 
 # remove all conan packages older than 1 week
-conan remove "*#*" --lru=$LRU_PERIOD -c
+conan remove "*#*:*#*" --lru=$LRU_PERIOD -c # stale binaries first
+conan remove "*#*" --lru=$LRU_PERIOD -c # unused recipes second


### PR DESCRIPTION
Same issue as  https://github.com/memgraph/infra/pull/544

The existing cleaning step was missing stale binaries, only cleaning unused recipes. Now we remove unused binaries _then_ unused recipes.
