### PR TITLE
feat: support a filter lambda in KSHORTEST path expansion

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3427,8 +3427,7 @@ antlrcpp::Any CypherMainVisitor::visitRelationshipPattern(MemgraphCypher::Relati
         } else {
           // Other variable expands only have the filter lambda.
           edge->filter_lambda_ = visit_lambda(relationshipLambdas[0]);
-          // Bidirectional search reusing inner searches across deviations has no single
-          // well-defined path leading to the edge being tested.
+          // A bidirectional search reusing inner searches has no one path leading to the tested edge.
           if (edge->type_ == EdgeAtom::Type::KSHORTEST && edge->filter_lambda_.accumulated_path) {
             throw SemanticException("KSHORTEST expansion does not support the accumulated path in a filter lambda.");
           }
@@ -3534,8 +3533,7 @@ antlrcpp::Any CypherMainVisitor::visitVariableExpansion(MemgraphCypher::Variable
     --n_expressions;  // Last expression is the limit
     limit = std::any_cast<Expression *>(ctx->k->accept(this));
   }
-  // After discounting the limit: the grammar puts `| k` in the same `expression` list as the
-  // bounds, so `-[*KSHORTEST 1..3 |2]-` has three of them.
+  // Counted after discounting `| k`, which the grammar puts in the same `expression` list.
   DMG_ASSERT(n_expressions <= 2U, "Expected 0, 1 or 2 bounds in range literal.");
 
   if (n_expressions == 0U) {

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3408,9 +3408,6 @@ antlrcpp::Any CypherMainVisitor::visitRelationshipPattern(MemgraphCypher::Relati
         }
         break;
       case 1:
-        if (edge->type_ == EdgeAtom::Type::KSHORTEST) {
-          throw SemanticException("KSHORTEST expansion does not support filter lambda.");
-        }
         if (edge->type_ == EdgeAtom::Type::WEIGHTED_SHORTEST_PATH ||
             edge->type_ == EdgeAtom::Type::ALL_SHORTEST_PATHS) {
           // For wShortest and allShortest, the first (and required) lambda is
@@ -3430,6 +3427,11 @@ antlrcpp::Any CypherMainVisitor::visitRelationshipPattern(MemgraphCypher::Relati
         } else {
           // Other variable expands only have the filter lambda.
           edge->filter_lambda_ = visit_lambda(relationshipLambdas[0]);
+          // KSHORTEST searches bidirectionally and reuses inner searches across deviations, so
+          // there is no single well-defined path leading to the edge being tested.
+          if (edge->type_ == EdgeAtom::Type::KSHORTEST && edge->filter_lambda_.accumulated_path) {
+            throw SemanticException("KSHORTEST expansion does not support the accumulated path in a filter lambda.");
+          }
           if (edge->filter_lambda_.accumulated_weight) {
             throw SemanticException(
                 "Accumulated weight in filter lambda can be used only with "

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3516,8 +3516,6 @@ antlrcpp::Any CypherMainVisitor::visitRelationshipTypes(MemgraphCypher::Relation
 }
 
 antlrcpp::Any CypherMainVisitor::visitVariableExpansion(MemgraphCypher::VariableExpansionContext *ctx) {
-  DMG_ASSERT(ctx->expression().size() <= 2U, "Expected 0, 1 or 2 bounds in range literal.");
-
   EdgeAtom::Type edge_type = EdgeAtom::Type::DEPTH_FIRST;
   if (!ctx->getTokens(MemgraphCypher::BFS).empty())
     edge_type = EdgeAtom::Type::BREADTH_FIRST;
@@ -3536,6 +3534,9 @@ antlrcpp::Any CypherMainVisitor::visitVariableExpansion(MemgraphCypher::Variable
     --n_expressions;  // Last expression is the limit
     limit = std::any_cast<Expression *>(ctx->k->accept(this));
   }
+  // Asserted after the limit is discounted: the grammar puts the `| k` path limit in the same
+  // `expression` list as the bounds, so `-[*KSHORTEST 1..3 |2]-` has three of them.
+  DMG_ASSERT(n_expressions <= 2U, "Expected 0, 1 or 2 bounds in range literal.");
 
   if (n_expressions == 0U) {
     // Case -[*]-

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3427,8 +3427,8 @@ antlrcpp::Any CypherMainVisitor::visitRelationshipPattern(MemgraphCypher::Relati
         } else {
           // Other variable expands only have the filter lambda.
           edge->filter_lambda_ = visit_lambda(relationshipLambdas[0]);
-          // KSHORTEST searches bidirectionally and reuses inner searches across deviations, so
-          // there is no single well-defined path leading to the edge being tested.
+          // Bidirectional search reusing inner searches across deviations has no single
+          // well-defined path leading to the edge being tested.
           if (edge->type_ == EdgeAtom::Type::KSHORTEST && edge->filter_lambda_.accumulated_path) {
             throw SemanticException("KSHORTEST expansion does not support the accumulated path in a filter lambda.");
           }
@@ -3534,8 +3534,8 @@ antlrcpp::Any CypherMainVisitor::visitVariableExpansion(MemgraphCypher::Variable
     --n_expressions;  // Last expression is the limit
     limit = std::any_cast<Expression *>(ctx->k->accept(this));
   }
-  // Asserted after the limit is discounted: the grammar puts the `| k` path limit in the same
-  // `expression` list as the bounds, so `-[*KSHORTEST 1..3 |2]-` has three of them.
+  // After discounting the limit: the grammar puts `| k` in the same `expression` list as the
+  // bounds, so `-[*KSHORTEST 1..3 |2]-` has three of them.
   DMG_ASSERT(n_expressions <= 2U, "Expected 0, 1 or 2 bounds in range literal.");
 
   if (n_expressions == 0U) {

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -979,6 +979,12 @@ bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
     if (edge_atom.upper_bound_) {
       edge_atom.upper_bound_->Accept(*this);
     }
+    // Visited here because this `PreVisit` returns false, suppressing the generic child traversal
+    // that would otherwise reach the `| k` limit. Without it the limit's identifiers keep
+    // `symbol_pos_ == -1`, which `DependantSymbolVisitor`'s always-on assert turns into an abort.
+    if (edge_atom.limit_) {
+      edge_atom.limit_->Accept(*this);
+    }
     scope.in_edge_range = false;
     scope.in_pattern = false;
     if (edge_atom.filter_lambda_.expression) {

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -930,8 +930,7 @@ bool SymbolGenerator::PostVisit(NodeAtom &) {
 }
 
 bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
-  // Not a `Scope &`: the `Accept` calls below can visit a pattern comprehension, which pushes
-  // onto `scopes_` and reallocates it. An index survives that, a reference does not.
+  // Not a `Scope &`: an `Accept` below can push onto `scopes_`, reallocating it.
   auto const scope_idx = scopes_.size() - 1;
   scopes_[scope_idx].visiting_edge = &edge_atom;
   if (scopes_[scope_idx].in_create || scopes_[scope_idx].in_merge) {
@@ -981,9 +980,8 @@ bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
     if (edge_atom.upper_bound_) {
       edge_atom.upper_bound_->Accept(*this);
     }
-    // Visited here because this `PreVisit` returns false, suppressing the generic child traversal
-    // that would otherwise reach the `| k` limit. Without it the limit's identifiers keep
-    // `symbol_pos_ == -1`, which `DependantSymbolVisitor`'s always-on assert turns into an abort.
+    // This `PreVisit` returns false, so the generic traversal never reaches the limit and its
+    // identifiers would keep `symbol_pos_ == -1`.
     if (edge_atom.limit_) {
       edge_atom.limit_->Accept(*this);
     }

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -930,16 +930,18 @@ bool SymbolGenerator::PostVisit(NodeAtom &) {
 }
 
 bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
-  auto &scope = scopes_.back();
-  scope.visiting_edge = &edge_atom;
-  if (scope.in_create || scope.in_merge) {
-    scope.in_create_edge = true;
+  // Not a `Scope &`: the `Accept` calls below can visit a pattern comprehension, which pushes
+  // onto `scopes_` and reallocates it. An index survives that, a reference does not.
+  auto const scope_idx = scopes_.size() - 1;
+  scopes_[scope_idx].visiting_edge = &edge_atom;
+  if (scopes_[scope_idx].in_create || scopes_[scope_idx].in_merge) {
+    scopes_[scope_idx].in_create_edge = true;
     if (edge_atom.edge_types_.size() != 1U) {
       throw SemanticException(
           "A single relationship type must be specified "
           "when creating an edge.");
     }
-    if (scope.in_create &&  // Merge allows bidirectionality
+    if (scopes_[scope_idx].in_create &&  // Merge allows bidirectionality
         edge_atom.direction_ == EdgeAtom::Direction::BOTH) {
       throw SemanticException(
           "Bidirectional relationship are not supported "
@@ -960,7 +962,7 @@ bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
     }
   }
 
-  if (!scope.in_create && has_expressions) {
+  if (!scopes_[scope_idx].in_create && has_expressions) {
     throw SemanticException("You can use expressions with edge types only with CREATE!");
   }
 
@@ -972,7 +974,7 @@ bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
     std::get<ParameterLookup *>(edge_atom.properties_)->Accept(*this);
   }
   if (edge_atom.IsVariable()) {
-    scope.in_edge_range = true;
+    scopes_[scope_idx].in_edge_range = true;
     if (edge_atom.lower_bound_) {
       edge_atom.lower_bound_->Accept(*this);
     }
@@ -985,8 +987,8 @@ bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
     if (edge_atom.limit_) {
       edge_atom.limit_->Accept(*this);
     }
-    scope.in_edge_range = false;
-    scope.in_pattern = false;
+    scopes_[scope_idx].in_edge_range = false;
+    scopes_[scope_idx].in_pattern = false;
     if (edge_atom.filter_lambda_.expression) {
       std::vector<Identifier *> filter_lambda_identifiers{edge_atom.filter_lambda_.inner_edge,
                                                           edge_atom.filter_lambda_.inner_node};
@@ -1022,11 +1024,11 @@ bool SymbolGenerator::PreVisit(EdgeAtom &edge_atom) {
       VisitWithIdentifiers({edge_atom.weight_lambda_.expression},
                            {edge_atom.weight_lambda_.inner_edge, edge_atom.weight_lambda_.inner_node});
     }
-    scope.in_pattern = true;
+    scopes_[scope_idx].in_pattern = true;
   }
-  scope.in_pattern_atom_identifier = true;
+  scopes_[scope_idx].in_pattern_atom_identifier = true;
   edge_atom.identifier_->Accept(*this);
-  scope.in_pattern_atom_identifier = false;
+  scopes_[scope_idx].in_pattern_atom_identifier = false;
   if (edge_atom.total_weight_) {
     if (HasSymbol(edge_atom.total_weight_->name_)) {
       throw RedeclareVariableError(edge_atom.total_weight_->name_);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3798,6 +3798,18 @@ class KShortestPathsCursor : public Cursor {
       upper_bound_ = self_.upper_bound_ ? EvaluateInt(evaluator, self_.upper_bound_, "Max depth in expansion")
                                         : std::numeric_limits<int64_t>::max();
 
+      // Both bounds are compared against a `size_t` further down, so a negative one converts to a
+      // huge unsigned value and silently disables the check instead of narrowing the search: the
+      // depth guard stops firing, and the lower-bound top-up loop below never terminates until
+      // every simple path has been enumerated. Every other shortest-path cursor already rejects
+      // this (BFS, WSHORTEST, ALLSHORTEST); KSHORTEST was the only one that did not.
+      if (upper_bound_ < 1) {
+        throw QueryRuntimeException("Maximum depth in KSHORTEST path expansion must be at least 1.");
+      }
+      if (lower_bound_ < 1) {
+        throw QueryRuntimeException("Minimum depth in KSHORTEST path expansion must be at least 1.");
+      }
+
       // Initialize for this new source-target pair
       current_source_ = source_vertex;
       current_target_ = target_vertex;
@@ -4319,6 +4331,10 @@ class KShortestPathsCursor : public Cursor {
     predecessors_.clear();
     // Cleared per input row: the lambda may read outer variables, so verdicts don't survive a row.
     expansion_memo_.clear();
+    // The `|K` limit counts paths per input row. Without this reset the counter carried across rows
+    // (and across `Reset()`), so once the first row had produced K paths every later row - and every
+    // outer row of a subquery or pattern comprehension - returned nothing at all.
+    n_returned_paths_ = 0;
   }
 };
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3750,7 +3750,11 @@ class KShortestPathsCursor : public Cursor {
                           : std::numeric_limits<int64_t>::max();
 
     // With neither a lambda nor access checks there is nothing to memoise, so don't pay for it.
-    memoize_expansion_ = self_.filter_lambda_.expression != nullptr || FineGrainedAccessCheckEnabled(context);
+    // Lambda-presence must stay the *left* operand: `ShouldExpand` skips the lambda entirely when
+    // this is false, so anything that makes memoisation conditional on something else (a flag, an
+    // entry cap) has to re-audit that branch or it will silently stop filtering.
+    fine_grained_access_check_enabled_ = FineGrainedAccessCheckEnabled(context);
+    memoize_expansion_ = self_.filter_lambda_.expression != nullptr || fine_grained_access_check_enabled_;
 
     auto push_next_path = [&](Frame &frame, ExpressionEvaluator &evaluator) {
       PushPathToFrame(shortest_paths_[current_path_index_++], &frame, evaluator.GetMemoryResource(), context);
@@ -3922,10 +3926,14 @@ class KShortestPathsCursor : public Cursor {
   utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> blocked_edges_;
   utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
   utils::pmr::unordered_map<VertexAccessor, double, VertexAccessorHash> distances_;
-  // Raw storage adjacency, deliberately *not* cleared per input row (unlike `expansion_memo_`): it
-  // is stable for the whole command epoch the cursor runs in and exists so Yen's repeated inner
-  // searches don't re-fetch. It must keep storing unfiltered edges - caching post-filter results
-  // here would be wrong the moment the lambda reads an outer-row value.
+  // Raw storage adjacency, deliberately *not* cleared per input row (unlike `expansion_memo_`), so
+  // Yen's repeated inner searches don't re-fetch. What makes that safe is not the transaction: a
+  // transaction spans several command epochs and `View::OLD` moves with `AdvanceCommand()`, and
+  // under non-snapshot isolation `OLD` visibility is evaluated live. What keeps one cursor inside
+  // one epoch is that MATCH plans `View::OLD` and the planner throws on a variable-length pattern
+  // whose view is anything else (the `view != storage::View::OLD` check in
+  // `rule_based_planner.hpp`). It must also keep storing unfiltered edges - caching post-filter
+  // results here would be wrong the moment the lambda reads an outer-row value.
   //
   // The edges are copied into an arena vector rather than cached as the `EdgeVertexAccessorResult`
   // storage hands back: that struct is not allocator-aware, so its `std::vector` would allocate from
@@ -3940,6 +3948,7 @@ class KShortestPathsCursor : public Cursor {
   // because the blocked sets - the only per-deviation inputs - are checked outside the memo.
   utils::pmr::unordered_map<ExpansionKey, bool, ExpansionKeyHash> expansion_memo_;
   bool memoize_expansion_{false};
+  bool fine_grained_access_check_enabled_{false};
 
   // Bidirectional search state
   using VertexEdgeMapT = utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>>;
@@ -4156,7 +4165,12 @@ class KShortestPathsCursor : public Cursor {
     if (!memoize_expansion_) return FineGrainedAccessCheck<To>(edge, context);
 
     const VertexAccessor &inner_node = Backward ? expand_from : next;
-    const ExpansionKey key{.edge = edge.Gid(), .node = inner_node.Gid(), .backward = Backward};
+    // The pass only has to be part of the key because the two halves check access on opposite
+    // endpoints of the same edge. With access checks off the verdict is a pure function of
+    // `(edge, inner_node)`, so dropping the pass merges two entries that are guaranteed to agree and
+    // saves evaluating the lambda a second time on every arc the two frontiers both reach.
+    const ExpansionKey key{
+        .edge = edge.Gid(), .node = inner_node.Gid(), .backward = Backward && fine_grained_access_check_enabled_};
     if (const auto it = expansion_memo_.find(key); it != expansion_memo_.end()) return it->second;
 
     // Access check first: an edge the user cannot read must never make the lambda run on it.

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3749,8 +3749,8 @@ class KShortestPathsCursor : public Cursor {
     limit_ = self_.limit_ ? EvaluateInt(evaluator, self_.limit_, "Limit in KSHORTEST path expansion")
                           : std::numeric_limits<int64_t>::max();
 
-    // Nothing to memoise without a lambda or access checks. Lambda-presence must stay the left
-    // operand: `ShouldExpand` skips the lambda entirely when this is false.
+    // Nothing to memoise without a lambda or access checks, so don't pay for the map. This is a
+    // cost switch only: `ShouldExpand` computes the same verdict either way.
     fine_grained_access_check_enabled_ = FineGrainedAccessCheckEnabled(context);
     memoize_expansion_ = self_.filter_lambda_.expression != nullptr || fine_grained_access_check_enabled_;
 
@@ -3835,7 +3835,10 @@ class KShortestPathsCursor : public Cursor {
         last_path = &shortest_paths_.back();
       }
 
-      if (n_returned_paths_ < limit_ && unsent_paths_count() > 0) {
+      // `InitializeKShortestPaths` reset the per-row count above, and the top-up loop serves
+      // nothing, so this row has spent none of its budget yet.
+      DMG_ASSERT(n_returned_paths_ == 0, "KSHORTEST path count must be reset before a new input row is served");
+      if (unsent_paths_count() > 0) {
         push_next_path(frame, evaluator);
         return true;
       }
@@ -4156,18 +4159,22 @@ class KShortestPathsCursor : public Cursor {
                     Frame &frame, ExpressionEvaluator &evaluator, ExecutionContext &context) {
     const VertexAccessor next = To == kTo ? edge.To() : edge.From();
     if (blocked_edges_.contains(edge) || blocked_vertices_.contains(next) || reached.contains(next)) return false;
-    if (!memoize_expansion_) return FineGrainedAccessCheck<To>(edge, context);
 
     const VertexAccessor &inner_node = Backward ? expand_from : next;
+    // Access check first: an edge the user cannot read must never make the lambda run on it.
+    auto verdict = [&] {
+      return FineGrainedAccessCheck<To>(edge, context) &&
+             EvaluateFilterLambda(edge, inner_node, frame, evaluator, context);
+    };
+    if (!memoize_expansion_) return verdict();
+
     // With access checks off the verdict is a pure function of `(edge, inner_node)`, so dropping
     // the pass merges two entries guaranteed to agree.
     const ExpansionKey key{
         .edge = edge.Gid(), .node = inner_node.Gid(), .backward = Backward && fine_grained_access_check_enabled_};
     if (const auto it = expansion_memo_.find(key); it != expansion_memo_.end()) return it->second;
 
-    // Access check first: an edge the user cannot read must never make the lambda run on it.
-    const bool allowed =
-        FineGrainedAccessCheck<To>(edge, context) && EvaluateFilterLambda(edge, inner_node, frame, evaluator, context);
+    const bool allowed = verdict();
     expansion_memo_.emplace(key, allowed);
     return allowed;
   }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3746,8 +3746,7 @@ class KShortestPathsCursor : public Cursor {
     ExpressionEvaluator evaluator =
         ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
 
-    // Nothing to memoise without a lambda or access checks, so don't pay for the map. This is a
-    // cost switch only: `ShouldExpand` computes the same verdict either way.
+    // A cost switch only, not a semantic one: `ShouldExpand` agrees either way.
     fine_grained_access_check_enabled_ = FineGrainedAccessCheckEnabled(context);
     memoize_expansion_ = self_.filter_lambda_.expression != nullptr || fine_grained_access_check_enabled_;
 
@@ -3758,8 +3757,8 @@ class KShortestPathsCursor : public Cursor {
 
     auto unsent_paths_count = [&]() { return shortest_paths_.size() - current_path_index_; };
 
-    // The limit is per input row, so guard each serving site rather than returning early: a
-    // saturated row must still fall through to the input loop, where `ResetState` zeroes the count.
+    // Guard each serving site rather than returning early: a saturated row must still reach the
+    // input loop, where `ResetState` zeroes the count.
     if (n_returned_paths_ < limit_) {
       // If we have cached shortest paths, return the next one
       if (unsent_paths_count() > 0) {
@@ -3792,9 +3791,8 @@ class KShortestPathsCursor : public Cursor {
       // Skip if source and target are the same vertex
       if (source_vertex == target_vertex) continue;
 
-      // Evaluated per row, not once per `Pull`: the count is per row (`ResetState` zeroes it), and a
-      // row-dependent `|k` reads this row's frame. Evaluating it before the input pull would read
-      // the previous row's values, or unbound nulls on the first pull.
+      // Per row, not once per `Pull`: a row-dependent `|k` needs this row's frame, and evaluating it
+      // before the input pull would read the previous row's - or unbound nulls on the first.
       limit_ = self_.limit_ ? EvaluateInt(evaluator, self_.limit_, "Limit in KSHORTEST path expansion")
                             : std::numeric_limits<int64_t>::max();
       if (limit_ < 0) {
@@ -3807,20 +3805,16 @@ class KShortestPathsCursor : public Cursor {
       upper_bound_ = self_.upper_bound_ ? EvaluateInt(evaluator, self_.upper_bound_, "Max depth in expansion")
                                         : std::numeric_limits<int64_t>::max();
 
-      // Both bounds are compared against a `size_t` below, so a negative one wraps to a huge value
-      // and disables the check instead of narrowing the search - the top-up loop then runs until
-      // every simple path is enumerated.
-      // Asymmetric on purpose: `upper_bound_ < 1` matches WSHORTEST/ALLSHORTEST, but no sibling has
-      // a lower-bound floor, and 0 is inert here (the top-up loop is already false at 0), so
-      // rejecting it would break the legal `-[*KSHORTEST 0..n]->`.
+      // A negative bound wraps when compared against a `size_t` below, disabling the check instead
+      // of narrowing the search. Asymmetric on purpose: `upper_bound_ < 1` matches
+      // WSHORTEST/ALLSHORTEST, while 0 is inert for the lower bound and `0..n` is legal.
       if (upper_bound_ < 1) {
         throw QueryRuntimeException("Maximum depth in KSHORTEST path expansion must be at least 1.");
       }
       if (lower_bound_ < 0) {
         throw QueryRuntimeException("Minimum depth in KSHORTEST path expansion must not be negative.");
       }
-      // An inverted range is legally empty, and BFS skips the row for it too. Not merely a
-      // shortcut: no path can exceed `upper_bound_`, so the top-up loop below would enumerate
+      // Legally empty, as in BFS. Not just a shortcut: the top-up loop would otherwise enumerate
       // every simple path and still serve nothing.
       if (lower_bound_ > upper_bound_) continue;
 
@@ -3844,8 +3838,7 @@ class KShortestPathsCursor : public Cursor {
         last_path = &shortest_paths_.back();
       }
 
-      // `InitializeKShortestPaths` reset the per-row count above, and the top-up loop serves
-      // nothing, so this row has spent none of its budget yet.
+      // The count was reset above and the top-up loop serves nothing, so this row is unspent.
       DMG_ASSERT(n_returned_paths_ == 0, "KSHORTEST path count must be reset before a new input row is served");
       if (n_returned_paths_ < limit_ && unsent_paths_count() > 0) {
         push_next_path(frame, evaluator);
@@ -3899,8 +3892,7 @@ class KShortestPathsCursor : public Cursor {
     }
   };
 
-  // One (edge, bound node) test of the expansion predicate. The pass is part of the key because the
-  // two halves of the bidirectional search check access on opposite endpoints of the same edge.
+  // The pass is in the key because the two halves of the search check opposite endpoints of an edge.
   struct ExpansionKey {
     storage::Gid edge;
     storage::Gid node;
@@ -3938,22 +3930,18 @@ class KShortestPathsCursor : public Cursor {
   utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> blocked_edges_;
   utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
   utils::pmr::unordered_map<VertexAccessor, double, VertexAccessorHash> distances_;
-  // Raw storage adjacency, deliberately not cleared per input row (unlike `expansion_memo_`) so
-  // Yen's repeated inner searches don't re-fetch. Must stay unfiltered: caching post-filter results
-  // would break the moment the lambda reads an outer-row value.
-  // Known pre-existing gap: a cursor can outlive its command epoch (`Apply` reuses one cursor
-  // across an `Accumulate` that calls `AdvanceCommand`), so the cache can go stale.
-  // Copied into an arena vector because `EdgeVertexAccessorResult` is not allocator-aware and its
-  // `std::vector` would escape this query's memory accounting. `expanded_count` is consumed before
-  // the insert, so it is not cached.
+  // Raw storage adjacency, kept across input rows (unlike `expansion_memo_`) so Yen's repeated inner
+  // searches don't re-fetch. Must stay unfiltered: a lambda reading an outer-row value would make
+  // post-filter results wrong. Copied into an arena vector because `EdgeVertexAccessorResult` is not
+  // allocator-aware and would escape this query's memory accounting.
+  // Pre-existing gap: a cursor can outlive its command epoch, so the cache can go stale.
   using CachedEdges = utils::pmr::vector<EdgeAccessor>;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> in_edges_;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> out_edges_;
   utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>, VertexAccessorHash> predecessors_;
 
-  // Memoised `access check && filter lambda` verdicts. Sound across Yen's O(k*L) inner searches
-  // because the blocked sets - the only per-deviation inputs - are checked outside the memo.
-  // Assumes the flag below is constant for the row; a mid-query license flip is not invalidated.
+  // Memoised `access check && filter lambda` verdicts. Sound across Yen's inner searches because the
+  // blocked sets - the only per-deviation inputs - are checked outside the memo.
   utils::pmr::unordered_map<ExpansionKey, bool, ExpansionKeyHash> expansion_memo_;
   bool memoize_expansion_{false};
   bool fine_grained_access_check_enabled_{false};
@@ -4160,9 +4148,8 @@ class KShortestPathsCursor : public Cursor {
     throw QueryRuntimeException("Expansion condition must evaluate to boolean or null");
   }
 
-  /// `To` picks the endpoint the traversal advances to. `Backward` marks the target-side pass,
-  /// where the lambda binds the vertex we expand *from* rather than the one we reach; that
-  /// asymmetry makes the search test exactly the (edge, node) pairs a forward walk would.
+  /// `Backward` marks the target-side pass, where the lambda binds the vertex we expand *from*, not
+  /// the one we reach - that asymmetry makes the search test the pairs a forward walk would.
   template <bool To, bool Backward>
   bool ShouldExpand(const EdgeAccessor &edge, const VertexAccessor &expand_from, const VertexEdgeMapT &reached,
                     Frame &frame, ExpressionEvaluator &evaluator, ExecutionContext &context) {
@@ -4177,8 +4164,7 @@ class KShortestPathsCursor : public Cursor {
     };
     if (!memoize_expansion_) return verdict();
 
-    // With access checks off the verdict is a pure function of `(edge, inner_node)`, so dropping
-    // the pass merges two entries guaranteed to agree.
+    // With access checks off the verdict depends only on `(edge, inner_node)`, so the two agree.
     const ExpansionKey key{
         .edge = edge.Gid(), .node = inner_node.Gid(), .backward = Backward && fine_grained_access_check_enabled_};
     if (const auto it = expansion_memo_.find(key); it != expansion_memo_.end()) return it->second;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3749,36 +3749,36 @@ class KShortestPathsCursor : public Cursor {
     limit_ = self_.limit_ ? EvaluateInt(evaluator, self_.limit_, "Limit in KSHORTEST path expansion")
                           : std::numeric_limits<int64_t>::max();
 
-    // With neither a lambda nor access checks there is nothing to memoise, so don't pay for it.
-    // Lambda-presence must stay the *left* operand: `ShouldExpand` skips the lambda entirely when
-    // this is false, so anything that makes memoisation conditional on something else (a flag, an
-    // entry cap) has to re-audit that branch or it will silently stop filtering.
+    // Nothing to memoise without a lambda or access checks. Lambda-presence must stay the left
+    // operand: `ShouldExpand` skips the lambda entirely when this is false.
     fine_grained_access_check_enabled_ = FineGrainedAccessCheckEnabled(context);
     memoize_expansion_ = self_.filter_lambda_.expression != nullptr || fine_grained_access_check_enabled_;
+
+    // A non-positive limit can never yield a path, so don't search at all.
+    if (limit_ <= 0) return false;
 
     auto push_next_path = [&](Frame &frame, ExpressionEvaluator &evaluator) {
       PushPathToFrame(shortest_paths_[current_path_index_++], &frame, evaluator.GetMemoryResource(), context);
       n_returned_paths_++;
     };
 
-    // Check if we reached the maximum number of paths to return
-    if (n_returned_paths_ >= limit_) {
-      return false;
-    }
-
     auto unsent_paths_count = [&]() { return shortest_paths_.size() - current_path_index_; };
 
-    // If we have cached shortest paths, return the next one
-    if (unsent_paths_count() > 0) {
-      push_next_path(frame, evaluator);
-      return true;
-    }
+    // The limit is per input row, so guard each serving site rather than returning early: a
+    // saturated row must still fall through to the input loop, where `ResetState` zeroes the count.
+    if (n_returned_paths_ < limit_) {
+      // If we have cached shortest paths, return the next one
+      if (unsent_paths_count() > 0) {
+        push_next_path(frame, evaluator);
+        return true;
+      }
 
-    // Try to compute the next shortest path for current input
-    if (current_input_initialized_ && current_source_.has_value() && current_target_.has_value() &&
-        ComputeNextShortestPath(current_source_.value(), current_target_.value(), frame, evaluator, context)) {
-      push_next_path(frame, evaluator);
-      return true;
+      // Try to compute the next shortest path for current input
+      if (current_input_initialized_ && current_source_.has_value() && current_target_.has_value() &&
+          ComputeNextShortestPath(current_source_.value(), current_target_.value(), frame, evaluator, context)) {
+        push_next_path(frame, evaluator);
+        return true;
+      }
     }
 
     // Need to pull new input
@@ -3802,16 +3802,17 @@ class KShortestPathsCursor : public Cursor {
       upper_bound_ = self_.upper_bound_ ? EvaluateInt(evaluator, self_.upper_bound_, "Max depth in expansion")
                                         : std::numeric_limits<int64_t>::max();
 
-      // Both bounds are compared against a `size_t` further down, so a negative one converts to a
-      // huge unsigned value and silently disables the check instead of narrowing the search: the
-      // depth guard stops firing, and the lower-bound top-up loop below never terminates until
-      // every simple path has been enumerated. Every other shortest-path cursor already rejects
-      // this (BFS, WSHORTEST, ALLSHORTEST); KSHORTEST was the only one that did not.
+      // Both bounds are compared against a `size_t` below, so a negative one wraps to a huge value
+      // and disables the check instead of narrowing the search - the top-up loop then runs until
+      // every simple path is enumerated.
+      // Asymmetric on purpose: `upper_bound_ < 1` matches WSHORTEST/ALLSHORTEST, but no sibling has
+      // a lower-bound floor, and 0 is inert here (the top-up loop is already false at 0), so
+      // rejecting it would break the legal `-[*KSHORTEST 0..n]->`.
       if (upper_bound_ < 1) {
         throw QueryRuntimeException("Maximum depth in KSHORTEST path expansion must be at least 1.");
       }
-      if (lower_bound_ < 1) {
-        throw QueryRuntimeException("Minimum depth in KSHORTEST path expansion must be at least 1.");
+      if (lower_bound_ < 0) {
+        throw QueryRuntimeException("Minimum depth in KSHORTEST path expansion must not be negative.");
       }
 
       // Initialize for this new source-target pair
@@ -3834,7 +3835,7 @@ class KShortestPathsCursor : public Cursor {
         last_path = &shortest_paths_.back();
       }
 
-      if (unsent_paths_count() > 0) {
+      if (n_returned_paths_ < limit_ && unsent_paths_count() > 0) {
         push_next_path(frame, evaluator);
         return true;
       }
@@ -3886,9 +3887,8 @@ class KShortestPathsCursor : public Cursor {
     }
   };
 
-  // Identifies one (edge, bound node) test of the expansion predicate. The pass is part of the key
-  // because the two halves of the bidirectional search check access on opposite endpoints of the
-  // same edge and bind opposite endpoints as the lambda's node.
+  // One (edge, bound node) test of the expansion predicate. The pass is part of the key because the
+  // two halves of the bidirectional search check access on opposite endpoints of the same edge.
   struct ExpansionKey {
     storage::Gid edge;
     storage::Gid node;
@@ -3926,19 +3926,14 @@ class KShortestPathsCursor : public Cursor {
   utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> blocked_edges_;
   utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
   utils::pmr::unordered_map<VertexAccessor, double, VertexAccessorHash> distances_;
-  // Raw storage adjacency, deliberately *not* cleared per input row (unlike `expansion_memo_`), so
-  // Yen's repeated inner searches don't re-fetch. What makes that safe is not the transaction: a
-  // transaction spans several command epochs and `View::OLD` moves with `AdvanceCommand()`, and
-  // under non-snapshot isolation `OLD` visibility is evaluated live. What keeps one cursor inside
-  // one epoch is that MATCH plans `View::OLD` and the planner throws on a variable-length pattern
-  // whose view is anything else (the `view != storage::View::OLD` check in
-  // `rule_based_planner.hpp`). It must also keep storing unfiltered edges - caching post-filter
-  // results here would be wrong the moment the lambda reads an outer-row value.
-  //
-  // The edges are copied into an arena vector rather than cached as the `EdgeVertexAccessorResult`
-  // storage hands back: that struct is not allocator-aware, so its `std::vector` would allocate from
-  // the global heap and escape this query's memory accounting even though the map itself does not.
-  // `expanded_count` is consumed before the insert and never read back, so it is not cached.
+  // Raw storage adjacency, deliberately not cleared per input row (unlike `expansion_memo_`) so
+  // Yen's repeated inner searches don't re-fetch. Must stay unfiltered: caching post-filter results
+  // would break the moment the lambda reads an outer-row value.
+  // Known pre-existing gap: a cursor can outlive its command epoch (`Apply` reuses one cursor
+  // across an `Accumulate` that calls `AdvanceCommand`), so the cache can go stale.
+  // Copied into an arena vector because `EdgeVertexAccessorResult` is not allocator-aware and its
+  // `std::vector` would escape this query's memory accounting. `expanded_count` is consumed before
+  // the insert, so it is not cached.
   using CachedEdges = utils::pmr::vector<EdgeAccessor>;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> in_edges_;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> out_edges_;
@@ -3946,6 +3941,7 @@ class KShortestPathsCursor : public Cursor {
 
   // Memoised `access check && filter lambda` verdicts. Sound across Yen's O(k*L) inner searches
   // because the blocked sets - the only per-deviation inputs - are checked outside the memo.
+  // Assumes the flag below is constant for the row; a mid-query license flip is not invalidated.
   utils::pmr::unordered_map<ExpansionKey, bool, ExpansionKeyHash> expansion_memo_;
   bool memoize_expansion_{false};
   bool fine_grained_access_check_enabled_{false};
@@ -4005,8 +4001,7 @@ class KShortestPathsCursor : public Cursor {
     // Get the deviation vertex
     VertexAccessor deviation_vertex = GetVertexAtIndex(source, base_path, deviation_index);
 
-    // Compute shortest path from deviation vertex to target with blocked elements. The candidate's
-    // total length is `deviation_index + spur_len`, so the spur gets what's left of the bound.
+    // The candidate's total is `deviation_index + spur_len`, so the spur gets what's left of it.
     auto spur_path = ComputeShortestPath(
         deviation_vertex, target, upper_bound_ - static_cast<int64_t>(deviation_index), frame, evaluator, context);
 
@@ -4154,9 +4149,8 @@ class KShortestPathsCursor : public Cursor {
   }
 
   /// `To` picks the endpoint the traversal advances to. `Backward` marks the target-side pass,
-  /// where the filter lambda binds the vertex we expand *from* rather than the one we reach - that
-  /// asymmetry is what makes the bidirectional search test exactly the (edge, node) pairs a forward
-  /// walk of the finished path would. Copied from `STShortestPathCursor::ShouldExpand`.
+  /// where the lambda binds the vertex we expand *from* rather than the one we reach; that
+  /// asymmetry makes the search test exactly the (edge, node) pairs a forward walk would.
   template <bool To, bool Backward>
   bool ShouldExpand(const EdgeAccessor &edge, const VertexAccessor &expand_from, const VertexEdgeMapT &reached,
                     Frame &frame, ExpressionEvaluator &evaluator, ExecutionContext &context) {
@@ -4165,10 +4159,8 @@ class KShortestPathsCursor : public Cursor {
     if (!memoize_expansion_) return FineGrainedAccessCheck<To>(edge, context);
 
     const VertexAccessor &inner_node = Backward ? expand_from : next;
-    // The pass only has to be part of the key because the two halves check access on opposite
-    // endpoints of the same edge. With access checks off the verdict is a pure function of
-    // `(edge, inner_node)`, so dropping the pass merges two entries that are guaranteed to agree and
-    // saves evaluating the lambda a second time on every arc the two frontiers both reach.
+    // With access checks off the verdict is a pure function of `(edge, inner_node)`, so dropping
+    // the pass merges two entries guaranteed to agree.
     const ExpansionKey key{
         .edge = edge.Gid(), .node = inner_node.Gid(), .backward = Backward && fine_grained_access_check_enabled_};
     if (const auto it = expansion_memo_.find(key); it != expansion_memo_.end()) return it->second;
@@ -4363,9 +4355,7 @@ class KShortestPathsCursor : public Cursor {
     predecessors_.clear();
     // Cleared per input row: the lambda may read outer variables, so verdicts don't survive a row.
     expansion_memo_.clear();
-    // The `|K` limit counts paths per input row. Without this reset the counter carried across rows
-    // (and across `Reset()`), so once the first row had produced K paths every later row - and every
-    // outer row of a subquery or pattern comprehension - returned nothing at all.
+    // Makes `|K` per input row; `Pull` guards each serving site instead of returning early.
     n_returned_paths_ = 0;
   }
 };

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4224,7 +4224,7 @@ class KShortestPathsCursor : public Cursor {
       AbortCheck(context);
       // Top-down step (expansion from the source).
       ++current_length;
-      if (current_length > upper_bound) return PathInfo(evaluator.GetMemoryResource());
+      if (std::cmp_greater(current_length, upper_bound)) return PathInfo(evaluator.GetMemoryResource());
 
       for (const auto &vertex : source_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
@@ -4278,7 +4278,7 @@ class KShortestPathsCursor : public Cursor {
 
       // Bottom-up step (expansion from the target).
       ++current_length;
-      if (current_length > upper_bound) return PathInfo(evaluator.GetMemoryResource());
+      if (std::cmp_greater(current_length, upper_bound)) return PathInfo(evaluator.GetMemoryResource());
 
       // When expanding from the target we have to be careful which edge
       // endpoint we pass to `should_expand`, because everything is

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3734,7 +3734,10 @@ class KShortestPathsCursor : public Cursor {
         blocked_edges_(mem),
         blocked_vertices_(mem),
         distances_(mem),
-        predecessors_(mem) {}
+        in_edges_(mem),
+        out_edges_(mem),
+        predecessors_(mem),
+        expansion_memo_(mem) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
@@ -3745,6 +3748,9 @@ class KShortestPathsCursor : public Cursor {
 
     limit_ = self_.limit_ ? EvaluateInt(evaluator, self_.limit_, "Limit in KSHORTEST path expansion")
                           : std::numeric_limits<int64_t>::max();
+
+    // With neither a lambda nor access checks there is nothing to memoise, so don't pay for it.
+    memoize_expansion_ = self_.filter_lambda_.expression != nullptr || FineGrainedAccessCheckEnabled(context);
 
     auto push_next_path = [&](Frame &frame, ExpressionEvaluator &evaluator) {
       PushPathToFrame(shortest_paths_[current_path_index_++], &frame, evaluator.GetMemoryResource(), context);
@@ -3766,7 +3772,7 @@ class KShortestPathsCursor : public Cursor {
 
     // Try to compute the next shortest path for current input
     if (current_input_initialized_ && current_source_.has_value() && current_target_.has_value() &&
-        ComputeNextShortestPath(current_source_.value(), current_target_.value(), evaluator, context)) {
+        ComputeNextShortestPath(current_source_.value(), current_target_.value(), frame, evaluator, context)) {
       push_next_path(frame, evaluator);
       return true;
     }
@@ -3797,7 +3803,7 @@ class KShortestPathsCursor : public Cursor {
       current_target_ = target_vertex;
       current_input_initialized_ = true;
 
-      if (!InitializeKShortestPaths(source_vertex, target_vertex, evaluator, context)) {
+      if (!InitializeKShortestPaths(source_vertex, target_vertex, frame, evaluator, context)) {
         // If no path found, continue to next input
         continue;
       }
@@ -3806,7 +3812,7 @@ class KShortestPathsCursor : public Cursor {
       auto *last_path = &shortest_paths_.back();
       while (last_path->edges.size() < lower_bound_) {
         current_path_index_ = shortest_paths_.size();
-        if (!ComputeNextShortestPath(current_source_.value(), current_target_.value(), evaluator, context)) {
+        if (!ComputeNextShortestPath(current_source_.value(), current_target_.value(), frame, evaluator, context)) {
           break;
         }
         last_path = &shortest_paths_.back();
@@ -3864,6 +3870,24 @@ class KShortestPathsCursor : public Cursor {
     }
   };
 
+  // Identifies one (edge, bound node) test of the expansion predicate. The pass is part of the key
+  // because the two halves of the bidirectional search check access on opposite endpoints of the
+  // same edge and bind opposite endpoints as the lambda's node.
+  struct ExpansionKey {
+    storage::Gid edge;
+    storage::Gid node;
+    bool backward;
+
+    friend bool operator==(const ExpansionKey &, const ExpansionKey &) = default;
+  };
+
+  struct ExpansionKeyHash {
+    size_t operator()(const ExpansionKey &key) const {
+      return utils::HashCombine<size_t, bool>{}(utils::HashCombine<storage::Gid, storage::Gid>{}(key.edge, key.node),
+                                                key.backward);
+    }
+  };
+
   const ExpandVariable &self_;
   UniqueCursorPtr input_cursor_;
   int64_t lower_bound_{1};
@@ -3886,19 +3910,28 @@ class KShortestPathsCursor : public Cursor {
   utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> blocked_edges_;
   utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
   utils::pmr::unordered_map<VertexAccessor, double, VertexAccessorHash> distances_;
+  // Raw storage adjacency, deliberately *not* cleared per input row (unlike `expansion_memo_`): it
+  // is stable for the whole cursor (one cursor = one transaction = one `View::OLD`) and exists so
+  // Yen's repeated inner searches don't re-fetch. It must keep storing unfiltered edges - caching
+  // post-filter results here would be wrong the moment the lambda reads an outer-row value.
   utils::pmr::unordered_map<VertexAccessor, EdgeVertexAccessorResult, VertexAccessorHash> in_edges_;
   utils::pmr::unordered_map<VertexAccessor, EdgeVertexAccessorResult, VertexAccessorHash> out_edges_;
   utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>, VertexAccessorHash> predecessors_;
 
+  // Memoised `access check && filter lambda` verdicts. Sound across Yen's O(k*L) inner searches
+  // because the blocked sets - the only per-deviation inputs - are checked outside the memo.
+  utils::pmr::unordered_map<ExpansionKey, bool, ExpansionKeyHash> expansion_memo_;
+  bool memoize_expansion_{false};
+
   // Bidirectional search state
   using VertexEdgeMapT = utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>>;
 
-  bool InitializeKShortestPaths(const VertexAccessor &source, const VertexAccessor &target,
+  bool InitializeKShortestPaths(const VertexAccessor &source, const VertexAccessor &target, Frame &frame,
                                 ExpressionEvaluator &evaluator, ExecutionContext &context) {
     ResetState();
 
     // Find the shortest path using Dijkstra's algorithm
-    auto shortest_path = ComputeShortestPath(source, target, evaluator, context);
+    auto shortest_path = ComputeShortestPath(source, target, upper_bound_, frame, evaluator, context);
     if (!shortest_path.edges.empty()) {
       shortest_paths_.emplace_back(std::move(shortest_path));
       AddPathToFoundSet(shortest_paths_.back());
@@ -3907,7 +3940,7 @@ class KShortestPathsCursor : public Cursor {
     return false;
   }
 
-  bool ComputeNextShortestPath(const VertexAccessor &source, const VertexAccessor &target,
+  bool ComputeNextShortestPath(const VertexAccessor &source, const VertexAccessor &target, Frame &frame,
                                ExpressionEvaluator &evaluator, ExecutionContext &context) {
     if (shortest_paths_.empty()) return false;
 
@@ -3915,7 +3948,7 @@ class KShortestPathsCursor : public Cursor {
 
     // Generate candidate paths by deviating at each vertex of the last shortest path
     for (size_t i = 0UZ; i < last_path.edges.size(); ++i) {
-      GenerateCandidatesFromDeviation(source, target, last_path, i, evaluator, context);
+      GenerateCandidatesFromDeviation(source, target, last_path, i, frame, evaluator, context);
     }
 
     // Find the best candidate path
@@ -3937,7 +3970,7 @@ class KShortestPathsCursor : public Cursor {
   }
 
   void GenerateCandidatesFromDeviation(const VertexAccessor &source, const VertexAccessor &target,
-                                       const PathInfo &base_path, size_t deviation_index,
+                                       const PathInfo &base_path, size_t deviation_index, Frame &frame,
                                        ExpressionEvaluator &evaluator, ExecutionContext &context) {
     // Set up blocked edges and vertices for this deviation
     SetupBlockedElementsForDeviation(source, base_path, deviation_index);
@@ -3945,8 +3978,10 @@ class KShortestPathsCursor : public Cursor {
     // Get the deviation vertex
     VertexAccessor deviation_vertex = GetVertexAtIndex(source, base_path, deviation_index);
 
-    // Compute shortest path from deviation vertex to target with blocked elements
-    auto spur_path = ComputeShortestPath(deviation_vertex, target, evaluator, context);
+    // Compute shortest path from deviation vertex to target with blocked elements. The candidate's
+    // total length is `deviation_index + spur_len`, so the spur gets what's left of the bound.
+    auto spur_path = ComputeShortestPath(
+        deviation_vertex, target, upper_bound_ - static_cast<int64_t>(deviation_index), frame, evaluator, context);
 
     if (!spur_path.edges.empty()) {
       // Combine the root path (up to deviation) with the spur path
@@ -4049,6 +4084,17 @@ class KShortestPathsCursor : public Cursor {
 
   static constexpr bool kTo = true;
   static constexpr bool kFrom = !kTo;
+  static constexpr bool kBackward = true;
+  static constexpr bool kForward = !kBackward;
+
+  static bool FineGrainedAccessCheckEnabled(const ExecutionContext &context) {
+#ifdef MG_ENTERPRISE
+    return license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker != nullptr;
+#else
+    (void)context;
+    return false;
+#endif
+  }
 
   template <bool To>
   static bool FineGrainedAccessCheck(const EdgeAccessor &edge, ExecutionContext &context) {
@@ -4065,17 +4111,45 @@ class KShortestPathsCursor : public Cursor {
 #endif
   }
 
-  template <bool To>
-  static bool ShouldExpand(const EdgeAccessor &edge, ExecutionContext &context, const VertexEdgeMapT &edges,
-                           const utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> &blocked_edges,
-                           const utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> &blocked_vertices) {
-    return FineGrainedAccessCheck<To>(edge, context) && !blocked_edges.contains(edge) &&
-           !blocked_vertices.contains(To == kTo ? edge.To() : edge.From()) &&
-           !edges.contains(To == kTo ? edge.To() : edge.From());
+  bool EvaluateFilterLambda(const EdgeAccessor &edge, const VertexAccessor &vertex, Frame &frame,
+                            ExpressionEvaluator &evaluator, ExecutionContext &context) {
+    if (!self_.filter_lambda_.expression) return true;
+
+    auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
+    frame_writer.WriteAt(self_.filter_lambda_.inner_node_symbol, vertex);
+    frame_writer.WriteAt(self_.filter_lambda_.inner_edge_symbol, edge);
+
+    TypedValue result = self_.filter_lambda_.expression->Accept(evaluator);
+    if (result.IsNull()) return false;
+    if (result.IsBool()) return result.ValueBool();
+
+    throw QueryRuntimeException("Expansion condition must evaluate to boolean or null");
   }
 
-  PathInfo ComputeShortestPath(const VertexAccessor &source, const VertexAccessor &target,
-                               ExpressionEvaluator &evaluator, ExecutionContext &context) {
+  /// `To` picks the endpoint the traversal advances to. `Backward` marks the target-side pass,
+  /// where the filter lambda binds the vertex we expand *from* rather than the one we reach - that
+  /// asymmetry is what makes the bidirectional search test exactly the (edge, node) pairs a forward
+  /// walk of the finished path would. Copied from `STShortestPathCursor::ShouldExpand`.
+  template <bool To, bool Backward>
+  bool ShouldExpand(const EdgeAccessor &edge, const VertexAccessor &expand_from, const VertexEdgeMapT &reached,
+                    Frame &frame, ExpressionEvaluator &evaluator, ExecutionContext &context) {
+    const VertexAccessor next = To == kTo ? edge.To() : edge.From();
+    if (blocked_edges_.contains(edge) || blocked_vertices_.contains(next) || reached.contains(next)) return false;
+    if (!memoize_expansion_) return FineGrainedAccessCheck<To>(edge, context);
+
+    const VertexAccessor &inner_node = Backward ? expand_from : next;
+    const ExpansionKey key{.edge = edge.Gid(), .node = inner_node.Gid(), .backward = Backward};
+    if (const auto it = expansion_memo_.find(key); it != expansion_memo_.end()) return it->second;
+
+    // Access check first: an edge the user cannot read must never make the lambda run on it.
+    const bool allowed =
+        FineGrainedAccessCheck<To>(edge, context) && EvaluateFilterLambda(edge, inner_node, frame, evaluator, context);
+    expansion_memo_.emplace(key, allowed);
+    return allowed;
+  }
+
+  PathInfo ComputeShortestPath(const VertexAccessor &source, const VertexAccessor &target, int64_t upper_bound,
+                               Frame &frame, ExpressionEvaluator &evaluator, ExecutionContext &context) {
     if (source == target) return PathInfo(evaluator.GetMemoryResource());
 
     // We expand from both directions, both from the source and the target.
@@ -4110,7 +4184,7 @@ class KShortestPathsCursor : public Cursor {
       AbortCheck(context);
       // Top-down step (expansion from the source).
       ++current_length;
-      if (current_length > upper_bound_) return PathInfo(evaluator.GetMemoryResource());
+      if (current_length > upper_bound) return PathInfo(evaluator.GetMemoryResource());
 
       for (const auto &vertex : source_frontier) {
         if (context.hops_limit.IsLimitReached()) break;
@@ -4122,7 +4196,7 @@ class KShortestPathsCursor : public Cursor {
             out_edges_.emplace(vertex, out_edges_result);
           }
           for (const auto &edge : out_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kTo>(edge, context, in_edge, blocked_edges_, blocked_vertices_)) {
+            if (!ShouldExpand<kTo, kForward>(edge, vertex, in_edge, frame, evaluator, context)) {
               continue;
             }
             in_edge.emplace(edge.To(), edge);
@@ -4140,7 +4214,7 @@ class KShortestPathsCursor : public Cursor {
             in_edges_.emplace(vertex, in_edges_result);
           }
           for (const auto &edge : in_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kFrom>(edge, context, in_edge, blocked_edges_, blocked_vertices_)) {
+            if (!ShouldExpand<kFrom, kForward>(edge, vertex, in_edge, frame, evaluator, context)) {
               continue;
             }
             in_edge.emplace(edge.From(), edge);
@@ -4158,7 +4232,7 @@ class KShortestPathsCursor : public Cursor {
 
       // Bottom-up step (expansion from the target).
       ++current_length;
-      if (current_length > upper_bound_) return PathInfo(evaluator.GetMemoryResource());
+      if (current_length > upper_bound) return PathInfo(evaluator.GetMemoryResource());
 
       // When expanding from the target we have to be careful which edge
       // endpoint we pass to `should_expand`, because everything is
@@ -4173,7 +4247,7 @@ class KShortestPathsCursor : public Cursor {
             out_edges_.emplace(vertex, out_edges_result);
           }
           for (const auto &edge : out_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kTo>(edge, context, out_edge, blocked_edges_, blocked_vertices_)) {
+            if (!ShouldExpand<kTo, kBackward>(edge, vertex, out_edge, frame, evaluator, context)) {
               continue;
             }
             out_edge.emplace(edge.To(), edge);
@@ -4191,7 +4265,7 @@ class KShortestPathsCursor : public Cursor {
             in_edges_.emplace(vertex, in_edges_result);
           }
           for (const auto &edge : in_edges_.at(vertex).edges) {
-            if (!ShouldExpand<kFrom>(edge, context, out_edge, blocked_edges_, blocked_vertices_)) {
+            if (!ShouldExpand<kFrom, kBackward>(edge, vertex, out_edge, frame, evaluator, context)) {
               continue;
             }
             out_edge.emplace(edge.From(), edge);
@@ -4243,6 +4317,8 @@ class KShortestPathsCursor : public Cursor {
     blocked_vertices_.clear();
     distances_.clear();
     predecessors_.clear();
+    // Cleared per input row: the lambda may read outer variables, so verdicts don't survive a row.
+    expansion_memo_.clear();
   }
 };
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3923,11 +3923,17 @@ class KShortestPathsCursor : public Cursor {
   utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
   utils::pmr::unordered_map<VertexAccessor, double, VertexAccessorHash> distances_;
   // Raw storage adjacency, deliberately *not* cleared per input row (unlike `expansion_memo_`): it
-  // is stable for the whole cursor (one cursor = one transaction = one `View::OLD`) and exists so
-  // Yen's repeated inner searches don't re-fetch. It must keep storing unfiltered edges - caching
-  // post-filter results here would be wrong the moment the lambda reads an outer-row value.
-  utils::pmr::unordered_map<VertexAccessor, EdgeVertexAccessorResult, VertexAccessorHash> in_edges_;
-  utils::pmr::unordered_map<VertexAccessor, EdgeVertexAccessorResult, VertexAccessorHash> out_edges_;
+  // is stable for the whole command epoch the cursor runs in and exists so Yen's repeated inner
+  // searches don't re-fetch. It must keep storing unfiltered edges - caching post-filter results
+  // here would be wrong the moment the lambda reads an outer-row value.
+  //
+  // The edges are copied into an arena vector rather than cached as the `EdgeVertexAccessorResult`
+  // storage hands back: that struct is not allocator-aware, so its `std::vector` would allocate from
+  // the global heap and escape this query's memory accounting even though the map itself does not.
+  // `expanded_count` is consumed before the insert and never read back, so it is not cached.
+  using CachedEdges = utils::pmr::vector<EdgeAccessor>;
+  utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> in_edges_;
+  utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> out_edges_;
   utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>, VertexAccessorHash> predecessors_;
 
   // Memoised `access check && filter lambda` verdicts. Sound across Yen's O(k*L) inner searches
@@ -4205,9 +4211,12 @@ class KShortestPathsCursor : public Cursor {
             auto out_edges_result =
                 UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
             context.number_of_hops += out_edges_result.expanded_count;
-            out_edges_.emplace(vertex, out_edges_result);
+            out_edges_.emplace(vertex,
+                               CachedEdges(out_edges_result.edges.begin(),
+                                           out_edges_result.edges.end(),
+                                           out_edges_.get_allocator().resource()));
           }
-          for (const auto &edge : out_edges_.at(vertex).edges) {
+          for (const auto &edge : out_edges_.at(vertex)) {
             if (!ShouldExpand<kTo, kForward>(edge, vertex, in_edge, frame, evaluator, context)) {
               continue;
             }
@@ -4223,9 +4232,12 @@ class KShortestPathsCursor : public Cursor {
             auto in_edges_result =
                 UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
             context.number_of_hops += in_edges_result.expanded_count;
-            in_edges_.emplace(vertex, in_edges_result);
+            in_edges_.emplace(
+                vertex,
+                CachedEdges(
+                    in_edges_result.edges.begin(), in_edges_result.edges.end(), in_edges_.get_allocator().resource()));
           }
-          for (const auto &edge : in_edges_.at(vertex).edges) {
+          for (const auto &edge : in_edges_.at(vertex)) {
             if (!ShouldExpand<kFrom, kForward>(edge, vertex, in_edge, frame, evaluator, context)) {
               continue;
             }
@@ -4256,9 +4268,12 @@ class KShortestPathsCursor : public Cursor {
             auto out_edges_result =
                 UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
             context.number_of_hops += out_edges_result.expanded_count;
-            out_edges_.emplace(vertex, out_edges_result);
+            out_edges_.emplace(vertex,
+                               CachedEdges(out_edges_result.edges.begin(),
+                                           out_edges_result.edges.end(),
+                                           out_edges_.get_allocator().resource()));
           }
-          for (const auto &edge : out_edges_.at(vertex).edges) {
+          for (const auto &edge : out_edges_.at(vertex)) {
             if (!ShouldExpand<kTo, kBackward>(edge, vertex, out_edge, frame, evaluator, context)) {
               continue;
             }
@@ -4274,9 +4289,12 @@ class KShortestPathsCursor : public Cursor {
             auto in_edges_result =
                 UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
             context.number_of_hops += in_edges_result.expanded_count;
-            in_edges_.emplace(vertex, in_edges_result);
+            in_edges_.emplace(
+                vertex,
+                CachedEdges(
+                    in_edges_result.edges.begin(), in_edges_result.edges.end(), in_edges_.get_allocator().resource()));
           }
-          for (const auto &edge : in_edges_.at(vertex).edges) {
+          for (const auto &edge : in_edges_.at(vertex)) {
             if (!ShouldExpand<kFrom, kBackward>(edge, vertex, out_edge, frame, evaluator, context)) {
               continue;
             }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3746,19 +3746,10 @@ class KShortestPathsCursor : public Cursor {
     ExpressionEvaluator evaluator =
         ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
 
-    limit_ = self_.limit_ ? EvaluateInt(evaluator, self_.limit_, "Limit in KSHORTEST path expansion")
-                          : std::numeric_limits<int64_t>::max();
-
     // Nothing to memoise without a lambda or access checks, so don't pay for the map. This is a
     // cost switch only: `ShouldExpand` computes the same verdict either way.
     fine_grained_access_check_enabled_ = FineGrainedAccessCheckEnabled(context);
     memoize_expansion_ = self_.filter_lambda_.expression != nullptr || fine_grained_access_check_enabled_;
-
-    if (limit_ < 0) {
-      throw QueryRuntimeException("Limit in KSHORTEST path expansion must not be negative.");
-    }
-    // Zero paths is a legal request, unlike a negative count, so serve it without searching.
-    if (limit_ == 0) return false;
 
     auto push_next_path = [&](Frame &frame, ExpressionEvaluator &evaluator) {
       PushPathToFrame(shortest_paths_[current_path_index_++], &frame, evaluator.GetMemoryResource(), context);
@@ -3800,6 +3791,17 @@ class KShortestPathsCursor : public Cursor {
 
       // Skip if source and target are the same vertex
       if (source_vertex == target_vertex) continue;
+
+      // Evaluated per row, not once per `Pull`: the count is per row (`ResetState` zeroes it), and a
+      // row-dependent `|k` reads this row's frame. Evaluating it before the input pull would read
+      // the previous row's values, or unbound nulls on the first pull.
+      limit_ = self_.limit_ ? EvaluateInt(evaluator, self_.limit_, "Limit in KSHORTEST path expansion")
+                            : std::numeric_limits<int64_t>::max();
+      if (limit_ < 0) {
+        throw QueryRuntimeException("Limit in KSHORTEST path expansion must not be negative.");
+      }
+      // Zero paths is a legal request, unlike a negative count, so skip this row without searching.
+      if (limit_ == 0) continue;
 
       lower_bound_ = self_.lower_bound_ ? EvaluateInt(evaluator, self_.lower_bound_, "Min depth in expansion") : 1;
       upper_bound_ = self_.upper_bound_ ? EvaluateInt(evaluator, self_.upper_bound_, "Max depth in expansion")
@@ -3845,7 +3847,7 @@ class KShortestPathsCursor : public Cursor {
       // `InitializeKShortestPaths` reset the per-row count above, and the top-up loop serves
       // nothing, so this row has spent none of its budget yet.
       DMG_ASSERT(n_returned_paths_ == 0, "KSHORTEST path count must be reset before a new input row is served");
-      if (unsent_paths_count() > 0) {
+      if (n_returned_paths_ < limit_ && unsent_paths_count() > 0) {
         push_next_path(frame, evaluator);
         return true;
       }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3754,8 +3754,11 @@ class KShortestPathsCursor : public Cursor {
     fine_grained_access_check_enabled_ = FineGrainedAccessCheckEnabled(context);
     memoize_expansion_ = self_.filter_lambda_.expression != nullptr || fine_grained_access_check_enabled_;
 
-    // A non-positive limit can never yield a path, so don't search at all.
-    if (limit_ <= 0) return false;
+    if (limit_ < 0) {
+      throw QueryRuntimeException("Limit in KSHORTEST path expansion must not be negative.");
+    }
+    // Zero paths is a legal request, unlike a negative count, so serve it without searching.
+    if (limit_ == 0) return false;
 
     auto push_next_path = [&](Frame &frame, ExpressionEvaluator &evaluator) {
       PushPathToFrame(shortest_paths_[current_path_index_++], &frame, evaluator.GetMemoryResource(), context);
@@ -3814,6 +3817,10 @@ class KShortestPathsCursor : public Cursor {
       if (lower_bound_ < 0) {
         throw QueryRuntimeException("Minimum depth in KSHORTEST path expansion must not be negative.");
       }
+      // An inverted range is legally empty, and BFS skips the row for it too. Not merely a
+      // shortcut: no path can exceed `upper_bound_`, so the top-up loop below would enumerate
+      // every simple path and still serve nothing.
+      if (lower_bound_ > upper_bound_) continue;
 
       // Initialize for this new source-target pair
       current_source_ = source_vertex;

--- a/tests/benchmark/expansion.cpp
+++ b/tests/benchmark/expansion.cpp
@@ -126,6 +126,127 @@ BENCHMARK_REGISTER_F(ExpansionBenchFixture, Expand)
     ->Range(1, 1 << 20)
     ->Unit(benchmark::kMillisecond);
 
+// A layered graph: every layer is fully connected to the next, so there are `width ^ kLayers`
+// distinct source-to-target paths - plenty of deviations for Yen's algorithm to chew through.
+class KShortestBenchFixture : public benchmark::Fixture {
+ protected:
+  static constexpr int kLayers = 3;
+
+  std::optional<memgraph::system::System> system;
+  std::optional<memgraph::query::AllowEverythingAuthChecker> auth_checker;
+  std::optional<memgraph::query::InterpreterContext> interpreter_context;
+  std::optional<memgraph::query::Interpreter> interpreter;
+  std::optional<memgraph::utils::Gatekeeper<memgraph::dbms::Database>> db_gk;
+  std::optional<memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock>>
+      repl_state;
+
+  void SetUp(const benchmark::State &state) override {
+    repl_state.emplace(std::nullopt);
+    memgraph::storage::Config config{};
+    config.durability.storage_directory = data_directory;
+    config.disk.main_storage_directory = data_directory / "disk";
+    db_gk.emplace(std::move(config));
+    auto db_acc_opt = db_gk->access();
+    MG_ASSERT(db_acc_opt, "Failed to access db");
+    auto &db_acc = *db_acc_opt;
+
+    system.emplace();
+    auth_checker.emplace();
+    interpreter_context.emplace(memgraph::query::InterpreterConfig{},
+                                nullptr,
+                                nullptr,
+                                nullptr,
+                                &repl_state.value(),
+                                *system,
+                                nullptr
+#ifdef MG_ENTERPRISE
+                                ,
+                                nullptr,
+                                nullptr
+#endif
+    );
+
+    auto source_label = db_acc->storage()->NameToLabel("Source");
+    auto target_label = db_acc->storage()->NameToLabel("Target");
+
+    {
+      auto dba = db_acc->Access(memgraph::storage::WRITE);
+      auto edge_type = dba->NameToEdgeType("edge_type");
+      auto id_property = dba->NameToProperty("id");
+      int64_t next_id = 0;
+      auto make_vertex = [&] {
+        auto vertex = dba->CreateVertex();
+        MG_ASSERT(vertex.SetProperty(id_property, memgraph::storage::PropertyValue(next_id++)).has_value());
+        return vertex;
+      };
+
+      auto source = make_vertex();
+      MG_ASSERT(source.AddLabel(source_label).has_value());
+      std::vector<memgraph::storage::VertexAccessor> previous_layer{source};
+
+      for (int layer = 0; layer < kLayers; ++layer) {
+        std::vector<memgraph::storage::VertexAccessor> current_layer;
+        for (int i = 0; i < state.range(0); ++i) current_layer.push_back(make_vertex());
+        for (auto &from : previous_layer) {
+          for (auto &to : current_layer) MG_ASSERT(dba->CreateEdge(&from, &to, edge_type).has_value());
+        }
+        previous_layer = std::move(current_layer);
+      }
+
+      auto target = make_vertex();
+      MG_ASSERT(target.AddLabel(target_label).has_value());
+      for (auto &from : previous_layer) MG_ASSERT(dba->CreateEdge(&from, &target, edge_type).has_value());
+
+      MG_ASSERT(dba->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    for (auto label : {source_label, target_label}) {
+      auto unique_acc = db_acc->UniqueAccess();
+      MG_ASSERT(unique_acc->CreateIndex(label).has_value());
+      MG_ASSERT(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    interpreter.emplace(&*interpreter_context, std::move(db_acc));
+    interpreter->SetUser(auth_checker->GenQueryUser(std::nullopt, {}));
+  }
+
+  void TearDown(const benchmark::State &) override {
+    interpreter = std::nullopt;
+    interpreter_context = std::nullopt;
+    db_gk.reset();
+    auth_checker.reset();
+    system.reset();
+    std::filesystem::remove_all(data_directory);
+  }
+
+  void RunQuery(benchmark::State &state, const char *query) {
+    while (state.KeepRunning()) {
+      ResultStreamFaker results(interpreter->current_db_.db_acc_->get()->storage());
+      interpreter->Prepare(query, memgraph::query::no_params_fn, {});
+      interpreter->PullAll(&results);
+    }
+  }
+};
+
+BENCHMARK_DEFINE_F(KShortestBenchFixture, KShortest)(benchmark::State &state) {
+  RunQuery(state, "MATCH (s:Source), (t:Target) WITH s, t MATCH (s)-[*KSHORTEST |20]->(t) RETURN count(*)");
+}
+
+BENCHMARK_REGISTER_F(KShortestBenchFixture, KShortest)->RangeMultiplier(2)->Range(2, 8)->Unit(benchmark::kMillisecond);
+
+// The same search with a filter lambda that accepts everything, so the difference against
+// `KShortest` above is the cost of evaluating (and memoising) the predicate.
+BENCHMARK_DEFINE_F(KShortestBenchFixture, KShortestFiltered)(benchmark::State &state) {
+  RunQuery(state,
+           "MATCH (s:Source), (t:Target) WITH s, t MATCH (s)-[*KSHORTEST |20 (r, n | n.id >= 0)]->(t) RETURN "
+           "count(*)");
+}
+
+BENCHMARK_REGISTER_F(KShortestBenchFixture, KShortestFiltered)
+    ->RangeMultiplier(2)
+    ->Range(2, 8)
+    ->Unit(benchmark::kMillisecond);
+
 int main(int argc, char **argv) {
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();

--- a/tests/benchmark/expansion.cpp
+++ b/tests/benchmark/expansion.cpp
@@ -126,15 +126,13 @@ BENCHMARK_REGISTER_F(ExpansionBenchFixture, Expand)
     ->Range(1, 1 << 20)
     ->Unit(benchmark::kMillisecond);
 
-// A layered graph: every layer is fully connected to the next, so there are `width ^ kLayers`
-// distinct source-to-target paths - plenty of deviations for Yen's algorithm to chew through.
+// Layers fully connected to the next, so `width ^ kLayers` distinct paths - plenty of deviations.
 class KShortestBenchFixture : public benchmark::Fixture {
  protected:
   static constexpr int kLayers = 3;
 
-  // How many independent source/target components to build. One means a single input row, which
-  // measures the inner Yen search alone; more than one also exercises the per-row work - clearing
-  // the expansion memo and reusing the adjacency cache, neither of which is visible with one row.
+  // One component means a single input row, measuring the inner Yen search alone; more than one also
+  // prices the per-row work - clearing the memo and reusing the adjacency cache.
   virtual int PairCount() const { return 1; }
 
   std::optional<memgraph::system::System> system;
@@ -249,8 +247,7 @@ BENCHMARK_DEFINE_F(KShortestBenchFixture, KShortest)(benchmark::State &state) {
 
 BENCHMARK_REGISTER_F(KShortestBenchFixture, KShortest)->RangeMultiplier(2)->Range(2, 8)->Unit(benchmark::kMillisecond);
 
-// The same search with a filter lambda that accepts everything, so the difference against
-// `KShortest` above is the cost of evaluating (and memoising) the predicate.
+// The same search with an always-true lambda: the delta against `KShortest` is the predicate's cost.
 BENCHMARK_DEFINE_F(KShortestBenchFixture, KShortestFiltered)(benchmark::State &state) {
   RunQuery(state,
            "MATCH (s:Source), (t:Target) WITH s, t MATCH (s)-[*KSHORTEST |20 (r, n | n.id >= 0)]->(t) RETURN "
@@ -262,17 +259,15 @@ BENCHMARK_REGISTER_F(KShortestBenchFixture, KShortestFiltered)
     ->Range(2, 8)
     ->Unit(benchmark::kMillisecond);
 
-// Several independent source/target pairs through one cursor. KSHORTEST requires both endpoints
-// bound, so this - not the single-pair case above - is the shape a real query takes. It is also the
-// only way to price the per-row work: the expansion memo is cleared per row, while the adjacency
-// cache deliberately is not, and neither shows up with a single row.
+// Several pairs through one cursor - the shape a real query takes, and the only way to price the
+// per-row work: the memo is cleared per row while the adjacency cache is not.
 class KShortestMultiRowBenchFixture : public KShortestBenchFixture {
  protected:
   int PairCount() const override { return 6; }
 };
 
-// No path limit, so the search is identical on master and this branch and the two are comparable.
-// (`|k` is not: the limit is now per row, so this branch legitimately searches every row.)
+// No `|k`, so master and this branch do the same search; with a limit they would not, since it is
+// now per row.
 BENCHMARK_DEFINE_F(KShortestMultiRowBenchFixture, KShortestMultiRow)(benchmark::State &state) {
   RunQuery(state,
            "MATCH (s:Source), (t:Target) WHERE s.pair = t.pair WITH s, t "
@@ -281,8 +276,7 @@ BENCHMARK_DEFINE_F(KShortestMultiRowBenchFixture, KShortestMultiRow)(benchmark::
 
 BENCHMARK_REGISTER_F(KShortestMultiRowBenchFixture, KShortestMultiRow)->Arg(2)->Arg(4)->Unit(benchmark::kMillisecond);
 
-// The same rows with an always-true lambda: the delta against `KShortestMultiRow` is the predicate
-// plus building and tearing down the memo once per input row.
+// The delta against `KShortestMultiRow` is the predicate plus the memo, once per input row.
 BENCHMARK_DEFINE_F(KShortestMultiRowBenchFixture, KShortestMultiRowFiltered)(benchmark::State &state) {
   RunQuery(state,
            "MATCH (s:Source), (t:Target) WHERE s.pair = t.pair WITH s, t "

--- a/tests/benchmark/expansion.cpp
+++ b/tests/benchmark/expansion.cpp
@@ -132,6 +132,11 @@ class KShortestBenchFixture : public benchmark::Fixture {
  protected:
   static constexpr int kLayers = 3;
 
+  // How many independent source/target components to build. One means a single input row, which
+  // measures the inner Yen search alone; more than one also exercises the per-row work - clearing
+  // the expansion memo and reusing the adjacency cache, neither of which is visible with one row.
+  virtual int PairCount() const { return 1; }
+
   std::optional<memgraph::system::System> system;
   std::optional<memgraph::query::AllowEverythingAuthChecker> auth_checker;
   std::optional<memgraph::query::InterpreterContext> interpreter_context;
@@ -173,6 +178,7 @@ class KShortestBenchFixture : public benchmark::Fixture {
       auto dba = db_acc->Access(memgraph::storage::WRITE);
       auto edge_type = dba->NameToEdgeType("edge_type");
       auto id_property = dba->NameToProperty("id");
+      auto pair_property = dba->NameToProperty("pair");
       int64_t next_id = 0;
       auto make_vertex = [&] {
         auto vertex = dba->CreateVertex();
@@ -180,22 +186,31 @@ class KShortestBenchFixture : public benchmark::Fixture {
         return vertex;
       };
 
-      auto source = make_vertex();
-      MG_ASSERT(source.AddLabel(source_label).has_value());
-      std::vector<memgraph::storage::VertexAccessor> previous_layer{source};
+      // The components are disjoint, so `pair` correlates each source with its own target.
+      for (int pair = 0; pair < PairCount(); ++pair) {
+        auto tag_pair = [&](memgraph::storage::VertexAccessor &vertex) {
+          MG_ASSERT(vertex.SetProperty(pair_property, memgraph::storage::PropertyValue(pair)).has_value());
+        };
 
-      for (int layer = 0; layer < kLayers; ++layer) {
-        std::vector<memgraph::storage::VertexAccessor> current_layer;
-        for (int i = 0; i < state.range(0); ++i) current_layer.push_back(make_vertex());
-        for (auto &from : previous_layer) {
-          for (auto &to : current_layer) MG_ASSERT(dba->CreateEdge(&from, &to, edge_type).has_value());
+        auto source = make_vertex();
+        MG_ASSERT(source.AddLabel(source_label).has_value());
+        tag_pair(source);
+        std::vector<memgraph::storage::VertexAccessor> previous_layer{source};
+
+        for (int layer = 0; layer < kLayers; ++layer) {
+          std::vector<memgraph::storage::VertexAccessor> current_layer;
+          for (int i = 0; i < state.range(0); ++i) current_layer.push_back(make_vertex());
+          for (auto &from : previous_layer) {
+            for (auto &to : current_layer) MG_ASSERT(dba->CreateEdge(&from, &to, edge_type).has_value());
+          }
+          previous_layer = std::move(current_layer);
         }
-        previous_layer = std::move(current_layer);
-      }
 
-      auto target = make_vertex();
-      MG_ASSERT(target.AddLabel(target_label).has_value());
-      for (auto &from : previous_layer) MG_ASSERT(dba->CreateEdge(&from, &target, edge_type).has_value());
+        auto target = make_vertex();
+        MG_ASSERT(target.AddLabel(target_label).has_value());
+        tag_pair(target);
+        for (auto &from : previous_layer) MG_ASSERT(dba->CreateEdge(&from, &target, edge_type).has_value());
+      }
 
       MG_ASSERT(dba->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
@@ -245,6 +260,38 @@ BENCHMARK_DEFINE_F(KShortestBenchFixture, KShortestFiltered)(benchmark::State &s
 BENCHMARK_REGISTER_F(KShortestBenchFixture, KShortestFiltered)
     ->RangeMultiplier(2)
     ->Range(2, 8)
+    ->Unit(benchmark::kMillisecond);
+
+// Several independent source/target pairs through one cursor. KSHORTEST requires both endpoints
+// bound, so this - not the single-pair case above - is the shape a real query takes. It is also the
+// only way to price the per-row work: the expansion memo is cleared per row, while the adjacency
+// cache deliberately is not, and neither shows up with a single row.
+class KShortestMultiRowBenchFixture : public KShortestBenchFixture {
+ protected:
+  int PairCount() const override { return 6; }
+};
+
+// No path limit, so the search is identical on master and this branch and the two are comparable.
+// (`|k` is not: the limit is now per row, so this branch legitimately searches every row.)
+BENCHMARK_DEFINE_F(KShortestMultiRowBenchFixture, KShortestMultiRow)(benchmark::State &state) {
+  RunQuery(state,
+           "MATCH (s:Source), (t:Target) WHERE s.pair = t.pair WITH s, t "
+           "MATCH (s)-[*KSHORTEST]->(t) RETURN count(*)");
+}
+
+BENCHMARK_REGISTER_F(KShortestMultiRowBenchFixture, KShortestMultiRow)->Arg(2)->Arg(4)->Unit(benchmark::kMillisecond);
+
+// The same rows with an always-true lambda: the delta against `KShortestMultiRow` is the predicate
+// plus building and tearing down the memo once per input row.
+BENCHMARK_DEFINE_F(KShortestMultiRowBenchFixture, KShortestMultiRowFiltered)(benchmark::State &state) {
+  RunQuery(state,
+           "MATCH (s:Source), (t:Target) WHERE s.pair = t.pair WITH s, t "
+           "MATCH (s)-[*KSHORTEST (r, n | n.id >= 0)]->(t) RETURN count(*)");
+}
+
+BENCHMARK_REGISTER_F(KShortestMultiRowBenchFixture, KShortestMultiRowFiltered)
+    ->Arg(2)
+    ->Arg(4)
     ->Unit(benchmark::kMillisecond);
 
 int main(int argc, char **argv) {

--- a/tests/e2e/hops_count/hops_count.py
+++ b/tests/e2e/hops_count/hops_count.py
@@ -225,14 +225,11 @@ def test_hops_count_3():
 
 
 def test_hops_count_kshortest_bounded_spur():
-    # A spur search after a deviation only needs the depth left over after the deviation, not the
-    # whole maximum depth. Every other KSHORTEST case here is unbounded or `..1`, where that is
-    # inert: unbounded leaves the spur bound unbounded too, and at `..1` only the deviation at
-    # index 0 exists, whose remaining depth is the full bound.
+    # A spur after a deviation only needs the depth left over, not the whole maximum. Every other
+    # KSHORTEST case here is unbounded or `..1`, where that is inert.
     execute_query("MATCH (n) DETACH DELETE n")
-    # a->b->c->t is the shortest path; a->b->m->t is the second. Deviating at c must not walk the
-    # dead-end c->p->q->r, which is only reachable within the *full* bound, never within what is
-    # left after two hops.
+    # a->b->c->t then a->b->m->t. Deviating at c must not walk the dead-end c->p->q->r, which fits
+    # the full bound but not what is left after two hops.
     execute_query(
         "CREATE (a:N {n: 'a'}), (b:N {n: 'b'}), (c:N {n: 'c'}), (t:N {n: 't'}), (m:N {n: 'm'}), "
         "       (p:N {n: 'p'}), (q:N {n: 'q'}), (r:N {n: 'r'}) "
@@ -243,18 +240,16 @@ def test_hops_count_kshortest_bounded_spur():
 
     prefix = "MATCH (a:N {n: 'a'}), (t:N {n: 't'}) WITH a, t MATCH (a)-[r:E *KSHORTEST"
 
-    # Both paths are found either way - only the hop budget differs, which is what makes this a
-    # hops test and not a results test. Bounding the spur by the full depth costs 9 here.
+    # Both paths are found either way; only the budget differs. The full-depth spur cost 9 here.
     summary = get_summary(f"{prefix} 1..3]->(t) RETURN r")
     assert summary["number_of_hops"] == 8
 
-    # A looser bound wastes more: the dead-end chain is three hops long, so the whole of it used to
-    # be walked. This cost 10 before.
+    # A looser bound wasted more - the whole three-hop dead end was walked. This cost 10 before.
     summary = get_summary(f"{prefix} 1..4]->(t) RETURN r")
     assert summary["number_of_hops"] == 8
 
-    # Control: with no upper bound there is nothing to subtract, so the count is unchanged. This
-    # pins that the two assertions above are about the bound and not about the graph.
+    # Control: nothing to subtract without an upper bound, so the assertions above are about the
+    # bound and not the graph.
     summary = get_summary(f"{prefix}]->(t) RETURN r")
     assert summary["number_of_hops"] == 10
 

--- a/tests/e2e/hops_count/hops_count.py
+++ b/tests/e2e/hops_count/hops_count.py
@@ -224,5 +224,40 @@ def test_hops_count_3():
     assert number_of_hops == 2  # scans by a and then expand to e
 
 
+def test_hops_count_kshortest_bounded_spur():
+    # A spur search after a deviation only needs the depth left over after the deviation, not the
+    # whole maximum depth. Every other KSHORTEST case here is unbounded or `..1`, where that is
+    # inert: unbounded leaves the spur bound unbounded too, and at `..1` only the deviation at
+    # index 0 exists, whose remaining depth is the full bound.
+    execute_query("MATCH (n) DETACH DELETE n")
+    # a->b->c->t is the shortest path; a->b->m->t is the second. Deviating at c must not walk the
+    # dead-end c->p->q->r, which is only reachable within the *full* bound, never within what is
+    # left after two hops.
+    execute_query(
+        "CREATE (a:N {n: 'a'}), (b:N {n: 'b'}), (c:N {n: 'c'}), (t:N {n: 't'}), (m:N {n: 'm'}), "
+        "       (p:N {n: 'p'}), (q:N {n: 'q'}), (r:N {n: 'r'}) "
+        "CREATE (a)-[:E]->(b), (b)-[:E]->(c), (c)-[:E]->(t), "
+        "       (b)-[:E]->(m), (m)-[:E]->(t), "
+        "       (c)-[:E]->(p), (p)-[:E]->(q), (q)-[:E]->(r)"
+    )
+
+    prefix = "MATCH (a:N {n: 'a'}), (t:N {n: 't'}) WITH a, t MATCH (a)-[r:E *KSHORTEST"
+
+    # Both paths are found either way - only the hop budget differs, which is what makes this a
+    # hops test and not a results test. Bounding the spur by the full depth costs 9 here.
+    summary = get_summary(f"{prefix} 1..3]->(t) RETURN r")
+    assert summary["number_of_hops"] == 8
+
+    # A looser bound wastes more: the dead-end chain is three hops long, so the whole of it used to
+    # be walked. This cost 10 before.
+    summary = get_summary(f"{prefix} 1..4]->(t) RETURN r")
+    assert summary["number_of_hops"] == 8
+
+    # Control: with no upper bound there is nothing to subtract, so the count is unchanged. This
+    # pins that the two assertions above are about the bound and not about the graph.
+    summary = get_summary(f"{prefix}]->(t) RETURN r")
+    assert summary["number_of_hops"] == 10
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/kshortest_limit/kshortest_limit.py
+++ b/tests/e2e/kshortest_limit/kshortest_limit.py
@@ -171,8 +171,7 @@ def test_kshortest_inline_property_filter():
     assert len(results) == 1, f"Expected 1 path, got {len(results)}"
     assert len(results[0]["r"]) == 2, f"Expected the two-hop matching path, got {len(results[0]['r'])} edges"
 
-    # Without a limit the answer was already correct, because the post-expansion filter got to see
-    # every path the search produced. Guard that it stayed correct.
+    # Already correct without a limit, since the post-expansion filter saw every path. Guard that.
     print("Test: inlined property map without a limit")
     results = execute_query(
         """

--- a/tests/e2e/kshortest_limit/kshortest_limit.py
+++ b/tests/e2e/kshortest_limit/kshortest_limit.py
@@ -133,6 +133,58 @@ def test_kshortest_limit():
     print("All tests passed! ✅")
 
 
+def test_kshortest_inline_property_filter():
+    """An inlined edge property map is now applied during the search, not only after it.
+
+    The planner turns `{p: 1}` into two filters: an inline one over the expansion's inner edge, and
+    a post-expansion `all(e IN r WHERE e.p = 1)`. The path limit is enforced inside the operator, so
+    before the inline filter was honoured the limit could be spent on paths the post-expansion filter
+    then threw away - yielding fewer than `k` matching paths, or none at all.
+
+    The graph makes the shortest path the non-matching one, so the ordering is deterministic rather
+    than dependent on storage iteration order.
+    """
+    print("Testing kshortest with an inlined edge property map...")
+    execute_query("MATCH (n) DETACH DELETE n")
+    execute_query(
+        """
+        CREATE (s:Route {id: 's'})
+        CREATE (m:Route {id: 'm'})
+        CREATE (t:Route {id: 't'})
+        CREATE (s)-[:LINK {p: 0}]->(t)
+        CREATE (s)-[:LINK {p: 1}]->(m)
+        CREATE (m)-[:LINK {p: 1}]->(t)
+    """
+    )
+
+    # The one-hop path is shorter but has p = 0, so the only matching path is the two-hop one.
+    print("Test: inlined property map with a limit of 1")
+    results = execute_query(
+        """
+        MATCH (s:Route {id: 's'}),(t:Route {id: 't'})
+        WITH s, t MATCH (s)-[r:LINK *KSHORTEST|1 {p: 1}]->(t) RETURN r
+    """
+    )
+    print(f"  Found {len(results)} matching paths with limit 1")
+    assert len(results) == 1, f"Expected 1 path, got {len(results)}"
+    assert len(results[0]["r"]) == 2, f"Expected the two-hop matching path, got {len(results[0]['r'])} edges"
+
+    # Without a limit the answer was already correct, because the post-expansion filter got to see
+    # every path the search produced. Guard that it stayed correct.
+    print("Test: inlined property map without a limit")
+    results = execute_query(
+        """
+        MATCH (s:Route {id: 's'}),(t:Route {id: 't'})
+        WITH s, t MATCH (s)-[r:LINK *KSHORTEST {p: 1}]->(t) RETURN r
+    """
+    )
+    print(f"  Found {len(results)} matching paths without a limit")
+    assert len(results) == 1, f"Expected 1 path, got {len(results)}"
+    assert len(results[0]["r"]) == 2, f"Expected the two-hop matching path, got {len(results[0]['r'])} edges"
+
+    print("Inlined property map tests passed! ✅")
+
+
 def test_syntax_errors():
     """Test that invalid syntax raises appropriate errors."""
     print("Testing syntax error cases...")
@@ -193,6 +245,7 @@ def test_syntax_errors():
 if __name__ == "__main__":
     try:
         test_kshortest_limit()
+        test_kshortest_inline_property_filter()
         test_syntax_errors()
         print("\n🎉 All tests completed successfully!")
     except Exception as e:

--- a/tests/e2e/kshortest_limit/kshortest_limit.py
+++ b/tests/e2e/kshortest_limit/kshortest_limit.py
@@ -34,9 +34,8 @@ def execute_query(query: str):
 def expect_error(query: str, label: str, expected: str):
     """Assert that a query fails with `expected` in the message.
 
-    Matching the message matters: a bare `except Exception` would also pass if the server were
-    unreachable, or if the query failed for a completely different reason than the one under test.
-    The assertions are raised outside the `except` block so they cannot be swallowed.
+    Matching the message matters: a bare `except Exception` also passes when the server is
+    unreachable, or when the query fails for an unrelated reason.
     """
     try:
         execute_query(query)
@@ -142,13 +141,10 @@ def test_kshortest_limit():
 def test_kshortest_inline_property_filter():
     """An inlined edge property map is now applied during the search, not only after it.
 
-    The planner turns `{p: 1}` into two filters: an inline one over the expansion's inner edge, and
-    a post-expansion `all(e IN r WHERE e.p = 1)`. The path limit is enforced inside the operator, so
-    before the inline filter was honoured the limit could be spent on paths the post-expansion filter
-    then threw away - yielding fewer than `k` matching paths, or none at all.
-
-    The graph makes the shortest path the non-matching one, so the ordering is deterministic rather
-    than dependent on storage iteration order.
+    The planner turns `{p: 1}` into an inline filter on the inner edge plus a post-expansion
+    `all(e IN r WHERE e.p = 1)`. The limit is enforced inside the operator, so before the inline
+    filter was honoured it could be spent on paths the post-expansion filter then discarded.
+    The shortest path is the non-matching one, so ordering does not depend on storage iteration.
     """
     print("Testing kshortest with an inlined edge property map...")
     execute_query("MATCH (n) DETACH DELETE n")
@@ -189,6 +185,97 @@ def test_kshortest_inline_property_filter():
     assert len(results[0]["r"]) == 2, f"Expected the two-hop matching path, got {len(results[0]['r'])} edges"
 
     print("Inlined property map tests passed! ✅")
+
+
+def test_kshortest_limit_is_per_input_row():
+    """The `|k` limit caps each input row independently, not the whole result stream.
+
+    The operator used to stop for good the first time one row produced `k` paths, dropping every
+    later row. Three disjoint pairs with two paths each discriminate all three candidate
+    semantics: per-row gives 3/6/6, a global budget 1/2/3, the old behaviour 1/2/6.
+    """
+    print("Testing that the kshortest limit is scoped to an input row...")
+    execute_query("MATCH (n) DETACH DELETE n")
+    for i in range(3):
+        execute_query(
+            f"""
+            CREATE (s:Src {{id: {i}}})
+            CREATE (m:Mid {{id: {i}}})
+            CREATE (t:Dst {{id: {i}}})
+            CREATE (s)-[:LINK]->(t)
+            CREATE (s)-[:LINK]->(m)
+            CREATE (m)-[:LINK]->(t)
+        """
+        )
+
+    for limit, expected in ((1, 3), (2, 6), (3, 6)):
+        results = execute_query(
+            f"""
+            MATCH (s:Src),(t:Dst) WHERE s.id = t.id
+            WITH s, t MATCH (s)-[r:LINK *KSHORTEST|{limit}]->(t) RETURN r
+        """
+        )
+        print(f"  limit {limit}: {len(results)} paths")
+        assert len(results) == expected, f"Expected {expected} paths with limit {limit}, got {len(results)}"
+
+    # A non-positive limit yields nothing at all, on every row.
+    for limit in (0, -1):
+        results = execute_query(
+            f"""
+            MATCH (s:Src),(t:Dst) WHERE s.id = t.id
+            WITH s, t MATCH (s)-[r:LINK *KSHORTEST|{limit}]->(t) RETURN r
+        """
+        )
+        assert len(results) == 0, f"Expected 0 paths with limit {limit}, got {len(results)}"
+
+    print("Per-input-row limit tests passed! ✅")
+
+
+def test_kshortest_depth_bounds():
+    """A zero lower bound is legal; a negative one and a non-positive upper bound are not.
+
+    `0..n` is accepted by every other expansion taking a lower bound, and 0 is inert here since
+    KSHORTEST already skips `source == target`. Only a negative bound wraps to a huge unsigned
+    value and makes the top-up loop enumerate every simple path.
+    """
+    print("Testing kshortest depth bounds...")
+    execute_query("MATCH (n) DETACH DELETE n")
+    execute_query(
+        """
+        CREATE (s:Src {id: 0})
+        CREATE (m:Mid {id: 0})
+        CREATE (t:Dst {id: 0})
+        CREATE (s)-[:LINK]->(t)
+        CREATE (s)-[:LINK]->(m)
+        CREATE (m)-[:LINK]->(t)
+    """
+    )
+
+    for bounds in ("0..3", "0..", "1..3"):
+        results = execute_query(
+            f"""
+            MATCH (s:Src),(t:Dst) WITH s, t MATCH (s)-[r:LINK *KSHORTEST {bounds}]->(t) RETURN r
+        """
+        )
+        print(f"  bounds {bounds!r}: {len(results)} paths")
+        assert len(results) == 2, f"Expected 2 paths for bounds {bounds}, got {len(results)}"
+
+    expect_error(
+        """
+        MATCH (s:Src),(t:Dst) WITH s, t MATCH (s)-[r:LINK *KSHORTEST (0-1)..3]->(t) RETURN r
+    """,
+        "negative lower bound",
+        "Minimum depth in KSHORTEST path expansion must not be negative.",
+    )
+    expect_error(
+        """
+        MATCH (s:Src),(t:Dst) WITH s, t MATCH (s)-[r:LINK *KSHORTEST 1..0]->(t) RETURN r
+    """,
+        "zero upper bound",
+        "Maximum depth in KSHORTEST path expansion must be at least 1.",
+    )
+
+    print("Depth bound tests passed! ✅")
 
 
 def test_syntax_errors():
@@ -256,6 +343,8 @@ if __name__ == "__main__":
     try:
         test_kshortest_limit()
         test_kshortest_inline_property_filter()
+        test_kshortest_limit_is_per_input_row()
+        test_kshortest_depth_bounds()
         test_syntax_errors()
         print("\n🎉 All tests completed successfully!")
     except Exception as e:

--- a/tests/e2e/kshortest_limit/kshortest_limit.py
+++ b/tests/e2e/kshortest_limit/kshortest_limit.py
@@ -218,15 +218,24 @@ def test_kshortest_limit_is_per_input_row():
         print(f"  limit {limit}: {len(results)} paths")
         assert len(results) == expected, f"Expected {expected} paths with limit {limit}, got {len(results)}"
 
-    # A non-positive limit yields nothing at all, on every row.
-    for limit in (0, -1):
-        results = execute_query(
-            f"""
-            MATCH (s:Src),(t:Dst) WHERE s.id = t.id
-            WITH s, t MATCH (s)-[r:LINK *KSHORTEST|{limit}]->(t) RETURN r
+    # Zero is a legal request for no paths, and yields nothing on every row.
+    results = execute_query(
         """
-        )
-        assert len(results) == 0, f"Expected 0 paths with limit {limit}, got {len(results)}"
+        MATCH (s:Src),(t:Dst) WHERE s.id = t.id
+        WITH s, t MATCH (s)-[r:LINK *KSHORTEST|0]->(t) RETURN r
+    """
+    )
+    assert len(results) == 0, f"Expected 0 paths with limit 0, got {len(results)}"
+
+    # A negative limit is not a request for anything, so it is an error rather than an empty result.
+    expect_error(
+        """
+        MATCH (s:Src),(t:Dst) WHERE s.id = t.id
+        WITH s, t MATCH (s)-[r:LINK *KSHORTEST|(0-1)]->(t) RETURN r
+    """,
+        "negative path limit",
+        "Limit in KSHORTEST path expansion must not be negative.",
+    )
 
     print("Per-input-row limit tests passed! ✅")
 
@@ -274,6 +283,14 @@ def test_kshortest_depth_bounds():
         "zero upper bound",
         "Maximum depth in KSHORTEST path expansion must be at least 1.",
     )
+    # An inverted range is legally empty, unlike the invalid bounds above.
+    results = execute_query(
+        """
+        MATCH (s:Src),(t:Dst) WITH s, t MATCH (s)-[r:LINK *KSHORTEST 4..3]->(t) RETURN r
+    """
+    )
+    print(f"  inverted range: {len(results)} paths")
+    assert len(results) == 0, f"Expected no paths for an inverted range, got {len(results)}"
 
     print("Depth bound tests passed! ✅")
 

--- a/tests/e2e/kshortest_limit/kshortest_limit.py
+++ b/tests/e2e/kshortest_limit/kshortest_limit.py
@@ -31,6 +31,16 @@ def execute_query(query: str):
             return list(result)
 
 
+def expect_error(query: str, label: str):
+    """Assert that a query fails. Never swallow the assertion itself."""
+    try:
+        execute_query(query)
+    except Exception as exc:
+        print(f"  Correctly got error for {label}: {exc}")
+        return
+    raise AssertionError(f"Expected an error for {label}")
+
+
 def test_kshortest_limit():
     """Test the kshortest path limit functionality."""
     print("Testing kshortest path limit functionality...")
@@ -98,6 +108,28 @@ def test_kshortest_limit():
     print(f"  Found {len(results)} paths with limit 5")
     assert len(results) == 3, f"Expected 3 paths, got {len(results)}"
 
+    # Test 5: kshortest with a filter lambda
+    print("Test 5: kshortest with a filter lambda")
+    results = execute_query(
+        """
+        MATCH (a:Person {name: 'Alice'}),(e:Person {name: 'Eve'})
+        WITH a, e MATCH (a)-[r:KNOWS *KSHORTEST (rel, n | n.name <> 'Bob')]->(e) RETURN r
+    """
+    )
+    print(f"  Found {len(results)} paths with the Bob detour filtered out")
+    assert len(results) == 2, f"Expected 2 paths, got {len(results)}"
+
+    # Test 6: kshortest with a filter lambda and a limit
+    print("Test 6: kshortest with a filter lambda and a limit")
+    results = execute_query(
+        """
+        MATCH (a:Person {name: 'Alice'}),(e:Person {name: 'Eve'})
+        WITH a, e MATCH (a)-[r:KNOWS *KSHORTEST|1 (rel, n | n.name <> 'Bob')]->(e) RETURN r
+    """
+    )
+    print(f"  Found {len(results)} paths with the filter and limit 1")
+    assert len(results) == 1, f"Expected 1 path, got {len(results)}"
+
     print("All tests passed! ✅")
 
 
@@ -117,29 +149,43 @@ def test_syntax_errors():
 
     # Test that limit with non-kshortest expansion raises error
     print("Test: limit with BFS should raise error")
-    try:
-        execute_query(
-            """
-            MATCH (a:Person {name: 'Alice'}),(b:Person {name: 'Bob'})
-            WITH a, b MATCH (a)-[r:KNOWS *BFS|2]->(b) RETURN r
+    expect_error(
         """
-        )
-        assert False, "Expected error for BFS with limit"
-    except Exception as e:
-        print(f"  Correctly got error: {e}")
+        MATCH (a:Person {name: 'Alice'}),(b:Person {name: 'Bob'})
+        WITH a, b MATCH (a)-[r:KNOWS *BFS|2]->(b) RETURN r
+    """,
+        "BFS with limit",
+    )
 
-    # kshortest with weight lambda and limit
-    print("Test: kshortest with weight lambda and limit")
-    try:
-        execute_query(
-            """
-            MATCH (a:Person {name: 'Alice'}),(e:Person {name: 'Eve'})
-            WITH a, e MATCH (a)-[r:KNOWS *KSHORTEST|2 (e, n | e.weight)]->(e) RETURN r
+    # kshortest accepts a two-argument filter lambda, but not the accumulated path
+    print("Test: kshortest with an accumulated path in the filter lambda should raise error")
+    expect_error(
         """
-        )
-        assert False, "Expected error for kshortest with weight lambda and limit"
-    except Exception as e:
-        print(f"  Correctly got error: {e}")
+        MATCH (a:Person {name: 'Alice'}),(b:Person {name: 'Bob'})
+        WITH a, b MATCH (a)-[r:KNOWS *KSHORTEST|2 (rel, n, p | size(p) > 0)]->(b) RETURN r
+    """,
+        "kshortest with an accumulated path in the filter lambda",
+    )
+
+    # kshortest takes at most one lambda; a weight lambda is not accepted
+    print("Test: kshortest with two lambdas should raise error")
+    expect_error(
+        """
+        MATCH (a:Person {name: 'Alice'}),(b:Person {name: 'Bob'})
+        WITH a, b MATCH (a)-[r:KNOWS *KSHORTEST|2 (rel, n | 1) (rel, n | true)]->(b) RETURN r
+    """,
+        "kshortest with two lambdas",
+    )
+
+    # A filter lambda evaluating to something other than a boolean or null must fail at runtime
+    print("Test: kshortest with a non-boolean filter lambda should raise error")
+    expect_error(
+        """
+        MATCH (a:Person {name: 'Alice'}),(b:Person {name: 'Bob'})
+        WITH a, b MATCH (a)-[r:KNOWS *KSHORTEST|2 (rel, n | 42)]->(b) RETURN r
+    """,
+        "kshortest with a non-boolean filter lambda",
+    )
 
     print("Syntax error tests passed! ✅")
 

--- a/tests/e2e/kshortest_limit/kshortest_limit.py
+++ b/tests/e2e/kshortest_limit/kshortest_limit.py
@@ -31,11 +31,17 @@ def execute_query(query: str):
             return list(result)
 
 
-def expect_error(query: str, label: str):
-    """Assert that a query fails. Never swallow the assertion itself."""
+def expect_error(query: str, label: str, expected: str):
+    """Assert that a query fails with `expected` in the message.
+
+    Matching the message matters: a bare `except Exception` would also pass if the server were
+    unreachable, or if the query failed for a completely different reason than the one under test.
+    The assertions are raised outside the `except` block so they cannot be swallowed.
+    """
     try:
         execute_query(query)
     except Exception as exc:
+        assert expected in str(exc), f"Expected {expected!r} in the error for {label}, got: {exc}"
         print(f"  Correctly got error for {label}: {exc}")
         return
     raise AssertionError(f"Expected an error for {label}")
@@ -207,6 +213,7 @@ def test_syntax_errors():
         WITH a, b MATCH (a)-[r:KNOWS *BFS|2]->(b) RETURN r
     """,
         "BFS with limit",
+        "Limit parameter is only supported with KSHORTEST path expansion.",
     )
 
     # kshortest accepts a two-argument filter lambda, but not the accumulated path
@@ -217,6 +224,7 @@ def test_syntax_errors():
         WITH a, b MATCH (a)-[r:KNOWS *KSHORTEST|2 (rel, n, p | size(p) > 0)]->(b) RETURN r
     """,
         "kshortest with an accumulated path in the filter lambda",
+        "KSHORTEST expansion does not support the accumulated path in a filter lambda.",
     )
 
     # kshortest takes at most one lambda; a weight lambda is not accepted
@@ -227,6 +235,7 @@ def test_syntax_errors():
         WITH a, b MATCH (a)-[r:KNOWS *KSHORTEST|2 (rel, n | 1) (rel, n | true)]->(b) RETURN r
     """,
         "kshortest with two lambdas",
+        "Only one filter lambda can be supplied.",
     )
 
     # A filter lambda evaluating to something other than a boolean or null must fail at runtime
@@ -237,6 +246,7 @@ def test_syntax_errors():
         WITH a, b MATCH (a)-[r:KNOWS *KSHORTEST|2 (rel, n | 42)]->(b) RETURN r
     """,
         "kshortest with a non-boolean filter lambda",
+        "Expansion condition must evaluate to boolean or null",
     )
 
     print("Syntax error tests passed! ✅")

--- a/tests/e2e/kshortest_limit/kshortest_limit.py
+++ b/tests/e2e/kshortest_limit/kshortest_limit.py
@@ -240,6 +240,73 @@ def test_kshortest_limit_is_per_input_row():
     print("Per-input-row limit tests passed! ✅")
 
 
+def test_kshortest_limit_can_depend_on_the_input_row():
+    """A `|k` that reads a frame value is evaluated per row, against that row's frame.
+
+    The limit used to be evaluated once at the top of every `Pull`, before the input row was
+    pulled. A frame-dependent `|k` therefore read unbound nulls on the first pull, and thereafter
+    capped each row by the *previous* row's value. Three symptoms, all covered below: a plain
+    property limit failed outright; a limit that evaluated to 0 against the empty frame ended the
+    whole result stream silently; and a row whose own limit was 0 still emitted one path while the
+    row after it was dropped.
+    """
+    print("Testing that the kshortest limit may depend on the input row...")
+    execute_query("MATCH (n) DETACH DELETE n")
+    # Three disjoint pairs, two paths each, carrying their own limit.
+    for i, k in enumerate((0, 1, 2)):
+        execute_query(
+            f"""
+            CREATE (s:Src {{id: {i}, k: {k}}})
+            CREATE (m:Mid {{id: {i}}})
+            CREATE (t:Dst {{id: {i}}})
+            CREATE (s)-[:LINK]->(t)
+            CREATE (s)-[:LINK]->(m)
+            CREATE (m)-[:LINK]->(t)
+        """
+        )
+
+    # Each row is capped by its own `s.k`: 0 + 1 + 2 paths. Evaluating the limit before the input
+    # pull instead raised "Limit in KSHORTEST path expansion must be an int".
+    results = execute_query(
+        """
+        MATCH (s:Src),(t:Dst) WHERE s.id = t.id
+        WITH s, t MATCH (s)-[r:LINK *KSHORTEST|s.k]->(t) RETURN s.id AS id, r
+    """
+    )
+    per_row = {}
+    for record in results:
+        per_row[record["id"]] = per_row.get(record["id"], 0) + 1
+    print(f"  per-row counts for |s.k: {per_row}")
+    assert len(results) == 3, f"Expected 3 paths in total for |s.k, got {len(results)}"
+    assert per_row == {1: 1, 2: 2}, f"Expected row 1 to yield 1 path and row 2 to yield 2, got {per_row}"
+
+    # A limit that is 0 for one row must skip that row only, not end the stream. Reading the limit
+    # from a stale frame gave 3 rows here: the k=0 row emitted a path and the last row vanished.
+    results = execute_query(
+        """
+        UNWIND [2, 0, 2] AS k
+        MATCH (s:Src {id: 0}),(t:Dst {id: 0})
+        WITH k, s, t MATCH (s)-[r:LINK *KSHORTEST|k]->(t) RETURN k, r
+    """
+    )
+    print(f"  |k over UNWIND [2, 0, 2]: {len(results)} paths")
+    assert len(results) == 4, f"Expected 2 + 0 + 2 = 4 paths, got {len(results)}"
+    assert all(record["k"] == 2 for record in results), "The k=0 row must contribute no paths"
+
+    # A limit expression that evaluates to 0 only on an unbound frame must not silence the query.
+    results = execute_query(
+        """
+        MATCH (s:Src),(t:Dst) WHERE s.id = t.id
+        WITH s, t MATCH (s)-[r:LINK *KSHORTEST|(CASE WHEN s.k IS NULL THEN 0 ELSE 2 END)]->(t)
+        RETURN r
+    """
+    )
+    print(f"  CASE-guarded limit: {len(results)} paths")
+    assert len(results) == 6, f"Expected 6 paths (2 per row), got {len(results)}"
+
+    print("Row-dependent limit tests passed! ✅")
+
+
 def test_kshortest_depth_bounds():
     """A zero lower bound is legal; a negative one and a non-positive upper bound are not.
 
@@ -361,6 +428,7 @@ if __name__ == "__main__":
         test_kshortest_limit()
         test_kshortest_inline_property_filter()
         test_kshortest_limit_is_per_input_row()
+        test_kshortest_limit_can_depend_on_the_input_row()
         test_kshortest_depth_bounds()
         test_syntax_errors()
         print("\n🎉 All tests completed successfully!")

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -55,6 +55,7 @@ using namespace memgraph::query;
 using namespace memgraph::query::frontend;
 using memgraph::query::TypedValue;
 using testing::ElementsAre;
+using testing::HasSubstr;
 using testing::NotNull;
 using testing::Pair;
 using testing::UnorderedElementsAre;
@@ -2867,15 +2868,58 @@ TEST_P(CypherMainVisitorTest, MatchKShortestReturn) {
 
 TEST_P(CypherMainVisitorTest, MatchKShortestWithFilterReturn) {
   auto &ast_generator = *GetParam();
-  ASSERT_THROW(ast_generator.ParseQuery("MATCH ()-[r:type1 *kShortest (e, n | e.prop = 42)]->() RETURN r"),
+  auto *query = dynamic_cast<CypherQuery *>(
+      ast_generator.ParseQuery("MATCH ()-[r:type1 *kShortest (e, n | e.prop = 42)]->() RETURN r"));
+  ASSERT_TRUE(query);
+  auto *single_query = query->single_query_;
+  ASSERT_EQ(single_query->clauses_.size(), 2U);
+  auto *match = dynamic_cast<Match *>(single_query->clauses_[0]);
+  ASSERT_TRUE(match);
+  auto *shortest = dynamic_cast<EdgeAtom *>(match->patterns_[0]->atoms_[1]);
+  ASSERT_TRUE(shortest);
+  EXPECT_EQ(shortest->type_, EdgeAtom::Type::KSHORTEST);
+  EXPECT_EQ(shortest->filter_lambda_.inner_edge->name_, "e");
+  EXPECT_TRUE(shortest->filter_lambda_.inner_edge->user_declared_);
+  EXPECT_EQ(shortest->filter_lambda_.inner_node->name_, "n");
+  EXPECT_TRUE(shortest->filter_lambda_.inner_node->user_declared_);
+  EXPECT_TRUE(shortest->filter_lambda_.expression);
+  EXPECT_FALSE(shortest->filter_lambda_.accumulated_path);
+  EXPECT_FALSE(shortest->weight_lambda_.expression);
+  CheckRWType(query, kRead);
+}
+
+TEST_P(CypherMainVisitorTest, MatchKShortestWithLimitAndFilterReturn) {
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(
+      ast_generator.ParseQuery("MATCH ()-[r:type1 *kShortest 1..3 |2 (e, n | e.prop = 42)]->() RETURN r"));
+  ASSERT_TRUE(query);
+  auto *match = dynamic_cast<Match *>(query->single_query_->clauses_[0]);
+  ASSERT_TRUE(match);
+  auto *shortest = dynamic_cast<EdgeAtom *>(match->patterns_[0]->atoms_[1]);
+  ASSERT_TRUE(shortest);
+  EXPECT_EQ(shortest->type_, EdgeAtom::Type::KSHORTEST);
+  EXPECT_TRUE(shortest->lower_bound_);
+  EXPECT_TRUE(shortest->upper_bound_);
+  EXPECT_TRUE(shortest->limit_);
+  EXPECT_TRUE(shortest->filter_lambda_.expression);
+}
+
+TEST_P(CypherMainVisitorTest, SemanticExceptionOnKShortestWithTwoLambdas) {
+  auto &ast_generator = *GetParam();
+  ASSERT_THROW(ast_generator.ParseQuery("MATCH ()-[r:type1 *kShortest (e, n | 1) (e, n | e.prop = 42)]->() RETURN r"),
                SemanticException);
 }
 
 TEST_P(CypherMainVisitorTest, MatchKShortestFilterByPathReturn) {
   auto &ast_generator = *GetParam();
-  ASSERT_THROW(ast_generator.ParseQuery("MATCH pth=()-[r:type1 *kShortest (e, n, p | startNode(relationships(e)[-1]) = "
-                                        "c:type3)]->(:type2) RETURN pth"),
-               SemanticException);
+  try {
+    ast_generator.ParseQuery(
+        "MATCH pth=()-[r:type1 *kShortest (e, n, p | startNode(relationships(e)[-1]) = "
+        "c:type3)]->(:type2) RETURN pth");
+    FAIL() << "Expected the accumulated path to be rejected for KSHORTEST";
+  } catch (const SemanticException &e) {
+    EXPECT_THAT(e.what(), HasSubstr("accumulated path"));
+  }
 }
 
 TEST_P(CypherMainVisitorTest, MatchKShortestFilterByPathWeightReturn) {

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -780,9 +780,12 @@ class Database {
     CheckPathsAndExtractLengths(&db_accessor, edges_in_result, baseline);
     if (fine_grained_test_type == FineGrainedTestType::ALL_DENIED) {
       EXPECT_EQ(baseline.size(), 0);
-    } else if (fine_grained_test_type == FineGrainedTestType::ALL_GRANTED) {
+    } else {
       // `CheckPathsAndExtractLengths` only validates the paths that came back, so it passes
-      // vacuously on zero rows. With everything granted a path always survives, so pin that.
+      // vacuously on zero rows. Every arm but `ALL_DENIED` leaves a path reachable, so pin that for
+      // all of them: on the label arms the assertions below degrade to a per-pair cap, which an
+      // empty result satisfies, so without this an arm that silently went to zero rows would assert
+      // nothing whatsoever.
       EXPECT_FALSE(baseline.empty());
     }
 

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -615,7 +615,9 @@ class Database {
     memgraph::query::Symbol edges_symbol = context.symbol_table.CreateSymbol("edges", true);
     memgraph::query::Symbol inner_node_symbol = context.symbol_table.CreateSymbol("inner_node", true);
     memgraph::query::Symbol inner_edge_symbol = context.symbol_table.CreateSymbol("inner_edge", true);
+    memgraph::query::Symbol blocked_symbol = context.symbol_table.CreateSymbol("blocked", true);
     memgraph::query::Identifier *inner_node = IDENT("inner_node")->MapTo(inner_node_symbol);
+    memgraph::query::Identifier *blocked = IDENT("blocked")->MapTo(blocked_symbol);
 
     std::vector<memgraph::query::VertexAccessor> vertices;
     std::vector<memgraph::query::EdgeAccessor> edges;
@@ -712,8 +714,18 @@ class Database {
 
     memgraph::query::Expression *filter_expr = nullptr;
     if (blocked_vertex_id) {
-      filter_expr =
-          NEQ(PROPERTY_LOOKUP(db_accessor, inner_node, PROPERTY_PAIR(db_accessor, "id")), LITERAL(*blocked_vertex_id));
+      // Compare vertex identities against a vertex bound on an outer frame symbol, the way
+      // `KShortestTest`'s USE_FRAME case does, rather than reading `inner_node.id`: a property
+      // lookup built here evaluates to null at runtime, which silently made the predicate false for
+      // every expansion and left this whole matrix passing on zero rows.
+      const auto blocked_vertex = std::ranges::find_if(
+          vertices, [&](const auto &v) { return GetProp(v, "id", &db_accessor).ValueInt() == *blocked_vertex_id; });
+      MG_ASSERT(blocked_vertex != vertices.end(), "The blocked vertex must be part of the fixture");
+      input_operator = std::make_shared<Yield>(
+          input_operator,
+          std::vector<memgraph::query::Symbol>{blocked_symbol},
+          std::vector<std::vector<memgraph::query::TypedValue>>{{memgraph::query::TypedValue(*blocked_vertex)}});
+      filter_expr = NEQ(inner_node, blocked);
       std::erase_if(edges_in_result, [id = *blocked_vertex_id](const auto &e) { return e.second == id; });
     }
 
@@ -739,6 +751,12 @@ class Database {
 
     switch (fine_grained_test_type) {
       case FineGrainedTestType::ALL_GRANTED:
+        // `CheckPathsAndExtractLengths` only validates the paths that came back, so on its own it
+        // passes vacuously if the expansion over-blocks and returns nothing. With every permission
+        // granted at least one path always survives - even with `blocked_vertex_id` set, which only
+        // removes the edges leading into that vertex - so pin non-emptiness here. The denied arms
+        // below can legitimately be empty, which is why they get no such assertion.
+        EXPECT_FALSE(results.empty());
         CheckPathsAndExtractLengths(&db_accessor, edges_in_result, results);
         break;
       case FineGrainedTestType::ALL_DENIED:

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <optional>
 #include <queue>
 
 #include "gtest/gtest.h"
@@ -240,6 +241,15 @@ enum class FineGrainedTestType {
   LABEL_3_DENIED
 };
 
+/* Various types of filter lambdas, mirroring `bfs_common.hpp`.
+ * NONE           - No filter lambda used.
+ * USE_FRAME      - Block a single edge or vertex read off the frame.
+ * USE_FRAME_NULL - Same, but the lambda returns null instead of false.
+ * USE_CTX        - Block vertex #5 by comparing its ID to a query parameter.
+ * ERROR          - Lambda evaluating to an integer instead of null or boolean.
+ */
+enum class FilterLambdaType { NONE, USE_FRAME, USE_FRAME_NULL, USE_CTX, ERROR };
+
 // Returns an operator that yields vertices given by their address.
 std::unique_ptr<memgraph::query::plan::LogicalOperator> YieldVertices(
     memgraph::query::DbAccessor *dba, std::vector<memgraph::query::VertexAccessor> vertices,
@@ -251,9 +261,48 @@ std::unique_ptr<memgraph::query::plan::LogicalOperator> YieldVertices(
   return std::make_unique<Yield>(input_op, std::vector<memgraph::query::Symbol>{symbol}, frames);
 }
 
+// Returns an operator that yields edges and vertices given by their address.
+std::unique_ptr<memgraph::query::plan::LogicalOperator> YieldEntities(
+    memgraph::query::DbAccessor *dba, std::vector<memgraph::query::VertexAccessor> vertices,
+    std::vector<memgraph::query::EdgeAccessor> edges, memgraph::query::Symbol symbol,
+    std::shared_ptr<memgraph::query::plan::LogicalOperator> input_op) {
+  std::vector<std::vector<memgraph::query::TypedValue>> frames;
+  for (const auto &vertex : vertices) {
+    frames.emplace_back(std::vector<memgraph::query::TypedValue>{memgraph::query::TypedValue(vertex)});
+  }
+  for (const auto &edge : edges) {
+    frames.emplace_back(std::vector<memgraph::query::TypedValue>{memgraph::query::TypedValue(edge)});
+  }
+  return std::make_unique<Yield>(input_op, std::vector<memgraph::query::Symbol>{symbol}, frames);
+}
+
 template <class TRecord>
 auto GetProp(const TRecord &rec, std::string prop, memgraph::query::DbAccessor *dba) {
   return *rec.GetProperty(memgraph::storage::View::OLD, dba->NameToProperty(prop));
+}
+
+// Removes from `edges` everything the filter lambda blocks, so the Yen oracle runs on exactly the
+// subgraph the expansion sees. Blocking an entity means blocking every edge whose traversal binds
+// it, i.e. the edge itself, or every edge leading into the vertex.
+std::vector<std::pair<int, int>> GetFilteredEdgeList(const memgraph::query::TypedValue &blocked,
+                                                     memgraph::query::EdgeAtom::Direction direction,
+                                                     const std::vector<std::string> &edge_types,
+                                                     memgraph::query::DbAccessor *dba) {
+  auto edges = kEdges;
+  // An edge is blocked in both directions, so drop it before accounting for direction.
+  if (blocked.IsEdge()) {
+    int from = GetProp(blocked.ValueEdge(), "from", dba).ValueInt();
+    int to = GetProp(blocked.ValueEdge(), "to", dba).ValueInt();
+    std::erase_if(edges, [from, to](const auto &e) { return std::get<0>(e) == from && std::get<1>(e) == to; });
+  }
+
+  auto edge_list = GetEdgeList(edges, direction, edge_types);
+
+  if (blocked.IsVertex()) {
+    int id = GetProp(blocked.ValueVertex(), "id", dba).ValueInt();
+    std::erase_if(edge_list, [id](const auto &e) { return e.second == id; });
+  }
+  return edge_list;
 }
 
 // Checks if the given path is actually a path from source to sink and if all
@@ -303,6 +352,14 @@ std::vector<int> CheckPathsAndExtractLengths(memgraph::query::DbAccessor *dba,
   return lengths;
 }
 
+// Mirrors the order `YieldEntities` emits, so the oracle can enumerate the same blocked entities.
+void AppendEntities(const std::vector<memgraph::query::VertexAccessor> &vertices,
+                    const std::vector<memgraph::query::EdgeAccessor> &edges,
+                    std::vector<memgraph::query::TypedValue> &out) {
+  for (const auto &vertex : vertices) out.emplace_back(vertex);
+  for (const auto &edge : edges) out.emplace_back(edge);
+}
+
 // Common interface for single-node and distributed Memgraph.
 class Database {
  public:
@@ -312,14 +369,15 @@ class Database {
       memgraph::query::EdgeAtom::Direction direction, const std::vector<memgraph::storage::EdgeTypeId> &edge_types,
       const std::shared_ptr<memgraph::query::plan::LogicalOperator> &input, bool existing_node,
       memgraph::query::Expression *lower_bound, memgraph::query::Expression *upper_bound,
-      memgraph::query::Expression *limit = nullptr) = 0;
+      const memgraph::query::plan::ExpansionLambda &filter_lambda, memgraph::query::Expression *limit = nullptr) = 0;
   virtual std::pair<std::vector<memgraph::query::VertexAccessor>, std::vector<memgraph::query::EdgeAccessor>>
   BuildGraph(memgraph::query::DbAccessor *dba, const std::vector<int> &vertex_locations,
              const std::vector<std::tuple<int, int, std::string>> &edges) = 0;
   virtual ~Database() = default;
 
   void KShortestTest(Database *db, int lower_bound, int upper_bound, memgraph::query::EdgeAtom::Direction direction,
-                     std::vector<std::string> edge_types, int limit = -1) {
+                     std::vector<std::string> edge_types, int limit = -1,
+                     FilterLambdaType filter_lambda_type = FilterLambdaType::NONE) {
     spdlog::info("KShortestTest: lower_bound={}, upper_bound={}, direction={}, edge_types={}",
                  lower_bound,
                  upper_bound,
@@ -329,9 +387,15 @@ class Database {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     memgraph::query::ExecutionContext context{.db_accessor = &dba, .metric_handles = &TestMetricHandles()};
+    memgraph::query::Symbol blocked_sym = context.symbol_table.CreateSymbol("blocked", true);
     memgraph::query::Symbol source_sym = context.symbol_table.CreateSymbol("source", true);
     memgraph::query::Symbol sink_sym = context.symbol_table.CreateSymbol("sink", true);
     memgraph::query::Symbol edges_sym = context.symbol_table.CreateSymbol("edges", true);
+    memgraph::query::Symbol inner_node_sym = context.symbol_table.CreateSymbol("inner_node", true);
+    memgraph::query::Symbol inner_edge_sym = context.symbol_table.CreateSymbol("inner_edge", true);
+    memgraph::query::Identifier *blocked = IDENT("blocked")->MapTo(blocked_sym);
+    memgraph::query::Identifier *inner_node = IDENT("inner_node")->MapTo(inner_node_sym);
+    memgraph::query::Identifier *inner_edge = IDENT("inner_edge")->MapTo(inner_edge_sym);
 
     std::vector<memgraph::query::VertexAccessor> vertices;
     std::vector<memgraph::query::EdgeAccessor> edges;
@@ -341,9 +405,57 @@ class Database {
 
     dba.AdvanceCommand();
 
+    std::shared_ptr<memgraph::query::plan::LogicalOperator> input_op;
+    memgraph::query::Expression *filter_expr = nullptr;
+    // The entities yielded into `blocked`, in the order the expansion will see them.
+    std::vector<memgraph::query::TypedValue> blocked_values;
+
+    // First build a filter lambda and an operator yielding blocked entities.
+    switch (filter_lambda_type) {
+      case FilterLambdaType::NONE:
+        // No filter lambda, nothing is ever blocked.
+        input_op = std::make_shared<Yield>(
+            nullptr,
+            std::vector<memgraph::query::Symbol>{blocked_sym},
+            std::vector<std::vector<memgraph::query::TypedValue>>{{memgraph::query::TypedValue()}});
+        blocked_values.emplace_back();
+        break;
+      case FilterLambdaType::USE_FRAME:
+        // We block each entity in the graph in turn.
+        input_op = YieldEntities(&dba, vertices, edges, blocked_sym, nullptr);
+        filter_expr = AND(NEQ(inner_node, blocked), NEQ(inner_edge, blocked));
+        AppendEntities(vertices, edges, blocked_values);
+        break;
+      case FilterLambdaType::USE_FRAME_NULL:
+        input_op = YieldEntities(&dba, vertices, edges, blocked_sym, nullptr);
+        filter_expr = IF(AND(NEQ(inner_node, blocked), NEQ(inner_edge, blocked)),
+                         LITERAL(true),
+                         LITERAL(memgraph::storage::ExternalPropertyValue()));
+        AppendEntities(vertices, edges, blocked_values);
+        break;
+      case FilterLambdaType::USE_CTX:
+        // We only block vertex #5, through a parameter rather than the frame.
+        input_op = std::make_shared<Yield>(
+            nullptr,
+            std::vector<memgraph::query::Symbol>{blocked_sym},
+            std::vector<std::vector<memgraph::query::TypedValue>>{{memgraph::query::TypedValue(vertices[5])}});
+        filter_expr = NEQ(PROPERTY_LOOKUP(dba, inner_node, PROPERTY_PAIR(dba, "id")), PARAMETER_LOOKUP(0));
+        context.evaluation_context.parameters.Add(0, memgraph::storage::ExternalPropertyValue(5));
+        blocked_values.emplace_back(vertices[5]);
+        break;
+      case FilterLambdaType::ERROR:
+        input_op = std::make_shared<Yield>(
+            nullptr,
+            std::vector<memgraph::query::Symbol>{blocked_sym},
+            std::vector<std::vector<memgraph::query::TypedValue>>{{memgraph::query::TypedValue()}});
+        filter_expr =
+            IF(EQ(PROPERTY_LOOKUP(dba, inner_node, PROPERTY_PAIR(dba, "id")), LITERAL(5)), LITERAL(42), LITERAL(true));
+        blocked_values.emplace_back();
+        break;
+    }
+
     // For k-shortest paths, we need both source and sink to be known
     // We run k-shortest paths for all possible source-sink pairs
-    std::shared_ptr<memgraph::query::plan::LogicalOperator> input_op = nullptr;
     input_op = YieldVertices(&dba, vertices, source_sym, input_op);
     input_op = YieldVertices(&dba, vertices, sink_sym, input_op);
 
@@ -353,24 +465,36 @@ class Database {
     }
     spdlog::info("KShortestTest: Using {} edge types", storage_edge_types.size());
 
-    input_op = db->MakeKShortestOperator(source_sym,
-                                         sink_sym,
-                                         edges_sym,
-                                         direction,
-                                         storage_edge_types,
-                                         input_op,
-                                         true,
-                                         lower_bound == -1 ? nullptr : LITERAL(lower_bound),
-                                         upper_bound == -1 ? nullptr : LITERAL(upper_bound),
-                                         limit == -1 ? nullptr : LITERAL(limit));
+    input_op =
+        db->MakeKShortestOperator(source_sym,
+                                  sink_sym,
+                                  edges_sym,
+                                  direction,
+                                  storage_edge_types,
+                                  input_op,
+                                  true,
+                                  lower_bound == -1 ? nullptr : LITERAL(lower_bound),
+                                  upper_bound == -1 ? nullptr : LITERAL(upper_bound),
+                                  memgraph::query::plan::ExpansionLambda{inner_edge_sym, inner_node_sym, filter_expr},
+                                  limit == -1 ? nullptr : LITERAL(limit));
 
     context.evaluation_context.properties = memgraph::query::NamesToProperties(storage.properties_, &dba);
     context.evaluation_context.labels = memgraph::query::NamesToLabels(storage.labels_, &dba);
     context.evaluation_context.edgetypes = memgraph::query::NamesToEdgeTypes(storage.edge_types_, &dba);
     std::vector<std::vector<memgraph::query::TypedValue>> results;
 
-    results =
-        PullResults(input_op.get(), &context, std::vector<memgraph::query::Symbol>{source_sym, sink_sym, edges_sym});
+    // A non-boolean, non-null lambda result must abort the pull.
+    if (filter_lambda_type == FilterLambdaType::ERROR) {
+      EXPECT_THROW(PullResults(input_op.get(),
+                               &context,
+                               std::vector<memgraph::query::Symbol>{source_sym, sink_sym, edges_sym, blocked_sym}),
+                   memgraph::query::QueryRuntimeException);
+      dba.Abort();
+      return;
+    }
+
+    results = PullResults(
+        input_op.get(), &context, std::vector<memgraph::query::Symbol>{source_sym, sink_sym, edges_sym, blocked_sym});
 
     spdlog::info("KShortestTest: Pulled {} results", results.size());
     if (limit != -1) {
@@ -378,19 +502,55 @@ class Database {
       ASSERT_LE(results.size(), limit) << "Pulled more results than limit";
     }
 
-    // Group results based on source-sink pair and compare them to results
+    if (upper_bound == -1) upper_bound = kVertexCount;
+    const int effective_lower_bound = lower_bound != -1 ? lower_bound : 1;
+    const int effective_upper_bound = upper_bound;
+
+    // The paths Yen's algorithm finds in the subgraph left over by the filter lambda, respecting
+    // the length bounds.
+    auto correct_paths_for = [&](const memgraph::query::TypedValue &blocked_entity, int source_id, int sink_id) {
+      auto paths = YenKShortestPaths(
+          kVertexCount, GetFilteredEdgeList(blocked_entity, direction, edge_types, &dba), source_id, sink_id);
+      // `paths` holds vertices, not edges, hence the -1 when comparing against the bounds.
+      std::erase_if(paths, [&](const std::vector<int> &path) {
+        return path.size() - 1 < static_cast<size_t>(effective_lower_bound) ||
+               path.size() - 1 > static_cast<size_t>(effective_upper_bound);
+      });
+      return paths;
+    };
+
+    // Without a limit every expected path must be returned, so a group missing entirely from
+    // `results` - which the per-group loop below cannot see - has to be caught by the total.
+    if (limit == -1) {
+      size_t expected_total = 0;
+      for (const auto &blocked_entity : blocked_values) {
+        for (int source_id = 0; source_id < kVertexCount; ++source_id) {
+          for (int sink_id = 0; sink_id < kVertexCount; ++sink_id) {
+            if (source_id != sink_id) expected_total += correct_paths_for(blocked_entity, source_id, sink_id).size();
+          }
+        }
+      }
+      EXPECT_EQ(results.size(), expected_total);
+    }
+
+    // Group results based on blocked entity and source-sink pair and compare them to results
     // obtained by running Yen's algorithm.
     for (size_t i = 0; i < results.size();) {
       int j = i;
+      auto blocked_entity = results[j][3];
       auto source = results[j][0];
       auto sink = results[j][1];
 
-      while (j < results.size() && memgraph::query::TypedValue::BoolEqual{}(results[j][0], source) &&
+      while (j < results.size() && memgraph::query::TypedValue::BoolEqual{}(results[j][3], blocked_entity) &&
+             memgraph::query::TypedValue::BoolEqual{}(results[j][0], source) &&
              memgraph::query::TypedValue::BoolEqual{}(results[j][1], sink)) {
         ++j;
       }
 
-      SCOPED_TRACE(fmt::format("source = {}, sink = {}", ToString(source, dba), ToString(sink, dba)));
+      SCOPED_TRACE(fmt::format("blocked = {}, source = {}, sink = {}",
+                               ToString(blocked_entity, dba),
+                               ToString(source, dba),
+                               ToString(sink, dba)));
 
       auto source_id = GetProp(source.ValueVertex(), "id", &dba).ValueInt();
       auto sink_id = GetProp(sink.ValueVertex(), "id", &dba).ValueInt();
@@ -402,25 +562,9 @@ class Database {
         continue;
       }
 
-      auto edges_filtered = GetEdgeList(kEdges, direction, edge_types);
-      auto correct_paths = YenKShortestPaths(kVertexCount, edges_filtered, source_id, sink_id);
+      auto edges_filtered = GetFilteredEdgeList(blocked_entity, direction, edge_types, &dba);
+      auto correct_paths = correct_paths_for(blocked_entity, source_id, sink_id);
       spdlog::info("KShortestTest: Yen algorithm found {} paths", correct_paths.size());
-
-      if (upper_bound == -1) upper_bound = kVertexCount;
-
-      // Remove paths whose length doesn't satisfy given bounds.
-      // correct_paths is a path of vertices, not edges, so we need to subtract 1 from the path length to get the number
-      // of edges.
-      correct_paths.erase(
-          std::remove_if(correct_paths.begin(),
-                         correct_paths.end(),
-                         [lower_bound = lower_bound != -1 ? lower_bound : 1,
-                          upper_bound = upper_bound != -1 ? upper_bound : std::numeric_limits<int>::max()](
-                             const std::vector<int> &path) {
-                           return path.size() - 1 < static_cast<size_t>(lower_bound) ||
-                                  path.size() - 1 > static_cast<size_t>(upper_bound);
-                         }),
-          correct_paths.end());
 
       int expected_count = static_cast<int>(correct_paths.size());
       // Converting from global limit to pair specific limit
@@ -456,16 +600,22 @@ class Database {
   }
 
 #ifdef MG_ENTERPRISE
+  // `blocked_vertex_id` additionally blocks every edge leading into that vertex with a filter
+  // lambda, so the expansion has to honour the access checks and the lambda at the same time.
   void KShortestTestWithFineGrainedFiltering(Database *db, int upper_bound,
                                              memgraph::query::EdgeAtom::Direction direction,
                                              std::vector<std::string> edge_types, int k,
-                                             FineGrainedTestType fine_grained_test_type) {
+                                             FineGrainedTestType fine_grained_test_type,
+                                             std::optional<int> blocked_vertex_id = std::nullopt) {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor db_accessor(storage_dba.get());
     memgraph::query::ExecutionContext context{.db_accessor = &db_accessor, .metric_handles = &TestMetricHandles()};
     memgraph::query::Symbol source_symbol = context.symbol_table.CreateSymbol("source", true);
     memgraph::query::Symbol sink_symbol = context.symbol_table.CreateSymbol("sink", true);
     memgraph::query::Symbol edges_symbol = context.symbol_table.CreateSymbol("edges", true);
+    memgraph::query::Symbol inner_node_symbol = context.symbol_table.CreateSymbol("inner_node", true);
+    memgraph::query::Symbol inner_edge_symbol = context.symbol_table.CreateSymbol("inner_edge", true);
+    memgraph::query::Identifier *inner_node = IDENT("inner_node")->MapTo(inner_node_symbol);
 
     std::vector<memgraph::query::VertexAccessor> vertices;
     std::vector<memgraph::query::EdgeAccessor> edges;
@@ -560,15 +710,24 @@ class Database {
       storage_edge_types.push_back(db_accessor.NameToEdgeType(t));
     }
 
-    input_operator = db->MakeKShortestOperator(source_symbol,
-                                               sink_symbol,
-                                               edges_symbol,
-                                               direction,
-                                               storage_edge_types,
-                                               input_operator,
-                                               true,
-                                               nullptr,
-                                               upper_bound == -1 ? nullptr : LITERAL(upper_bound));
+    memgraph::query::Expression *filter_expr = nullptr;
+    if (blocked_vertex_id) {
+      filter_expr =
+          NEQ(PROPERTY_LOOKUP(db_accessor, inner_node, PROPERTY_PAIR(db_accessor, "id")), LITERAL(*blocked_vertex_id));
+      std::erase_if(edges_in_result, [id = *blocked_vertex_id](const auto &e) { return e.second == id; });
+    }
+
+    input_operator = db->MakeKShortestOperator(
+        source_symbol,
+        sink_symbol,
+        edges_symbol,
+        direction,
+        storage_edge_types,
+        input_operator,
+        true,
+        nullptr,
+        upper_bound == -1 ? nullptr : LITERAL(upper_bound),
+        memgraph::query::plan::ExpansionLambda{inner_edge_symbol, inner_node_symbol, filter_expr});
 
     context.evaluation_context.properties = memgraph::query::NamesToProperties(storage.properties_, &db_accessor);
     context.evaluation_context.labels = memgraph::query::NamesToLabels(storage.labels_, &db_accessor);
@@ -594,6 +753,137 @@ class Database {
     }
 
     db_accessor.Abort();
+  }
+
+  // The access check must run before the filter lambda: an edge the user cannot read must never
+  // make the lambda run on it. Edge (5)-[:b]->(3) is the only one with `to` = 3, and edge type "b"
+  // is denied - so the lambda below, which evaluates to an integer exactly on that edge, may never
+  // be reached. No edge type filter is given to the operator, so storage really does hand the
+  // expansion the denied edge.
+  void KShortestTestAccessCheckBeforeFilterLambda(Database *db) {
+    auto storage_dba = db->Access();
+    memgraph::query::DbAccessor db_accessor(storage_dba.get());
+    memgraph::query::ExecutionContext context{.db_accessor = &db_accessor, .metric_handles = &TestMetricHandles()};
+    memgraph::query::Symbol source_symbol = context.symbol_table.CreateSymbol("source", true);
+    memgraph::query::Symbol sink_symbol = context.symbol_table.CreateSymbol("sink", true);
+    memgraph::query::Symbol edges_symbol = context.symbol_table.CreateSymbol("edges", true);
+    memgraph::query::Symbol inner_node_symbol = context.symbol_table.CreateSymbol("inner_node", true);
+    memgraph::query::Symbol inner_edge_symbol = context.symbol_table.CreateSymbol("inner_edge", true);
+    memgraph::query::Identifier *inner_edge = IDENT("inner_edge")->MapTo(inner_edge_symbol);
+
+    std::vector<memgraph::query::VertexAccessor> vertices;
+    std::vector<memgraph::query::EdgeAccessor> edges;
+    std::tie(vertices, edges) = db->BuildGraph(&db_accessor, kVertexLocations, kEdges);
+    db_accessor.AdvanceCommand();
+
+    memgraph::auth::User user{"test"};
+    user.fine_grained_access_handler().label_permissions().GrantGlobal(memgraph::auth::FineGrainedPermission::READ);
+    user.fine_grained_access_handler().edge_type_permissions().Grant({"a"},
+                                                                     memgraph::auth::FineGrainedPermission::READ);
+    user.fine_grained_access_handler().edge_type_permissions().Deny({"b"}, memgraph::auth::kAllEdgeTypePermissions);
+    memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
+    context.auth_checker = &auth_checker;
+
+    std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;
+    input_operator = YieldVertices(&db_accessor, vertices, source_symbol, input_operator);
+    input_operator = YieldVertices(&db_accessor, vertices, sink_symbol, input_operator);
+
+    auto *filter_expr = IF(EQ(PROPERTY_LOOKUP(db_accessor, inner_edge, PROPERTY_PAIR(db_accessor, "to")), LITERAL(3)),
+                           LITERAL(42),
+                           LITERAL(true));
+
+    input_operator = db->MakeKShortestOperator(
+        source_symbol,
+        sink_symbol,
+        edges_symbol,
+        memgraph::query::EdgeAtom::Direction::OUT,
+        {},
+        input_operator,
+        true,
+        nullptr,
+        nullptr,
+        memgraph::query::plan::ExpansionLambda{inner_edge_symbol, inner_node_symbol, filter_expr});
+
+    context.evaluation_context.properties = memgraph::query::NamesToProperties(storage.properties_, &db_accessor);
+    context.evaluation_context.labels = memgraph::query::NamesToLabels(storage.labels_, &db_accessor);
+    context.evaluation_context.edgetypes = memgraph::query::NamesToEdgeTypes(storage.edge_types_, &db_accessor);
+
+    std::vector<std::vector<memgraph::query::TypedValue>> results;
+    ASSERT_NO_THROW(results =
+                        PullResults(input_operator.get(),
+                                    &context,
+                                    std::vector<memgraph::query::Symbol>{source_symbol, sink_symbol, edges_symbol}));
+
+    EXPECT_FALSE(results.empty());
+    CheckPathsAndExtractLengths(
+        &db_accessor, GetEdgeList(kEdges, memgraph::query::EdgeAtom::Direction::OUT, {"a"}), results);
+
+    db_accessor.Abort();
+  }
+
+  // Memoising an expansion verdict must not merge the two halves of the bidirectional search. They
+  // check access on opposite endpoints of the same edge while binding the same vertex as the
+  // lambda's node, so keying the memo on (edge, node) alone makes one half answer for the other.
+  //
+  // Vertex 4 is denied and is the target, and (2)-[:b]->(4) runs straight from source to target.
+  // The source side sees that edge first and is denied on `To` = 4. The target side then sees the
+  // same edge - binding the same vertex 4, because the target-side pass binds the vertex it
+  // expands *from* - but checks `From` = 2 and is allowed; endpoint vertices are seeded into the
+  // search without an access check, which is pre-existing behaviour shared with `*BFS`. A memo
+  // that cannot tell the two passes apart replays the source side's `false` and loses the
+  // one-hop path, falling back to (2)-[:a]->(5)-[:a]->(4).
+  void KShortestTestMemoDistinguishesSearchDirections(Database *db) {
+    auto storage_dba = db->Access();
+    memgraph::query::DbAccessor db_accessor(storage_dba.get());
+    memgraph::query::ExecutionContext context{.db_accessor = &db_accessor, .metric_handles = &TestMetricHandles()};
+    memgraph::query::Symbol source_symbol = context.symbol_table.CreateSymbol("source", true);
+    memgraph::query::Symbol sink_symbol = context.symbol_table.CreateSymbol("sink", true);
+    memgraph::query::Symbol edges_symbol = context.symbol_table.CreateSymbol("edges", true);
+    memgraph::query::Symbol inner_node_symbol = context.symbol_table.CreateSymbol("inner_node", true);
+    memgraph::query::Symbol inner_edge_symbol = context.symbol_table.CreateSymbol("inner_edge", true);
+
+    std::vector<memgraph::query::VertexAccessor> vertices;
+    std::vector<memgraph::query::EdgeAccessor> edges;
+    std::tie(vertices, edges) = db->BuildGraph(&db_accessor, kVertexLocations, kEdges);
+    db_accessor.AdvanceCommand();
+
+    memgraph::auth::User user{"test"};
+    user.fine_grained_access_handler().edge_type_permissions().GrantGlobal(memgraph::auth::FineGrainedPermission::READ);
+    user.fine_grained_access_handler().label_permissions().GrantGlobal(memgraph::auth::FineGrainedPermission::READ);
+    user.fine_grained_access_handler().label_permissions().Deny({"4"}, memgraph::auth::kAllLabelPermissions);
+    memgraph::glue::FineGrainedAuthChecker auth_checker{user, &db_accessor};
+    context.auth_checker = &auth_checker;
+
+    std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;
+    input_operator = YieldVertices(&db_accessor, {vertices[2]}, source_symbol, input_operator);
+    // Vertex 1 is only reachable from vertex 2 through the denied vertex 4, so it doubles as a
+    // check that the denial is in effect at all.
+    input_operator = YieldVertices(&db_accessor, {vertices[4], vertices[1]}, sink_symbol, input_operator);
+
+    input_operator = db->MakeKShortestOperator(
+        source_symbol,
+        sink_symbol,
+        edges_symbol,
+        memgraph::query::EdgeAtom::Direction::OUT,
+        {},
+        input_operator,
+        true,
+        nullptr,
+        nullptr,
+        memgraph::query::plan::ExpansionLambda{inner_edge_symbol, inner_node_symbol, nullptr});
+
+    context.evaluation_context.properties = memgraph::query::NamesToProperties(storage.properties_, &db_accessor);
+    context.evaluation_context.labels = memgraph::query::NamesToLabels(storage.labels_, &db_accessor);
+    context.evaluation_context.edgetypes = memgraph::query::NamesToEdgeTypes(storage.edge_types_, &db_accessor);
+
+    auto results = PullResults(
+        input_operator.get(), &context, std::vector<memgraph::query::Symbol>{source_symbol, sink_symbol, edges_symbol});
+
+    ASSERT_FALSE(results.empty());
+    // The one-hop (2)-[:b]->(4) must come out first.
+    EXPECT_EQ(results[0][2].ValueList().size(), 1);
+    // Nothing may reach vertex 1, which is only reachable through the denied vertex 4.
+    for (const auto &row : results) EXPECT_EQ(row[1].ValueVertex(), vertices[4]);
   }
 #endif
 

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -895,6 +895,54 @@ class Database {
   }
 #endif
 
+  // An inverted depth range is provably empty, because no path can exceed the upper bound. Assert
+  // on the work done and not just on the empty result: without a guard the lower-bound top-up loop
+  // enumerates every simple path in the graph before giving up, which on a larger graph does not
+  // terminate in any useful time.
+  void KShortestTestInvertedRangeDoesNotSearch(Database *db) {
+    auto storage_dba = db->Access();
+    memgraph::query::DbAccessor dba(storage_dba.get());
+    memgraph::query::ExecutionContext context{.db_accessor = &dba, .metric_handles = &TestMetricHandles()};
+    memgraph::query::Symbol source_sym = context.symbol_table.CreateSymbol("source", true);
+    memgraph::query::Symbol sink_sym = context.symbol_table.CreateSymbol("sink", true);
+    memgraph::query::Symbol edges_sym = context.symbol_table.CreateSymbol("edges", true);
+    memgraph::query::Symbol inner_node_sym = context.symbol_table.CreateSymbol("inner_node", true);
+    memgraph::query::Symbol inner_edge_sym = context.symbol_table.CreateSymbol("inner_edge", true);
+
+    std::vector<memgraph::query::VertexAccessor> vertices;
+    std::vector<memgraph::query::EdgeAccessor> edges;
+    std::tie(vertices, edges) = db->BuildGraph(&dba, kVertexLocations, kEdges);
+    dba.AdvanceCommand();
+
+    std::shared_ptr<memgraph::query::plan::LogicalOperator> input_op = nullptr;
+    input_op = YieldVertices(&dba, vertices, source_sym, input_op);
+    input_op = YieldVertices(&dba, vertices, sink_sym, input_op);
+
+    auto input_operator =
+        db->MakeKShortestOperator(source_sym,
+                                  sink_sym,
+                                  edges_sym,
+                                  memgraph::query::EdgeAtom::Direction::OUT,
+                                  {},
+                                  input_op,
+                                  true,
+                                  LITERAL(kVertexCount + 1),
+                                  LITERAL(kVertexCount),
+                                  memgraph::query::plan::ExpansionLambda{inner_edge_sym, inner_node_sym, nullptr});
+
+    context.evaluation_context.properties = memgraph::query::NamesToProperties(storage.properties_, &dba);
+    context.evaluation_context.labels = memgraph::query::NamesToLabels(storage.labels_, &dba);
+    context.evaluation_context.edgetypes = memgraph::query::NamesToEdgeTypes(storage.edge_types_, &dba);
+
+    auto results = PullResults(
+        input_operator.get(), &context, std::vector<memgraph::query::Symbol>{source_sym, sink_sym, edges_sym});
+
+    EXPECT_TRUE(results.empty());
+    EXPECT_EQ(context.number_of_hops, 0) << "An inverted range must be rejected before anything is expanded";
+
+    dba.Abort();
+  }
+
  protected:
   memgraph::query::AstStorage storage;
 };

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <map>
 #include <optional>
 #include <queue>
 
@@ -336,6 +337,19 @@ void CheckPath(memgraph::query::DbAccessor *dba, const memgraph::query::VertexAc
   ASSERT_EQ(curr, sink);
 }
 
+// The vertex ids a result row's path visits, in traversal order, starting at the source. Two runs
+// over separately built copies of the same fixture are comparable through these, unlike gids.
+std::vector<int> PathVertexIds(memgraph::query::DbAccessor *dba, const std::vector<memgraph::query::TypedValue> &row) {
+  auto curr = row[0].ValueVertex();
+  std::vector<int> ids{static_cast<int>(GetProp(curr, "id", dba).ValueInt())};
+  for (const auto &edge_tv : row[2].ValueList()) {
+    auto edge = edge_tv.ValueEdge();
+    curr = edge.From() == curr ? edge.To() : edge.From();
+    ids.push_back(static_cast<int>(GetProp(curr, "id", dba).ValueInt()));
+  }
+  return ids;
+}
+
 // Given a list of k-shortest path results of form (from, to, path),
 // checks if all paths are valid and returns the path lengths.
 std::vector<int> CheckPathsAndExtractLengths(memgraph::query::DbAccessor *dba,
@@ -602,9 +616,10 @@ class Database {
 #ifdef MG_ENTERPRISE
   // `blocked_vertex_id` additionally blocks every edge leading into that vertex with a filter
   // lambda, so the expansion has to honour the access checks and the lambda at the same time.
+  // `limit` is the `|k` path limit, or -1 for none.
   void KShortestTestWithFineGrainedFiltering(Database *db, int upper_bound,
                                              memgraph::query::EdgeAtom::Direction direction,
-                                             std::vector<std::string> edge_types, int k,
+                                             std::vector<std::string> edge_types, int limit,
                                              FineGrainedTestType fine_grained_test_type,
                                              std::optional<int> blocked_vertex_id = std::nullopt) {
     auto storage_dba = db->Access();
@@ -697,73 +712,149 @@ class Database {
     context.auth_checker = &auth_checker;
 
     // We run k-shortest paths for all possible source-sink pairs
-    std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;
     if (fine_grained_test_type == FineGrainedTestType::LABEL_0_DENIED) {
       vertices.erase(std::remove_if(vertices.begin(),
                                     vertices.end(),
                                     [&](const auto &v) { return GetProp(v, "id", &db_accessor).ValueInt() == 0; }),
                      vertices.end());
     }
-    input_operator = YieldVertices(&db_accessor, vertices, source_symbol, input_operator);
-    input_operator = YieldVertices(&db_accessor, vertices, sink_symbol, input_operator);
 
     std::vector<memgraph::storage::EdgeTypeId> storage_edge_types;
     for (const auto &t : edge_types) {
       storage_edge_types.push_back(db_accessor.NameToEdgeType(t));
     }
 
-    memgraph::query::Expression *filter_expr = nullptr;
+    const memgraph::query::VertexAccessor *blocked_vertex = nullptr;
+    auto edges_after_lambda = edges_in_result;
     if (blocked_vertex_id) {
-      // Compare vertex identities against an outer frame symbol, not `inner_node.id`: a property
-      // lookup built here evaluates to null, which left this whole matrix passing on zero rows.
-      const auto blocked_vertex = std::ranges::find_if(
+      const auto it = std::ranges::find_if(
           vertices, [&](const auto &v) { return GetProp(v, "id", &db_accessor).ValueInt() == *blocked_vertex_id; });
-      MG_ASSERT(blocked_vertex != vertices.end(), "The blocked vertex must be part of the fixture");
-      input_operator = std::make_shared<Yield>(
-          input_operator,
-          std::vector<memgraph::query::Symbol>{blocked_symbol},
-          std::vector<std::vector<memgraph::query::TypedValue>>{{memgraph::query::TypedValue(*blocked_vertex)}});
-      filter_expr = NEQ(inner_node, blocked);
-      std::erase_if(edges_in_result, [id = *blocked_vertex_id](const auto &e) { return e.second == id; });
+      MG_ASSERT(it != vertices.end(), "The blocked vertex must be part of the fixture");
+      blocked_vertex = &*it;
+      std::erase_if(edges_after_lambda, [id = *blocked_vertex_id](const auto &e) { return e.second == id; });
     }
-
-    input_operator = db->MakeKShortestOperator(
-        source_symbol,
-        sink_symbol,
-        edges_symbol,
-        direction,
-        storage_edge_types,
-        input_operator,
-        true,
-        nullptr,
-        upper_bound == -1 ? nullptr : LITERAL(upper_bound),
-        memgraph::query::plan::ExpansionLambda{inner_edge_symbol, inner_node_symbol, filter_expr});
 
     context.evaluation_context.properties = memgraph::query::NamesToProperties(storage.properties_, &db_accessor);
     context.evaluation_context.labels = memgraph::query::NamesToLabels(storage.labels_, &db_accessor);
     context.evaluation_context.edgetypes = memgraph::query::NamesToEdgeTypes(storage.edge_types_, &db_accessor);
-    std::vector<std::vector<memgraph::query::TypedValue>> results;
 
-    results = PullResults(
-        input_operator.get(), &context, std::vector<memgraph::query::Symbol>{source_symbol, sink_symbol, edges_symbol});
+    // One pass over the whole source-sink cartesian. The access checks are always on; only the
+    // filter lambda and the path limit vary, so two runs are directly comparable.
+    auto run = [&](bool with_lambda, int path_limit) {
+      std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;
+      input_operator = YieldVertices(&db_accessor, vertices, source_symbol, input_operator);
+      input_operator = YieldVertices(&db_accessor, vertices, sink_symbol, input_operator);
 
-    switch (fine_grained_test_type) {
-      case FineGrainedTestType::ALL_GRANTED:
-        // `CheckPathsAndExtractLengths` only validates the paths that came back, so it passes
-        // vacuously on zero rows. With everything granted a path always survives, so pin that.
-        // The denied arms below can legitimately be empty.
-        EXPECT_FALSE(results.empty());
-        CheckPathsAndExtractLengths(&db_accessor, edges_in_result, results);
-        break;
-      case FineGrainedTestType::ALL_DENIED:
-        EXPECT_EQ(results.size(), 0);
-        break;
-      case FineGrainedTestType::EDGE_TYPE_A_DENIED:
-      case FineGrainedTestType::EDGE_TYPE_B_DENIED:
-      case FineGrainedTestType::LABEL_0_DENIED:
-      case FineGrainedTestType::LABEL_3_DENIED:
-        CheckPathsAndExtractLengths(&db_accessor, edges_in_result, results);
-        break;
+      memgraph::query::Expression *filter_expr = nullptr;
+      if (with_lambda) {
+        // Compare vertex identities against an outer frame symbol, not `inner_node.id`: a property
+        // lookup built here evaluates to null, which left this whole matrix passing on zero rows.
+        input_operator = std::make_shared<Yield>(
+            input_operator,
+            std::vector<memgraph::query::Symbol>{blocked_symbol},
+            std::vector<std::vector<memgraph::query::TypedValue>>{{memgraph::query::TypedValue(*blocked_vertex)}});
+        filter_expr = NEQ(inner_node, blocked);
+      }
+
+      input_operator = db->MakeKShortestOperator(
+          source_symbol,
+          sink_symbol,
+          edges_symbol,
+          direction,
+          storage_edge_types,
+          input_operator,
+          true,
+          nullptr,
+          upper_bound == -1 ? nullptr : LITERAL(upper_bound),
+          memgraph::query::plan::ExpansionLambda{inner_edge_symbol, inner_node_symbol, filter_expr},
+          path_limit == -1 ? nullptr : LITERAL(path_limit));
+      return PullResults(input_operator.get(),
+                         &context,
+                         std::vector<memgraph::query::Symbol>{source_symbol, sink_symbol, edges_symbol});
+    };
+
+    // The reference run: access checks only, no lambda, no limit. Every expectation below is
+    // derived from it, so none of them has to model what the access checks did - which matters,
+    // because the endpoints are seeded without a check, so a denied source or sink still yields.
+    const auto baseline = run(false, -1);
+    CheckPathsAndExtractLengths(&db_accessor, edges_in_result, baseline);
+    if (fine_grained_test_type == FineGrainedTestType::ALL_DENIED) {
+      EXPECT_EQ(baseline.size(), 0);
+    } else if (fine_grained_test_type == FineGrainedTestType::ALL_GRANTED) {
+      // `CheckPathsAndExtractLengths` only validates the paths that came back, so it passes
+      // vacuously on zero rows. With everything granted a path always survives, so pin that.
+      EXPECT_FALSE(baseline.empty());
+    }
+
+    // The lambda binds the arc head in forward path order at every position except index 0, which
+    // is the seeded source, so it must reject exactly the paths that visit the blocked vertex
+    // later. Sorted so it can be compared as a multiset and binary-searched below.
+    std::vector<std::vector<int>> expected_paths;
+    for (const auto &row : baseline) {
+      auto ids = PathVertexIds(&db_accessor, row);
+      if (blocked_vertex_id && std::find(ids.begin() + 1, ids.end(), *blocked_vertex_id) != ids.end()) continue;
+      expected_paths.push_back(std::move(ids));
+    }
+    std::ranges::sort(expected_paths);
+
+    const auto results = run(blocked_vertex_id.has_value(), limit);
+    CheckPathsAndExtractLengths(&db_accessor, edges_after_lambda, results);
+
+    std::vector<std::vector<int>> actual_paths;
+    for (const auto &row : results) actual_paths.push_back(PathVertexIds(&db_accessor, row));
+    std::ranges::sort(actual_paths);
+
+    std::map<std::pair<int, int>, size_t> actual_per_pair;
+    for (const auto &path : actual_paths) ++actual_per_pair[{path.front(), path.back()}];
+
+    // Deriving from the reference run is only valid while an arc's access verdict is a property of
+    // the arc. It is not when a *vertex* is denied: `FineGrainedAccessCheck` tests the endpoint away
+    // from the vertex being expanded, which is the arc's head on the source-side pass but its tail
+    // on the target-side pass, and the search abandons the whole search as soon as one frontier
+    // empties. So pruning anywhere can cost a path that the predicate does not touch, and the
+    // reference run cannot predict it. Denying an edge type is symmetric and stays predictable.
+    const bool verdict_depends_on_search_direction = fine_grained_test_type == FineGrainedTestType::LABEL_0_DENIED ||
+                                                     fine_grained_test_type == FineGrainedTestType::LABEL_3_DENIED;
+
+    if (verdict_depends_on_search_direction) {
+      if (limit != -1) {
+        for (const auto &[pair, count] : actual_per_pair) {
+          SCOPED_TRACE(fmt::format("source = {}, sink = {}", pair.first, pair.second));
+          EXPECT_LE(count, static_cast<size_t>(limit));
+        }
+      }
+    } else if (limit == -1) {
+      // Without a limit the two runs must agree path for path. This is what pins over-blocking: a
+      // memoised verdict reused where it should not be would silently drop paths, and a subset
+      // check like `CheckPathsAndExtractLengths` cannot see that.
+      EXPECT_EQ(actual_paths, expected_paths);
+    } else {
+      // With a limit only the per-pair counts are determined - which of several equally long paths
+      // a pair keeps is not - so check the cap, the total, and that every path is one the
+      // unlimited run also produced.
+      std::map<std::pair<int, int>, size_t> expected_per_pair;
+      for (const auto &path : expected_paths) ++expected_per_pair[{path.front(), path.back()}];
+
+      size_t expected_total = 0;
+      for (const auto &[pair, count] : expected_per_pair) {
+        expected_total += std::min(count, static_cast<size_t>(limit));
+      }
+      // Catches a pair the expansion dropped entirely, which the per-pair loop below cannot see.
+      EXPECT_EQ(actual_paths.size(), expected_total);
+
+      for (const auto &[pair, count] : actual_per_pair) {
+        SCOPED_TRACE(fmt::format("source = {}, sink = {}", pair.first, pair.second));
+        EXPECT_EQ(count, std::min(expected_per_pair[pair], static_cast<size_t>(limit)));
+      }
+      for (const auto &path : actual_paths) {
+        EXPECT_TRUE(std::ranges::binary_search(expected_paths, path))
+            << "Returned a path the unlimited run did not: " << memgraph::utils::JoinVector(path, "->");
+      }
+    }
+
+    if (blocked_vertex_id && fine_grained_test_type == FineGrainedTestType::ALL_GRANTED) {
+      // If the lambda pruned nothing, this arm would prove nothing about it.
+      EXPECT_LT(results.size(), baseline.size());
     }
 
     db_accessor.Abort();

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -499,7 +499,6 @@ class Database {
     spdlog::info("KShortestTest: Pulled {} results", results.size());
     if (limit != -1) {
       spdlog::info("KShortestTest: Limit: {}", limit);
-      ASSERT_LE(results.size(), limit) << "Pulled more results than limit";
     }
 
     if (upper_bound == -1) upper_bound = kVertexCount;
@@ -567,11 +566,10 @@ class Database {
       spdlog::info("KShortestTest: Yen algorithm found {} paths", correct_paths.size());
 
       int expected_count = static_cast<int>(correct_paths.size());
-      // Converting from global limit to pair specific limit
-      if (limit != -1 && j == limit) {
-        spdlog::info("KShortestTest: Limit reached, expected count: {}, limit: {}, j: {}", expected_count, limit, j);
-        if (i == j) break;
-        expected_count = j - i;
+      // The limit applies per input row, so every group is capped by it independently.
+      if (limit != -1 && expected_count > limit) {
+        spdlog::info("KShortestTest: Limit caps this group, expected count: {}, limit: {}", expected_count, limit);
+        expected_count = limit;
         correct_paths.resize(expected_count);
       }
       EXPECT_EQ(j - i, expected_count);

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -281,14 +281,9 @@ auto GetProp(const TRecord &rec, std::string prop, memgraph::query::DbAccessor *
   return *rec.GetProperty(memgraph::storage::View::OLD, dba->NameToProperty(prop));
 }
 
-// Removes from `edges` everything the filter lambda blocks, so the Yen oracle runs on exactly the
-// subgraph the expansion sees. Blocking an entity means blocking every edge whose traversal binds
-// it, i.e. the edge itself, or every edge leading into the vertex.
-//
-// A blocked edge is matched by its `(from, to)` property pair rather than by gid, so this is only
-// exact while `kEdges` holds no two edges between the same ordered pair of vertices - the cursor
-// would block one parallel edge where this blocks all of them. Keep `kEdges` free of parallel edges,
-// or switch this to comparing gids.
+// Removes everything the filter lambda blocks, so the Yen oracle runs on the subgraph the expansion
+// sees: the blocked edge itself, or every edge leading into the blocked vertex.
+// Matches a blocked edge by `(from, to)`, not gid, so keep `kEdges` free of parallel edges.
 std::vector<std::pair<int, int>> GetFilteredEdgeList(const memgraph::query::TypedValue &blocked,
                                                      memgraph::query::EdgeAtom::Direction direction,
                                                      const std::vector<std::string> &edge_types,
@@ -523,14 +518,16 @@ class Database {
       return paths;
     };
 
-    // Without a limit every expected path must be returned, so a group missing entirely from
-    // `results` - which the per-group loop below cannot see - has to be caught by the total.
-    if (limit == -1) {
+    // A wholly missing group is invisible to the per-group loop below, so the total has to catch
+    // it. Must be asserted with a limit too: the limit caps each group, never removes one.
+    {
       size_t expected_total = 0;
       for (const auto &blocked_entity : blocked_values) {
         for (int source_id = 0; source_id < kVertexCount; ++source_id) {
           for (int sink_id = 0; sink_id < kVertexCount; ++sink_id) {
-            if (source_id != sink_id) expected_total += correct_paths_for(blocked_entity, source_id, sink_id).size();
+            if (source_id == sink_id) continue;
+            const auto group = correct_paths_for(blocked_entity, source_id, sink_id).size();
+            expected_total += limit == -1 ? group : std::min(group, static_cast<size_t>(limit));
           }
         }
       }
@@ -717,10 +714,8 @@ class Database {
 
     memgraph::query::Expression *filter_expr = nullptr;
     if (blocked_vertex_id) {
-      // Compare vertex identities against a vertex bound on an outer frame symbol, the way
-      // `KShortestTest`'s USE_FRAME case does, rather than reading `inner_node.id`: a property
-      // lookup built here evaluates to null at runtime, which silently made the predicate false for
-      // every expansion and left this whole matrix passing on zero rows.
+      // Compare vertex identities against an outer frame symbol, not `inner_node.id`: a property
+      // lookup built here evaluates to null, which left this whole matrix passing on zero rows.
       const auto blocked_vertex = std::ranges::find_if(
           vertices, [&](const auto &v) { return GetProp(v, "id", &db_accessor).ValueInt() == *blocked_vertex_id; });
       MG_ASSERT(blocked_vertex != vertices.end(), "The blocked vertex must be part of the fixture");
@@ -754,11 +749,9 @@ class Database {
 
     switch (fine_grained_test_type) {
       case FineGrainedTestType::ALL_GRANTED:
-        // `CheckPathsAndExtractLengths` only validates the paths that came back, so on its own it
-        // passes vacuously if the expansion over-blocks and returns nothing. With every permission
-        // granted at least one path always survives - even with `blocked_vertex_id` set, which only
-        // removes the edges leading into that vertex - so pin non-emptiness here. The denied arms
-        // below can legitimately be empty, which is why they get no such assertion.
+        // `CheckPathsAndExtractLengths` only validates the paths that came back, so it passes
+        // vacuously on zero rows. With everything granted a path always survives, so pin that.
+        // The denied arms below can legitimately be empty.
         EXPECT_FALSE(results.empty());
         CheckPathsAndExtractLengths(&db_accessor, edges_in_result, results);
         break;
@@ -776,11 +769,9 @@ class Database {
     db_accessor.Abort();
   }
 
-  // The access check must run before the filter lambda: an edge the user cannot read must never
-  // make the lambda run on it. Edge (5)-[:b]->(3) is the only one with `to` = 3, and edge type "b"
-  // is denied - so the lambda below, which evaluates to an integer exactly on that edge, may never
-  // be reached. No edge type filter is given to the operator, so storage really does hand the
-  // expansion the denied edge.
+  // The access check must run before the lambda. Edge (5)-[:b]->(3) is the only one with `to` = 3
+  // and type "b" is denied, so the lambda - which returns an integer exactly there - must never
+  // run on it. The operator gets no edge type filter, so storage really does hand it that edge.
   void KShortestTestAccessCheckBeforeFilterLambda(Database *db) {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor db_accessor(storage_dba.get());
@@ -842,23 +833,13 @@ class Database {
     db_accessor.Abort();
   }
 
-  // Memoising an expansion verdict must not merge the two halves of the bidirectional search. They
-  // check access on opposite endpoints of the same edge while binding the same vertex as the
-  // lambda's node, so keying the memo on (edge, node) alone makes one half answer for the other.
-  //
-  // Vertex 4 is denied and is the target, and (2)-[:b]->(4) runs straight from source to target.
-  // The source side sees that edge first and is denied on `To` = 4. The target side then sees the
-  // same edge - binding the same vertex 4, because the target-side pass binds the vertex it
-  // expands *from* - but checks `From` = 2 and is allowed; endpoint vertices are seeded into the
-  // search without an access check, which is pre-existing behaviour shared with `*BFS`. A memo
-  // that cannot tell the two passes apart replays the source side's `false` and loses the
-  // one-hop path, falling back to (2)-[:a]->(5)-[:a]->(4).
-  //
-  // That dependency is structural, not incidental: for the two halves to disagree about one edge,
-  // one of the access-checked endpoints has to be a vertex admitted without a check, because any
-  // mid-path denied vertex is rejected by whichever half reaches it first. So if the endpoint
-  // seeding gap is ever closed, this test returns zero rows and needs redesigning around the new
-  // behaviour rather than relaxing.
+  // The memo must not merge the two halves of the bidirectional search: they check access on
+  // opposite endpoints of the same edge while binding the same vertex as the lambda's node.
+  // Denied vertex 4 is the target and (2)-[:b]->(4) runs source to target. The source side is
+  // denied on `To` = 4; the target side binds the same vertex 4 but checks `From` = 2 and allows.
+  // A memo blind to the pass replays the `false` and loses the one-hop path.
+  // Depends on endpoints being seeded without an access check (pre-existing, shared with `*BFS`).
+  // If that gap is closed this returns zero rows and needs redesigning, not relaxing.
   void KShortestTestMemoDistinguishesSearchDirections(Database *db) {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor db_accessor(storage_dba.get());

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -282,8 +282,7 @@ auto GetProp(const TRecord &rec, std::string prop, memgraph::query::DbAccessor *
   return *rec.GetProperty(memgraph::storage::View::OLD, dba->NameToProperty(prop));
 }
 
-// Removes everything the filter lambda blocks, so the Yen oracle runs on the subgraph the expansion
-// sees: the blocked edge itself, or every edge leading into the blocked vertex.
+// Removes everything the lambda blocks, so the Yen oracle runs on the subgraph the expansion sees.
 // Matches a blocked edge by `(from, to)`, not gid, so keep `kEdges` free of parallel edges.
 std::vector<std::pair<int, int>> GetFilteredEdgeList(const memgraph::query::TypedValue &blocked,
                                                      memgraph::query::EdgeAtom::Direction direction,
@@ -337,8 +336,8 @@ void CheckPath(memgraph::query::DbAccessor *dba, const memgraph::query::VertexAc
   ASSERT_EQ(curr, sink);
 }
 
-// The vertex ids a result row's path visits, in traversal order, starting at the source. Two runs
-// over separately built copies of the same fixture are comparable through these, unlike gids.
+// The vertex ids a row's path visits, from the source. Comparable across separately built copies
+// of the fixture, unlike gids.
 std::vector<int> PathVertexIds(memgraph::query::DbAccessor *dba, const std::vector<memgraph::query::TypedValue> &row) {
   auto curr = row[0].ValueVertex();
   std::vector<int> ids{static_cast<int>(GetProp(curr, "id", dba).ValueInt())};
@@ -424,7 +423,6 @@ class Database {
     // The entities yielded into `blocked`, in the order the expansion will see them.
     std::vector<memgraph::query::TypedValue> blocked_values;
 
-    // First build a filter lambda and an operator yielding blocked entities.
     switch (filter_lambda_type) {
       case FilterLambdaType::NONE:
         // No filter lambda, nothing is ever blocked.
@@ -519,8 +517,7 @@ class Database {
     const int effective_lower_bound = lower_bound != -1 ? lower_bound : 1;
     const int effective_upper_bound = upper_bound;
 
-    // The paths Yen's algorithm finds in the subgraph left over by the filter lambda, respecting
-    // the length bounds.
+    // The paths Yen's algorithm finds in the subgraph the lambda leaves, within the length bounds.
     auto correct_paths_for = [&](const memgraph::query::TypedValue &blocked_entity, int source_id, int sink_id) {
       auto paths = YenKShortestPaths(
           kVertexCount, GetFilteredEdgeList(blocked_entity, direction, edge_types, &dba), source_id, sink_id);
@@ -532,8 +529,8 @@ class Database {
       return paths;
     };
 
-    // A wholly missing group is invisible to the per-group loop below, so the total has to catch
-    // it. Must be asserted with a limit too: the limit caps each group, never removes one.
+    // A wholly missing group is invisible to the per-group loop, so the total has to catch it. Needed
+    // with a limit too: the limit caps a group, never removes one.
     {
       size_t expected_total = 0;
       for (const auto &blocked_entity : blocked_values) {
@@ -614,9 +611,8 @@ class Database {
   }
 
 #ifdef MG_ENTERPRISE
-  // `blocked_vertex_id` additionally blocks every edge leading into that vertex with a filter
-  // lambda, so the expansion has to honour the access checks and the lambda at the same time.
-  // `limit` is the `|k` path limit, or -1 for none.
+  // `blocked_vertex_id` also blocks every edge into that vertex with a filter lambda, so the
+  // expansion must honour the access checks and the lambda at once. `limit` is `|k`, or -1 for none.
   void KShortestTestWithFineGrainedFiltering(Database *db, int upper_bound,
                                              memgraph::query::EdgeAtom::Direction direction,
                                              std::vector<std::string> edge_types, int limit,
@@ -738,8 +734,7 @@ class Database {
     context.evaluation_context.labels = memgraph::query::NamesToLabels(storage.labels_, &db_accessor);
     context.evaluation_context.edgetypes = memgraph::query::NamesToEdgeTypes(storage.edge_types_, &db_accessor);
 
-    // One pass over the whole source-sink cartesian. The access checks are always on; only the
-    // filter lambda and the path limit vary, so two runs are directly comparable.
+    // One pass over the source-sink cartesian; only the lambda and the limit vary between runs.
     auto run = [&](bool with_lambda, int path_limit) {
       std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;
       input_operator = YieldVertices(&db_accessor, vertices, source_symbol, input_operator);
@@ -773,25 +768,20 @@ class Database {
                          std::vector<memgraph::query::Symbol>{source_symbol, sink_symbol, edges_symbol});
     };
 
-    // The reference run: access checks only, no lambda, no limit. Every expectation below is
-    // derived from it, so none of them has to model what the access checks did - which matters,
-    // because the endpoints are seeded without a check, so a denied source or sink still yields.
+    // The reference run: access checks only. Everything below derives from it, so nothing has to
+    // model the checks - the endpoints are seeded unchecked, so a denied source or sink still yields.
     const auto baseline = run(false, -1);
     CheckPathsAndExtractLengths(&db_accessor, edges_in_result, baseline);
     if (fine_grained_test_type == FineGrainedTestType::ALL_DENIED) {
       EXPECT_EQ(baseline.size(), 0);
     } else {
-      // `CheckPathsAndExtractLengths` only validates the paths that came back, so it passes
-      // vacuously on zero rows. Every arm but `ALL_DENIED` leaves a path reachable, so pin that for
-      // all of them: on the label arms the assertions below degrade to a per-pair cap, which an
-      // empty result satisfies, so without this an arm that silently went to zero rows would assert
-      // nothing whatsoever.
+      // `CheckPathsAndExtractLengths` passes vacuously on zero rows, and on the label arms the
+      // assertions below degrade to a per-pair cap an empty result also satisfies.
       EXPECT_FALSE(baseline.empty());
     }
 
-    // The lambda binds the arc head in forward path order at every position except index 0, which
-    // is the seeded source, so it must reject exactly the paths that visit the blocked vertex
-    // later. Sorted so it can be compared as a multiset and binary-searched below.
+    // The lambda binds the arc head at every position but index 0, the seeded source, so it rejects
+    // exactly the paths visiting the blocked vertex later. Sorted to compare as a multiset.
     std::vector<std::vector<int>> expected_paths;
     for (const auto &row : baseline) {
       auto ids = PathVertexIds(&db_accessor, row);
@@ -810,12 +800,10 @@ class Database {
     std::map<std::pair<int, int>, size_t> actual_per_pair;
     for (const auto &path : actual_paths) ++actual_per_pair[{path.front(), path.back()}];
 
-    // Deriving from the reference run is only valid while an arc's access verdict is a property of
-    // the arc. It is not when a *vertex* is denied: `FineGrainedAccessCheck` tests the endpoint away
-    // from the vertex being expanded, which is the arc's head on the source-side pass but its tail
-    // on the target-side pass, and the search abandons the whole search as soon as one frontier
-    // empties. So pruning anywhere can cost a path that the predicate does not touch, and the
-    // reference run cannot predict it. Denying an edge type is symmetric and stays predictable.
+    // Deriving from the reference run holds only while an arc's verdict is a property of the arc. It
+    // is not when a *vertex* is denied: the check tests the endpoint away from the vertex being
+    // expanded, so it is the arc's head on one pass and its tail on the other, and the search stops
+    // as soon as one frontier empties. Denying an edge type is symmetric and stays predictable.
     const bool verdict_depends_on_search_direction = fine_grained_test_type == FineGrainedTestType::LABEL_0_DENIED ||
                                                      fine_grained_test_type == FineGrainedTestType::LABEL_3_DENIED;
 
@@ -827,14 +815,12 @@ class Database {
         }
       }
     } else if (limit == -1) {
-      // Without a limit the two runs must agree path for path. This is what pins over-blocking: a
-      // memoised verdict reused where it should not be would silently drop paths, and a subset
-      // check like `CheckPathsAndExtractLengths` cannot see that.
+      // Without a limit the two runs must agree path for path, which is what pins over-blocking - a
+      // subset check like `CheckPathsAndExtractLengths` cannot see a dropped path.
       EXPECT_EQ(actual_paths, expected_paths);
     } else {
-      // With a limit only the per-pair counts are determined - which of several equally long paths
-      // a pair keeps is not - so check the cap, the total, and that every path is one the
-      // unlimited run also produced.
+      // With a limit, which of several equally long paths a pair keeps is undetermined, so check only
+      // the cap, the total, and that every path also came out of the unlimited run.
       std::map<std::pair<int, int>, size_t> expected_per_pair;
       for (const auto &path : expected_paths) ++expected_per_pair[{path.front(), path.back()}];
 
@@ -864,8 +850,7 @@ class Database {
   }
 
   // The access check must run before the lambda. Edge (5)-[:b]->(3) is the only one with `to` = 3
-  // and type "b" is denied, so the lambda - which returns an integer exactly there - must never
-  // run on it. The operator gets no edge type filter, so storage really does hand it that edge.
+  // and type "b" is denied, so the lambda - which returns an integer there - must never see it.
   void KShortestTestAccessCheckBeforeFilterLambda(Database *db) {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor db_accessor(storage_dba.get());
@@ -927,13 +912,11 @@ class Database {
     db_accessor.Abort();
   }
 
-  // The memo must not merge the two halves of the bidirectional search: they check access on
-  // opposite endpoints of the same edge while binding the same vertex as the lambda's node.
-  // Denied vertex 4 is the target and (2)-[:b]->(4) runs source to target. The source side is
-  // denied on `To` = 4; the target side binds the same vertex 4 but checks `From` = 2 and allows.
-  // A memo blind to the pass replays the `false` and loses the one-hop path.
-  // Depends on endpoints being seeded without an access check (pre-existing, shared with `*BFS`).
-  // If that gap is closed this returns zero rows and needs redesigning, not relaxing.
+  // The memo must not merge the two halves of the bidirectional search. Denied vertex 4 is the
+  // target: the source side checks `To` = 4 and denies, the target side binds the same vertex but
+  // checks `From` = 2 and allows, so a pass-blind memo replays the `false` and loses the path.
+  // Relies on endpoints being seeded unchecked (pre-existing, shared with `*BFS`); if that is ever
+  // fixed this returns zero rows and needs redesigning, not relaxing.
   void KShortestTestMemoDistinguishesSearchDirections(Database *db) {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor db_accessor(storage_dba.get());
@@ -958,8 +941,7 @@ class Database {
 
     std::shared_ptr<memgraph::query::plan::LogicalOperator> input_operator = nullptr;
     input_operator = YieldVertices(&db_accessor, {vertices[2]}, source_symbol, input_operator);
-    // Vertex 1 is only reachable from vertex 2 through the denied vertex 4, so it doubles as a
-    // check that the denial is in effect at all.
+    // Vertex 1 sits behind the denied vertex 4, so this also proves the denial is in effect.
     input_operator = YieldVertices(&db_accessor, {vertices[4], vertices[1]}, sink_symbol, input_operator);
 
     input_operator = db->MakeKShortestOperator(
@@ -989,10 +971,8 @@ class Database {
   }
 #endif
 
-  // An inverted depth range is provably empty, because no path can exceed the upper bound. Assert
-  // on the work done and not just on the empty result: without a guard the lower-bound top-up loop
-  // enumerates every simple path in the graph before giving up, which on a larger graph does not
-  // terminate in any useful time.
+  // An inverted range is provably empty. Assert on the work done, not just the empty result:
+  // unguarded, the top-up loop enumerates every simple path in the graph first.
   void KShortestTestInvertedRangeDoesNotSearch(Database *db) {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -284,6 +284,11 @@ auto GetProp(const TRecord &rec, std::string prop, memgraph::query::DbAccessor *
 // Removes from `edges` everything the filter lambda blocks, so the Yen oracle runs on exactly the
 // subgraph the expansion sees. Blocking an entity means blocking every edge whose traversal binds
 // it, i.e. the edge itself, or every edge leading into the vertex.
+//
+// A blocked edge is matched by its `(from, to)` property pair rather than by gid, so this is only
+// exact while `kEdges` holds no two edges between the same ordered pair of vertices - the cursor
+// would block one parallel edge where this blocks all of them. Keep `kEdges` free of parallel edges,
+// or switch this to comparing gids.
 std::vector<std::pair<int, int>> GetFilteredEdgeList(const memgraph::query::TypedValue &blocked,
                                                      memgraph::query::EdgeAtom::Direction direction,
                                                      const std::vector<std::string> &edge_types,
@@ -848,6 +853,12 @@ class Database {
   // search without an access check, which is pre-existing behaviour shared with `*BFS`. A memo
   // that cannot tell the two passes apart replays the source side's `false` and loses the
   // one-hop path, falling back to (2)-[:a]->(5)-[:a]->(4).
+  //
+  // That dependency is structural, not incidental: for the two halves to disagree about one edge,
+  // one of the access-checked endpoints has to be a vertex admitted without a check, because any
+  // mid-path denied vertex is rejected by whichever half reaches it first. So if the endpoint
+  // seeding gap is ever closed, this test returns zero rows and needs redesigning around the new
+  // behaviour rather than relaxing.
   void KShortestTestMemoDistinguishesSearchDirections(Database *db) {
     auto storage_dba = db->Access();
     memgraph::query::DbAccessor db_accessor(storage_dba.get());

--- a/tests/unit/kshortest_fine_grained.cpp
+++ b/tests/unit/kshortest_fine_grained.cpp
@@ -104,9 +104,50 @@ class VertexDb : public Database {
 };
 
 #ifdef MG_ENTERPRISE
-class FineGrainedKShortestTestInMemory
-    : public ::testing::TestWithParam<
-          std::tuple<int, EdgeAtom::Direction, std::vector<std::string>, int, FineGrainedTestType>> {
+// One access-check case. `blocked_vertex` nullopt runs the access checks alone; 4 adds a filter
+// lambda blocking every edge into vertex 4 on top of them.
+struct FineGrainedCase {
+  int upper_bound;
+  EdgeAtom::Direction direction;
+  std::vector<std::string> edge_types;
+  int limit;
+  FineGrainedTestType test_type;
+  std::optional<int> blocked_vertex;
+};
+
+// Enumerated rather than combined so the combinations that cannot assert anything stay out: without
+// a lambda and without a limit the harness would compare the reference run to itself, and with
+// everything denied the result is empty whatever the lambda does.
+inline std::vector<FineGrainedCase> FineGrainedCases() {
+  static constexpr auto kTypes = std::array{FineGrainedTestType::ALL_GRANTED,
+                                            FineGrainedTestType::ALL_DENIED,
+                                            FineGrainedTestType::EDGE_TYPE_A_DENIED,
+                                            FineGrainedTestType::EDGE_TYPE_B_DENIED,
+                                            FineGrainedTestType::LABEL_0_DENIED,
+                                            FineGrainedTestType::LABEL_3_DENIED};
+  std::vector<FineGrainedCase> cases;
+  for (auto direction : {EdgeAtom::Direction::OUT, EdgeAtom::Direction::IN, EdgeAtom::Direction::BOTH}) {
+    for (auto limit : {-1, 3}) {
+      for (auto test_type : kTypes) {
+        for (std::optional<int> blocked : {std::optional<int>{}, std::optional<int>{4}}) {
+          if (!blocked && limit == -1) continue;
+          if (blocked && test_type == FineGrainedTestType::ALL_DENIED) continue;
+          cases.push_back({3, direction, {"a", "b"}, limit, test_type, blocked});
+        }
+      }
+    }
+  }
+  return cases;
+}
+
+// On disk only the cases without a lambda are worth repeating; see the smoke test below.
+inline std::vector<FineGrainedCase> FineGrainedCasesWithoutLambda() {
+  auto cases = FineGrainedCases();
+  std::erase_if(cases, [](const FineGrainedCase &c) { return c.blocked_vertex.has_value(); });
+  return cases;
+}
+
+class FineGrainedKShortestTestInMemory : public ::testing::TestWithParam<FineGrainedCase> {
  public:
   using StorageType = memgraph::storage::InMemoryStorage;
 
@@ -121,43 +162,15 @@ class FineGrainedKShortestTestInMemory
   static std::unique_ptr<VertexDb<StorageType>> db_;
 };
 
-TEST_P(FineGrainedKShortestTestInMemory, All) {
-  int upper_bound;
-  EdgeAtom::Direction direction;
-  std::vector<std::string> edge_types;
-  int limit;
-  FineGrainedTestType fine_grained_test_type;
-
-  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
-
+TEST_P(FineGrainedKShortestTestInMemory, AccessChecks) {
+  const auto &c = GetParam();
   this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type);
-}
-
-// The same matrix, plus a lambda blocking every edge into vertex 4, on top of the access checks.
-TEST_P(FineGrainedKShortestTestInMemory, WithFilterLambda) {
-  int upper_bound;
-  EdgeAtom::Direction direction;
-  std::vector<std::string> edge_types;
-  int limit;
-  FineGrainedTestType fine_grained_test_type;
-
-  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
-
-  this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type, 4);
+      db_.get(), c.upper_bound, c.direction, c.edge_types, c.limit, c.test_type, c.blocked_vertex);
 }
 
 std::unique_ptr<VertexDb<FineGrainedKShortestTestInMemory::StorageType>> FineGrainedKShortestTestInMemory::db_{nullptr};
 
-INSTANTIATE_TEST_SUITE_P(
-    FineGrained, FineGrainedKShortestTestInMemory,
-    testing::Combine(testing::Values(3),
-                     testing::Values(EdgeAtom::Direction::OUT, EdgeAtom::Direction::IN, EdgeAtom::Direction::BOTH),
-                     testing::Values(std::vector<std::string>{"a", "b"}), testing::Values(-1, 3),
-                     testing::Values(FineGrainedTestType::ALL_GRANTED, FineGrainedTestType::ALL_DENIED,
-                                     FineGrainedTestType::EDGE_TYPE_A_DENIED, FineGrainedTestType::EDGE_TYPE_B_DENIED,
-                                     FineGrainedTestType::LABEL_0_DENIED, FineGrainedTestType::LABEL_3_DENIED)));
+INSTANTIATE_TEST_SUITE_P(FineGrained, FineGrainedKShortestTestInMemory, testing::ValuesIn(FineGrainedCases()));
 
 TEST_F(FineGrainedKShortestTestInMemory, AccessCheckRunsBeforeFilterLambda) {
   db_->KShortestTestAccessCheckBeforeFilterLambda(db_.get());
@@ -167,9 +180,7 @@ TEST_F(FineGrainedKShortestTestInMemory, MemoDistinguishesSearchDirections) {
   db_->KShortestTestMemoDistinguishesSearchDirections(db_.get());
 }
 
-class FineGrainedKShortestTestOnDisk
-    : public ::testing::TestWithParam<
-          std::tuple<int, EdgeAtom::Direction, std::vector<std::string>, int, FineGrainedTestType>> {
+class FineGrainedKShortestTestOnDisk : public ::testing::TestWithParam<FineGrainedCase> {
  public:
   using StorageType = memgraph::storage::DiskStorage;
 
@@ -184,41 +195,22 @@ class FineGrainedKShortestTestOnDisk
   static std::unique_ptr<VertexDb<StorageType>> db_;
 };
 
-TEST_P(FineGrainedKShortestTestOnDisk, All) {
-  int upper_bound;
-  EdgeAtom::Direction direction;
-  std::vector<std::string> edge_types;
-  int limit;
-  FineGrainedTestType fine_grained_test_type;
-
-  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
-
+TEST_P(FineGrainedKShortestTestOnDisk, AccessChecks) {
+  const auto &c = GetParam();
   this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type);
+      db_.get(), c.upper_bound, c.direction, c.edge_types, c.limit, c.test_type, c.blocked_vertex);
 }
 
-// The same matrix, plus a lambda blocking every edge into vertex 4, on top of the access checks.
-TEST_P(FineGrainedKShortestTestOnDisk, WithFilterLambda) {
-  int upper_bound;
-  EdgeAtom::Direction direction;
-  std::vector<std::string> edge_types;
-  int limit;
-  FineGrainedTestType fine_grained_test_type;
-
-  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
-
-  this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type, 4);
+// One on-disk case for the lambda on top of the access checks; the matrix runs in memory, since
+// neither the cursor nor the auth checker has a storage-mode-specific path. All granted with no
+// limit is the arm that compares path for path.
+TEST_F(FineGrainedKShortestTestOnDisk, WithFilterLambda) {
+  db_->KShortestTestWithFineGrainedFiltering(
+      db_.get(), 3, EdgeAtom::Direction::BOTH, {"a", "b"}, -1, FineGrainedTestType::ALL_GRANTED, 4);
 }
 
 std::unique_ptr<VertexDb<FineGrainedKShortestTestOnDisk::StorageType>> FineGrainedKShortestTestOnDisk::db_{nullptr};
 
-INSTANTIATE_TEST_SUITE_P(
-    FineGrained, FineGrainedKShortestTestOnDisk,
-    testing::Combine(testing::Values(3),
-                     testing::Values(EdgeAtom::Direction::OUT, EdgeAtom::Direction::IN, EdgeAtom::Direction::BOTH),
-                     testing::Values(std::vector<std::string>{"a", "b"}), testing::Values(-1, 3),
-                     testing::Values(FineGrainedTestType::ALL_GRANTED, FineGrainedTestType::ALL_DENIED,
-                                     FineGrainedTestType::EDGE_TYPE_A_DENIED, FineGrainedTestType::EDGE_TYPE_B_DENIED,
-                                     FineGrainedTestType::LABEL_0_DENIED, FineGrainedTestType::LABEL_3_DENIED)));
+INSTANTIATE_TEST_SUITE_P(FineGrained, FineGrainedKShortestTestOnDisk,
+                         testing::ValuesIn(FineGrainedCasesWithoutLambda()));
 #endif

--- a/tests/unit/kshortest_fine_grained.cpp
+++ b/tests/unit/kshortest_fine_grained.cpp
@@ -134,8 +134,7 @@ TEST_P(FineGrainedKShortestTestInMemory, All) {
       db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type);
 }
 
-// The same matrix, with a filter lambda blocking every edge that leads into vertex 4 on top of the
-// access checks.
+// The same matrix, plus a lambda blocking every edge into vertex 4, on top of the access checks.
 TEST_P(FineGrainedKShortestTestInMemory, WithFilterLambda) {
   int upper_bound;
   EdgeAtom::Direction direction;
@@ -198,8 +197,7 @@ TEST_P(FineGrainedKShortestTestOnDisk, All) {
       db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type);
 }
 
-// The same matrix, with a filter lambda blocking every edge that leads into vertex 4 on top of the
-// access checks.
+// The same matrix, plus a lambda blocking every edge into vertex 4, on top of the access checks.
 TEST_P(FineGrainedKShortestTestOnDisk, WithFilterLambda) {
   int upper_bound;
   EdgeAtom::Direction direction;

--- a/tests/unit/kshortest_fine_grained.cpp
+++ b/tests/unit/kshortest_fine_grained.cpp
@@ -46,13 +46,11 @@ class VertexDb : public Database {
     return db_->Access(memgraph::storage::WRITE);
   }
 
-  std::unique_ptr<LogicalOperator> MakeKShortestOperator(Symbol source_sym, Symbol sink_sym, Symbol edge_sym,
-                                                         EdgeAtom::Direction direction,
-                                                         const std::vector<memgraph::storage::EdgeTypeId> &edge_types,
-                                                         const std::shared_ptr<LogicalOperator> &input,
-                                                         bool existing_node, memgraph::query::Expression *lower_bound,
-                                                         memgraph::query::Expression *upper_bound,
-                                                         memgraph::query::Expression *limit) override {
+  std::unique_ptr<LogicalOperator> MakeKShortestOperator(
+      Symbol source_sym, Symbol sink_sym, Symbol edge_sym, EdgeAtom::Direction direction,
+      const std::vector<memgraph::storage::EdgeTypeId> &edge_types, const std::shared_ptr<LogicalOperator> &input,
+      bool existing_node, memgraph::query::Expression *lower_bound, memgraph::query::Expression *upper_bound,
+      const memgraph::query::plan::ExpansionLambda &filter_lambda, memgraph::query::Expression *limit) override {
     return std::make_unique<ExpandVariable>(input,
                                             source_sym,
                                             sink_sym,
@@ -64,7 +62,7 @@ class VertexDb : public Database {
                                             nullptr,
                                             upper_bound,
                                             existing_node,
-                                            memgraph::query::plan::ExpansionLambda{},
+                                            filter_lambda,
                                             std::nullopt,
                                             std::nullopt,
                                             limit);
@@ -136,6 +134,21 @@ TEST_P(FineGrainedKShortestTestInMemory, All) {
       db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type);
 }
 
+// The same matrix, with a filter lambda blocking every edge that leads into vertex 4 on top of the
+// access checks.
+TEST_P(FineGrainedKShortestTestInMemory, WithFilterLambda) {
+  int upper_bound;
+  EdgeAtom::Direction direction;
+  std::vector<std::string> edge_types;
+  int k;
+  FineGrainedTestType fine_grained_test_type;
+
+  std::tie(upper_bound, direction, edge_types, k, fine_grained_test_type) = GetParam();
+
+  this->db_->KShortestTestWithFineGrainedFiltering(
+      db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type, 4);
+}
+
 std::unique_ptr<VertexDb<FineGrainedKShortestTestInMemory::StorageType>> FineGrainedKShortestTestInMemory::db_{nullptr};
 
 INSTANTIATE_TEST_SUITE_P(
@@ -146,6 +159,14 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(FineGrainedTestType::ALL_GRANTED, FineGrainedTestType::ALL_DENIED,
                                      FineGrainedTestType::EDGE_TYPE_A_DENIED, FineGrainedTestType::EDGE_TYPE_B_DENIED,
                                      FineGrainedTestType::LABEL_0_DENIED, FineGrainedTestType::LABEL_3_DENIED)));
+
+TEST_F(FineGrainedKShortestTestInMemory, AccessCheckRunsBeforeFilterLambda) {
+  db_->KShortestTestAccessCheckBeforeFilterLambda(db_.get());
+}
+
+TEST_F(FineGrainedKShortestTestInMemory, MemoDistinguishesSearchDirections) {
+  db_->KShortestTestMemoDistinguishesSearchDirections(db_.get());
+}
 
 class FineGrainedKShortestTestOnDisk
     : public ::testing::TestWithParam<
@@ -175,6 +196,21 @@ TEST_P(FineGrainedKShortestTestOnDisk, All) {
 
   this->db_->KShortestTestWithFineGrainedFiltering(
       db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type);
+}
+
+// The same matrix, with a filter lambda blocking every edge that leads into vertex 4 on top of the
+// access checks.
+TEST_P(FineGrainedKShortestTestOnDisk, WithFilterLambda) {
+  int upper_bound;
+  EdgeAtom::Direction direction;
+  std::vector<std::string> edge_types;
+  int k;
+  FineGrainedTestType fine_grained_test_type;
+
+  std::tie(upper_bound, direction, edge_types, k, fine_grained_test_type) = GetParam();
+
+  this->db_->KShortestTestWithFineGrainedFiltering(
+      db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type, 4);
 }
 
 std::unique_ptr<VertexDb<FineGrainedKShortestTestOnDisk::StorageType>> FineGrainedKShortestTestOnDisk::db_{nullptr};

--- a/tests/unit/kshortest_fine_grained.cpp
+++ b/tests/unit/kshortest_fine_grained.cpp
@@ -125,13 +125,13 @@ TEST_P(FineGrainedKShortestTestInMemory, All) {
   int upper_bound;
   EdgeAtom::Direction direction;
   std::vector<std::string> edge_types;
-  int k;
+  int limit;
   FineGrainedTestType fine_grained_test_type;
 
-  std::tie(upper_bound, direction, edge_types, k, fine_grained_test_type) = GetParam();
+  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
 
   this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type);
+      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type);
 }
 
 // The same matrix, plus a lambda blocking every edge into vertex 4, on top of the access checks.
@@ -139,13 +139,13 @@ TEST_P(FineGrainedKShortestTestInMemory, WithFilterLambda) {
   int upper_bound;
   EdgeAtom::Direction direction;
   std::vector<std::string> edge_types;
-  int k;
+  int limit;
   FineGrainedTestType fine_grained_test_type;
 
-  std::tie(upper_bound, direction, edge_types, k, fine_grained_test_type) = GetParam();
+  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
 
   this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type, 4);
+      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type, 4);
 }
 
 std::unique_ptr<VertexDb<FineGrainedKShortestTestInMemory::StorageType>> FineGrainedKShortestTestInMemory::db_{nullptr};
@@ -154,7 +154,7 @@ INSTANTIATE_TEST_SUITE_P(
     FineGrained, FineGrainedKShortestTestInMemory,
     testing::Combine(testing::Values(3),
                      testing::Values(EdgeAtom::Direction::OUT, EdgeAtom::Direction::IN, EdgeAtom::Direction::BOTH),
-                     testing::Values(std::vector<std::string>{"a", "b"}), testing::Values(3),
+                     testing::Values(std::vector<std::string>{"a", "b"}), testing::Values(-1, 3),
                      testing::Values(FineGrainedTestType::ALL_GRANTED, FineGrainedTestType::ALL_DENIED,
                                      FineGrainedTestType::EDGE_TYPE_A_DENIED, FineGrainedTestType::EDGE_TYPE_B_DENIED,
                                      FineGrainedTestType::LABEL_0_DENIED, FineGrainedTestType::LABEL_3_DENIED)));
@@ -188,13 +188,13 @@ TEST_P(FineGrainedKShortestTestOnDisk, All) {
   int upper_bound;
   EdgeAtom::Direction direction;
   std::vector<std::string> edge_types;
-  int k;
+  int limit;
   FineGrainedTestType fine_grained_test_type;
 
-  std::tie(upper_bound, direction, edge_types, k, fine_grained_test_type) = GetParam();
+  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
 
   this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type);
+      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type);
 }
 
 // The same matrix, plus a lambda blocking every edge into vertex 4, on top of the access checks.
@@ -202,13 +202,13 @@ TEST_P(FineGrainedKShortestTestOnDisk, WithFilterLambda) {
   int upper_bound;
   EdgeAtom::Direction direction;
   std::vector<std::string> edge_types;
-  int k;
+  int limit;
   FineGrainedTestType fine_grained_test_type;
 
-  std::tie(upper_bound, direction, edge_types, k, fine_grained_test_type) = GetParam();
+  std::tie(upper_bound, direction, edge_types, limit, fine_grained_test_type) = GetParam();
 
   this->db_->KShortestTestWithFineGrainedFiltering(
-      db_.get(), upper_bound, direction, edge_types, k, fine_grained_test_type, 4);
+      db_.get(), upper_bound, direction, edge_types, limit, fine_grained_test_type, 4);
 }
 
 std::unique_ptr<VertexDb<FineGrainedKShortestTestOnDisk::StorageType>> FineGrainedKShortestTestOnDisk::db_{nullptr};
@@ -217,7 +217,7 @@ INSTANTIATE_TEST_SUITE_P(
     FineGrained, FineGrainedKShortestTestOnDisk,
     testing::Combine(testing::Values(3),
                      testing::Values(EdgeAtom::Direction::OUT, EdgeAtom::Direction::IN, EdgeAtom::Direction::BOTH),
-                     testing::Values(std::vector<std::string>{"a", "b"}), testing::Values(3),
+                     testing::Values(std::vector<std::string>{"a", "b"}), testing::Values(-1, 3),
                      testing::Values(FineGrainedTestType::ALL_GRANTED, FineGrainedTestType::ALL_DENIED,
                                      FineGrainedTestType::EDGE_TYPE_A_DENIED, FineGrainedTestType::EDGE_TYPE_B_DENIED,
                                      FineGrainedTestType::LABEL_0_DENIED, FineGrainedTestType::LABEL_3_DENIED)));

--- a/tests/unit/kshortest_general.cpp
+++ b/tests/unit/kshortest_general.cpp
@@ -150,8 +150,7 @@ TEST_F(GeneralKShortestTestInMemory, KShortestWithLimit) {
   spdlog::info("KShortestTest: Testing with limit 5");
   db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::OUT, {}, 5);
 
-  // A lower bound with a limit: the top-up loop skips the paths below the bound before the limit is
-  // served, so the two interact. Every other limit case leaves the lower bound unset.
+  // The top-up loop skips paths below the bound before the limit is served, so the two interact.
   spdlog::info("KShortestTest: Testing lower bound 2 with limit 1");
   db_->KShortestTest(db_.get(), 2, -1, EdgeAtom::Direction::OUT, {}, 1);
 }

--- a/tests/unit/kshortest_general.cpp
+++ b/tests/unit/kshortest_general.cpp
@@ -149,6 +149,11 @@ TEST_F(GeneralKShortestTestInMemory, KShortestWithLimit) {
   // Test with limit 5 (more than available paths)
   spdlog::info("KShortestTest: Testing with limit 5");
   db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::OUT, {}, 5);
+
+  // A lower bound with a limit: the top-up loop skips the paths below the bound before the limit is
+  // served, so the two interact. Every other limit case leaves the lower bound unset.
+  spdlog::info("KShortestTest: Testing lower bound 2 with limit 1");
+  db_->KShortestTest(db_.get(), 2, -1, EdgeAtom::Direction::OUT, {}, 1);
 }
 
 TEST_F(GeneralKShortestTestInMemory, InvertedRangeDoesNotSearch) {

--- a/tests/unit/kshortest_general.cpp
+++ b/tests/unit/kshortest_general.cpp
@@ -184,8 +184,19 @@ INSTANTIATE_TEST_SUITE_P(Filtered, FilteredKShortestTestInMemory,
                          testing::Combine(testing::Values(3, -1),
                                           testing::Values(EdgeAtom::Direction::OUT, EdgeAtom::Direction::IN,
                                                           EdgeAtom::Direction::BOTH),
-                                          testing::Values(FilterLambdaType::USE_FRAME, FilterLambdaType::USE_FRAME_NULL,
-                                                          FilterLambdaType::USE_CTX, FilterLambdaType::ERROR)));
+                                          testing::Values(FilterLambdaType::USE_FRAME, FilterLambdaType::USE_CTX)));
+
+// A null verdict prunes exactly as false does, one line apart in `EvaluateFilterLambda`, so the
+// expectations match `USE_FRAME` and there is nothing for the matrix to vary.
+TEST_F(FilteredKShortestTestInMemory, NullLambdaPrunesLikeFalse) {
+  db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::BOTH, {}, -1, FilterLambdaType::USE_FRAME_NULL);
+}
+
+// The non-boolean verdict throws on the first edge that reaches vertex 5, which every direction and
+// bound does, so the harness returns before it looks at either.
+TEST_F(FilteredKShortestTestInMemory, NonBooleanLambdaThrows) {
+  db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::BOTH, {}, -1, FilterLambdaType::ERROR);
+}
 
 // Filter lambda combined with a path limit, which the lambda must not disturb.
 TEST_F(FilteredKShortestTestInMemory, FilteredWithLimit) {

--- a/tests/unit/kshortest_general.cpp
+++ b/tests/unit/kshortest_general.cpp
@@ -44,13 +44,11 @@ class VertexDb : public Database {
     return db_->Access(memgraph::storage::WRITE);
   }
 
-  std::unique_ptr<LogicalOperator> MakeKShortestOperator(Symbol source_sym, Symbol sink_sym, Symbol edge_sym,
-                                                         EdgeAtom::Direction direction,
-                                                         const std::vector<memgraph::storage::EdgeTypeId> &edge_types,
-                                                         const std::shared_ptr<LogicalOperator> &input,
-                                                         bool existing_node, memgraph::query::Expression *lower_bound,
-                                                         memgraph::query::Expression *upper_bound,
-                                                         memgraph::query::Expression *limit) override {
+  std::unique_ptr<LogicalOperator> MakeKShortestOperator(
+      Symbol source_sym, Symbol sink_sym, Symbol edge_sym, EdgeAtom::Direction direction,
+      const std::vector<memgraph::storage::EdgeTypeId> &edge_types, const std::shared_ptr<LogicalOperator> &input,
+      bool existing_node, memgraph::query::Expression *lower_bound, memgraph::query::Expression *upper_bound,
+      const memgraph::query::plan::ExpansionLambda &filter_lambda, memgraph::query::Expression *limit) override {
     return std::make_unique<ExpandVariable>(input,
                                             source_sym,
                                             sink_sym,
@@ -62,7 +60,7 @@ class VertexDb : public Database {
                                             lower_bound,
                                             upper_bound,
                                             existing_node,
-                                            memgraph::query::plan::ExpansionLambda{},
+                                            filter_lambda,
                                             std::nullopt,
                                             std::nullopt,
                                             limit);
@@ -153,6 +151,40 @@ TEST_F(GeneralKShortestTestInMemory, KShortestWithLimit) {
   db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::OUT, {}, 5);
 }
 
+// Filter lambda: the k shortest paths of the subgraph the lambda leaves behind.
+class FilteredKShortestTestInMemory
+    : public ::testing::TestWithParam<std::tuple<int, EdgeAtom::Direction, FilterLambdaType>> {
+ public:
+  using StorageType = memgraph::storage::InMemoryStorage;
+
+  static void SetUpTestCase() { db_ = std::make_unique<VertexDb<StorageType>>(); }
+
+  static void TearDownTestCase() { db_ = nullptr; }
+
+ protected:
+  static std::unique_ptr<VertexDb<StorageType>> db_;
+};
+
+TEST_P(FilteredKShortestTestInMemory, All) {
+  auto const [upper_bound, direction, filter_lambda_type] = GetParam();
+  this->db_->KShortestTest(db_.get(), -1, upper_bound, direction, {}, -1, filter_lambda_type);
+}
+
+std::unique_ptr<VertexDb<FilteredKShortestTestInMemory::StorageType>> FilteredKShortestTestInMemory::db_{nullptr};
+
+INSTANTIATE_TEST_SUITE_P(Filtered, FilteredKShortestTestInMemory,
+                         testing::Combine(testing::Values(3, -1),
+                                          testing::Values(EdgeAtom::Direction::OUT, EdgeAtom::Direction::IN,
+                                                          EdgeAtom::Direction::BOTH),
+                                          testing::Values(FilterLambdaType::USE_FRAME, FilterLambdaType::USE_FRAME_NULL,
+                                                          FilterLambdaType::USE_CTX, FilterLambdaType::ERROR)));
+
+// Filter lambda combined with a path limit, which the lambda must not disturb.
+TEST_F(FilteredKShortestTestInMemory, FilteredWithLimit) {
+  db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::OUT, {}, 1, FilterLambdaType::USE_CTX);
+  db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::OUT, {}, 3, FilterLambdaType::USE_CTX);
+}
+
 class GeneralKShortestTestOnDisk
     : public ::testing::TestWithParam<std::tuple<int, int, EdgeAtom::Direction, std::vector<std::string>>> {
  public:
@@ -198,4 +230,9 @@ TEST_F(GeneralKShortestTestOnDisk, KShortestWithLimit) {
 
   // Test with limit 5 (more than available paths)
   db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::OUT, {}, 5);
+}
+
+// One filter lambda case on disk storage; the exhaustive matrix runs in memory.
+TEST_F(GeneralKShortestTestOnDisk, KShortestWithFilterLambda) {
+  db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::BOTH, {}, -1, FilterLambdaType::USE_CTX);
 }

--- a/tests/unit/kshortest_general.cpp
+++ b/tests/unit/kshortest_general.cpp
@@ -151,6 +151,10 @@ TEST_F(GeneralKShortestTestInMemory, KShortestWithLimit) {
   db_->KShortestTest(db_.get(), -1, -1, EdgeAtom::Direction::OUT, {}, 5);
 }
 
+TEST_F(GeneralKShortestTestInMemory, InvertedRangeDoesNotSearch) {
+  db_->KShortestTestInvertedRangeDoesNotSearch(db_.get());
+}
+
 // Filter lambda: the k shortest paths of the subgraph the lambda leaves behind.
 class FilteredKShortestTestInMemory
     : public ::testing::TestWithParam<std::tuple<int, EdgeAtom::Direction, FilterLambdaType>> {

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -927,6 +927,36 @@ TYPED_TEST(TestSymbolGenerator, MatchBfsUsesLaterSymbolError) {
   EXPECT_THROW(memgraph::query::MakeSymbolTable(query), UnboundVariableError);
 }
 
+TYPED_TEST(TestSymbolGenerator, MatchKShortestLimitUsesPreviousOuterSymbol) {
+  // Test MATCH (a) -[r *KSHORTEST|a.prop]-> (m) RETURN r
+  // `PreVisit(EdgeAtom &)` returns false, suppressing the generic child traversal, so the `| k`
+  // limit resolves only because it is visited explicitly.
+  auto prop = this->dba.NameToProperty("prop");
+  auto *node_a = NODE("a");
+  auto *limit = PROPERTY_LOOKUP(this->dba, "a", prop);
+  auto *kshortest =
+      this->storage.template Create<EdgeAtom>(IDENT("r"), EdgeAtom::Type::KSHORTEST, EdgeAtom::Direction::OUT);
+  kshortest->filter_lambda_.inner_edge = IDENT("e");
+  kshortest->filter_lambda_.inner_node = IDENT("n");
+  kshortest->limit_ = limit;
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(node_a, kshortest, NODE("m"))), RETURN("r")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  EXPECT_EQ(symbol_table.at(*node_a->identifier_), symbol_table.at(*dynamic_cast<Identifier *>(limit->expression_)));
+}
+
+TYPED_TEST(TestSymbolGenerator, MatchKShortestLimitUsesEdgeSymbolError) {
+  // Test MATCH (n) -[r *KSHORTEST|r]-> (m) RETURN r
+  // The limit is visited inside the edge-range scope, so it cannot reference the edge list the
+  // expansion itself binds.
+  auto *kshortest =
+      this->storage.template Create<EdgeAtom>(IDENT("r"), EdgeAtom::Type::KSHORTEST, EdgeAtom::Direction::OUT);
+  kshortest->filter_lambda_.inner_edge = IDENT("e");
+  kshortest->filter_lambda_.inner_node = IDENT("n");
+  kshortest->limit_ = IDENT("r");
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), kshortest, NODE("m"))), RETURN("r")));
+  EXPECT_THROW(memgraph::query::MakeSymbolTable(query), UnboundVariableError);
+}
+
 TYPED_TEST(TestSymbolGenerator, MatchVariableLambdaSymbols) {
   // MATCH ()-[*]-() RETURN 42 AS res
   auto ident_n = this->storage.template Create<Identifier>("anon_n", false);

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -957,11 +957,10 @@ TYPED_TEST(TestSymbolGenerator, MatchKShortestLimitUsesEdgeSymbolError) {
   EXPECT_THROW(memgraph::query::MakeSymbolTable(query), UnboundVariableError);
 }
 
-// `PreVisit(EdgeAtom &)` must not hold a `Scope &` across its children's `Accept` calls. A pattern
-// comprehension in a bound or in the `| k` limit pushes a scope of its own, and `scopes_` is built
-// with capacity 1, so the push reallocates. The writes after the child traversal then land in the
-// freed buffer, leaving `in_pattern_atom_identifier` unset on the live scope - the edge identifier
-// is resolved as a plain variable reference and a valid query answers "Unbound variable: r".
+// `PreVisit(EdgeAtom &)` must not hold a `Scope &` across its children's `Accept` calls: a pattern
+// comprehension in a bound or in `| k` pushes a scope, reallocating the capacity-1 `scopes_`, and the
+// writes after the traversal then miss the live scope. The edge identifier is left unbound, so a
+// valid query answers "Unbound variable: r".
 TYPED_TEST(TestSymbolGenerator, EdgeAtomChildScopePushKeepsTheEdgeBound) {
   // MATCH (n) -[r *BFS 1..size([(n)-[e]->(m) | m])]-> (o) RETURN r
   auto *bound_edge = IDENT("r");

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -957,6 +957,39 @@ TYPED_TEST(TestSymbolGenerator, MatchKShortestLimitUsesEdgeSymbolError) {
   EXPECT_THROW(memgraph::query::MakeSymbolTable(query), UnboundVariableError);
 }
 
+// `PreVisit(EdgeAtom &)` must not hold a `Scope &` across its children's `Accept` calls. A pattern
+// comprehension in a bound or in the `| k` limit pushes a scope of its own, and `scopes_` is built
+// with capacity 1, so the push reallocates. The writes after the child traversal then land in the
+// freed buffer, leaving `in_pattern_atom_identifier` unset on the live scope - the edge identifier
+// is resolved as a plain variable reference and a valid query answers "Unbound variable: r".
+TYPED_TEST(TestSymbolGenerator, EdgeAtomChildScopePushKeepsTheEdgeBound) {
+  // MATCH (n) -[r *BFS 1..size([(n)-[e]->(m) | m])]-> (o) RETURN r
+  auto *bound_edge = IDENT("r");
+  auto *bfs =
+      this->storage.template Create<EdgeAtom>(bound_edge, EdgeAtom::Type::BREADTH_FIRST, EdgeAtom::Direction::OUT);
+  bfs->filter_lambda_.inner_edge = IDENT("inner_e");
+  bfs->filter_lambda_.inner_node = IDENT("inner_n");
+  bfs->lower_bound_ = LITERAL(1);
+  bfs->upper_bound_ =
+      FN("size", PATTERN_COMPREHENSION(nullptr, PATTERN(NODE("n"), EDGE("e"), NODE("m")), nullptr, IDENT("m")));
+  auto *bound_query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), bfs, NODE("o"))), RETURN("r")));
+  auto bound_symbols = memgraph::query::MakeSymbolTable(bound_query);
+  EXPECT_EQ(bound_symbols.at(*bound_edge).type(), Symbol::Type::EDGE_LIST);
+
+  // MATCH (n) -[r *KSHORTEST|size([(n)-[e]->(m) | m])]-> (o) RETURN r
+  // The limit is the child this branch newly visits, so it pushes a scope from a fresh site.
+  auto *limit_edge = IDENT("r");
+  auto *kshortest =
+      this->storage.template Create<EdgeAtom>(limit_edge, EdgeAtom::Type::KSHORTEST, EdgeAtom::Direction::OUT);
+  kshortest->filter_lambda_.inner_edge = IDENT("inner_e");
+  kshortest->filter_lambda_.inner_node = IDENT("inner_n");
+  kshortest->limit_ =
+      FN("size", PATTERN_COMPREHENSION(nullptr, PATTERN(NODE("n"), EDGE("e"), NODE("m")), nullptr, IDENT("m")));
+  auto *limit_query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), kshortest, NODE("o"))), RETURN("r")));
+  auto limit_symbols = memgraph::query::MakeSymbolTable(limit_query);
+  EXPECT_EQ(limit_symbols.at(*limit_edge).type(), Symbol::Type::EDGE_LIST);
+}
+
 TYPED_TEST(TestSymbolGenerator, MatchVariableLambdaSymbols) {
   // MATCH ()-[*]-() RETURN 42 AS res
   auto ident_n = this->storage.template Create<Identifier>("anon_n", false);


### PR DESCRIPTION
**What.** `-[*KSHORTEST (r, n | pred)]->` now returns the k shortest paths of the subgraph the predicate leaves behind. The three-argument `(r, n, p | ...)` form raises a semantic error: KSHORTEST searches bidirectionally and reuses inner searches across Yen's deviations, so there is no one path leading to the edge being tested.

**How.** Everything below the parser already carried `filter_lambda_` — the planner built it, `Clone` copied it, the plan JSON emitted it — and only the cursor ignored it, so the change is a semantic throw in `cypher_main_visitor.cpp` plus `KShortestPathsCursor::ShouldExpand` in `operator.cpp`. The cursor copies `STShortestPathCursor`'s node-binding convention: the source-side pass binds the vertex the edge leads to, the target-side pass the vertex it expands from, which is what makes a bidirectional search test the same `(edge, node)` pairs a forward walk of the finished path would. Yen runs the inner search `O(k·L)` times over the same edges, so the verdict is memoised per input row, keyed on `(edge, node, pass)`; the pass matters only when access checks are on, since that is when the two passes check opposite endpoints.

**Why.** KSHORTEST was the only variable expansion without a filter lambda, so narrowing a k-shortest search meant post-filtering whole paths — which changes the answer, since a path Yen already counted toward `k` cannot be replaced.

### Behaviour changes

- **`|k` now applies per input row.** `n_returned_paths_` was missing from `ResetState`, so it accumulated across rows while `limit_` meant "k paths". Once the running total reached `k`, the check at the top of `Pull` returned false — the cursor's "permanently exhausted" signal — before the input loop ran, so later rows were never pulled: `-[*KSHORTEST|1]->` over N pairs returned one row for the whole query. The count was also non-monotonic; over two pairs with two paths each, `|2` gave 2 rows but `|3` gave 4.
- **`|k` may reference the current row, and a negative `|k` errors.** Identifiers inside the limit were never resolved, so `-[*KSHORTEST|n.k]->` reached the cursor with an unresolved symbol and died on an unwrapped `std::out_of_range` ("An unknown exception occurred"). `SymbolGenerator::PreVisit(EdgeAtom &)` now visits `limit_`, and the cursor evaluates it once per input row beside the depth bounds rather than once per `Pull`. A limit of `0` skips its row instead of ending the pull; a negative limit raises a query error rather than returning no rows.
- **An invalid depth bound now errors** instead of silently disabling the check (both bounds are compared against a `size_t`, so a negative one wrapped). `upper_bound < 1` matches WSHORTEST/ALLSHORTEST; the lower bound rejects only negatives, since no sibling has a lower-bound floor and `0` is inert here.
- **An inlined property map is applied during the search.** With a limit this changes answers, not just cost: `-[*KSHORTEST|1 {p:1}]->` returned 0 rows on a graph whose only matching path was one hop longer than a non-matching one.

### Also fixed

`SymbolGenerator::PreVisit(EdgeAtom &)` held a `Scope &` across its children's `Accept` calls. A pattern comprehension in an edge pattern pushes a scope, reallocating the capacity-1 `scopes_`, so the writes after the traversal landed in freed memory and left the edge identifier unbound — a valid query answered `Unbound variable: r`. Reachable on master from a plain `MATCH`, independent of KSHORTEST.

`in_edges_`/`out_edges_` were the only members missing from the constructor's memory-resource init list and now use the query arena. A consistency fix, not a limit-escape fix — with jemalloc the malloc/extent hooks already charged those bytes. `EdgeVertexAccessorResult` is not allocator-aware, so the cursor caches an arena vector rather than the struct storage returns.

`GenerateCandidatesFromDeviation` compared the *spur* length against the upper bound, but a candidate's total is `deviation_index + spur_len`; the spur now gets `upper_bound_ - deviation_index`. Results are preserved, hop accounting is not — `number_of_hops` drops and a query under `USING HOPS LIMIT` can keep budget it previously spent.