### PR TITLE
fix: three defects in EXISTS subquery bodies (crash, missing test, false rejection)

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3954,8 +3954,11 @@ antlrcpp::Any CypherMainVisitor::visitExistsSubquery(MemgraphCypher::ExistsSubqu
     // Curly-brace subquery form: { cypherQuery }
     // Set the flag to indicate we are parsing an EXISTS subquery
     auto old_flag = parsing_exists_subquery_;
+    // The body's clauses are its own, so the enclosing WITH's "everything must be aliased" rule does not reach them.
+    auto old_in_with = std::exchange(in_with_, false);
     parsing_exists_subquery_ = true;
     auto *cypher_query = std::any_cast<CypherQuery *>(ctx->cypherQuery()->accept(this));
+    in_with_ = old_in_with;
     parsing_exists_subquery_ = old_flag;
     exists->content_ = cypher_query;
 
@@ -4248,9 +4251,10 @@ antlrcpp::Any CypherMainVisitor::visitCaseAlternatives(MemgraphCypher::CaseAlter
 
 antlrcpp::Any CypherMainVisitor::visitWith(MemgraphCypher::WithContext *ctx) {
   auto *with = storage_->Create<With>();
-  in_with_ = true;
+  // Restored, not cleared: a WITH inside an EXISTS body inside a WITH's own body would otherwise release the outer one.
+  auto old_in_with = std::exchange(in_with_, true);
   with->body_ = std::any_cast<ReturnBody>(ctx->returnBody()->accept(this));
-  in_with_ = false;
+  in_with_ = old_in_with;
   if (ctx->DISTINCT()) {
     with->body_.distinct = true;
   }

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -4251,7 +4251,8 @@ antlrcpp::Any CypherMainVisitor::visitCaseAlternatives(MemgraphCypher::CaseAlter
 
 antlrcpp::Any CypherMainVisitor::visitWith(MemgraphCypher::WithContext *ctx) {
   auto *with = storage_->Create<With>();
-  // Restored, not cleared: a WITH inside an EXISTS body inside a WITH's own body would otherwise release the outer one.
+  // Restored rather than cleared, so the flag is this function's own business. Defensive today: the only way to reach
+  // a nested WITH is through an EXISTS body, and that visit already clears the flag and re-arms it on the way out.
   auto old_in_with = std::exchange(in_with_, true);
   with->body_ = std::any_cast<ReturnBody>(ctx->returnBody()->accept(this));
   in_with_ = old_in_with;

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -611,7 +611,8 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
 
       // A body whose clauses all dropped plans to nothing, yet still matches one (empty) row. Substituted per query
       // part, not once on the branch root: each UNION branch is its own part, and the combinator below dereferences
-      // both operands.
+      // both operands. `in_exists_subquery` stays set across the recursive `Plan` calls this one makes, so this also
+      // catches a nested `CALL {}` body that plans to nothing - `HandleSubquery` dereferences that one too.
       if (context.in_exists_subquery && !input_op) {
         input_op = std::make_unique<Once>();
       }
@@ -1676,7 +1677,7 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
 
   /// The EXISTS branch, without either fold's tail. The pattern form is rooted at an `Once(bound_symbols)` so the
   /// branch correlates through the shared frame; the subquery form correlates by planning recursively against those
-  /// same bound symbols, and gets a bare `Once` from an operator's null-input guard.
+  /// same bound symbols, and gets a bare `Once` from `Plan` for any query part that plans to nothing.
   std::unique_ptr<LogicalOperator> MakeExistsBranch(const ExistsMatching &matching, const SymbolTable &symbol_table,
                                                     AstStorage &storage,
                                                     const std::unordered_set<Symbol> &bound_symbols,

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -609,6 +609,13 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
         input_op = std::make_unique<EmptyResult>(std::move(input_op));
       }
 
+      // A body whose clauses all dropped plans to nothing, yet still matches one (empty) row. Substituted per query
+      // part, not once on the branch root: each UNION branch is its own part, and the combinator below dereferences
+      // both operands.
+      if (context.in_exists_subquery && !input_op) {
+        input_op = std::make_unique<Once>();
+      }
+
       if (query_part.query_combinator) {
         final_plan = MergeWithCombinator(std::move(input_op), std::move(final_plan), *query_part.query_combinator);
       } else {
@@ -1692,11 +1699,8 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       exists_branch_after_write_ = write_occurred;
       context_->bound_symbols = std::move(branch_bound_symbols);
 
-      std::unique_ptr<LogicalOperator> last_op = Plan(*matching.subquery);
-      // A body whose clauses all dropped plans to nothing, yet still matches one (empty) row - so give the fold a
-      // branch to pull rather than a null it would dereference when making its cursor.
-      if (!last_op) last_op = std::make_unique<Once>();
-      return last_op;
+      // Plan substitutes a Once for a query part that plans to nothing, so this never comes back null.
+      return Plan(*matching.subquery);
     }
 
     std::vector<Symbol> once_symbols(bound_symbols.begin(), bound_symbols.end());

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1153,3 +1153,21 @@ Feature: WHERE exists
           | false |
           | true  |
           | true  |
+
+  Scenario: EXISTS subquery body with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WHERE EXISTS {
+              RETURN 1
+          }
+          RETURN n.id as id;
+          """
+      Then the result should be:
+          | id    |
+          | 1     |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1229,3 +1229,96 @@ Feature: WHERE exists
       Then the result should be:
           | h    |
           | true |
+
+  Scenario: EXISTS subquery body that is a UNION of a branch with rows and one with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          CREATE (:Node {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              MATCH (x:Node) RETURN x AS c
+              UNION
+              RETURN 2 AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |
+          | true |
+
+  Scenario: EXISTS subquery body that is a UNION of two branches matching nothing
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              MATCH (x:Missing) RETURN x AS c
+              UNION
+              MATCH (y:AlsoMissing) RETURN y AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h     |
+          | false |
+
+  Scenario: EXISTS subquery body with no operators in a projection
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              RETURN 1
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |
+
+  Scenario: EXISTS subquery body with no operators in a WITH projection
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WITH n, EXISTS {
+              RETURN 1
+          } AS e
+          RETURN e;
+          """
+      Then the result should be:
+          | e    |
+          | true |
+
+  Scenario: EXISTS subquery body with no operators in an ORDER BY
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WITH n ORDER BY EXISTS {
+              RETURN 1
+          }
+          RETURN n.id AS id;
+          """
+      Then the result should be:
+          | id    |
+          | 1     |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1171,3 +1171,61 @@ Feature: WHERE exists
       Then the result should be:
           | id    |
           | 1     |
+
+  Scenario: EXISTS subquery body that is a UNION of bodies with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WHERE EXISTS {
+              RETURN 1 AS c
+              UNION
+              RETURN 2 AS c
+          }
+          RETURN n.id as id;
+          """
+      Then the result should be:
+          | id    |
+          | 1     |
+
+  Scenario: EXISTS subquery in a projection whose body is a UNION with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              RETURN 1 AS c
+              UNION ALL
+              RETURN 2 AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |
+
+  Scenario: EXISTS subquery body that is a UNION of one matching and one empty branch
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              MATCH (x:Missing) RETURN x AS c
+              UNION
+              RETURN 2 AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8007,6 +8007,31 @@ TEST_P(CypherMainVisitorTest, ExistsThrow) {
                                                "EXISTS supports only a single relation or a subquery as its input.");
 }
 
+TEST_P(CypherMainVisitorTest, ExistsBodyIsNotJudgedByTheEnclosingWith) {
+  auto &ast_generator = *GetParam();
+
+  // `in_with_` gates "only variables can be non-aliased" for a WITH's own return items. An EXISTS body's clauses are
+  // not those items, so the flag must not still be set while they are visited - the body's `RETURN 1` is legal.
+  {
+    const auto *query =
+        dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH (n) WITH n, EXISTS { RETURN 1 } AS e RETURN e;"));
+    ASSERT_TRUE(query);
+    const auto *with = dynamic_cast<With *>(query->single_query_->clauses_[1]);
+    ASSERT_TRUE(with);
+    ASSERT_EQ(with->body_.named_expressions.size(), 2U);
+    EXPECT_TRUE(dynamic_cast<Exists *>(with->body_.named_expressions[1]->expression_));
+  }
+  // A body WITH restores the flag rather than clearing it, so the outer WITH's own items are still checked.
+  {
+    const auto *query = dynamic_cast<CypherQuery *>(
+        ast_generator.ParseQuery("MATCH (n) WITH n, EXISTS { MATCH (m) WITH m AS m RETURN 1 } AS e RETURN e;"));
+    ASSERT_TRUE(query);
+  }
+  TestInvalidQueryWithMessage<SemanticException>("MATCH (n) WITH n, EXISTS { RETURN 1 } AS e, n.prop RETURN e;",
+                                                 ast_generator,
+                                                 "Only variables can be non-aliased in WITH.");
+}
+
 TEST_P(CypherMainVisitorTest, Exists) {
   auto &ast_generator = *GetParam();
   {

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8021,13 +8021,29 @@ TEST_P(CypherMainVisitorTest, ExistsBodyIsNotJudgedByTheEnclosingWith) {
     ASSERT_EQ(with->body_.named_expressions.size(), 2U);
     EXPECT_TRUE(dynamic_cast<Exists *>(with->body_.named_expressions[1]->expression_));
   }
-  // A body WITH restores the flag rather than clearing it, so the outer WITH's own items are still checked.
+  // `visitReturnBody` visits ORDER BY before the return items, both while the flag is set, so the body of an EXISTS
+  // sorted on is judged by the same rule and was refused for the same reason.
+  {
+    const auto *query = dynamic_cast<CypherQuery *>(
+        ast_generator.ParseQuery("MATCH (n) WITH n ORDER BY EXISTS { RETURN 1 } RETURN n;"));
+    ASSERT_TRUE(query);
+    const auto *with = dynamic_cast<With *>(query->single_query_->clauses_[1]);
+    ASSERT_TRUE(with);
+    ASSERT_EQ(with->body_.order_by.size(), 1U);
+    EXPECT_TRUE(dynamic_cast<Exists *>(with->body_.order_by[0].expression));
+  }
+  // Clearing the flag for the body does not disarm it for the body's own WITH, which has return items of its own.
   {
     const auto *query = dynamic_cast<CypherQuery *>(
         ast_generator.ParseQuery("MATCH (n) WITH n, EXISTS { MATCH (m) WITH m AS m RETURN 1 } AS e RETURN e;"));
     ASSERT_TRUE(query);
   }
-  TestInvalidQueryWithMessage<SemanticException>("MATCH (n) WITH n, EXISTS { RETURN 1 } AS e, n.prop RETURN e;",
+  TestInvalidQueryWithMessage<SemanticException>(
+      "MATCH (n) WITH n, EXISTS { MATCH (m) WITH m, m.prop RETURN 1 } AS e RETURN e;",
+      ast_generator,
+      "Only variables can be non-aliased in WITH.");
+  // The outer WITH's own items are still checked. The body is aliased, so this can only be the `n.prop`.
+  TestInvalidQueryWithMessage<SemanticException>("MATCH (n) WITH n, EXISTS { RETURN 1 AS c } AS e, n.prop RETURN e;",
                                                  ast_generator,
                                                  "Only variables can be non-aliased in WITH.");
 }

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5206,6 +5206,85 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
   DeleteListContent(&exists_union_plan);
 }
 
+// A body's RETURN is dropped inside an exists subquery, so a UNION of RETURN-only branches plans both sides to
+// nothing. Each part gets its own Once before the combinator merges them - substituting one on the branch root would
+// come too late, and GenUnion dereferences both operands for their output symbols.
+
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodies) {
+  // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } RETURN n
+  FakeDbAccessor dba;
+
+  auto *exists_subquery =
+      QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("c"))), UNION(SINGLE_QUERY(RETURN(LITERAL(2), AS("c")))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EXISTS_SUBQUERY(exists_subquery)), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
+                                               new ExpectDistinct(),
+                                               new ExpectLimit(),
+                                               new ExpectEvaluatePatternFilter()};
+
+  // The branch correlates to nothing, so the filter is satisfied before the scan and sits below it.
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectFilter(std::vector<std::list<BaseOpChecker *>>{exists_union_plan}),
+            ExpectScanAll(),
+            ExpectProduce());
+
+  DeleteListContent(&left_exists_part);
+  DeleteListContent(&right_exists_part);
+  DeleteListContent(&exists_union_plan);
+}
+
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfEmptyBodies) {
+  // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION ALL RETURN 2 AS c } RETURN n - UNION ALL drops the Distinct.
+  FakeDbAccessor dba;
+
+  auto *exists_subquery =
+      QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("c"))), UNION_ALL(SINGLE_QUERY(RETURN(LITERAL(2), AS("c")))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EXISTS_SUBQUERY(exists_subquery)), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> exists_union_plan{
+      new ExpectUnion(left_exists_part, right_exists_part), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectFilter(std::vector<std::list<BaseOpChecker *>>{exists_union_plan}),
+            ExpectScanAll(),
+            ExpectProduce());
+
+  DeleteListContent(&left_exists_part);
+  DeleteListContent(&right_exists_part);
+  DeleteListContent(&exists_union_plan);
+}
+
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodiesInReturnProjection) {
+  // MATCH (n) RETURN EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } AS h - the projection reaches the same branch
+  // through the forced fold, which has no Limit/EvaluatePatternFilter tail to hide a null root.
+  auto *exists_subquery =
+      QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("c"))), UNION(SINGLE_QUERY(RETURN(LITERAL(2), AS("c")))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), RETURN(EXISTS_SUBQUERY(exists_subquery), AS("h"))));
+
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+
+  Checkers input{ExpectOnce{}, ExpectScanAll{}};
+  Checkers branch{ExpectUnion{left_exists_part, right_exists_part}, ExpectDistinct{}};
+
+  CheckPlan<TypeParam>(
+      query, this->storage, ExpectExistsRollUpApply{std::move(input), std::move(branch)}, ExpectProduce());
+
+  DeleteListContent(&left_exists_part);
+  DeleteListContent(&right_exists_part);
+}
+
 // The forced bool fold: an EXISTS in a WITH/RETURN body is spliced onto the main chain as a RollUpApply, because
 // EvaluatePatternFilter is only usable as a Filter side branch.
 


