### PR TITLE
fix: Resolve IN-list cardinality and cost estimation

### DIFF
--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -771,12 +771,13 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
       -> std::optional<double> {
     auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
     utils::OnScopeExit restore([&, saved = resolved_ranges[slot]]() { resolved_ranges[slot] = saved; });
+    auto pvrs = resolved_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) | ranges::to_vector;
     double sum = 0.0;
     for (auto *elem : list.elements_) {
       auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
       if (!resolved) return std::nullopt;
       resolved_ranges[slot] = *resolved;
-      auto pvrs = resolved_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) | ranges::to_vector;
+      pvrs[slot] = *resolved;
       sum += db_accessor_->VerticesCount(label, properties, pvrs);
     }
     return sum;

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -747,7 +747,7 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
       case Type::IS_NOT_NULL:
         return db_accessor_->VerticesCount(property);
       case Type::EQUAL:
-      case Type::IN: {  // IN is lowered to EQUAL + Unwind at plan-build time, so fallthrough here is defensive
+      case Type::IN: {
         if (auto val = ConstPropertyValue(range.lower_->value())) {
           return db_accessor_->VerticesCount(
               property, storage::ToPropertyValue(*val, db_accessor_->GetStorageAccessor()->GetNameIdMapper()));
@@ -769,6 +769,8 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     return EstimateInListSum(db_accessor_, label, properties, list, slot, pvrs, parameters);
   }
 
+  // Helper function to estimate cardinality for label properties queries.
+  // Used by both single-threaded and parallel scan operators.
   double EstimateLabelPropertiesCardinality(storage::LabelId label,
                                             std::vector<storage::PropertyPath> const &properties,
                                             std::vector<ExpressionRange> const &expression_ranges) {

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -762,9 +762,9 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     std::unreachable();
   }
 
-  // For an expression of the form `x IN [lst]`, resolve the IN membership list
-  // by summing per-element VerticesCount. Returns `nullopt` if any element
-  // cannot be resolved at plan time.
+  // Compute the marginal sum for a single IN slot: temporarily mark the slot as
+  // IsNotNull for other callers, iterate its elements, sum VerticesCount.
+  // All other slots in resolved_ranges must already be non-nullopt.
   auto EstimateInListCardinality(storage::LabelId label, std::vector<storage::PropertyPath> const &properties,
                                  ListLiteral const &list, size_t slot,
                                  std::vector<std::optional<storage::PropertyValueRange>> &resolved_ranges)
@@ -776,7 +776,6 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
       auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
       if (!resolved) return std::nullopt;
       resolved_ranges[slot] = *resolved;
-      if (ranges::any_of(resolved_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) return std::nullopt;
       auto pvrs = resolved_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) | ranges::to_vector;
       sum += db_accessor_->VerticesCount(label, properties, pvrs);
     }
@@ -798,18 +797,49 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
       return db_accessor_->VerticesCount(label, properties, pvrs);
     }
 
+    // Collect unresolved IN slots
+    std::vector<size_t> in_slots;
     for (size_t i = 0; i < expression_ranges.size(); ++i) {
-      if (maybe_ranges[i] || !expression_ranges[i].membership_list_) continue;
-      if (auto sum =
-              EstimateInListCardinality(label, properties, *expression_ranges[i].membership_list_, i, maybe_ranges)) {
-        maybe_ranges[i] = storage::PropertyValueRange::IsNotNull();
-        if (ranges::none_of(maybe_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
-          return *sum;
-        }
-      }
+      if (!maybe_ranges[i] && expression_ranges[i].membership_list_) in_slots.push_back(i);
     }
 
-    return db_accessor_->VerticesCount(label, properties) * CardParam::kFilter;
+    if (in_slots.empty()) {
+      return db_accessor_->VerticesCount(label, properties) * CardParam::kFilter;
+    }
+
+    // Temporarily set all IN slots to IsNotNull so each can be estimated independently
+    for (auto slot : in_slots) {
+      maybe_ranges[slot] = storage::PropertyValueRange::IsNotNull();
+    }
+
+    // If non-IN slots are still unresolved, fall back
+    if (ranges::any_of(maybe_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
+      return db_accessor_->VerticesCount(label, properties) * CardParam::kFilter;
+    }
+
+    if (in_slots.size() == 1) {
+      // Single IN: exact per-element sum
+      auto sum = EstimateInListCardinality(
+          label, properties, *expression_ranges[in_slots[0]].membership_list_, in_slots[0], maybe_ranges);
+      return sum.value_or(db_accessor_->VerticesCount(label, properties) * CardParam::kFilter);
+    }
+
+    // Multiple IN slots: independence assumption. S_0 * S_1 * ... / T^(k-1)
+    auto const total =
+        db_accessor_->VerticesCount(label, properties, maybe_ranges | ranges::views::transform([](auto const &opt) {
+                                                         return *opt;
+                                                       }) | ranges::to_vector);
+    if (total == 0) return 0.0;
+
+    double result = 1.0;
+    for (auto slot : in_slots) {
+      auto marginal =
+          EstimateInListCardinality(label, properties, *expression_ranges[slot].membership_list_, slot, maybe_ranges);
+      if (!marginal) return db_accessor_->VerticesCount(label, properties) * CardParam::kFilter;
+      result *= *marginal;
+    }
+    result /= std::pow(static_cast<double>(total), static_cast<double>(in_slots.size() - 1));
+    return std::min(result, static_cast<double>(total));
   }
 
   // Helper function to estimate cardinality for point-based queries.

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -830,12 +830,13 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     for (auto slot : in_slots) {
       unwind_factor *= static_cast<double>(expression_ranges[slot].membership_list_->elements_.size());
     }
+    if (unwind_factor == 0) return 0.0;
 
     if (in_slots.size() == 1) {
       auto sum = EstimateInListCardinality(
           label, properties, *expression_ranges[in_slots[0]].membership_list_, in_slots[0], maybe_ranges);
       auto total = sum.value_or(db_accessor_->VerticesCount(label, properties) * CardParam::kFilter);
-      return unwind_factor > 0 ? total / unwind_factor : total;
+      return total / unwind_factor;
     }
 
     // Multiple IN slots: independence assumption. S_0 * S_1 * ... / T^(k-1)
@@ -854,7 +855,7 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     }
     result /= std::pow(static_cast<double>(total), static_cast<double>(in_slots.size() - 1));
     result = std::min(result, static_cast<double>(total));
