### PR TITLE
fix(license): publish license tier + validity as one atomic to close the revalidation race

### DIFF
--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -32,6 +32,7 @@
 
 #include "slk/serialization.hpp"
 #include "slk/streams.hpp"
+#include "utils/atomic_utils.hpp"
 #include "utils/base64.hpp"
 #include "utils/logging.hpp"
 #include "utils/memory_tracker.hpp"
@@ -169,8 +170,11 @@ void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
   };
 
   if (enterprise_enabled_) [[unlikely]] {
-    is_valid_.store(true, std::memory_order_release);
-    set_memory_limit(0, license_type_);
+    atomic_struct_update<LicenseState>(state_, [](LicenseState s) {
+      s.valid = true;
+      return s;
+    });
+    set_memory_limit(0, state_.load(std::memory_order_acquire).type);
     return;
   }
 
@@ -218,7 +222,10 @@ void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
       spdlog::warn("No valid license found. Running in community mode.");
       locked->reset();
     }
-    is_valid_.store(false, std::memory_order_relaxed);
+    atomic_struct_update<LicenseState>(state_, [](LicenseState s) {
+      s.valid = false;
+      return s;
+    });
     set_memory_limit(0);
     return;
   }
@@ -250,22 +257,18 @@ void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
     }
   }
 
-  // Write license_type_ before the release store so the acquire load in IsEnterpriseValidFast()
-  // establishes a happens-before and reads the correct type.
-  license_type_ = winner.license.type;
-  is_valid_.store(true, std::memory_order_release);
+  state_.store(LicenseState{.valid = true, .type = winner.license.type}, std::memory_order_release);
 }
 
 void LicenseChecker::EnableTesting(const LicenseType license_type) {
   enterprise_enabled_ = true;
-  license_type_ = license_type;
   {
     auto locked = previous_license_info_.Lock();
     locked->emplace("test-key", "test-org");
     (*locked)->is_valid = true;
     (*locked)->license.type = license_type;
   }
-  is_valid_.store(true, std::memory_order_release);
+  state_.store(LicenseState{.valid = true, .type = license_type}, std::memory_order_release);
   spdlog::info("The license type {} is set for testing.", LicenseTypeToString(license_type));
 }
 
@@ -275,7 +278,10 @@ void LicenseChecker::DisableTesting() {
     auto locked = previous_license_info_.Lock();
     locked->reset();
   }
-  is_valid_.store(false, std::memory_order_relaxed);
+  atomic_struct_update<LicenseState>(state_, [](LicenseState s) {
+    s.valid = false;
+    return s;
+  });
   spdlog::info("The license is disabled for testing.");
 }
 
@@ -451,10 +457,8 @@ DetailedLicenseInfo LicenseChecker::GetDetailedLicenseInfo() {
 }
 
 bool LicenseChecker::IsEnterpriseValidFast() const {
-  // Acquire synchronizes with release stores in RevalidateLicense/EnableTesting.
-  // This ensures we see the license_type_ write that precedes those release stores,
-  // avoiding a data race on the non-atomic license_type_.
-  return is_valid_.load(std::memory_order_acquire) && IsEnterpriseTier(license_type_);
+  const auto s = state_.load(std::memory_order_acquire);
+  return s.valid && IsEnterpriseTier(s.type);
 }
 
 std::string Encode(const License &license) {

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -38,6 +38,14 @@ constexpr bool IsEnterpriseTier(LicenseType type) noexcept {
   return type == LicenseType::ENTERPRISE || type == LicenseType::AI_PLATFORM || type == LicenseType::OEM;
 }
 
+// Validity and tier are published together as one atomic value, so a reader always observes a pair
+// that was actually stored together, never a mix of an old type with a new validity (or vice versa).
+struct LicenseState {
+  bool valid{false};
+  LicenseType type{LicenseType::ENTERPRISE};
+  bool operator==(const LicenseState &) const = default;
+};
+
 std::string LicenseTypeToString(LicenseType license_type);
 
 inline constexpr std::string_view kLicenseTypeEnterprise = "enterprise";
@@ -126,12 +134,16 @@ struct LicenseChecker {
  private:
   void RevalidateLicense(utils::Settings &settings);
 
+  // Written once at startup (SetCliLicense/CheckEnvLicense on the main thread) before the background
+  // scheduler and the Bolt server exist; thread creation publishes them to every later reader. This
+  // startup-only invariant is what makes these non-atomic fields safe -- a runtime writer would need
+  // explicit serialisation (they are not trivially copyable, so unlike state_ they cannot be atomics).
   std::optional<std::pair<std::string, std::string>> cli_license_info_;
   std::optional<std::pair<std::string, std::string>> env_license_info_;
   mutable utils::Synchronized<std::optional<LicenseInfo>, utils::SpinLock> previous_license_info_{std::nullopt};
   bool enterprise_enabled_{false};
-  std::atomic<bool> is_valid_{false};
-  LicenseType license_type_;
+  std::atomic<LicenseState> state_{};
+  static_assert(std::atomic<LicenseState>::is_always_lock_free);
   utils::Scheduler scheduler_;
 
   friend void RegisterLicenseSettings(LicenseChecker &license_checker, utils::Settings &settings);


### PR DESCRIPTION
License validity and tier were two separate fields — `is_valid_` (`std::atomic<bool>`) and `license_type_` (plain `LicenseType`) — read together from ~150 sites via `IsEnterpriseValidFast()`. The release/acquire handshake on `is_valid_` orders nothing about the separate non-atomic `license_type_` write once `is_valid_` has latched `true`, so periodic revalidation races the readers. A torn read fails **open** on fine-grained access control (`auth_checker.cpp` treats it as allowed; `operator.cpp` skips its throw).

Publish both as a single `std::atomic<LicenseState>` holding `{valid, type}`, so a reader always observes a pair that was actually stored together and no cross-field ordering contract remains. The read path is one lock-free acquire load; `static_assert(is_always_lock_free)` pins it. No new locking is needed — the atomic alone removes the race, and `RevalidateLicense`'s other side-effects already carry their own locks.
