### PR TITLE
fix(storage-mode): bounded-wait try_exclusively so a transient holder doesn't fail the on-disk switch

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6564,7 +6564,10 @@ Callback SwitchMemoryDevice(storage::StorageMode current_mode, storage::StorageM
           "automatically start in the default in-memory transactional storage mode.");
     }
     if (SwitchingFromInMemoryToDisk(current_mode, requested_mode)) {
-      if (!db.try_exclusively([](auto &in) {
+      // Bounded wait rather than a single-shot check: transient accessor holders (a /metrics scrape,
+      // a Lab session between queries) release within ms; 3s rides them out but still refuses a busy DB.
+      constexpr auto kSwitchToDiskExclusiveTimeout = std::chrono::seconds{3};
+      if (!db.try_exclusively(kSwitchToDiskExclusiveTimeout, [](auto &in) {
             if (!in.streams()->GetStreamInfo().empty()) {
               throw utils::BasicException(
                   "You cannot switch from an in-memory storage mode to the on-disk storage mode when there are "

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -271,6 +271,24 @@ struct Gatekeeper {
       return {run_t{}, std::forward<Func>(func), *owner_->value_};
     }
 
+    // Bounded-wait variant of the check above: wait up to `timeout` for count_ == 1 (sole live
+    // accessor) before running `func` exclusively, so a transient holder doesn't force a refusal.
+    // Safe under the same invariants as try_delete: every count_ decrement notifies cv_ under mutex_
+    // (no missed wakeup), and our own live accessor keeps count_ >= 1 so value_ cannot be destroyed.
+    template <typename Func>
+    [[nodiscard]] auto try_exclusively(std::chrono::steady_clock::duration timeout, Func &&func)
+        -> EvalResult<std::invoke_result_t<Func, T &>> {
+      if (!owner_) return {not_run_t{}};
+      // Prevent new access
+      auto guard = std::unique_lock{owner_->mutex_};
+      // Wait for exclusive access; on timeout refuse without running func.
+      if (!owner_->cv_.wait_for(guard, timeout, [this] { return owner_->count_ == 1; })) {
+        return {not_run_t{}};
+      }
+      // Invoke and hold result in wrapper type
+      return {run_t{}, std::forward<Func>(func), *owner_->value_};
+    }
+
     // Completely invalidated the accessor if return true
     template <typename Func = decltype([](T &) { return true; })>
     [[nodiscard]] bool try_delete(std::chrono::milliseconds timeout = std::chrono::milliseconds(100),

--- a/tests/unit/hot_cold_gatekeeper.cpp
+++ b/tests/unit/hot_cold_gatekeeper.cpp
@@ -226,3 +226,106 @@ TEST(HotColdGatekeeper, DtorWaitsForAccessorRelease) {
   EXPECT_GE(elapsed, kHold);
   t.join();
 }
+
+// ---------------------------------------------------------------------------
+// TryExclusivelyTimedWaitsOutTransientHolder
+// ---------------------------------------------------------------------------
+// A second accessor that releases shortly (a transient DatabaseAccess, e.g. a
+// /metrics scrape) must be WAITED OUT by the bounded-wait try_exclusively: the
+// exclusive func runs once count drops back to 1, within the deadline.
+TEST(HotColdGatekeeper, TryExclusivelyTimedWaitsOutTransientHolder) {
+  auto gk = make_hot();
+
+  auto primary = gk.access();
+  ASSERT_TRUE(primary.has_value());
+
+  // Transient second accessor acquired HERE so count==2 is established before the
+  // try_exclusively call below (acquiring it inside the worker would race the call
+  // and let it observe count==1 immediately). The worker releases it after ~100ms.
+  auto transient = gk.access();
+  ASSERT_TRUE(transient.has_value());
+  constexpr auto kHold = std::chrono::milliseconds(100);
+  std::thread t([&] {
+    std::this_thread::sleep_for(kHold);
+    transient->reset();
+  });
+
+  bool ran = false;
+  const auto start = std::chrono::steady_clock::now();
+  // 3s deadline mirrors the STORAGE MODE switch; the transient holder releases well within it.
+  auto result = primary->try_exclusively(std::chrono::seconds(3), [&](Widget &w) {
+    ran = true;
+    return w.v;
+  });
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_TRUE(static_cast<bool>(result));  // func ran
+  EXPECT_TRUE(ran);
+  EXPECT_EQ(result.value(), 42);
+  EXPECT_GE(elapsed, kHold);                    // actually waited for the release
+  EXPECT_LT(elapsed, std::chrono::seconds(3));  // and did not exhaust the deadline
+
+  t.join();
+}
+
+// ---------------------------------------------------------------------------
+// TryExclusivelyTimedRefusesPersistentHolder
+// ---------------------------------------------------------------------------
+// A second accessor held for the whole call must make the bounded-wait
+// try_exclusively time out cleanly: func never runs, and it returns after
+// roughly the deadline.
+TEST(HotColdGatekeeper, TryExclusivelyTimedRefusesPersistentHolder) {
+  auto gk = make_hot();
+
+  auto primary = gk.access();
+  ASSERT_TRUE(primary.has_value());
+  auto persistent = gk.access();  // count==2 for the entire call
+  ASSERT_TRUE(persistent.has_value());
+
+  bool ran = false;
+  constexpr auto kTimeout = std::chrono::milliseconds(100);
+  const auto start = std::chrono::steady_clock::now();
+  auto result = primary->try_exclusively(kTimeout, [&](Widget &w) {
+    ran = true;
+    return w.v;
+  });
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_FALSE(static_cast<bool>(result));  // func did NOT run
+  EXPECT_FALSE(ran);
+  EXPECT_GE(elapsed, kTimeout);  // waited the full deadline before refusing
+}
+
+// ---------------------------------------------------------------------------
+// TryExclusivelyNonBlockingFailsFast
+// ---------------------------------------------------------------------------
+// The single-shot overload keeps fail-fast semantics: with count==2 it refuses
+// immediately; once the extra accessor is released it runs.
+TEST(HotColdGatekeeper, TryExclusivelyNonBlockingFailsFast) {
+  auto gk = make_hot();
+
+  auto primary = gk.access();
+  ASSERT_TRUE(primary.has_value());
+
+  {
+    auto second = gk.access();  // count==2
+    ASSERT_TRUE(second.has_value());
+
+    bool ran = false;
+    const auto start = std::chrono::steady_clock::now();
+    auto result = primary->try_exclusively([&](Widget &w) {
+      ran = true;
+      return w.v;
+    });
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_FALSE(static_cast<bool>(result));  // refused
+    EXPECT_FALSE(ran);
+    EXPECT_LT(elapsed, std::chrono::milliseconds(50));  // did not wait
+  }
+  // second released; count==1.
+
+  auto result = primary->try_exclusively([](Widget &w) { return w.v; });
+  EXPECT_TRUE(static_cast<bool>(result));
+  EXPECT_EQ(result.value(), 42);
+}


### PR DESCRIPTION
Switching a database to on-disk needs sole access, but try_exclusively checked count_ == 1 once, non-blocking — so a metrics scrape or a between-queries Lab session refused the switch. A bounded-wait overload (3 s at the call site) now rides out transient millisecond holders while still refusing a genuinely stuck session.