### PR TITLE
fix: bump cyptography to address CVE-2026-69247

### DIFF
--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1228,7 +1228,7 @@ package_smoke_image() {
   # mgp_networkx, nxalg, wcc, graph_analyzer, etc.). Mirrors the pip
   # installs in release/docker/v7_deb.dockerfile. gssapi has no PyPI wheels
   # so it must be supplied as a pre-built wheel via --wheels-dir.
-  local pip_packages="cryptography==49.0.0 PyJWT==2.13.0 requests==2.32.5 \
+  local pip_packages="cryptography==50.0.0 PyJWT==2.13.0 requests==2.32.5 \
 ldap3==2.6 pyyaml==6.0.1 python3-saml==1.16.0 lxml==6.1.0 xmlsec==1.3.16 \
 gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==${networkx_version}"
 

--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==49.0.0
+cryptography==50.0.0
 PyJWT==2.13.0
 requests==2.34.2
 ldap3==2.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 behave==1.2.6
 boto3==1.40.59
 chardet==4.0.0
-cryptography==49.0.0
+cryptography==50.0.0
 faker==37.3.0
 gqlalchemy==1.8.0
 idna==3.15

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -18,7 +18,7 @@ pulsar-client==3.5.0
 pyarrow==24.0.0
 PyJWT==2.13.0
 pymgclient==1.5.2
-pyopenssl==26.3.0
+pyopenssl==26.4.0
 pytest==9.0.3
 pytest-cov==6.0.0
 pytest-flake8==1.3.0


### PR DESCRIPTION
Bump `cryptography` Python module packaged with Memgraph and MAGE to address high severity CVE: [CVE-2026-69247](https://github.com/advisories/GHSA-g6cj-pr64-35w5)

