### PR TITLE
fix: use index for filters on variables imported into CALL subqueries

### DIFF
--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -169,7 +169,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
                             .node2_symbol = op.common_.node_symbol,
                             .direction = op.common_.direction,
                             .edge_types = op.common_.edge_types};
-    auto indexed_scan = GenScanByEdgeIndex(op, common);
+    auto indexed_scan = GenScanByEdgeIndex(op, common, /*can_scan_by_edge_id=*/!op.common_.existing_node);
     if (indexed_scan) {
       // We know (and checked) that the input of Expand was a Scan
       // GenScanByEdgeIndex replaced the Expand, yet maintained the input
@@ -979,8 +979,10 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   bool DefaultPreVisit() override { throw utils::NotYetImplemented("Operator not yet covered by EdgeIndexRewriter"); }
 
+  /// @param can_scan_by_edge_id false when the destination node is already bound on the frame.
   template <class TOperator>
-  auto GenScanByEdgeIndex(const TOperator &op, const ScanByEdgeCommon &common) -> std::shared_ptr<LogicalOperator> {
+  auto GenScanByEdgeIndex(const TOperator &op, const ScanByEdgeCommon &common, bool can_scan_by_edge_id = true)
+      -> std::shared_ptr<LogicalOperator> {
     const auto &input = op.input();
     const auto &view = op.view_;
 
@@ -1001,6 +1003,9 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
 
     for (const auto &filter : filters_.IdFilters(common.edge_symbol)) {
       if (filter.id_filter->is_symbol_in_value_ || !are_bound(filter.used_symbols)) continue;
+      // ScanAllByEdgeId carries no edge types and no node identity, and we erase the id filter below,
+      // so a pattern constraining either must keep its Expand instead of matching the wrong edge.
+      if (!can_scan_by_edge_id || !common.edge_types.empty() || common.node1_symbol == common.node2_symbol) continue;
       auto *value = filter.id_filter->value_;
       filter_exprs_for_removal_.insert(filter.expression);
       filters_.EraseFilter(filter);

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -744,9 +744,8 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
   std::vector<LogicalOperator *> prev_ops_;
   OrderByEliminator<TDbAccessor> order_by_eliminator_;
   std::unordered_set<Symbol> additional_bound_symbols_;
-  // See IndexLookupRewriter::inherited_bound_symbols_: live on the frame but not produced by this
-  // branch, so it stays out of the plan. Never cleared, so PostVisit(Cartesian) cannot wipe it.
-  std::unordered_set<Symbol> inherited_bound_symbols_;
+  // See IndexLookupRewriter::inherited_bound_symbols_.
+  std::unordered_set<Symbol> const inherited_bound_symbols_;
 
   /// Try to record a newly-created edge scan for ORDER BY elimination.
   /// GenScanByEdgeIndex may wrap the scan in a Filter (for edge-type checking

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -1278,16 +1278,16 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     LOG_FATAL("Error during index rewriting of the query!");
   }
 
-  // What a subquery branch inherits: everything its input side has bound, plus anything this rewriter
-  // itself inherited, so nested subqueries keep the outermost scope's symbols.
+  // A subquery branch additionally inherits whatever its input side has bound.
   auto InheritedFor(const LogicalOperator &op) const -> std::unordered_set<Symbol> {
     auto const input_symbols = op.input()->ModifiedSymbols(*symbol_table_);
-    std::unordered_set<Symbol> inherited(input_symbols.begin(), input_symbols.end());
-    inherited.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
-    return inherited;
+    return {input_symbols.begin(), input_symbols.end()};
   }
 
+  // Every branch gets a fresh rewriter, so what this one inherited has to be handed down explicitly or
+  // a Union/Merge/Optional branch inside a subquery would lose the enclosing scope again.
   void RewriteBranch(std::shared_ptr<LogicalOperator> *branch, std::unordered_set<Symbol> inherited = {}) {
+    inherited.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
     EdgeIndexRewriter<TDbAccessor> rewriter(symbol_table_, ast_storage_, db_, false, std::move(inherited));
     (*branch)->Accept(rewriter);
     if (rewriter.new_root_) {

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -39,10 +39,11 @@ template <class TDbAccessor>
 class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
  public:
   EdgeIndexRewriter(SymbolTable *symbol_table, AstStorage *ast_storage, TDbAccessor *db,
-                    bool parallel_execution = false)
+                    bool parallel_execution = false, std::unordered_set<Symbol> inherited_bound_symbols = {})
       : symbol_table_(symbol_table),
         ast_storage_(ast_storage),
         db_(db),
+        inherited_bound_symbols_(std::move(inherited_bound_symbols)),
         order_by_eliminator_(db, prev_ops_, parallel_execution) {}
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
@@ -636,7 +637,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PreVisit(Apply &op) override {
     prev_ops_.push_back(&op);
     op.input()->Accept(*this);
-    RewriteBranch(&op.subquery_);
+    RewriteBranch(&op.subquery_, InheritedFor(op));
     return false;
   }
 
@@ -700,7 +701,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PreVisit(PeriodicSubquery &op) override {
     prev_ops_.push_back(&op);
     op.input()->Accept(*this);
-    RewriteBranch(&op.subquery_);
+    RewriteBranch(&op.subquery_, InheritedFor(op));
     return false;
   }
 
@@ -743,6 +744,9 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
   std::vector<LogicalOperator *> prev_ops_;
   OrderByEliminator<TDbAccessor> order_by_eliminator_;
   std::unordered_set<Symbol> additional_bound_symbols_;
+  // See IndexLookupRewriter::inherited_bound_symbols_: live on the frame but not produced by this
+  // branch, so it stays out of the plan. Never cleared, so PostVisit(Cartesian) cannot wipe it.
+  std::unordered_set<Symbol> inherited_bound_symbols_;
 
   /// Try to record a newly-created edge scan for ORDER BY elimination.
   /// GenScanByEdgeIndex may wrap the scan in a Filter (for edge-type checking
@@ -984,6 +988,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
 
     std::unordered_set<Symbol> bound_symbols(modified_symbols.begin(), modified_symbols.end());
     bound_symbols.insert(additional_bound_symbols_.begin(), additional_bound_symbols_.end());
+    bound_symbols.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
 
     auto are_bound = [&bound_symbols](const auto &used_symbols) {
       for (const auto &used_symbol : used_symbols) {
@@ -1273,8 +1278,17 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     LOG_FATAL("Error during index rewriting of the query!");
   }
 
-  void RewriteBranch(std::shared_ptr<LogicalOperator> *branch) {
-    EdgeIndexRewriter<TDbAccessor> rewriter(symbol_table_, ast_storage_, db_);
+  // What a subquery branch inherits: everything its input side has bound, plus anything this rewriter
+  // itself inherited, so nested subqueries keep the outermost scope's symbols.
+  auto InheritedFor(const LogicalOperator &op) const -> std::unordered_set<Symbol> {
+    auto const input_symbols = op.input()->ModifiedSymbols(*symbol_table_);
+    std::unordered_set<Symbol> inherited(input_symbols.begin(), input_symbols.end());
+    inherited.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
+    return inherited;
+  }
+
+  void RewriteBranch(std::shared_ptr<LogicalOperator> *branch, std::unordered_set<Symbol> inherited = {}) {
+    EdgeIndexRewriter<TDbAccessor> rewriter(symbol_table_, ast_storage_, db_, false, std::move(inherited));
     (*branch)->Accept(rewriter);
     if (rewriter.new_root_) {
       *branch = rewriter.new_root_;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -829,6 +829,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PreVisit(Apply &op) override {
     prev_ops_.push_back(&op);
     op.input()->Accept(*this);
+    // Inherited symbols arrive via the branch's bottom Once, not additional_bound_symbols_: seeding
+    // that here would let a branch-internal SetOnParent overwrite Apply::input_, i.e. the outer plan.
     RewriteBranch(&op.subquery_);
     return false;
   }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -178,12 +178,14 @@ template <class TDbAccessor>
 class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
  public:
   IndexLookupRewriter(SymbolTable *symbol_table, AstStorage *ast_storage, TDbAccessor *db, IndexHints index_hints,
-                      const Parameters &parameters, bool parallel_execution = false)
+                      const Parameters &parameters, bool parallel_execution = false,
+                      std::unordered_set<Symbol> inherited_bound_symbols = {})
       : symbol_table_(symbol_table),
         ast_storage_(ast_storage),
         db_(db),
         index_hints_(std::move(index_hints)),
         parameters_(parameters),
+        inherited_bound_symbols_(std::move(inherited_bound_symbols)),
         order_by_eliminator_(db, prev_ops_, parallel_execution) {}
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
@@ -829,9 +831,10 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PreVisit(Apply &op) override {
     prev_ops_.push_back(&op);
     op.input()->Accept(*this);
-    // Inherited symbols arrive via the branch's bottom Once, not additional_bound_symbols_: seeding
-    // that here would let a branch-internal SetOnParent overwrite Apply::input_, i.e. the outer plan.
-    RewriteBranch(&op.subquery_);
+    // The branch sees the outer scope's symbols, but pass them to the child rewriter rather than
+    // seeding additional_bound_symbols_ and descending with `*this`: a branch-internal SetOnParent
+    // would then overwrite Apply::input_, i.e. the outer plan.
+    RewriteBranch(&op.subquery_, InheritedFor(op));
     return false;
   }
 
@@ -895,7 +898,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PreVisit(PeriodicSubquery &op) override {
     prev_ops_.push_back(&op);
     op.input()->Accept(*this);
-    RewriteBranch(&op.subquery_);
+    RewriteBranch(&op.subquery_, InheritedFor(op));
     return false;
   }
 
@@ -942,6 +945,12 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   // additional symbols that are present from other non-main branches but have influence on indexing
   std::unordered_set<Symbol> additional_bound_symbols_;
+  // Symbols a subquery branch inherits from the enclosing scope. They are live on the frame, but they
+  // are NOT produced by this branch, so this must never be pushed into the plan (e.g. onto the
+  // branch's bottom Once): ModifiedSymbols has consumers that read it as "produced by this subtree",
+  // and PlanValidator and the Cartesian->IndexedJoin conversion both mis-fire on inherited symbols.
+  // Unlike additional_bound_symbols_ this is never cleared, so PostVisit(Cartesian) cannot wipe it.
+  std::unordered_set<Symbol> inherited_bound_symbols_;
 
   struct LabelPropertyIndex {
     LabelIx label;
@@ -1000,8 +1009,18 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     LOG_FATAL("Error during index rewriting of the query!");
   }
 
-  void RewriteBranch(std::shared_ptr<LogicalOperator> *branch) {
-    IndexLookupRewriter<TDbAccessor> rewriter(symbol_table_, ast_storage_, db_, index_hints_, parameters_);
+  // What a subquery branch inherits: everything its input side has bound, plus anything this rewriter
+  // itself inherited, so nested subqueries keep the outermost scope's symbols.
+  auto InheritedFor(const LogicalOperator &op) const -> std::unordered_set<Symbol> {
+    auto const input_symbols = op.input()->ModifiedSymbols(*symbol_table_);
+    std::unordered_set<Symbol> inherited(input_symbols.begin(), input_symbols.end());
+    inherited.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
+    return inherited;
+  }
+
+  void RewriteBranch(std::shared_ptr<LogicalOperator> *branch, std::unordered_set<Symbol> inherited = {}) {
+    IndexLookupRewriter<TDbAccessor> rewriter(
+        symbol_table_, ast_storage_, db_, index_hints_, parameters_, false, std::move(inherited));
     (*branch)->Accept(rewriter);
     if (rewriter.new_root_) {
       *branch = rewriter.new_root_;
@@ -1715,6 +1734,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
     std::unordered_set<Symbol> bound_symbols(modified_symbols.begin(), modified_symbols.end());
     bound_symbols.insert(additional_bound_symbols_.begin(), additional_bound_symbols_.end());
+    bound_symbols.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
 
     auto are_bound = [&bound_symbols](const auto &used_symbols) {
       for (const auto &used_symbol : used_symbols) {

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -205,6 +205,17 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   // free the memory.
   bool PostVisit(Filter &op) override {
     prev_ops_.pop_back();
+
+    // Predicates we consumed here. The Cartesian decision below needs these, not the leftovers.
+    std::vector<FilterInfo> removed_filters;
+    {
+      Filters own_filters;
+      own_filters.CollectFilterExpression(op.expression_, *symbol_table_);
+      for (auto const &filter : own_filters) {
+        if (filter_exprs_for_removal_.contains(filter.expression)) removed_filters.push_back(filter);
+      }
+    }
+
     ExpressionRemovalResult removal = RemoveExpressions(op.expression_, filter_exprs_for_removal_, ast_storage_);
     op.expression_ = removal.trimmed_expression;
     if (op.expression_) {
@@ -213,9 +224,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       op.all_filters_ = std::move(leftover_filters);
     }
 
-    // Filters are pushed down as far as they can go.
-    // If there is a Cartesian after, that means that the filter is working on data from both branches.
-    // In that case, we need to convert the Cartesian into a Join
+    // A Cartesian pulls its right branch once per pass, not once per left row, so it cannot feed a
+    // seek keyed on the other branch. Convert only when a consumed filter created such a dependency.
     if (removal.did_remove) {
       LogicalOperator *input = op.input().get();
       LogicalOperator *parent = &op;
@@ -226,24 +236,18 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         input = input->input().get();
       }
 
-      const bool is_child_cartesian = input->GetTypeInfo() == Cartesian::kType;
-      if (is_child_cartesian) {
-        std::unordered_set<Symbol> modified_symbols;
-        // Number of symbols is small
-        for (const auto &filter : op.all_filters_) {
-          modified_symbols.insert(filter.used_symbols.begin(), filter.used_symbols.end());
-        }
-        auto does_modify = [&]() {
-          const auto &symbols = input->ModifiedSymbols(*symbol_table_);
-          return std::ranges::any_of(
-              symbols, [&modified_symbols](const auto &sym_in) { return modified_symbols.contains(sym_in); });
+      if (input->GetTypeInfo() == Cartesian::kType) {
+        auto *cartesian = dynamic_cast<Cartesian *>(input);
+        // A one-sided predicate, or one on an inherited symbol, leaves the branches independent.
+        // Converting those costs a re-execution per main row and forfeits JoinRewriter's HashJoin.
+        auto spans_both_branches = [cartesian](FilterInfo const &filter) {
+          auto touches = [&filter](std::vector<Symbol> const &side) {
+            return std::ranges::any_of(side, [&filter](Symbol const &s) { return filter.used_symbols.contains(s); });
+          };
+          return touches(cartesian->left_symbols_) && touches(cartesian->right_symbols_);
         };
-        if (does_modify()) {
-          // if we removed something from filter in front of a Cartesian, then we are doing a join from
-          // 2 different branches
-          auto *cartesian = dynamic_cast<Cartesian *>(input);
-          auto indexed_join = std::make_shared<IndexedJoin>(cartesian->left_op_, cartesian->right_op_);
-          parent->set_input(indexed_join);
+        if (std::ranges::any_of(removed_filters, spans_both_branches)) {
+          parent->set_input(std::make_shared<IndexedJoin>(cartesian->left_op_, cartesian->right_op_));
         }
       }
     }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1009,16 +1009,16 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     LOG_FATAL("Error during index rewriting of the query!");
   }
 
-  // What a subquery branch inherits: everything its input side has bound, plus anything this rewriter
-  // itself inherited, so nested subqueries keep the outermost scope's symbols.
+  // A subquery branch additionally inherits whatever its input side has bound.
   auto InheritedFor(const LogicalOperator &op) const -> std::unordered_set<Symbol> {
     auto const input_symbols = op.input()->ModifiedSymbols(*symbol_table_);
-    std::unordered_set<Symbol> inherited(input_symbols.begin(), input_symbols.end());
-    inherited.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
-    return inherited;
+    return {input_symbols.begin(), input_symbols.end()};
   }
 
+  // Every branch gets a fresh rewriter, so what this one inherited has to be handed down explicitly or
+  // a Union/Merge/Optional branch inside a subquery would lose the enclosing scope again.
   void RewriteBranch(std::shared_ptr<LogicalOperator> *branch, std::unordered_set<Symbol> inherited = {}) {
+    inherited.insert(inherited_bound_symbols_.begin(), inherited_bound_symbols_.end());
     IndexLookupRewriter<TDbAccessor> rewriter(
         symbol_table_, ast_storage_, db_, index_hints_, parameters_, false, std::move(inherited));
     (*branch)->Accept(rewriter);

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -949,12 +949,9 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   // additional symbols that are present from other non-main branches but have influence on indexing
   std::unordered_set<Symbol> additional_bound_symbols_;
-  // Symbols a subquery branch inherits from the enclosing scope. They are live on the frame, but they
-  // are NOT produced by this branch, so this must never be pushed into the plan (e.g. onto the
-  // branch's bottom Once): ModifiedSymbols has consumers that read it as "produced by this subtree",
-  // and PlanValidator and the Cartesian->IndexedJoin conversion both mis-fire on inherited symbols.
-  // Unlike additional_bound_symbols_ this is never cleared, so PostVisit(Cartesian) cannot wipe it.
-  std::unordered_set<Symbol> inherited_bound_symbols_;
+  // Enclosing scope's symbols: live on the frame, but not produced by this branch, so they must stay
+  // out of the plan - ModifiedSymbols has consumers that read it as "produced by this subtree".
+  std::unordered_set<Symbol> const inherited_bound_symbols_;
 
   struct LabelPropertyIndex {
     LabelIx label;

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -267,7 +267,13 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     auto const initial_bound_symbols = context.bound_symbols;
     for (const auto &query_part : query_parts.query_parts) {
       context.bound_symbols = initial_bound_symbols;
+      // A subquery branch is index-rewritten in isolation, so inherited symbols reach it only through
+      // its bottom Once; left empty, no filter on an imported variable can select an index.
       std::unique_ptr<LogicalOperator> input_op;
+      if (!initial_bound_symbols.empty()) {
+        input_op =
+            std::make_unique<Once>(std::vector<Symbol>(initial_bound_symbols.begin(), initial_bound_symbols.end()));
+      }
 
       context.is_write_query = false;
       for (const auto &single_query_part : query_part.single_query_parts) {

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -267,13 +267,7 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     auto const initial_bound_symbols = context.bound_symbols;
     for (const auto &query_part : query_parts.query_parts) {
       context.bound_symbols = initial_bound_symbols;
-      // A subquery branch is index-rewritten in isolation, so inherited symbols reach it only through
-      // its bottom Once; left empty, no filter on an imported variable can select an index.
       std::unique_ptr<LogicalOperator> input_op;
-      if (!initial_bound_symbols.empty()) {
-        input_op =
-            std::make_unique<Once>(std::vector<Symbol>(initial_bound_symbols.begin(), initial_bound_symbols.end()));
-      }
 
       context.is_write_query = false;
       for (const auto &single_query_part : query_part.single_query_parts) {

--- a/tests/e2e/query_planning/query_planning_subquery.py
+++ b/tests/e2e/query_planning/query_planning_subquery.py
@@ -75,7 +75,6 @@ def test_scoped_subquery_import_index_result_equivalence(memgraph):
     so assert the indexed plan returns what the unindexed one does across rows carrying different
     lists. Catches a stale or wrongly-scoped seek key, the only way this could give wrong results.
     """
-    memgraph.execute("MATCH (n) DETACH DELETE n;")
     for i in range(12):
         memgraph.execute(f"CREATE (:L {{p: 'v{i}'}});")
 

--- a/tests/e2e/query_planning/query_planning_subquery.py
+++ b/tests/e2e/query_planning/query_planning_subquery.py
@@ -65,5 +65,57 @@ def test_variable_start_planner_nested_and_left_ast_corruption(memgraph):
     assert result == []
 
 
+def _plan(memgraph, query):
+    return "\n".join(row["QUERY PLAN"] for row in memgraph.execute_and_fetch("EXPLAIN " + query))
+
+
+def test_scoped_subquery_import_index_result_equivalence(memgraph):
+    """
+    The seek key inside `CALL (ids) { ... }` is derived from a value that changes on every outer row,
+    so assert the indexed plan returns what the unindexed one does across rows carrying different
+    lists. Catches a stale or wrongly-scoped seek key, the only way this could give wrong results.
+    """
+    memgraph.execute("MATCH (n) DETACH DELETE n;")
+    for i in range(12):
+        memgraph.execute(f"CREATE (:L {{p: 'v{i}'}});")
+
+    query = """
+        UNWIND [{i: 0, ids: ['v0', 'v1']},
+                {i: 1, ids: ['v3']},
+                {i: 2, ids: []},
+                {i: 3, ids: ['v5', 'v7', 'v11']},
+                {i: 4, ids: ['v2', 'v2']},
+                {i: 5, ids: ['nope']}] AS row
+        WITH row.i AS i, row.ids AS ids
+        CALL (ids) {
+            MATCH (n:L) WHERE n.p IN ids
+            RETURN collect(n.p) AS found
+        }
+        RETURN i, found ORDER BY i
+    """
+
+    def run():
+        return [(row["i"], sorted(row["found"])) for row in memgraph.execute_and_fetch(query)]
+
+    expected = [
+        (0, ["v0", "v1"]),
+        (1, ["v3"]),
+        (2, []),
+        (3, ["v11", "v5", "v7"]),
+        (4, ["v2"]),
+        (5, []),
+    ]
+
+    unindexed = run()
+    assert "ScanAllByLabelProperties" not in _plan(memgraph, query)
+    assert unindexed == expected
+
+    memgraph.execute("CREATE INDEX ON :L(p);")
+    indexed_plan = _plan(memgraph, query)
+    assert "ScanAllByLabelProperties" in indexed_plan, f"index not used inside scoped CALL:\n{indexed_plan}"
+
+    assert run() == unindexed
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/query_planning/query_planning_subquery.py
+++ b/tests/e2e/query_planning/query_planning_subquery.py
@@ -69,16 +69,13 @@ def _plan(memgraph, query):
     return "\n".join(row["QUERY PLAN"] for row in memgraph.execute_and_fetch("EXPLAIN " + query))
 
 
-def test_scoped_subquery_import_does_not_invalidate_optional_edge_index_plan(memgraph):
+def test_scoped_subquery_import_with_optional_and_edge_index(memgraph):
     """
-    Regression guard. The inherited symbols must reach the branch's index rewriter WITHOUT entering the
-    plan: PlanValidator::PreVisit(Optional) intersects the input's ModifiedSymbols with the optional
-    branch's and forbids indexed edge scans when they overlap, so an inherited symbol visible in
-    ModifiedSymbols invalidates every candidate plan and the query dies with
-    "Could not create a valid query plan".
+    An OPTIONAL MATCH filtering an edge on the imported variable, with an edge index present. Covers
+    both import forms, and is the only coverage of CALL (*) / all_variables_scoped_.
 
-    Unit tests cannot cover this: the query_plan.cpp harness runs the rewriters but never calls
-    IsValidPlan.
+    Has to be e2e: PlanValidator rejects indexed edge scans under an Optional whose branch and input
+    share a symbol, and the query_plan.cpp harness runs the rewriters but never calls IsValidPlan.
     """
     memgraph.execute("CREATE EDGE INDEX ON :T;")
     try:
@@ -101,9 +98,9 @@ def test_scoped_subquery_import_does_not_invalidate_optional_edge_index_plan(mem
 
 def test_scoped_subquery_import_does_not_convert_unrelated_cartesian(memgraph):
     """
-    The Cartesian -> IndexedJoin conversion must fire only when a *removed* filter spanned both
-    branches. Converting otherwise re-executes the sub-branch per main row and forfeits the HashJoin,
-    since JoinRewriter runs later and only rewrites Cartesian. Measured 0.009s -> 2.1s at 30k rows.
+    The Cartesian -> IndexedJoin conversion must fire only when a removed filter spans both branches.
+    Converting otherwise re-executes the sub-branch once per main row, and forfeits the HashJoin
+    because JoinRewriter runs later and only rewrites Cartesian.
     """
     memgraph.execute("CREATE INDEX ON :L(p);")
     memgraph.execute("UNWIND range(1, 5) AS i CREATE (:A {id: i});")
@@ -137,9 +134,9 @@ def test_scoped_subquery_import_does_not_convert_unrelated_cartesian(memgraph):
 
 def test_scoped_subquery_import_index_result_equivalence(memgraph):
     """
-    The seek key inside `CALL (ids) { ... }` is derived from a value that changes on every outer row,
-    so assert the indexed plan returns what the unindexed one does across rows carrying different
-    lists. Catches a stale or wrongly-scoped seek key, the only way this could give wrong results.
+    The seek key inside `CALL (ids) { ... }` changes on every outer row, so the indexed plan must
+    return what the unindexed one does across rows carrying different lists. Catches a stale or
+    wrongly-scoped seek key.
     """
     for i in range(12):
         memgraph.execute(f"CREATE (:L {{p: 'v{i}'}});")

--- a/tests/e2e/query_planning/query_planning_subquery.py
+++ b/tests/e2e/query_planning/query_planning_subquery.py
@@ -69,6 +69,60 @@ def _plan(memgraph, query):
     return "\n".join(row["QUERY PLAN"] for row in memgraph.execute_and_fetch("EXPLAIN " + query))
 
 
+def test_scoped_subquery_import_does_not_invalidate_optional_edge_index_plan(memgraph):
+    """
+    Regression guard. The inherited symbols must reach the branch's index rewriter WITHOUT entering the
+    plan: PlanValidator::PreVisit(Optional) intersects the input's ModifiedSymbols with the optional
+    branch's and forbids indexed edge scans when they overlap, so an inherited symbol visible in
+    ModifiedSymbols invalidates every candidate plan and the query dies with
+    "Could not create a valid query plan".
+
+    Unit tests cannot cover this: the query_plan.cpp harness runs the rewriters but never calls
+    IsValidPlan.
+    """
+    memgraph.execute("CREATE EDGE INDEX ON :T;")
+    try:
+        memgraph.execute("CREATE (a:L {p: 1}), (b:L {p: 2});")
+        memgraph.execute("MATCH (a:L {p: 1}), (b:L {p: 2}) CREATE (a)-[:T {p: 1}]->(b);")
+
+        query = """
+            WITH 1 AS v
+            CALL (v) { MATCH (a) OPTIONAL MATCH ()-[e:T]->() WHERE e.p = v RETURN a, e }
+            RETURN count(*) AS c
+        """
+        assert [row["c"] for row in memgraph.execute_and_fetch(query)] == [2]
+        # CALL (*) reaches the same code path via all_variables_scoped_.
+        star = query.replace("CALL (v)", "CALL (*)")
+        assert [row["c"] for row in memgraph.execute_and_fetch(star)] == [2]
+    finally:
+        # the memgraph fixture's drop_indexes() does not cover edge indexes
+        memgraph.execute("DROP EDGE INDEX ON :T;")
+
+
+def test_scoped_subquery_import_does_not_convert_unrelated_cartesian(memgraph):
+    """
+    Regression guard. An inherited symbol visible in Cartesian::ModifiedSymbols makes does_modify() in
+    IndexLookupRewriter::PostVisit(Filter) false-positive, converting an unrelated Cartesian into an
+    IndexedJoin whose sub-branch is an unindexed scan re-executed once per main row - O(M) to O(N*M).
+    The Cartesian must survive while the indexed scan is still picked up.
+    """
+    memgraph.execute("CREATE INDEX ON :L(p);")
+    memgraph.execute("UNWIND range(1, 5) AS i CREATE (:A {id: i});")
+    memgraph.execute("UNWIND range(1, 5) AS i CREATE (:B {id: i});")
+    memgraph.execute("UNWIND range(1, 3) AS i CREATE (:L {p: 1, q: i});")
+
+    query = """
+        WITH 1 AS v
+        CALL (v) { MATCH (a:A), (b:B) UNWIND [1] AS x MATCH (c:L) WHERE c.p = v RETURN a, b, c }
+        RETURN count(*) AS c
+    """
+    plan = _plan(memgraph, query)
+    assert "ScanAllByLabelProperties" in plan, f"the fix itself stopped working:\n{plan}"
+    assert "IndexedJoin" not in plan, f"unrelated Cartesian was converted:\n{plan}"
+    assert "Cartesian" in plan, f"Cartesian did not survive:\n{plan}"
+    assert [row["c"] for row in memgraph.execute_and_fetch(query)] == [75]
+
+
 def test_scoped_subquery_import_index_result_equivalence(memgraph):
     """
     The seek key inside `CALL (ids) { ... }` is derived from a value that changes on every outer row,

--- a/tests/e2e/query_planning/query_planning_subquery.py
+++ b/tests/e2e/query_planning/query_planning_subquery.py
@@ -101,26 +101,38 @@ def test_scoped_subquery_import_does_not_invalidate_optional_edge_index_plan(mem
 
 def test_scoped_subquery_import_does_not_convert_unrelated_cartesian(memgraph):
     """
-    Regression guard. An inherited symbol visible in Cartesian::ModifiedSymbols makes does_modify() in
-    IndexLookupRewriter::PostVisit(Filter) false-positive, converting an unrelated Cartesian into an
-    IndexedJoin whose sub-branch is an unindexed scan re-executed once per main row - O(M) to O(N*M).
-    The Cartesian must survive while the indexed scan is still picked up.
+    The Cartesian -> IndexedJoin conversion must fire only when a *removed* filter spanned both
+    branches. Converting otherwise re-executes the sub-branch per main row and forfeits the HashJoin,
+    since JoinRewriter runs later and only rewrites Cartesian. Measured 0.009s -> 2.1s at 30k rows.
     """
     memgraph.execute("CREATE INDEX ON :L(p);")
     memgraph.execute("UNWIND range(1, 5) AS i CREATE (:A {id: i});")
     memgraph.execute("UNWIND range(1, 5) AS i CREATE (:B {id: i});")
     memgraph.execute("UNWIND range(1, 3) AS i CREATE (:L {p: 1, q: i});")
 
+    # c.p = v touches one side only, so the Cartesian must survive. No UNWIND in between, so this
+    # actually reaches the conversion decision.
     query = """
         WITH 1 AS v
-        CALL (v) { MATCH (a:A), (b:B) UNWIND [1] AS x MATCH (c:L) WHERE c.p = v RETURN a, b, c }
+        CALL (v) { MATCH (a:A), (c:L) WHERE c.p = v RETURN a, c }
         RETURN count(*) AS c
     """
     plan = _plan(memgraph, query)
     assert "ScanAllByLabelProperties" in plan, f"the fix itself stopped working:\n{plan}"
     assert "IndexedJoin" not in plan, f"unrelated Cartesian was converted:\n{plan}"
     assert "Cartesian" in plan, f"Cartesian did not survive:\n{plan}"
-    assert [row["c"] for row in memgraph.execute_and_fetch(query)] == [75]
+    assert [row["c"] for row in memgraph.execute_and_fetch(query)] == [15]
+
+    # The gate must not under-fire: a genuine cross-branch filter still has to convert.
+    joining = """
+        WITH 1 AS v
+        CALL (v) { MATCH (a:A), (c:L) WHERE c.p = a.id RETURN a, c }
+        RETURN count(*) AS c
+    """
+    joining_plan = _plan(memgraph, joining)
+    assert "ScanAllByLabelProperties" in joining_plan, f"cross-branch seek was lost:\n{joining_plan}"
+    assert "Cartesian" not in joining_plan, f"cross-branch filter left a Cartesian:\n{joining_plan}"
+    assert [row["c"] for row in memgraph.execute_and_fetch(joining)] == [3]
 
 
 def test_scoped_subquery_import_index_result_equivalence(memgraph):

--- a/tests/unit/query_common.hpp
+++ b/tests/unit/query_common.hpp
@@ -653,15 +653,6 @@ auto GetCallSubqueryScoped(AstStorage &storage, TSubquery *subquery, const std::
   return call_subquery;
 }
 
-// `CALL (*) { ... }`
-template <typename TSubquery>
-auto GetCallSubqueryStar(AstStorage &storage, TSubquery *subquery) {
-  auto *call_subquery = GetCallSubquery(storage, subquery);
-  call_subquery->has_variable_scope_ = true;
-  call_subquery->all_variables_scoped_ = true;
-  return call_subquery;
-}
-
 auto GetCallPeriodicSubquery(AstStorage &storage, SingleQuery *subquery, CommitFrequency commit_frequency) {
   auto *periodic_subquery = storage.Create<memgraph::query::CallSubquery>();
 
@@ -878,7 +869,6 @@ auto GetExistsSubquery(AstStorage &storage, CypherQuery *subquery) {
 #define CALL_SUBQUERY(...) memgraph::query::test_common::GetCallSubquery(this->storage, __VA_ARGS__)
 #define CALL_PERIODIC_SUBQUERY(...) memgraph::query::test_common::GetCallPeriodicSubquery(this->storage, __VA_ARGS__)
 #define CALL_SUBQUERY_SCOPED(...) memgraph::query::test_common::GetCallSubqueryScoped(this->storage, __VA_ARGS__)
-#define CALL_SUBQUERY_STAR(...) memgraph::query::test_common::GetCallSubqueryStar(this->storage, __VA_ARGS__)
 #define PATTERN_COMPREHENSION(variable, pattern, filter, resultExpr) \
   this->storage.template Create<memgraph::query::PatternComprehension>(variable, pattern, filter, resultExpr)
 #define ENUM_VALUE(...) this->storage.template Create<memgraph::query::EnumValueAccess>(__VA_ARGS__)

--- a/tests/unit/query_common.hpp
+++ b/tests/unit/query_common.hpp
@@ -640,6 +640,28 @@ auto GetCallSubquery(AstStorage &storage, CypherQuery *subquery) {
   return call_subquery;
 }
 
+// `CALL (v1, v2, ...) { ... }`. Each import builds as `NEXPR(name, IDENT(name))`, which is what
+// SymbolGenerator::PreVisit(CallSubquery) expects. There is no aliased form: the grammar's
+// scopeClause is `ASTERISK | variable (',' variable)*`, so `CALL (v AS w)` does not parse.
+template <typename TSubquery>
+auto GetCallSubqueryScoped(AstStorage &storage, TSubquery *subquery, const std::vector<std::string> &imports) {
+  auto *call_subquery = GetCallSubquery(storage, subquery);
+  call_subquery->has_variable_scope_ = true;
+  for (const auto &name : imports) {
+    call_subquery->scoped_variables_.push_back(storage.Create<NamedExpression>(name, storage.Create<Identifier>(name)));
+  }
+  return call_subquery;
+}
+
+// `CALL (*) { ... }`
+template <typename TSubquery>
+auto GetCallSubqueryStar(AstStorage &storage, TSubquery *subquery) {
+  auto *call_subquery = GetCallSubquery(storage, subquery);
+  call_subquery->has_variable_scope_ = true;
+  call_subquery->all_variables_scoped_ = true;
+  return call_subquery;
+}
+
 auto GetCallPeriodicSubquery(AstStorage &storage, SingleQuery *subquery, CommitFrequency commit_frequency) {
   auto *periodic_subquery = storage.Create<memgraph::query::CallSubquery>();
 
@@ -855,6 +877,8 @@ auto GetExistsSubquery(AstStorage &storage, CypherQuery *subquery) {
 #define CALL_PROCEDURE(...) memgraph::query::test_common::GetCallProcedure(storage, __VA_ARGS__)
 #define CALL_SUBQUERY(...) memgraph::query::test_common::GetCallSubquery(this->storage, __VA_ARGS__)
 #define CALL_PERIODIC_SUBQUERY(...) memgraph::query::test_common::GetCallPeriodicSubquery(this->storage, __VA_ARGS__)
+#define CALL_SUBQUERY_SCOPED(...) memgraph::query::test_common::GetCallSubqueryScoped(this->storage, __VA_ARGS__)
+#define CALL_SUBQUERY_STAR(...) memgraph::query::test_common::GetCallSubqueryStar(this->storage, __VA_ARGS__)
 #define PATTERN_COMPREHENSION(variable, pattern, filter, resultExpr) \
   this->storage.template Create<memgraph::query::PatternComprehension>(variable, pattern, filter, resultExpr)
 #define ENUM_VALUE(...) this->storage.template Create<memgraph::query::EnumValueAccess>(__VA_ARGS__)

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -59,6 +59,17 @@ namespace ms = memgraph::storage;
 
 namespace {
 
+/// Walks down the single-input chain from @p root and returns the first operator of type TOp, or nullptr.
+template <class TOp>
+TOp *FindOpOfType(memgraph::query::plan::LogicalOperator *root) {
+  for (auto *op = root; op != nullptr;) {
+    if (auto *found = dynamic_cast<TOp *>(op)) return found;
+    if (!op->HasSingleInput()) return nullptr;
+    op = op->input().get();
+  }
+  return nullptr;
+}
+
 class Planner {
  public:
   template <class TDbAccessor>
@@ -2906,142 +2917,113 @@ TYPED_TEST(TestPlanner, SubqueryReturnAllIncludesSubquerySymbols) {
   EXPECT_TRUE(output_names.count("outer")) << "RETURN * should include 'outer' from outer scope";
 }
 
-namespace {
-// Collects every RollUpApply whose list-collection branch may run without a successful input pull.
-class PassInputRollUpApplyCollector : public virtual HierarchicalLogicalOperatorVisitor {
- public:
-  using HierarchicalLogicalOperatorVisitor::PostVisit;
-  using HierarchicalLogicalOperatorVisitor::PreVisit;
-  using HierarchicalLogicalOperatorVisitor::Visit;
-
-  bool Visit(Once & /*unused*/) override { return true; }
-
-  bool PreVisit(RollUpApply &op) override {
-    if (op.pass_input_) ops.push_back(&op);
-    return true;
-  }
-
-  std::vector<RollUpApply *> ops;
-};
-
-// Finds the first operator of type TOp anywhere in the plan, branches included.
-template <typename TOp>
-class FirstOpFinder : public virtual HierarchicalLogicalOperatorVisitor {
- public:
-  using HierarchicalLogicalOperatorVisitor::PostVisit;
-  using HierarchicalLogicalOperatorVisitor::PreVisit;
-  using HierarchicalLogicalOperatorVisitor::Visit;
-
-  bool Visit(Once & /*unused*/) override { return true; }
-
-  bool PreVisit(TOp &op) override {
-    if (found == nullptr) found = &op;
-    return true;
-  }
-
-  TOp *found{nullptr};
-};
-
-template <typename TOp>
-TOp *FindFirstOp(LogicalOperator &root) {
-  FirstOpFinder<TOp> finder;
-  root.Accept(finder);
-  return finder.found;
-}
-}  // namespace
-
-// RollUpApplyCursor::Pull runs the branch even when the input pull fails (`|| self_.pass_input_`), so
-// a symbol declared bound at that branch's input Once need not be on the frame. Pin that it stays
-// empty even inside a scoped CALL, whose query part does have inherited symbols.
-TYPED_TEST(TestPlanner, RollUpApplyPassInputOnceStaysEmpty) {
-  FakeDbAccessor dba;
-  // WITH 1 AS x CALL (x) { MATCH (n) WHERE [(n)--() | 1] = [] RETURN n } RETURN n
-  // A comprehension in a MATCH's WHERE is the only shape producing a pass_input_ RollUpApply.
-  auto *pattern_comp =
-      PATTERN_COMPREHENSION(nullptr, PATTERN(NODE("n"), EDGE("anon1"), NODE("anon2")), nullptr, LITERAL(1));
-  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EQ(pattern_comp, LIST())), RETURN("n"));
-  auto *query = QUERY(SINGLE_QUERY(
-      WITH(LITERAL(1), AS("x")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"x"}), RETURN("n")));
-
-  auto symbol_table = memgraph::query::MakeSymbolTable(query);
-  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
-
-  PassInputRollUpApplyCollector collector;
-  planner.plan().Accept(collector);
-  ASSERT_FALSE(collector.ops.empty()) << "test observes no pass_input_ RollUpApply; it proves nothing";
-  for (auto *op : collector.ops) {
-    auto *once = dynamic_cast<Once *>(op->input_.get());
-    ASSERT_NE(once, nullptr) << "pass_input_ RollUpApply input is not a Once";
-    EXPECT_TRUE(once->symbols_.empty()) << "pass_input_ RollUpApply input Once must declare no symbols";
-  }
-}
-
-// A predicate on a variable imported into a scoped CALL must drive a label-property index.
-TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesLabelPropertyIndexIn) {
-  // WITH ['a'] AS ids CALL (ids) { MATCH (n:label) WHERE n.property IN ids RETURN n } RETURN n
+// A predicate on a variable imported into a scoped CALL must drive an index. The branch is rewritten
+// by its own rewriter, so the imported symbol reaches it only via inherited_bound_symbols_.
+TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesLabelPropertyIndex) {
   FakeDbAccessor dba;
   auto label = dba.Label("label");
   auto property = PROPERTY_PAIR(dba, "property");
-  dba.SetIndexCount(label, property.second, 1);
 
+  // WITH ['a'] AS ids CALL (ids) { MATCH (n:label) WHERE n.property IN ids RETURN n } RETURN n
   auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))),
                                 WHERE(IN_LIST(PROPERTY_LOOKUP(dba, "n", property), IDENT("ids"))),
                                 RETURN("n"));
   auto *query = QUERY(SINGLE_QUERY(WITH(LIST(LITERAL("a")), AS("ids")),
                                    CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"ids"}),
                                    RETURN("n")));
+  {
+    // Without the index the same shape must stay ScanAll + Filter: nothing fabricates index usage.
+    auto symbol_table = memgraph::query::MakeSymbolTable(query);
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    std::list<BaseOpChecker *> branch{new ExpectScanAll(), new ExpectFilter(), new ExpectProduce()};
+    CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
+    DeleteListContent(&branch);
+  }
+  {
+    dba.SetIndexCount(label, property.second, 1);
+    auto symbol_table = memgraph::query::MakeSymbolTable(query);
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    // No Filter in the branch: the predicate is fully consumed by the scan.
+    auto *fake_identifier = IDENT("fake");
+    std::list<BaseOpChecker *> branch{
+        new ExpectUnwind(),
+        new ExpectScanAllByLabelProperties(label,
+                                           std::vector{ms::PropertyPath{property.second}},
+                                           std::vector{ExpressionRange::Equal(fake_identifier)}),
+        new ExpectProduce()};
+    CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
+    DeleteListContent(&branch);
+
+    // The checker compares bound expressions by type hash only, so pin the seek key separately: it
+    // must be the Unwind's element symbol, not `ids` (the list itself).
+    auto *apply = FindOpOfType<Apply>(&planner.plan());
+    ASSERT_NE(apply, nullptr);
+    auto *unwind = FindOpOfType<Unwind>(apply->subquery_.get());
+    auto *scan = FindOpOfType<ScanAllByLabelProperties>(apply->subquery_.get());
+    ASSERT_NE(unwind, nullptr);
+    ASSERT_NE(scan, nullptr);
+    ASSERT_EQ(scan->expression_ranges_.size(), 1U);
+    ASSERT_TRUE(scan->expression_ranges_[0].lower_.has_value());
+    auto *seek = memgraph::utils::Downcast<memgraph::query::Identifier>(scan->expression_ranges_[0].lower_->value());
+    ASSERT_NE(seek, nullptr) << "seek key is not an Identifier";
+    EXPECT_EQ(symbol_table.at(*seek), unwind->output_symbol_);
+  }
+}
+
+// The customer-reported shape: plain equality, no IN-list lowering in the way.
+TYPED_TEST(TestPlanner, SubqueryScopedImportEqualityDrivesLabelPropertyIndex) {
+  // WITH 'a' AS v CALL (v) { MATCH (n:label) WHERE n.property = v RETURN n } RETURN n
+  FakeDbAccessor dba;
+  auto label = dba.Label("label");
+  auto property = PROPERTY_PAIR(dba, "property");
+  dba.SetIndexCount(label, property.second, 1);
+
+  auto *subquery = SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n", "label"))), WHERE(EQ(PROPERTY_LOOKUP(dba, "n", property), IDENT("v"))), RETURN("n"));
+  auto *query = QUERY(SINGLE_QUERY(
+      WITH(LITERAL("a"), AS("v")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"v"}), RETURN("n")));
 
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  // No Filter in the branch: the predicate is fully consumed by the scan.
   auto *fake_identifier = IDENT("fake");
-  std::list<BaseOpChecker *> subquery_plan{
-      new ExpectUnwind(),
+  std::list<BaseOpChecker *> branch{
       new ExpectScanAllByLabelProperties(
           label, std::vector{ms::PropertyPath{property.second}}, std::vector{ExpressionRange::Equal(fake_identifier)}),
       new ExpectProduce()};
-  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
-  DeleteListContent(&subquery_plan);
-
-  // The checker compares bound expressions by type hash only, so pin the seek key separately: it must
-  // be the Unwind's element symbol, not `ids` (the list itself).
-  auto *unwind = FindFirstOp<Unwind>(planner.plan());
-  auto *scan = FindFirstOp<ScanAllByLabelProperties>(planner.plan());
-  ASSERT_NE(unwind, nullptr);
-  ASSERT_NE(scan, nullptr);
-  ASSERT_EQ(scan->expression_ranges_.size(), 1U);
-  ASSERT_TRUE(scan->expression_ranges_[0].lower_.has_value());
-  auto *seek_ident =
-      memgraph::utils::Downcast<memgraph::query::Identifier>(scan->expression_ranges_[0].lower_->value());
-  ASSERT_NE(seek_ident, nullptr) << "seek key is not an Identifier";
-  EXPECT_EQ(symbol_table.at(*seek_ident), unwind->output_symbol_);
+  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
 }
 
-// Regression guard: the edge rewriter already picked an index here before the Once was seeded, unlike
-// the node one, so this must keep working.
-TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesEdgeIndex) {
-  // WITH 1 AS v CALL (v) { MATCH ()-[e:type]->() WHERE e.property = v RETURN e } RETURN e
+// id() lookups gate on bound symbols too, so they are fixed by the same change. The edge-type
+// *property* path is not, because its candidate selection never consults the bound set.
+TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesIdIndex) {
   FakeDbAccessor dba;
-  auto edge_type = dba.EdgeType("type");
-  auto property = PROPERTY_PAIR(dba, "property");
-  dba.SetIndexCount(edge_type, property.second, 1);
-
-  auto *subquery = SINGLE_QUERY(
-      MATCH(PATTERN(NODE("anon1"), EDGE("e", memgraph::query::EdgeAtom::Direction::OUT, {"type"}), NODE("anon2"))),
-      WHERE(EQ(PROPERTY_LOOKUP(dba, "e", property), IDENT("v"))),
-      RETURN("e"));
-  auto *query = QUERY(SINGLE_QUERY(
-      WITH(LITERAL(1), AS("v")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"v"}), RETURN("e")));
-
-  auto symbol_table = memgraph::query::MakeSymbolTable(query);
-  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
-
-  auto *fake_identifier = IDENT("fake");
-  std::list<BaseOpChecker *> subquery_plan{
-      new ExpectScanAllByEdgeTypePropertyValue(edge_type, property, fake_identifier), new ExpectProduce()};
-  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
-  DeleteListContent(&subquery_plan);
+  {
+    // WITH 0 AS v CALL (v) { MATCH (n) WHERE id(n) = v RETURN n } RETURN n
+    auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EQ(FN("id", IDENT("n")), IDENT("v"))), RETURN("n"));
+    auto *query = QUERY(SINGLE_QUERY(
+        WITH(LITERAL(0), AS("v")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"v"}), RETURN("n")));
+    auto symbol_table = memgraph::query::MakeSymbolTable(query);
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    std::list<BaseOpChecker *> branch{new ExpectScanAllById(), new ExpectProduce()};
+    CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
+    DeleteListContent(&branch);
+  }
+  {
+    // WITH 0 AS v CALL (v) { MATCH ()-[e]->() WHERE id(e) = v RETURN e } RETURN e
+    auto *subquery =
+        SINGLE_QUERY(MATCH(PATTERN(NODE("anon1"), EDGE("e", memgraph::query::EdgeAtom::Direction::OUT), NODE("anon2"))),
+                     WHERE(EQ(FN("id", IDENT("e")), IDENT("v"))),
+                     RETURN("e"));
+    auto *query = QUERY(SINGLE_QUERY(
+        WITH(LITERAL(0), AS("v")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"v"}), RETURN("e")));
+    auto symbol_table = memgraph::query::MakeSymbolTable(query);
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    std::list<BaseOpChecker *> branch{new ExpectScanAllByEdgeId(), new ExpectProduce()};
+    CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
+    DeleteListContent(&branch);
+  }
 }
 
 // The scanned symbol is in the filter's value, so is_symbol_in_value_ must still block the index.
@@ -3064,29 +3046,9 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportSelfReferentialFilterNoIndex) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> subquery_plan{new ExpectScanAllByLabel(), new ExpectFilter(), new ExpectProduce()};
-  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
-  DeleteListContent(&subquery_plan);
-}
-
-// With no index at all the same shape must stay ScanAll + Filter.
-TYPED_TEST(TestPlanner, SubqueryScopedImportNoIndexFallsBackToScanFilter) {
-  FakeDbAccessor dba;
-  auto property = PROPERTY_PAIR(dba, "property");
-
-  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))),
-                                WHERE(IN_LIST(PROPERTY_LOOKUP(dba, "n", property), IDENT("ids"))),
-                                RETURN("n"));
-  auto *query = QUERY(SINGLE_QUERY(WITH(LIST(LITERAL("a")), AS("ids")),
-                                   CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"ids"}),
-                                   RETURN("n")));
-
-  auto symbol_table = memgraph::query::MakeSymbolTable(query);
-  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
-
-  std::list<BaseOpChecker *> subquery_plan{new ExpectScanAll(), new ExpectFilter(), new ExpectProduce()};
-  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
-  DeleteListContent(&subquery_plan);
+  std::list<BaseOpChecker *> branch{new ExpectScanAllByLabel(), new ExpectFilter(), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
 }
 
 TYPED_TEST(TestPlanner, PatternComprehensionInReturn) {
@@ -5390,17 +5352,6 @@ TExpand *ExpectCorrelatedBranch(RollUpApply *rollup) {
   EXPECT_NE(dynamic_cast<Once *>(expand->input_.get()), nullptr)
       << "the expansion must start from the bound symbol on the frame, not a ScanAll";
   return expand;
-}
-
-/// Walks down the single-input chain from @p root and returns the first operator of type TOp, or nullptr.
-template <class TOp>
-TOp *FindOpOfType(memgraph::query::plan::LogicalOperator *root) {
-  for (auto *op = root; op != nullptr;) {
-    if (auto *found = dynamic_cast<TOp *>(op)) return found;
-    if (!op->HasSingleInput()) return nullptr;
-    op = op->input().get();
-  }
-  return nullptr;
 }
 
 /// Asserts @p rollup's comprehension branch is uncorrelated - it legitimately scans - and that both the scan and the

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2906,6 +2906,189 @@ TYPED_TEST(TestPlanner, SubqueryReturnAllIncludesSubquerySymbols) {
   EXPECT_TRUE(output_names.count("outer")) << "RETURN * should include 'outer' from outer scope";
 }
 
+namespace {
+// Collects every RollUpApply whose list-collection branch may run without a successful input pull.
+class PassInputRollUpApplyCollector : public virtual HierarchicalLogicalOperatorVisitor {
+ public:
+  using HierarchicalLogicalOperatorVisitor::PostVisit;
+  using HierarchicalLogicalOperatorVisitor::PreVisit;
+  using HierarchicalLogicalOperatorVisitor::Visit;
+
+  bool Visit(Once & /*unused*/) override { return true; }
+
+  bool PreVisit(RollUpApply &op) override {
+    if (op.pass_input_) ops.push_back(&op);
+    return true;
+  }
+
+  std::vector<RollUpApply *> ops;
+};
+
+// Finds the first operator of type TOp anywhere in the plan, branches included.
+template <typename TOp>
+class FirstOpFinder : public virtual HierarchicalLogicalOperatorVisitor {
+ public:
+  using HierarchicalLogicalOperatorVisitor::PostVisit;
+  using HierarchicalLogicalOperatorVisitor::PreVisit;
+  using HierarchicalLogicalOperatorVisitor::Visit;
+
+  bool Visit(Once & /*unused*/) override { return true; }
+
+  bool PreVisit(TOp &op) override {
+    if (found == nullptr) found = &op;
+    return true;
+  }
+
+  TOp *found{nullptr};
+};
+
+template <typename TOp>
+TOp *FindFirstOp(LogicalOperator &root) {
+  FirstOpFinder<TOp> finder;
+  root.Accept(finder);
+  return finder.found;
+}
+}  // namespace
+
+// RollUpApplyCursor::Pull runs the branch even when the input pull fails (`|| self_.pass_input_`), so
+// a symbol declared bound at that branch's input Once need not be on the frame. Pin that it stays
+// empty even inside a scoped CALL, whose query part does have inherited symbols.
+TYPED_TEST(TestPlanner, RollUpApplyPassInputOnceStaysEmpty) {
+  FakeDbAccessor dba;
+  // WITH 1 AS x CALL (x) { MATCH (n) WHERE [(n)--() | 1] = [] RETURN n } RETURN n
+  // A comprehension in a MATCH's WHERE is the only shape producing a pass_input_ RollUpApply.
+  auto *pattern_comp =
+      PATTERN_COMPREHENSION(nullptr, PATTERN(NODE("n"), EDGE("anon1"), NODE("anon2")), nullptr, LITERAL(1));
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EQ(pattern_comp, LIST())), RETURN("n"));
+  auto *query = QUERY(SINGLE_QUERY(
+      WITH(LITERAL(1), AS("x")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"x"}), RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  PassInputRollUpApplyCollector collector;
+  planner.plan().Accept(collector);
+  ASSERT_FALSE(collector.ops.empty()) << "test observes no pass_input_ RollUpApply; it proves nothing";
+  for (auto *op : collector.ops) {
+    auto *once = dynamic_cast<Once *>(op->input_.get());
+    ASSERT_NE(once, nullptr) << "pass_input_ RollUpApply input is not a Once";
+    EXPECT_TRUE(once->symbols_.empty()) << "pass_input_ RollUpApply input Once must declare no symbols";
+  }
+}
+
+// A predicate on a variable imported into a scoped CALL must drive a label-property index.
+TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesLabelPropertyIndexIn) {
+  // WITH ['a'] AS ids CALL (ids) { MATCH (n:label) WHERE n.property IN ids RETURN n } RETURN n
+  FakeDbAccessor dba;
+  auto label = dba.Label("label");
+  auto property = PROPERTY_PAIR(dba, "property");
+  dba.SetIndexCount(label, property.second, 1);
+
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))),
+                                WHERE(IN_LIST(PROPERTY_LOOKUP(dba, "n", property), IDENT("ids"))),
+                                RETURN("n"));
+  auto *query = QUERY(SINGLE_QUERY(WITH(LIST(LITERAL("a")), AS("ids")),
+                                   CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"ids"}),
+                                   RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  // No Filter in the branch: the predicate is fully consumed by the scan.
+  auto *fake_identifier = IDENT("fake");
+  std::list<BaseOpChecker *> subquery_plan{
+      new ExpectUnwind(),
+      new ExpectScanAllByLabelProperties(
+          label, std::vector{ms::PropertyPath{property.second}}, std::vector{ExpressionRange::Equal(fake_identifier)}),
+      new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
+  DeleteListContent(&subquery_plan);
+
+  // The checker compares bound expressions by type hash only, so pin the seek key separately: it must
+  // be the Unwind's element symbol, not `ids` (the list itself).
+  auto *unwind = FindFirstOp<Unwind>(planner.plan());
+  auto *scan = FindFirstOp<ScanAllByLabelProperties>(planner.plan());
+  ASSERT_NE(unwind, nullptr);
+  ASSERT_NE(scan, nullptr);
+  ASSERT_EQ(scan->expression_ranges_.size(), 1U);
+  ASSERT_TRUE(scan->expression_ranges_[0].lower_.has_value());
+  auto *seek_ident =
+      memgraph::utils::Downcast<memgraph::query::Identifier>(scan->expression_ranges_[0].lower_->value());
+  ASSERT_NE(seek_ident, nullptr) << "seek key is not an Identifier";
+  EXPECT_EQ(symbol_table.at(*seek_ident), unwind->output_symbol_);
+}
+
+// Regression guard: the edge rewriter already picked an index here before the Once was seeded, unlike
+// the node one, so this must keep working.
+TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesEdgeIndex) {
+  // WITH 1 AS v CALL (v) { MATCH ()-[e:type]->() WHERE e.property = v RETURN e } RETURN e
+  FakeDbAccessor dba;
+  auto edge_type = dba.EdgeType("type");
+  auto property = PROPERTY_PAIR(dba, "property");
+  dba.SetIndexCount(edge_type, property.second, 1);
+
+  auto *subquery = SINGLE_QUERY(
+      MATCH(PATTERN(NODE("anon1"), EDGE("e", memgraph::query::EdgeAtom::Direction::OUT, {"type"}), NODE("anon2"))),
+      WHERE(EQ(PROPERTY_LOOKUP(dba, "e", property), IDENT("v"))),
+      RETURN("e"));
+  auto *query = QUERY(SINGLE_QUERY(
+      WITH(LITERAL(1), AS("v")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"v"}), RETURN("e")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  auto *fake_identifier = IDENT("fake");
+  std::list<BaseOpChecker *> subquery_plan{
+      new ExpectScanAllByEdgeTypePropertyValue(edge_type, property, fake_identifier), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
+  DeleteListContent(&subquery_plan);
+}
+
+// The scanned symbol is in the filter's value, so is_symbol_in_value_ must still block the index.
+TYPED_TEST(TestPlanner, SubqueryScopedImportSelfReferentialFilterNoIndex) {
+  // WITH 1 AS x CALL (x) { MATCH (n:label) WHERE n.property = x + n.other RETURN n } RETURN n
+  FakeDbAccessor dba;
+  auto label = dba.Label("label");
+  auto property = PROPERTY_PAIR(dba, "property");
+  auto other = PROPERTY_PAIR(dba, "other");
+  dba.SetIndexCount(label, 1);
+  dba.SetIndexCount(label, property.second, 1);
+
+  auto *subquery =
+      SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))),
+                   WHERE(EQ(PROPERTY_LOOKUP(dba, "n", property), ADD(IDENT("x"), PROPERTY_LOOKUP(dba, "n", other)))),
+                   RETURN("n"));
+  auto *query = QUERY(SINGLE_QUERY(
+      WITH(LITERAL(1), AS("x")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"x"}), RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> subquery_plan{new ExpectScanAllByLabel(), new ExpectFilter(), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
+  DeleteListContent(&subquery_plan);
+}
+
+// With no index at all the same shape must stay ScanAll + Filter.
+TYPED_TEST(TestPlanner, SubqueryScopedImportNoIndexFallsBackToScanFilter) {
+  FakeDbAccessor dba;
+  auto property = PROPERTY_PAIR(dba, "property");
+
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("n", "label"))),
+                                WHERE(IN_LIST(PROPERTY_LOOKUP(dba, "n", property), IDENT("ids"))),
+                                RETURN("n"));
+  auto *query = QUERY(SINGLE_QUERY(WITH(LIST(LITERAL("a")), AS("ids")),
+                                   CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"ids"}),
+                                   RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> subquery_plan{new ExpectScanAll(), new ExpectFilter(), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(subquery_plan), ExpectProduce());
+  DeleteListContent(&subquery_plan);
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInReturn) {
   FakeDbAccessor dba;
   const auto prop = PROPERTY_PAIR(dba, "prop");

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2970,7 +2970,7 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesLabelPropertyIndex) {
   }
 }
 
