### PR TITLE
fix: Speed up delete edge replication

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -1295,6 +1295,43 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
 
   std::unordered_map<EdgeSetPropertyCacheKey, EdgeAccessor, EdgeSetPropertyCacheKeyHash> edge_set_property_cache;
 
+  // Edge deletions are buffered and applied as one batch. DeleteEdgesEx resolves the whole batch from gids and
+  // hands it to a single DetachDelete, which groups by endpoint vertex and scans each vertex's adjacency once —
+  // so the batch costs O(degree) per vertex where a delta-at-a-time loop costs O(degree) per edge. Main is
+  // already on the batched path (the Delete operator buffers, then calls DetachDelete once), which is why
+  // deleting a dense vertex's edges is linear there and was quadratic here.
+  //
+  // The WAL encoder emits deltas in fixed passes (vertex writes, edge creates, edge property sets, edge deletes,
+  // vertex deletes), so every edge delete of a transaction arrives as one contiguous run and a single batch
+  // absorbs all of them.
+  std::vector<storage::InMemoryStorage::EdgeDeleteSpec> pending_edge_deletes;
+
+  // Bounds the buffer's memory: main may split one transaction's deletions across several DetachDelete calls
+  // (the Delete operator's buffer size), so a transaction can carry far more edge deletes than main ever held
+  // at once. Flushing mid-run only costs one extra adjacency scan per vertex per chunk.
+  constexpr size_t kMaxPendingEdgeDeletes = 100'000;
+
+  auto flush_pending_edge_deletes = [&]() {
+    if (pending_edge_deletes.empty()) return;
+    // A non-empty buffer implies the accessor was created when the first edge delete was buffered.
+    DMG_ASSERT(commit_accessor, "Buffered edge deletions without a commit accessor");
+    auto const deleted = commit_accessor->DeleteEdgesEx(pending_edge_deletes);
+    // Each buffered edge was already traced with its gid above, so the timestamp is enough to correlate.
+    if (!deleted.has_value()) {
+      throw utils::BasicException(
+          "Failed to delete a batch of {} edges at timestamp {}.", pending_edge_deletes.size(), commit_timestamp);
+    }
+    // Resolving by gid no longer visits the edge through a visibility-checked lookup, so the count is what
+    // catches a WAL naming an edge the replica does not have.
+    if (*deleted != pending_edge_deletes.size()) {
+      throw utils::BasicException("Deleted {} of {} edges in the batch at timestamp {}.",
+                                  *deleted,
+                                  pending_edge_deletes.size(),
+                                  commit_timestamp);
+    }
+    pending_edge_deletes.clear();
+  };
+
   decoder->ResetCrcAcc();
   for (bool transaction_complete = false; !transaction_complete; ++current_delta_idx, ++current_batch_counter) {
     if (current_batch_counter == deltas_batch_progress_size) {
@@ -1422,22 +1459,15 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
                         from_vertex_gid,
                         to_vertex_gid);
           auto *transaction = get_replication_accessor(delta_timestamp);
-          auto from_vertex = transaction->FindVertex(data.from_vertex, View::NEW);
-          if (!from_vertex) {
-            throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
-          }
-          auto to_vertex = transaction->FindVertex(data.to_vertex, View::NEW);
-          if (!to_vertex) {
-            throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
-          }
-          auto edgeType = transaction->NameToEdgeType(data.edge_type);
-          auto edge = transaction->FindEdge(data.gid, View::NEW, edgeType, &*from_vertex, &*to_vertex);
-          if (!edge) {
-            throw utils::BasicException("Couldn't find edge {} when deleting edge.", edge_gid);
-          }
-          if (auto ret = transaction->DeleteEdge(&*edge); !ret.has_value()) {
-            throw utils::BasicException(
-                "Failed to delete edge {} between vertices {} and {}.", edge_gid, from_vertex_gid, to_vertex_gid);
+          // The record already says everything needed to delete the edge, so nothing is resolved here; the
+          // batch is flushed by the next non-edge-delete delta and resolves its edges together.
+          pending_edge_deletes.push_back(
+              storage::InMemoryStorage::EdgeDeleteSpec{.edge_gid = data.gid,
+                                                       .from_gid = data.from_vertex,
+                                                       .to_gid = data.to_vertex,
+                                                       .edge_type = transaction->NameToEdgeType(data.edge_type)});
+          if (pending_edge_deletes.size() >= kMaxPendingEdgeDeletes) {
+            flush_pending_edge_deletes();
           }
         },
         [&](WalEdgeSetProperty const &data) {
@@ -2095,6 +2125,13 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
     if (loading_wal && !should_commit) continue;
 
     try {
+      // Any other delta may observe the effect of the buffered deletions, so the batch is flushed before it runs.
+      // Guarding here rather than inside each handler keeps the invariant in one place: the transaction-end delta
+      // (which commits) and the vertex-delete deltas (which require detached vertices) are both covered, as is
+      // every handler added later.
+      if (!std::holds_alternative<WalEdgeDelete>(delta.data_)) {
+        flush_pending_edge_deletes();
+      }
       std::visit(delta_apply, delta.data_);
     } catch (const std::exception &e) {
       spdlog::error("Applying deltas failed because of {}", e.what());
@@ -2102,6 +2139,10 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
     }
     applied_deltas++;
   }
+
+  // The transaction-end delta goes through the flush guard before it commits, so the buffer is always drained
+  // by the time the loop exits.
+  DMG_ASSERT(pending_edge_deletes.empty(), "Buffered edge deletions were never applied");
 
   spdlog::debug("Applied {} deltas. Committed {} txns.", applied_deltas, num_committed_txns);
 

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -2142,7 +2142,7 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
 
   // The transaction-end delta goes through the flush guard before it commits, so the buffer is always drained
   // by the time the loop exits.
-  DMG_ASSERT(pending_edge_deletes.empty(), "Buffered edge deletions were never applied");
+  MG_ASSERT(pending_edge_deletes.empty(), "Buffered edge deletions were never applied");
 
   spdlog::debug("Applied {} deltas. Committed {} txns.", applied_deltas, num_committed_txns);
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -5013,6 +5013,25 @@ EdgeInfo ScanOutEdgesForGid(Vertex *from_vertex, Gid edge_gid) {
   }
   return std::nullopt;
 }