### PR DESCRIPTION
Three defects in EXISTS bodies. None is caused by #4504, but #4504 makes each reachable from a new
position.

Closes #4478.

### Crashes the server

An EXISTS body that plans to no operators is dereferenced by whatever consumes it. Three shapes,
each a SIGSEGV that drops the server for every session and every database:

```cypher
RETURN EXISTS { RETURN 1 UNION RETURN 2 };
MATCH (n) WHERE EXISTS { RETURN 1 UNION ALL RETURN 2 } RETURN n;
MATCH (n) WHERE EXISTS { MATCH (m) RETURN m AS c UNION CALL { RETURN 1 AS z } RETURN 1 AS c } RETURN n;
```

The empty-row substitution moves into the planner's per-query-part loop, so every part that plans to
nothing gets it before any consumer — union combinator, nested subquery — can dereference it.

### Falsely rejected

```cypher
MATCH (n) WITH n, EXISTS { RETURN 1 } AS e RETURN e;
MATCH (n) WITH n ORDER BY EXISTS { RETURN 1 } RETURN n;
```

Both threw *"Only variables can be non-aliased in WITH."*, though the EXISTS is aliased in the first
and isn't a return item at all in the second. The flag gating that rule stayed set while the visitor
descended into the body, so the body's own `RETURN 1` was judged by the enclosing WITH's rule. It is
now cleared for the body and restored afterwards, leaving the outer WITH's items checked as before.

Both spellings already fail this way on master. The aliasing check runs in the parser, before the
semantic gate that refuses `EXISTS` in these positions, so master reports the aliasing error and the
position error never surfaces — visible in that `EXISTS { RETURN 1 AS c }` reports the position error
while `EXISTS { RETURN 1 }` reports the aliasing one. Neither position is usable on master regardless;
#4504 legalises them, which is what turns this from a misleading message into a false rejection of a
valid query.