-// The customer-reported shape: plain equality, no IN-list lowering in the way.
+// Plain equality, which reaches the scan directly rather than through the IN-list lowering.
 TYPED_TEST(TestPlanner, SubqueryScopedImportEqualityDrivesLabelPropertyIndex) {
   // WITH 'a' AS v CALL (v) { MATCH (n:label) WHERE n.property = v RETURN n } RETURN n
   FakeDbAccessor dba;
@@ -2995,8 +2995,8 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportEqualityDrivesLabelPropertyIndex) {
   DeleteListContent(&branch);
 }
 
-// id() lookups gate on bound symbols too, so they are fixed by the same change. The edge-type
-// *property* path is not, because its candidate selection never consults the bound set.
+// id() lookups gate on bound symbols, so an imported symbol drives them too. The edge-type property
+// path does not, because its candidate selection never consults the bound set.
 TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesIdIndex) {
   FakeDbAccessor dba;
   {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3026,6 +3026,37 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportDrivesIdIndex) {
   }
 }
 
+// ScanAllByEdgeId carries no edge type and no node identity, so patterns constraining either must
+// keep their Expand. The untyped form above still gets the id scan.
+TYPED_TEST(TestPlanner, SubqueryScopedImportEdgeIdKeepsPatternConstraints) {
+  FakeDbAccessor dba;
+  auto expect_no_edge_id_scan = [&](memgraph::query::CypherQuery *query) {
+    auto symbol_table = memgraph::query::MakeSymbolTable(query);
+    auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+    std::list<BaseOpChecker *> branch{new ExpectScanAll(), new ExpectExpand(), new ExpectFilter(), new ExpectProduce()};
+    CheckPlan(planner.plan(), symbol_table, ExpectProduce(), ExpectApply(branch), ExpectProduce());
+    DeleteListContent(&branch);
+  };
+  {
+    // WITH 0 AS v CALL (v) { MATCH (x)-[e:type]->(y) WHERE id(e) = v RETURN e } RETURN e
+    auto *subquery = SINGLE_QUERY(
+        MATCH(PATTERN(NODE("x"), EDGE("e", memgraph::query::EdgeAtom::Direction::OUT, {"type"}), NODE("y"))),
+        WHERE(EQ(FN("id", IDENT("e")), IDENT("v"))),
+        RETURN("e"));
+    expect_no_edge_id_scan(QUERY(SINGLE_QUERY(
+        WITH(LITERAL(0), AS("v")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"v"}), RETURN("e"))));
+  }
+  {
+    // Repeated node symbol: WITH 0 AS v CALL (v) { MATCH (x)-[e]->(x) WHERE id(e) = v RETURN e } RETURN e
+    auto *subquery =
+        SINGLE_QUERY(MATCH(PATTERN(NODE("x"), EDGE("e", memgraph::query::EdgeAtom::Direction::OUT), NODE("x"))),
+                     WHERE(EQ(FN("id", IDENT("e")), IDENT("v"))),
+                     RETURN("e"));
+    expect_no_edge_id_scan(QUERY(SINGLE_QUERY(
+        WITH(LITERAL(0), AS("v")), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"v"}), RETURN("e"))));
+  }
+}
+
 // The scanned symbol is in the filter's value, so is_symbol_in_value_ must still block the index.
 TYPED_TEST(TestPlanner, SubqueryScopedImportSelfReferentialFilterNoIndex) {
   // WITH 1 AS x CALL (x) { MATCH (n:label) WHERE n.property = x + n.other RETURN n } RETURN n


### PR DESCRIPTION
Inside a scoped `CALL (v) { ... }`, a predicate on the imported variable never selected an index. The branch planned as `ScanAll` + `Filter`, and since `Apply` re-runs the branch per input row, that is a full label scan for every row entering the subquery — `node_count x row_count` vertices visited where an index seek would do.

`PreVisit(Apply)` in both index rewriters calls `RewriteBranch`, which builds a **fresh** rewriter for the branch — deliberately, so a branch-internal `SetOnParent` cannot overwrite `Apply::input_`, i.e. the outer plan. That fresh rewriter starts with an empty bound set, so the `are_bound` gate rejects every filter referencing an imported symbol. The symbol is live on the frame, just not produced by the branch's own subtree, which is all `ModifiedSymbols` can see.

Both rewriters now carry an `inherited_bound_symbols_`, set from the `Apply`/`PeriodicSubquery` input's `ModifiedSymbols` when `RewriteBranch` constructs the child, and folded into `are_bound`. `RewriteBranch` also folds in whatever the current rewriter inherited, so `Union`/`Merge`/`Optional` branches and nested subqueries keep the enclosing scope. It stays out of the plan itself: `ModifiedSymbols` has consumers that read it as "produced by this subtree", which inherited symbols are not.

Making more filters indexable reaches two places that decide *plan shape* rather than a seek key, so both are tightened here:

- **`Cartesian` -> `IndexedJoin`** now requires a *removed* filter whose symbols reach into both `left_symbols_` and `right_symbols_`. A predicate confined to one side, or on an inherited symbol which belongs to neither, leaves the branches independent; converting those re-executes the sub-branch once per main-branch row and, because `JoinRewriter` runs afterwards and only rewrites `Cartesian`, forfeits the hash join. The decision reads the removed filters rather than the leftover ones; the stale pre-removal set is left as is, since other conversions depend on it.
- **`id(e)` on a constrained edge pattern** no longer takes the id path. `ScanAllByEdgeId` cannot carry an edge type — its constructor passes `{}` for `edge_types` — nor a node identity, and the id filter is erased, so a typed, multi-type or repeated-node pattern would match the wrong edge. Those patterns keep their `Expand`; untyped ones still get the scan. This is pre-existing behaviour, reachable from `WITH id(t) AS v MATCH (x)-[e:T]->(y) WHERE id(e) = v` and from legacy `CALL { WITH v ... }`, both of which this closes.

Effect, inside a scoped subquery:

| predicate | before | after |
|---|---|---|
| `n.p IN ids` | `ScanAll`+`Filter` | `Unwind`+`ScanAllByLabelProperties` |
| `n.p = v`, `MATCH (n:L {p: v})` | `ScanAll`+`Filter` | `ScanAllByLabelProperties` |
| `id(n) = v` | `ScanAll`+`Filter` | `ScanAllById` |
| `id(e) = v`, `id(e) IN ids` (untyped pattern) | `ScanAll`+`Filter` | `ScanAllByEdgeId` |
| two patterns joined by an equality, one filtered on `v` | `HashJoin`+`Filter` | `HashJoin` + an indexed scan |
| two independent patterns, one filtered on `v` | `Cartesian`+`Filter` | `Cartesian` + an indexed scan |
| both branches of a `UNION` | one branch only | both |

Applies to `CALL (v) { ... }`, `CALL (*) { ... }` and the `CALL ... IN TRANSACTIONS` forms. Legacy `CALL { WITH v ... }` is unaffected — its leading `WITH` already re-binds the symbol inside the branch — as is the edge-type property path, whose candidate selection never consults bound symbols.

One behaviour change: once a predicate drives an index, comparing the property to a value that cannot be a property — a node, edge or path — raises `'vertex' cannot be used as a property value` where the unindexed plan silently matched nothing. Every other bound-symbol path already behaves this way.

Key files: `src/query/plan/rewrite/index_lookup.hpp`, `src/query/plan/rewrite/edge_index_lookup.hpp`.