### PR TITLE
File IO improvements

### DIFF
--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -161,6 +161,19 @@ DEFINE_uint64(storage_snapshot_writeback_window_mib,
               "system, which can let a large snapshot slow down queries and evict cached data.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_bool(storage_release_recovered_snapshot_page_cache,
+            memgraph::storage::Config::Durability().release_recovered_snapshot_page_cache,
+            "Release a snapshot from the operating system's file cache once recovery has loaded it, so it stops "
+            "holding memory the database could use. Set to false to leave it cached.");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_bool(storage_release_sent_snapshot_page_cache,
+            memgraph::storage::Config::Durability().release_sent_snapshot_page_cache,
+            "Release a snapshot from the operating system's file cache once it has been sent to a replica. Off by "
+            "default, because any further replica syncing from the same snapshot then has to read it from disk "
+            "again. Set to true to free the memory sooner on an instance that syncs a replica once.");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint64(storage_recovery_thread_count,
               std::max(static_cast<uint64_t>(memgraph::utils::GetSafeHardwareConcurrency()),
                        memgraph::storage::Config::Durability().recovery_thread_count),

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -154,6 +154,13 @@ DEFINE_uint64(storage_snapshot_thread_count,
               "The number of threads used to create snapshots.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_uint64(storage_snapshot_writeback_window_mib,
+              memgraph::storage::Config::Durability().snapshot_writeback_window_mib,
+              "How much of a snapshot may build up in the operating system's file cache before it is written out "
+              "to disk and released, in MiB. Applies per snapshot thread. Set to 0 to leave this to the operating "
+              "system, which can let a large snapshot slow down queries and evict cached data.");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint64(storage_recovery_thread_count,
               std::max(static_cast<uint64_t>(memgraph::utils::GetSafeHardwareConcurrency()),
                        memgraph::storage::Config::Durability().recovery_thread_count),

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -94,6 +94,10 @@ DECLARE_uint64(storage_snapshot_thread_count);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint64(storage_snapshot_writeback_window_mib);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_bool(storage_release_recovered_snapshot_page_cache);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_bool(storage_release_sent_snapshot_page_cache);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint64(storage_recovery_thread_count);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_enable_schema_metadata);

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -92,6 +92,8 @@ DECLARE_bool(storage_parallel_schema_recovery);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint64(storage_snapshot_thread_count);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_uint64(storage_snapshot_writeback_window_mib);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint64(storage_recovery_thread_count);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_enable_schema_metadata);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -70,6 +70,7 @@
 #include "utils/build_info.hpp"
 #include "utils/file.hpp"
 #include "utils/logging.hpp"
+#include "utils/page_cache_releaser.hpp"
 #include "utils/readable_size.hpp"
 #include "utils/resource_monitoring.hpp"
 #include "utils/scheduler.hpp"
@@ -306,6 +307,11 @@ int main(int argc, char **argv) {
                  build_info.build_name);
   }
 
+  // Owns the thread that drops read-through snapshots from the page cache. Declared here so it
+  // outlives every database that can hand it a file, and is joined before `main` returns rather
+  // than during static destruction.
+  auto const page_cache_releaser = memgraph::utils::InstallPageCacheReleaser();
+
   // Fail fast if --cluster-{cert,key,ca}-file are partially configured.
   // Must run after logger init so the fatal message is delivered.
   memgraph::flags::ValidateIntraClusterTLSFlags();