+
+// Plural form of ScanOutEdgesForGid: resolves a whole set of GIDs in one pass over the adjacency rather than
+// one pass each, which is what keeps deleting many of a dense vertex's edges linear. Found GIDs are erased from
+// `wanted`, so whatever remains on return is the set this vertex does not have. Kept separate from the singular
+// form rather than sharing an implementation with it: that one is called per vertex by the full-scan light-edge
+// path, which must not pay for a set allocation.
+std::vector<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>> ScanOutEdgesForGids(Vertex *from_vertex,
+                                                                                     std::unordered_set<Gid> &wanted) {
+  std::vector<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>> found;
+  found.reserve(wanted.size());
+
+  std::shared_lock const guard{from_vertex->lock};
+  for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
+    if (wanted.erase(edge_ref.ptr->gid) == 0) continue;
+    found.emplace_back(edge_ref, edge_type, from_vertex, to_vertex);
+    if (wanted.empty()) break;
+  }
+  return found;
+}
 }  // namespace
 
 EdgeInfo InMemoryStorage::FindHeavyEdge(Gid edge_gid) {
@@ -5106,6 +5125,77 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
     throw utils::BasicException("Vertex with GID {} not found in the database", from_vertex_gid.AsUint());
   }
   return ExtractEdgeInfo(&(*vertex_it), edge_ptr);
