### PR TITLE
fix: user agent fail on MAGE e2e

### DIFF
--- a/tests/mage/e2e/xml_test/load_test1/test.yml
+++ b/tests/mage/e2e/xml_test/load_test1/test.yml
@@ -1,6 +1,6 @@
 query: >
     WITH "https://www.w3schools.com/xml/note.xml" AS xmlUrl
-    CALL xml_module.load(xmlUrl, false, "", "", {}) YIELD output_map as file
+    CALL xml_module.load(xmlUrl, false, "", "", {`User-Agent`: "Memgraph-XML-Module-Test/1.0"}) YIELD output_map as file
     RETURN file
 
 output:

--- a/tests/mage/e2e/xml_test/load_test2/test.yml
+++ b/tests/mage/e2e/xml_test/load_test2/test.yml
@@ -1,6 +1,6 @@
 query: >
     WITH "https://www.w3schools.com/xml/plant_catalog.xml" AS xmlUrl
-    CALL xml_module.load(xmlUrl, false, "", './/ZONE[.="4"]', {}) YIELD output_map as plants
+    CALL xml_module.load(xmlUrl, false, "", './/ZONE[.="4"]', {`User-Agent`: "Memgraph-XML-Module-Test/1.0"}) YIELD output_map as plants
     RETURN count(plants) AS count
 
 output:

--- a/tests/mage/e2e/xml_test/load_test3/test.yml
+++ b/tests/mage/e2e/xml_test/load_test3/test.yml
@@ -1,6 +1,6 @@
 query: >
     WITH "https://www.w3schools.com/xml/simple.xml" AS xmlUrl
-    CALL xml_module.load(xmlUrl, true, "", '', {}) YIELD output_map as value
+    CALL xml_module.load(xmlUrl, true, "", '', {`User-Agent`: "Memgraph-XML-Module-Test/1.0"}) YIELD output_map as value
     RETURN value
 
 output:


### PR DESCRIPTION
Test examples for `xml_module` now require a User-Agent header to be set otherwise we get a 403 when loading from https://www.w3schools.com.