@@ -538,6 +544,8 @@ int main(int argc, char **argv) {
                      .snapshot_thread_count = FLAGS_storage_snapshot_thread_count,
                      .recovery_thread_count = FLAGS_storage_recovery_thread_count,
                      .snapshot_writeback_window_mib = FLAGS_storage_snapshot_writeback_window_mib,
+                     .release_recovered_snapshot_page_cache = FLAGS_storage_release_recovered_snapshot_page_cache,
+                     .release_sent_snapshot_page_cache = FLAGS_storage_release_sent_snapshot_page_cache,
                      .allow_parallel_snapshot_creation = FLAGS_storage_parallel_snapshot_creation,
                      .allow_parallel_schema_creation = FLAGS_storage_parallel_schema_recovery},
       .transaction = {.isolation_level = memgraph::flags::ParseIsolationLevel()},

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -537,6 +537,7 @@ int main(int argc, char **argv) {
                      .items_per_batch = FLAGS_storage_items_per_batch,
                      .snapshot_thread_count = FLAGS_storage_snapshot_thread_count,
                      .recovery_thread_count = FLAGS_storage_recovery_thread_count,
+                     .snapshot_writeback_window_mib = FLAGS_storage_snapshot_writeback_window_mib,
                      .allow_parallel_snapshot_creation = FLAGS_storage_parallel_snapshot_creation,
                      .allow_parallel_schema_creation = FLAGS_storage_parallel_schema_recovery},
       .transaction = {.isolation_level = memgraph::flags::ParseIsolationLevel()},

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -104,6 +104,10 @@ struct Config {
     uint64_t snapshot_thread_count{8};    // PER INSTANCE SYSTEM FLAG
     uint64_t recovery_thread_count{8};    // PER INSTANCE SYSTEM FLAG
 
+    // Per snapshot writer, so a parallel snapshot may hold this much again for every thread it
+    // uses. 0 disables pacing.
+    uint64_t snapshot_writeback_window_mib{32};  // PER INSTANCE SYSTEM FLAG
+
     bool allow_parallel_snapshot_creation{false};  // PER DATABASE
     bool allow_parallel_schema_creation{false};    // PER DATABASE
     friend bool operator==(const Durability &lrh, const Durability &rhs) = default;

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -108,6 +108,16 @@ struct Config {
     // uses. 0 disables pacing.
     uint64_t snapshot_writeback_window_mib{32};  // PER INSTANCE SYSTEM FLAG
 
+    // Whether a snapshot is released from the page cache once recovery has loaded it. Nothing on
+    // this instance reads that file again, so its pages only compete with the graph built from them.
+    bool release_recovered_snapshot_page_cache{true};  // PER INSTANCE SYSTEM FLAG
+
+    // Whether a snapshot is released from the page cache once it has been sent to a replica. A
+    // separate decision from the one above, and off by default: the file cache is reclaimable on
+    // demand, so releasing it buys memory the kernel could take back anyway, while costing every
+    // further replica syncing from the same snapshot a re-read from the device.
+    bool release_sent_snapshot_page_cache{false};  // PER INSTANCE SYSTEM FLAG
+
     bool allow_parallel_snapshot_creation{false};  // PER DATABASE
     bool allow_parallel_schema_creation{false};    // PER DATABASE
     friend bool operator==(const Durability &lrh, const Durability &rhs) = default;

--- a/src/storage/v2/durability/serialization.cpp
+++ b/src/storage/v2/durability/serialization.cpp
@@ -283,6 +283,13 @@ uint64_t Encoder<FileType>::GetPosition() {
 }
 
 template <typename FileType>
+std::optional<uint64_t> Encoder<FileType>::AppendFrom(int src_fd, uint64_t size)
+  requires std::same_as<FileType, utils::NonConcurrentOutputFile>
+{
+  return file_.AppendFrom(src_fd, size);
+}
+
+template <typename FileType>
 void Encoder<FileType>::SetPosition(uint64_t position) {
   file_.SetPosition(FileType::Position::SET, position);
 }
@@ -293,8 +300,10 @@ void Encoder<FileType>::Sync() {
 }
 
 template <typename FileType>
-void Encoder<FileType>::Finalize() {
+void Encoder<FileType>::Finalize(utils::PageCachePolicy page_cache) {
   file_.Sync();
+  // After the sync every page is clean, which is the only state in which dropping them works.
+  if (page_cache == utils::PageCachePolicy::kDrop) file_.DropCachedPages();
   file_.Close();
 }
 

--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -11,8 +11,10 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <string_view>
 
 #include "storage/v2/config.hpp"
@@ -61,6 +63,10 @@ class Encoder final : public BaseEncoder {
   // directly.
   void Write(const uint8_t *data, uint64_t size);
 
+  /// See NonConcurrentOutputFile::AppendFrom.
+  [[nodiscard]] std::optional<uint64_t> AppendFrom(int src_fd, uint64_t size)
+    requires std::same_as<FileType, utils::NonConcurrentOutputFile>;
+
   void WriteMarker(Marker marker) override;
   void WriteBool(bool value) override;
   void WriteUint(uint64_t value) override;
@@ -78,7 +84,16 @@ class Encoder final : public BaseEncoder {
 
   void Sync();
 
-  void Finalize();
+  /// See NonConcurrentOutputFile::EnableWritebackPacing.
+  void EnableWritebackPacing(size_t window_bytes,
+                             utils::PageCachePolicy completed_window = utils::PageCachePolicy::kDrop)
+    requires std::same_as<FileType, utils::NonConcurrentOutputFile>
+  {
+    file_.EnableWritebackPacing(window_bytes, completed_window);
+  }
+
+  /// Syncs and closes the file, disposing of its pages as `page_cache` says.
+  void Finalize(utils::PageCachePolicy page_cache = utils::PageCachePolicy::kKeep);
 
   // Disable flushing of the internal buffer.
   void DisableFlushing()
@@ -97,8 +112,6 @@ class Encoder final : public BaseEncoder {
 
   auto GetPath() const { return file_.path(); }
 
-  auto native_handle() const { return file_.fd(); }
-
   void ResetCrcAcc() override { crc_acc.Reset(); }
 
   auto CrcAccValue() const -> uint32_t override { return crc_acc.Value(); }
@@ -112,6 +125,14 @@ class Encoder final : public BaseEncoder {
 /// (e.g. file and network).
 class BaseDecoder {
  protected:
+  // An interface base with a protected destructor still has to say what its special members are, or
+  // a derived class that owns a move-only handle silently loses its move constructor to the
+  // deprecated implicit copy.
+  BaseDecoder() = default;
+  BaseDecoder(const BaseDecoder &) = default;
+  BaseDecoder(BaseDecoder &&) = default;
+  BaseDecoder &operator=(const BaseDecoder &) = default;
+  BaseDecoder &operator=(BaseDecoder &&) = default;
   ~BaseDecoder() = default;
 
  public:
@@ -141,6 +162,9 @@ class Decoder final : public BaseDecoder {
   // directly.
   bool Read(uint8_t *data, size_t size);
   bool Peek(uint8_t *data, size_t size);
+
+  /// See InputFile::DropCachedPages.
+  void DropCachedPages() const { file_.DropCachedPages(); }
 
   std::optional<Marker> PeekMarker();
 

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -59,6 +59,7 @@
 #include "utils/logging.hpp"
 #include "utils/message.hpp"
 #include "utils/on_scope_exit.hpp"
+#include "utils/page_cache_releaser.hpp"
 #include "utils/spin_lock.hpp"
 #include "utils/synchronized.hpp"
 #include "utils/thread.hpp"
@@ -432,6 +433,17 @@ bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Ver
   }
   return all_ok;
 };
+
+// Drops a fully-read snapshot from the page cache, off the caller's thread where the process has a
+// releaser to do that on, and on the caller's thread where it does not. Both reach the same state;
+// only the second one waits.
+void DropPageCache(Decoder snapshot) {
+  if (auto const releaser = utils::PageCacheReleaserHandle().lock()) {
+    releaser->Drop(std::move(snapshot));
+    return;
+  }
+  snapshot.DropCachedPages();
+}
 
 // Function used to read information about the snapshot file.
 SnapshotInfo ReadSnapshotInfoPreVersion23(const std::filesystem::path &path) {
@@ -13523,6 +13535,14 @@ RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipLis
   const auto version = snapshot.Initialize(path, kSnapshotMagic);
   if (!version) throw RecoveryFailure("Couldn't read snapshot magic and/or version!");
   if (!IsVersionSupported(*version)) throw RecoveryFailure(fmt::format("Invalid snapshot version {}", *version));
+
+  // Recovery is the only reader of this file, and once it is done the pages are pure overhead: they
+  // compete for memory with the graph just built from them. Dropped after the load rather than
+  // behind the read point, because the load revisits ranges it has already read, and dropping
+  // during it makes those ranges come back from the device a second time.
+  utils::OnScopeExit const drop_page_cache{[&snapshot, &config] {
+    if (config.durability.release_recovered_snapshot_page_cache) DropPageCache(std::move(snapshot));
+  }};
 
   switch (*version) {
     case 14U: {

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -10,10 +10,10 @@
 // licenses/APL.txt.
 
 #include "storage/v2/durability/snapshot.hpp"
+
 #include <range/v3/all.hpp>
 
 #include <fmt/core.h>
-#include <sys/sendfile.h>
 #include <algorithm>
 #include <atomic>
 #include <filesystem>
@@ -279,19 +279,17 @@ bool WaitAndCombine(task_results_t &partial_results, SnapshotEncoder &snapshot_e
         throw RecoveryFailure("Couldn't open snapshot part {}!", res.snapshot_path);
       }
       utils::OnScopeExit cleanup{[part_fd] { close(part_fd); }};
-      // Use sendfile for efficient copying (zero-copy)
-      off_t offset = 0;
-      auto size = res.snapshot_size;
-      while (size > 0) {
-        ssize_t bytes_sent = sendfile(snapshot_encoder.native_handle(), part_fd, &offset, size);
-        if (bytes_sent == -1) {
-          throw RecoveryFailure("Couldn't copy {} part to snapshot! Error: {}", res.snapshot_path, strerror(errno));
-        }
-        if (bytes_sent == 0) {
-          spdlog::trace("EOF {}", res.snapshot_path);
-          break;
-        }
-        size -= bytes_sent;
+      // Copied inside the kernel, and through the encoder so that writeback pacing still bounds
+      // the dirty pages of the snapshot these parts are being folded into.
+      auto const copied = snapshot_encoder.AppendFrom(part_fd, res.snapshot_size);
+      if (!copied) {
+        throw RecoveryFailure("Couldn't copy {} part to snapshot! Error: {}", res.snapshot_path, strerror(errno));
+      }
+      // The part was sized after its last write and synced before its promise was set, so ending
+      // early is not EOF but a part shorter than it claimed to be.
+      if (*copied < res.snapshot_size) {
+        throw RecoveryFailure(
+            "Snapshot part {} ended after {} of {} bytes!", res.snapshot_path, *copied, res.snapshot_size);
       }
     }
   }
@@ -329,7 +327,8 @@ bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Ver
                            uint64_t &offset_edges, uint64_t &offset_vertices, SnapshotEncoder &snapshot_encoder,
                            uint64_t &edges_count, uint64_t &vertices_count, std::vector<BatchInfo> &edge_batch_infos,
                            std::vector<BatchInfo> &vertex_batch_infos, std::unordered_set<uint64_t> &used_ids,
-                           uint64_t thread_count, auto &&snapshot_aborted, SnapshotProgress *progress = nullptr) {
+                           uint64_t thread_count, size_t writeback_window, auto &&snapshot_aborted,
+                           SnapshotProgress *progress = nullptr) {
   SafeTaskQueue tasks;
 
   // Generate edge tasks
@@ -342,12 +341,15 @@ bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Ver
       tasks.AddTask([&edge_res,
                      &partial_edge_handler,
                      id,
+                     writeback_window,
                      start_gid = edge_batch_gid[id],
                      end_gid = edge_batch_gid[id + 1],
                      path = snapshot_encoder.GetPath()] {
         // Create workers temporary file
         {
           SnapshotEncoder edges_snapshot;
+          // This part is copied into the snapshot and deleted moments later, so its pages stay.
+          edges_snapshot.EnableWritebackPacing(writeback_window, utils::PageCachePolicy::kKeep);
           const auto snapshot_path = fmt::format("{}_edge_part_{}", path, id);
           if (!edges_snapshot.Initialize(snapshot_path)) {
             spdlog::warn(
@@ -359,7 +361,7 @@ bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Ver
           }
           // Fill snapshot with edges
           edge_res[id].first = partial_edge_handler(start_gid, end_gid, edges_snapshot);
-          edges_snapshot.Finalize();
+          edges_snapshot.Finalize(utils::PageCachePolicy::kKeep);
         }
         // Signal that the snapshot is done
         edge_res[id].second.set_value(true);
@@ -374,12 +376,14 @@ bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Ver
     tasks.AddTask([&vertex_res,
                    &partial_vertex_handler,
                    id,
+                   writeback_window,
                    start_gid = vertex_batch_gid[id],
                    end_gid = vertex_batch_gid[id + 1],
                    path = snapshot_encoder.GetPath()] {
       // Create workers temporary file
       {
         SnapshotEncoder vertex_snapshot;
+        vertex_snapshot.EnableWritebackPacing(writeback_window, utils::PageCachePolicy::kKeep);
         const auto snapshot_path = fmt::format("{}_vertex_part_{}", path, id);
         if (!vertex_snapshot.Initialize(snapshot_path)) {
           spdlog::warn(
@@ -391,7 +395,7 @@ bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Ver
         }
         // Fill snapshot with vertices
         vertex_res[id].first = partial_vertex_handler(start_gid, end_gid, vertex_snapshot);
-        vertex_snapshot.Finalize();
+        vertex_snapshot.Finalize(utils::PageCachePolicy::kKeep);
       }
       // Signal that the snapshot is done
       vertex_res[id].second.set_value(true);
@@ -14157,8 +14161,17 @@ std::optional<std::filesystem::path> CreateSnapshot(
     return true;
   };
 
+  // How much of this snapshot may sit in the page cache as dirty pages before it is handed to
+  // writeback and dropped. A snapshot is a multi-gigabyte streaming write; left to the kernel's
+  // defaults its dirty pages accumulate until every writer on the machine is throttled at
+  // `dirty_ratio`, and its clean pages evict whatever the workload was using. Pacing costs a little
+  // snapshot throughput and stops the snapshot degrading everything around it. Each parallel writer
+  // below gets the same window, so the footprint scales with the thread count. 0 disables it.
+  auto const writeback_window = storage->config_.durability.snapshot_writeback_window_mib * 1024UL * 1024UL;
+
   spdlog::info("snapshot starting: {} (trigger={})", path, trigger);
   SnapshotEncoder snapshot;
+  snapshot.EnableWritebackPacing(writeback_window);
   if (!snapshot.Initialize(path, kSnapshotMagic, kVersion)) {
     spdlog::warn(
         "Failed to open snapshot file {}. Not a fatal failure, snapshot creation will be retried on the next scheduled "
@@ -14521,6 +14534,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
                                vertex_batch_infos,
                                used_ids,
                                storage->config_.durability.snapshot_thread_count,
+                               writeback_window,
                                snapshot_aborted,
                                progress)) {
       spdlog::warn(
@@ -15096,7 +15110,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     return std::nullopt;
   }
 
-  snapshot.Finalize();
+  snapshot.Finalize(utils::PageCachePolicy::kDrop);
   // The snapshot file is now complete and valid on disk. Mark cleanup as done BEFORE any
   // post-finalize housekeeping (file_size / retention / WAL-ensure below) so that a throw from
   // those steps cannot trip partial_file_cleanup into deleting a finalized, valid snapshot.

--- a/src/storage/v2/indices/label_property_index.cpp
+++ b/src/storage/v2/indices/label_property_index.cpp
@@ -122,9 +122,9 @@ auto PropertiesPermutationHelper::MatchesValue(PropertyId outer_prop_id, Propert
   return relevant_paths | rv::transform(is_match) | r::to_vector;
 }
 
-auto PropertiesPermutationHelper::MatchesValues(PropertyStore const &properties, IndexOrderedValuesView values) const
-    -> std::vector<bool> {
-  return properties.ArePropertiesEqual(sorted_properties_, values, position_lookup_);
+void PropertiesPermutationHelper::MatchesValues(PropertyStore const &properties, IndexOrderedValuesView values,
+                                                std::vector<bool> &out) const {
+  properties.ArePropertiesEqual(sorted_properties_, values, position_lookup_, out);
 }
 
 size_t PropertyValueRange::hash() const noexcept {

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -260,10 +260,13 @@ struct PropertiesPermutationHelper {
       -> std::vector<std::pair<std::ptrdiff_t, bool>>;
 
   /** Efficiently compares multiple values in the property store with the given
-   * values. This returns a vector of boolean flags indicating per-element
-   * equality (in monotonic property id order.)
+   * values. Fills `out` with per-element equality flags, in monotonic property id order.
+   *
+   * `out` is supplied by the caller rather than returned, because both callers walk index
+   * entries in a loop and so pay for the storage once instead of once per entry. Its previous
+   * contents are discarded.
    */
-  auto MatchesValues(PropertyStore const &properties, IndexOrderedValuesView values) const -> std::vector<bool>;
+  void MatchesValues(PropertyStore const &properties, IndexOrderedValuesView values, std::vector<bool> &out) const;
 
   /** Returns an augmented view over the values in the given vector, where each
    * element is a tuple comprising: (position, [property id path], and value).

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -115,11 +115,11 @@ void EraseEntriesAtKey(Acc &acc, IndexOrderedValuesVector const &values, Vertex 
 // given label and properties.
 bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, PropertiesPermutationHelper const &helper,
                                       IndexOrderedValuesView values, Transaction *transaction, View view,
-                                      bool use_cache = true) {
+                                      std::vector<bool> &scratch, bool use_cache = true) {
   bool exists = true;
   bool deleted = false;
   bool has_label = false;
-  auto current_values_equal_to_value = std::vector<bool>{};
+  auto &current_values_equal_to_value = scratch;
   const Delta *delta = nullptr;
   auto guard = std::shared_lock{vertex.lock};
   delta = vertex.delta();
@@ -127,7 +127,7 @@ bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, Prope
   if (!delta && deleted) return false;
   has_label = std::ranges::contains(vertex.labels, label);
   if (!delta && !has_label) return false;
-  current_values_equal_to_value = helper.MatchesValues(vertex.properties, values);
+  helper.MatchesValues(vertex.properties, values, current_values_equal_to_value);
 
   // If vertex has non-sequential deltas, hold lock while applying them
   if (!vertex.has_uncommitted_non_sequential_deltas()) {
@@ -211,12 +211,12 @@ bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, Prope
 /// properties values.
 inline bool AnyVersionHasLabelProperties(const Vertex &vertex, LabelId label, std::span<PropertyPath const> key,
                                          PropertiesPermutationHelper const &helper, IndexOrderedValuesView values,
-                                         uint64_t timestamp) {
+                                         uint64_t timestamp, std::vector<bool> &scratch) {
   Delta const *delta;
   bool exists = true;
   bool deleted;
   bool has_label;
-  auto current_values_equal_to_value = std::vector<bool>{};
+  auto &current_values_equal_to_value = scratch;
   {
     auto guard = std::shared_lock{vertex.lock};
     delta = vertex.delta();
@@ -224,7 +224,7 @@ inline bool AnyVersionHasLabelProperties(const Vertex &vertex, LabelId label, st
     if (delta == nullptr && deleted) return false;
     has_label = std::ranges::contains(vertex.labels, label);
     if (delta == nullptr && !has_label) return false;
-    current_values_equal_to_value = helper.MatchesValues(vertex.properties, values);
+    helper.MatchesValues(vertex.properties, values, current_values_equal_to_value);
   }
 
   if (exists && !deleted && has_label && std::ranges::all_of(current_values_equal_to_value, std::identity{})) {
@@ -259,7 +259,7 @@ inline bool AnyVersionHasLabelProperties(const Vertex &vertex, LabelId label, st
 void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_vertex, auto &current_vertex_accessor,
                         auto *storage, auto *transaction, auto view, auto label, const auto &lower_bound,
                         const auto &upper_bound, auto &permutation_helper, memgraph::storage::Gid max_gid,
-                        bool use_cache = true, bool reverse_iteration = false) {
+                        std::vector<bool> &match_scratch, bool use_cache = true, bool reverse_iteration = false) {
   for (; index_iterator != end; ++index_iterator) {
     if (index_iterator->vertex == current_vertex) {
       continue;
@@ -361,6 +361,7 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
                                          index_iterator->values.as_view(),
                                          transaction,
                                          view,
+                                         match_scratch,
                                          use_cache)) {
       current_vertex = index_iterator->vertex;
       current_vertex_accessor = VertexAccessor(current_vertex, storage, transaction);
@@ -1092,6 +1093,7 @@ uint64_t InMemoryLabelPropertyIndex::RemoveObsoleteEntries(Storage *storage, uin
         auto it = index_acc.begin();
         auto end_it = index_acc.end();
         if (it == end_it) return false;
+        auto match_scratch = std::vector<bool>{};
         while (true) {
           if (maybe_stop() && token.stop_requested()) return true;
 
@@ -1106,7 +1108,8 @@ uint64_t InMemoryLabelPropertyIndex::RemoveObsoleteEntries(Storage *storage, uin
                                                                      property_paths,
                                                                      permutationHelper,
                                                                      it->values.as_view(),
-                                                                     oldest_active_start_timestamp)) {
+                                                                     oldest_active_start_timestamp,
+                                                                     match_scratch)) {
               index_acc.remove(*it);
             }
           }
@@ -1162,6 +1165,7 @@ void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid()
                      self_->upper_bound_,
                      self_->permutation_helper_,
                      self_->max_gid_,
+                     match_scratch_,
                      /*use_cache=*/true,
                      /*reverse_iteration=*/is_desc);
 }
@@ -1531,6 +1535,7 @@ void InMemoryLabelPropertyIndex::ChunkedIterable<EntryT>::Iterator::AdvanceUntil
                      self_->upper_bound_,
                      self_->permutation_helper_,
                      self_->max_gid_,
+                     match_scratch_,
                      /*use_cache=*/false,
                      /*reverse_iteration=*/is_desc);
 }

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -18,6 +18,7 @@
 #include <span>
 #include <tuple>
 #include <variant>
+#include <vector>
 
 #include "memory/db_arena_fwd.hpp"
 #include "metrics/metric_handles.hpp"
@@ -309,6 +310,9 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
       typename utils::SkipListDb<EntryT>::Iterator index_iterator_;
       VertexAccessor current_vertex_accessor_;
       Vertex *current_vertex_;
+      // Owned by the iterator rather than by each advance, so one buffer serves the whole sweep.
+      // Its width is the index's arity, so it stops growing after the first entry compared.
+      std::vector<bool> match_scratch_;
     };
 
     Iterator begin();
@@ -367,6 +371,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
       typename utils::SkipListDb<EntryT>::ChunkedIterator index_iterator_;
       VertexAccessor current_vertex_accessor_;
       Vertex *current_vertex_{nullptr};
+      // See the corresponding member on Iterable::Iterator.
+      std::vector<bool> match_scratch_;
     };
 
     class Chunk {

--- a/src/storage/v2/inmemory/replication/recovery.hpp
+++ b/src/storage/v2/inmemory/replication/recovery.hpp
@@ -48,8 +48,9 @@ inline auto GetFilePathWithoutDataDir(std::filesystem::path const &orig, std::fi
 
 template <typename T>
   requires(std::is_same_v<T, std::filesystem::path>)
-bool WriteFiles(const T &path, std::filesystem::path const &root_data_dir, replication::Encoder &encoder) {
-  if (!encoder.WriteFile(path, GetFilePathWithoutDataDir(path, root_data_dir))) {
+bool WriteFiles(const T &path, std::filesystem::path const &root_data_dir, replication::Encoder &encoder,
+                utils::PageCachePolicy const page_cache) {
+  if (!encoder.WriteFile(path, GetFilePathWithoutDataDir(path, root_data_dir), page_cache)) {
     spdlog::error("File {} couldn't be loaded so it won't be transferred to the replica.", path);
     return false;
   }
@@ -58,10 +59,11 @@ bool WriteFiles(const T &path, std::filesystem::path const &root_data_dir, repli
 
 template <typename T>
   requires(std::is_same_v<T, std::vector<std::filesystem::path>>)
-bool WriteFiles(const T &paths, std::filesystem::path const &root_data_dir, replication::Encoder &encoder) {
+bool WriteFiles(const T &paths, std::filesystem::path const &root_data_dir, replication::Encoder &encoder,
+                utils::PageCachePolicy const page_cache) {
   for (const auto &path : paths) {
     // Flush the segment so the file data could start at the beginning of the next segment
-    if (!encoder.WriteFile(path, GetFilePathWithoutDataDir(path, root_data_dir))) {
+    if (!encoder.WriteFile(path, GetFilePathWithoutDataDir(path, root_data_dir), page_cache)) {
       spdlog::error("File {} couldn't be loaded so it won't be transferred to the replica.", path);
       return false;
     }
@@ -95,7 +97,8 @@ template <rpc::IsRpc T, typename R, typename... Args>
 std::optional<typename T::Response> TransferDurabilityFiles(const R &files, rpc::Client &client,
                                                             std::filesystem::path const &root_data_dir,
                                                             replication_coordination_glue::ReplicationMode const mode,
-                                                            std::string const &instance_name, Args &&...args) {
+                                                            std::string const &instance_name,
+                                                            utils::PageCachePolicy const page_cache, Args &&...args) {
   metrics::ScopedHistogramTimer const timer{RpcInfo<T>::histogram()};
   std::optional<rpc::Client::StreamHandler<T>> maybe_stream_result;
 
@@ -120,7 +123,7 @@ std::optional<typename T::Response> TransferDurabilityFiles(const R &files, rpc:
   builder->FlushSegment(/*final_segment*/ false, /*force_flush*/ true);
 
   // If writing files failed, fail the task by returning empty optional
-  if (replication::Encoder encoder(builder); !WriteFiles(files, root_data_dir, encoder)) {
+  if (replication::Encoder encoder(builder); !WriteFiles(files, root_data_dir, encoder, page_cache)) {
     return std::nullopt;
   }
 

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -2721,15 +2721,16 @@ bool PropertyStore::IsPropertyEqual(PropertyId property, const PropertyValue &va
   return WithReader(property_equal);
 }
 
-auto PropertyStore::ArePropertiesEqual(std::span<PropertyPath const> ordered_properties,
+void PropertyStore::ArePropertiesEqual(std::span<PropertyPath const> ordered_properties,
                                        std::span<PropertyValue const> values,
-                                       std::span<std::size_t const> position_lookup) const -> std::vector<bool> {
+                                       std::span<std::size_t const> position_lookup, std::vector<bool> &result) const {
   auto max_history_depth = r::max_element(ordered_properties, {}, std::mem_fn(&PropertyPath::size))->size() - 1;
   ReaderPropPositionHistory history{max_history_depth};
 
-  auto properties_are_equal = [&](Reader &reader) -> std::vector<bool> {
-    auto result = std::vector<bool>(ordered_properties.size(), false);
+  // assign rather than construct: a reused buffer keeps its capacity
+  result.assign(ordered_properties.size(), false);
 
+  auto properties_are_equal = [&](Reader &reader) {
     auto const get_result = [&](Reader &reader, PropertyPath const &path, PropertyValue const &cmp_val) {
       auto const orig_reader = reader;
 
@@ -2759,9 +2760,8 @@ auto PropertyStore::ArePropertiesEqual(std::span<PropertyPath const> ordered_pro
       auto const &value = values[position_lookup[pos]];
       safe_reader(std::tuple{property, std::cref(value)}, std::tuple{std::cref(value), pos});
     }
-    return result;
   };
-  return WithReader(properties_are_equal);
+  WithReader(properties_are_equal);
 }
 
 std::map<PropertyId, PropertyValue> PropertyStore::Properties() const {

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -114,10 +114,13 @@ class PropertyStore {
   /// allocations while performing the equality check. The time complexity of
   /// this function is O(n). `position_lookup` is an ordering mapping of values
   /// to match given property from `ordered_properties`, hence value for
-  /// `ordered_properties[0]` is `values[position_lookup[0]]`. The
-  /// returned results in std::vector<bool> correspond to `ordered_properties`
-  auto ArePropertiesEqual(std::span<PropertyPath const> ordered_properties, std::span<PropertyValue const> values,
-                          std::span<std::size_t const> position_lookup) const -> std::vector<bool>;
+  /// `ordered_properties[0]` is `values[position_lookup[0]]`. The results
+  /// written to `result` correspond to `ordered_properties`.
+  ///
+  /// `result` is supplied by the caller, and its previous contents are discarded: the comparison
+  /// itself never allocated, a returned vector did, and both callers walk index entries in a loop.
+  void ArePropertiesEqual(std::span<PropertyPath const> ordered_properties, std::span<PropertyValue const> values,
+                          std::span<std::size_t const> position_lookup, std::vector<bool> &result) const;
 
   /// Returns all properties currently stored in the store. The time complexity
   /// of this function is O(n).

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -740,6 +740,9 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                     main_mem_storage->config_.durability.root_data_directory,
                     repl_mode,
                     client_.name_,
+                    main_mem_storage->config_.durability.release_sent_snapshot_page_cache
+                        ? utils::PageCachePolicy::kDrop
+                        : utils::PageCachePolicy::kKeep,
                     main_uuid,
                     main_mem_storage->uuid());
                 // Error happened on our side when trying to load snapshot file
@@ -799,6 +802,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                     main_mem_storage->config_.durability.root_data_directory,
                     repl_mode,
                     client_.name_,
+                    utils::PageCachePolicy::kKeep,
                     wals.size(),
                     main_uuid,
                     main_mem_storage->uuid(),
@@ -856,6 +860,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                       main_mem_storage->config_.durability.root_data_directory,
                       repl_mode,
                       client_.name_,
+                      utils::PageCachePolicy::kKeep,
                       main_uuid,
                       main_mem_storage->uuid(),
                       do_reset);

--- a/src/storage/v2/replication/serialization.cpp
+++ b/src/storage/v2/replication/serialization.cpp
@@ -78,7 +78,8 @@ void Encoder::WriteFileData(utils::InputFile *file) {
   }
 }
 
-bool Encoder::WriteFile(const std::filesystem::path &path, std::filesystem::path const &path_to_write) {
+bool Encoder::WriteFile(const std::filesystem::path &path, std::filesystem::path const &path_to_write,
+                        utils::PageCachePolicy const page_cache) {
   builder_->PrepareForFileSending();
   utils::InputFile file;
   if (!file.Open(path)) {
@@ -93,6 +94,9 @@ bool Encoder::WriteFile(const std::filesystem::path &path, std::filesystem::path
   auto const file_size = file.GetSize();
   WriteUint(file_size);
   WriteFileData(&file);
+  // The read is done and left the file's pages clean, which is the only state they can be evicted
+  // in. The bytes are already in the stream's buffers, so nothing here waits on the replica.
+  if (page_cache == utils::PageCachePolicy::kDrop) file.DropCachedPages();
   return true;
 }
 

--- a/src/storage/v2/replication/serialization.hpp
+++ b/src/storage/v2/replication/serialization.hpp
@@ -48,7 +48,10 @@ class Encoder final : public durability::BaseEncoder {
 
   void WriteFileData(utils::InputFile *file);
 
-  bool WriteFile(const std::filesystem::path &path, std::filesystem::path const &path_to_write);
+  /// Sends `path` to the replica, disposing of its pages afterwards as `page_cache` says. Pass
+  /// `kKeep` for a file that is still being written to, or that something else is going to read.
+  bool WriteFile(const std::filesystem::path &path, std::filesystem::path const &path_to_write,
+                 utils::PageCachePolicy page_cache);
 
   uint64_t GetPosition() override;
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(mg-utils
     startup_failure.cpp
     memory.cpp
     memory_tracker.cpp
+    page_cache_releaser.cpp
     readable_size.cpp
     signals.cpp
     sysinfo/memory.cpp

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -12,8 +12,11 @@
 #include "utils/file.hpp"
 
 #include <fcntl.h>
+#include <sys/sendfile.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -22,6 +25,7 @@
 #include <ranges>
 #include <thread>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "utils/exceptions.hpp"
@@ -145,6 +149,9 @@ bool RenamePath(const std::filesystem::path &src, const std::filesystem::path &d
 }
 
 bool HasReadAccess(const std::filesystem::path &path) { return access(path.c_str(), R_OK) == 0; }
+
+// `len == 0` means "to the end of the file".
+void DropCachedPages(int fd) { ::posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED); }
 
 static_assert(std::is_same_v<off_t, ssize_t>, "off_t must fit into ssize_t!");
 
@@ -376,6 +383,8 @@ void InputFile::FoldPendingCrc() {
                   static_cast<uint32_t>(consumed_up_to - crc_fold_position_));
   crc_fold_position_ = consumed_up_to;
 }
+
+void InputFile::DropCachedPages() const { utils::DropCachedPages(fd_); }
 
 bool InputFile::LoadBuffer() {
   // The buffer is about to be discarded; fold its consumed bytes into the CRC first. When the buffer was fully
@@ -737,6 +746,7 @@ bool NonConcurrentOutputFile::Open(const std::filesystem::path &path, Mode mode)
             path_);
   path_ = path;
   written_since_last_sync_ = 0;
+  RestartPacing(0);  // otherwise a reused handle carries the previous file's offset into this one
 
   int flags = O_WRONLY | O_CLOEXEC | O_CREAT;
   if (mode == Mode::APPEND_TO_EXISTING) flags |= O_APPEND;
@@ -815,6 +825,11 @@ size_t NonConcurrentOutputFile::SeekFile(const Position position, const ssize_t 
     }
     MG_ASSERT(
         pos >= 0, "While trying to set the position in {} an error occured: {} ({})", path_, strerror(errno), errno);
+    // A seek that does not move is not a move. Asking a file for its position is such a seek, and
+    // the snapshot writer asks at every batch boundary, so treating it as one would abandon the
+    // window in flight over and over: its bytes never handed to writeback, and the window before
+    // it never disposed of.
+    if (std::cmp_not_equal(pos, pacing_offset_)) RestartPacing(static_cast<size_t>(pos));
     return pos;
   }
 }
@@ -937,6 +952,7 @@ void NonConcurrentOutputFile::FlushBuffer() {
 
 void NonConcurrentOutputFile::FlushBufferInternal(size_t to_write) {
   auto *buffer = buffer_.data();
+  auto const flushed = to_write;
   while (to_write > 0) {
     auto written = write(fd_, buffer, to_write);
     if (written == -1 && errno == EINTR) {
@@ -956,6 +972,110 @@ void NonConcurrentOutputFile::FlushBufferInternal(size_t to_write) {
     to_write -= written;
     buffer += written;
   }
+
+  PaceWriteback(flushed);
+}
+
+void NonConcurrentOutputFile::EnableWritebackPacing(size_t window_bytes, PageCachePolicy completed_window) {
+  pacing_window_ = window_bytes;
+  pacing_completed_window_ = completed_window;
+  RestartPacing(0);
+}
+
+void NonConcurrentOutputFile::RestartPacing(size_t offset) {
+  pacing_offset_ = offset;
+  pacing_pending_start_ = offset;
+  pacing_prev_start_ = 0;
+  pacing_prev_len_ = 0;
+}
+
+void NonConcurrentOutputFile::DropCachedPages() {
+  utils::DropCachedPages(fd_);
+  // The windows in flight describe ranges that are no longer cached, so nothing is owed on them.
+  RestartPacing(pacing_offset_);
+}
+
+std::optional<uint64_t> NonConcurrentOutputFile::AppendFrom(int src_fd, uint64_t size) {
+  FlushBuffer();  // whatever is buffered belongs in front of the copied bytes
+
+  uint64_t copied = 0;
+  off_t src_offset = 0;
+  while (copied < size) {
+    // Copied a buffer at a time rather than in one call, so that pacing sees the same granularity
+    // of output here as it does from the buffered path. Handed a whole file at once it would treat
+    // that file as a single window and bound nothing.
+    auto const chunk = std::min<uint64_t>(size - copied, kFileBufferSize);
+    auto const sent = ::sendfile(fd_, src_fd, &src_offset, chunk);
+    if (sent == -1) {
+      if (errno == EINTR) continue;
+      return std::nullopt;
+    }
+    if (sent == 0) break;  // the source ended early
+    copied += static_cast<uint64_t>(sent);
+    PaceWriteback(static_cast<size_t>(sent));
+  }
+  return copied;
+}
+
+void NonConcurrentOutputFile::PaceWriteback(size_t bytes) {
+  if (pacing_window_ == 0) return;
+  pacing_offset_ += bytes;
+
+  auto const pending_len = pacing_offset_ - pacing_pending_start_;
+  if (pending_len < pacing_window_) return;
+
+  // What a failed `sync_file_range` means. EIO and ENOSPC are the same class of failure that makes
+  // a failed `fsync` fatal in this file, and they must not be swallowed: Linux reports a given
+  // writeback error to an open file once, so a pacing call that consumes one and drops it leaves
+  // the later `fsync` in `Sync` free to report success for data that never reached the disk. Every
+  // other failure says pacing does not apply to this descriptor rather than that anything is wrong
+  // with the data; the file is written exactly as it was before pacing, so pacing turns itself off
+  // and the file carries on. A descriptor pacing cannot work on will not become one.
+  auto const failed = [this](int rc) {
+    if (rc == 0) return false;
+    auto const err = errno;
+    MG_ASSERT(err != EIO && err != ENOSPC,
+              "While waiting for writeback of {} an error occurred: {} ({}). Data already written to this "
+              "file may not have reached the physical device, and no later fsync will report it.",
+              path_,
+              strerror(err),
+              err);
+    spdlog::warn("Disabling writeback pacing for {}: sync_file_range failed with {} ({}).", path_, strerror(err), err);
+    pacing_window_ = 0;
+    return true;
+  };
+
+  // Two windows are in flight: the one just completed is handed to writeback, and the one handed
+  // over previously is waited for and then disposed of. Dropping has to come after the pages are
+  // clean, because POSIX_FADV_DONTNEED silently does nothing to a dirty page; that is what the
+  // WAIT_BEFORE on the older window buys.
+  //
+  // The WRITE-only call is asynchronous in intent, but the kernel may still block it once the range
+  // exceeds the device's request queue. That is the trade pacing exists to make: this writer waits
+  // instead of every writer on the machine waiting at `dirty_ratio`.
+  if (failed(::sync_file_range(fd_,
+                               static_cast<off64_t>(pacing_pending_start_),
+                               static_cast<off64_t>(pending_len),
+                               SYNC_FILE_RANGE_WRITE))) {
+    return;
+  }
+
+  if (pacing_prev_len_ != 0) {
+    if (failed(::sync_file_range(fd_,
+                                 static_cast<off64_t>(pacing_prev_start_),
+                                 static_cast<off64_t>(pacing_prev_len_),
+                                 SYNC_FILE_RANGE_WAIT_BEFORE))) {
+      return;
+    }
+    if (pacing_completed_window_ == PageCachePolicy::kDrop) {
+      ::posix_fadvise(
+          fd_, static_cast<off_t>(pacing_prev_start_), static_cast<off_t>(pacing_prev_len_), POSIX_FADV_DONTNEED);
+    }
+  }
+
+  pacing_prev_start_ = pacing_pending_start_;
+  pacing_prev_len_ = pending_len;
+  pacing_pending_start_ = pacing_offset_;
 }
 
 void NonConcurrentOutputFile::FlushBufferInternal() {

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -1031,17 +1031,27 @@ void NonConcurrentOutputFile::PaceWriteback(size_t bytes) {
   // other failure says pacing does not apply to this descriptor rather than that anything is wrong
   // with the data; the file is written exactly as it was before pacing, so pacing turns itself off
   // and the file carries on. A descriptor pacing cannot work on will not become one.
-  auto const failed = [this](int rc) {
-    if (rc == 0) return false;
-    auto const err = errno;
-    MG_ASSERT(err != EIO && err != ENOSPC,
-              "While waiting for writeback of {} an error occurred: {} ({}). Data already written to this "
-              "file may not have reached the physical device, and no later fsync will report it.",
-              path_,
-              strerror(err),
-              err);
-    spdlog::warn("Disabling writeback pacing for {}: sync_file_range failed with {} ({}).", path_, strerror(err), err);
-    pacing_window_ = 0;
+  //
+  // Returns whether pacing is still on. Retrying the whole range after EINTR is what `Sync` does
+  // with `fsync`, and is safe because handing the same range over again asks for the same work.
+  auto const sync_range = [this](uint64_t start, uint64_t len, unsigned int flags) {
+    while (::sync_file_range(fd_, static_cast<off64_t>(start), static_cast<off64_t>(len), flags) != 0) {
+      auto const err = errno;
+      if (err == EINTR) continue;
+      MG_ASSERT(err != EIO && err != ENOSPC,
+                "While waiting for writeback of {} an error occurred: {} ({}). Data already written to this "
+                "file may not have reached the physical device, and no later fsync will report it.",
+                path_,
+                strerror(err),
+                err);
+      // A closed descriptor is this class losing track of its own file, which no filesystem can
+      // cause and disabling pacing would hide.
+      DMG_ASSERT(err != EBADF, "Writeback pacing for {} was given a closed descriptor.", path_);
+      spdlog::warn(
+          "Disabling writeback pacing for {}: sync_file_range failed with {} ({}).", path_, strerror(err), err);
+      pacing_window_ = 0;
+      return false;
+    }
     return true;
   };
 
@@ -1053,20 +1063,10 @@ void NonConcurrentOutputFile::PaceWriteback(size_t bytes) {
   // The WRITE-only call is asynchronous in intent, but the kernel may still block it once the range
   // exceeds the device's request queue. That is the trade pacing exists to make: this writer waits
   // instead of every writer on the machine waiting at `dirty_ratio`.
-  if (failed(::sync_file_range(fd_,
-                               static_cast<off64_t>(pacing_pending_start_),
-                               static_cast<off64_t>(pending_len),
-                               SYNC_FILE_RANGE_WRITE))) {
-    return;
-  }
+  if (!sync_range(pacing_pending_start_, pending_len, SYNC_FILE_RANGE_WRITE)) return;
 
   if (pacing_prev_len_ != 0) {
-    if (failed(::sync_file_range(fd_,
-                                 static_cast<off64_t>(pacing_prev_start_),
-                                 static_cast<off64_t>(pacing_prev_len_),
-                                 SYNC_FILE_RANGE_WAIT_BEFORE))) {
-      return;
-    }
+    if (!sync_range(pacing_prev_start_, pacing_prev_len_, SYNC_FILE_RANGE_WAIT_BEFORE)) return;
     if (pacing_completed_window_ == PageCachePolicy::kDrop) {
       ::posix_fadvise(
           fd_, static_cast<off_t>(pacing_prev_start_), static_cast<off_t>(pacing_prev_len_), POSIX_FADV_DONTNEED);

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -83,6 +84,23 @@ bool HasReadAccess(const std::filesystem::path &path);
 /// emptying.
 inline constexpr size_t kFileBufferSize = 262'144;
 
+/// What should happen to a file's pages in the operating system's page cache once we are done with
+/// them.
+///
+/// `kDrop` suits output nothing will read again, which stops a large finished file competing for
+/// memory with the working set. `kKeep` suits a file about to be read back, where dropping only
+/// means fetching the same bytes off the device again; clean pages cost a reader nothing to
+/// reclaim, so keeping them does not recreate the memory pressure dropping exists to relieve.
+enum class PageCachePolicy : uint8_t { kKeep, kDrop };
+
+/// Drop `fd`'s pages from the page cache, best effort.
+///
+/// Only clean pages go: POSIX_FADV_DONTNEED silently skips dirty ones, so call this after a sync,
+/// and only when the file is not about to be read back. Advisory, and it reports a refusal by
+/// returning an error number rather than by setting errno; there is nothing to do about one beyond
+/// leaving the pages where they are.
+void DropCachedPages(int fd);
+
 /// This class implements a file handler that is used to read binary files. It
 /// was developed because the C++ standard library has an awful API and makes
 /// handling of binary data extremely tedious.
@@ -141,6 +159,9 @@ class InputFile {
 
   /// Closes the currently opened file. On failure it crashes the program.
   void Close() noexcept;
+
+  /// See `utils::DropCachedPages`. Reading leaves clean pages behind, so no sync is needed first.
+  void DropCachedPages() const;
 
   /// Restarts CRC accumulation from the current position.
   void ResetCrc();
@@ -267,6 +288,9 @@ class OutputFile {
   /// and misuse it crashes the program.
   void Sync();
 
+  /// See `utils::DropCachedPages`.
+  void DropCachedPages() const { utils::DropCachedPages(fd_); }
+
   /// Closes the currently opened file. It doesn't perform a `Sync` on the
   /// file. On failure and misuse it crashes the program.
   void Close() noexcept;
@@ -296,6 +320,8 @@ class OutputFile {
   void FlushBufferInternal();
   void FlushBufferInternal(size_t to_write);
 
+  // Runs without `flush_lock_`, unlike the flush path. Any per-file state touched by both would
+  // race, which is why writeback pacing is offered on `NonConcurrentOutputFile` and not here.
   size_t SeekFile(Position position, ssize_t offset);
 
   // put flush lock on its own cacheline
@@ -375,6 +401,41 @@ class NonConcurrentOutputFile {
   /// and misuse it crashes the program.
   void Sync();
 
+  /// Bound the dirty page cache this file is allowed to accumulate, in `window_bytes` at a time.
+  ///
+  /// A multi-gigabyte streaming write otherwise fills the page cache with its own dirty pages until
+  /// the kernel throttles *every* writer on the machine at `dirty_ratio`, and evicts the working
+  /// set on the way out. Each window is handed to writeback as it is produced and then treated
+  /// according to `completed_window`, so the dirty footprint stays at about two windows however
+  /// large the file grows.
+  ///
+  /// Opt-in, and `window_bytes == 0` opts back out, because it is the wrong trade for a small
+  /// latency-sensitive file: it gives up a little throughput here so this file stops disturbing
+  /// everything else. Enabling restarts pacing from offset 0, so a reused handle cannot carry a
+  /// stale offset into a new file.
+  void EnableWritebackPacing(size_t window_bytes, PageCachePolicy completed_window = PageCachePolicy::kDrop);
+
+  /// See `utils::DropCachedPages`. Independent of pacing, and honoured either way: bounding the
+  /// dirty footprint while writing and disposing of the finished file are separate decisions.
+  ///
+  /// On a paced file one call also collects what the windows could not: the final partial window,
+  /// the window whose drop was scheduled for a boundary that never came, the windows abandoned by
+  /// each seek, and the pages the writer went back to patch after their region had been dropped.
+  void DropCachedPages();
+
+  /// Appends up to `size` bytes from the start of `src_fd` to this file, copying within the kernel.
+  ///
+  /// Returns the number of bytes appended, which is short of `size` only if `src_fd` ends early,
+  /// or `nullopt` if the copy failed, with `errno` left for the caller to report against a path it
+  /// knows and this does not.
+  ///
+  /// Anything buffered is flushed first, so it lands in front of the copied bytes.
+  [[nodiscard]] std::optional<uint64_t> AppendFrom(int src_fd, uint64_t size);
+
+  /// Where writeback pacing believes the file position is. Test-only: pacing is advisory
+  /// throughout, so this is the only thing separating pacing that works from pacing that stopped.
+  size_t PacingOffset() const { return pacing_offset_; }
+
   /// Closes the currently opened file. It doesn't perform a `Sync` on the
   /// file. On failure and misuse it crashes the program.
   void Close() noexcept;
@@ -385,9 +446,6 @@ class NonConcurrentOutputFile {
   /// Get the size of the file.
   size_t GetSize();
 
-  /// Get the POSIX file handle
-  auto fd() const { return fd_; }
-
  private:
   void FlushBuffer();
   void FlushBufferInternal();
@@ -395,9 +453,31 @@ class NonConcurrentOutputFile {
 
   size_t SeekFile(Position position, ssize_t offset);
 
+  // Hand the window `bytes` just completed to writeback and dispose of the one before it. Call
+  // after every successful write to the descriptor, whatever route those bytes took.
+  void PaceWriteback(size_t bytes);
+
+  // Abandon the windows in flight and treat `offset` as the current file position. Pacing knows
+  // where it is by counting bytes written, which is the file offset only while the file is
+  // append-only. The snapshot writer is not: it seeks back to patch batch sizes and the offset
+  // table, and without this the windows would silently address the wrong ranges from the first
+  // seek onwards. That is harmless to the data, since both syscalls are advisory, but pacing would
+  // stop doing anything useful. Leaves the configuration alone; only the progress is reset.
+  void RestartPacing(size_t offset);
+
   int fd_{-1};
   size_t buffer_position_{0};
   size_t written_since_last_sync_{0};
+
+  // Writeback pacing; see `EnableWritebackPacing`. A zero window means pacing is off, whether
+  // because it was never enabled or because a `sync_file_range` failure turned it off.
+  size_t pacing_window_{0};
+  PageCachePolicy pacing_completed_window_{PageCachePolicy::kDrop};
+  size_t pacing_offset_{0};         // bytes written to the file so far
+  size_t pacing_pending_start_{0};  // start of the window not yet handed to writeback
+  size_t pacing_prev_start_{0};     // window handed to writeback, not yet disposed of
+  size_t pacing_prev_len_{0};
+
   std::array<uint8_t, kFileBufferSize> buffer_;  // intentionally uninitialized for performance
 
   // Path should be cold data

--- a/src/utils/page_cache_releaser.cpp
+++ b/src/utils/page_cache_releaser.cpp
@@ -1,0 +1,39 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "utils/page_cache_releaser.hpp"
+
+#include "utils/spin_lock.hpp"
+#include "utils/synchronized.hpp"
+
+namespace memgraph::utils {
+
+namespace {
+// Non-owning, so the releaser's lifetime is exactly the handle `main` holds. Synchronized because
+// install and lookup are not otherwise ordered: a replica loads a received snapshot on a
+// replication thread, and a test may install one after those threads exist.
+auto &Installed() {
+  static Synchronized<std::weak_ptr<PageCacheReleaser>, SpinLock> installed;
+  return installed;
+}
+}  // namespace
+
+std::shared_ptr<PageCacheReleaser> InstallPageCacheReleaser() {
+  auto releaser = std::make_shared<PageCacheReleaser>();
+  Installed().WithLock([&](auto &installed) { installed = releaser; });
+  return releaser;
+}
+
+std::weak_ptr<PageCacheReleaser> PageCacheReleaserHandle() {
+  return Installed().WithLock([](auto const &installed) { return installed; });
+}
+
+}  // namespace memgraph::utils

--- a/src/utils/page_cache_releaser.hpp
+++ b/src/utils/page_cache_releaser.hpp
@@ -1,0 +1,59 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "utils/thread_pool.hpp"
+
+namespace memgraph::utils {
+
+/// Drops fully-read files from the page cache away from the thread that read them.
+///
+/// The drop costs kernel work proportional to the size of the file, does not get faster with more
+/// threads, and nothing waits on its result. On the recovery path that would be time an instance
+/// spends not yet serving, for a benefit that is just as good arriving a moment later.
+class PageCacheReleaser {
+ public:
+  PageCacheReleaser() = default;
+
+  PageCacheReleaser(PageCacheReleaser const &) = delete;
+  PageCacheReleaser(PageCacheReleaser &&) = delete;
+  PageCacheReleaser &operator=(PageCacheReleaser const &) = delete;
+  PageCacheReleaser &operator=(PageCacheReleaser &&) = delete;
+  ~PageCacheReleaser() = default;
+
+  /// Takes ownership of `file` and drops its pages on the releaser's thread. Ownership is what keeps
+  /// the descriptor open until the drop has happened.
+  template <typename File>
+  void Drop(File file) {
+    pool_.AddTask([file = std::move(file)]() mutable { file.DropCachedPages(); });
+  }
+
+ private:
+  ThreadPool pool_{1};
+};
+
+/// Installs the process-wide releaser and returns the handle that owns it.
+///
+/// The caller must hold the handle for as long as anything can hand this a file, and release it
+/// while the process is still running. Letting it reach static destruction instead leaves the
+/// worker being joined at a point where its ordering against the loggers and allocators it can
+/// touch is undefined. Installing again replaces the handle.
+[[nodiscard]] std::shared_ptr<PageCacheReleaser> InstallPageCacheReleaser();
+
+/// The installed releaser, expired when no handle is being held. A caller that cannot lock it
+/// drops the pages itself, which reaches the same state and only costs it the wait.
+std::weak_ptr<PageCacheReleaser> PageCacheReleaserHandle();
+
+}  // namespace memgraph::utils

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -238,6 +238,13 @@ startup_config_dict = {
     ),
     "storage_properties_on_edges": ("false", "true", "Controls whether edges have properties."),
     "storage_snapshot_thread_count": ("12", "12", "The number of threads used to create snapshots."),
+    "storage_snapshot_writeback_window_mib": (
+        "32",
+        "32",
+        "How much of a snapshot may build up in the operating system's file cache before it is written out to "
+        "disk and released, in MiB. Applies per snapshot thread. Set to 0 to leave this to the operating system, "
+        "which can let a large snapshot slow down queries and evict cached data.",
+    ),
     "storage_recovery_thread_count": ("12", "12", "The number of threads used to recover persisted data from disk."),
     "storage_snapshot_interval_sec": (
         "300",

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -245,6 +245,19 @@ startup_config_dict = {
         "disk and released, in MiB. Applies per snapshot thread. Set to 0 to leave this to the operating system, "
         "which can let a large snapshot slow down queries and evict cached data.",
     ),
+    "storage_release_recovered_snapshot_page_cache": (
+        "true",
+        "true",
+        "Release a snapshot from the operating system's file cache once recovery has loaded it, so it stops "
+        "holding memory the database could use. Set to false to leave it cached.",
+    ),
+    "storage_release_sent_snapshot_page_cache": (
+        "false",
+        "false",
+        "Release a snapshot from the operating system's file cache once it has been sent to a replica. Off by "
+        "default, because any further replica syncing from the same snapshot then has to read it from disk again. "
+        "Set to true to free the memory sooner on an instance that syncs a replica once.",
+    ),
     "storage_recovery_thread_count": ("12", "12", "The number of threads used to recover persisted data from disk."),
     "storage_snapshot_interval_sec": (
         "300",

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -487,6 +487,11 @@ add_unit_test(utils_file
     LINK_TARGETS mg-utils
 )
 
+add_unit_test(utils_page_cache_releaser
+    SOURCES utils_page_cache_releaser.cpp
+    LINK_TARGETS mg-utils
+)
+
 add_unit_test(utils_stat
     SOURCES utils_stat.cpp
     LINK_TARGETS mg-utils

--- a/tests/unit/page_cache_probe.hpp
+++ b/tests/unit/page_cache_probe.hpp
@@ -1,0 +1,77 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/// Observing the page cache from a test.
+///
+/// Dropping pages is advisory, so a file's contents say nothing about whether it worked: residency
+/// is the only thing that distinguishes a release that happened from one the kernel ignored. Every
+/// assertion built on it has to be gated on the filesystem being one where it means anything.
+#pragma once
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include "utils/file.hpp"
+#include "utils/on_scope_exit.hpp"
+
+namespace memgraph::test {
+
+/// Residency of `path` in the page cache, as a fraction of its pages, via mincore(2).
+/// std::nullopt when the file is empty or the mapping fails.
+inline std::optional<double> ResidentFraction(const std::filesystem::path &path) {
+  const int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd == -1) return std::nullopt;
+  const auto close_fd = utils::OnScopeExit{[fd] { ::close(fd); }};
+
+  struct stat st{};
+  if (::fstat(fd, &st) == -1 || st.st_size == 0) return std::nullopt;
+  const auto size = static_cast<size_t>(st.st_size);
+
+  void *addr = ::mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
+  if (addr == MAP_FAILED) return std::nullopt;
+  const auto unmap = utils::OnScopeExit{[addr, size] { ::munmap(addr, size); }};
+
+  const auto page = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
+  const auto pages = (size + page - 1) / page;
+  std::vector<unsigned char> resident(pages, 0);
+  if (::mincore(addr, size, resident.data()) == -1) return std::nullopt;
+
+  // The low bit is the "in core" flag; the rest are unspecified.
+  const auto in_core = std::ranges::count_if(resident, [](unsigned char v) { return (v & 1U) != 0; });
+  return static_cast<double>(in_core) / static_cast<double>(pages);
+}
+
+/// Whether this filesystem honours POSIX_FADV_DONTNEED at all. tmpfs does not: every page reads as
+/// resident forever, so a residency assertion there is a statement about the filesystem rather than
+/// about the code. Probed with a throwaway file, because "pages are resident" is true on tmpfs too
+/// and cannot tell the two apart.
+inline bool PageCacheEvictionObservable(const std::filesystem::path &probe) {
+  const std::vector<uint8_t> data(1U << 20, 0xAB);
+  utils::NonConcurrentOutputFile file;
+  file.Open(probe, utils::NonConcurrentOutputFile::Mode::OVERWRITE_EXISTING);
+  file.Write(data.data(), data.size());
+  file.Sync();
+  const auto before = ResidentFraction(probe);
+  file.DropCachedPages();
+  const auto after = ResidentFraction(probe);
+  file.Close();
+  return before && after && *before > 0.9 && *after < 0.05;
+}
+
+}  // namespace memgraph::test

--- a/tests/unit/rpc_file_framing.cpp
+++ b/tests/unit/rpc_file_framing.cpp
@@ -32,6 +32,8 @@
 #include <utility>
 #include <vector>
 
+#include "page_cache_probe.hpp"
+
 #include "communication/buffer.hpp"
 #include "communication/session.hpp"
 #include "flags/general.hpp"
@@ -199,7 +201,7 @@ class RpcFileFraming : public ::testing::Test {
         std::ofstream f{root_ / "wal" / name, std::ios::binary};
         f.write(content.data(), static_cast<std::streamsize>(content.size()));
       }
-      encoder.WriteFile(root_ / "wal" / name, fs::path{"wal"} / name);
+      encoder.WriteFile(root_ / "wal" / name, fs::path{"wal"} / name, memgraph::utils::PageCachePolicy::kKeep);
       w.expected.emplace_back(name, std::move(content));
     }
     builder.Finalize();
@@ -319,4 +321,56 @@ TEST_F(RpcFileFraming, SequentialMessagesOnOneConnection) {
   ASSERT_EQ(counts.size(), 2U);
   EXPECT_EQ(counts[0], 1U) << "first message";
   EXPECT_EQ(counts[1], 2U) << "second message (state leaked from first?)";
+}
+
+// Sending a snapshot to a replica reads it once, front to back, and the main has no use for it
+// afterwards. The WAL segment sent alongside it is the one still being appended to, so the two
+// have to be distinguishable, and nothing about the file itself distinguishes them: the caller
+// says which it is and the encoder acts on that.
+class ReplicationEncoderPageCache : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    root_ = fs::temp_directory_path() / "mg_repl_page_cache";
+    fs::remove_all(root_);
+    fs::create_directories(root_ / "wal");
+  }
+
+  void TearDown() override { fs::remove_all(root_); }
+
+  // Sends `file` through an Encoder that discards the wire, and reports how much of the file is
+  // left in the page cache. Large enough that residency is measured over many pages.
+  std::optional<double> ResidencyAfterSending(const fs::path &file, memgraph::utils::PageCachePolicy page_cache) {
+    const std::vector<uint8_t> content(8U << 20, 'x');
+    {
+      memgraph::utils::OutputFile out;
+      out.Open(file, memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING);
+      out.Write(content.data(), content.size());
+      // Clean pages are the only ones DONTNEED can evict, and a snapshot on disk is long since
+      // synced by the time a replica asks for it.
+      out.Sync();
+      out.Close();
+    }
+
+    Builder builder([](const uint8_t *, size_t, bool) {});
+    Encoder encoder{&builder};
+    EXPECT_TRUE(encoder.WriteFile(file, file.filename(), page_cache));
+    builder.Finalize();
+    return memgraph::test::ResidentFraction(file);
+  }
+
+  fs::path root_;
+};
+
+TEST_F(ReplicationEncoderPageCache, DroppingLeavesTheSentFileEvicted) {
+  if (!memgraph::test::PageCacheEvictionObservable(root_ / "probe.bin")) {
+    GTEST_SKIP() << "page cache eviction is not observable under " << root_;
+  }
+
+  const auto kept = ResidencyAfterSending(root_ / "wal" / "kept.bin", memgraph::utils::PageCachePolicy::kKeep);
+  ASSERT_TRUE(kept.has_value());
+  EXPECT_GT(*kept, 0.9) << "sending reads the whole file, so keeping should leave it resident";
+
+  const auto dropped = ResidencyAfterSending(root_ / "wal" / "dropped.bin", memgraph::utils::PageCachePolicy::kDrop);
+  ASSERT_TRUE(dropped.has_value());
+  EXPECT_LT(*dropped, 0.05) << "kDrop left " << (*dropped * 100) << "% of the sent file resident";
 }

--- a/tests/unit/storage_v2_property_store.cpp
+++ b/tests/unit/storage_v2_property_store.cpp
@@ -32,6 +32,25 @@ using enum CoordinateReferenceSystem;
 
 namespace {
 
+/** `ArePropertiesEqual` and `MatchesValues` fill a caller-supplied buffer rather than returning
+ * one, so that a caller walking index entries allocates once per loop instead of once per entry.
+ * These assertions read better against a returned value, so the buffer is kept here rather than at
+ * every call site.
+ */
+auto EqualityMask(PropertyStore const &store, std::span<PropertyPath const> paths,
+                  std::span<PropertyValue const> values, std::span<std::size_t const> lookup) -> std::vector<bool> {
+  std::vector<bool> result;
+  store.ArePropertiesEqual(paths, values, lookup, result);
+  return result;
+}
+
+auto EqualityMask(PropertiesPermutationHelper const &helper, PropertyStore const &store, IndexOrderedValuesView values)
+    -> std::vector<bool> {
+  std::vector<bool> result;
+  helper.MatchesValues(store, values, result);
+  return result;
+}
+
 /** Helper for creating nested maps easily. */
 
 /** Type for  a key-value pair.
@@ -1355,7 +1374,7 @@ TEST(PropertyStore, ArePropertiesEqual_ComparesOneNestedValue) {
        }) {
     PropertyStore store;
     store.InitProperties(data);
-    EXPECT_EQ(store.ArePropertiesEqual(std::array{test.path}, std::array{test.value}, std::array<std::size_t, 1>{0}),
+    EXPECT_EQ(EqualityMask(store, std::array{test.path}, std::array{test.value}, std::array<std::size_t, 1>{0}),
               std::vector{test.result});
   }
 }
@@ -1403,7 +1422,7 @@ TEST(PropertyStore, ArePropertiesEqual_ComparesMultipleNestedValues) {
     Test{.paths = {PP{p4}}, .values = {PV{}}, .lookup = {0}, .result = {true}},
            // clang-format on
        }) {
-    EXPECT_EQ(store.ArePropertiesEqual(test.paths, test.values, test.lookup), test.result);
+    EXPECT_EQ(EqualityMask(store, test.paths, test.values, test.lookup), test.result);
   }
 }
 
@@ -1425,9 +1444,10 @@ TEST(PropertyStore, ArePropertiesEqual_ComparesMultipleNestedMaps) {
   PropertyStore store;
   store.InitProperties(data);
 
-  EXPECT_EQ(store.ArePropertiesEqual(std::array{PropertyPath{p1, p2}, PropertyPath{p1, p5}},
-                                     std::array{map_prop_value_1, map_prop_value_2},
-                                     std::array<std::size_t, 2>{0, 1}),
+  EXPECT_EQ(EqualityMask(store,
+                         std::array{PropertyPath{p1, p2}, PropertyPath{p1, p5}},
+                         std::array{map_prop_value_1, map_prop_value_2},
+                         std::array<std::size_t, 2>{0, 1}),
             (std::vector{true, true}));
 }
 
@@ -1958,21 +1978,24 @@ TEST(PropertiesPermutationHelper, MatchesValues_ReturnsABooleanMaskOfMatches) {
   PropertyStore store;
   store.InitProperties(data);
 
-  EXPECT_EQ(prop_reader.MatchesValues(
+  EXPECT_EQ(EqualityMask(
+                prop_reader,
                 store,
                 IndexOrderedValuesVector{
                     {PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"date"}}}),
             (std::vector{true, true, true, true}));
 
   EXPECT_EQ(
-      prop_reader.MatchesValues(
+      EqualityMask(
+          prop_reader,
           store,
           IndexOrderedValuesVector{
               {PropertyValue{"applex"}, PropertyValue{"bananax"}, PropertyValue{"cherryx"}, PropertyValue{"datex"}}}),
       (std::vector{false, false, false, false}));
 
   EXPECT_EQ(
-      prop_reader.MatchesValues(
+      EqualityMask(
+          prop_reader,
           store,
           IndexOrderedValuesVector{
               {PropertyValue{"apple"}, PropertyValue{"bananax"}, PropertyValue{"cherry"}, PropertyValue{"datex"}}}),
@@ -1996,13 +2019,15 @@ TEST(PropertiesPermutationHelper, MatchesValues_WorksWithOutOfOrderProperties) {
   PropertyStore store;
   store.InitProperties(data);
 
-  EXPECT_EQ(prop_reader.MatchesValues(
+  EXPECT_EQ(EqualityMask(
+                prop_reader,
                 store,
                 IndexOrderedValuesVector{
                     {PropertyValue{"cherry"}, PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"date"}}}),
             (std::vector{true, true, true, true}));
 
-  EXPECT_EQ(prop_reader.MatchesValues(
+  EXPECT_EQ(EqualityMask(
+                prop_reader,
                 store,
                 IndexOrderedValuesVector{
                     {PropertyValue{"apple"}, PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"date"}}}),
@@ -2027,13 +2052,15 @@ TEST(PropertiesPermutationHelper, MatchesValues_WorksWithNestedProperties) {
   PropertyStore store;
   store.InitProperties(data);
 
-  EXPECT_EQ(prop_reader.MatchesValues(
+  EXPECT_EQ(EqualityMask(
+                prop_reader,
                 store,
                 IndexOrderedValuesVector{
                     {PropertyValue{"banana"}, PropertyValue{"cherry"}, PropertyValue{"apple"}, PropertyValue{"date"}}}),
             (std::vector{true, true, true, true}));
 
-  EXPECT_EQ(prop_reader.MatchesValues(
+  EXPECT_EQ(EqualityMask(
+                prop_reader,
                 store,
                 IndexOrderedValuesVector{
                     {PropertyValue{"apple"}, PropertyValue{"cherry"}, PropertyValue{"banana"}, PropertyValue{"date"}}}),

--- a/tests/unit/utils_file.cpp
+++ b/tests/unit/utils_file.cpp
@@ -1107,6 +1107,25 @@ class FileCacheHintTest : public ::testing::Test {
     file.Close();
   }
 
+  enum class PositionQueries : uint8_t { kNone, kEveryBatch };
+
+  // Residency of `path` once `data` has been streamed to it with pacing on, which is what says
+  // whether pacing disposed of the windows it completed.
+  static std::optional<double> ResidencyAfterPacedWrite(const fs::path &path, const std::vector<uint8_t> &data,
+                                                        PositionQueries queries) {
+    PacedFile file;
+    file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+    file.EnableWritebackPacing(kWindow);
+    for (size_t offset = 0; offset < data.size(); offset += kChunk) {
+      file.Write(data.data() + offset, std::min(kChunk, data.size() - offset));
+      if (queries == PositionQueries::kEveryBatch) file.GetPosition();
+    }
+    file.Sync();
+    auto const resident = memgraph::test::ResidentFraction(path);
+    file.Close();
+    return resident;
+  }
+
   std::vector<uint8_t> ReadFileContents(const fs::path &path) const {
     std::ifstream ifs(path, std::ios::binary);
     return std::vector<uint8_t>(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
@@ -1231,29 +1250,31 @@ TEST_F(FileCacheHintTest, AppendingFromAnotherFileKeepsPacingAlignedWithTheFile)
 // every batch boundary. If that counted as a move it would abandon the window in flight each time,
 // so no window would ever be handed to writeback or dropped, which on a large snapshot is most of
 // the file. Residency is what shows it: the pacer's own offset is right either way.
+//
+// The baseline is the same write without the queries, and it is also the gate: whether pacing can
+// drop anything at all is a property of the filesystem, and one that `PageCacheEvictionObservable`
+// cannot answer, because it asks about a file that has been fsynced. On overlayfs, which is what a
+// container's own filesystem is, `sync_file_range` reports success having done nothing: it writes
+// back the mapping of the inode it is given, and the overlay inode holds no pages, they are all on
+// the upper filesystem's inode. The pages stay dirty, DONTNEED skips dirty pages, and nothing is
+// released. `fsync` is passed through to the upper file and so still works, which is why whole-file
+// eviction after a sync is observable there and this is not.
 TEST_F(FileCacheHintTest, RepositioningToTheCurrentOffsetKeepsTheWindowInFlight) {
-  if (!memgraph::test::PageCacheEvictionObservable(test_dir_ / "probe.bin")) {
-    GTEST_SKIP() << "page cache eviction is not observable under " << test_dir_;
-  }
-
   const auto data = Pattern(kTotal);
-  const auto path = test_dir_ / "position_queried.bin";
 
-  PacedFile file;
-  file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
-  file.EnableWritebackPacing(kWindow);
-  for (size_t offset = 0; offset < data.size(); offset += kChunk) {
-    file.Write(data.data() + offset, std::min(kChunk, data.size() - offset));
-    file.GetPosition();  // what the snapshot writer does at every batch boundary
+  const auto baseline = ResidencyAfterPacedWrite(test_dir_ / "streamed.bin", data, PositionQueries::kNone);
+  ASSERT_TRUE(baseline.has_value());
+  if (*baseline >= 0.5) {
+    GTEST_SKIP() << "paced writeback releases nothing under " << test_dir_ << ": a stream with no position query at all"
+                 << " left " << (*baseline * 100) << "% of the file cached";
   }
-  file.Sync();
 
-  const auto resident = memgraph::test::ResidentFraction(path);
-  file.Close();
-
+  const auto resident =
+      ResidencyAfterPacedWrite(test_dir_ / "position_queried.bin", data, PositionQueries::kEveryBatch);
   ASSERT_TRUE(resident.has_value());
   EXPECT_LT(*resident, 0.5) << "asking for the position abandoned the window in flight: " << (*resident * 100)
-                            << "% of the file is still cached";
+                            << "% of the file is still cached, against " << (*baseline * 100)
+                            << "% without the queries";
 }
 
 // `EnableWritebackPacing` is the one place that sets the window, and it must also reset where pacing

--- a/tests/unit/utils_file.cpp
+++ b/tests/unit/utils_file.cpp
@@ -9,6 +9,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
 #include <chrono>
 #include <fstream>
 #include <map>
@@ -19,7 +25,9 @@
 
 #include <gtest/gtest.h>
 
+#include "page_cache_probe.hpp"
 #include "utils/file.hpp"
+#include "utils/on_scope_exit.hpp"
 #include "utils/spin_lock.hpp"
 #include "utils/string.hpp"
 #include "utils/synchronized.hpp"
@@ -1048,4 +1056,330 @@ TEST_F(UtilsFileTest, ConcurrentReadingAndWritting) {
     return std::any_of(
         read_counts.cbegin(), read_counts.cend(), [](const auto read_count) { return read_count == number_of_writes; });
   }));
+}
+
+// Writeback pacing is advisory: every syscall it issues can be refused by the kernel with no visible
+// effect. What is *not* advisory is that it may never change a byte of the file, whatever the writer
+// does to it in between. That is the invariant these tests hold.
+class FileCacheHintTest : public ::testing::Test {
+ protected:
+  // The only file type that offers pacing. `OutputFile` deliberately does not: it backs the WAL,
+  // where the trade is wrong, and where `SeekFile` runs without the lock that serialises flushing.
+  using PacedFile = memgraph::utils::NonConcurrentOutputFile;
+
+  void SetUp() override {
+    test_dir_ = fs::temp_directory_path() / "MG_test_file_cache_hints";
+    fs::create_directories(test_dir_);
+  }
+
+  void TearDown() override {
+    if (fs::exists(test_dir_)) {
+      fs::remove_all(test_dir_);
+    }
+  }
+
+  // Comfortably more than one internal buffer (256 KiB) and several pacing windows, so flushes and
+  // window boundaries actually interleave.
+  static constexpr size_t kWindow = 512 * 1024;
+  static constexpr size_t kTotal = 4 * 1024 * 1024;
+
+  // Position-dependent bytes, so a misplaced write shows up as a mismatch at a known offset rather
+  // than as plausible-looking data.
+  static std::vector<uint8_t> Pattern(size_t size, uint8_t salt = 0) {
+    std::vector<uint8_t> data(size);
+    for (size_t i = 0; i < size; ++i) {
+      data[i] = static_cast<uint8_t>((i * 31 + salt) & 0xFF);
+    }
+    return data;
+  }
+
+  // Chunk size shares no factor with the internal buffer or the window, so writes straddle both.
+  static constexpr size_t kChunk = 7000;
+
+  static void WriteStreaming(const fs::path &path, const std::vector<uint8_t> &data, size_t window) {
+    PacedFile file;
+    file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+    file.EnableWritebackPacing(window);
+    for (size_t offset = 0; offset < data.size(); offset += kChunk) {
+      file.Write(data.data() + offset, std::min(kChunk, data.size() - offset));
+    }
+    file.Sync();
+    file.Close();
+  }
+
+  std::vector<uint8_t> ReadFileContents(const fs::path &path) const {
+    std::ifstream ifs(path, std::ios::binary);
+    return std::vector<uint8_t>(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
+  }
+
+  fs::path test_dir_;
+};
+
+TEST_F(FileCacheHintTest, PacedAndUnpacedWritesProduceIdenticalBytes) {
+  const auto data = Pattern(kTotal);
+  const auto paced = test_dir_ / "paced.bin";
+  const auto unpaced = test_dir_ / "unpaced.bin";
+
+  WriteStreaming(paced, data, kWindow);
+  WriteStreaming(unpaced, data, 0);
+
+  EXPECT_EQ(ReadFileContents(paced), data);
+  EXPECT_EQ(ReadFileContents(unpaced), data);
+}
+
+// The snapshot writer's shape: stream a lot of output, seek back over several already-written
+// windows to patch a placeholder, then return to the end and carry on. A pacer that still believed
+// it was at the old end would from here on address ranges that correspond to nothing.
+TEST_F(FileCacheHintTest, PacingSurvivesTheWriterSeekingBackToPatch) {
+  const auto body = Pattern(kTotal);
+  const auto tail = Pattern(kWindow * 3, 77);
+  const std::vector<uint8_t> patched{1, 2, 3, 4, 5, 6, 7, 8};
+  const auto path = test_dir_ / "patched.bin";
+
+  PacedFile file;
+  file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+  file.EnableWritebackPacing(kWindow);
+
+  // A placeholder the writer comes back to fill in once it knows the value, as the snapshot encoder
+  // does for each batch's size and for the offset table.
+  const std::vector<uint8_t> placeholder(patched.size(), 0);
+  file.Write(placeholder.data(), placeholder.size());
+
+  for (size_t offset = 0; offset < body.size(); offset += kChunk) {
+    file.Write(body.data() + offset, std::min(kChunk, body.size() - offset));
+  }
+
+  const auto end = file.GetPosition();
+  ASSERT_EQ(file.SetPosition(PacedFile::Position::SET, 0), 0U);
+  file.Write(patched.data(), patched.size());
+
+  ASSERT_EQ(file.SetPosition(PacedFile::Position::SET, static_cast<ssize_t>(end)), end);
+  file.Write(tail.data(), tail.size());
+
+  file.Sync();
+  file.Close();
+
+  const auto contents = ReadFileContents(path);
+  ASSERT_EQ(contents.size(), patched.size() + body.size() + tail.size());
+  EXPECT_TRUE(std::equal(patched.begin(), patched.end(), contents.begin()));
+  EXPECT_TRUE(std::equal(body.begin(), body.end(), contents.begin() + patched.size()));
+  EXPECT_TRUE(std::equal(tail.begin(), tail.end(), contents.begin() + patched.size() + body.size()));
+}
+
+// Pacing knows where it is by counting bytes written, which is the file offset only while the file
+// is append-only. Seeking must therefore reposition it. Byte content cannot show this: misaligned
+// windows still write correct bytes, so this asserts on the pacer's own view of the file.
+TEST_F(FileCacheHintTest, SeekingRepositionsPacing) {
+  const auto data = Pattern(kTotal);
+  const auto path = test_dir_ / "repositioned.bin";
+
+  PacedFile file;
+  file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+  file.EnableWritebackPacing(kWindow);
+  for (size_t offset = 0; offset < data.size(); offset += kChunk) {
+    file.Write(data.data() + offset, std::min(kChunk, data.size() - offset));
+  }
+  file.Sync();
+  EXPECT_EQ(file.PacingOffset(), kTotal) << "pacing did not follow an append-only write";
+
+  file.SetPosition(PacedFile::Position::SET, 0);
+  EXPECT_EQ(file.PacingOffset(), 0U) << "pacing kept addressing the old end of the file after a seek";
+
+  const auto middle = static_cast<ssize_t>(kTotal / 2);
+  file.SetPosition(PacedFile::Position::SET, middle);
+  EXPECT_EQ(file.PacingOffset(), static_cast<size_t>(middle));
+
+  file.Close();
+}
+
+// Parallel snapshot creation appends each worker's part with `sendfile`, straight at the descriptor.
+// Pacing counts the bytes it is handed, so output that skips the buffer has to be counted too, or
+// every window after it addresses a range the file has already moved past, which for a parallel
+// snapshot is all of the data. The buffered head must also land in front of the copied bytes.
+TEST_F(FileCacheHintTest, AppendingFromAnotherFileKeepsPacingAlignedWithTheFile) {
+  const auto head = Pattern(kChunk);
+  const auto part = Pattern(kTotal, 91);
+  const auto part_path = test_dir_ / "part.bin";
+  WriteStreaming(part_path, part, 0);
+
+  const int src_fd = ::open(part_path.c_str(), O_RDONLY);
+  ASSERT_NE(src_fd, -1);
+  const auto close_src = memgraph::utils::OnScopeExit{[src_fd] { ::close(src_fd); }};
+
+  const auto path = test_dir_ / "appended.bin";
+  PacedFile file;
+  file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+  file.EnableWritebackPacing(kWindow);
+  file.Write(head.data(), head.size());
+
+  const auto copied = file.AppendFrom(src_fd, part.size());
+  ASSERT_TRUE(copied.has_value());
+  EXPECT_EQ(*copied, part.size());
+  file.Sync();
+
+  EXPECT_EQ(file.PacingOffset(), head.size() + part.size())
+      << "pacing lost track of bytes that did not pass through Write";
+  file.Close();
+
+  const auto contents = ReadFileContents(path);
+  ASSERT_EQ(contents.size(), head.size() + part.size());
+  EXPECT_TRUE(std::equal(head.begin(), head.end(), contents.begin()));
+  EXPECT_TRUE(std::equal(part.begin(), part.end(), contents.begin() + head.size()));
+}
+
+// Asking a file for its position seeks to where the file already is, and the snapshot writer asks at
+// every batch boundary. If that counted as a move it would abandon the window in flight each time,
+// so no window would ever be handed to writeback or dropped, which on a large snapshot is most of
+// the file. Residency is what shows it: the pacer's own offset is right either way.
+TEST_F(FileCacheHintTest, RepositioningToTheCurrentOffsetKeepsTheWindowInFlight) {
+  if (!memgraph::test::PageCacheEvictionObservable(test_dir_ / "probe.bin")) {
+    GTEST_SKIP() << "page cache eviction is not observable under " << test_dir_;
+  }
+
+  const auto data = Pattern(kTotal);
+  const auto path = test_dir_ / "position_queried.bin";
+
+  PacedFile file;
+  file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+  file.EnableWritebackPacing(kWindow);
+  for (size_t offset = 0; offset < data.size(); offset += kChunk) {
+    file.Write(data.data() + offset, std::min(kChunk, data.size() - offset));
+    file.GetPosition();  // what the snapshot writer does at every batch boundary
+  }
+  file.Sync();
+
+  const auto resident = memgraph::test::ResidentFraction(path);
+  file.Close();
+
+  ASSERT_TRUE(resident.has_value());
+  EXPECT_LT(*resident, 0.5) << "asking for the position abandoned the window in flight: " << (*resident * 100)
+                            << "% of the file is still cached";
+}
+
+// `EnableWritebackPacing` is the one place that sets the window, and it must also reset where pacing
+// thinks it is; otherwise re-enabling on a reused handle would carry a stale offset into the new
+// file.
+TEST_F(FileCacheHintTest, EnablingPacingStartsFromTheBeginning) {
+  const auto data = Pattern(kTotal);
+  const auto path = test_dir_ / "re_enabled.bin";
+
+  PacedFile file;
+  file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+  file.EnableWritebackPacing(kWindow);
+  file.Write(data.data(), data.size());
+  file.Sync();
+  ASSERT_EQ(file.PacingOffset(), kTotal);
+
+  file.EnableWritebackPacing(kWindow);
+  EXPECT_EQ(file.PacingOffset(), 0U);
+
+  file.Close();
+}
+
+// Opening resets pacing too, so a handle reused for a second file starts from that file's
+// beginning without the caller having to re-enable.
+TEST_F(FileCacheHintTest, ReopeningAHandleStartsPacingFromTheNewFile) {
+  const auto data = Pattern(kTotal);
+
+  PacedFile file;
+  file.Open(test_dir_ / "first.bin", PacedFile::Mode::OVERWRITE_EXISTING);
+  file.EnableWritebackPacing(kWindow);
+  file.Write(data.data(), data.size());
+  file.Sync();
+  ASSERT_EQ(file.PacingOffset(), kTotal);
+  file.Close();
+
+  file.Open(test_dir_ / "second.bin", PacedFile::Mode::OVERWRITE_EXISTING);
+  EXPECT_EQ(file.PacingOffset(), 0U) << "pacing carried the previous file's offset into this one";
+
+  file.Write(data.data(), kChunk);
+  file.Sync();
+  EXPECT_EQ(file.PacingOffset(), kChunk);
+
+  file.Close();
+}
+
+// Dropping is an explicit request from a caller that knows this file is finished with, not a
+// feature of pacing. Bounding the dirty footprint while writing and releasing the file afterwards
+// are separate decisions, and a deployment that turns pacing off still gets the release it asked
+// for.
+TEST_F(FileCacheHintTest, DroppingCachedPagesEvictsAnUnpacedFile) {
+  if (!memgraph::test::PageCacheEvictionObservable(test_dir_ / "probe.bin")) {
+    GTEST_SKIP() << "page cache eviction is not observable under " << test_dir_;
+  }
+
+  const auto data = Pattern(kTotal);
+  const auto path = test_dir_ / "unpaced_release.bin";
+
+  PacedFile file;
+  file.Open(path, PacedFile::Mode::OVERWRITE_EXISTING);
+  for (size_t offset = 0; offset < data.size(); offset += kChunk) {
+    file.Write(data.data() + offset, std::min(kChunk, data.size() - offset));
+  }
+  // Clean pages are the only ones DONTNEED can evict.
+  file.Sync();
+
+  const auto before = memgraph::test::ResidentFraction(path);
+  ASSERT_TRUE(before.has_value());
+  ASSERT_GT(*before, 0.9) << "the file was not cached to begin with";
+
+  file.DropCachedPages();
+  const auto after = memgraph::test::ResidentFraction(path);
+  file.Close();
+
+  ASSERT_TRUE(after.has_value());
+  EXPECT_LT(*after, 0.05) << "dropping left " << (*after * 100) << "% of an unpaced file resident";
+}
+
+// A descriptor pacing cannot work on must disable pacing rather than have every flush repeat a
+// syscall that cannot succeed. /dev/null gives that deterministically: sync_file_range answers
+// ESPIPE for anything that is not a regular file, block device or directory. It refuses fsync too,
+// so this file is never synced; nothing here is about durability.
+//
+// The fatal branch, EIO and ENOSPC, needs an injected device failure and is not covered here.
+TEST_F(FileCacheHintTest, PacingDisablesItselfOnADescriptorItCannotPace) {
+  PacedFile file;
+  ASSERT_TRUE(file.Open("/dev/null", PacedFile::Mode::APPEND_TO_EXISTING));
+  file.EnableWritebackPacing(kWindow);
+
+  // Crossing the first window boundary is what issues the syscall, and what fails.
+  const auto data = Pattern(kWindow * 2);
+  file.Write(data.data(), data.size());
+  const auto after_failure = file.PacingOffset();
+  ASSERT_GT(after_failure, 0U) << "the write never reached a window boundary";
+
+  // Pacing is off now, so further writes are neither tracked nor retried.
+  file.Write(data.data(), data.size());
+  EXPECT_EQ(file.PacingOffset(), after_failure) << "pacing kept running on a descriptor it cannot pace";
+
+  file.Close();
+}
+
+// Recovery releases the snapshot through the same handle it read it with, once the load is done.
+// Reading a file leaves its pages clean, and clean pages are the ones DONTNEED can evict.
+TEST_F(FileCacheHintTest, ReadingAFileThenDroppingItEvictsIt) {
+  const auto data = Pattern(kTotal);
+  const auto path = test_dir_ / "read_then_dropped.bin";
+  WriteStreaming(path, data, 0);
+
+  if (!memgraph::test::PageCacheEvictionObservable(test_dir_ / "probe.bin")) {
+    GTEST_SKIP() << "page cache eviction is not observable under " << test_dir_;
+  }
+
+  memgraph::utils::InputFile file;
+  ASSERT_TRUE(file.Open(path));
+  std::vector<uint8_t> scratch(kChunk);
+  for (size_t offset = 0; offset < data.size(); offset += kChunk) {
+    ASSERT_TRUE(file.Read(scratch.data(), std::min(kChunk, data.size() - offset)));
+  }
+
+  const auto before = memgraph::test::ResidentFraction(path);
+  ASSERT_TRUE(before.has_value());
+
+  file.DropCachedPages();
+  const auto after = memgraph::test::ResidentFraction(path);
+  file.Close();
+
+  ASSERT_TRUE(after.has_value());
+  EXPECT_LT(*after, 0.05) << "dropping left " << (*after * 100) << "% resident, was " << (*before * 100) << "%";
 }

--- a/tests/unit/utils_page_cache_releaser.cpp
+++ b/tests/unit/utils_page_cache_releaser.cpp
@@ -1,0 +1,106 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "page_cache_probe.hpp"
+#include "utils/file.hpp"
+#include "utils/page_cache_releaser.hpp"
+
+namespace {
+
+constexpr size_t kFileBytes = 8U << 20U;
+
+class PageCacheReleaserTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::filesystem::create_directories(dir_);
+    observable_ = memgraph::test::PageCacheEvictionObservable(dir_ / "probe");
+  }
+
+  void TearDown() override {
+    std::error_code error_code;
+    std::filesystem::remove_all(dir_, error_code);
+  }
+
+  // A file whose pages are resident and clean, which is the only state they can be evicted in.
+  std::filesystem::path WriteResidentFile(std::string_view name) const {
+    auto const path = dir_ / name;
+    std::vector<uint8_t> const data(kFileBytes, 0xCD);
+    memgraph::utils::NonConcurrentOutputFile file;
+    file.Open(path, memgraph::utils::NonConcurrentOutputFile::Mode::OVERWRITE_EXISTING);
+    file.Write(data.data(), data.size());
+    file.Sync();
+    file.Close();
+    return path;
+  }
+
+  std::filesystem::path dir_{std::filesystem::temp_directory_path() / "MG_test_utils_page_cache_releaser"};
+  bool observable_{false};
+};
+
+TEST_F(PageCacheReleaserTest, NoReleaserIsInstalledByDefault) {
+  EXPECT_EQ(memgraph::utils::PageCacheReleaserHandle().lock(), nullptr);
+}
+
+TEST_F(PageCacheReleaserTest, TheHandleExpiresWhenItsOwnerLetsGo) {
+  // Nothing keeps the releaser, and so its thread, alive beyond the handle its owner holds. This is
+  // what lets an owner decide when the thread is joined.
+  {
+    auto const owner = memgraph::utils::InstallPageCacheReleaser();
+    ASSERT_NE(memgraph::utils::PageCacheReleaserHandle().lock(), nullptr);
+  }
+  EXPECT_EQ(memgraph::utils::PageCacheReleaserHandle().lock(), nullptr);
+}
+
+TEST_F(PageCacheReleaserTest, AnInstalledReleaserEvictsTheFileItIsGiven) {
+  if (!observable_) GTEST_SKIP() << "filesystem does not honour POSIX_FADV_DONTNEED";
+
+  auto const path = WriteResidentFile("handed_over");
+  memgraph::utils::InputFile file;
+  ASSERT_TRUE(file.Open(path));
+  ASSERT_GT(*memgraph::test::ResidentFraction(path), 0.9);
+
+  auto const owner = memgraph::utils::InstallPageCacheReleaser();
+  owner->Drop(std::move(file));
+
+  // The drop is asynchronous by design, so the test waits for the effect rather than for the task:
+  // waiting on the task would assert the mechanism, and residency is what the releaser exists for.
+  auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (*memgraph::test::ResidentFraction(path) < 0.05) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_LT(*memgraph::test::ResidentFraction(path), 0.05);
+}
+
+TEST_F(PageCacheReleaserTest, DroppingWithoutAReleaserStillEvicts) {
+  if (!observable_) GTEST_SKIP() << "filesystem does not honour POSIX_FADV_DONTNEED";
+
+  // The synchronous fallback a caller takes when it cannot lock the handle. Same outcome, and it
+  // has already happened by the time the call returns.
+  auto const path = WriteResidentFile("synchronous");
+  memgraph::utils::InputFile file;
+  ASSERT_TRUE(file.Open(path));
+  ASSERT_GT(*memgraph::test::ResidentFraction(path), 0.9);
+
+  ASSERT_EQ(memgraph::utils::PageCacheReleaserHandle().lock(), nullptr);
+  file.DropCachedPages();
+  EXPECT_LT(*memgraph::test::ResidentFraction(path), 0.05);
+}
+
+}  // namespace


### PR DESCRIPTION
Snapshot writes and snapshot recovery each push a large file through the page cache with no hint to the kernel, so a big write throttles every writer on the box and the file stays resident afterwards, evicting the working set. Writes now hand each window to writeback and drop it once clean, and both a finished snapshot and a recovered one are released from the cache when done. Off for the WAL. The release happens after recovery rather than behind the read point on purpose: recovery revisits ranges it has already read, so dropping during the load sends them back to the device a second time, which doubles physical reads while leaving elapsed time unchanged on fast local storage. No format change. The window is settable with --storage-snapshot-writeback-window-mib, default 32 and 0 to disable, because pacing does nothing on a filesystem that ignores the calls it is built from and protects nobody on an instance that is not serving anything while it writes; it applies per snapshot writer, so a parallel snapshot holds it once per thread. One behaviour change: a writeback error during a paced snapshot is now fatal like a failed fsync. Also included: an unrelated allocation fix in the GC's index sweep.