+}
+
+Result<size_t> InMemoryStorage::InMemoryAccessor::DeleteEdgesEx(std::span<EdgeDeleteSpec const> edges) {
+  if (edges.empty()) return size_t{0};
+
+  // Deliberately not routed through InMemoryStorage::FindEdge: that has to recover the edge type and the
+  // to-vertex from adjacency (via ExtractEdgeInfo / ScanOutEdgesForGid) because its callers know only a GID,
+  // which costs an O(degree) scan per edge. Every spec here already names both, so the only open question is
+  // the EdgeRef — and only the light config needs to touch adjacency to answer it.
+  std::vector<EdgeAccessor> accessors;
+  accessors.reserve(edges.size());
+
+  // Memoized because a batch is typically many edges around few vertices — a hub's whole fan-out resolves to
+  // the same Vertex*, and without this each edge would repeat the skip-list lookup. Safe for the length of the
+  // batch: vertices are only ever deleted after their edges, so nothing here can be removed mid-resolution.
+  std::unordered_map<Gid, Vertex *> resolved_vertices;
+  auto resolve_vertex = [&](Gid gid) -> Vertex * {
+    auto [it, inserted] = resolved_vertices.try_emplace(gid, nullptr);
+    if (inserted) {
+      auto vertex = FindVertex(gid, View::NEW);
+      it->second = vertex ? vertex->vertex_ : nullptr;
+    }
+    return it->second;
+  };
+
+  // Held until after DetachDelete so an Edge* taken out of the skip list cannot be reclaimed underneath the
+  // batch. Engaged only when there is a skip list to read, i.e. heavy edges.
+  std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
+
+  if (!config_.storage_light_edge) {
+    if (config_.properties_on_edges) edge_acc = static_cast<InMemoryStorage *>(storage_)->edges_.access();
+
+    for (auto const &spec : edges) {
+      auto *from_vertex = resolve_vertex(spec.from_gid);
+      auto *to_vertex = resolve_vertex(spec.to_gid);
+      if (!from_vertex || !to_vertex) return std::unexpected{Error::NONEXISTENT_OBJECT};
+
+      // Mirrors the split in CreateEdgeInternal: without properties no Edge object is ever allocated and the
+      // EdgeRef carries the GID itself; with them, the edges_ skip list is keyed by GID.
+      auto edge_ref = EdgeRef{spec.edge_gid};
+      if (edge_acc) {
+        auto edge_it = edge_acc->find(spec.edge_gid);
+        if (edge_it == edge_acc->end()) return std::unexpected{Error::NONEXISTENT_OBJECT};
+        edge_ref = EdgeRef{&*edge_it};
+      }
+      accessors.emplace_back(edge_ref, spec.edge_type, from_vertex, to_vertex, storage_, &transaction_);
+    }
+  } else {
+    // Light edges are in no skip list, so adjacency is the only way to reach the Edge*. Grouping by from-vertex
+    // turns that into one scan per vertex instead of one per edge.
+    std::unordered_map<Gid, std::unordered_set<Gid>> wanted_by_from_vertex;
+    for (auto const &spec : edges) {
+      wanted_by_from_vertex[spec.from_gid].insert(spec.edge_gid);
+    }
+
+    for (auto &[from_gid, wanted] : wanted_by_from_vertex) {
+      auto *from_vertex = resolve_vertex(from_gid);
+      if (!from_vertex) return std::unexpected{Error::NONEXISTENT_OBJECT};
+
+      for (auto const &[edge_ref, edge_type, from_v, to_v] : ScanOutEdgesForGids(from_vertex, wanted)) {
+        accessors.emplace_back(edge_ref, edge_type, from_v, to_v, storage_, &transaction_);
+      }
+      if (!wanted.empty()) return std::unexpected{Error::NONEXISTENT_OBJECT};
+    }
+  }
+
+  auto edge_ptrs = accessors | rv::transform([](EdgeAccessor &edge) { return &edge; }) | r::to_vector;
+  auto res = DetachDelete({}, std::move(edge_ptrs), false);
+  if (!res) return std::unexpected{res.error()};
+  if (!*res) return size_t{0};
+  return (*res)->second.size();
 }
 
 Edge *InMemoryStorage::LightEdgePool::Create(Gid gid, Delta *delta) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -5014,23 +5014,44 @@ EdgeInfo ScanOutEdgesForGid(Vertex *from_vertex, Gid edge_gid) {
   return std::nullopt;
 }
 
-// Plural form of ScanOutEdgesForGid: resolves a whole set of GIDs in one pass over the adjacency rather than
-// one pass each, which is what keeps deleting many of a dense vertex's edges linear. Found GIDs are erased from
-// `wanted`, so whatever remains on return is the set this vertex does not have. Kept separate from the singular
+// Plural, either-direction form of ScanOutEdgesForGid: resolves a whole set of GIDs in one pass over one
+// vertex's adjacency rather than one pass each. An edge is linked from both of its endpoints, so a caller that
+// knows both can scan whichever list is shorter — see CheaperScanSide. Found GIDs are erased from `wanted`, so
+// whatever remains on return is the set this vertex does not have on this side. Kept separate from the singular
 // form rather than sharing an implementation with it: that one is called per vertex by the full-scan light-edge
 // path, which must not pay for a set allocation.
