### PR TITLE
fix(replication): key the 2PC commit cache by uuid and abort the cached accessor before storage teardown

### DIFF
--- a/src/dbms/CMakeLists.txt
+++ b/src/dbms/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(mg-dbms
     tenant_profiles.cpp
     coordinator_handler.cpp
     inmemory/replication_handlers.cpp
+    inmemory/two_pc_commit_cache.cpp
     replication_handlers.cpp
     rpc.cpp
     database_protector.cpp

--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -16,6 +16,7 @@
 #include "spdlog/spdlog.h"
 
 #include "dbms/database_info.hpp"
+#include "dbms/inmemory/replication_handlers.hpp"
 #include "dbms/inmemory/storage_helper.hpp"
 #include "flags/coord_flag_env_handler.hpp"
 #include "flags/general.hpp"
@@ -63,7 +64,30 @@ struct PlanInvalidatorForDatabase : storage::PlanInvalidator {
   query::PlanCacheLRU &plan_cache;
 };
 
-Database::~Database() = default;
+Database::~Database() {
+  // Every teardown path -- Delete_/DeferDelete, Gatekeeper::Accessor::try_delete(),
+  // Gatekeeper::finish_suspend(), ~Gatekeeper, DbmsHandler::Update()'s drop-and-recreate, and the
+  // implicit teardown at process exit -- funnels through this destructor. The cached 2PC commit
+  // accessor in InMemoryReplicationHandlers is storage-level, not gatekeeper-counted, so none of
+  // those drains observes or waits on it; discarding it here, structurally, replaces having to
+  // remember an AbortTwoPCForTenant call at every one of those sites individually. This is safe
+  // because the destructor body runs before any member is destroyed, so storage_ -- and the per-DB
+  // arena its deltas were allocated from -- is still fully intact. AbortTwoPCForTenant is
+  // UUID-scoped, so a 2PC cached for a different tenant is left untouched. This deliberately takes
+  // no utils::Gatekeeper path: finish_suspend() holds the non-recursive GKInternals::mutex_ across
+  // ~Database (gatekeeper.hpp:400), so any gatekeeper re-entry from here would self-deadlock.
+  try {
+    // GatekeeperGuard clears the arena TLS state around Database construction/destruction, and
+    // Abort() walking deltas allocates -- re-establish the scope so those allocations are
+    // attributed to this tenant's arena rather than whatever happened to be in TLS.
+    const memory::DbArenaScope db_arena_scope{this};
+    InMemoryReplicationHandlers::AbortTwoPCForTenant(uuid());
+  } catch (...) {  // NOLINT(bugprone-empty-catch)
+    // A destructor is implicitly noexcept; Abort() walks deltas and can throw during allocation.
+    // Letting that escape would call std::terminate, so swallow it here -- same rationale as
+    // ~Gatekeeper's swallowed spdlog throw (gatekeeper.hpp).
+  }
+}
 
 std::unique_ptr<storage::Accessor> Database::Access(storage::StorageAccessType rw_type,
                                                     std::optional<storage::IsolationLevel> override_isolation_level,

--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -65,26 +65,19 @@ struct PlanInvalidatorForDatabase : storage::PlanInvalidator {
 };
 
 Database::~Database() {
-  // Every teardown path -- Delete_/DeferDelete, Gatekeeper::Accessor::try_delete(),
-  // Gatekeeper::finish_suspend(), ~Gatekeeper, DbmsHandler::Update()'s drop-and-recreate, and the
-  // implicit teardown at process exit -- funnels through this destructor. The cached 2PC commit
-  // accessor in InMemoryReplicationHandlers is storage-level, not gatekeeper-counted, so none of
-  // those drains observes or waits on it; discarding it here, structurally, replaces having to
-  // remember an AbortTwoPCForTenant call at every one of those sites individually. This is safe
-  // because the destructor body runs before any member is destroyed, so storage_ -- and the per-DB
-  // arena its deltas were allocated from -- is still fully intact. AbortTwoPCForTenant is
-  // UUID-scoped, so a 2PC cached for a different tenant is left untouched. This deliberately takes
-  // no utils::Gatekeeper path: finish_suspend() holds the non-recursive GKInternals::mutex_ across
-  // ~Database (gatekeeper.hpp:400), so any gatekeeper re-entry from here would self-deadlock.
+  // Every teardown path (drop, suspend, drop-recreate, process exit) destroys via this destructor, and
+  // the cached 2PC accessor is storage-level, not gatekeeper-counted -- this is the one choke point
+  // that reaches it. Safe: the body runs before storage_ is destroyed.
+  //
+  // Must not call any utils::Gatekeeper method here -- finish_suspend() holds GKInternals::mutex_
+  // across ~Database (gatekeeper.hpp:394), so re-entry would self-deadlock.
   try {
-    // GatekeeperGuard clears the arena TLS state around Database construction/destruction, and
-    // Abort() walking deltas allocates -- re-establish the scope so those allocations are
-    // attributed to this tenant's arena rather than whatever happened to be in TLS.
+    // GatekeeperGuard clears arena TLS around Database destruction; re-establish it so Abort()'s
+    // delta walk allocates against this tenant's arena, not stale TLS.
     const memory::DbArenaScope db_arena_scope{this};
     InMemoryReplicationHandlers::AbortTwoPCForTenant(uuid());
   } catch (const std::exception &e) {
-    // A destructor is implicitly noexcept, so this can't escape (~Database is on that chain too);
-    // log so a stuck 2PC has a diagnostic anchor, same rationale as ~Gatekeeper's wrapped spdlog::trace.
+    // spdlog can throw; swallow it so it can't escape this implicitly-noexcept destructor (mirrors ~Gatekeeper).
     try {
       spdlog::error(
           "Database::~Database: failed to abort cached 2PC for tenant {}: {} -- prepared transaction stays pinned in "

--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -82,10 +82,25 @@ Database::~Database() {
     // attributed to this tenant's arena rather than whatever happened to be in TLS.
     const memory::DbArenaScope db_arena_scope{this};
     InMemoryReplicationHandlers::AbortTwoPCForTenant(uuid());
-  } catch (...) {  // NOLINT(bugprone-empty-catch)
-    // A destructor is implicitly noexcept; Abort() walks deltas and can throw during allocation.
-    // Letting that escape would call std::terminate, so swallow it here -- same rationale as
-    // ~Gatekeeper's swallowed spdlog throw (gatekeeper.hpp).
+  } catch (const std::exception &e) {
+    // A destructor is implicitly noexcept, so this can't escape (~Database is on that chain too);
+    // log so a stuck 2PC has a diagnostic anchor, same rationale as ~Gatekeeper's wrapped spdlog::trace.
+    try {
+      spdlog::error(
+          "Database::~Database: failed to abort cached 2PC for tenant {}: {} -- prepared transaction stays pinned in "
+          "the commit log.",
+          std::string{uuid()},
+          e.what());
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+    }
+  } catch (...) {
+    try {
+      spdlog::error(
+          "Database::~Database: failed to abort cached 2PC for tenant {} (unknown exception) -- prepared transaction "
+          "stays pinned in the commit log.",
+          std::string{uuid()});
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+    }
   }
 }
 

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -510,8 +510,8 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
     heartbeat.Stop();
 
     if (deltas_res) {
-      dbms::TwoPCCommitCache::Instance().Store(std::move(deltas_res->commit_acc), req.durability_commit_timestamp,
-                                               storage->uuid());
+      dbms::TwoPCCommitCache::Store(
+          std::move(deltas_res->commit_acc), req.durability_commit_timestamp, storage->uuid());
       res.success = true;
     }
   }
@@ -545,7 +545,7 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
   // engine_lock_ happens below, on the local, with the cache's internal lock already released --
   // see TwoPCCommitCache::TakeMatching's declaration comment for the mismatch-leaves-it-populated
   // contract.
-  auto extracted = dbms::TwoPCCommitCache::Instance().TakeMatching(req.durability_commit_timestamp);
+  auto extracted = dbms::TwoPCCommitCache::TakeMatching(req.durability_commit_timestamp);
 
   // In this handler, we can either commit or abort. If cached accessor is nullptr, it is impossible we should commit
   // because replying to prepare happens after assignment to the accessor
@@ -606,7 +606,7 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
 void InMemoryReplicationHandlers::DestroyReplAccessor() {
   // Extract under the cache's internal lock, then abort the local outside it -- AbortAndResetCommitTs()
   // walks the transaction's deltas and must not run with the cache mutex held.
-  auto accessor = dbms::TwoPCCommitCache::Instance().TakeAny();
+  auto accessor = dbms::TwoPCCommitCache::TakeAny();
   if (accessor) {
     accessor->AbortAndResetCommitTs();
   }
@@ -617,7 +617,7 @@ void InMemoryReplicationHandlers::AbortTwoPCForTenant(utils::UUID const &uuid, r
   // pending 2PC for a different tenant would be wrongly dropped. See TwoPCCommitCache::TakeForTenant's
   // declaration comment for why the comparison uses the uuid captured at populate time, not one
   // re-derived from the accessor.
-  auto accessor = dbms::TwoPCCommitCache::Instance().TakeForTenant(uuid);
+  auto accessor = dbms::TwoPCCommitCache::TakeForTenant(uuid);
   if (accessor) {
     // on_progress is reported per delta undone: an interrupted 2PC's abort is O(deltas), and the RPC
     // pre-abort callers run it inside a handler whose peer is timing them.

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -478,8 +478,9 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
 
     // Abort prev txn if needed
     // It could happen that the main instance died before sending finalize for the previous commit and then
-    // the new instance becomes main and sends prepare
-    DestroyReplAccessor(&heartbeat);
+    // the new instance becomes main and sends prepare. Scoped to this tenant so an RPC for storage A cannot
+    // abort a different tenant's still-pending 2PC (that would strand it and reply commit-OK falsely).
+    AbortTwoPCForTenant(storage->uuid(), &heartbeat);
     auto &repl_storage_state = storage->repl_storage_state_;
 
     if (*maybe_epoch_id != repl_storage_state.epoch_.id()) {
@@ -602,11 +603,24 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
   rpc::SendFinalResponse(res, request_version, res_builder);
 }
 
-void InMemoryReplicationHandlers::DestroyReplAccessor(rpc::ProgressHeartbeat *heartbeat) {
+void InMemoryReplicationHandlers::DestroyReplAccessor() {
   // Extract under the cache's internal lock, then abort the local outside it -- AbortAndResetCommitTs()
   // walks the transaction's deltas and must not run with the cache mutex held.
   auto accessor = dbms::TwoPCCommitCache::Instance().TakeAny();
   if (accessor) {
+    accessor->AbortAndResetCommitTs();
+  }
+}
+
+void InMemoryReplicationHandlers::AbortTwoPCForTenant(utils::UUID const &uuid, rpc::ProgressHeartbeat *heartbeat) {
+  // TD-3': single global 2PC slot — only abort it when the cached accessor is this tenant's, else a
+  // pending 2PC for a different tenant would be wrongly dropped. See TwoPCCommitCache::TakeForTenant's
+  // declaration comment for why the comparison uses the uuid captured at populate time, not one
+  // re-derived from the accessor.
+  auto accessor = dbms::TwoPCCommitCache::Instance().TakeForTenant(uuid);
+  if (accessor) {
+    // on_progress is reported per delta undone: an interrupted 2PC's abort is O(deltas), and the RPC
+    // pre-abort callers run it inside a handler whose peer is timing them.
     auto const on_progress = [heartbeat]() -> storage::ProgressCallback {
       if (heartbeat == nullptr) return {};
       return [heartbeat] { heartbeat->RecordProgress(); };
@@ -615,20 +629,9 @@ void InMemoryReplicationHandlers::DestroyReplAccessor(rpc::ProgressHeartbeat *he
   }
 }
 
-void InMemoryReplicationHandlers::AbortTwoPCForTenant(utils::UUID const &uuid) {
-  // TD-3': single global 2PC slot — only abort it when the cached accessor is this tenant's, else a
-  // pending 2PC for a different tenant would be wrongly dropped. See TwoPCCommitCache::TakeForTenant's
-  // declaration comment for why the comparison uses the uuid captured at populate time, not one
-  // re-derived from the accessor.
-  auto accessor = dbms::TwoPCCommitCache::Instance().TakeForTenant(uuid);
-  if (accessor) {
-    accessor->AbortAndResetCommitTs();
-  }
-}
-
 void InMemoryReplicationHandlers::AbortPrevTxnIfNeeded(storage::InMemoryStorage *const storage,
                                                        rpc::ProgressHeartbeat *heartbeat) {
-  DestroyReplAccessor(heartbeat);
+  AbortTwoPCForTenant(storage->uuid(), heartbeat);
   if (storage->wal_file_) {
     storage->wal_file_->FinalizeWal();
     storage->wal_file_.reset();

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -12,6 +12,7 @@
 #include "dbms/inmemory/replication_handlers.hpp"
 
 #include "dbms/dbms_handler.hpp"
+#include "dbms/inmemory/two_pc_commit_cache.hpp"
 #include "memory/db_arena_fwd.hpp"
 #include "rpc/file_replication_handler.hpp"
 #include "rpc/progress_heartbeat.hpp"
@@ -227,58 +228,6 @@ void LogWrongMain(utils::UUID const &current_main_uuid, const utils::UUID &main_
                 rpc_req,
                 std::string(main_req_id),
                 std::string(current_main_uuid));
-}
-
-// Single global slot holding the in-flight 2PC commit accessor between PrepareCommitRpc and
-// FinalizeCommitRpc (see AbortTwoPCForTenant's declaration comment for why it is a single slot).
-struct TwoPCCache {
-  std::unique_ptr<storage::ReplicationAccessor> commit_accessor_;
-  uint64_t durability_commit_timestamp_{};
-  // Captured from storage->uuid() when the slot is populated (PrepareCommitHandler), never
-  // re-derived from commit_accessor_->uuid(). Accessor::uuid() forwards to storage_->uuid()
-  // (storage.hpp:846), and every guard that consults this field exists precisely for the case
-  // where that Storage may already be gone (e.g. AbortTwoPCForTenant runs from the tenant-drop
-  // path) -- asking the accessor who it belongs to would be the very use-after-free the guard is
-  // meant to prevent.
-  utils::UUID uuid_{};
-
-  TwoPCCache() = default;
-  TwoPCCache(TwoPCCache &&) = default;
-  TwoPCCache(TwoPCCache const &) = delete;
-  // Assignment is deleted deliberately: an implicitly-generated member-wise move-assignment runs
-  // in forward declaration order, which for any future member owning a lifetime/scope token would
-  // release that token before commit_accessor_ (whose ~InMemoryAccessor dereferences storage_) is
-  // destroyed. Deleting assignment forces every mutation through explicit per-member assignment or
-  // extract-then-clear, turning the ordering into a compile-time constraint instead of a
-  // convention someone can silently break.
-  TwoPCCache &operator=(TwoPCCache &&) = delete;
-  TwoPCCache &operator=(TwoPCCache const &) = delete;
-};
-
-// Guards TwoPCCache. Discipline: EXTRACT the accessor out of the slot while holding this lock,
-// then run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on the extracted local
-// OUTSIDE the lock -- those walk the whole transaction's deltas and take engine_lock_, and this
-// lock must never be held across that. This is hardening, not a fix for a live race: today the
-// replica RPC server is single-threaded (kReplicationServerThreads = 1, replication_server.cpp:28)
-// and the two cross-thread callers (AbortTwoPCForTenant off the tenant-drop path) are serialised
-// against the RPC thread by a real thread join.
-//
-// Heap-allocated and deliberately never freed -- one slot for the whole process, holding at most
-// one accessor, so the leak is bounded. Two reasons this matters, both load-bearing:
-//  1. No static destructor. A static object here that is still populated at process exit would be
-//     destroyed after main() returns, i.e. after every Database/InMemoryStorage is already gone,
-//     and destroying the cached ReplicationAccessor then dereferences freed storage
-//     (~InMemoryAccessor calls Abort()/FinalizeTransaction(); ~ResourceLockGuard unlocks a freed
-//     main_lock_). main's shutdown path already clears this slot in order while the storages are
-//     alive; leaking the slot only matters for paths that bypass that ordered clear, where not
-//     aborting is strictly safer than aborting against freed memory.
-//  2. No cross-TU destruction-order dependency. ~Database (dbms/database.cpp) calls
-//     AbortTwoPCForTenant, and destruction order across translation units is unspecified, so a
-//     Database with static storage duration could otherwise reach a static slot here after it had
-//     already been destroyed.
-auto TwoPCCacheSlot() -> utils::Synchronized<TwoPCCache, std::mutex> & {
-  static auto *slot = new utils::Synchronized<TwoPCCache, std::mutex>{};
-  return *slot;
 }
 
 }  // namespace
@@ -560,13 +509,11 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
     heartbeat.Stop();
 
     if (deltas_res) {
-      TwoPCCacheSlot().WithLock([&](TwoPCCache &cache) {
-        cache.commit_accessor_ = std::move(deltas_res->commit_acc);
-        cache.durability_commit_timestamp_ = req.durability_commit_timestamp;
-        cache.uuid_ = storage->uuid();
-      });
+      dbms::TwoPCCommitCache::Instance().Store(std::move(deltas_res->commit_acc), req.durability_commit_timestamp,
+                                               storage->uuid());
       res.success = true;
     }
+  }
   rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
 }
 
@@ -593,41 +540,28 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
 
   const memory::DbArenaScope db_arena_scope{db_acc->get()};
 
-  // Extract the cached accessor out of the slot while holding the cache lock; everything that
-  // walks its deltas or touches engine_lock_ happens below, on the local, with the lock released.
-  // mismatched_cached_timestamp is only set when the slot stayed populated (mismatch path below
-  // must NOT clear it -- unlike the "missing" case, this is not treated as terminal by the caller).
-  struct CacheExtractResult {
-    std::unique_ptr<storage::ReplicationAccessor> accessor;  // non-null only once timestamps matched
-    std::optional<uint64_t> mismatched_cached_timestamp;
-  };
-
-  auto extracted = TwoPCCacheSlot().WithLock([&](TwoPCCache &cache) -> CacheExtractResult {
-    if (!cache.commit_accessor_) {
-      return {};
-    }
-    if (req.durability_commit_timestamp != cache.durability_commit_timestamp_) {
-      return {.mismatched_cached_timestamp = cache.durability_commit_timestamp_};
-    }
-    return {.accessor = std::move(cache.commit_accessor_)};
-  });
+  // Extract the cached accessor out of the slot; everything that walks its deltas or touches
+  // engine_lock_ happens below, on the local, with the cache's internal lock already released --
+  // see TwoPCCommitCache::TakeMatching's declaration comment for the mismatch-leaves-it-populated
+  // contract.
+  auto extracted = dbms::TwoPCCommitCache::Instance().TakeMatching(req.durability_commit_timestamp);
 
   // In this handler, we can either commit or abort. If cached accessor is nullptr, it is impossible we should commit
   // because replying to prepare happens after assignment to the accessor
   // If cached accessor is nullptr, and we should abort (e.g. exception was thrown while processing deltas), we can
   // safely return here OK because it means that the abort already happened while destructing accessor during
   // ReadAndApplyDeltasSingleTxn
-  if (!extracted.accessor && !extracted.mismatched_cached_timestamp) {
+  if (!extracted.accessor && !extracted.mismatched_durability_commit_timestamp) {
     spdlog::warn("Cached commit accessor became invalid between two phases");
     storage::replication::FinalizeCommitRes const res(true);
     rpc::SendFinalResponse(res, request_version, res_builder);
     return;
   }
 
-  if (extracted.mismatched_cached_timestamp) {
+  if (extracted.mismatched_durability_commit_timestamp) {
     spdlog::warn("Trying to finalize txn with ldt {} but the last prepared txn is with ldt {}",
                  req.durability_commit_timestamp,
-                 *extracted.mismatched_cached_timestamp);
+                 *extracted.mismatched_durability_commit_timestamp);
     storage::replication::FinalizeCommitRes const res(true);
     rpc::SendFinalResponse(res, request_version, res_builder);
     return;
@@ -669,11 +603,9 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
 }
 
 void InMemoryReplicationHandlers::DestroyReplAccessor(rpc::ProgressHeartbeat *heartbeat) {
-  // Extract under the cache lock, then abort the local outside it -- AbortAndResetCommitTs() walks
-  // the transaction's deltas and must not run with the cache mutex held.
-  auto accessor = TwoPCCacheSlot().WithLock([](TwoPCCache &cache) -> std::unique_ptr<storage::ReplicationAccessor> {
-    return std::move(cache.commit_accessor_);
-  });
+  // Extract under the cache's internal lock, then abort the local outside it -- AbortAndResetCommitTs()
+  // walks the transaction's deltas and must not run with the cache mutex held.
+  auto accessor = dbms::TwoPCCommitCache::Instance().TakeAny();
   if (accessor) {
     auto const on_progress = [heartbeat]() -> storage::ProgressCallback {
       if (heartbeat == nullptr) return {};
@@ -685,15 +617,10 @@ void InMemoryReplicationHandlers::DestroyReplAccessor(rpc::ProgressHeartbeat *he
 
 void InMemoryReplicationHandlers::AbortTwoPCForTenant(utils::UUID const &uuid) {
   // TD-3': single global 2PC slot — only abort it when the cached accessor is this tenant's, else a
-  // pending 2PC for a different tenant would be wrongly dropped. The comparison uses the uuid_
-  // captured at populate time (see the TwoPCCache definition above), not one re-derived from the
-  // accessor.
-  auto accessor = TwoPCCacheSlot().WithLock([&](TwoPCCache &cache) -> std::unique_ptr<storage::ReplicationAccessor> {
-    if (cache.commit_accessor_ && cache.uuid_ == uuid) {
-      return std::move(cache.commit_accessor_);
-    }
-    return nullptr;
-  });
+  // pending 2PC for a different tenant would be wrongly dropped. See TwoPCCommitCache::TakeForTenant's
+  // declaration comment for why the comparison uses the uuid captured at populate time, not one
+  // re-derived from the accessor.
+  auto accessor = dbms::TwoPCCommitCache::Instance().TakeForTenant(uuid);
   if (accessor) {
     accessor->AbortAndResetCommitTs();
   }

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -229,9 +229,59 @@ void LogWrongMain(utils::UUID const &current_main_uuid, const utils::UUID &main_
                 std::string(current_main_uuid));
 }
 
-}  // namespace
+// Single global slot holding the in-flight 2PC commit accessor between PrepareCommitRpc and
+// FinalizeCommitRpc (see AbortTwoPCForTenant's declaration comment for why it is a single slot).
+struct TwoPCCache {
+  std::unique_ptr<storage::ReplicationAccessor> commit_accessor_;
+  uint64_t durability_commit_timestamp_{};
+  // Captured from storage->uuid() when the slot is populated (PrepareCommitHandler), never
+  // re-derived from commit_accessor_->uuid(). Accessor::uuid() forwards to storage_->uuid()
+  // (storage.hpp:846), and every guard that consults this field exists precisely for the case
+  // where that Storage may already be gone (e.g. AbortTwoPCForTenant runs from the tenant-drop
+  // path) -- asking the accessor who it belongs to would be the very use-after-free the guard is
+  // meant to prevent.
+  utils::UUID uuid_{};
 
-TwoPCCache InMemoryReplicationHandlers::two_pc_cache_;
+  TwoPCCache() = default;
+  TwoPCCache(TwoPCCache &&) = default;
+  TwoPCCache(TwoPCCache const &) = delete;
+  // Assignment is deleted deliberately: an implicitly-generated member-wise move-assignment runs
+  // in forward declaration order, which for any future member owning a lifetime/scope token would
+  // release that token before commit_accessor_ (whose ~InMemoryAccessor dereferences storage_) is
+  // destroyed. Deleting assignment forces every mutation through explicit per-member assignment or
+  // extract-then-clear, turning the ordering into a compile-time constraint instead of a
+  // convention someone can silently break.
+  TwoPCCache &operator=(TwoPCCache &&) = delete;
+  TwoPCCache &operator=(TwoPCCache const &) = delete;
+};
+
+// Guards TwoPCCache. Discipline: EXTRACT the accessor out of the slot while holding this lock,
+// then run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on the extracted local
+// OUTSIDE the lock -- those walk the whole transaction's deltas and take engine_lock_, and this
+// lock must never be held across that. This is hardening, not a fix for a live race: today the
+// replica RPC server is single-threaded (kReplicationServerThreads = 1, replication_server.cpp:28)
+// and the two cross-thread callers (AbortTwoPCForTenant off the tenant-drop path) are serialised
+// against the RPC thread by a real thread join.
+//
+// Heap-allocated and deliberately never freed -- one slot for the whole process, holding at most
+// one accessor, so the leak is bounded. Two reasons this matters, both load-bearing:
+//  1. No static destructor. A static object here that is still populated at process exit would be
+//     destroyed after main() returns, i.e. after every Database/InMemoryStorage is already gone,
+//     and destroying the cached ReplicationAccessor then dereferences freed storage
+//     (~InMemoryAccessor calls Abort()/FinalizeTransaction(); ~ResourceLockGuard unlocks a freed
+//     main_lock_). main's shutdown path already clears this slot in order while the storages are
+//     alive; leaking the slot only matters for paths that bypass that ordered clear, where not
+//     aborting is strictly safer than aborting against freed memory.
+//  2. No cross-TU destruction-order dependency. ~Database (dbms/database.cpp) calls
+//     AbortTwoPCForTenant, and destruction order across translation units is unspecified, so a
+//     Database with static storage duration could otherwise reach a static slot here after it had
+//     already been destroyed.
+auto TwoPCCacheSlot() -> utils::Synchronized<TwoPCCache, std::mutex> & {
+  static auto *slot = new utils::Synchronized<TwoPCCache, std::mutex>{};
+  return *slot;
+}
+
+}  // namespace
 
 void InMemoryReplicationHandlers::Register(
     dbms::DbmsHandler *dbms_handler,
@@ -510,11 +560,13 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
     heartbeat.Stop();
 
     if (deltas_res) {
-      two_pc_cache_.commit_accessor_ = std::move(deltas_res->commit_acc);
-      two_pc_cache_.durability_commit_timestamp_ = req.durability_commit_timestamp;
+      TwoPCCacheSlot().WithLock([&](TwoPCCache &cache) {
+        cache.commit_accessor_ = std::move(deltas_res->commit_acc);
+        cache.durability_commit_timestamp_ = req.durability_commit_timestamp;
+        cache.uuid_ = storage->uuid();
+      });
       res.success = true;
     }
-  }
   rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
 }
 
@@ -541,27 +593,47 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
 
   const memory::DbArenaScope db_arena_scope{db_acc->get()};
 
+  // Extract the cached accessor out of the slot while holding the cache lock; everything that
+  // walks its deltas or touches engine_lock_ happens below, on the local, with the lock released.
+  // mismatched_cached_timestamp is only set when the slot stayed populated (mismatch path below
+  // must NOT clear it -- unlike the "missing" case, this is not treated as terminal by the caller).
+  struct CacheExtractResult {
+    std::unique_ptr<storage::ReplicationAccessor> accessor;  // non-null only once timestamps matched
+    std::optional<uint64_t> mismatched_cached_timestamp;
+  };
+
+  auto extracted = TwoPCCacheSlot().WithLock([&](TwoPCCache &cache) -> CacheExtractResult {
+    if (!cache.commit_accessor_) {
+      return {};
+    }
+    if (req.durability_commit_timestamp != cache.durability_commit_timestamp_) {
+      return {.mismatched_cached_timestamp = cache.durability_commit_timestamp_};
+    }
+    return {.accessor = std::move(cache.commit_accessor_)};
+  });
+
   // In this handler, we can either commit or abort. If cached accessor is nullptr, it is impossible we should commit
   // because replying to prepare happens after assignment to the accessor
   // If cached accessor is nullptr, and we should abort (e.g. exception was thrown while processing deltas), we can
   // safely return here OK because it means that the abort already happened while destructing accessor during
   // ReadAndApplyDeltasSingleTxn
-  if (!two_pc_cache_.commit_accessor_) {
+  if (!extracted.accessor && !extracted.mismatched_cached_timestamp) {
     spdlog::warn("Cached commit accessor became invalid between two phases");
     storage::replication::FinalizeCommitRes const res(true);
     rpc::SendFinalResponse(res, request_version, res_builder);
     return;
   }
 
-  if (req.durability_commit_timestamp != two_pc_cache_.durability_commit_timestamp_) {
+  if (extracted.mismatched_cached_timestamp) {
     spdlog::warn("Trying to finalize txn with ldt {} but the last prepared txn is with ldt {}",
                  req.durability_commit_timestamp,
-                 two_pc_cache_.durability_commit_timestamp_);
+                 *extracted.mismatched_cached_timestamp);
     storage::replication::FinalizeCommitRes const res(true);
     rpc::SendFinalResponse(res, request_version, res_builder);
     return;
   }
 
+  auto commit_accessor = std::move(extracted.accessor);
   auto *mem_storage = static_cast<storage::InMemoryStorage *>(db_acc->get()->storage());
 
   if (req.decision) {
@@ -574,20 +646,20 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
     // This has another consequence. A WAL file will contain deltas with commit ts e.g 100 although the last durable
     // timestamp for the transaction which commits these deltas will be different because of the fact that we are
     // taking here another commit timestamp.
-    auto &commit_ts = two_pc_cache_.commit_accessor_->GetCommitTimestamp();
+    auto &commit_ts = commit_accessor->GetCommitTimestamp();
     DMG_ASSERT(commit_ts.has_value(), "Commit ts without a value");
     auto guard = std::lock_guard{mem_storage->engine_lock_};
     // Mark the old commit ts as finished before emplacing the new one
     mem_storage->commit_log_->MarkFinished(*commit_ts);
     commit_ts.emplace(mem_storage->GetCommitTimestamp());
-    two_pc_cache_.commit_accessor_->FinalizeCommitPhase(req.durability_commit_timestamp);
+    commit_accessor->FinalizeCommitPhase(req.durability_commit_timestamp);
     spdlog::trace("Finalized txn on replica");
   } else {
-    two_pc_cache_.commit_accessor_->AbortAndResetCommitTs();
+    commit_accessor->AbortAndResetCommitTs();
     spdlog::trace("Aborted txn on replica");
   }
 
-  two_pc_cache_.commit_accessor_.reset();
+  commit_accessor.reset();
   if (mem_storage->wal_file_) {
     mem_storage->FinalizeWalFile();
   }
@@ -597,21 +669,33 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
 }
 
 void InMemoryReplicationHandlers::DestroyReplAccessor(rpc::ProgressHeartbeat *heartbeat) {
-  if (two_pc_cache_.commit_accessor_) {
+  // Extract under the cache lock, then abort the local outside it -- AbortAndResetCommitTs() walks
+  // the transaction's deltas and must not run with the cache mutex held.
+  auto accessor = TwoPCCacheSlot().WithLock([](TwoPCCache &cache) -> std::unique_ptr<storage::ReplicationAccessor> {
+    return std::move(cache.commit_accessor_);
+  });
+  if (accessor) {
     auto const on_progress = [heartbeat]() -> storage::ProgressCallback {
       if (heartbeat == nullptr) return {};
       return [heartbeat] { heartbeat->RecordProgress(); };
     }();
-    two_pc_cache_.commit_accessor_->AbortAndResetCommitTs(on_progress);
-    two_pc_cache_.commit_accessor_.reset();
+    accessor->AbortAndResetCommitTs(on_progress);
   }
 }
 
 void InMemoryReplicationHandlers::AbortTwoPCForTenant(utils::UUID const &uuid) {
   // TD-3': single global 2PC slot — only abort it when the cached accessor is this tenant's, else a
-  // pending 2PC for a different tenant would be wrongly dropped. uuid() == storage_->uuid().
-  if (two_pc_cache_.commit_accessor_ && two_pc_cache_.commit_accessor_->uuid() == uuid) {
-    DestroyReplAccessor();
+  // pending 2PC for a different tenant would be wrongly dropped. The comparison uses the uuid_
+  // captured at populate time (see the TwoPCCache definition above), not one re-derived from the
+  // accessor.
+  auto accessor = TwoPCCacheSlot().WithLock([&](TwoPCCache &cache) -> std::unique_ptr<storage::ReplicationAccessor> {
+    if (cache.commit_accessor_ && cache.uuid_ == uuid) {
+      return std::move(cache.commit_accessor_);
+    }
+    return nullptr;
+  });
+  if (accessor) {
+    accessor->AbortAndResetCommitTs();
   }
 }
 

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -43,24 +43,25 @@ class InMemoryReplicationHandlers {
 
   // If the connection between MAIN and REPLICA dies just after sending PrepareCommitRes and receiving
   // FinalizeCommitReq, then there is the possibility that the cached_commit_accessor_ will stay alive for too long
-  // preventing therefore processing of CurrentWalRpc, WalFilesRpc, SnapshotRpc.
+  // preventing therefore processing of CurrentWalRpc, WalFilesRpc, SnapshotRpc. Scoped to `storage`'s own uuid
+  // (via AbortTwoPCForTenant) because the cached accessor holds main_lock_ on its own storage, so it can only
+  // ever block that same tenant's recovery -- nothing is lost by not aborting other tenants' pending 2PCs here.
   // It should also be invoked during the promote
   static void AbortPrevTxnIfNeeded(storage::InMemoryStorage *storage, rpc::ProgressHeartbeat *heartbeat = nullptr);
 
-  // Destroys repl accessor needed for 2PC
-  // `on_progress` is reported per delta undone: an interrupted 2PC leaves an abort that is O(deltas), and
-  // callers run it inside an RPC handler whose peer is timing them.
-  static void DestroyReplAccessor(rpc::ProgressHeartbeat *heartbeat = nullptr);
+  // Aborts + destroys whatever accessor is cached, regardless of tenant. Deliberately tenant-oblivious,
+  // so only safe once the replica RPC listener pool is joined (process shutdown, main promotion) -- otherwise
+  // it can steal another tenant's still-pending accessor and abort it concurrently with that tenant's teardown.
+  static void DestroyReplAccessor();
 
-  // TD-3': abort + reset the cached 2PC commit accessor ONLY if it belongs to the given tenant's
-  // storage. Invoked by the replica SuspendDatabaseRpc apply path before the tenant is torn down:
-  // the cached accessor is storage-level (not gatekeeper-counted), so the suspend freeze does not
-  // drain it, and destroying the storage with the accessor still cached would dangle it. The slot
-  // is a single global (not per-UUID), so the UUID check prevents wrongly aborting a pending 2PC for
-  // a different tenant. The UUID compared against is the one captured when the slot was populated,
-  // not re-derived from the accessor -- see TwoPCCommitCache (dbms/inmemory/two_pc_commit_cache.hpp)
-  // for why.
-  static void AbortTwoPCForTenant(utils::UUID const &uuid);
+  // Abort + reset the cached 2PC commit accessor ONLY if it belongs to `uuid`. The slot is a single
+  // global, not per-tenant, so this is what every tenant-aware call site (AbortPrevTxnIfNeeded,
+  // PrepareCommitHandler, the suspend path) uses instead of DestroyReplAccessor to avoid dropping a
+  // different tenant's pending 2PC. `heartbeat`, when set, is pinged per delta undone so a large abort
+  // (an interrupted 2PC's abort is O(deltas)) does not stall the RPC peer timing the handler. See
+  // TwoPCCommitCache (dbms/inmemory/two_pc_commit_cache.hpp) for why the uuid compared against is the
+  // one captured at Store time, not re-derived from the accessor.
+  static void AbortTwoPCForTenant(utils::UUID const &uuid, rpc::ProgressHeartbeat *heartbeat = nullptr);
 
  private:
   struct LoadWalStatus {

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -28,11 +28,6 @@ class ProgressHeartbeat;
 
 namespace memgraph::dbms {
 
-struct TwoPCCache {
-  std::unique_ptr<storage::ReplicationAccessor> commit_accessor_;
-  uint64_t durability_commit_timestamp_;
-};
-
 class InMemoryReplicationHandlers {
  public:
   // Although it seems a bit unintuitive this is ok. The logic is following:
@@ -62,7 +57,8 @@ class InMemoryReplicationHandlers {
   // the cached accessor is storage-level (not gatekeeper-counted), so the suspend freeze does not
   // drain it, and destroying the storage with the accessor still cached would dangle it. The slot
   // is a single global (not per-UUID), so the UUID check prevents wrongly aborting a pending 2PC for
-  // a different tenant.
+  // a different tenant. The UUID compared against is the one captured when the slot was populated,
+  // not re-derived from the accessor -- see the cache definition in replication_handlers.cpp for why.
   static void AbortTwoPCForTenant(utils::UUID const &uuid);
 
  private:
@@ -111,8 +107,6 @@ class InMemoryReplicationHandlers {
   static std::optional<storage::SingleTxnDeltasProcessingResult> ReadAndApplyDeltasSingleTxn(
       storage::InMemoryStorage *storage, storage::durability::BaseDecoder *decoder, uint64_t version,
       rpc::ProgressHeartbeat &heartbeat, bool two_phase_commit, bool loading_wal);
-
-  static TwoPCCache two_pc_cache_;
 };
 
 }  // namespace memgraph::dbms

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -58,7 +58,8 @@ class InMemoryReplicationHandlers {
   // drain it, and destroying the storage with the accessor still cached would dangle it. The slot
   // is a single global (not per-UUID), so the UUID check prevents wrongly aborting a pending 2PC for
   // a different tenant. The UUID compared against is the one captured when the slot was populated,
-  // not re-derived from the accessor -- see the cache definition in replication_handlers.cpp for why.
+  // not re-derived from the accessor -- see TwoPCCommitCache (dbms/inmemory/two_pc_commit_cache.hpp)
+  // for why.
   static void AbortTwoPCForTenant(utils::UUID const &uuid);
 
  private:

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -40,11 +40,6 @@ auto TwoPCCommitCache::Slot() -> utils::Synchronized<Record, std::mutex> & {
   return *slot;
 }
 
-auto TwoPCCommitCache::Instance() -> TwoPCCommitCache & {
-  static auto *instance = new TwoPCCommitCache{};
-  return *instance;
-}
-
 void TwoPCCommitCache::Store(std::unique_ptr<storage::ReplicationAccessor> accessor,
                              uint64_t durability_commit_timestamp, utils::UUID uuid) {
   // Extract any pre-existing accessor instead of move-assigning over it in place: destroying it

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -59,7 +59,7 @@ TwoPCCommitCache::Owner::~Owner() {
       spdlog::error(
           "TwoPCCommitCache::~Owner: slot still populated at shutdown -- leaking the accessor rather than aborting "
           "it against freed storage.");
-      (void)cache.commit_accessor_.release();
+      [[maybe_unused]] auto *const leaked = cache.commit_accessor_.release();
     }
   });
   delete slot;

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -1,0 +1,89 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "dbms/inmemory/two_pc_commit_cache.hpp"
+
+#include "storage/v2/inmemory/storage.hpp"
+
+#include <utility>
+
+namespace memgraph::dbms {
+
+// Backing storage for the slot: the cached accessor plus enough metadata to validate and scope
+// it. See TwoPCCommitCache's class comment (two_pc_commit_cache.hpp) for the slot's overall
+// lifetime discipline.
+struct TwoPCCommitCache::Record {
+  std::unique_ptr<storage::ReplicationAccessor> commit_accessor_;
+  uint64_t durability_commit_timestamp_{};
+  // Captured from storage->uuid() when the slot is populated (Store), never re-derived from
+  // commit_accessor_->uuid() -- see Store's declaration comment in two_pc_commit_cache.hpp for
+  // why.
+  utils::UUID uuid_{};
+
+  Record() = default;
+  Record(Record &&) = default;
+  Record(Record const &) = delete;
+  // Assignment is deleted deliberately: an implicitly-generated member-wise move-assignment runs
+  // in forward declaration order, which for any future member owning a lifetime/scope token would
+  // release that token before commit_accessor_ (whose ~InMemoryAccessor dereferences storage_) is
+  // destroyed. Deleting assignment forces every mutation through explicit per-member assignment or
+  // extract-then-clear, turning the ordering into a compile-time constraint instead of a
+  // convention someone can silently break.
+  Record &operator=(Record &&) = delete;
+  Record &operator=(Record const &) = delete;
+};
+
+auto TwoPCCommitCache::Slot() -> utils::Synchronized<Record, std::mutex> & {
+  static auto *slot = new utils::Synchronized<Record, std::mutex>{};
+  return *slot;
+}
+
+auto TwoPCCommitCache::Instance() -> TwoPCCommitCache & {
+  static auto *instance = new TwoPCCommitCache{};
+  return *instance;
+}
+
+void TwoPCCommitCache::Store(std::unique_ptr<storage::ReplicationAccessor> accessor,
+                             uint64_t durability_commit_timestamp, utils::UUID uuid) {
+  Slot().WithLock([&](Record &cache) {
+    cache.commit_accessor_ = std::move(accessor);
+    cache.durability_commit_timestamp_ = durability_commit_timestamp;
+    cache.uuid_ = uuid;
+  });
+}
+
+auto TwoPCCommitCache::TakeMatching(uint64_t durability_commit_timestamp) -> Taken {
+  return Slot().WithLock([&](Record &cache) -> Taken {
+    if (!cache.commit_accessor_) {
+      return {};
+    }
+    if (durability_commit_timestamp != cache.durability_commit_timestamp_) {
+      return {.mismatched_durability_commit_timestamp = cache.durability_commit_timestamp_};
+    }
+    return {.accessor = std::move(cache.commit_accessor_)};
+  });
+}
+
+auto TwoPCCommitCache::TakeForTenant(utils::UUID const &uuid) -> std::unique_ptr<storage::ReplicationAccessor> {
+  return Slot().WithLock([&](Record &cache) -> std::unique_ptr<storage::ReplicationAccessor> {
+    if (cache.commit_accessor_ && cache.uuid_ == uuid) {
+      return std::move(cache.commit_accessor_);
+    }
+    return nullptr;
+  });
+}
+
+auto TwoPCCommitCache::TakeAny() -> std::unique_ptr<storage::ReplicationAccessor> {
+  return Slot().WithLock(
+      [](Record &cache) -> std::unique_ptr<storage::ReplicationAccessor> { return std::move(cache.commit_accessor_); });
+}
+
+}  // namespace memgraph::dbms

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -12,6 +12,7 @@
 #include "dbms/inmemory/two_pc_commit_cache.hpp"
 
 #include "storage/v2/inmemory/storage.hpp"
+#include "utils/logging.hpp"
 
 #include <utility>
 
@@ -33,9 +34,38 @@ struct TwoPCCommitCache::Record {
   Record &operator=(Record const &) = delete;
 };
 
+utils::Synchronized<TwoPCCommitCache::Record, std::mutex> *TwoPCCommitCache::installed_slot_ = nullptr;
+
 auto TwoPCCommitCache::Slot() -> utils::Synchronized<Record, std::mutex> & {
-  static auto *slot = new utils::Synchronized<Record, std::mutex>{};
-  return *slot;
+  if (installed_slot_ != nullptr) return *installed_slot_;
+  // No Owner installed (unit tests, embedded use): fall back to a lazily-created, leaked singleton --
+  // the lifetime the whole slot used to have. Production installs an Owner in main() before any
+  // replica RPC can populate the slot, so this branch is never taken there.
+  static auto *fallback = new utils::Synchronized<Record, std::mutex>{};
+  return *fallback;
+}
+
+TwoPCCommitCache::Owner::Owner() {
+  MG_ASSERT(installed_slot_ == nullptr, "TwoPCCommitCache::Owner constructed more than once");
+  installed_slot_ = new utils::Synchronized<Record, std::mutex>{};
+}
+
+TwoPCCommitCache::Owner::~Owner() {
+  auto *slot = std::exchange(installed_slot_, nullptr);
+  if (slot == nullptr) return;
+  // The ordered ~Database drain (dbms/database.cpp) should have emptied the slot before we get here.
+  // If anything is somehow still cached its storage is already gone, so DESTROYING the accessor would
+  // be a use-after-free -- detach and leak it (release()) instead, exactly as the old never-freed slot
+  // did implicitly. Only then free the now-empty Synchronized shell.
+  slot->WithLock([](Record &cache) {
+    if (cache.commit_accessor_) {
+      spdlog::error(
+          "TwoPCCommitCache::~Owner: slot still populated at shutdown -- leaking the accessor rather than aborting "
+          "it against freed storage.");
+      (void)cache.commit_accessor_.release();
+    }
+  });
+  delete slot;
 }
 
 void TwoPCCommitCache::Store(std::unique_ptr<storage::ReplicationAccessor> accessor,

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -50,19 +50,25 @@ TwoPCCommitCache::Owner::Owner() {
 }
 
 TwoPCCommitCache::Owner::~Owner() {
-  auto *slot = std::exchange(installed_slot_, nullptr);
-  if (slot == nullptr) return;
-  // ~Database drain (dbms/database.cpp) should have emptied the slot. If not, storage is gone and
-  // DESTROYING the accessor would be a use-after-free -- release() without calling Abort() instead.
-  slot->WithLock([](Record &cache) {
-    if (cache.commit_accessor_) {
-      spdlog::error(
-          "TwoPCCommitCache::~Owner: slot still populated at shutdown -- leaking the accessor rather than aborting "
-          "it against freed storage.");
-      [[maybe_unused]] auto *const leaked = cache.commit_accessor_.release();
-    }
-  });
-  delete slot;
+  // A destructor is implicitly noexcept, so an escaping exception (mutex-lock failure, spdlog OOM)
+  // would std::terminate. This is best-effort shutdown teardown -- swallow it; a leak beats a crash.
+  try {
+    auto *slot = std::exchange(installed_slot_, nullptr);
+    if (slot == nullptr) return;
+    // ~Database drain (dbms/database.cpp) should have emptied the slot. If not, storage is gone and
+    // DESTROYING the accessor would be a use-after-free -- release() without calling Abort() instead.
+    slot->WithLock([](Record &cache) {
+      if (cache.commit_accessor_) {
+        spdlog::error(
+            "TwoPCCommitCache::~Owner: slot still populated at shutdown -- leaking the accessor rather than aborting "
+            "it against freed storage.");
+        [[maybe_unused]] auto *const leaked = cache.commit_accessor_.release();
+      }
+    });
+    delete slot;
+  } catch (...) {
+    // Nothing safe left to do during teardown.
+  }
 }
 
 void TwoPCCommitCache::Store(std::unique_ptr<storage::ReplicationAccessor> accessor,

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -53,11 +53,19 @@ auto TwoPCCommitCache::Instance() -> TwoPCCommitCache & {
 
 void TwoPCCommitCache::Store(std::unique_ptr<storage::ReplicationAccessor> accessor,
                              uint64_t durability_commit_timestamp, utils::UUID uuid) {
-  Slot().WithLock([&](Record &cache) {
+  // Extract any pre-existing accessor out of the lambda instead of move-assigning over it in
+  // place: a populated slot here would otherwise be destroyed while the lock is held, and
+  // ~InMemoryAccessor runs Abort(), which takes engine_lock_. A non-null `stale` means a caller
+  // skipped the abort that is supposed to precede a re-populate, so this is a safety net rather
+  // than an expected path.
+  auto stale = Slot().WithLock([&](Record &cache) {
+    auto stale = std::move(cache.commit_accessor_);
     cache.commit_accessor_ = std::move(accessor);
     cache.durability_commit_timestamp_ = durability_commit_timestamp;
     cache.uuid_ = uuid;
+    return stale;
   });
+  // `stale` destructs here, with the lock released.
 }
 
 auto TwoPCCommitCache::TakeMatching(uint64_t durability_commit_timestamp) -> Taken {

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -17,8 +17,6 @@
 
 namespace memgraph::dbms {
 
-// Backing storage for the slot: the cached accessor plus metadata to validate and scope it. See
-// TwoPCCommitCache's class comment (two_pc_commit_cache.hpp) for the lifetime discipline.
 struct TwoPCCommitCache::Record {
   std::unique_ptr<storage::ReplicationAccessor> commit_accessor_;
   uint64_t durability_commit_timestamp_{};

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -66,8 +66,9 @@ TwoPCCommitCache::Owner::~Owner() {
       }
     });
     delete slot;
+    // NOLINTNEXTLINE(bugprone-empty-catch): intentional silent swallow -- see the note above; a
+    // destructor must not throw, and at process teardown there is nothing safe left to do.
   } catch (...) {
-    // Nothing safe left to do during teardown.
   }
 }
 

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -17,26 +17,20 @@
 
 namespace memgraph::dbms {
 
-// Backing storage for the slot: the cached accessor plus enough metadata to validate and scope
-// it. See TwoPCCommitCache's class comment (two_pc_commit_cache.hpp) for the slot's overall
-// lifetime discipline.
+// Backing storage for the slot: the cached accessor plus metadata to validate and scope it. See
+// TwoPCCommitCache's class comment (two_pc_commit_cache.hpp) for the lifetime discipline.
 struct TwoPCCommitCache::Record {
   std::unique_ptr<storage::ReplicationAccessor> commit_accessor_;
   uint64_t durability_commit_timestamp_{};
-  // Captured from storage->uuid() when the slot is populated (Store), never re-derived from
-  // commit_accessor_->uuid() -- see Store's declaration comment in two_pc_commit_cache.hpp for
-  // why.
+  // Captured from storage->uuid() by Store, never re-derived from commit_accessor_->uuid() --
+  // see Store's declaration comment in two_pc_commit_cache.hpp for why.
   utils::UUID uuid_{};
 
   Record() = default;
   Record(Record &&) = default;
   Record(Record const &) = delete;
-  // Assignment is deleted deliberately: an implicitly-generated member-wise move-assignment runs
-  // in forward declaration order, which for any future member owning a lifetime/scope token would
-  // release that token before commit_accessor_ (whose ~InMemoryAccessor dereferences storage_) is
-  // destroyed. Deleting assignment forces every mutation through explicit per-member assignment or
-  // extract-then-clear, turning the ordering into a compile-time constraint instead of a
-  // convention someone can silently break.
+  // Deleted deliberately: implicit member-wise move-assignment could release a future
+  // lifetime-owning member out of order relative to commit_accessor_'s destruction.
   Record &operator=(Record &&) = delete;
   Record &operator=(Record const &) = delete;
 };
@@ -53,11 +47,8 @@ auto TwoPCCommitCache::Instance() -> TwoPCCommitCache & {
 
 void TwoPCCommitCache::Store(std::unique_ptr<storage::ReplicationAccessor> accessor,
                              uint64_t durability_commit_timestamp, utils::UUID uuid) {
-  // Extract any pre-existing accessor out of the lambda instead of move-assigning over it in
-  // place: a populated slot here would otherwise be destroyed while the lock is held, and
-  // ~InMemoryAccessor runs Abort(), which takes engine_lock_. A non-null `stale` means a caller
-  // skipped the abort that is supposed to precede a re-populate, so this is a safety net rather
-  // than an expected path.
+  // Extract any pre-existing accessor instead of move-assigning over it in place: destroying it
+  // under the lock would run ~InMemoryAccessor's Abort(), which takes engine_lock_.
   auto stale = Slot().WithLock([&](Record &cache) {
     auto stale = std::move(cache.commit_accessor_);
     cache.commit_accessor_ = std::move(accessor);
@@ -65,7 +56,6 @@ void TwoPCCommitCache::Store(std::unique_ptr<storage::ReplicationAccessor> acces
     cache.uuid_ = uuid;
     return stale;
   });
-  // `stale` destructs here, with the lock released.
 }
 
 auto TwoPCCommitCache::TakeMatching(uint64_t durability_commit_timestamp) -> Taken {

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -66,9 +66,9 @@ TwoPCCommitCache::Owner::~Owner() {
       }
     });
     delete slot;
-    // NOLINTNEXTLINE(bugprone-empty-catch): intentional silent swallow -- see the note above; a
-    // destructor must not throw, and at process teardown there is nothing safe left to do.
-  } catch (...) {
+    // Intentional silent swallow: a destructor must not throw (see the note above), and at process
+    // teardown there is nothing safe left to do.
+  } catch (...) {  // NOLINT(bugprone-empty-catch)
   }
 }
 

--- a/src/dbms/inmemory/two_pc_commit_cache.cpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.cpp
@@ -38,9 +38,8 @@ utils::Synchronized<TwoPCCommitCache::Record, std::mutex> *TwoPCCommitCache::ins
 
 auto TwoPCCommitCache::Slot() -> utils::Synchronized<Record, std::mutex> & {
   if (installed_slot_ != nullptr) return *installed_slot_;
-  // No Owner installed (unit tests, embedded use): fall back to a lazily-created, leaked singleton --
-  // the lifetime the whole slot used to have. Production installs an Owner in main() before any
-  // replica RPC can populate the slot, so this branch is never taken there.
+  // No Owner installed (unit tests, embedded use): lazily-created leaked singleton fallback.
+  // Production installs an Owner before any replica RPC, so this path is never taken there.
   static auto *fallback = new utils::Synchronized<Record, std::mutex>{};
   return *fallback;
 }
@@ -53,10 +52,8 @@ TwoPCCommitCache::Owner::Owner() {
 TwoPCCommitCache::Owner::~Owner() {
   auto *slot = std::exchange(installed_slot_, nullptr);
   if (slot == nullptr) return;
-  // The ordered ~Database drain (dbms/database.cpp) should have emptied the slot before we get here.
-  // If anything is somehow still cached its storage is already gone, so DESTROYING the accessor would
-  // be a use-after-free -- detach and leak it (release()) instead, exactly as the old never-freed slot
-  // did implicitly. Only then free the now-empty Synchronized shell.
+  // ~Database drain (dbms/database.cpp) should have emptied the slot. If not, storage is gone and
+  // DESTROYING the accessor would be a use-after-free -- release() without calling Abort() instead.
   slot->WithLock([](Record &cache) {
     if (cache.commit_accessor_) {
       spdlog::error(

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -61,12 +61,11 @@ class TwoPCCommitCache {
   TwoPCCommitCache &operator=(TwoPCCommitCache const &) = delete;
   TwoPCCommitCache &operator=(TwoPCCommitCache &&) = delete;
 
-  // Populates the slot, capturing the tenant uuid alongside the accessor. Captured from
-  // storage->uuid() at call time, never re-derived later from accessor->uuid(): Accessor::uuid()
-  // forwards to storage_->uuid() (storage.hpp:846), and every guard that consults the captured
-  // uuid exists precisely for the case where that Storage may already be gone (e.g.
-  // TakeForTenant runs from the tenant-drop path) -- asking the accessor who it belongs to would
-  // be the very use-after-free the guard is meant to prevent.
+  // Populates the slot, capturing the tenant uuid from storage->uuid() rather than deriving it
+  // later from accessor->uuid() (storage_->uuid(), storage.hpp:846). This decouples the uuid
+  // checks in TakeForTenant/TakeMatching from relying on cross-file destroy-before-extract
+  // ordering holding at every call site -- robustness, not a fix for a currently-reachable
+  // use-after-free.
   void Store(std::unique_ptr<storage::ReplicationAccessor> accessor, uint64_t durability_commit_timestamp,
              utils::UUID uuid);
 

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -79,15 +79,15 @@ class TwoPCCommitCache {
   // the cached one. On mismatch the slot is deliberately LEFT POPULATED and the cached value is
   // reported via mismatched_durability_commit_timestamp -- unlike the "missing" case (both fields
   // empty), a mismatch is not treated as terminal by the caller.
-  auto TakeMatching(uint64_t durability_commit_timestamp) -> Taken;
+  [[nodiscard]] auto TakeMatching(uint64_t durability_commit_timestamp) -> Taken;
 
   // Takes the accessor out iff it belongs to `uuid` (the uuid captured by Store, not one
   // re-derived from the accessor -- see Store's comment for why). No-op (returns nullptr)
   // otherwise, so a pending 2PC for a different tenant is not wrongly dropped.
-  auto TakeForTenant(utils::UUID const &uuid) -> std::unique_ptr<storage::ReplicationAccessor>;
+  [[nodiscard]] auto TakeForTenant(utils::UUID const &uuid) -> std::unique_ptr<storage::ReplicationAccessor>;
 
   // Takes whatever is cached, regardless of tenant.
-  auto TakeAny() -> std::unique_ptr<storage::ReplicationAccessor>;
+  [[nodiscard]] auto TakeAny() -> std::unique_ptr<storage::ReplicationAccessor>;
 
  private:
   TwoPCCommitCache() = default;

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -25,17 +25,17 @@ namespace memgraph::dbms {
 
 // Single global slot holding the in-flight 2PC commit accessor between PrepareCommitRpc and
 // FinalizeCommitRpc (see InMemoryReplicationHandlers::AbortTwoPCForTenant's declaration comment
-// in replication_handlers.hpp for why it is a single slot rather than one per tenant).
+// in dbms/inmemory/replication_handlers.hpp for why it is a single slot rather than one per tenant).
 //
-// Guards the slot with a private mutex. Discipline: EXTRACT the accessor out of the slot while
-// holding that lock, then run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on the
+// Guards the slot with a private mutex. This lock is load-bearing, not prophylactic: ~Database
+// calls AbortTwoPCForTenant, and it runs on whichever thread destroys the Database -- including
+// DeferDelete's background defer_pool_ thread (dbms/handler.hpp), which can be tearing down tenant B
+// while the replica RPC thread services tenant A. Discipline: EXTRACT the accessor out of the slot
+// while holding the lock, then run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on the
 // extracted local OUTSIDE the lock -- those walk the whole transaction's deltas and take
-// engine_lock_, and this lock must never be held across that. This is hardening, not a fix for a
-// live race: today the replica RPC server is single-threaded (kReplicationServerThreads = 1,
-// replication_server.cpp:28) and the cross-thread caller (AbortTwoPCForTenant, off the
-// tenant-drop path) is serialised against the RPC thread by a real thread join. Every public
-// method below returns with the lock released and never touches the accessor itself, so callers
-// get this discipline for free.
+// engine_lock_, and this lock must never be held across that. Every public method below returns
+// with the lock released and never touches the accessor itself, so callers get this discipline for
+// free.
 //
 // The singleton returned by Instance() is heap-allocated and deliberately never freed -- one slot
 // for the whole process, holding at most one accessor, so the leak is bounded. Two reasons this

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -23,61 +23,44 @@
 
 namespace memgraph::dbms {
 
-// Single global slot holding the in-flight 2PC commit accessor between PrepareCommitRpc and
-// FinalizeCommitRpc (see InMemoryReplicationHandlers::AbortTwoPCForTenant's declaration comment
-// in dbms/inmemory/replication_handlers.hpp for why it is a single slot rather than one per tenant).
+// Process-wide single slot holding the in-flight 2PC commit accessor between PrepareCommitRpc and
+// FinalizeCommitRpc; single slot rather than per-tenant, per AbortTwoPCForTenant's declaration
+// comment (dbms/inmemory/replication_handlers.hpp).
 //
-// Guards the slot with a private mutex. This lock is load-bearing, not prophylactic: ~Database
-// calls AbortTwoPCForTenant, and it runs on whichever thread destroys the Database -- including
-// DeferDelete's background defer_pool_ thread (dbms/handler.hpp), which can be tearing down tenant B
-// while the replica RPC thread services tenant A. Discipline: EXTRACT the accessor out of the slot
-// while holding the lock, then run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on the
-// extracted local OUTSIDE the lock -- those walk the whole transaction's deltas and take
-// engine_lock_, and this lock must never be held across that. Every public method below returns
-// with the lock released and never touches the accessor itself, so callers get this discipline for
-// free.
+// Lock discipline (load-bearing): every method EXTRACTS the accessor under the slot lock and returns
+// with the lock released; callers run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on
+// the extracted local OUTSIDE the lock. Those take engine_lock_, and the slot lock must never be held
+// across that. Concurrent because ~Database -> AbortTwoPCForTenant may run on DeferDelete's
+// defer_pool_ thread (dbms/handler.hpp) tearing down tenant B while the RPC thread serves tenant A.
 //
-// The slot (Slot(), below) is heap-allocated and deliberately never freed -- one slot for the whole
-// process, holding at most one accessor, so the leak is bounded. Two reasons this matters, both
-// load-bearing:
-//  1. No static destructor. A static object here that is still populated at process exit would be
-//     destroyed after main() returns, i.e. after every Database/InMemoryStorage is already gone,
-//     and destroying the cached ReplicationAccessor then dereferences freed storage
-//     (~InMemoryAccessor calls Abort()/FinalizeTransaction(); ~ResourceLockGuard unlocks a freed
-//     main_lock_). main's shutdown path already clears this slot in order while the storages are
-//     alive; leaking the slot only matters for paths that bypass that ordered clear, where not
-//     aborting is strictly safer than aborting against freed memory.
-//  2. No cross-TU destruction-order dependency. ~Database (dbms/database.cpp) calls
-//     AbortTwoPCForTenant, and destruction order across translation units is unspecified, so a
-//     Database with static storage duration could otherwise reach a static slot here after it had
-//     already been destroyed.
+// Slot() is heap-allocated and deliberately never freed. No static destructor: a populated static
+// slot would be destroyed after main() returns, once every Database/InMemoryStorage is gone, so
+// destroying the cached accessor would dereference freed storage. main's shutdown clears the slot in
+// order while storages are alive; on paths that bypass that, leaking (not aborting) is strictly
+// safer. Also avoids a cross-TU destruction-order dependency with ~Database (dbms/database.cpp).
 class TwoPCCommitCache {
  public:
-  // Static-only: all state lives in the process-wide Slot() (below), so the type is never instantiated.
+  // Static-only utility; all state lives in Slot().
   TwoPCCommitCache() = delete;
 
-  // Populates the slot, capturing the tenant uuid from storage->uuid() rather than deriving it
-  // later from accessor->uuid() (storage_->uuid(), storage.hpp:846). This decouples the uuid
-  // checks in TakeForTenant/TakeMatching from relying on cross-file destroy-before-extract
-  // ordering holding at every call site -- robustness, not a fix for a currently-reachable
-  // use-after-free.
+  // Captures the tenant uuid from storage->uuid() rather than re-deriving it from accessor->uuid()
+  // later, so TakeForTenant/TakeMatching don't depend on destroy-before-extract ordering at the call
+  // sites (robustness, not a fix for a reachable use-after-free).
   static void Store(std::unique_ptr<storage::ReplicationAccessor> accessor, uint64_t durability_commit_timestamp,
                     utils::UUID uuid);
 
   struct Taken {
-    std::unique_ptr<storage::ReplicationAccessor> accessor;          // non-null only when the ldt matched
+    std::unique_ptr<storage::ReplicationAccessor> accessor;          // non-null only when the timestamp matched
     std::optional<uint64_t> mismatched_durability_commit_timestamp;  // set only when the slot stayed populated
   };
 
-  // FinalizeCommitHandler's read: takes the accessor out iff `durability_commit_timestamp` matches
-  // the cached one. On mismatch the slot is deliberately LEFT POPULATED and the cached value is
-  // reported via mismatched_durability_commit_timestamp -- unlike the "missing" case (both fields
-  // empty), a mismatch is not treated as terminal by the caller.
+  // Takes the accessor out iff `durability_commit_timestamp` matches the cached one. On mismatch the
+  // slot is LEFT POPULATED and the cached value returned via mismatched_durability_commit_timestamp --
+  // distinct from the "missing" case (both fields empty), which the caller treats as terminal.
   [[nodiscard]] static auto TakeMatching(uint64_t durability_commit_timestamp) -> Taken;
 
-  // Takes the accessor out iff it belongs to `uuid` (the uuid captured by Store, not one
-  // re-derived from the accessor -- see Store's comment for why). No-op (returns nullptr)
-  // otherwise, so a pending 2PC for a different tenant is not wrongly dropped.
+  // Takes the accessor out iff it belongs to `uuid` (the uuid captured by Store; see Store).
+  // No-op returning nullptr otherwise, so a pending 2PC for a different tenant is not wrongly dropped.
   [[nodiscard]] static auto TakeForTenant(utils::UUID const &uuid) -> std::unique_ptr<storage::ReplicationAccessor>;
 
   // Takes whatever is cached, regardless of tenant.

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -24,32 +24,24 @@
 namespace memgraph::dbms {
 
 // Process-wide single slot holding the in-flight 2PC commit accessor between PrepareCommitRpc and
-// FinalizeCommitRpc; single slot rather than per-tenant, per AbortTwoPCForTenant's declaration
-// comment (dbms/inmemory/replication_handlers.hpp).
+// FinalizeCommitRpc.
 //
-// Lock discipline (load-bearing): every method EXTRACTS the accessor under the slot lock and returns
-// with the lock released; callers run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on
-// the extracted local OUTSIDE the lock. Those take engine_lock_, and the slot lock must never be held
-// across that. Concurrent because ~Database -> AbortTwoPCForTenant may run on DeferDelete's
-// defer_pool_ thread (dbms/handler.hpp) tearing down tenant B while the RPC thread serves tenant A.
+// Lock discipline (load-bearing): every method extracts the accessor under the slot lock and runs
+// AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on it OUTSIDE the lock -- those take
+// engine_lock_, which must never be held under the slot lock. ~Database -> AbortTwoPCForTenant can
+// run on the defer_pool_ thread (dbms/handler.hpp) concurrently with an RPC handler, so the slot
+// lock is what serialises them.
 //
-// Slot lifetime is owned by a single Owner (below), constructed early in main() BEFORE the
-// DbmsHandler so it is destroyed AFTER it: by then ~DbmsHandler has run every ~Database, each
-// draining its own tenant's entry (dbms/database.cpp) while its storage is still alive, so the slot
-// is empty and freeing it dereferences no storage. This replaces the older "never freed" slot, whose
-// only purpose was to dodge a static destructor running after main() once every Database was already
-// gone. A populated slot must still never be DESTROYED against dead storage, so ~Owner detaches
-// (leaks) any stray accessor instead of aborting it -- reachable only if the ordered ~Database drain
-// were bypassed. When no Owner is installed (unit tests, embedded), Slot() falls back to a lazily
-// created leaked singleton, preserving the pre-Owner behaviour for those short-lived processes.
+// The slot is owned by an RAII Owner (below) held in main(), freed before static destruction -- the
+// same pattern as utils::PageCacheReleaser. With no Owner installed (unit tests) Slot() uses a leaked
+// fallback.
 class TwoPCCommitCache {
  public:
-  // Static-only utility; all state lives in Slot().
   TwoPCCommitCache() = delete;
 
-  // RAII owner of the process-wide slot. Construct EXACTLY ONE, early in main() and BEFORE the
-  // DbmsHandler, so the slot outlives every Database yet is freed deterministically inside main()
-  // rather than at static-destruction time. See the class comment for the ordering contract.
+  // RAII owner of the process-wide slot; construct exactly one in main() BEFORE the DbmsHandler, so
+  // the slot outlives every Database and is freed only after ~DbmsHandler has drained it (~Database
+  // empties each tenant's entry while its storage is still alive).
   class Owner {
    public:
     Owner();
@@ -60,9 +52,8 @@ class TwoPCCommitCache {
     Owner &operator=(Owner &&) = delete;
   };
 
-  // Captures the tenant uuid from storage->uuid() rather than re-deriving it from accessor->uuid()
-  // later, so TakeForTenant/TakeMatching don't depend on destroy-before-extract ordering at the call
-  // sites (robustness, not a fix for a reachable use-after-free).
+  // Captures the tenant uuid at populate time rather than re-deriving it from the accessor later, so
+  // Take* never depend on destroy-before-extract ordering (robustness, not a reachable-UAF fix).
   static void Store(std::unique_ptr<storage::ReplicationAccessor> accessor, uint64_t durability_commit_timestamp,
                     utils::UUID uuid);
 

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -1,0 +1,105 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include "storage/v2/inmemory/storagefwd.hpp"
+
+#include "utils/synchronized.hpp"
+#include "utils/uuid.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+
+namespace memgraph::dbms {
+
+// Single global slot holding the in-flight 2PC commit accessor between PrepareCommitRpc and
+// FinalizeCommitRpc (see InMemoryReplicationHandlers::AbortTwoPCForTenant's declaration comment
+// in replication_handlers.hpp for why it is a single slot rather than one per tenant).
+//
+// Guards the slot with a private mutex. Discipline: EXTRACT the accessor out of the slot while
+// holding that lock, then run AbortAndResetCommitTs()/FinalizeCommitPhase()/destruction on the
+// extracted local OUTSIDE the lock -- those walk the whole transaction's deltas and take
+// engine_lock_, and this lock must never be held across that. This is hardening, not a fix for a
+// live race: today the replica RPC server is single-threaded (kReplicationServerThreads = 1,
+// replication_server.cpp:28) and the cross-thread caller (AbortTwoPCForTenant, off the
+// tenant-drop path) is serialised against the RPC thread by a real thread join. Every public
+// method below returns with the lock released and never touches the accessor itself, so callers
+// get this discipline for free.
+//
+// The singleton returned by Instance() is heap-allocated and deliberately never freed -- one slot
+// for the whole process, holding at most one accessor, so the leak is bounded. Two reasons this
+// matters, both load-bearing:
+//  1. No static destructor. A static object here that is still populated at process exit would be
+//     destroyed after main() returns, i.e. after every Database/InMemoryStorage is already gone,
+//     and destroying the cached ReplicationAccessor then dereferences freed storage
+//     (~InMemoryAccessor calls Abort()/FinalizeTransaction(); ~ResourceLockGuard unlocks a freed
+//     main_lock_). main's shutdown path already clears this slot in order while the storages are
+//     alive; leaking the slot only matters for paths that bypass that ordered clear, where not
+//     aborting is strictly safer than aborting against freed memory.
+//  2. No cross-TU destruction-order dependency. ~Database (dbms/database.cpp) calls
+//     AbortTwoPCForTenant, and destruction order across translation units is unspecified, so a
+//     Database with static storage duration could otherwise reach a static slot here after it had
+//     already been destroyed.
+class TwoPCCommitCache {
+ public:
+  // The process-wide slot. Deliberately never destroyed -- see the class comment above.
+  static auto Instance() -> TwoPCCommitCache &;
+
+  TwoPCCommitCache(TwoPCCommitCache const &) = delete;
+  TwoPCCommitCache(TwoPCCommitCache &&) = delete;
+  TwoPCCommitCache &operator=(TwoPCCommitCache const &) = delete;
+  TwoPCCommitCache &operator=(TwoPCCommitCache &&) = delete;
+
+  // Populates the slot, capturing the tenant uuid alongside the accessor. Captured from
+  // storage->uuid() at call time, never re-derived later from accessor->uuid(): Accessor::uuid()
+  // forwards to storage_->uuid() (storage.hpp:846), and every guard that consults the captured
+  // uuid exists precisely for the case where that Storage may already be gone (e.g.
+  // TakeForTenant runs from the tenant-drop path) -- asking the accessor who it belongs to would
+  // be the very use-after-free the guard is meant to prevent.
+  void Store(std::unique_ptr<storage::ReplicationAccessor> accessor, uint64_t durability_commit_timestamp,
+             utils::UUID uuid);
+
+  struct Taken {
+    std::unique_ptr<storage::ReplicationAccessor> accessor;          // non-null only when the ldt matched
+    std::optional<uint64_t> mismatched_durability_commit_timestamp;  // set only when the slot stayed populated
+  };
+
+  // FinalizeCommitHandler's read: takes the accessor out iff `durability_commit_timestamp` matches
+  // the cached one. On mismatch the slot is deliberately LEFT POPULATED and the cached value is
+  // reported via mismatched_durability_commit_timestamp -- unlike the "missing" case (both fields
+  // empty), a mismatch is not treated as terminal by the caller.
+  auto TakeMatching(uint64_t durability_commit_timestamp) -> Taken;
+
+  // Takes the accessor out iff it belongs to `uuid` (the uuid captured by Store, not one
+  // re-derived from the accessor -- see Store's comment for why). No-op (returns nullptr)
+  // otherwise, so a pending 2PC for a different tenant is not wrongly dropped.
+  auto TakeForTenant(utils::UUID const &uuid) -> std::unique_ptr<storage::ReplicationAccessor>;
+
+  // Takes whatever is cached, regardless of tenant.
+  auto TakeAny() -> std::unique_ptr<storage::ReplicationAccessor>;
+
+ private:
+  TwoPCCommitCache() = default;
+
+  // Defined in two_pc_commit_cache.cpp, where storage::ReplicationAccessor is a complete type.
+  // Kept incomplete here so this header does not have to pull in the full storage definition.
+  struct Record;
+
+  // The Synchronized<Record> instance backing the singleton, heap-allocated and never freed --
+  // see the class comment above for why. Returning it via a function (rather than a member field)
+  // lets Record stay incomplete in this header.
+  static auto Slot() -> utils::Synchronized<Record, std::mutex> &;
+};
+
+}  // namespace memgraph::dbms

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -33,15 +33,32 @@ namespace memgraph::dbms {
 // across that. Concurrent because ~Database -> AbortTwoPCForTenant may run on DeferDelete's
 // defer_pool_ thread (dbms/handler.hpp) tearing down tenant B while the RPC thread serves tenant A.
 //
-// Slot() is heap-allocated and deliberately never freed. No static destructor: a populated static
-// slot would be destroyed after main() returns, once every Database/InMemoryStorage is gone, so
-// destroying the cached accessor would dereference freed storage. main's shutdown clears the slot in
-// order while storages are alive; on paths that bypass that, leaking (not aborting) is strictly
-// safer. Also avoids a cross-TU destruction-order dependency with ~Database (dbms/database.cpp).
+// Slot lifetime is owned by a single Owner (below), constructed early in main() BEFORE the
+// DbmsHandler so it is destroyed AFTER it: by then ~DbmsHandler has run every ~Database, each
+// draining its own tenant's entry (dbms/database.cpp) while its storage is still alive, so the slot
+// is empty and freeing it dereferences no storage. This replaces the older "never freed" slot, whose
+// only purpose was to dodge a static destructor running after main() once every Database was already
+// gone. A populated slot must still never be DESTROYED against dead storage, so ~Owner detaches
+// (leaks) any stray accessor instead of aborting it -- reachable only if the ordered ~Database drain
+// were bypassed. When no Owner is installed (unit tests, embedded), Slot() falls back to a lazily
+// created leaked singleton, preserving the pre-Owner behaviour for those short-lived processes.
 class TwoPCCommitCache {
  public:
   // Static-only utility; all state lives in Slot().
   TwoPCCommitCache() = delete;
+
+  // RAII owner of the process-wide slot. Construct EXACTLY ONE, early in main() and BEFORE the
+  // DbmsHandler, so the slot outlives every Database yet is freed deterministically inside main()
+  // rather than at static-destruction time. See the class comment for the ordering contract.
+  class Owner {
+   public:
+    Owner();
+    ~Owner();
+    Owner(Owner const &) = delete;
+    Owner &operator=(Owner const &) = delete;
+    Owner(Owner &&) = delete;
+    Owner &operator=(Owner &&) = delete;
+  };
 
   // Captures the tenant uuid from storage->uuid() rather than re-deriving it from accessor->uuid()
   // later, so TakeForTenant/TakeMatching don't depend on destroy-before-extract ordering at the call
@@ -71,10 +88,13 @@ class TwoPCCommitCache {
   // Kept incomplete here so this header does not have to pull in the full storage definition.
   struct Record;
 
-  // The Synchronized<Record> backing the cache, heap-allocated and never freed -- see the class
-  // comment above for why. Returning it via a function (rather than a member field) lets Record
-  // stay incomplete in this header.
+  // The live slot: the Owner-installed one when present, else a leaked fallback (see the class
+  // comment). A member function rather than a data member so Record can stay incomplete here.
   static auto Slot() -> utils::Synchronized<Record, std::mutex> &;
+
+  // Installed by Owner's constructor, cleared by its destructor; nullptr when no Owner exists, in
+  // which case Slot() uses the fallback. Pointer-to-incomplete is fine.
+  static utils::Synchronized<Record, std::mutex> *installed_slot_;
 };
 
 }  // namespace memgraph::dbms

--- a/src/dbms/inmemory/two_pc_commit_cache.hpp
+++ b/src/dbms/inmemory/two_pc_commit_cache.hpp
@@ -37,9 +37,9 @@ namespace memgraph::dbms {
 // with the lock released and never touches the accessor itself, so callers get this discipline for
 // free.
 //
-// The singleton returned by Instance() is heap-allocated and deliberately never freed -- one slot
-// for the whole process, holding at most one accessor, so the leak is bounded. Two reasons this
-// matters, both load-bearing:
+// The slot (Slot(), below) is heap-allocated and deliberately never freed -- one slot for the whole
+// process, holding at most one accessor, so the leak is bounded. Two reasons this matters, both
+// load-bearing:
 //  1. No static destructor. A static object here that is still populated at process exit would be
 //     destroyed after main() returns, i.e. after every Database/InMemoryStorage is already gone,
 //     and destroying the cached ReplicationAccessor then dereferences freed storage
@@ -53,21 +53,16 @@ namespace memgraph::dbms {
 //     already been destroyed.
 class TwoPCCommitCache {
  public:
-  // The process-wide slot. Deliberately never destroyed -- see the class comment above.
-  static auto Instance() -> TwoPCCommitCache &;
-
-  TwoPCCommitCache(TwoPCCommitCache const &) = delete;
-  TwoPCCommitCache(TwoPCCommitCache &&) = delete;
-  TwoPCCommitCache &operator=(TwoPCCommitCache const &) = delete;
-  TwoPCCommitCache &operator=(TwoPCCommitCache &&) = delete;
+  // Static-only: all state lives in the process-wide Slot() (below), so the type is never instantiated.
+  TwoPCCommitCache() = delete;
 
   // Populates the slot, capturing the tenant uuid from storage->uuid() rather than deriving it
   // later from accessor->uuid() (storage_->uuid(), storage.hpp:846). This decouples the uuid
   // checks in TakeForTenant/TakeMatching from relying on cross-file destroy-before-extract
   // ordering holding at every call site -- robustness, not a fix for a currently-reachable
   // use-after-free.
-  void Store(std::unique_ptr<storage::ReplicationAccessor> accessor, uint64_t durability_commit_timestamp,
-             utils::UUID uuid);
+  static void Store(std::unique_ptr<storage::ReplicationAccessor> accessor, uint64_t durability_commit_timestamp,
+                    utils::UUID uuid);
 
   struct Taken {
     std::unique_ptr<storage::ReplicationAccessor> accessor;          // non-null only when the ldt matched
@@ -78,26 +73,24 @@ class TwoPCCommitCache {
   // the cached one. On mismatch the slot is deliberately LEFT POPULATED and the cached value is
   // reported via mismatched_durability_commit_timestamp -- unlike the "missing" case (both fields
   // empty), a mismatch is not treated as terminal by the caller.
-  [[nodiscard]] auto TakeMatching(uint64_t durability_commit_timestamp) -> Taken;
+  [[nodiscard]] static auto TakeMatching(uint64_t durability_commit_timestamp) -> Taken;
 
   // Takes the accessor out iff it belongs to `uuid` (the uuid captured by Store, not one
   // re-derived from the accessor -- see Store's comment for why). No-op (returns nullptr)
   // otherwise, so a pending 2PC for a different tenant is not wrongly dropped.
-  [[nodiscard]] auto TakeForTenant(utils::UUID const &uuid) -> std::unique_ptr<storage::ReplicationAccessor>;
+  [[nodiscard]] static auto TakeForTenant(utils::UUID const &uuid) -> std::unique_ptr<storage::ReplicationAccessor>;
 
   // Takes whatever is cached, regardless of tenant.
-  [[nodiscard]] auto TakeAny() -> std::unique_ptr<storage::ReplicationAccessor>;
+  [[nodiscard]] static auto TakeAny() -> std::unique_ptr<storage::ReplicationAccessor>;
 
  private:
-  TwoPCCommitCache() = default;
-
   // Defined in two_pc_commit_cache.cpp, where storage::ReplicationAccessor is a complete type.
   // Kept incomplete here so this header does not have to pull in the full storage definition.
   struct Record;
 
-  // The Synchronized<Record> instance backing the singleton, heap-allocated and never freed --
-  // see the class comment above for why. Returning it via a function (rather than a member field)
-  // lets Record stay incomplete in this header.
+  // The Synchronized<Record> backing the cache, heap-allocated and never freed -- see the class
+  // comment above for why. Returning it via a function (rather than a member field) lets Record
+  // stay incomplete in this header.
   static auto Slot() -> utils::Synchronized<Record, std::mutex> &;
 };
 

--- a/src/dbms/replication_handlers.cpp
+++ b/src/dbms/replication_handlers.cpp
@@ -82,18 +82,15 @@ void CreateDatabaseHandler(system::ReplicaHandlerAccessToState &system_state_acc
     return;
   }
 
-  // If the replica holds this name HOT under a DIFFERENT uuid, Update() below drops+recreates the local
-  // storage (Delete_ frees the OLD-uuid InMemoryStorage). That free is storage-level, not
-  // gatekeeper-counted, so nothing else drains a cached 2PC commit accessor for the OLD uuid; abort it
-  // first so a later FinalizeCommitRpc/DestroyReplAccessor for that uuid can't touch freed storage.
-  // Same-uuid Update is a no-op salient refresh, so *local != req.config.uuid keeps this from aborting an
-  // in-flight 2PC for the very tenant being created/updated (mirrors the SystemRecovery loops below).
-  // Defence-in-depth: the expected_group_timestamp gate above, plus DropDatabaseHandler already calling
-  // AbortTwoPCForTenant(req.uuid) before its own Delete(), appear to close the obvious races that would
-  // reach here with a live 2PC under the OLD uuid -- but this was the one teardown funnel in the file
-  // without the guard, and correctness here shouldn't depend on that reachability argument staying true.
-  const auto name = std::string{*req.config.name.str_view()};
-  if (const auto local = dbms_handler.GetHotUuid(name); local && *local != req.config.uuid) {
+  // Update() drops+recreates the tenant when the name exists under a DIFFERENT uuid. That drop's free is
+  // deferred, not synchronous: Update() keeps its own accessor alive across Delete_(), so DeferDelete's
+  // try_delete() sees count_ > 1 and hands the Gatekeeper to defer_pool_, which frees it on a background
+  // thread with no ordering against this RPC thread -- the actual reason to abort here, up front. The
+  // cached 2PC commit accessor is storage-level, not gatekeeper-counted, so nothing drains it before that
+  // free. Same-uuid Update is a no-op salient refresh, so *local != req.config.uuid avoids aborting an
+  // in-flight 2PC for the very tenant being created/updated. Defence-in-depth: reachability here is
+  // unproven.
+  if (const auto local = dbms_handler.GetHotUuid(*req.config.name.str_view()); local && *local != req.config.uuid) {
     InMemoryReplicationHandlers::AbortTwoPCForTenant(*local);
   }
 

--- a/src/dbms/replication_handlers.cpp
+++ b/src/dbms/replication_handlers.cpp
@@ -82,6 +82,21 @@ void CreateDatabaseHandler(system::ReplicaHandlerAccessToState &system_state_acc
     return;
   }
 
+  // If the replica holds this name HOT under a DIFFERENT uuid, Update() below drops+recreates the local
+  // storage (Delete_ frees the OLD-uuid InMemoryStorage). That free is storage-level, not
+  // gatekeeper-counted, so nothing else drains a cached 2PC commit accessor for the OLD uuid; abort it
+  // first so a later FinalizeCommitRpc/DestroyReplAccessor for that uuid can't touch freed storage.
+  // Same-uuid Update is a no-op salient refresh, so *local != req.config.uuid keeps this from aborting an
+  // in-flight 2PC for the very tenant being created/updated (mirrors the SystemRecovery loops below).
+  // Defence-in-depth: the expected_group_timestamp gate above, plus DropDatabaseHandler already calling
+  // AbortTwoPCForTenant(req.uuid) before its own Delete(), appear to close the obvious races that would
+  // reach here with a live 2PC under the OLD uuid -- but this was the one teardown funnel in the file
+  // without the guard, and correctness here shouldn't depend on that reachability argument staying true.
+  const auto name = std::string{*req.config.name.str_view()};
+  if (const auto local = dbms_handler.GetHotUuid(name); local && *local != req.config.uuid) {
+    InMemoryReplicationHandlers::AbortTwoPCForTenant(*local);
+  }
+
   try {
     // Create new
     if (auto const new_db = dbms_handler.Update(req.config); new_db.has_value()) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1197,14 +1197,13 @@ int main(int argc, char **argv) {
       }
     }
 
-    // The static 2PC commit-accessor cache (InMemoryReplicationHandlers) outlives `dbms_handler` (a local of
-    // main()) -- it has static storage duration, so without this it would still hold an accessor into a
-    // Database that main() is about to destroy, and its static destructor would use-after-free that storage.
-    // Safe here specifically: ReplicationState::Shutdown() above joins the ReplicationServer's RPC listener
-    // thread pool (Server::AwaitShutdown -> Listener::AwaitShutdown), so no handler can repopulate the slot
-    // afterwards -- same reasoning already applied in ReplicationHandler::DoToMainPromotion (see
-    // replication_handler.cpp). Left unconditional (outside the `if` above): a coordinator instance never
-    // populates this replica-only slot, so the call is a harmless no-op there.
+    // Defense-in-depth, not a UAF fix: the 2PC commit-accessor slot is a deliberately-leaked heap
+    // singleton with no static destructor (TwoPCCommitCache::Instance()/Slot()), so skipping this would
+    // just defer the abort to ~Database during ~DbmsHandler teardown instead of crashing. Doing it here
+    // aborts the in-flight prepared txn now, while storages are alive, and TakeAny() (not uuid-scoped) is
+    // safe because Shutdown() above already joined the replica's RPC worker threads, so nothing can
+    // repopulate the slot afterwards. Left unconditional: a coordinator never populates this replica-only
+    // slot, so it's a no-op there.
     memgraph::dbms::InMemoryReplicationHandlers::DestroyReplAccessor();
 
     if (dbms_handler.has_value()) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -32,6 +32,7 @@
 #include "coordination/coordinator_state.hpp"
 #include "dbms/constants.hpp"
 #include "dbms/dbms_handler.hpp"
+#include "dbms/inmemory/replication_handlers.hpp"
 #include "flags/all.hpp"
 #include "flags/bolt.hpp"
 #include "flags/coord_flag_env_handler.hpp"
@@ -1195,6 +1196,16 @@ int main(int argc, char **argv) {
         locked_repl_state->Shutdown();
       }
     }
+
+    // The static 2PC commit-accessor cache (InMemoryReplicationHandlers) outlives `dbms_handler` (a local of
+    // main()) -- it has static storage duration, so without this it would still hold an accessor into a
+    // Database that main() is about to destroy, and its static destructor would use-after-free that storage.
+    // Safe here specifically: ReplicationState::Shutdown() above joins the ReplicationServer's RPC listener
+    // thread pool (Server::AwaitShutdown -> Listener::AwaitShutdown), so no handler can repopulate the slot
+    // afterwards -- same reasoning already applied in ReplicationHandler::DoToMainPromotion (see
+    // replication_handler.cpp). Left unconditional (outside the `if` above): a coordinator instance never
+    // populates this replica-only slot, so the call is a harmless no-op there.
+    memgraph::dbms::InMemoryReplicationHandlers::DestroyReplAccessor();
 
     if (dbms_handler.has_value()) {
       dbms_handler->ForEach([](memgraph::dbms::DatabaseAccess acc) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -864,7 +864,7 @@ int main(int argc, char **argv) {
   // AFTER it: ~DbmsHandler runs every ~Database, each draining its own tenant's cached 2PC while its
   // storage is still alive, leaving an empty slot for this Owner to free. Unconditional: harmless on
   // a coordinator, which never populates the replica-only slot.
-  memgraph::dbms::TwoPCCommitCache::Owner two_pc_cache_owner;
+  const memgraph::dbms::TwoPCCommitCache::Owner two_pc_cache_owner;
 
   std::optional<memgraph::dbms::DbmsHandler> dbms_handler;
   if (!is_coordinator_instance) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1198,7 +1198,7 @@ int main(int argc, char **argv) {
     }
 
     // Defense-in-depth, not a UAF fix: the 2PC commit-accessor slot is a deliberately-leaked heap
-    // singleton with no static destructor (TwoPCCommitCache::Instance()/Slot()), so skipping this would
+    // singleton with no static destructor (TwoPCCommitCache::Slot()), so skipping this would
     // just defer the abort to ~Database during ~DbmsHandler teardown instead of crashing. Doing it here
     // aborts the in-flight prepared txn now, while storages are alive, and TakeAny() (not uuid-scoped) is
     // safe because Shutdown() above already joined the replica's RPC worker threads, so nothing can

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -32,7 +32,7 @@
 #include "coordination/coordinator_state.hpp"
 #include "dbms/constants.hpp"
 #include "dbms/dbms_handler.hpp"
-#include "dbms/inmemory/replication_handlers.hpp"
+#include "dbms/inmemory/two_pc_commit_cache.hpp"
 #include "flags/all.hpp"
 #include "flags/bolt.hpp"
 #include "flags/coord_flag_env_handler.hpp"
@@ -860,6 +860,12 @@ int main(int argc, char **argv) {
 
 #endif
 
+  // Owns the process-wide 2PC commit-accessor slot. Declared BEFORE dbms_handler so it is destroyed
+  // AFTER it: ~DbmsHandler runs every ~Database, each draining its own tenant's cached 2PC while its
+  // storage is still alive, leaving an empty slot for this Owner to free. Unconditional: harmless on
+  // a coordinator, which never populates the replica-only slot.
+  memgraph::dbms::TwoPCCommitCache::Owner two_pc_cache_owner;
+
   std::optional<memgraph::dbms::DbmsHandler> dbms_handler;
   if (!is_coordinator_instance) {
     dbms_handler.emplace(db_config);
@@ -1196,15 +1202,6 @@ int main(int argc, char **argv) {
         locked_repl_state->Shutdown();
       }
     }
-
-    // Defense-in-depth, not a UAF fix: the 2PC commit-accessor slot is a deliberately-leaked heap
-    // singleton with no static destructor (TwoPCCommitCache::Slot()), so skipping this would
-    // just defer the abort to ~Database during ~DbmsHandler teardown instead of crashing. Doing it here
-    // aborts the in-flight prepared txn now, while storages are alive, and TakeAny() (not uuid-scoped) is
-    // safe because Shutdown() above already joined the replica's RPC worker threads, so nothing can
-    // repopulate the slot afterwards. Left unconditional: a coordinator never populates this replica-only
-    // slot, so it's a no-op there.
-    memgraph::dbms::InMemoryReplicationHandlers::DestroyReplAccessor();
 
     if (dbms_handler.has_value()) {
       dbms_handler->ForEach([](memgraph::dbms::DatabaseAccess acc) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -814,6 +814,11 @@ add_unit_test(storage_v2_recover_snapshot
     LINK_TARGETS mg::storage mg-dbms
 )
 
+add_unit_test(two_pc_commit_cache
+    SOURCES two_pc_commit_cache.cpp
+    LINK_TARGETS mg::storage mg-dbms
+)
+
 add_unit_test(storage_v2_retention.
         SOURCES storage_v2_retention.cpp
         LINK_TARGETS mg::storage

--- a/tests/unit/two_pc_commit_cache.cpp
+++ b/tests/unit/two_pc_commit_cache.cpp
@@ -69,7 +69,10 @@ auto TakeReplicationAccessor(InMemoryStorage *storage) -> std::unique_ptr<Replic
 // against a storage that's still alive, exactly like Group A's file-level comment promises.
 class TwoPCCommitCacheTest : public ::testing::Test {
  protected:
-  void TearDown() override { TwoPCCommitCache::Instance().TakeAny(); }
+  void TearDown() override {
+    // See the class comment above: drain the slot while storage_a_/storage_b_ are still alive.
+    auto leftover = TwoPCCommitCache::Instance().TakeAny();
+  }
 
   std::unique_ptr<InMemoryStorage> storage_a_ = MakeStorage(kUuidA);
   std::unique_ptr<InMemoryStorage> storage_b_ = MakeStorage(kUuidB);
@@ -205,7 +208,12 @@ auto MakeDatabaseConfig(std::filesystem::path const &storage_directory) -> memgr
 // has been freed -- this must fail on a revert of that call.
 class TwoPCCommitCacheDatabaseTest : public ::testing::Test {
  protected:
-  void TearDown() override { TwoPCCommitCache::Instance().TakeAny(); }
+  void TearDown() override {
+    // Both TEST_Fs below already drain the slot themselves before their Database(s) go out of
+    // scope, so this always finds it empty; drain anyway so a future test added to this fixture
+    // can't leak an entry into the next one.
+    auto leftover = TwoPCCommitCache::Instance().TakeAny();
+  }
 };
 
 TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingDatabaseDiscardsItsCachedAccessor) {
@@ -233,8 +241,17 @@ TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingDatabaseDiscardsItsCachedAccessor
   // ~Database must have discarded the cached accessor via AbortTwoPCForTenant(uuid()). Without
   // that call, this cache entry is untouched and TakeAny() below returns a ReplicationAccessor
   // whose storage_ points at the just-freed Database's InMemoryStorage -- a dangling pointer, not
-  // merely a leaked slot.
-  ASSERT_EQ(TwoPCCommitCache::Instance().TakeAny(), nullptr);
+  // merely a leaked slot. Capture it and release() before asserting: on the FAILING path `taken`
+  // owns that dangling accessor, and letting it destruct here (~InMemoryAccessor -> Abort(),
+  // ~ResourceLockGuard -> unlock a freed main_lock_) would crash the test binary against freed
+  // memory instead of reporting this ASSERT_EQ's clean gtest failure. TakeAny() has already
+  // emptied the slot by this point regardless of what we do with the returned pointer.
+  auto taken = TwoPCCommitCache::Instance().TakeAny();
+  auto *const raw = taken.get();
+  if (taken != nullptr) {
+    taken.release();
+  }
+  ASSERT_EQ(raw, nullptr);
 }
 
 TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingUnrelatedDatabaseLeavesOtherTenantsEntryInPlace) {

--- a/tests/unit/two_pc_commit_cache.cpp
+++ b/tests/unit/two_pc_commit_cache.cpp
@@ -22,6 +22,7 @@
 #include <string_view>
 
 #include "dbms/database.hpp"
+#include "dbms/inmemory/replication_handlers.hpp"
 #include "dbms/inmemory/two_pc_commit_cache.hpp"
 #include "memory/db_arena.hpp"
 #include "storage/v2/config.hpp"
@@ -29,6 +30,7 @@
 
 namespace {
 
+using memgraph::dbms::InMemoryReplicationHandlers;
 using memgraph::dbms::TwoPCCommitCache;
 using memgraph::storage::InMemoryStorage;
 using memgraph::storage::ReplicationAccessor;
@@ -168,6 +170,55 @@ TEST_F(TwoPCCommitCacheTest, TakeAnyIgnoresUuidAndEmptiesSlot) {
   ASSERT_NE(taken, nullptr);
 
   // Slot is empty now.
+  ASSERT_EQ(cache.TakeAny(), nullptr);
+}
+
+// Regression coverage for InMemoryReplicationHandlers::AbortPrevTxnIfNeeded's tenant scoping: it
+// used to call the tenant-oblivious DestroyReplAccessor(), so a recovery/prepare RPC for tenant B
+// would steal and abort tenant A's cached 2PC accessor -- a cross-tenant use-after-free race
+// against A's own concurrent teardown, and (if A survived the race) silent divergence where
+// FinalizeCommitHandler later finds an empty slot and replies "committed" to MAIN for a txn the
+// replica had actually aborted. Drives the exact fixed call (AbortPrevTxnIfNeeded is public static)
+// with two real storages, no RPC handshake required. This pair (...LeavesOtherTenantsEntryIntact /
+// ...ClearsOwnTenantsEntry) pins the tenant-scoped behaviour on both sides: must not touch a
+// different tenant's slot, must still clear its own.
+TEST_F(TwoPCCommitCacheTest, AbortPrevTxnIfNeededLeavesOtherTenantsEntryIntact) {
+  auto &cache = TwoPCCommitCache::Instance();
+  UUID uuid_a;
+  uuid_a.set(kUuidA);
+
+  auto accessor_a = TakeReplicationAccessor(storage_a_.get());
+  // See DestroyingDatabaseDiscardsItsCachedAccessor's comment above: AbortAndResetCommitTs
+  // unconditionally dereferences commit_timestamp_, so seed it even though this build's DMG_ASSERT
+  // would not catch an unseeded one.
+  accessor_a->GetCommitTimestamp().emplace(kCommitTs);
+  cache.Store(std::move(accessor_a), kCommitTs, uuid_a);
+
+  // Fixed behavior: AbortPrevTxnIfNeeded is scoped to storage_b_'s own uuid, so it must be a no-op
+  // against A's populated slot. Before the fix, this called the tenant-oblivious
+  // DestroyReplAccessor() and would have stolen and aborted A's accessor here.
+  InMemoryReplicationHandlers::AbortPrevTxnIfNeeded(storage_b_.get());
+
+  // A's entry must have survived. Take it back out and let it destruct while storage_a_ is still a
+  // live fixture member (drained here rather than deferred to TearDown, matching Group A's pattern).
+  auto still_a = cache.TakeForTenant(uuid_a);
+  ASSERT_NE(still_a, nullptr);
+}
+
+TEST_F(TwoPCCommitCacheTest, AbortPrevTxnIfNeededClearsOwnTenantsEntry) {
+  auto &cache = TwoPCCommitCache::Instance();
+  UUID uuid_a;
+  uuid_a.set(kUuidA);
+
+  auto accessor_a = TakeReplicationAccessor(storage_a_.get());
+  accessor_a->GetCommitTimestamp().emplace(kCommitTs);
+  cache.Store(std::move(accessor_a), kCommitTs, uuid_a);
+
+  // AbortPrevTxnIfNeeded(storage_a_) is scoped to storage_a_'s own uuid, so the cached accessor
+  // (which belongs to that same uuid) must be taken, aborted, and reset by this call.
+  InMemoryReplicationHandlers::AbortPrevTxnIfNeeded(storage_a_.get());
+
+  // Slot is empty now -- AbortPrevTxnIfNeeded already consumed it via AbortTwoPCForTenant.
   ASSERT_EQ(cache.TakeAny(), nullptr);
 }
 

--- a/tests/unit/two_pc_commit_cache.cpp
+++ b/tests/unit/two_pc_commit_cache.cpp
@@ -64,7 +64,7 @@ auto TakeReplicationAccessor(InMemoryStorage *storage) -> std::unique_ptr<Replic
   return std::unique_ptr<ReplicationAccessor>(static_cast<ReplicationAccessor *>(acc.release()));
 }
 
-// The cache is a process-wide singleton (TwoPCCommitCache::Instance()), so tests share it.
+// The cache is a process-wide singleton (its state lives in TwoPCCommitCache's static slot), so tests share it.
 // TearDown drains any leftover slot with TakeAny() so one test's leftovers cannot make a later
 // test pass (or fail) for the wrong reason. Storage members are declared in the fixture (not as
 // TEST_F-local variables) so they outlive TearDown()'s drain -- letting an accessor destruct
@@ -73,7 +73,7 @@ class TwoPCCommitCacheTest : public ::testing::Test {
  protected:
   void TearDown() override {
     // See the class comment above: drain the slot while storage_a_/storage_b_ are still alive.
-    auto leftover = TwoPCCommitCache::Instance().TakeAny();
+    auto leftover = TwoPCCommitCache::TakeAny();
   }
 
   std::unique_ptr<InMemoryStorage> storage_a_ = MakeStorage(kUuidA);
@@ -85,92 +85,87 @@ class TwoPCCommitCacheTest : public ::testing::Test {
 // TakeForTenant with a non-matching uuid must not consume the slot: the pending 2PC belongs to a
 // different tenant and must survive for that tenant's own FinalizeCommitRpc/TakeForTenant to find.
 TEST_F(TwoPCCommitCacheTest, TakeForTenantNonMatchingUuidLeavesSlotPopulated) {
-  auto &cache = TwoPCCommitCache::Instance();
   UUID uuid_a;
   uuid_a.set(kUuidA);
   UUID uuid_b;
   uuid_b.set(kUuidB);
 
-  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCommitTs, uuid_a);
+  TwoPCCommitCache::Store(TakeReplicationAccessor(storage_a_.get()), kCommitTs, uuid_a);
 
   // Wrong tenant: must return nullptr and must NOT empty the slot.
-  auto wrong_take = cache.TakeForTenant(uuid_b);
+  auto wrong_take = TwoPCCommitCache::TakeForTenant(uuid_b);
   ASSERT_EQ(wrong_take, nullptr);
 
   // Prove "still populated" by having the real owner successfully take it afterwards.
-  auto right_take = cache.TakeForTenant(uuid_a);
+  auto right_take = TwoPCCommitCache::TakeForTenant(uuid_a);
   ASSERT_NE(right_take, nullptr);
 
   // Slot is empty now; a second take (by anyone) must fail.
-  ASSERT_EQ(cache.TakeForTenant(uuid_a), nullptr);
+  ASSERT_EQ(TwoPCCommitCache::TakeForTenant(uuid_a), nullptr);
 }
 
 TEST_F(TwoPCCommitCacheTest, TakeForTenantMatchingUuidEmptiesSlot) {
-  auto &cache = TwoPCCommitCache::Instance();
   UUID uuid_a;
   uuid_a.set(kUuidA);
 
-  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCommitTs, uuid_a);
+  TwoPCCommitCache::Store(TakeReplicationAccessor(storage_a_.get()), kCommitTs, uuid_a);
 
-  auto first_take = cache.TakeForTenant(uuid_a);
+  auto first_take = TwoPCCommitCache::TakeForTenant(uuid_a);
   ASSERT_NE(first_take, nullptr);
 
   // Second call on the now-empty slot must return nullptr.
-  ASSERT_EQ(cache.TakeForTenant(uuid_a), nullptr);
+  ASSERT_EQ(TwoPCCommitCache::TakeForTenant(uuid_a), nullptr);
 }
 
 // Mirrors FinalizeCommitHandler's "reply true, keep the slot" path: a durability_commit_timestamp
 // mismatch is not terminal, so the accessor must stay cached for a later, matching call.
 TEST_F(TwoPCCommitCacheTest, TakeMatchingNonMatchingTimestampLeavesSlotPopulated) {
-  auto &cache = TwoPCCommitCache::Instance();
   UUID uuid_a;
   uuid_a.set(kUuidA);
   constexpr uint64_t kCachedTs = 42;
   constexpr uint64_t kWrongTs = 43;
 
-  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCachedTs, uuid_a);
+  TwoPCCommitCache::Store(TakeReplicationAccessor(storage_a_.get()), kCachedTs, uuid_a);
 
-  auto mismatch = cache.TakeMatching(kWrongTs);
+  auto mismatch = TwoPCCommitCache::TakeMatching(kWrongTs);
   ASSERT_EQ(mismatch.accessor, nullptr);
   ASSERT_TRUE(mismatch.mismatched_durability_commit_timestamp.has_value());
   EXPECT_EQ(*mismatch.mismatched_durability_commit_timestamp, kCachedTs);
 
   // Slot must still be populated -- a matching call afterwards succeeds.
-  auto match = cache.TakeMatching(kCachedTs);
+  auto match = TwoPCCommitCache::TakeMatching(kCachedTs);
   ASSERT_NE(match.accessor, nullptr);
   ASSERT_FALSE(match.mismatched_durability_commit_timestamp.has_value());
 }
 
 TEST_F(TwoPCCommitCacheTest, TakeMatchingMatchingTimestampEmptiesSlot) {
-  auto &cache = TwoPCCommitCache::Instance();
   UUID uuid_a;
   uuid_a.set(kUuidA);
   constexpr uint64_t kCachedTs = 7;
 
-  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCachedTs, uuid_a);
+  TwoPCCommitCache::Store(TakeReplicationAccessor(storage_a_.get()), kCachedTs, uuid_a);
 
-  auto match = cache.TakeMatching(kCachedTs);
+  auto match = TwoPCCommitCache::TakeMatching(kCachedTs);
   ASSERT_NE(match.accessor, nullptr);
 
   // Slot is empty now; even the same timestamp must miss.
-  auto second = cache.TakeMatching(kCachedTs);
+  auto second = TwoPCCommitCache::TakeMatching(kCachedTs);
   ASSERT_EQ(second.accessor, nullptr);
   ASSERT_FALSE(second.mismatched_durability_commit_timestamp.has_value());
 }
 
 TEST_F(TwoPCCommitCacheTest, TakeAnyIgnoresUuidAndEmptiesSlot) {
-  auto &cache = TwoPCCommitCache::Instance();
   UUID uuid_b;
   uuid_b.set(kUuidB);
 
   // Cached for tenant B; TakeAny must return it regardless of tenant.
-  cache.Store(TakeReplicationAccessor(storage_b_.get()), kCommitTs, uuid_b);
+  TwoPCCommitCache::Store(TakeReplicationAccessor(storage_b_.get()), kCommitTs, uuid_b);
 
-  auto taken = cache.TakeAny();
+  auto taken = TwoPCCommitCache::TakeAny();
   ASSERT_NE(taken, nullptr);
 
   // Slot is empty now.
-  ASSERT_EQ(cache.TakeAny(), nullptr);
+  ASSERT_EQ(TwoPCCommitCache::TakeAny(), nullptr);
 }
 
 // Regression coverage for InMemoryReplicationHandlers::AbortPrevTxnIfNeeded's tenant scoping: it
@@ -183,7 +178,6 @@ TEST_F(TwoPCCommitCacheTest, TakeAnyIgnoresUuidAndEmptiesSlot) {
 // ...ClearsOwnTenantsEntry) pins the tenant-scoped behaviour on both sides: must not touch a
 // different tenant's slot, must still clear its own.
 TEST_F(TwoPCCommitCacheTest, AbortPrevTxnIfNeededLeavesOtherTenantsEntryIntact) {
-  auto &cache = TwoPCCommitCache::Instance();
   UUID uuid_a;
   uuid_a.set(kUuidA);
 
@@ -192,7 +186,7 @@ TEST_F(TwoPCCommitCacheTest, AbortPrevTxnIfNeededLeavesOtherTenantsEntryIntact) 
   // unconditionally dereferences commit_timestamp_, so seed it even though this build's DMG_ASSERT
   // would not catch an unseeded one.
   accessor_a->GetCommitTimestamp().emplace(kCommitTs);
-  cache.Store(std::move(accessor_a), kCommitTs, uuid_a);
+  TwoPCCommitCache::Store(std::move(accessor_a), kCommitTs, uuid_a);
 
   // Fixed behavior: AbortPrevTxnIfNeeded is scoped to storage_b_'s own uuid, so it must be a no-op
   // against A's populated slot. Before the fix, this called the tenant-oblivious
@@ -201,25 +195,24 @@ TEST_F(TwoPCCommitCacheTest, AbortPrevTxnIfNeededLeavesOtherTenantsEntryIntact) 
 
   // A's entry must have survived. Take it back out and let it destruct while storage_a_ is still a
   // live fixture member (drained here rather than deferred to TearDown, matching Group A's pattern).
-  auto still_a = cache.TakeForTenant(uuid_a);
+  auto still_a = TwoPCCommitCache::TakeForTenant(uuid_a);
   ASSERT_NE(still_a, nullptr);
 }
 
 TEST_F(TwoPCCommitCacheTest, AbortPrevTxnIfNeededClearsOwnTenantsEntry) {
-  auto &cache = TwoPCCommitCache::Instance();
   UUID uuid_a;
   uuid_a.set(kUuidA);
 
   auto accessor_a = TakeReplicationAccessor(storage_a_.get());
   accessor_a->GetCommitTimestamp().emplace(kCommitTs);
-  cache.Store(std::move(accessor_a), kCommitTs, uuid_a);
+  TwoPCCommitCache::Store(std::move(accessor_a), kCommitTs, uuid_a);
 
   // AbortPrevTxnIfNeeded(storage_a_) is scoped to storage_a_'s own uuid, so the cached accessor
   // (which belongs to that same uuid) must be taken, aborted, and reset by this call.
   InMemoryReplicationHandlers::AbortPrevTxnIfNeeded(storage_a_.get());
 
   // Slot is empty now -- AbortPrevTxnIfNeeded already consumed it via AbortTwoPCForTenant.
-  ASSERT_EQ(cache.TakeAny(), nullptr);
+  ASSERT_EQ(TwoPCCommitCache::TakeAny(), nullptr);
 }
 
 namespace {
@@ -263,7 +256,7 @@ class TwoPCCommitCacheDatabaseTest : public ::testing::Test {
     // Both TEST_Fs below already drain the slot themselves before their Database(s) go out of
     // scope, so this always finds it empty; drain anyway so a future test added to this fixture
     // can't leak an entry into the next one.
-    auto leftover = TwoPCCommitCache::Instance().TakeAny();
+    auto leftover = TwoPCCommitCache::TakeAny();
   }
 };
 
@@ -284,7 +277,7 @@ TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingDatabaseDiscardsItsCachedAccessor
     // be a real UB dereference of an empty optional, not a caught assertion. Seed it so the
     // aborted-transaction path this test exercises is well-defined regardless of build type.
     accessor->GetCommitTimestamp().emplace(kCommitTs);
-    TwoPCCommitCache::Instance().Store(std::move(accessor), kCommitTs, db_uuid);
+    TwoPCCommitCache::Store(std::move(accessor), kCommitTs, db_uuid);
 
     // db (and its storage/arena) is destroyed at the end of this scope.
   }
@@ -297,7 +290,7 @@ TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingDatabaseDiscardsItsCachedAccessor
   // ~ResourceLockGuard -> unlock a freed main_lock_) would crash the test binary against freed
   // memory instead of reporting this ASSERT_EQ's clean gtest failure. TakeAny() has already
   // emptied the slot by this point regardless of what we do with the returned pointer.
-  auto taken = TwoPCCommitCache::Instance().TakeAny();
+  auto taken = TwoPCCommitCache::TakeAny();
   auto *const raw = taken.get();
   if (taken != nullptr) {
     taken.release();
@@ -317,7 +310,7 @@ TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingUnrelatedDatabaseLeavesOtherTenan
     auto *inmemory_storage_a = static_cast<InMemoryStorage *>(db_a->storage());
     auto accessor_a = TakeReplicationAccessor(inmemory_storage_a);
     accessor_a->GetCommitTimestamp().emplace(kCommitTs);
-    TwoPCCommitCache::Instance().Store(std::move(accessor_a), kCommitTs, uuid_a);
+    TwoPCCommitCache::Store(std::move(accessor_a), kCommitTs, uuid_a);
   }
 
   {
@@ -328,6 +321,6 @@ TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingUnrelatedDatabaseLeavesOtherTenan
   }
 
   // A's entry must have survived db_b's destruction.
-  auto still_a = TwoPCCommitCache::Instance().TakeForTenant(uuid_a);
+  auto still_a = TwoPCCommitCache::TakeForTenant(uuid_a);
   ASSERT_NE(still_a, nullptr);
 }

--- a/tests/unit/two_pc_commit_cache.cpp
+++ b/tests/unit/two_pc_commit_cache.cpp
@@ -104,19 +104,6 @@ TEST_F(TwoPCCommitCacheTest, TakeForTenantNonMatchingUuidLeavesSlotPopulated) {
   ASSERT_EQ(TwoPCCommitCache::TakeForTenant(uuid_a), nullptr);
 }
 
-TEST_F(TwoPCCommitCacheTest, TakeForTenantMatchingUuidEmptiesSlot) {
-  UUID uuid_a;
-  uuid_a.set(kUuidA);
-
-  TwoPCCommitCache::Store(TakeReplicationAccessor(storage_a_.get()), kCommitTs, uuid_a);
-
-  auto first_take = TwoPCCommitCache::TakeForTenant(uuid_a);
-  ASSERT_NE(first_take, nullptr);
-
-  // Second call on the now-empty slot must return nullptr.
-  ASSERT_EQ(TwoPCCommitCache::TakeForTenant(uuid_a), nullptr);
-}
-
 // Mirrors FinalizeCommitHandler's "reply true, keep the slot" path: a durability_commit_timestamp
 // mismatch is not terminal, so the accessor must stay cached for a later, matching call.
 TEST_F(TwoPCCommitCacheTest, TakeMatchingNonMatchingTimestampLeavesSlotPopulated) {

--- a/tests/unit/two_pc_commit_cache.cpp
+++ b/tests/unit/two_pc_commit_cache.cpp
@@ -1,0 +1,265 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Group A below locks in TwoPCCommitCache's slot-management contract (Store/TakeForTenant/
+// TakeMatching/TakeAny) in isolation. Those tests keep their backing storage alive for the whole
+// test, so on their own they do NOT reproduce the use-after-free this cache exists to fix -- see
+// Group B for the test that fails without the ~Database fix (AbortTwoPCForTenant call).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string_view>
+
+#include "dbms/database.hpp"
+#include "dbms/inmemory/two_pc_commit_cache.hpp"
+#include "memory/db_arena.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+
+namespace {
+
+using memgraph::dbms::TwoPCCommitCache;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::ReplicationAccessor;
+using memgraph::storage::StorageAccessType;
+using memgraph::utils::UUID;
+
+// Two fixed, distinct, valid UUID strings -- explicit rather than relying on Config{}'s
+// default-constructed (randomly generated) uuid, so uuid-mismatch coverage cannot flake on a
+// collision.
+constexpr std::string_view kUuidA = "11111111-1111-1111-1111-111111111111";
+constexpr std::string_view kUuidB = "22222222-2222-2222-2222-222222222222";
+
+// A durability_commit_timestamp low enough that CommitLog::MarkFinished (invoked transitively by
+// AbortAndResetCommitTs, on the path exercised in Group B) accepts it unconditionally --
+// CommitLog::FindOrCreateBlock handles any id, so any small constant works; verified empirically
+// by running this suite.
+constexpr uint64_t kCommitTs = 1;
+
+auto MakeStorage(std::string_view uuid_str) -> std::unique_ptr<InMemoryStorage> {
+  memgraph::storage::Config config{};
+  config.salient.uuid.set(uuid_str);
+  return std::make_unique<InMemoryStorage>(config);
+}
+
+// Mirrors production's downcast at InMemoryReplicationHandlers::ReadAndApplyDeltasSingleTxn
+// (commit_accessor.reset(static_cast<storage::ReplicationAccessor *>(acc.release()))):
+// ReplicationAccessor adds no data members over InMemoryStorage::InMemoryAccessor, so a WRITE
+// accessor from Access() may be released and re-owned as a ReplicationAccessor.
+auto TakeReplicationAccessor(InMemoryStorage *storage) -> std::unique_ptr<ReplicationAccessor> {
+  auto acc = storage->Access(StorageAccessType::WRITE);
+  return std::unique_ptr<ReplicationAccessor>(static_cast<ReplicationAccessor *>(acc.release()));
+}
+
+// The cache is a process-wide singleton (TwoPCCommitCache::Instance()), so tests share it.
+// TearDown drains any leftover slot with TakeAny() so one test's leftovers cannot make a later
+// test pass (or fail) for the wrong reason. Storage members are declared in the fixture (not as
+// TEST_F-local variables) so they outlive TearDown()'s drain -- letting an accessor destruct
+// against a storage that's still alive, exactly like Group A's file-level comment promises.
+class TwoPCCommitCacheTest : public ::testing::Test {
+ protected:
+  void TearDown() override { TwoPCCommitCache::Instance().TakeAny(); }
+
+  std::unique_ptr<InMemoryStorage> storage_a_ = MakeStorage(kUuidA);
+  std::unique_ptr<InMemoryStorage> storage_b_ = MakeStorage(kUuidB);
+};
+
+}  // namespace
+
+// TakeForTenant with a non-matching uuid must not consume the slot: the pending 2PC belongs to a
+// different tenant and must survive for that tenant's own FinalizeCommitRpc/TakeForTenant to find.
+TEST_F(TwoPCCommitCacheTest, TakeForTenantNonMatchingUuidLeavesSlotPopulated) {
+  auto &cache = TwoPCCommitCache::Instance();
+  UUID uuid_a;
+  uuid_a.set(kUuidA);
+  UUID uuid_b;
+  uuid_b.set(kUuidB);
+
+  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCommitTs, uuid_a);
+
+  // Wrong tenant: must return nullptr and must NOT empty the slot.
+  auto wrong_take = cache.TakeForTenant(uuid_b);
+  ASSERT_EQ(wrong_take, nullptr);
+
+  // Prove "still populated" by having the real owner successfully take it afterwards.
+  auto right_take = cache.TakeForTenant(uuid_a);
+  ASSERT_NE(right_take, nullptr);
+
+  // Slot is empty now; a second take (by anyone) must fail.
+  ASSERT_EQ(cache.TakeForTenant(uuid_a), nullptr);
+}
+
+TEST_F(TwoPCCommitCacheTest, TakeForTenantMatchingUuidEmptiesSlot) {
+  auto &cache = TwoPCCommitCache::Instance();
+  UUID uuid_a;
+  uuid_a.set(kUuidA);
+
+  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCommitTs, uuid_a);
+
+  auto first_take = cache.TakeForTenant(uuid_a);
+  ASSERT_NE(first_take, nullptr);
+
+  // Second call on the now-empty slot must return nullptr.
+  ASSERT_EQ(cache.TakeForTenant(uuid_a), nullptr);
+}
+
+// Mirrors FinalizeCommitHandler's "reply true, keep the slot" path: a durability_commit_timestamp
+// mismatch is not terminal, so the accessor must stay cached for a later, matching call.
+TEST_F(TwoPCCommitCacheTest, TakeMatchingNonMatchingTimestampLeavesSlotPopulated) {
+  auto &cache = TwoPCCommitCache::Instance();
+  UUID uuid_a;
+  uuid_a.set(kUuidA);
+  constexpr uint64_t kCachedTs = 42;
+  constexpr uint64_t kWrongTs = 43;
+
+  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCachedTs, uuid_a);
+
+  auto mismatch = cache.TakeMatching(kWrongTs);
+  ASSERT_EQ(mismatch.accessor, nullptr);
+  ASSERT_TRUE(mismatch.mismatched_durability_commit_timestamp.has_value());
+  EXPECT_EQ(*mismatch.mismatched_durability_commit_timestamp, kCachedTs);
+
+  // Slot must still be populated -- a matching call afterwards succeeds.
+  auto match = cache.TakeMatching(kCachedTs);
+  ASSERT_NE(match.accessor, nullptr);
+  ASSERT_FALSE(match.mismatched_durability_commit_timestamp.has_value());
+}
+
+TEST_F(TwoPCCommitCacheTest, TakeMatchingMatchingTimestampEmptiesSlot) {
+  auto &cache = TwoPCCommitCache::Instance();
+  UUID uuid_a;
+  uuid_a.set(kUuidA);
+  constexpr uint64_t kCachedTs = 7;
+
+  cache.Store(TakeReplicationAccessor(storage_a_.get()), kCachedTs, uuid_a);
+
+  auto match = cache.TakeMatching(kCachedTs);
+  ASSERT_NE(match.accessor, nullptr);
+
+  // Slot is empty now; even the same timestamp must miss.
+  auto second = cache.TakeMatching(kCachedTs);
+  ASSERT_EQ(second.accessor, nullptr);
+  ASSERT_FALSE(second.mismatched_durability_commit_timestamp.has_value());
+}
+
+TEST_F(TwoPCCommitCacheTest, TakeAnyIgnoresUuidAndEmptiesSlot) {
+  auto &cache = TwoPCCommitCache::Instance();
+  UUID uuid_b;
+  uuid_b.set(kUuidB);
+
+  // Cached for tenant B; TakeAny must return it regardless of tenant.
+  cache.Store(TakeReplicationAccessor(storage_b_.get()), kCommitTs, uuid_b);
+
+  auto taken = cache.TakeAny();
+  ASSERT_NE(taken, nullptr);
+
+  // Slot is empty now.
+  ASSERT_EQ(cache.TakeAny(), nullptr);
+}
+
+namespace {
+
+// RAII temp directory for the Group B Database fixtures below -- mirrors the TmpDirManager
+// pattern in tests/unit/storage_v2_recover_snapshot.cpp.
+class TmpDirManager final {
+ public:
+  explicit TmpDirManager(std::string_view directory) : path_{std::filesystem::temp_directory_path() / directory} {
+    std::filesystem::remove_all(path_);
+    std::filesystem::create_directories(path_);
+  }
+
+  ~TmpDirManager() { std::filesystem::remove_all(path_); }
+
+  TmpDirManager(const TmpDirManager &) = delete;
+  TmpDirManager &operator=(const TmpDirManager &) = delete;
+  TmpDirManager(TmpDirManager &&) = delete;
+  TmpDirManager &operator=(TmpDirManager &&) = delete;
+
+  const std::filesystem::path &Path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+auto MakeDatabaseConfig(std::filesystem::path const &storage_directory) -> memgraph::storage::Config {
+  memgraph::storage::Config config{};
+  config.durability.storage_directory = storage_directory;
+  return config;
+}
+
+}  // namespace
+
+// Group B: the load-bearing coverage. Without ~Database's AbortTwoPCForTenant call, a cached
+// accessor keeps pointing into a Database's storage after that Database (and its per-DB arena)
+// has been freed -- this must fail on a revert of that call.
+class TwoPCCommitCacheDatabaseTest : public ::testing::Test {
+ protected:
+  void TearDown() override { TwoPCCommitCache::Instance().TakeAny(); }
+};
+
+TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingDatabaseDiscardsItsCachedAccessor) {
+  TmpDirManager tmp_dir{"MG_test_unit_two_pc_commit_cache_owning"};
+  UUID db_uuid;
+
+  {
+    memgraph::dbms::Database db{MakeDatabaseConfig(tmp_dir.Path())};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    db_uuid = db.uuid();
+
+    auto *inmemory_storage = static_cast<InMemoryStorage *>(db.storage());
+    auto accessor = TakeReplicationAccessor(inmemory_storage);
+    // AbortAndResetCommitTs (reached via ~Database -> AbortTwoPCForTenant -> TakeForTenant) does
+    // Abort() then DMG_ASSERT(commit_timestamp_) and dereferences it unconditionally. This build
+    // is RelWithDebInfo/NDEBUG, so DMG_ASSERT compiles out -- an unseeded commit_timestamp_ would
+    // be a real UB dereference of an empty optional, not a caught assertion. Seed it so the
+    // aborted-transaction path this test exercises is well-defined regardless of build type.
+    accessor->GetCommitTimestamp().emplace(kCommitTs);
+    TwoPCCommitCache::Instance().Store(std::move(accessor), kCommitTs, db_uuid);
+
+    // db (and its storage/arena) is destroyed at the end of this scope.
+  }
+
+  // ~Database must have discarded the cached accessor via AbortTwoPCForTenant(uuid()). Without
+  // that call, this cache entry is untouched and TakeAny() below returns a ReplicationAccessor
+  // whose storage_ points at the just-freed Database's InMemoryStorage -- a dangling pointer, not
+  // merely a leaked slot.
+  ASSERT_EQ(TwoPCCommitCache::Instance().TakeAny(), nullptr);
+}
+
+TEST_F(TwoPCCommitCacheDatabaseTest, DestroyingUnrelatedDatabaseLeavesOtherTenantsEntryInPlace) {
+  TmpDirManager tmp_dir_a{"MG_test_unit_two_pc_commit_cache_kept_a"};
+  TmpDirManager tmp_dir_b{"MG_test_unit_two_pc_commit_cache_kept_b"};
+
+  auto db_a = std::make_unique<memgraph::dbms::Database>(MakeDatabaseConfig(tmp_dir_a.Path()));
+  const memgraph::memory::DbArenaScope arena_scope_a{&db_a->Arena()};
+  auto const uuid_a = db_a->uuid();
+
+  {
+    auto *inmemory_storage_a = static_cast<InMemoryStorage *>(db_a->storage());
+    auto accessor_a = TakeReplicationAccessor(inmemory_storage_a);
+    accessor_a->GetCommitTimestamp().emplace(kCommitTs);
+    TwoPCCommitCache::Instance().Store(std::move(accessor_a), kCommitTs, uuid_a);
+  }
+
+  {
+    memgraph::dbms::Database db_b{MakeDatabaseConfig(tmp_dir_b.Path())};
+    const memgraph::memory::DbArenaScope arena_scope_b{&db_b.Arena()};
+    // db_b is destroyed at the end of this scope. It never cached anything, so its
+    // AbortTwoPCForTenant(uuid_b) call must be a no-op against A's still-populated slot.
+  }
+
+  // A's entry must have survived db_b's destruction.
+  auto still_a = TwoPCCommitCache::Instance().TakeForTenant(uuid_a);
+  ASSERT_NE(still_a, nullptr);
+}


### PR DESCRIPTION
The two-phase-commit commit-accessor cache was keyed by the accessor and outlived its storage, so a plain `DROP DATABASE` (and process exit) could free a tenant's storage out from under a live cached accessor — a use-after-free.

### Changes
- **Key the cache by uuid.** The slot records the tenant uuid captured at `Store` time and is aborted for the right tenant via `TakeForTenant(uuid)`, instead of relying on accessor identity.
- **Abort in `~Database`.** The tenant's cached 2PC is aborted before `storage_` is torn down — the one choke point every teardown path (drop, suspend, drop-recreate, process exit) passes through.
- **Tenant-scope the pre-abort call sites** (`PrepareCommitHandler`, `AbortPrevTxnIfNeeded`, and the `CreateDatabase` drop-recreate apply path) so an RPC for one tenant can't strand another tenant's still-pending 2PC.
- **Extract a testable `TwoPCCommitCache` component**, with a unit test covering the slot contract and the `~Database` use-after-free regression (fails on a revert of the `~Database` abort).
- **Own the slot's lifetime with an RAII guard in `main()`** (`TwoPCCommitCache::Owner`) so it is freed deterministically before static destruction — the same `main()`-stack-owned process-singleton pattern as `utils::PageCacheReleaser` — replacing the previously leaked-forever slot and the manual shutdown clear.

The single-slot / ts-only-on-finalize design is safe because the replica replication RPC server is single-threaded, so `Prepare`/`Finalize`/`CreateDatabase` handlers are serialized; the only concurrent slot access is the `defer_pool_` background `~Database`, which is serialized against the RPC thread by the slot mutex.