-    return unwind_factor > 0 ? result / unwind_factor : result;
+    return result / unwind_factor;
   }
 
   // Helper function to estimate cardinality for point-based queries.

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -746,8 +746,25 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     switch (range.type_) {
       case Type::IS_NOT_NULL:
         return db_accessor_->VerticesCount(property);
-      case Type::EQUAL:
+      case Type::EQUAL: {
+        if (auto val = ConstPropertyValue(range.lower_->value())) {
+          return db_accessor_->VerticesCount(
+              property, storage::ToPropertyValue(*val, db_accessor_->GetStorageAccessor()->GetNameIdMapper()));
+        }
+        return db_accessor_->VerticesCount(property) * CardParam::kFilter;
+      }
       case Type::IN: {
+        if (auto *list = range.membership_list_) {
+          auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
+          double sum = 0.0;
+          for (auto *elem : list->elements_) {
+            auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
+            if (!resolved) return db_accessor_->VerticesCount(property) * CardParam::kFilter;
+            sum += db_accessor_->VerticesCount(property, resolved->lower_->value());
+          }
+          auto n = static_cast<double>(list->elements_.size());
+          return n > 0 ? sum / n : sum;
+        }
         if (auto val = ConstPropertyValue(range.lower_->value())) {
           return db_accessor_->VerticesCount(
               property, storage::ToPropertyValue(*val, db_accessor_->GetStorageAccessor()->GetNameIdMapper()));

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -21,6 +21,16 @@
 
 namespace memgraph::query::plan {
 
+// The IN-to-Unwind lowering wraps the original list in toSet(coalesce(list, [])).
+// Extract the inner ListLiteral if the expression matches that pattern.
+inline auto ExtractListFromInUnwind(Expression *expr) -> ListLiteral * {
+  auto *func = utils::Downcast<Function>(expr);
+  if (!func || func->function_name_ != "TOSET" || func->arguments_.size() != 1) return nullptr;
+  auto *coalesce = utils::Downcast<Coalesce>(func->arguments_[0]);
+  if (!coalesce || coalesce->expressions_.empty()) return nullptr;
+  return utils::Downcast<ListLiteral>(coalesce->expressions_[0]);
+}
+
 /**
  * The symbol statistics specify essential DB statistics which
  * help the query planner (namely here the cost estimator), to decide
@@ -426,10 +436,14 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     // if the Unwind expression is a list literal, we can deduce cardinality
     // exactly, otherwise we approximate
     double unwind_value;
-    if (auto *literal = utils::Downcast<query::ListLiteral>(unwind.input_expression_))
+    if (auto *literal = utils::Downcast<query::ListLiteral>(unwind.input_expression_)) {
       unwind_value = literal->elements_.size();
-    else
+    } else if (auto *list = ExtractListFromInUnwind(unwind.input_expression_)) {
+      // IN-to-Unwind lowering wraps the list in toSet(coalesce(list, []))
+      unwind_value = list->elements_.size();
+    } else {
       unwind_value = MiscParam::kUnwindNoLiteral;
+    }
 
     cardinality_ *= unwind_value;
     return true;
@@ -752,10 +766,11 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
   double EstimateLabelPropertiesCardinality(storage::LabelId label,
                                             const std::vector<storage::PropertyPath> &properties,
                                             const std::vector<ExpressionRange> &expression_ranges) {
+    auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
+
     auto maybe_propertyvalue_ranges =
-        expression_ranges | ranges::views::transform([&](ExpressionRange const &er) {
-          return er.ResolveAtPlantime(parameters, db_accessor_->GetStorageAccessor()->GetNameIdMapper());
-        }) |
+        expression_ranges |
+        ranges::views::transform([&](ExpressionRange const &er) { return er.ResolveAtPlantime(parameters, mapper); }) |
         ranges::to_vector;
 
     if (ranges::none_of(maybe_propertyvalue_ranges, [](auto &&pvr) { return pvr == std::nullopt; })) {
@@ -764,9 +779,48 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
                                   ranges::to_vector;
 
       return db_accessor_->VerticesCount(label, properties, propertyvalue_ranges);
-    } else {
-      return db_accessor_->VerticesCount(label, properties) * CardParam::kFilter;
     }
+
+    // If resolution failed, check if any expression range has an original IN list
+    // whose elements we can resolve individually and sum their cardinalities.
+    for (size_t i = 0; i < expression_ranges.size(); ++i) {
+      if (maybe_propertyvalue_ranges[i] || !expression_ranges[i].original_in_list_) continue;
+
+      auto *list = utils::Downcast<ListLiteral>(expression_ranges[i].original_in_list_);
+      if (!list) continue;
+
+      double sum = 0.0;
+      bool all_resolved = true;
+      for (auto *elem : list->elements_) {
+        auto elem_range = ExpressionRange::Equal(elem);
+        auto resolved = elem_range.ResolveAtPlantime(parameters, mapper);
+        if (!resolved) {
+          all_resolved = false;
+          break;
+        }
+        // Build a full property-value-ranges vector, substituting this element for position i
+        auto per_elem_ranges = maybe_propertyvalue_ranges;
+        per_elem_ranges[i] = *resolved;
+        if (ranges::none_of(per_elem_ranges, [](auto &&pvr) { return pvr == std::nullopt; })) {
+          auto pvrs =
+              per_elem_ranges | ranges::views::transform([](auto &&optional) { return *optional; }) | ranges::to_vector;
+          sum += db_accessor_->VerticesCount(label, properties, pvrs);
+        } else {
+          all_resolved = false;
+          break;
+        }
+      }
+      if (all_resolved) {
+        maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();  // mark as resolved
+        // Replace the full estimate with the sum
+        // If all other ranges are already resolved, return the sum directly
+        if (ranges::none_of(maybe_propertyvalue_ranges, [](auto &&pvr) { return pvr == std::nullopt; })) {
+          return sum;
+        }
+      }
+    }
+
+    return db_accessor_->VerticesCount(label, properties) * CardParam::kFilter;
   }
 
   // Helper function to estimate cardinality for point-based queries.

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -18,6 +18,7 @@
 #include "query/plan/operator.hpp"
 #include "query/plan/rewrite/index_lookup.hpp"
 #include "utils/math.hpp"
+#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::query::plan {
 
@@ -769,15 +770,14 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
                                  std::vector<std::optional<storage::PropertyValueRange>> &resolved_ranges)
       -> std::optional<double> {
     auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
+    utils::OnScopeExit restore([&, saved = resolved_ranges[slot]]() { resolved_ranges[slot] = saved; });
     double sum = 0.0;
     for (auto *elem : list.elements_) {
       auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
       if (!resolved) return std::nullopt;
-      auto per_elem_ranges = resolved_ranges;
-      per_elem_ranges[slot] = *resolved;
-      if (ranges::any_of(per_elem_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) return std::nullopt;
-      auto pvrs = per_elem_ranges | ranges::views::transform([](auto const &optional) { return *optional; }) |
-                  ranges::to_vector;
+      resolved_ranges[slot] = *resolved;
+      if (ranges::any_of(resolved_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) return std::nullopt;
+      auto pvrs = resolved_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) | ranges::to_vector;
       sum += db_accessor_->VerticesCount(label, properties, pvrs);
     }
     return sum;

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -18,7 +18,6 @@
 #include "query/plan/operator.hpp"
 #include "query/plan/rewrite/index_lookup.hpp"
 #include "utils/math.hpp"
-#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::query::plan {
 
@@ -762,25 +761,12 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     std::unreachable();
   }
 
-  // Compute the marginal sum for a single IN slot: temporarily mark the slot as
-  // IsNotNull for other callers, iterate its elements, sum VerticesCount.
-  // All other slots in resolved_ranges must already be non-nullopt.
   auto EstimateInListCardinality(storage::LabelId label, std::vector<storage::PropertyPath> const &properties,
                                  ListLiteral const &list, size_t slot,
-                                 std::vector<std::optional<storage::PropertyValueRange>> &resolved_ranges)
+                                 std::vector<std::optional<storage::PropertyValueRange>> const &resolved_ranges)
       -> std::optional<double> {
-    auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
-    utils::OnScopeExit restore([&, saved = resolved_ranges[slot]]() { resolved_ranges[slot] = saved; });
     auto pvrs = resolved_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) | ranges::to_vector;
-    double sum = 0.0;
-    for (auto *elem : list.elements_) {
-      auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
-      if (!resolved) return std::nullopt;
-      resolved_ranges[slot] = *resolved;
-      pvrs[slot] = *resolved;
-      sum += db_accessor_->VerticesCount(label, properties, pvrs);
-    }
-    return sum;
+    return EstimateInListSum(db_accessor_, label, properties, list, slot, pvrs, parameters);
   }
 
   double EstimateLabelPropertiesCardinality(storage::LabelId label,

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -21,8 +21,9 @@
 
 namespace memgraph::query::plan {
 
-// The IN-to-Unwind lowering wraps the original list in toSet(coalesce(list, [])).
-// Extract the inner ListLiteral if the expression matches that pattern.
+// The `IN` -> `Unwind` lowering wraps the original list in toSet(coalesce(list, [])).
+// Extracts and returns the inner `ListLiteral` if the expression matches that
+// form, else returns `nullptr`.
 inline auto ExtractListFromInUnwind(Expression *expr) -> ListLiteral * {
   auto *func = utils::Downcast<Function>(expr);
   if (!func || func->function_name_ != "TOSET" || func->arguments_.size() != 1) return nullptr;
@@ -439,7 +440,6 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     if (auto *literal = utils::Downcast<query::ListLiteral>(unwind.input_expression_)) {
       unwind_value = literal->elements_.size();
     } else if (auto *list = ExtractListFromInUnwind(unwind.input_expression_)) {
-      // IN-to-Unwind lowering wraps the list in toSet(coalesce(list, []))
       unwind_value = list->elements_.size();
     } else {
       unwind_value = MiscParam::kUnwindNoLiteral;
@@ -761,60 +761,50 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     std::unreachable();
   }
 
-  // Helper function to estimate cardinality for label properties queries.
-  // Used by both single-threaded and parallel scan operators.
+  // For an expression of the form `x IN [lst]`, resolve the IN membership list
+  // by summing per-element VerticesCount. Returns `nullopt` if any element
+  // cannot be resolved at plan time.
+  auto EstimateInListCardinality(storage::LabelId label, std::vector<storage::PropertyPath> const &properties,
+                                 ListLiteral const &list, size_t slot,
+                                 std::vector<std::optional<storage::PropertyValueRange>> &resolved_ranges)
+      -> std::optional<double> {
+    auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
+    double sum = 0.0;
+    for (auto *elem : list.elements_) {
+      auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
+      if (!resolved) return std::nullopt;
+      auto per_elem_ranges = resolved_ranges;
+      per_elem_ranges[slot] = *resolved;
+      if (ranges::any_of(per_elem_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) return std::nullopt;
+      auto pvrs = per_elem_ranges | ranges::views::transform([](auto const &optional) { return *optional; }) |
+                  ranges::to_vector;
+      sum += db_accessor_->VerticesCount(label, properties, pvrs);
+    }
+    return sum;
+  }
+
   double EstimateLabelPropertiesCardinality(storage::LabelId label,
-                                            const std::vector<storage::PropertyPath> &properties,
-                                            const std::vector<ExpressionRange> &expression_ranges) {
+                                            std::vector<storage::PropertyPath> const &properties,
+                                            std::vector<ExpressionRange> const &expression_ranges) {
     auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
 
-    auto maybe_propertyvalue_ranges =
+    auto maybe_ranges =
         expression_ranges |
         ranges::views::transform([&](ExpressionRange const &er) { return er.ResolveAtPlantime(parameters, mapper); }) |
         ranges::to_vector;
 
-    if (ranges::none_of(maybe_propertyvalue_ranges, [](auto &&pvr) { return pvr == std::nullopt; })) {
-      auto propertyvalue_ranges = maybe_propertyvalue_ranges |
-                                  ranges::views::transform([](auto &&optional) { return *optional; }) |
-                                  ranges::to_vector;
-
-      return db_accessor_->VerticesCount(label, properties, propertyvalue_ranges);
+    if (ranges::none_of(maybe_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
+      auto pvrs = maybe_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) | ranges::to_vector;
+      return db_accessor_->VerticesCount(label, properties, pvrs);
     }
 
-    // If resolution failed, check if any expression range has an original IN list
-    // whose elements we can resolve individually and sum their cardinalities.
     for (size_t i = 0; i < expression_ranges.size(); ++i) {
-      if (maybe_propertyvalue_ranges[i] || !expression_ranges[i].membership_list_) continue;
-
-      auto *list = expression_ranges[i].membership_list_;
-
-      double sum = 0.0;
-      bool all_resolved = true;
-      for (auto *elem : list->elements_) {
-        auto elem_range = ExpressionRange::Equal(elem);
-        auto resolved = elem_range.ResolveAtPlantime(parameters, mapper);
-        if (!resolved) {
-          all_resolved = false;
-          break;
-        }
-        // Build a full property-value-ranges vector, substituting this element for position i
-        auto per_elem_ranges = maybe_propertyvalue_ranges;
-        per_elem_ranges[i] = *resolved;
-        if (ranges::none_of(per_elem_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
-          auto pvrs = per_elem_ranges | ranges::views::transform([](auto const &optional) { return *optional; }) |
-                      ranges::to_vector;
-          sum += db_accessor_->VerticesCount(label, properties, pvrs);
-        } else {
-          all_resolved = false;
-          break;
-        }
-      }
-      if (all_resolved) {
-        maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();  // mark as resolved
-        // Replace the full estimate with the sum
-        // If all other ranges are already resolved, return the sum directly
-        if (ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
-          return sum;
+      if (maybe_ranges[i] || !expression_ranges[i].membership_list_) continue;
+      if (auto sum =
+              EstimateInListCardinality(label, properties, *expression_ranges[i].membership_list_, i, maybe_ranges)) {
+        maybe_ranges[i] = storage::PropertyValueRange::IsNotNull();
+        if (ranges::none_of(maybe_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
+          return *sum;
         }
       }
     }

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -806,11 +806,19 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
       return db_accessor_->VerticesCount(label, properties) * CardParam::kFilter;
     }
 
+    // The Unwind above each IN slot already multiplies cardinality by the list
+    // length, so the scan factor must be per-input-row (i.e. divided by the
+    // product of list lengths) to avoid double-counting.
+    double unwind_factor = 1.0;
+    for (auto slot : in_slots) {
+      unwind_factor *= static_cast<double>(expression_ranges[slot].membership_list_->elements_.size());
+    }
+
     if (in_slots.size() == 1) {
-      // Single IN: exact per-element sum
       auto sum = EstimateInListCardinality(
           label, properties, *expression_ranges[in_slots[0]].membership_list_, in_slots[0], maybe_ranges);
-      return sum.value_or(db_accessor_->VerticesCount(label, properties) * CardParam::kFilter);
+      auto total = sum.value_or(db_accessor_->VerticesCount(label, properties) * CardParam::kFilter);
+      return unwind_factor > 0 ? total / unwind_factor : total;
     }
 
     // Multiple IN slots: independence assumption. S_0 * S_1 * ... / T^(k-1)
@@ -828,7 +836,8 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
       result *= *marginal;
     }
     result /= std::pow(static_cast<double>(total), static_cast<double>(in_slots.size() - 1));
-    return std::min(result, static_cast<double>(total));
+    result = std::min(result, static_cast<double>(total));
+    return unwind_factor > 0 ? result / unwind_factor : result;
   }
 
   // Helper function to estimate cardinality for point-based queries.

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -784,10 +784,9 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     // If resolution failed, check if any expression range has an original IN list
     // whose elements we can resolve individually and sum their cardinalities.
     for (size_t i = 0; i < expression_ranges.size(); ++i) {
-      if (maybe_propertyvalue_ranges[i] || !expression_ranges[i].original_in_list_) continue;
+      if (maybe_propertyvalue_ranges[i] || !expression_ranges[i].membership_list_) continue;
 
-      auto *list = utils::Downcast<ListLiteral>(expression_ranges[i].original_in_list_);
-      if (!list) continue;
+      auto *list = expression_ranges[i].membership_list_;
 
       double sum = 0.0;
       bool all_resolved = true;
@@ -801,9 +800,9 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
         // Build a full property-value-ranges vector, substituting this element for position i
         auto per_elem_ranges = maybe_propertyvalue_ranges;
         per_elem_ranges[i] = *resolved;
-        if (ranges::none_of(per_elem_ranges, [](auto &&pvr) { return pvr == std::nullopt; })) {
-          auto pvrs =
-              per_elem_ranges | ranges::views::transform([](auto &&optional) { return *optional; }) | ranges::to_vector;
+        if (ranges::none_of(per_elem_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
+          auto pvrs = per_elem_ranges | ranges::views::transform([](auto const &optional) { return *optional; }) |
+                      ranges::to_vector;
           sum += db_accessor_->VerticesCount(label, properties, pvrs);
         } else {
           all_resolved = false;
@@ -814,7 +813,7 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
         maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();  // mark as resolved
         // Replace the full estimate with the sum
         // If all other ranges are already resolved, return the sum directly
-        if (ranges::none_of(maybe_propertyvalue_ranges, [](auto &&pvr) { return pvr == std::nullopt; })) {
+        if (ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
           return sum;
         }
       }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -130,8 +130,7 @@ ExpressionRange::ExpressionRange(ExpressionRange const &other, AstStorage &stora
       upper_{other.upper_
                  ? std::make_optional(utils::Bound(other.upper_->value()->Clone(&storage), other.upper_->type()))
                  : std::nullopt},
-      membership_list_{other.membership_list_ ? static_cast<ListLiteral *>(other.membership_list_->Clone(&storage))
-                                              : nullptr} {}
+      membership_list_{other.membership_list_ ? other.membership_list_->Clone(&storage) : nullptr} {}
 
 auto ExpressionRange::Equal(Expression *value) -> ExpressionRange {
   // Only store lower bound, Evaluate will only use the lower bound

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -139,7 +139,7 @@ auto ExpressionRange::Equal(Expression *value) -> ExpressionRange {
 }
 
 auto ExpressionRange::In(Expression *runtime_value, ListLiteral *membership_list) -> ExpressionRange {
-  auto er = ExpressionRange{Type::EQUAL, utils::MakeBoundInclusive(runtime_value), std::nullopt};
+  auto er = ExpressionRange{Type::IN, utils::MakeBoundInclusive(runtime_value), std::nullopt};
   er.membership_list_ = membership_list;
   return er;
 }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -130,16 +130,17 @@ ExpressionRange::ExpressionRange(ExpressionRange const &other, AstStorage &stora
       upper_{other.upper_
                  ? std::make_optional(utils::Bound(other.upper_->value()->Clone(&storage), other.upper_->type()))
                  : std::nullopt},
-      original_in_list_{other.original_in_list_ ? other.original_in_list_->Clone(&storage) : nullptr} {}
+      membership_list_{other.membership_list_ ? static_cast<ListLiteral *>(other.membership_list_->Clone(&storage))
+                                              : nullptr} {}
 
 auto ExpressionRange::Equal(Expression *value) -> ExpressionRange {
   // Only store lower bound, Evaluate will only use the lower bound
   return {Type::EQUAL, utils::MakeBoundInclusive(value), std::nullopt};
 }
 
-auto ExpressionRange::In(Expression *runtime_value, Expression *original_list) -> ExpressionRange {
+auto ExpressionRange::In(Expression *runtime_value, ListLiteral *membership_list) -> ExpressionRange {
   auto er = ExpressionRange{Type::EQUAL, utils::MakeBoundInclusive(runtime_value), std::nullopt};
-  er.original_in_list_ = original_list;
+  er.membership_list_ = membership_list;
   return er;
 }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -129,11 +129,18 @@ ExpressionRange::ExpressionRange(ExpressionRange const &other, AstStorage &stora
                  : std::nullopt},
       upper_{other.upper_
                  ? std::make_optional(utils::Bound(other.upper_->value()->Clone(&storage), other.upper_->type()))
-                 : std::nullopt} {}
+                 : std::nullopt},
+      original_in_list_{other.original_in_list_ ? other.original_in_list_->Clone(&storage) : nullptr} {}
 
 auto ExpressionRange::Equal(Expression *value) -> ExpressionRange {
   // Only store lower bound, Evaluate will only use the lower bound
   return {Type::EQUAL, utils::MakeBoundInclusive(value), std::nullopt};
+}
+
+auto ExpressionRange::In(Expression *runtime_value, Expression *original_list) -> ExpressionRange {
+  auto er = ExpressionRange{Type::EQUAL, utils::MakeBoundInclusive(runtime_value), std::nullopt};
+  er.original_in_list_ = original_list;
+  return er;
 }
 
 auto ExpressionRange::RegexMatch() -> ExpressionRange { return {Type::REGEX_MATCH, std::nullopt, std::nullopt}; }

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -44,6 +44,7 @@ struct ExecutionContext;
 class DbAccessor;
 class ExpressionEvaluator;
 class Frame;
+class ListLiteral;
 class SymbolTable;
 
 namespace plan {
@@ -54,10 +55,10 @@ struct ExpressionRange {
   Type type_;
   std::optional<utils::Bound<Expression *>> lower_;
   std::optional<utils::Bound<Expression *>> upper_;
-  Expression *original_in_list_{nullptr};
+  ListLiteral *membership_list_{nullptr};
 
   static auto Equal(Expression *value) -> ExpressionRange;
-  static auto In(Expression *runtime_value, Expression *original_list) -> ExpressionRange;
+  static auto In(Expression *runtime_value, ListLiteral *membership_list) -> ExpressionRange;
   static auto RegexMatch() -> ExpressionRange;
   static auto Range(std::optional<utils::Bound<Expression *>> lower, std::optional<utils::Bound<Expression *>> upper)
       -> ExpressionRange;

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -55,7 +55,7 @@ struct ExpressionRange {
   Type type_;
   std::optional<utils::Bound<Expression *>> lower_;
   std::optional<utils::Bound<Expression *>> upper_;
-  ListLiteral *membership_list_{nullptr};
+  ListLiteral *membership_list_{nullptr};  // Non-owning; lives in AstStorage. Cloned by copy ctor.
 
   static auto Equal(Expression *value) -> ExpressionRange;
   static auto In(Expression *runtime_value, ListLiteral *membership_list) -> ExpressionRange;

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -54,8 +54,10 @@ struct ExpressionRange {
   Type type_;
   std::optional<utils::Bound<Expression *>> lower_;
   std::optional<utils::Bound<Expression *>> upper_;
+  Expression *original_in_list_{nullptr};
 
   static auto Equal(Expression *value) -> ExpressionRange;
+  static auto In(Expression *runtime_value, Expression *original_list) -> ExpressionRange;
   static auto RegexMatch() -> ExpressionRange;
   static auto Range(std::optional<utils::Bound<Expression *>> lower, std::optional<utils::Bound<Expression *>> upper)
       -> ExpressionRange;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1643,6 +1643,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                             parameters_);
           if (!marginal) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
           result *= *marginal;
+          pvrs[slot] = storage::PropertyValueRange::IsNotNull();
         }
         result /= std::pow(static_cast<double>(total), static_cast<double>(in_slots.size() - 1));
         return std::min(result, static_cast<double>(total));

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1824,6 +1824,12 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       return filter_info;
     };
 
+    auto const capture_membership_list = [](FilterInfo const &fi) -> ListLiteral * {
+      if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
+        return utils::Downcast<ListLiteral>(fi.property_filter->value_);
+      return nullptr;
+    };
+
     ScanByIndexMetadata metadata;
     metadata.node_symbol = node_symbol;
 
@@ -1936,13 +1942,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       });
       // Capture original IN list member expressions before make_unwinds
       // replaces them with anonymous symbols
-      auto membership_lists = found_index->filters |
-                              ranges::views::transform([](FilterInfo const &fi) -> ListLiteral * {
-                                if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
-                                  return utils::Downcast<ListLiteral>(fi.property_filter->value_);
-                                return nullptr;
-                              }) |
-                              ranges::to_vector;
+      auto membership_lists =
+          found_index->filters | ranges::views::transform(capture_membership_list) | ranges::to_vector;
       auto value_expressions = found_index->filters | ranges::views::transform(make_unwinds) | ranges::to_vector;
       auto expr_ranges =
           ranges::views::zip(value_expressions, membership_lists) |
@@ -2019,12 +2020,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
               }
             }
             auto or_membership_lists =
-                label_property_index.filters | ranges::views::transform([](FilterInfo const &fi) -> ListLiteral * {
-                  if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
-                    return utils::Downcast<ListLiteral>(fi.property_filter->value_);
-                  return nullptr;
-                }) |
-                ranges::to_vector;
+                label_property_index.filters | ranges::views::transform(capture_membership_list) | ranges::to_vector;
             auto value_expressions =
                 label_property_index.filters | ranges::views::transform(make_unwinds) | ranges::to_vector;
             auto expr_ranges = ranges::views::zip(value_expressions, or_membership_lists) |

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1606,23 +1606,46 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
           return db_->VerticesCount(scan_op->label_, scan_op->properties_, propertyvalue_ranges);
         }
-        // Try resolving IN membership lists element-by-element.
-        // Process each IN slot: sum per-element VerticesCount, then mark
-        // the slot as IsNotNull so subsequent slots see it as resolved.
+        // Collect unresolved IN slots and batch-set to IsNotNull.
+        std::vector<size_t> in_slots;
         for (size_t i = 0; i < scan_op->expression_ranges_.size(); ++i) {
           if (maybe_propertyvalue_ranges[i] || !scan_op->expression_ranges_[i].membership_list_) continue;
-          auto &list = *scan_op->expression_ranges_[i].membership_list_;
+          in_slots.push_back(i);
           maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
-          // If any other slot is still unresolved, fall back to coarse total index count.
-          if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
-            return db_->VerticesCount(scan_op->label_, scan_op->properties_);
-          auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
-                      ranges::to_vector;
-          auto sum = EstimateInListSum(db_, scan_op->label_, scan_op->properties_, list, i, pvrs, parameters_);
-          if (!sum) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
-          if (ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
-            return *sum;
         }
+        if (in_slots.empty()) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
+        // If non-IN slots are still unresolved, fall back.
+        if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
+          return db_->VerticesCount(scan_op->label_, scan_op->properties_);
+        auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
+                    ranges::to_vector;
+        if (in_slots.size() == 1) {
+          auto sum = EstimateInListSum(db_,
+                                       scan_op->label_,
+                                       scan_op->properties_,
+                                       *scan_op->expression_ranges_[in_slots[0]].membership_list_,
+                                       in_slots[0],
+                                       pvrs,
+                                       parameters_);
+          return sum.value_or(db_->VerticesCount(scan_op->label_, scan_op->properties_));
+        }
+        // Multiple IN slots: independence assumption.
+        auto const total = db_->VerticesCount(scan_op->label_, scan_op->properties_, pvrs);
+        if (total == 0) return 0.0;
+        double result = 1.0;
+        for (auto slot : in_slots) {
+          auto marginal = EstimateInListSum(db_,
+                                            scan_op->label_,
+                                            scan_op->properties_,
+                                            *scan_op->expression_ranges_[slot].membership_list_,
+                                            slot,
+                                            pvrs,
+                                            parameters_);
+          if (!marginal) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
+          result *= *marginal;
+        }
+        result /= std::pow(static_cast<double>(total), static_cast<double>(in_slots.size() - 1));
+        return std::min(result, static_cast<double>(total));
         return db_->VerticesCount(scan_op->label_, scan_op->properties_);
       });
       return static_cast<double>(cardinality);

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1753,12 +1753,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           return ExpressionRange::Equal(filter.property_filter->value_);
         }
         case PropertyFilter::Type::IN: {
-          // After unwind rewrite, value_ is the anonymous symbol.
-          // Preserve membership_list for cost estimation.
-          if (membership_list) {
-            return ExpressionRange::In(filter.property_filter->value_, membership_list);
-          }
-          return ExpressionRange::Equal(filter.property_filter->value_);
+          return ExpressionRange::In(filter.property_filter->value_, membership_list);
         }
         case PropertyFilter::Type::REGEX_MATCH: {
           return ExpressionRange::RegexMatch();
@@ -1904,7 +1899,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       const bool has_in = std::ranges::any_of(found_index->filters, [](const FilterInfo &f) {
         return f.property_filter && f.property_filter->type_ == PropertyFilter::Type::IN;
       });
-      // Capture original IN list expressions before make_unwinds replaces them with anonymous symbols
+      // Capture original IN list member expressions before make_unwinds
+      // replaces them with anonymous symbols
       auto membership_lists = found_index->filters |
                               ranges::views::transform([](FilterInfo const &fi) -> ListLiteral * {
                                 if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
@@ -1913,11 +1909,10 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                               }) |
                               ranges::to_vector;
       auto value_expressions = found_index->filters | ranges::views::transform(make_unwinds) | ranges::to_vector;
-      std::vector<ExpressionRange> expr_ranges;
-      expr_ranges.reserve(value_expressions.size());
-      for (size_t i = 0; i < value_expressions.size(); ++i) {
-        expr_ranges.push_back(to_expression_range(value_expressions[i], membership_lists[i]));
-      }
+      auto expr_ranges =
+          ranges::views::zip(value_expressions, membership_lists) |
+          ranges::views::transform([&](auto const &pair) { return to_expression_range(pair.first, pair.second); }) |
+          ranges::to_vector;
 
       auto op = std::make_unique<ScanAllByLabelProperties>(input,
                                                            node_symbol,
@@ -1997,11 +1992,10 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                 ranges::to_vector;
             auto value_expressions =
                 label_property_index.filters | ranges::views::transform(make_unwinds) | ranges::to_vector;
-            std::vector<ExpressionRange> expr_ranges;
-            expr_ranges.reserve(value_expressions.size());
-            for (size_t i = 0; i < value_expressions.size(); ++i) {
-              expr_ranges.push_back(to_expression_range(value_expressions[i], or_membership_lists[i]));
-            }
+            auto expr_ranges = ranges::views::zip(value_expressions, or_membership_lists) |
+                               ranges::views::transform(
+                                   [&](auto const &pair) { return to_expression_range(pair.first, pair.second); }) |
+                               ranges::to_vector;
             auto label_property_index_scan =
                 std::make_unique<ScanAllByLabelProperties>(input,
                                                            node_symbol,

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1746,7 +1746,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       return true;
     };
 
-    auto const to_expression_range = [&](auto &&filter, Expression *original_in_list = nullptr) -> ExpressionRange {
+    auto const to_expression_range = [&](auto &&filter, ListLiteral *membership_list = nullptr) -> ExpressionRange {
       DMG_ASSERT(filter.property_filter);
       switch (filter.property_filter->type_) {
         case PropertyFilter::Type::EQUAL: {
@@ -1754,9 +1754,9 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         }
         case PropertyFilter::Type::IN: {
           // After unwind rewrite, value_ is the anonymous symbol.
-          // Preserve original_in_list for cost estimation.
-          if (original_in_list) {
-            return ExpressionRange::In(filter.property_filter->value_, original_in_list);
+          // Preserve membership_list for cost estimation.
+          if (membership_list) {
+            return ExpressionRange::In(filter.property_filter->value_, membership_list);
           }
           return ExpressionRange::Equal(filter.property_filter->value_);
         }
@@ -1905,18 +1905,18 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         return f.property_filter && f.property_filter->type_ == PropertyFilter::Type::IN;
       });
       // Capture original IN list expressions before make_unwinds replaces them with anonymous symbols
-      auto original_in_lists = found_index->filters |
-                               ranges::views::transform([](FilterInfo const &fi) -> Expression * {
-                                 if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
-                                   return fi.property_filter->value_;
-                                 return nullptr;
-                               }) |
-                               ranges::to_vector;
+      auto membership_lists = found_index->filters |
+                              ranges::views::transform([](FilterInfo const &fi) -> ListLiteral * {
+                                if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
+                                  return utils::Downcast<ListLiteral>(fi.property_filter->value_);
+                                return nullptr;
+                              }) |
+                              ranges::to_vector;
       auto value_expressions = found_index->filters | ranges::views::transform(make_unwinds) | ranges::to_vector;
       std::vector<ExpressionRange> expr_ranges;
       expr_ranges.reserve(value_expressions.size());
       for (size_t i = 0; i < value_expressions.size(); ++i) {
-        expr_ranges.push_back(to_expression_range(value_expressions[i], original_in_lists[i]));
+        expr_ranges.push_back(to_expression_range(value_expressions[i], membership_lists[i]));
       }
 
       auto op = std::make_unique<ScanAllByLabelProperties>(input,
@@ -1988,10 +1988,10 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                 metadata.expressions_to_mark_for_removal.push_back(filter_info.expression);
               }
             }
-            auto or_original_in_lists =
-                label_property_index.filters | ranges::views::transform([](FilterInfo const &fi) -> Expression * {
+            auto or_membership_lists =
+                label_property_index.filters | ranges::views::transform([](FilterInfo const &fi) -> ListLiteral * {
                   if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
-                    return fi.property_filter->value_;
+                    return utils::Downcast<ListLiteral>(fi.property_filter->value_);
                   return nullptr;
                 }) |
                 ranges::to_vector;
@@ -2000,7 +2000,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
             std::vector<ExpressionRange> expr_ranges;
             expr_ranges.reserve(value_expressions.size());
             for (size_t i = 0; i < value_expressions.size(); ++i) {
-              expr_ranges.push_back(to_expression_range(value_expressions[i], or_original_in_lists[i]));
+              expr_ranges.push_back(to_expression_range(value_expressions[i], or_membership_lists[i]));
             }
             auto label_property_index_scan =
                 std::make_unique<ScanAllByLabelProperties>(input,

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1587,8 +1587,34 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
           return db_->VerticesCount(scan_op->label_, scan_op->properties_, propertyvalue_ranges);
         }
-        // no values, but we still have the label + properties
-        // use basic count without property ranges (ranges depend on runtime parameters)
+        // Try resolving IN membership lists element-by-element
+        auto *mapper = db_->GetStorageAccessor()->GetNameIdMapper();
+        for (size_t i = 0; i < scan_op->expression_ranges_.size(); ++i) {
+          if (maybe_propertyvalue_ranges[i] || !scan_op->expression_ranges_[i].membership_list_) continue;
+          auto &list = *scan_op->expression_ranges_[i].membership_list_;
+          auto saved = maybe_propertyvalue_ranges[i];
+          double sum = 0.0;
+          bool ok = true;
+          for (auto *elem : list.elements_) {
+            auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters_, mapper);
+            if (!resolved) {
+              ok = false;
+              break;
+            }
+            maybe_propertyvalue_ranges[i] = *resolved;
+            if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
+              ok = false;
+              break;
+            }
+            auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
+                        ranges::to_vector;
+            sum += db_->VerticesCount(scan_op->label_, scan_op->properties_, pvrs);
+          }
+          maybe_propertyvalue_ranges[i] = ok ? storage::PropertyValueRange::IsNotNull() : saved;
+          if (ok && ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
+            return sum;
+          }
+        }
         return db_->VerticesCount(scan_op->label_, scan_op->properties_);
       });
       return static_cast<double>(cardinality);
@@ -1605,6 +1631,15 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           return static_cast<double>(db_->VerticesCount(scan_op->property_, pvr->lower_->value()));
         }
         return static_cast<double>(db_->VerticesCount(scan_op->property_, pvr->lower_, pvr->upper_));
+      }
+      if (auto *list = scan_op->expression_range_.membership_list_) {
+        double sum = 0.0;
+        for (auto *elem : list->elements_) {
+          auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters_, mapper);
+          if (!resolved) return static_cast<double>(db_->VerticesCount(scan_op->property_));
+          sum += db_->VerticesCount(scan_op->property_, resolved->lower_->value());
+        }
+        return sum;
       }
       return static_cast<double>(db_->VerticesCount(scan_op->property_));
     }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1597,13 +1597,14 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
           if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
             return db_->VerticesCount(scan_op->label_, scan_op->properties_);
+          auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
+                      ranges::to_vector;
           double sum = 0.0;
           for (auto *elem : list.elements_) {
             auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters_, mapper);
             if (!resolved) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
             maybe_propertyvalue_ranges[i] = *resolved;
-            auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
-                        ranges::to_vector;
+            pvrs[i] = *resolved;
             sum += db_->VerticesCount(scan_op->label_, scan_op->properties_, pvrs);
           }
           maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1587,33 +1587,28 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
           return db_->VerticesCount(scan_op->label_, scan_op->properties_, propertyvalue_ranges);
         }
-        // Try resolving IN membership lists element-by-element
+        // Try resolving IN membership lists element-by-element.
+        // Process each IN slot: sum per-element VerticesCount, then mark
+        // the slot as IsNotNull so subsequent slots see it as resolved.
         auto *mapper = db_->GetStorageAccessor()->GetNameIdMapper();
         for (size_t i = 0; i < scan_op->expression_ranges_.size(); ++i) {
           if (maybe_propertyvalue_ranges[i] || !scan_op->expression_ranges_[i].membership_list_) continue;
           auto &list = *scan_op->expression_ranges_[i].membership_list_;
-          auto saved = maybe_propertyvalue_ranges[i];
+          maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
+          if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
+            return db_->VerticesCount(scan_op->label_, scan_op->properties_);
           double sum = 0.0;
-          bool ok = true;
           for (auto *elem : list.elements_) {
             auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters_, mapper);
-            if (!resolved) {
-              ok = false;
-              break;
-            }
+            if (!resolved) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
             maybe_propertyvalue_ranges[i] = *resolved;
-            if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
-              ok = false;
-              break;
-            }
             auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
                         ranges::to_vector;
             sum += db_->VerticesCount(scan_op->label_, scan_op->properties_, pvrs);
           }
-          maybe_propertyvalue_ranges[i] = ok ? storage::PropertyValueRange::IsNotNull() : saved;
-          if (ok && ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; })) {
+          maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
+          if (ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
             return sum;
-          }
         }
         return db_->VerticesCount(scan_op->label_, scan_op->properties_);
       });
@@ -1734,10 +1729,14 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                estimated_count};
     }
     if (prop_filter.type_ == PropertyFilter::Type::IN) {
+      auto *membership_list = utils::Downcast<ListLiteral>(prop_filter.value_);
       auto unwound = UnwindMembershipList(*symbol_table_, ast_storage_, input, prop_filter.value_);
       return ScanByIndexResult{
-          std::make_shared<ScanAllByVertexProperty>(
-              std::move(unwound.op), node_symbol, best->property, ExpressionRange::Equal(unwound.element), view),
+          std::make_shared<ScanAllByVertexProperty>(std::move(unwound.op),
+                                                    node_symbol,
+                                                    best->property,
+                                                    ExpressionRange::In(unwound.element, membership_list),
+                                                    view),
           std::move(metadata),
           true,
           estimated_count};

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1746,12 +1746,18 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       return true;
     };
 
-    auto const to_expression_range = [&](auto &&filter) -> ExpressionRange {
+    auto const to_expression_range = [&](auto &&filter, Expression *original_in_list = nullptr) -> ExpressionRange {
       DMG_ASSERT(filter.property_filter);
       switch (filter.property_filter->type_) {
-        case PropertyFilter::Type::EQUAL:
+        case PropertyFilter::Type::EQUAL: {
+          return ExpressionRange::Equal(filter.property_filter->value_);
+        }
         case PropertyFilter::Type::IN: {
-          // Because of the unwind rewrite IN is the same as EQUAL
+          // After unwind rewrite, value_ is the anonymous symbol.
+          // Preserve original_in_list for cost estimation.
+          if (original_in_list) {
+            return ExpressionRange::In(filter.property_filter->value_, original_in_list);
+          }
           return ExpressionRange::Equal(filter.property_filter->value_);
         }
         case PropertyFilter::Type::REGEX_MATCH: {
@@ -1898,8 +1904,20 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       const bool has_in = std::ranges::any_of(found_index->filters, [](const FilterInfo &f) {
         return f.property_filter && f.property_filter->type_ == PropertyFilter::Type::IN;
       });
+      // Capture original IN list expressions before make_unwinds replaces them with anonymous symbols
+      auto original_in_lists = found_index->filters |
+                               ranges::views::transform([](FilterInfo const &fi) -> Expression * {
+                                 if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
+                                   return fi.property_filter->value_;
+                                 return nullptr;
+                               }) |
+                               ranges::to_vector;
       auto value_expressions = found_index->filters | ranges::views::transform(make_unwinds) | ranges::to_vector;
-      auto expr_ranges = value_expressions | ranges::views::transform(to_expression_range) | ranges::to_vector;
+      std::vector<ExpressionRange> expr_ranges;
+      expr_ranges.reserve(value_expressions.size());
+      for (size_t i = 0; i < value_expressions.size(); ++i) {
+        expr_ranges.push_back(to_expression_range(value_expressions[i], original_in_lists[i]));
+      }
 
       auto op = std::make_unique<ScanAllByLabelProperties>(input,
                                                            node_symbol,
@@ -1970,9 +1988,20 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                 metadata.expressions_to_mark_for_removal.push_back(filter_info.expression);
               }
             }
+            auto or_original_in_lists =
+                label_property_index.filters | ranges::views::transform([](FilterInfo const &fi) -> Expression * {
+                  if (fi.property_filter && fi.property_filter->type_ == PropertyFilter::Type::IN)
+                    return fi.property_filter->value_;
+                  return nullptr;
+                }) |
+                ranges::to_vector;
             auto value_expressions =
                 label_property_index.filters | ranges::views::transform(make_unwinds) | ranges::to_vector;
-            auto expr_ranges = value_expressions | ranges::views::transform(to_expression_range) | ranges::to_vector;
+            std::vector<ExpressionRange> expr_ranges;
+            expr_ranges.reserve(value_expressions.size());
+            for (size_t i = 0; i < value_expressions.size(); ++i) {
+              expr_ranges.push_back(to_expression_range(value_expressions[i], or_original_in_lists[i]));
+            }
             auto label_property_index_scan =
                 std::make_unique<ScanAllByLabelProperties>(input,
                                                            node_symbol,

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -61,6 +61,21 @@ auto property_path_converter(TDbAccessor *db) {
 }
 }  // namespace
 
+template <typename TDbAccessor>
+auto EstimateInListSum(TDbAccessor *db, storage::LabelId label, std::vector<storage::PropertyPath> const &properties,
+                       ListLiteral const &list, size_t slot, std::vector<storage::PropertyValueRange> &pvrs,
+                       Parameters const &parameters) -> std::optional<double> {
+  auto *mapper = db->GetStorageAccessor()->GetNameIdMapper();
+  double sum = 0.0;
+  for (auto *elem : list.elements_) {
+    auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
+    if (!resolved) return std::nullopt;
+    pvrs[slot] = *resolved;
+    sum += db->VerticesCount(label, properties, pvrs);
+  }
+  return sum;
+}
+
 /// Holds a given query's index hints after sorting them by type
 struct IndexHints {
   IndexHints() = default;
@@ -1590,7 +1605,6 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         // Try resolving IN membership lists element-by-element.
         // Process each IN slot: sum per-element VerticesCount, then mark
         // the slot as IsNotNull so subsequent slots see it as resolved.
-        auto *mapper = db_->GetStorageAccessor()->GetNameIdMapper();
         for (size_t i = 0; i < scan_op->expression_ranges_.size(); ++i) {
           if (maybe_propertyvalue_ranges[i] || !scan_op->expression_ranges_[i].membership_list_) continue;
           auto &list = *scan_op->expression_ranges_[i].membership_list_;
@@ -1599,17 +1613,11 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
             return db_->VerticesCount(scan_op->label_, scan_op->properties_);
           auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
                       ranges::to_vector;
-          double sum = 0.0;
-          for (auto *elem : list.elements_) {
-            auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters_, mapper);
-            if (!resolved) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
-            maybe_propertyvalue_ranges[i] = *resolved;
-            pvrs[i] = *resolved;
-            sum += db_->VerticesCount(scan_op->label_, scan_op->properties_, pvrs);
-          }
+          auto sum = EstimateInListSum(db_, scan_op->label_, scan_op->properties_, list, i, pvrs, parameters_);
+          if (!sum) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
           maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
           if (ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
-            return sum;
+            return *sum;
         }
         return db_->VerticesCount(scan_op->label_, scan_op->properties_);
       });

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1646,7 +1646,6 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         }
         result /= std::pow(static_cast<double>(total), static_cast<double>(in_slots.size() - 1));
         return std::min(result, static_cast<double>(total));
-        return db_->VerticesCount(scan_op->label_, scan_op->properties_);
       });
       return static_cast<double>(cardinality);
     }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -61,6 +61,10 @@ auto property_path_converter(TDbAccessor *db) {
 }
 }  // namespace
 
+// Sum the estimated vertex count for each element in an IN-list on a single
+// index slot. Resolves each element at plan time and calls VerticesCount with
+// pvrs[slot] set to that element's value. All other entries in pvrs must
+// already be resolved.
 template <typename TDbAccessor>
 auto EstimateInListSum(TDbAccessor *db, storage::LabelId label, std::vector<storage::PropertyPath> const &properties,
                        ListLiteral const &list, size_t slot, std::vector<storage::PropertyValueRange> &pvrs,
@@ -1609,13 +1613,13 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           if (maybe_propertyvalue_ranges[i] || !scan_op->expression_ranges_[i].membership_list_) continue;
           auto &list = *scan_op->expression_ranges_[i].membership_list_;
           maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
+          // If any other slot is still unresolved, fall back to coarse total index count.
           if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
             return db_->VerticesCount(scan_op->label_, scan_op->properties_);
           auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
                       ranges::to_vector;
           auto sum = EstimateInListSum(db_, scan_op->label_, scan_op->properties_, list, i, pvrs, parameters_);
           if (!sum) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
-          maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
           if (ranges::none_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
             return *sum;
         }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1613,10 +1613,10 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           in_slots.push_back(i);
           maybe_propertyvalue_ranges[i] = storage::PropertyValueRange::IsNotNull();
         }
-        if (in_slots.empty()) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
+        if (in_slots.empty()) return db_->VerticesCount(scan_op->label_, scan_op->properties_) * CardParam::kFilter;
         // If non-IN slots are still unresolved, fall back.
         if (ranges::any_of(maybe_propertyvalue_ranges, [](auto const &pvr) { return pvr == std::nullopt; }))
-          return db_->VerticesCount(scan_op->label_, scan_op->properties_);
+          return db_->VerticesCount(scan_op->label_, scan_op->properties_) * CardParam::kFilter;
         auto pvrs = maybe_propertyvalue_ranges | ranges::views::transform([](auto const &opt) { return *opt; }) |
                     ranges::to_vector;
         if (in_slots.size() == 1) {
@@ -1627,7 +1627,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                        in_slots[0],
                                        pvrs,
                                        parameters_);
-          return sum.value_or(db_->VerticesCount(scan_op->label_, scan_op->properties_));
+          return sum.value_or(db_->VerticesCount(scan_op->label_, scan_op->properties_) * CardParam::kFilter);
         }
         // Multiple IN slots: independence assumption.
         auto const total = db_->VerticesCount(scan_op->label_, scan_op->properties_, pvrs);
@@ -1641,7 +1641,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                             slot,
                                             pvrs,
                                             parameters_);
-          if (!marginal) return db_->VerticesCount(scan_op->label_, scan_op->properties_);
+          if (!marginal) return db_->VerticesCount(scan_op->label_, scan_op->properties_) * CardParam::kFilter;
           result *= *marginal;
           pvrs[slot] = storage::PropertyValueRange::IsNotNull();
         }

--- a/tests/e2e/query_planning/CMakeLists.txt
+++ b/tests/e2e/query_planning/CMakeLists.txt
@@ -10,5 +10,6 @@ copy_query_planning_e2e_python_files(query_planning_point_index.py)
 copy_query_planning_e2e_python_files(query_planning_subquery.py)
 copy_query_planning_e2e_python_files(query_planning_valid_query_plans.py)
 copy_query_planning_e2e_python_files(query_planning_orderby_index.py)
+copy_query_planning_e2e_python_files(query_planning_in_list.py)
 
 copy_e2e_files(query_planning workloads.yaml)

--- a/tests/e2e/query_planning/query_planning_in_list.py
+++ b/tests/e2e/query_planning/query_planning_in_list.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import sys
+
+import pytest
+from common import memgraph
+
+QUERY_PLAN = "QUERY PLAN"
+
+
+def get_plan(memgraph, query):
+    results = list(memgraph.execute_and_fetch(f"EXPLAIN {query}"))
+    return [x[QUERY_PLAN] for x in results]
+
+
+def setup_graph(memgraph):
+    """Create two labels with very different cardinalities and connect them."""
+    memgraph.execute("CREATE INDEX ON :Big(prop);")
+    memgraph.execute("CREATE INDEX ON :Small(prop);")
+    # 500 Big nodes, 5 Small nodes, each Small connected to every Big.
+    memgraph.execute("UNWIND range(1, 500) AS i CREATE (:Big {prop: toString(i)})")
+    memgraph.execute("UNWIND range(1, 5) AS i CREATE (:Small {prop: 'val' + toString(i)})")
+    memgraph.execute("MATCH (b:Big), (s:Small) CREATE (b)-[:REL]->(s)")
+
+
+def first_scan_operator(plan):
+    """Return the last plan line that contains 'Scan' (i.e. the bottom-most scan)."""
+    scans = [line for line in plan if "Scan" in line]
+    return scans[-1] if scans else None
+
+
+def test_in_list_picks_same_start_as_equality(memgraph):
+    """IN ['x'] should produce the same starting scan as = 'x'."""
+    setup_graph(memgraph)
+
+    eq_plan = get_plan(
+        memgraph,
+        "MATCH (a:Big)--(b:Small) WHERE b.prop = 'val1' RETURN a",
+    )
+    in_plan = get_plan(
+        memgraph,
+        "MATCH (a:Big)--(b:Small) WHERE b.prop IN ['val1'] RETURN a",
+    )
+
+    eq_scan = first_scan_operator(eq_plan)
+    in_scan = first_scan_operator(in_plan)
+
+    # Both should start from Small (the selective side).
+    assert "Small" in eq_scan, f"Equality plan should scan Small, got: {eq_scan}"
+    assert "Small" in in_scan, f"IN plan should scan Small, got: {in_scan}"
+
+
+def test_in_list_multi_element(memgraph):
+    """IN ['x', 'y'] with two matching values should still pick the selective label."""
+    setup_graph(memgraph)
+
+    plan = get_plan(
+        memgraph,
+        "MATCH (a:Big)--(b:Small) WHERE b.prop IN ['val1', 'val2'] RETURN a",
+    )
+
+    scan = first_scan_operator(plan)
+    assert "Small" in scan, f"Multi-element IN should scan Small, got: {scan}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/query_planning/query_planning_in_list.py
+++ b/tests/e2e/query_planning/query_planning_in_list.py
@@ -32,8 +32,8 @@ def setup_graph(memgraph):
     memgraph.execute("MATCH (b:Big), (s:Small) CREATE (b)-[:REL]->(s)")
 
 
-def first_scan_operator(plan):
-    """Return the last plan line that contains 'Scan' (i.e. the bottom-most scan)."""
+def bottom_scan_operator(plan):
+    """Return the bottom-most (first-to-execute) scan in the plan."""
     scans = [line for line in plan if "Scan" in line]
     return scans[-1] if scans else None
 
@@ -51,8 +51,8 @@ def test_in_list_picks_same_start_as_equality(memgraph):
         "MATCH (a:Big)--(b:Small) WHERE b.prop IN ['val1'] RETURN a",
     )
 
-    eq_scan = first_scan_operator(eq_plan)
-    in_scan = first_scan_operator(in_plan)
+    eq_scan = bottom_scan_operator(eq_plan)
+    in_scan = bottom_scan_operator(in_plan)
 
     # Both should start from Small (the selective side).
     assert "Small" in eq_scan, f"Equality plan should scan Small, got: {eq_scan}"
@@ -68,7 +68,7 @@ def test_in_list_multi_element(memgraph):
         "MATCH (a:Big)--(b:Small) WHERE b.prop IN ['val1', 'val2'] RETURN a",
     )
 
-    scan = first_scan_operator(plan)
+    scan = bottom_scan_operator(plan)
     assert "Small" in scan, f"Multi-element IN should scan Small, got: {scan}"
 
 

--- a/tests/e2e/query_planning/query_planning_in_list.py
+++ b/tests/e2e/query_planning/query_planning_in_list.py
@@ -23,13 +23,18 @@ def get_plan(memgraph, query):
 
 
 def setup_graph(memgraph):
-    """Create two labels with very different cardinalities and connect them."""
-    memgraph.execute("CREATE INDEX ON :Big(prop);")
-    memgraph.execute("CREATE INDEX ON :Small(prop);")
-    # 500 Big nodes, 5 Small nodes, each Small connected to every Big.
-    memgraph.execute("UNWIND range(1, 500) AS i CREATE (:Big {prop: toString(i)})")
-    memgraph.execute("UNWIND range(1, 5) AS i CREATE (:Small {prop: 'val' + toString(i)})")
-    memgraph.execute("MATCH (b:Big), (s:Small) CREATE (b)-[:REL]->(s)")
+    """Create two labels with similar cardinalities and connect them.
+
+    Both labels have 50 nodes. Without IN-list awareness the planner sees
+    the IN side as expensive (Unwind factor * label count * kFilter) and
+    picks the wrong starting scan. With the fix the planner uses the actual
+    per-element sum and correctly starts from the selective IN side.
+    """
+    memgraph.execute("CREATE INDEX ON :A(prop);")
+    memgraph.execute("CREATE INDEX ON :B(prop);")
+    memgraph.execute("UNWIND range(1, 50) AS i CREATE (:A {prop: toString(i)})")
+    memgraph.execute("UNWIND range(1, 50) AS i CREATE (:B {prop: toString(i)})")
+    memgraph.execute("MATCH (a:A), (b:B) CREATE (a)-[:REL]->(b)")
 
 
 def bottom_scan_operator(plan):
@@ -39,37 +44,44 @@ def bottom_scan_operator(plan):
 
 
 def test_in_list_picks_same_start_as_equality(memgraph):
-    """IN ['x'] should produce the same starting scan as = 'x'."""
+    """IN ['x'] should produce the same starting scan as = 'x'.
+
+    Both labels have 50 nodes. Equality on A matches 1 node, so the planner
+    should start from A. IN ['x'] should behave identically.
+    """
     setup_graph(memgraph)
 
     eq_plan = get_plan(
         memgraph,
-        "MATCH (a:Big)--(b:Small) WHERE b.prop = 'val1' RETURN a",
+        "MATCH (a:A)--(b:B) WHERE a.prop = '1' RETURN b",
     )
     in_plan = get_plan(
         memgraph,
-        "MATCH (a:Big)--(b:Small) WHERE b.prop IN ['val1'] RETURN a",
+        "MATCH (a:A)--(b:B) WHERE a.prop IN ['1'] RETURN b",
     )
 
     eq_scan = bottom_scan_operator(eq_plan)
     in_scan = bottom_scan_operator(in_plan)
 
-    # Both should start from Small (the selective side).
-    assert "Small" in eq_scan, f"Equality plan should scan Small, got: {eq_scan}"
-    assert "Small" in in_scan, f"IN plan should scan Small, got: {in_scan}"
+    assert ":A" in eq_scan, f"Equality plan should scan A, got: {eq_scan}"
+    assert ":A" in in_scan, f"IN plan should scan A, got: {in_scan}"
 
 
 def test_in_list_multi_element(memgraph):
-    """IN ['x', 'y'] with two matching values should still pick the selective label."""
+    """IN ['x', 'y'] with two matching values: planner should still start from the IN side.
+
+    A has 50 nodes; B has 50 nodes. IN ['1', '2'] on A matches 2 nodes,
+    which is far cheaper than scanning all 50 B nodes.
+    """
     setup_graph(memgraph)
 
     plan = get_plan(
         memgraph,
-        "MATCH (a:Big)--(b:Small) WHERE b.prop IN ['val1', 'val2'] RETURN a",
+        "MATCH (a:A)--(b:B) WHERE a.prop IN ['1', '2'] RETURN b",
     )
 
     scan = bottom_scan_operator(plan)
-    assert "Small" in scan, f"Multi-element IN should scan Small, got: {scan}"
+    assert ":A" in scan, f"Multi-element IN should scan A, got: {scan}"
 
 
 if __name__ == "__main__":

--- a/tests/e2e/query_planning/workloads.yaml
+++ b/tests/e2e/query_planning/workloads.yaml
@@ -41,3 +41,8 @@ workloads:
     binary: "tests/e2e/pytest_runner.sh"
     args: ["query_planning/query_planning_orderby_index.py"]
     <<: *queries_cluster
+
+  - name: "Query planning IN list cardinality"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["query_planning/query_planning_in_list.py"]
+    <<: *queries_cluster

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -497,6 +497,27 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListNonexistentValue) {
   EXPECT_COST(CostParam::kMinimumCost);
 }
 
+TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesMultipleInLists) {
+  AddVertices(100, 30, 20);
+  // Composite index on (prop_c, prop_a, prop_b). All three properties are set to the same
+  // value i for each vertex, so only diagonal entries (i,i,i) exist.
+  // prop_c = 5 (resolved), prop_a IN [5, 10] (unresolved), prop_b IN [5, 10] (unresolved).
+  // True matches: only (5,5,5). Independence estimate: S_a * S_b / T = 1 * 1 / 1 = 1.
+  // Without the fix, this falls back to VerticesCount(label, props) * 0.25 = 20 * 0.25 = 5.
+  auto *list_a = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
+  auto *list_b = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
+  auto *sym_a = storage_.Create<Identifier>("anon_a");
+  auto *sym_b = storage_.Create<Identifier>("anon_b");
+  MakeOp<ScanAllByLabelProperties>(
+      nullptr,
+      NextSymbol(),
+      label,
+      std::vector{ms::PropertyPath{prop_c}, ms::PropertyPath{prop_a}, ms::PropertyPath{prop_b}},
+      std::vector{
+          ExpressionRange::Equal(Literal(5)), ExpressionRange::In(sym_a, list_a), ExpressionRange::In(sym_b, list_b)});
+  EXPECT_COST(1 * CostParam::kScanAllByLabelProperties);
+}
+
 #undef TEST_OP
 #undef EXPECT_COST
 

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -480,8 +480,7 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInList) {
 
 TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListMultipleElements) {
   AddVertices(100, 30, 20);
-  // IN [5, 10]: 2 elements, each matches 1 vertex. Unwind factor = 2, scan sum = 2.
-  // Current estimate: 2 * 2 = 4 (double-counted; will be fixed in next commit).
+  // IN [5, 10]: 2 elements, each matches 1 vertex. Unwind factor = 2, scan per-row = 1.
   auto *list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
   auto *unwind_expr = MakeInUnwindExpression(storage_, {Literal(5), Literal(10)});
   MakeOp<memgraph::query::plan::Unwind>(last_op_, unwind_expr, NextSymbol());
@@ -491,8 +490,8 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListMultipleElements) {
                                    label,
                                    std::vector{ms::PropertyPath{prop_a}},
                                    std::vector{ExpressionRange::In(unwind_sym, list)});
-  // cost = CostParam::kUnwind + (2 * 2) * CostParam::kScanAllByLabelProperties
-  EXPECT_COST(CostParam::kUnwind + 4 * CostParam::kScanAllByLabelProperties);
+  // Scan returns per-row factor: S / n = 2 / 2 = 1. Cardinality = 2 * 1 = 2.
+  EXPECT_COST(CostParam::kUnwind + 2 * CostParam::kScanAllByLabelProperties);
 }
 
 TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListNonexistentValue) {
@@ -517,7 +516,7 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesMultipleInLists) {
   // value i for each vertex, so only diagonal entries (i,i,i) exist.
   // prop_c = 5 (resolved), prop_a IN [5, 10] (unresolved), prop_b IN [5, 10] (unresolved).
   // True matches: only (5,5,5). Independence estimate: S_a * S_b / T = 1 * 1 / 1 = 1.
-  // Unwind factors: 2 * 2 = 4. Current estimate: 4 * 1 = 4 (double-counted).
+  // Unwind factors: 2 * 2 = 4. Scan per-row = 1 / 4 = 0.25. Final cardinality = 1.
   auto *list_a = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
   auto *list_b = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
   // Chain two Unwinds (the real plan has two Unwinds for two IN clauses)
@@ -536,8 +535,8 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesMultipleInLists) {
           ExpressionRange::Equal(Literal(5)), ExpressionRange::In(sym_a, list_a), ExpressionRange::In(sym_b, list_b)});
   // Unwind 1: cost += 1 * kUnwind, cardinality = 2
   // Unwind 2: cost += 2 * kUnwind, cardinality = 4
-  // Scan(S=1): cardinality *= 1 = 4, cost += 4 * kScanAllByLabelProperties
-  EXPECT_COST(3 * CostParam::kUnwind + 4 * CostParam::kScanAllByLabelProperties);
+  // Scan: independence result = 1, unwind_factor = 4, per-row = 0.25. cardinality = 4 * 0.25 = 1.
+  EXPECT_COST(3 * CostParam::kUnwind + 1 * CostParam::kScanAllByLabelProperties);
 }
 
 #undef TEST_OP

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -463,38 +463,52 @@ TEST_F(QueryCostEstimator, UnwindInLowering) {
 
 TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInList) {
   AddVertices(100, 30, 20);
+  // IN [12]: 1 element, matches 1 vertex. Unwind factor = 1, scan sum = 1.
+  // Current estimate: 1 * 1 = 1 (no double-count for single element).
   auto *list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(12)});
+  auto *unwind_expr = MakeInUnwindExpression(storage_, {Literal(12)});
+  MakeOp<memgraph::query::plan::Unwind>(last_op_, unwind_expr, NextSymbol());
   auto *unwind_sym = storage_.Create<Identifier>("anon_sym");
-  MakeOp<ScanAllByLabelProperties>(nullptr,
+  MakeOp<ScanAllByLabelProperties>(last_op_,
                                    NextSymbol(),
                                    label,
                                    std::vector{ms::PropertyPath{prop_a}},
                                    std::vector{ExpressionRange::In(unwind_sym, list)});
-  EXPECT_COST(1 * CostParam::kScanAllByLabelProperties);
+  // cost = CostParam::kUnwind + (1 * 1) * CostParam::kScanAllByLabelProperties
+  EXPECT_COST(CostParam::kUnwind + 1 * CostParam::kScanAllByLabelProperties);
 }
 
 TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListMultipleElements) {
   AddVertices(100, 30, 20);
+  // IN [5, 10]: 2 elements, each matches 1 vertex. Unwind factor = 2, scan sum = 2.
+  // Current estimate: 2 * 2 = 4 (double-counted; will be fixed in next commit).
   auto *list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
+  auto *unwind_expr = MakeInUnwindExpression(storage_, {Literal(5), Literal(10)});
+  MakeOp<memgraph::query::plan::Unwind>(last_op_, unwind_expr, NextSymbol());
   auto *unwind_sym = storage_.Create<Identifier>("anon_sym");
-  MakeOp<ScanAllByLabelProperties>(nullptr,
+  MakeOp<ScanAllByLabelProperties>(last_op_,
                                    NextSymbol(),
                                    label,
                                    std::vector{ms::PropertyPath{prop_a}},
                                    std::vector{ExpressionRange::In(unwind_sym, list)});
-  EXPECT_COST(2 * CostParam::kScanAllByLabelProperties);
+  // cost = CostParam::kUnwind + (2 * 2) * CostParam::kScanAllByLabelProperties
+  EXPECT_COST(CostParam::kUnwind + 4 * CostParam::kScanAllByLabelProperties);
 }
 
 TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListNonexistentValue) {
   AddVertices(100, 30, 20);
+  // IN [999]: 1 element, matches 0 vertices. Unwind factor = 1, scan sum = 0.
   auto *list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(999)});
+  auto *unwind_expr = MakeInUnwindExpression(storage_, {Literal(999)});
+  MakeOp<memgraph::query::plan::Unwind>(last_op_, unwind_expr, NextSymbol());
   auto *unwind_sym = storage_.Create<Identifier>("anon_sym");
-  MakeOp<ScanAllByLabelProperties>(nullptr,
+  MakeOp<ScanAllByLabelProperties>(last_op_,
                                    NextSymbol(),
                                    label,
                                    std::vector{ms::PropertyPath{prop_a}},
                                    std::vector{ExpressionRange::In(unwind_sym, list)});
-  EXPECT_COST(CostParam::kMinimumCost);
+  // cardinality = 1 * 0 = 0, cost = min_cost + CostParam::kUnwind
+  EXPECT_COST(CostParam::kUnwind + CostParam::kMinimumCost);
 }
 
 TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesMultipleInLists) {
@@ -503,19 +517,27 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesMultipleInLists) {
   // value i for each vertex, so only diagonal entries (i,i,i) exist.
   // prop_c = 5 (resolved), prop_a IN [5, 10] (unresolved), prop_b IN [5, 10] (unresolved).
   // True matches: only (5,5,5). Independence estimate: S_a * S_b / T = 1 * 1 / 1 = 1.
-  // Without the fix, this falls back to VerticesCount(label, props) * 0.25 = 20 * 0.25 = 5.
+  // Unwind factors: 2 * 2 = 4. Current estimate: 4 * 1 = 4 (double-counted).
   auto *list_a = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
   auto *list_b = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
+  // Chain two Unwinds (the real plan has two Unwinds for two IN clauses)
+  auto *unwind_expr_a = MakeInUnwindExpression(storage_, {Literal(5), Literal(10)});
+  MakeOp<memgraph::query::plan::Unwind>(last_op_, unwind_expr_a, NextSymbol());
+  auto *unwind_expr_b = MakeInUnwindExpression(storage_, {Literal(5), Literal(10)});
+  MakeOp<memgraph::query::plan::Unwind>(last_op_, unwind_expr_b, NextSymbol());
   auto *sym_a = storage_.Create<Identifier>("anon_a");
   auto *sym_b = storage_.Create<Identifier>("anon_b");
   MakeOp<ScanAllByLabelProperties>(
-      nullptr,
+      last_op_,
       NextSymbol(),
       label,
       std::vector{ms::PropertyPath{prop_c}, ms::PropertyPath{prop_a}, ms::PropertyPath{prop_b}},
       std::vector{
           ExpressionRange::Equal(Literal(5)), ExpressionRange::In(sym_a, list_a), ExpressionRange::In(sym_b, list_b)});
-  EXPECT_COST(1 * CostParam::kScanAllByLabelProperties);
+  // Unwind 1: cost += 1 * kUnwind, cardinality = 2
+  // Unwind 2: cost += 2 * kUnwind, cardinality = 4
+  // Scan(S=1): cardinality *= 1 = 4, cost += 4 * kScanAllByLabelProperties
+  EXPECT_COST(3 * CostParam::kUnwind + 4 * CostParam::kScanAllByLabelProperties);
 }
 
 #undef TEST_OP

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -443,6 +443,7 @@ TEST_F(QueryCostEstimator, UnwindNoLiteral) {
           MiscParam::kUnwindNoLiteral);
 }
 
+namespace {
 // Helper to build the toSet(coalesce(list, [])) AST pattern produced by IN-to-Unwind lowering.
 Expression *MakeInUnwindExpression(AstStorage &storage, std::vector<Expression *> elements) {
   auto *inner_list = storage.Create<ListLiteral>(std::move(elements));
@@ -453,6 +454,7 @@ Expression *MakeInUnwindExpression(AstStorage &storage, std::vector<Expression *
   toset->arguments_ = {coalesced};
   return toset;
 }
+}  // namespace
 
 TEST_F(QueryCostEstimator, UnwindInLowering) {
   auto *expr = MakeInUnwindExpression(storage_, {Literal(1), Literal(2), Literal(3)});

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -443,6 +443,60 @@ TEST_F(QueryCostEstimator, UnwindNoLiteral) {
           MiscParam::kUnwindNoLiteral);
 }
 
+// Helper to build the toSet(coalesce(list, [])) AST pattern produced by IN-to-Unwind lowering.
+Expression *MakeInUnwindExpression(AstStorage &storage, std::vector<Expression *> elements) {
+  auto *inner_list = storage.Create<ListLiteral>(std::move(elements));
+  auto *empty_list = storage.Create<ListLiteral>(std::vector<Expression *>{});
+  auto *coalesced = storage.Create<Coalesce>(std::vector<Expression *>{inner_list, empty_list});
+  auto *toset = storage.Create<Function>();
+  toset->function_name_ = "TOSET";
+  toset->arguments_ = {coalesced};
+  return toset;
+}
+
+TEST_F(QueryCostEstimator, UnwindInLowering) {
+  auto *expr = MakeInUnwindExpression(storage_, {Literal(1), Literal(2), Literal(3)});
+  TEST_OP(MakeOp<memgraph::query::plan::Unwind>(last_op_, expr, NextSymbol()), CostParam::kUnwind, 3);
+}
+
+// -- IN-list cardinality estimation tests --
+
+TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInList) {
+  AddVertices(100, 30, 20);
+  auto *list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(12)});
+  auto *unwind_sym = storage_.Create<Identifier>("anon_sym");
+  MakeOp<ScanAllByLabelProperties>(nullptr,
+                                   NextSymbol(),
+                                   label,
+                                   std::vector{ms::PropertyPath{prop_a}},
+                                   std::vector{ExpressionRange::In(unwind_sym, list)});
+  EXPECT_COST(1 * CostParam::kScanAllByLabelProperties);
+}
+
+TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListMultipleElements) {
+  AddVertices(100, 30, 20);
+  auto *list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(5), Literal(10)});
+  auto *unwind_sym = storage_.Create<Identifier>("anon_sym");
+  MakeOp<ScanAllByLabelProperties>(nullptr,
+                                   NextSymbol(),
+                                   label,
+                                   std::vector{ms::PropertyPath{prop_a}},
+                                   std::vector{ExpressionRange::In(unwind_sym, list)});
+  EXPECT_COST(2 * CostParam::kScanAllByLabelProperties);
+}
+
+TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesInListNonexistentValue) {
+  AddVertices(100, 30, 20);
+  auto *list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(999)});
+  auto *unwind_sym = storage_.Create<Identifier>("anon_sym");
+  MakeOp<ScanAllByLabelProperties>(nullptr,
+                                   NextSymbol(),
+                                   label,
+                                   std::vector{ms::PropertyPath{prop_a}},
+                                   std::vector{ExpressionRange::In(unwind_sym, list)});
+  EXPECT_COST(CostParam::kMinimumCost);
+}
+
 #undef TEST_OP
 #undef EXPECT_COST
 
@@ -486,6 +540,20 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesDescSameCostAsAsc) {
   auto desc_cost = Cost();
 
   EXPECT_FLOAT_EQ(asc_cost, desc_cost);
+}
+
+TEST_F(QueryCostEstimator, ExtractListFromInUnwindNonMatching) {
+  EXPECT_EQ(ExtractListFromInUnwind(nullptr), nullptr);
+  EXPECT_EQ(ExtractListFromInUnwind(Literal(42)), nullptr);
+  auto *plain_list = storage_.Create<ListLiteral>(std::vector<Expression *>{Literal(1)});
+  EXPECT_EQ(ExtractListFromInUnwind(plain_list), nullptr);
+}
+
+TEST_F(QueryCostEstimator, ExtractListFromInUnwindMatching) {
+  auto *expr = MakeInUnwindExpression(storage_, {Literal(1), Literal(2)});
+  auto *extracted = ExtractListFromInUnwind(expr);
+  ASSERT_NE(extracted, nullptr);
+  EXPECT_EQ(extracted->elements_.size(), 2);
 }
 
 // TODO test cost when ScanAll, Expand, Accumulate, Limit

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2516,7 +2516,7 @@ TYPED_TEST(TestPlanner, LabelPropertyInListValidOptimization) {
               ExpectUnwind(),
               ExpectScanAllByLabelProperties(label,
                                              std::vector{ms::PropertyPath{property.second}},
-                                             std::vector{ExpressionRange::In(fake_identifier, nullptr)}),
+                                             std::vector{ExpressionRange::In(fake_identifier, lit_list_a)}),
               ExpectProduce());
   }
 }

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2516,7 +2516,7 @@ TYPED_TEST(TestPlanner, LabelPropertyInListValidOptimization) {
               ExpectUnwind(),
               ExpectScanAllByLabelProperties(label,
                                              std::vector{ms::PropertyPath{property.second}},
-                                             std::vector{ExpressionRange::Equal(fake_identifier)}),
+                                             std::vector{ExpressionRange::In(fake_identifier, nullptr)}),
               ExpectProduce());
   }
 }
@@ -2534,13 +2534,13 @@ TYPED_TEST(TestPlanner, LabelPropertyInListParameter) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
   auto fake_identifier = IDENT("fake");
-  CheckPlan(
-      planner.plan(),
-      symbol_table,
-      ExpectUnwind(),
-      ExpectScanAllByLabelProperties(
-          label, std::vector{ms::PropertyPath{property.second}}, std::vector{ExpressionRange::Equal(fake_identifier)}),
-      ExpectProduce());
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectUnwind(),
+            ExpectScanAllByLabelProperties(label,
+                                           std::vector{ms::PropertyPath{property.second}},
+                                           std::vector{ExpressionRange::In(fake_identifier, nullptr)}),
+            ExpectProduce());
 }
 
 TYPED_TEST(TestPlanner, LabelPropertyInListWhereLabelPropertyOnLeftNotListOnRight) {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2949,7 +2949,7 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesLabelPropertyIndex) {
         new ExpectUnwind(),
         new ExpectScanAllByLabelProperties(label,
                                            std::vector{ms::PropertyPath{property.second}},
-                                           std::vector{ExpressionRange::Equal(fake_identifier)}),
+                                           std::vector{ExpressionRange::In(fake_identifier, nullptr)}),
         new ExpectProduce()};
     CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
     DeleteListContent(&branch);

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -639,6 +639,7 @@ class ExpectScanAllByLabelProperties : public OpChecker<ScanAllByLabelProperties
 
     auto const compare_expression_range = [&](auto &&lhs, auto &&rhs) {
       if (lhs.type_ != rhs.type_) return false;
+      if ((lhs.membership_list_ == nullptr) != (rhs.membership_list_ == nullptr)) return false;
       return compare_bound_expression(lhs.lower_, rhs.lower_) && compare_bound_expression(lhs.upper_, rhs.upper_);
     };
 


### PR DESCRIPTION
Fixes cardinality estimations when using `IN` expressions with `label+properties` indices.

Previously, `MATCH (x:L) WHERE x.p IN ["a", "b"]` would unwind the `IN` to two rows with an anonymous symbol that could not be resolved by `ResolveAtPlantime`. It would instead fall back to an estimate based on total vertex count of that label and property.

We now pass the underlying membership list through to the estimator, where it can iterate the list members and sum the estimated cardinality for each property value.

This also supports multiple properties against a composite index, e.g., for `WHERE x.a IN [...] AND x.b IN [...])`, we estimate each slot's marginal cardinality independently and combine them.

The same unresolved-symbol problem existed in the index rewriter's `EstimateIndexedScanCardinality`, which is used when comparing candidate indices (including `USING` index hints). Both paths now share the same `EstimateInListSum` helper. 