-std::vector<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>> ScanOutEdgesForGids(Vertex *from_vertex,
-                                                                                     std::unordered_set<Gid> &wanted) {
+std::vector<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>> ScanEdgesForGids(Vertex *vertex,
+                                                                                  EdgeDirection direction,
+                                                                                  std::unordered_set<Gid> &wanted) {
   std::vector<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>> found;
   found.reserve(wanted.size());
 
-  std::shared_lock const guard{from_vertex->lock};
-  for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
+  auto const scanning_out = direction == EdgeDirection::OUT;
+  std::shared_lock const guard{vertex->lock};
+  // The Vertex* in an adjacency entry is always the opposing endpoint, so which end `vertex` is depends on the
+  // list being walked.
+  for (const auto &[edge_type, opposing_vertex, edge_ref] : scanning_out ? vertex->out_edges : vertex->in_edges) {
     if (wanted.erase(edge_ref.ptr->gid) == 0) continue;
-    found.emplace_back(edge_ref, edge_type, from_vertex, to_vertex);
+    found.emplace_back(
+        edge_ref, edge_type, scanning_out ? vertex : opposing_vertex, scanning_out ? opposing_vertex : vertex);
     if (wanted.empty()) break;
   }
   return found;
+}
+
+// Which endpoint's adjacency is cheaper to scan for an edge between these two vertices. Sizes are read one lock
+// at a time: only ever holding one means no lock-ordering rule is needed and a self-loop needs no special case,
+// unlike FindEdges which holds both at once.
+EdgeDirection CheaperScanSide(Vertex *from_vertex, Vertex *to_vertex) {
+  auto const out_n = std::invoke([&] {
+    std::shared_lock const guard{from_vertex->lock};
+    return from_vertex->out_edges.size();
+  });
+  auto const in_n = std::invoke([&] {
+    std::shared_lock const guard{to_vertex->lock};
+    return to_vertex->in_edges.size();
+  });
+  return out_n <= in_n ? EdgeDirection::OUT : EdgeDirection::IN;
 }
 }  // namespace
 
@@ -5150,44 +5171,71 @@ Result<size_t> InMemoryStorage::InMemoryAccessor::DeleteEdgesEx(std::span<EdgeDe
     return it->second;
   };
 
+  // A spec already names the edge type and both endpoints, so the configs differ only in how they answer the
+  // one remaining question — which EdgeRef the GID denotes.
+  auto emplace_from_spec = [&](EdgeDeleteSpec const &spec, EdgeRef edge_ref) {
+    auto *from_vertex = resolve_vertex(spec.from_gid);
+    auto *to_vertex = resolve_vertex(spec.to_gid);
+    if (!from_vertex || !to_vertex) return false;
+    accessors.emplace_back(edge_ref, spec.edge_type, from_vertex, to_vertex, storage_, &transaction_);
+    return true;
+  };
+
   // Held until after DetachDelete so an Edge* taken out of the skip list cannot be reclaimed underneath the
   // batch. Engaged only when there is a skip list to read, i.e. heavy edges.
   std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
 
-  if (!config_.storage_light_edge) {
-    if (config_.properties_on_edges) edge_acc = static_cast<InMemoryStorage *>(storage_)->edges_.access();
+  if (!config_.properties_on_edges) {
+    // No Edge object is ever allocated, so the EdgeRef carries the GID itself and there is nothing to look up.
+    // Mirrors the same split in CreateEdgeInternal. Light edges cannot reach this arm: they imply properties.
+    for (auto const &spec : edges) {
+      if (!emplace_from_spec(spec, EdgeRef{spec.edge_gid})) return std::unexpected{Error::NONEXISTENT_OBJECT};
+    }
+  } else if (!config_.storage_light_edge) {
+    // Heavy edges are in the edges_ skip list, keyed by GID.
+    edge_acc = static_cast<InMemoryStorage *>(storage_)->edges_.access();
+    for (auto const &spec : edges) {
+      auto edge_it = edge_acc->find(spec.edge_gid);
+      if (edge_it == edge_acc->end()) return std::unexpected{Error::NONEXISTENT_OBJECT};
+      if (!emplace_from_spec(spec, EdgeRef{&*edge_it})) return std::unexpected{Error::NONEXISTENT_OBJECT};
+    }
+  } else {
+    // Light edges are in no skip list, so adjacency is the only way to reach the Edge*.
+    //
+    // Each edge is linked from both endpoints, so it is resolved from whichever side is cheaper, and edges that
+    // pick the same vertex are bucketed to share one scan. Both halves matter: the side choice is what makes
+    // deleting a handful of a supernode's edges cost O(1) each instead of a full scan of the supernode, and the
+    // bucketing is what makes deleting all of them cost one scan rather than one per edge.
+    std::unordered_map<Vertex *, std::unordered_set<Gid>> wanted_by_out_vertex;
+    std::unordered_map<Vertex *, std::unordered_set<Gid>> wanted_by_in_vertex;
 
     for (auto const &spec : edges) {
       auto *from_vertex = resolve_vertex(spec.from_gid);
       auto *to_vertex = resolve_vertex(spec.to_gid);
       if (!from_vertex || !to_vertex) return std::unexpected{Error::NONEXISTENT_OBJECT};
 
-      // Mirrors the split in CreateEdgeInternal: without properties no Edge object is ever allocated and the
-      // EdgeRef carries the GID itself; with them, the edges_ skip list is keyed by GID.
-      auto edge_ref = EdgeRef{spec.edge_gid};
-      if (edge_acc) {
-        auto edge_it = edge_acc->find(spec.edge_gid);
-        if (edge_it == edge_acc->end()) return std::unexpected{Error::NONEXISTENT_OBJECT};
-        edge_ref = EdgeRef{&*edge_it};
+      if (CheaperScanSide(from_vertex, to_vertex) == EdgeDirection::OUT) {
+        wanted_by_out_vertex[from_vertex].insert(spec.edge_gid);
+      } else {
+        wanted_by_in_vertex[to_vertex].insert(spec.edge_gid);
       }
-      accessors.emplace_back(edge_ref, spec.edge_type, from_vertex, to_vertex, storage_, &transaction_);
-    }
-  } else {
-    // Light edges are in no skip list, so adjacency is the only way to reach the Edge*. Grouping by from-vertex
-    // turns that into one scan per vertex instead of one per edge.
-    std::unordered_map<Gid, std::unordered_set<Gid>> wanted_by_from_vertex;
-    for (auto const &spec : edges) {
-      wanted_by_from_vertex[spec.from_gid].insert(spec.edge_gid);
     }
 
-    for (auto &[from_gid, wanted] : wanted_by_from_vertex) {
-      auto *from_vertex = resolve_vertex(from_gid);
-      if (!from_vertex) return std::unexpected{Error::NONEXISTENT_OBJECT};
-
-      for (auto const &[edge_ref, edge_type, from_v, to_v] : ScanOutEdgesForGids(from_vertex, wanted)) {
+    // Returns false if this vertex turned out not to have some of the edges asked of it.
+    auto drain_bucket = [&](Vertex *vertex, EdgeDirection direction, std::unordered_set<Gid> &wanted) {
+      for (auto const &[edge_ref, edge_type, from_v, to_v] : ScanEdgesForGids(vertex, direction, wanted)) {
         accessors.emplace_back(edge_ref, edge_type, from_v, to_v, storage_, &transaction_);
       }
-      if (!wanted.empty()) return std::unexpected{Error::NONEXISTENT_OBJECT};
+      return wanted.empty();
+    };
+
+    // The two maps partition the batch — the loop above put each edge in exactly one of them — so these are two
+    // halves of a single pass over the edges, not one pass per direction. No edge is looked at twice.
+    for (auto &[vertex, wanted] : wanted_by_out_vertex) {
+      if (!drain_bucket(vertex, EdgeDirection::OUT, wanted)) return std::unexpected{Error::NONEXISTENT_OBJECT};
+    }
+    for (auto &[vertex, wanted] : wanted_by_in_vertex) {
+      if (!drain_bucket(vertex, EdgeDirection::IN, wanted)) return std::unexpected{Error::NONEXISTENT_OBJECT};
     }
   }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -148,6 +148,15 @@ class InMemoryStorage final : public Storage {
 
   ~InMemoryStorage() override;
 
+  /// Identifies one edge to delete without holding an EdgeAccessor for it. These are exactly the fields a WAL
+  /// edge-delete record carries, so a replica can ask for a deletion straight from what it decoded.
+  struct EdgeDeleteSpec {
+    Gid edge_gid;
+    Gid from_gid;
+    Gid to_gid;
+    EdgeTypeId edge_type;
+  };
+
   class InMemoryAccessor : public Storage::Accessor {
    private:
     friend class InMemoryStorage;
@@ -730,6 +739,17 @@ class InMemoryStorage final : public Storage {
     /// @throw std::bad_alloc
     Result<EdgeAccessor> CreateEdgeEx(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type, storage::Gid gid);
 
+    /// Deletes edges identified only by gid, in one DetachDelete, and returns how many were deleted.
+    ///
+    /// Each edge is resolved by the cheapest route this storage config allows, so a caller holding nothing but
+    /// decoded WAL data never pays for the adjacency scan and accessor vector that FindEdge would build:
+    ///   - properties off: no Edge object exists, the EdgeRef is the gid itself, so nothing is looked up;
+    ///   - heavy edges:    the edges_ skip list is keyed by gid;
+    ///   - light edges:    only adjacency can produce the Edge*, so the batch is grouped by from-vertex and each
+    ///                     group is resolved in a single pass over that vertex's out edges.
+    /// @throw std::bad_alloc
+    Result<size_t> DeleteEdgesEx(std::span<EdgeDeleteSpec const> edges);
+
     /// During commit, in some cases you do not need to hand over deltas to GC
     /// in those cases this method is a light weight way to unlink and discard our deltas
     void FastDiscardOfDeltas(std::unique_lock<std::mutex> gc_guard);
@@ -1105,6 +1125,11 @@ class ReplicationAccessor final : public InMemoryStorage::InMemoryAccessor {
   /// @throw std::bad_alloc
   Result<EdgeAccessor> CreateEdgeEx(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type, storage::Gid gid) {
     return InMemoryAccessor::CreateEdgeEx(from, to, edge_type, gid);
+  }
+
+  /// @throw std::bad_alloc
+  Result<size_t> DeleteEdgesEx(std::span<InMemoryStorage::EdgeDeleteSpec const> edges) {
+    return InMemoryAccessor::DeleteEdgesEx(edges);
   }
 
   auto GetCommitTimestamp() -> std::optional<uint64_t> & { return commit_timestamp_; }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -745,8 +745,8 @@ class InMemoryStorage final : public Storage {
     /// decoded WAL data never pays for the adjacency scan and accessor vector that FindEdge would build:
     ///   - properties off: no Edge object exists, the EdgeRef is the gid itself, so nothing is looked up;
     ///   - heavy edges:    the edges_ skip list is keyed by gid;
-    ///   - light edges:    only adjacency can produce the Edge*, so the batch is grouped by from-vertex and each
-    ///                     group is resolved in a single pass over that vertex's out edges.
+    ///   - light edges:    only adjacency can produce the Edge*, so each edge is resolved from whichever of its
+    ///                     two endpoints has the shorter list, with edges picking the same vertex sharing a pass.
     /// @throw std::bad_alloc
     Result<size_t> DeleteEdgesEx(std::span<EdgeDeleteSpec const> edges);
 

--- a/tests/e2e/replication/edge_delete.py
+++ b/tests/e2e/replication/edge_delete.py
@@ -13,8 +13,20 @@ import sys
 import time
 
 import pytest
-from common import execute_and_fetch_all
-from mg_utils import mg_sleep_and_assert_collection
+from common import connect, execute_and_fetch_all
+from mg_utils import mg_sleep_and_assert, mg_sleep_and_assert_collection
+
+REPLICA_BOLT_PORTS = [7688, 7689]
+
+
+def replica_cursors():
+    return [connect(host="localhost", port=port).cursor() for port in REPLICA_BOLT_PORTS]
+
+
+def assert_on_replicas(cursors, query, expected):
+    """Waits for every replica to converge on `expected` for `query`."""
+    for cursor in cursors:
+        mg_sleep_and_assert(expected, lambda cursor=cursor: execute_and_fetch_all(cursor, query))
 
 
 # BUGFIX: for issue https://github.com/memgraph/memgraph/issues/1515
@@ -82,6 +94,89 @@ def test_replication_handles_delete_when_multiple_edges_of_same_type(connection,
 
     actual_data = mg_sleep_and_assert_collection(expected_data, retrieve_data)
     assert all([x in actual_data for x in expected_data])
+
+
+def test_replication_deletes_all_edges_of_a_dense_vertex(connection):
+    # Replicas apply a transaction's edge deletions as one batch. A single hub whose whole fan-out is deleted in
+    # one transaction is the case that batch exists for, so assert the replicas end up with the hub and its
+    # leaves intact and no edges left.
+    conn = connection(7687, "main")
+    cursor = conn.cursor()
+    replicas = replica_cursors()
+
+    execute_and_fetch_all(cursor, "CREATE (:Hub {id: 0});")
+    execute_and_fetch_all(cursor, "MATCH (h:Hub) UNWIND range(1, 500) AS i CREATE (h)-[:X]->(:Leaf {id: i});")
+    execute_and_fetch_all(cursor, "MATCH (:Hub)-[r:X]->(:Leaf) DELETE r;")
+
+    assert_on_replicas(replicas, "MATCH ()-[r]->() RETURN count(r);", [(0,)])
+    assert_on_replicas(replicas, "MATCH (n) RETURN count(n);", [(501,)])
+
+
+def test_replication_deletes_edges_and_their_vertices_in_one_transaction(connection):
+    # DETACH DELETE emits the edge deletions and the vertex deletions in the same transaction. Deleting a vertex
+    # requires it to already be detached, so this covers the batch being flushed before the vertex deltas run.
+    conn = connection(7687, "main")
+    cursor = conn.cursor()
+    replicas = replica_cursors()
+
+    execute_and_fetch_all(cursor, "CREATE (:Hub {id: 0});")
+    execute_and_fetch_all(cursor, "MATCH (h:Hub) UNWIND range(1, 300) AS i CREATE (h)-[:X]->(:Leaf {id: i});")
+    execute_and_fetch_all(cursor, "MATCH (n:Hub) DETACH DELETE n;")
+
+    assert_on_replicas(replicas, "MATCH ()-[r]->() RETURN count(r);", [(0,)])
+    assert_on_replicas(replicas, "MATCH (n:Hub) RETURN count(n);", [(0,)])
+    assert_on_replicas(replicas, "MATCH (n:Leaf) RETURN count(n);", [(300,)])
+
+
+def test_replication_deletes_a_subset_of_parallel_edges_and_self_loops(connection, pytestconfig):
+    # Batched deletion erases edges from an endpoint's adjacency by gid. Parallel edges between one pair and
+    # self-loops are where a gid-blind implementation would take out the wrong edge, so delete half of each and
+    # assert the replicas keep exactly the intended survivors.
+    with_props = pytestconfig.getoption("with_props")
+
+    conn = connection(7687, "main")
+    cursor = conn.cursor()
+    replicas = replica_cursors()
+
+    edge_props = " {i: i}" if with_props else ""
+    execute_and_fetch_all(cursor, "CREATE (:A {id: 1}), (:B {id: 2});")
+    execute_and_fetch_all(cursor, f"MATCH (a:A), (b:B) UNWIND range(1, 100) AS i CREATE (a)-[:PAR{edge_props}]->(b);")
+    execute_and_fetch_all(cursor, f"MATCH (a:A) UNWIND range(1, 100) AS i CREATE (a)-[:LOOP{edge_props}]->(a);")
+
+    if with_props:
+        execute_and_fetch_all(cursor, "MATCH ()-[r:PAR]->() WHERE r.i % 2 = 0 DELETE r;")
+        execute_and_fetch_all(cursor, "MATCH ()-[r:LOOP]->() WHERE r.i % 2 = 0 DELETE r;")
+    else:
+        execute_and_fetch_all(cursor, "MATCH ()-[r:PAR]->() WITH r LIMIT 50 DELETE r;")
+        execute_and_fetch_all(cursor, "MATCH ()-[r:LOOP]->() WITH r LIMIT 50 DELETE r;")
+
+    assert_on_replicas(replicas, "MATCH ()-[r:PAR]->() RETURN count(r);", [(50,)])
+    assert_on_replicas(replicas, "MATCH ()-[r:LOOP]->() RETURN count(r);", [(50,)])
+
+    if with_props:
+        # Only with edge properties is an individual edge identifiable, which is what pins down that the
+        # surviving edges are the ones that were meant to survive rather than just the right count.
+        expected_survivors = [(i,) for i in range(1, 100, 2)]
+        assert_on_replicas(replicas, "MATCH ()-[r:PAR]->() RETURN r.i ORDER BY r.i;", expected_survivors)
+        assert_on_replicas(replicas, "MATCH ()-[r:LOOP]->() RETURN r.i ORDER BY r.i;", expected_survivors)
+
+
+def test_replication_sets_properties_and_deletes_edges_in_one_transaction(connection, pytestconfig):
+    # Edge property writes and edge deletions land in the same transaction here. The property writes must still
+    # be visible on the surviving edges once the deletion batch has been applied.
+    if not pytestconfig.getoption("with_props"):
+        pytest.skip("Requires properties on edges")
+
+    conn = connection(7687, "main")
+    cursor = conn.cursor()
+    replicas = replica_cursors()
+
+    execute_and_fetch_all(cursor, "CREATE (:Hub {id: 0});")
+    execute_and_fetch_all(cursor, "MATCH (h:Hub) UNWIND range(1, 200) AS i CREATE (h)-[:X {i: i}]->(:Leaf {id: i});")
+    execute_and_fetch_all(cursor, "MATCH ()-[r:X]->() SET r.tag = r.i * 10 WITH r WHERE r.i > 50 DELETE r;")
+
+    assert_on_replicas(replicas, "MATCH ()-[r:X]->() RETURN count(r);", [(50,)])
+    assert_on_replicas(replicas, "MATCH ()-[r:X]->() RETURN sum(r.tag);", [(sum(i * 10 for i in range(1, 51)),)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Deleting edges on a replica was quadratic where main is linear.

## The problem

Main's `Delete` operator buffers and calls `DetachDelete` once with the whole edge set, so `DetachRemainingEdges` runs its `std::partition` **once per endpoint vertex**.

The replica got one WAL `EDGE_DELETE` record per edge and applied each in isolation: `FindVertex` ×2, then `FindEdge` (which materializes a filtered, delta-applied `vector<EdgeAccessor>` and linear-searches it), then `DeleteEdge` → `DetachDelete` with a single edge, partitioning `from->out_edges` *and* `to->in_edges` for that one edge.

Deleting D edges off a vertex of degree D: **O(D) on main, O(D²) on the replica.**

The local durability recovery path in `wal.cpp` was already fine (swap-and-pop, single scan) — only replication was affected.

## 1. Batch the deletions

`WalEdgeDelete` now buffers `{edge_gid, from_gid, to_gid, edge_type}` rather than applying immediately, and the batch goes through a single `DetachDelete`.

This is safe and complete because of how the WAL encoder orders a transaction's deltas — five fixed passes (vertex writes → edge creates → edge property sets → **edge deletes** → vertex deletes). Every edge deletion of a transaction therefore arrives as one contiguous run, and the ordering constraints fall out for free: property sets always precede deletes, vertex deletes always follow.

The flush guard sits at the `std::visit` dispatch site rather than inside each handler, so the transaction-end delta (which commits) and the vertex-delete deltas (which require already-detached vertices) are both covered, as is any handler added later. The buffer is capped at 100k edges, because main's `DELETE` buffer size can split one transaction across several `DetachDelete` calls — the replica can see more deletions in a transaction than main ever held at once.

## 2. Resolve edges from the GID, per storage config

New `InMemoryAccessor::DeleteEdgesEx`. A WAL record already names the edge type and both endpoints, so the only open question is which `EdgeRef` the GID denotes:

| config | resolution | per edge |
|---|---|---|
| properties off | no `Edge` object is ever allocated — the `EdgeRef` carries the GID | no lookup at all |
| heavy | `edges_` skip list, keyed by GID | O(log E) |
| light | adjacency — nothing else holds the `Edge*` | see below |

Endpoint lookups are memoized, so a hub's whole fan-out costs one skip-list lookup instead of one per edge.

Deliberately **not** routed through `InMemoryStorage::FindEdge`: that has to recover the edge type and to-vertex from adjacency (`ExtractEdgeInfo` / `ScanOutEdgesForGid`) because its callers know only a GID. Reusing it would put an O(degree) scan back on every edge, including heavy, undoing the fix.

## 3. Light edges resolve from the cheaper endpoint

An edge is linked from both of its endpoints, so each is resolved from whichever adjacency list is shorter (`CheaperScanSide`), with edges landing on the same vertex bucketed to share one scan (`ScanEdgesForGids`, the plural either-direction form of the existing `ScanOutEdgesForGid`).

Both halves matter:

| case | before | after |
|---|---|---|
| delete 10 edges off a 1M-degree hub | 1M-entry scan | ~10 × O(1) |
| delete all D edges of a D-degree hub | one D-entry scan | one D-entry scan |
| D edges from D hubs into one leaf | D × O(hub degree) | one D-entry scan of the leaf |

`CheaperScanSide` reads the two degrees one lock at a time; holding only one lock means no ordering rule is needed and a self-loop needs no special case, unlike `FindEdges` which holds both at once.

## Correctness

`FindEdge` performed a `View::NEW` visibility check that caught a WAL naming an edge the replica does not have. Resolving by GID skips that, so the flush now compares `DeleteEdgesEx`'s returned count against the batch size and fails the transaction on mismatch. That covers all three paths, including a stale `Edge*` read from `edges_` for an already-deleted-but-not-yet-GC'd edge — it won't match adjacency, so it shows up as a short count.

Delta *ordering* within the replica's transaction changes (all out-edge deltas per vertex, then in-edge). Main already has this property, and the WAL encoder re-normalizes into its passes when re-encoding, so cascaded replication is unaffected.
