### PR TITLE
fix(multi-tenancy): make tenant-profile durability atomic on DROP and RENAME

### DIFF
--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -597,19 +597,27 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
     const auto old_val = durability_->Get(old_key);
 
     if (old_val) {
-      // Parse the existing value and update the name
-      auto json = nlohmann::json::parse(*old_val);
-      json["name"] = new_name;
-
-      // Update in durability store
-      durability_->Put(new_key, json.dump());
-      durability_->Delete(old_key);
+      // The stored value is name-independent (only "uuid"/"rel_dir"/cold fields; the name lives in
+      // the key), so move it verbatim instead of parsing and rewriting it.
+      if (durability_->Put(new_key, *old_val)) {
+        durability_->Delete(old_key);
+      } else {
+        // Only drop the old key once the new one is durably in place; otherwise the tenant would be
+        // left with no durability record under either name and vanish on the next restart.
+        spdlog::error("Failed to write durability record for renamed database {} (was {}).", new_name, old_name);
+      }
     }
   }
 
   // Update tenant profile membership (no-op if database had no profile attached).
   if (tenant_profiles_) {
-    [[maybe_unused]] auto renamed = tenant_profiles_->RenameDatabase(old_name, new_name);
+    // The rename itself already committed (in-memory + durably); a failure here is just a
+    // profile-membership bookkeeping row, so it must not stop us from falling through to
+    // AddAction<RenameDatabase> below — skipping that is what used to cause MAIN/replica divergence.
+    auto renamed = tenant_profiles_->RenameDatabase(old_name, new_name);
+    if (!renamed.has_value() && renamed.error() == TenantProfiles::RenameError::DURABILITY_ERROR) {
+      spdlog::warn("Failed to persist tenant profile membership rename for database {} (was {}).", new_name, old_name);
+    }
   }
 
   // Add system action for replication

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -460,6 +460,14 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
     return std::unexpected{DeleteError::NON_EXISTENT};
   }
 
+  // Detach from tenant profile BEFORE the durability key is erased below, so a crash in
+  // between cannot leave a stale profile mapping pointing at a name that no longer has a
+  // tenant. Return value is safe to ignore here — if the DB is not attached, detaching is a
+  // no-op.
+  if (tenant_profiles_) {
+    [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(db_name);
+  }
+
   // Remove from durability list
   if (durability_) durability_->Delete(Durability::GenKey(db_name));
 
@@ -468,13 +476,6 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
   (void)std::filesystem::remove_all(storage_path, ec);
   if (ec) {
     spdlog::error(R"(Failed to clean disk while deleting database "{}" stored in {})", db_name, storage_path);
-  }
-
-  // Detach from tenant profile. Return value is safe to ignore here because this
-  // code path (TryDelete) is exclusive with the DetachFromDatabase call in Delete_
-  // below. If the DB is not attached, detaching is a no-op.
-  if (tenant_profiles_) {
-    [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(db_name);
   }
 
   // Success
@@ -779,14 +780,18 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
   const std::string name_copy{name};
   suspended_.erase(it);
   db_handler_.EraseColdShell(name_copy);  // guaranteed to succeed: we just verified state==COLD above
+  // Detach from tenant profile BEFORE the durability key is erased below, so a crash in
+  // between cannot leave a stale profile mapping pointing at a name that no longer has a
+  // tenant. Return value is safe to ignore here — if the DB is not attached, detaching is a
+  // no-op.
+  if (tenant_profiles_) {
+    [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(name_copy);
+  }
   if (durability_) durability_->Delete(Durability::GenKey(name_copy));
   std::error_code ec;
   (void)std::filesystem::remove_all(data_dir, ec);
   if (ec) {
     spdlog::error(R"(Failed to clean disk while dropping suspended database "{}" at {})", name_copy, data_dir.string());
-  }
-  if (tenant_profiles_) {
-    [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(name_copy);
   }
   UpdateColdGauge_();
   return uuid;
@@ -821,15 +826,16 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
     database.streams()->DropAll();
   }
 
-  // Remove from durability list
-  if (durability_) durability_->Delete(Durability::GenKey(db_name));
-
-  // Detach from tenant profile. Return value is safe to ignore here because this
-  // code path (Delete_) is exclusive with the TryDelete path above. If the DB is
-  // not attached, detaching is a no-op.
+  // Detach from tenant profile BEFORE the durability key is erased below, so a crash in
+  // between cannot leave a stale profile mapping pointing at a name that no longer has a
+  // tenant. Return value is safe to ignore here — if the DB is not attached, detaching is a
+  // no-op.
   if (tenant_profiles_) {
     [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(db_name);
   }
+
+  // Remove from durability list
+  if (durability_) durability_->Delete(Durability::GenKey(db_name));
 
   // Check if db exists
   // Low level handlers

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -606,8 +606,9 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
         // the divergence (its durable key was never written, so the durability update silently no-ops).
         spdlog::error(
             "Failed to persist rename of database {} to {}; rolling back in-memory rename.", old_name, new_name);
-        // NOLINTNEXTLINE(readability-suspicious-call-argument): intentional reverse rename -- the DB is
-        // currently named new_name, so rename it back to old_name to undo the in-memory rename above.
+        // Intentional reverse rename -- the DB is currently named new_name, so rename it back to
+        // old_name to undo the in-memory rename above (arg/param names legitimately mismatch).
+        // NOLINTNEXTLINE(readability-suspicious-call-argument)
         [[maybe_unused]] auto rolled_back = db_handler_.Rename(new_name, old_name);
         (*new_db)->storage()->config_.salient.name = old_name;
         return std::unexpected{RenameError::FAIL};

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -368,10 +368,8 @@ DbmsHandler::DbmsHandler(storage::Config config, ResumeRetryPolicy resume_retry_
   tenant_profiles_ = std::make_unique<TenantProfiles>(*durability_);
 
   {
-    // Live set is built from the durable key prefix, NOT Get_/db_handler_: Get_ is HOT-gated, so a
-    // suspended (COLD) tenant would look absent and PruneDatabases would wrongly delete its
-    // attachment. The key prefix covers HOT and COLD identically, and stays correct even for an
-    // entry whose value failed to parse above, since its key is still present.
+    // Built from the durable key prefix, not Get_: Get_ is HOT-gated, so a suspended (COLD) tenant
+    // would look absent and have its attachment pruned. A key also survives a value that failed to parse.
     std::set<std::string> live{std::string{kDefaultDB}};
     for (auto pit = durability_->begin(std::string(kDBPrefix)), pend = durability_->end(std::string(kDBPrefix));
          pit != pend;
@@ -478,8 +476,7 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
     return std::unexpected{DeleteError::NON_EXISTENT};
   }
 
-  // The tenant's durability key rides along in the detach's atomic batch, so a crash can't retire
-  // one without the other; the fallback below only fires when detach didn't run or wasn't attached.
+  // Delete the key here only if the detach did not retire it: no profile attached, or a durability error.
   bool retired_with_detach = false;
   if (tenant_profiles_) {
     retired_with_detach = tenant_profiles_->DetachFromDatabase(db_name, {Durability::GenKey(db_name)}).has_value();
@@ -795,8 +792,7 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
   const std::string name_copy{name};
   suspended_.erase(it);
   db_handler_.EraseColdShell(name_copy);  // guaranteed to succeed: we just verified state==COLD above
-  // The tenant's durability key rides along in the detach's atomic batch, so a crash can't retire
-  // one without the other; the fallback below only fires when detach didn't run or wasn't attached.
+  // Delete the key here only if the detach did not retire it: no profile attached, or a durability error.
   bool retired_with_detach = false;
   if (tenant_profiles_) {
     retired_with_detach = tenant_profiles_->DetachFromDatabase(name_copy, {Durability::GenKey(name_copy)}).has_value();
@@ -840,8 +836,7 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
     database.streams()->DropAll();
   }
 
-  // The tenant's durability key rides along in the detach's atomic batch, so a crash can't retire
-  // one without the other; the fallback below only fires when detach didn't run or wasn't attached.
+  // Delete the key here only if the detach did not retire it: no profile attached, or a durability error.
   bool retired_with_detach = false;
   if (tenant_profiles_) {
     retired_with_detach = tenant_profiles_->DetachFromDatabase(db_name, {Durability::GenKey(db_name)}).has_value();

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -601,9 +601,8 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
       // the key), so move it verbatim instead of parsing and rewriting it.
       const std::map<std::string, std::string> to_put{{new_key, *old_val}};
       const std::vector<std::string> to_delete{old_key};
-      // Single atomic batch: a separate Put-then-Delete would leave the tenant durably recorded under
-      // BOTH names if the process died (or Delete failed) between the two calls, and the next boot's
-      // restore loop would then restore the same uuid/data-dir twice.
+      // Atomic batch: a separate Put-then-Delete could leave the tenant durably recorded under BOTH
+      // names if the process died mid-way, and the restore loop would then restore the same uuid twice.
       if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) {
         spdlog::error("Failed to persist rename of database {} to {}; still durably recorded as {}.",
                       old_name,
@@ -615,9 +614,8 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
 
   // Update tenant profile membership (no-op if database had no profile attached).
   if (tenant_profiles_) {
-    // The rename itself already committed (in-memory + durably); a failure here is just a
-    // profile-membership bookkeeping row, so it must not stop us from falling through to
-    // AddAction<RenameDatabase> below — skipping that is what used to cause MAIN/replica divergence.
+    // The rename already committed (in-memory + durably); a profile-membership failure here must not skip
+    // the fallthrough to AddAction<RenameDatabase> below — that gap used to cause MAIN/replica divergence.
     auto renamed = tenant_profiles_->RenameDatabase(old_name, new_name);
     if (!renamed.has_value() && renamed.error() == TenantProfiles::RenameError::DURABILITY_ERROR) {
       spdlog::warn("Failed to persist tenant profile membership rename for database {} (was {}).", new_name, old_name);

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -478,16 +478,13 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
     return std::unexpected{DeleteError::NON_EXISTENT};
   }
 
-  // Detach from tenant profile BEFORE the durability key is erased below, so a crash in
-  // between cannot leave a stale profile mapping pointing at a name that no longer has a
-  // tenant. Return value is safe to ignore here — if the DB is not attached, detaching is a
-  // no-op.
+  // The tenant's durability key rides along in the detach's atomic batch, so a crash can't retire
+  // one without the other; the fallback below only fires when detach didn't run or wasn't attached.
+  bool retired_with_detach = false;
   if (tenant_profiles_) {
-    [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(db_name);
+    retired_with_detach = tenant_profiles_->DetachFromDatabase(db_name, {Durability::GenKey(db_name)}).has_value();
   }
-
-  // Remove from durability list
-  if (durability_) durability_->Delete(Durability::GenKey(db_name));
+  if (!retired_with_detach && durability_) durability_->Delete(Durability::GenKey(db_name));
 
   // Delete disk storage
   std::error_code ec;
@@ -798,14 +795,13 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
   const std::string name_copy{name};
   suspended_.erase(it);
   db_handler_.EraseColdShell(name_copy);  // guaranteed to succeed: we just verified state==COLD above
-  // Detach from tenant profile BEFORE the durability key is erased below, so a crash in
-  // between cannot leave a stale profile mapping pointing at a name that no longer has a
-  // tenant. Return value is safe to ignore here — if the DB is not attached, detaching is a
-  // no-op.
+  // The tenant's durability key rides along in the detach's atomic batch, so a crash can't retire
+  // one without the other; the fallback below only fires when detach didn't run or wasn't attached.
+  bool retired_with_detach = false;
   if (tenant_profiles_) {
-    [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(name_copy);
+    retired_with_detach = tenant_profiles_->DetachFromDatabase(name_copy, {Durability::GenKey(name_copy)}).has_value();
   }
-  if (durability_) durability_->Delete(Durability::GenKey(name_copy));
+  if (!retired_with_detach && durability_) durability_->Delete(Durability::GenKey(name_copy));
   std::error_code ec;
   (void)std::filesystem::remove_all(data_dir, ec);
   if (ec) {
@@ -844,16 +840,13 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
     database.streams()->DropAll();
   }
 
-  // Detach from tenant profile BEFORE the durability key is erased below, so a crash in
-  // between cannot leave a stale profile mapping pointing at a name that no longer has a
-  // tenant. Return value is safe to ignore here — if the DB is not attached, detaching is a
-  // no-op.
+  // The tenant's durability key rides along in the detach's atomic batch, so a crash can't retire
+  // one without the other; the fallback below only fires when detach didn't run or wasn't attached.
+  bool retired_with_detach = false;
   if (tenant_profiles_) {
-    [[maybe_unused]] auto detached = tenant_profiles_->DetachFromDatabase(db_name);
+    retired_with_detach = tenant_profiles_->DetachFromDatabase(db_name, {Durability::GenKey(db_name)}).has_value();
   }
-
-  // Remove from durability list
-  if (durability_) durability_->Delete(Durability::GenKey(db_name));
+  if (!retired_with_detach && durability_) durability_->Delete(Durability::GenKey(db_name));
 
   // Check if db exists
   // Low level handlers

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -476,12 +476,7 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
     return std::unexpected{DeleteError::NON_EXISTENT};
   }
 
-  // Delete the key here only if the detach did not retire it: no profile attached, or a durability error.
-  bool retired_with_detach = false;
-  if (tenant_profiles_) {
-    retired_with_detach = tenant_profiles_->DetachFromDatabase(db_name, {Durability::GenKey(db_name)}).has_value();
-  }
-  if (!retired_with_detach && durability_) durability_->Delete(Durability::GenKey(db_name));
+  DetachProfileAndRetireDurabilityKey_(db_name);
 
   // Delete disk storage
   std::error_code ec;
@@ -599,23 +594,31 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
     if (old_val) {
       // The stored value is name-independent (only "uuid"/"rel_dir"/cold fields; the name lives in
       // the key), so move it verbatim instead of parsing and rewriting it.
-      const std::map<std::string, std::string> to_put{{new_key, *old_val}};
+      const std::map<std::string, std::string> to_put{{new_key, std::move(*old_val)}};
       const std::vector<std::string> to_delete{old_key};
       // Atomic batch: a separate Put-then-Delete could leave the tenant durably recorded under BOTH
       // names if the process died mid-way, and the restore loop would then restore the same uuid twice.
       if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) {
-        spdlog::error("Failed to persist rename of database {} to {}; still durably recorded as {}.",
-                      old_name,
-                      new_name,
-                      old_name);
+        // The batch is atomic, so on failure old_name still stands alone durably -- but the in-memory
+        // rename above has already taken effect. Roll it back and fail the operation rather than
+        // replicate a rename MAIN never durably committed: otherwise a crash leaves MAIN recovering
+        // old_name while the replica has new_name, and any later DDL on the phantom new_name compounds
+        // the divergence (its durable key was never written, so the durability update silently no-ops).
+        spdlog::error(
+            "Failed to persist rename of database {} to {}; rolling back in-memory rename.", old_name, new_name);
+        [[maybe_unused]] auto rolled_back = db_handler_.Rename(new_name, old_name);
+        (*new_db)->storage()->config_.salient.name = old_name;
+        return std::unexpected{RenameError::FAIL};
       }
     }
   }
 
-  // Update tenant profile membership (no-op if database had no profile attached).
+  // Update tenant profile membership (no-op if database had no profile attached). Reached only after the
+  // tenant durability record has durably moved (the failure branch above returned), so this profile
+  // rewrite is the sole remaining durable write.
   if (tenant_profiles_) {
-    // The rename already committed (in-memory + durably); a profile-membership failure here must not skip
-    // the fallthrough to AddAction<RenameDatabase> below — that gap used to cause MAIN/replica divergence.
+    // A profile-membership failure here must NOT skip the AddAction<RenameDatabase> below: the rename is
+    // already durable, so refusing to replicate it is exactly what would diverge MAIN and its replicas.
     auto renamed = tenant_profiles_->RenameDatabase(old_name, new_name);
     if (!renamed.has_value() && renamed.error() == TenantProfiles::RenameError::DURABILITY_ERROR) {
       spdlog::warn("Failed to persist tenant profile membership rename for database {} (was {}).", new_name, old_name);
@@ -802,12 +805,7 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
   const std::string name_copy{name};
   suspended_.erase(it);
   db_handler_.EraseColdShell(name_copy);  // guaranteed to succeed: we just verified state==COLD above
-  // Delete the key here only if the detach did not retire it: no profile attached, or a durability error.
-  bool retired_with_detach = false;
-  if (tenant_profiles_) {
-    retired_with_detach = tenant_profiles_->DetachFromDatabase(name_copy, {Durability::GenKey(name_copy)}).has_value();
-  }
-  if (!retired_with_detach && durability_) durability_->Delete(Durability::GenKey(name_copy));
+  DetachProfileAndRetireDurabilityKey_(name_copy);
   std::error_code ec;
   (void)std::filesystem::remove_all(data_dir, ec);
   if (ec) {
@@ -846,12 +844,7 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
     database.streams()->DropAll();
   }
 
-  // Delete the key here only if the detach did not retire it: no profile attached, or a durability error.
-  bool retired_with_detach = false;
-  if (tenant_profiles_) {
-    retired_with_detach = tenant_profiles_->DetachFromDatabase(db_name, {Durability::GenKey(db_name)}).has_value();
-  }
-  if (!retired_with_detach && durability_) durability_->Delete(Durability::GenKey(db_name));
+  DetachProfileAndRetireDurabilityKey_(db_name);
 
   // Check if db exists
   // Low level handlers
@@ -865,6 +858,14 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
   });
 
   return {};  // Success
+}
+
+void DbmsHandler::DetachProfileAndRetireDurabilityKey_(std::string_view db_name) {
+  bool retired_with_detach = false;
+  if (tenant_profiles_) {
+    retired_with_detach = tenant_profiles_->DetachFromDatabase(db_name, {Durability::GenKey(db_name)}).has_value();
+  }
+  if (!retired_with_detach && durability_) durability_->Delete(Durability::GenKey(db_name));
 }
 
 void DbmsHandler::UpdateDurability(const storage::Config &config, std::optional<std::filesystem::path> rel_dir) {

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -589,7 +589,7 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
   if (durability_) {
     const auto old_key = Durability::GenKey(old_name);
     const auto new_key = Durability::GenKey(new_name);
-    const auto old_val = durability_->Get(old_key);
+    auto old_val = durability_->Get(old_key);
 
     if (old_val) {
       // The stored value is name-independent (only "uuid"/"rel_dir"/cold fields; the name lives in
@@ -606,6 +606,8 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
         // the divergence (its durable key was never written, so the durability update silently no-ops).
         spdlog::error(
             "Failed to persist rename of database {} to {}; rolling back in-memory rename.", old_name, new_name);
+        // NOLINTNEXTLINE(readability-suspicious-call-argument): intentional reverse rename -- the DB is
+        // currently named new_name, so rename it back to old_name to undo the in-memory rename above.
         [[maybe_unused]] auto rolled_back = db_handler_.Rename(new_name, old_name);
         (*new_db)->storage()->config_.salient.name = old_name;
         return std::unexpected{RenameError::FAIL};

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -599,12 +599,16 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
     if (old_val) {
       // The stored value is name-independent (only "uuid"/"rel_dir"/cold fields; the name lives in
       // the key), so move it verbatim instead of parsing and rewriting it.
-      if (durability_->Put(new_key, *old_val)) {
-        durability_->Delete(old_key);
-      } else {
-        // Only drop the old key once the new one is durably in place; otherwise the tenant would be
-        // left with no durability record under either name and vanish on the next restart.
-        spdlog::error("Failed to write durability record for renamed database {} (was {}).", new_name, old_name);
+      const std::map<std::string, std::string> to_put{{new_key, *old_val}};
+      const std::vector<std::string> to_delete{old_key};
+      // Single atomic batch: a separate Put-then-Delete would leave the tenant durably recorded under
+      // BOTH names if the process died (or Delete failed) between the two calls, and the next boot's
+      // restore loop would then restore the same uuid/data-dir twice.
+      if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) {
+        spdlog::error("Failed to persist rename of database {} to {}; still durably recorded as {}.",
+                      old_name,
+                      new_name,
+                      old_name);
       }
     }
   }

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -1505,6 +1505,18 @@ DbmsHandler::ResumeResult DbmsHandler::Resume_(std::string_view name, system::Tr
             std::chrono::duration<double>(std::chrono::steady_clock::now() - resume_start).count());
       });
 
+      // A resumed tenant is a freshly built Database with a default (uncapped) tracker, so the
+      // attached profile's memory cap has to be re-applied.
+      best_effort("re-applying tenant profile memory limit", [&] {
+        if (tenant_profiles_) {
+          if (auto profile_name = tenant_profiles_->GetProfileForDatabase(name)) {
+            if (auto profile = tenant_profiles_->Get(*profile_name); profile && profile->memory_limit > 0) {
+              acc.get()->SetTenantMemoryLimit(profile->memory_limit);
+            }
+          }
+        }
+      });
+
       // Flip the durable entry back to HOT (drop the cold marker) so a restart recovers it HOT.
       // Done in a SEPARATE short lock_ scope AFTER the publish. The write is guarded by
       // !suspended_.contains: if a SUSPEND raced in after our publish-erase and re-suspended the tenant,

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -366,6 +366,24 @@ DbmsHandler::DbmsHandler(storage::Config config, ResumeRetryPolicy resume_retry_
    * TENANT PROFILES
    */
   tenant_profiles_ = std::make_unique<TenantProfiles>(*durability_);
+
+  {
+    // Live set is built from the durable key prefix, NOT Get_/db_handler_: Get_ is HOT-gated, so a
+    // suspended (COLD) tenant would look absent and PruneDatabases would wrongly delete its
+    // attachment. The key prefix covers HOT and COLD identically, and stays correct even for an
+    // entry whose value failed to parse above, since its key is still present.
+    std::set<std::string> live{std::string{kDefaultDB}};
+    for (auto pit = durability_->begin(std::string(kDBPrefix)), pend = durability_->end(std::string(kDBPrefix));
+         pit != pend;
+         ++pit) {
+      live.insert(pit->first.substr(kDBPrefix.size()));
+    }
+    const auto pruned = tenant_profiles_->PruneDatabases(live);
+    if (pruned != 0) {
+      spdlog::warn("Pruned {} tenant profile attachment(s) whose database no longer exists.", pruned);
+    }
+  }
+
   RestoreTenantProfiles_();
 }
 

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -964,6 +964,11 @@ class DbmsHandler {
   // Caller must hold lock_ (write).
   std::expected<utils::UUID, DeleteError> DeleteCold_(std::string_view name);
 
+  // Retire the tenant's own durability key together with its profile detach in one atomic kvstore batch
+  // when a profile is attached; otherwise delete the key on its own. Safe (no-op on the key) when the
+  // database has no attached profile. Caller must hold lock_.
+  void DetachProfileAndRetireDurabilityKey_(std::string_view db_name);
+
   // Cold-tenant fast path shared by every Delete/TryDelete overload: if `name` is currently in
   // suspended_, drop it via DeleteCold_ (bypassing the HOT gatekeeper path, which would otherwise
   // return NON_EXISTENT for a no-value shell) and return the DeleteResult. Records a DropDatabase

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -1064,8 +1064,7 @@ class DbmsHandler {
           }
         } catch (const UnknownDatabaseException &) {
           if (suspended_.contains(db_name)) {
-            // Get_ is HOT-gated, so a suspended tenant throws here even though it exists; its cap is
-            // applied by Resume_ instead.
+            // SuspendedDatabaseException derives from UnknownDatabaseException, so a COLD tenant lands here too.
             spdlog::info("Tenant profile '{}' targets suspended database '{}' — limit will be applied on resume",
                          profile.name,
                          db_name);

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -1063,7 +1063,15 @@ class DbmsHandler {
                 "Applied tenant profile '{}' (limit={}) to database '{}'", profile.name, profile.memory_limit, db_name);
           }
         } catch (const UnknownDatabaseException &) {
-          spdlog::warn("Tenant profile '{}' references unknown database '{}' — skipping", profile.name, db_name);
+          if (suspended_.contains(db_name)) {
+            // Get_ is HOT-gated, so a suspended tenant throws here even though it exists; its cap is
+            // applied by Resume_ instead.
+            spdlog::info("Tenant profile '{}' targets suspended database '{}' — limit will be applied on resume",
+                         profile.name,
+                         db_name);
+          } else {
+            spdlog::warn("Tenant profile '{}' references unknown database '{}' — skipping", profile.name, db_name);
+          }
         }
       }
     }

--- a/src/dbms/tenant_profiles.cpp
+++ b/src/dbms/tenant_profiles.cpp
@@ -100,7 +100,7 @@ std::optional<TenantProfiles::Profile> TenantProfiles::Get(std::string_view name
   if (!stored) return std::nullopt;
   try {
     return FromJson(nlohmann::json::parse(*stored), name);
-  } catch (const nlohmann::json::parse_error &e) {
+  } catch (const nlohmann::json::exception &e) {
     spdlog::warn("Failed to parse tenant profile '{}': {}", name, e.what());
     return std::nullopt;
   }
@@ -114,7 +114,10 @@ std::vector<TenantProfiles::Profile> TenantProfiles::GetAll() const {
     auto name = key.substr(kPrefix.size());
     try {
       result.push_back(FromJson(nlohmann::json::parse(value), name));
-    } catch (const nlohmann::json::parse_error &e) {
+    } catch (const nlohmann::json::exception &e) {
+      // Base json::exception, not parse_error: FromJson's .get<int64_t>() on a wrong-typed persisted field
+      // throws type_error, a sibling of parse_error, and this runs on the ctor's startup path with no
+      // enclosing try/catch up to main().
       spdlog::warn("Failed to parse tenant profile '{}': {}", name, e.what());
     }
   }
@@ -230,14 +233,26 @@ std::expected<void, TenantProfiles::RenameError> TenantProfiles::RenameDatabase(
   auto profile_stored = durability_->Get(ProfileKey(*profile_name));
   if (!profile_stored) return std::unexpected{RenameError::DURABILITY_ERROR};
 
-  Profile profile = FromJson(nlohmann::json::parse(*profile_stored), *profile_name);
-  profile.databases.erase(std::string{old_name});
-  profile.databases.insert(std::string{new_name});
+  std::map<std::string, std::string> to_put;
+  try {
+    Profile profile = FromJson(nlohmann::json::parse(*profile_stored), *profile_name);
+    profile.databases.erase(std::string{old_name});
+    profile.databases.insert(std::string{new_name});
+    to_put.emplace(ProfileKey(profile.name), ProfileToJson(profile).dump());
+    to_put.emplace(DbMappingKey(new_name), *profile_name);
+  } catch (const nlohmann::json::exception &e) {
+    // Corrupt reads the same as unreadable to the caller, so reuse DURABILITY_ERROR rather than add a new
+    // variant. The old mapping key is deliberately left in place: the caller (DbmsHandler::Rename) still
+    // completes and replicates the rename, and the next boot's PruneDatabases collects the now-stale
+    // mapping once the old database name is no longer in the live set.
+    spdlog::warn("Tenant profile '{}' durable entry is corrupt ({}); failed to rename database '{}' to '{}'.",
+                 *profile_name,
+                 e.what(),
+                 old_name,
+                 new_name);
+    return std::unexpected{RenameError::DURABILITY_ERROR};
+  }
 
-  const std::map<std::string, std::string> to_put{
-      {ProfileKey(profile.name), ProfileToJson(profile).dump()},
-      {DbMappingKey(new_name), *profile_name},
-  };
   const std::vector<std::string> to_delete{DbMappingKey(old_name)};
   if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) return std::unexpected{RenameError::DURABILITY_ERROR};
   return {};

--- a/src/dbms/tenant_profiles.cpp
+++ b/src/dbms/tenant_profiles.cpp
@@ -13,6 +13,7 @@
 
 #ifdef MG_ENTERPRISE
 
+#include <iterator>
 #include <map>
 #include <set>
 
@@ -144,7 +145,8 @@ std::expected<int64_t, TenantProfiles::AttachError> TenantProfiles::AttachToData
   return new_profile.memory_limit;
 }
 
-std::expected<void, TenantProfiles::DetachError> TenantProfiles::DetachFromDatabase(std::string_view db_name) {
+std::expected<void, TenantProfiles::DetachError> TenantProfiles::DetachFromDatabase(
+    std::string_view db_name, std::vector<std::string> extra_keys_to_delete) {
   const std::unique_lock lock{mutex_};
   auto profile_name = durability_->Get(DbMappingKey(db_name));
   if (!profile_name) return std::unexpected{DetachError::NOT_ATTACHED};
@@ -168,7 +170,10 @@ std::expected<void, TenantProfiles::DetachError> TenantProfiles::DetachFromDatab
     return std::unexpected{DetachError::DURABILITY_ERROR};
   }
 
-  const std::vector<std::string> to_delete{DbMappingKey(db_name)};
+  std::vector<std::string> to_delete{DbMappingKey(db_name)};
+  to_delete.insert(to_delete.end(),
+                   std::make_move_iterator(extra_keys_to_delete.begin()),
+                   std::make_move_iterator(extra_keys_to_delete.end()));
   if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) return std::unexpected{DetachError::DURABILITY_ERROR};
   return {};
 }

--- a/src/dbms/tenant_profiles.cpp
+++ b/src/dbms/tenant_profiles.cpp
@@ -14,6 +14,8 @@
 #ifdef MG_ENTERPRISE
 
 #include <map>
+#include <set>
+
 #include <nlohmann/json.hpp>
 
 #include "spdlog/spdlog.h"
@@ -157,6 +159,47 @@ std::expected<void, TenantProfiles::DetachError> TenantProfiles::DetachFromDatab
   const std::vector<std::string> to_delete{DbMappingKey(db_name)};
   if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) return std::unexpected{DetachError::DURABILITY_ERROR};
   return {};
+}
+
+std::size_t TenantProfiles::PruneDatabases(const std::set<std::string> &live_db_names) {
+  const std::unique_lock lock{mutex_};
+
+  std::vector<std::string> to_delete;
+  // Group stale db names by the profile they point at, keyed by profile name, so that a profile
+  // attached to two stale databases gets its JSON re-read/rewritten once: the batch below is a
+  // std::map keyed by ProfileKey(profile.name), and a second put of the same key would silently
+  // overwrite the first, losing whichever prune lost the race.
+  std::map<std::string, std::set<std::string>> stale_by_profile;
+  const auto mapping_end = durability_->end(std::string{kDbMappingPrefix});
+  for (auto it = durability_->begin(std::string{kDbMappingPrefix}); it != mapping_end; ++it) {
+    const auto &[key, profile_name] = *it;
+    auto db_name = key.substr(kDbMappingPrefix.size());
+    if (live_db_names.contains(db_name)) continue;
+    to_delete.push_back(key);
+    stale_by_profile[profile_name].insert(std::move(db_name));
+  }
+  if (to_delete.empty()) return 0;
+
+  std::map<std::string, std::string> to_put;
+  for (const auto &[profile_name, stale_dbs] : stale_by_profile) {
+    auto stored = durability_->Get(ProfileKey(profile_name));
+    if (!stored) continue;
+    try {
+      Profile profile = FromJson(nlohmann::json::parse(*stored), profile_name);
+      for (const auto &db_name : stale_dbs) profile.databases.erase(db_name);
+      to_put.emplace(ProfileKey(profile.name), ProfileToJson(profile).dump());
+    } catch (const nlohmann::json::exception &e) {
+      // The mapping key is deleted regardless: it points at a database that already failed the
+      // live_db_names check, so it is garbage whether or not the profile it names can be parsed.
+      // Only nlohmann::json::exception is caught so std::bad_alloc keeps propagating.
+      spdlog::warn("Tenant profile '{}' durable entry is corrupt ({}); pruning its stale database mapping(s) anyway.",
+                   profile_name,
+                   e.what());
+    }
+  }
+
+  if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) return 0;
+  return to_delete.size();
 }
 
 std::expected<void, TenantProfiles::RenameError> TenantProfiles::RenameDatabase(std::string_view old_name,

--- a/src/dbms/tenant_profiles.cpp
+++ b/src/dbms/tenant_profiles.cpp
@@ -160,9 +160,8 @@ std::expected<void, TenantProfiles::DetachError> TenantProfiles::DetachFromDatab
     profile.databases.erase(std::string{db_name});
     to_put.emplace(ProfileKey(profile.name), ProfileToJson(profile).dump());
   } catch (const nlohmann::json::exception &e) {
-    // Corrupt is indistinguishable from unreadable to the caller, so this reuses DURABILITY_ERROR
-    // rather than adding a new error; the mapping key is left untouched (not deleted here) because
-    // PruneDatabases (boot reconciliation) already prunes mappings whose profile can't be parsed.
+    // Corrupt reads the same as unreadable to the caller, so reuse DURABILITY_ERROR; the mapping key is
+    // left behind on purpose -- the next boot's PruneDatabases collects it once the database key is gone.
     spdlog::warn("Tenant profile '{}' durable entry is corrupt ({}); failed to detach database '{}'.",
                  *profile_name,
                  e.what(),
@@ -182,10 +181,8 @@ std::size_t TenantProfiles::PruneDatabases(const std::set<std::string> &live_db_
   const std::unique_lock lock{mutex_};
 
   std::vector<std::string> to_delete;
-  // Group stale db names by the profile they point at, keyed by profile name, so that a profile
-  // attached to two stale databases gets its JSON re-read/rewritten once: the batch below is a
-  // std::map keyed by ProfileKey(profile.name), and a second put of the same key would silently
-  // overwrite the first, losing whichever prune lost the race.
+  // Group stale db names by profile so a profile attached to two stale databases is read and rewritten
+  // once: to_put is keyed by ProfileKey, so a duplicate emplace is dropped and one erase would be lost.
   std::map<std::string, std::set<std::string>> stale_by_profile;
   const auto mapping_end = durability_->end(std::string{kDbMappingPrefix});
   for (auto it = durability_->begin(std::string{kDbMappingPrefix}); it != mapping_end; ++it) {
@@ -206,16 +203,21 @@ std::size_t TenantProfiles::PruneDatabases(const std::set<std::string> &live_db_
       for (const auto &db_name : stale_dbs) profile.databases.erase(db_name);
       to_put.emplace(ProfileKey(profile.name), ProfileToJson(profile).dump());
     } catch (const nlohmann::json::exception &e) {
-      // The mapping key is deleted regardless: it points at a database that already failed the
-      // live_db_names check, so it is garbage whether or not the profile it names can be parsed.
-      // Only nlohmann::json::exception is caught so std::bad_alloc keeps propagating.
+      // The mapping key is deleted regardless -- its database already failed the live_db_names check,
+      // so it is garbage either way. Catching only json::exception keeps std::bad_alloc propagating.
       spdlog::warn("Tenant profile '{}' durable entry is corrupt ({}); pruning its stale database mapping(s) anyway.",
                    profile_name,
                    e.what());
     }
   }
 
-  if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) return 0;
+  if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) {
+    spdlog::error(
+        "Failed to durably prune {} stale tenant profile database attachment(s); they survive this boot and "
+        "reconciliation will be retried on the next one.",
+        to_delete.size());
+    return 0;
+  }
   return to_delete.size();
 }
 

--- a/src/dbms/tenant_profiles.cpp
+++ b/src/dbms/tenant_profiles.cpp
@@ -115,9 +115,8 @@ std::vector<TenantProfiles::Profile> TenantProfiles::GetAll() const {
     try {
       result.push_back(FromJson(nlohmann::json::parse(value), name));
     } catch (const nlohmann::json::exception &e) {
-      // Base json::exception, not parse_error: FromJson's .get<int64_t>() on a wrong-typed persisted field
-      // throws type_error, a sibling of parse_error, and this runs on the ctor's startup path with no
-      // enclosing try/catch up to main().
+      // Base json::exception, not parse_error: a wrong-typed field makes FromJson's .get<int64_t>() throw
+      // sibling type_error, and GetAll runs on the boot path with no enclosing catch up to main().
       spdlog::warn("Failed to parse tenant profile '{}': {}", name, e.what());
     }
   }
@@ -241,10 +240,8 @@ std::expected<void, TenantProfiles::RenameError> TenantProfiles::RenameDatabase(
     to_put.emplace(ProfileKey(profile.name), ProfileToJson(profile).dump());
     to_put.emplace(DbMappingKey(new_name), *profile_name);
   } catch (const nlohmann::json::exception &e) {
-    // Corrupt reads the same as unreadable to the caller, so reuse DURABILITY_ERROR rather than add a new
-    // variant. The old mapping key is deliberately left in place: the caller (DbmsHandler::Rename) still
-    // completes and replicates the rename, and the next boot's PruneDatabases collects the now-stale
-    // mapping once the old database name is no longer in the live set.
+    // Corrupt reads the same as unreadable to the caller, so reuse DURABILITY_ERROR. DbmsHandler::Rename
+    // still completes/replicates regardless; the old mapping key is left for PruneDatabases to collect.
     spdlog::warn("Tenant profile '{}' durable entry is corrupt ({}); failed to rename database '{}' to '{}'.",
                  *profile_name,
                  e.what(),

--- a/src/dbms/tenant_profiles.cpp
+++ b/src/dbms/tenant_profiles.cpp
@@ -152,10 +152,22 @@ std::expected<void, TenantProfiles::DetachError> TenantProfiles::DetachFromDatab
   auto profile_stored = durability_->Get(ProfileKey(*profile_name));
   if (!profile_stored) return std::unexpected{DetachError::DURABILITY_ERROR};
 
-  Profile profile = FromJson(nlohmann::json::parse(*profile_stored), *profile_name);
-  profile.databases.erase(std::string{db_name});
+  std::map<std::string, std::string> to_put;
+  try {
+    Profile profile = FromJson(nlohmann::json::parse(*profile_stored), *profile_name);
+    profile.databases.erase(std::string{db_name});
+    to_put.emplace(ProfileKey(profile.name), ProfileToJson(profile).dump());
+  } catch (const nlohmann::json::exception &e) {
+    // Corrupt is indistinguishable from unreadable to the caller, so this reuses DURABILITY_ERROR
+    // rather than adding a new error; the mapping key is left untouched (not deleted here) because
+    // PruneDatabases (boot reconciliation) already prunes mappings whose profile can't be parsed.
+    spdlog::warn("Tenant profile '{}' durable entry is corrupt ({}); failed to detach database '{}'.",
+                 *profile_name,
+                 e.what(),
+                 db_name);
+    return std::unexpected{DetachError::DURABILITY_ERROR};
+  }
 
-  const std::map<std::string, std::string> to_put{{ProfileKey(profile.name), ProfileToJson(profile).dump()}};
   const std::vector<std::string> to_delete{DbMappingKey(db_name)};
   if (!durability_->PutAndDeleteMultiple(to_put, to_delete)) return std::unexpected{DetachError::DURABILITY_ERROR};
   return {};

--- a/src/dbms/tenant_profiles.hpp
+++ b/src/dbms/tenant_profiles.hpp
@@ -76,7 +76,8 @@ class TenantProfiles {
   /// name inside the pointed-to Profile's `databases`) that nothing else ever reconciles. This removes
   /// every persisted database->profile attachment whose database name is absent from `live_db_names`:
   /// the mapping key is deleted and the name is dropped from its profile's `databases`, atomically.
-  /// Returns the number of attachments pruned (0 = nothing to prune); callers use this for logging only.
+  /// Returns the number of attachments pruned. 0 means either nothing needed pruning or the durability batch
+  /// failed (logged here at error level) -- a caller cannot tell those apart and must not read 0 as success.
   std::size_t PruneDatabases(const std::set<std::string> &live_db_names);
 
   std::optional<std::string> GetProfileForDatabase(std::string_view db_name) const;

--- a/src/dbms/tenant_profiles.hpp
+++ b/src/dbms/tenant_profiles.hpp
@@ -71,13 +71,14 @@ class TenantProfiles {
                                                       std::vector<std::string> extra_keys_to_delete = {});
   std::expected<void, RenameError> RenameDatabase(std::string_view old_name, std::string_view new_name);
 
-  /// Startup reconciliation. A crash between DROP DATABASE erasing the tenant's durability key and the
-  /// matching DetachFromDatabase call leaves a permanently stale kDbMappingPrefix entry (and a dangling
-  /// name inside the pointed-to Profile's `databases`) that nothing else ever reconciles. This removes
-  /// every persisted database->profile attachment whose database name is absent from `live_db_names`:
-  /// the mapping key is deleted and the name is dropped from its profile's `databases`, atomically.
-  /// Returns the number of attachments pruned. 0 means either nothing needed pruning or the durability batch
-  /// failed (logged here at error level) -- a caller cannot tell those apart and must not read 0 as success.
+  /// Startup reconciliation. A DROP that retires the tenant's durability key without its detach -- the
+  /// detach refuses on a corrupt profile record and the caller retires the key anyway, and older
+  /// releases wrote the two non-atomically -- leaves a permanently stale kDbMappingPrefix entry (and a
+  /// dangling name inside the pointed-to Profile's `databases`) that nothing else ever reconciles. This
+  /// removes every persisted database->profile attachment whose database name is absent from
+  /// `live_db_names`: the mapping key is deleted and the name is dropped from its profile's `databases`,
+  /// atomically. Returns the number pruned; 0 is ambiguous between nothing-to-prune and a failed
+  /// durability batch (logged here at error level), so a caller must not read 0 as success.
   std::size_t PruneDatabases(const std::set<std::string> &live_db_names);
 
   std::optional<std::string> GetProfileForDatabase(std::string_view db_name) const;

--- a/src/dbms/tenant_profiles.hpp
+++ b/src/dbms/tenant_profiles.hpp
@@ -59,7 +59,16 @@ class TenantProfiles {
   std::vector<Profile> GetAll() const;
 
   std::expected<int64_t, AttachError> AttachToDatabase(std::string_view profile_name, std::string_view db_name);
-  std::expected<void, DetachError> DetachFromDatabase(std::string_view db_name);
+
+  /// Detaches `db_name` from whichever profile it is attached to. `extra_keys_to_delete` are folded into
+  /// the SAME atomic kvstore batch as the detach itself and are deleted if and only if the function
+  /// returns success; on ANY error -- including NOT_ATTACHED -- none of them are deleted and the caller
+  /// remains responsible for them. This exists so a DROP DATABASE can retire the tenant's own durability
+  /// key (`database:<name>`) together with its profile attachment in one write: without it, a crash
+  /// between two separate writes could leave the tenant key behind after its attachment is already gone,
+  /// resurrecting the tenant on the next boot with no attachment left to reconcile it.
+  std::expected<void, DetachError> DetachFromDatabase(std::string_view db_name,
+                                                      std::vector<std::string> extra_keys_to_delete = {});
   std::expected<void, RenameError> RenameDatabase(std::string_view old_name, std::string_view new_name);
 
   /// Startup reconciliation. A crash between DROP DATABASE erasing the tenant's durability key and the

--- a/src/dbms/tenant_profiles.hpp
+++ b/src/dbms/tenant_profiles.hpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <expected>
 #include <optional>
+#include <set>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
@@ -60,6 +61,15 @@ class TenantProfiles {
   std::expected<int64_t, AttachError> AttachToDatabase(std::string_view profile_name, std::string_view db_name);
   std::expected<void, DetachError> DetachFromDatabase(std::string_view db_name);
   std::expected<void, RenameError> RenameDatabase(std::string_view old_name, std::string_view new_name);
+
+  /// Startup reconciliation. A crash between DROP DATABASE erasing the tenant's durability key and the
+  /// matching DetachFromDatabase call leaves a permanently stale kDbMappingPrefix entry (and a dangling
+  /// name inside the pointed-to Profile's `databases`) that nothing else ever reconciles. This removes
+  /// every persisted database->profile attachment whose database name is absent from `live_db_names`:
+  /// the mapping key is deleted and the name is dropped from its profile's `databases`, atomically.
+  /// Returns the number of attachments pruned (0 = nothing to prune); callers use this for logging only.
+  std::size_t PruneDatabases(const std::set<std::string> &live_db_names);
+
   std::optional<std::string> GetProfileForDatabase(std::string_view db_name) const;
 
  private:

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -75,8 +75,9 @@ SeededRoot MakeSeededRoot(std::string_view tag) {
 // rel_dir rooted at kMultiTenantDir/<uuid> as New_/UpdateDurability recompute it (dbms_handler.cpp:860).
 struct SeededHotEntry {
   memgraph::utils::UUID uuid;
-  // Bytes written for this entry; read back verbatim by RenameMovesTenantDurabilityRecordVerbatim to catch
-  // a rename that parses/mutates/re-dumps the record. Do not delete this field as write-only.
+  // Bytes that SeedHotEntry wrote for this entry. Previously read back verbatim by
+  // RenameMovesTenantDurabilityRecordVerbatim; that test now captures the live post-construction value
+  // directly, so this field is no longer read but kept to avoid reshaping the return type.
   std::string json_str;
 };
 
@@ -847,6 +848,21 @@ TEST(DBMS_Handler, RenameMovesTenantDurabilityRecordVerbatim) {
   std::unique_ptr<DbmsHandler> handler;
   ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
 
+  // Capture the live durable value the ctor (New_->UpdateDurability) wrote for "before". The handler
+  // holds the KVStore lock (one-writer-at-a-time contract, see comment above SeedHotEntry), so reset
+  // it first, read in a fresh KVStore scope, then reconstruct. UpdateDurability is deterministic for
+  // the same (uuid, rel_dir) pair, so the second construction leaves "before"'s value unchanged and
+  // live_before remains equal to whatever the rename will consume.
+  std::string live_before;
+  {
+    handler.reset();
+    memgraph::kvstore::KVStore snap_kv{sr.durability_dir};
+    auto v = snap_kv.Get(std::string{kDBPrefixLiteral} + "before");
+    ASSERT_TRUE(v.has_value()) << "database:before must exist after handler construction";
+    live_before = *v;
+  }
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
+
   auto res = handler->Rename("before", "after");
   ASSERT_TRUE(res.has_value()) << "a plain, healthy rename must succeed";
 
@@ -857,15 +873,16 @@ TEST(DBMS_Handler, RenameMovesTenantDurabilityRecordVerbatim) {
 
   {
     memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
-    auto new_val = verify_kv.Get(std::string{kDBPrefixLiteral} + "after");
-    ASSERT_TRUE(new_val.has_value()) << "database:after must exist";
-    EXPECT_EQ(*new_val, seeded.json_str)
-        << "the moved record must be byte-identical to what was seeded -- parsing and re-dumping it (the "
-           "pre-fix behavior) would not round-trip to the exact same bytes";
+    auto after_val = verify_kv.Get(std::string{kDBPrefixLiteral} + "after");
+    ASSERT_TRUE(after_val.has_value()) << "database:after must exist";
+    EXPECT_EQ(*after_val, live_before)
+        << "the moved record must be byte-identical to the live value that was under database:before "
+           "immediately before the rename; the pre-fix behavior (parse -> inject \"name\" field -> dump) "
+           "would produce a different byte string and fail this comparison";
     EXPECT_FALSE(verify_kv.Get(std::string{kDBPrefixLiteral} + "before").has_value())
         << "database:before must no longer exist";
 
-    const auto entry_json = nlohmann::json::parse(*new_val);
+    const auto entry_json = nlohmann::json::parse(*after_val);
     EXPECT_FALSE(entry_json.contains("name"))
         << "the pre-fix code injected a \"name\" field on every rename; Durability::GenVal never writes one "
            "and nothing reads it back -- it was write-only litter";

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -73,23 +73,16 @@ SeededRoot MakeSeededRoot(std::string_view tag) {
 
 // Exact shape of Durability::GenVal (dbms_handler.cpp:114): {"uuid": <uuid>, "rel_dir": <path>}, with
 // rel_dir rooted at kMultiTenantDir/<uuid> as New_/UpdateDurability recompute it (dbms_handler.cpp:860).
-memgraph::utils::UUID SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
-  const memgraph::utils::UUID uuid;
-  nlohmann::json j;
-  j["uuid"] = uuid;
-  j["rel_dir"] = std::filesystem::path(std::string{memgraph::dbms::kMultiTenantDir}) / std::string{uuid};
-  kv.Put(std::string{kDBPrefixLiteral} + std::string{name}, j.dump());
-  return uuid;
-}
-
-// Same shape as SeedHotEntry, but also hands back the exact bytes it wrote: needed by tests asserting that
-// a durability record survives an operation VERBATIM (byte-for-byte), not merely "still there".
 struct SeededHotEntry {
   memgraph::utils::UUID uuid;
+  // The exact bytes written for this entry. Needed by RenameMovesTenantDurabilityRecordVerbatim, which
+  // asserts the durability record survives RENAME byte-for-byte (VERBATIM), not merely "still present" --
+  // a parse-and-recompare wouldn't catch a rename that parses, mutates, and re-dumps the record. Callers
+  // that only need the uuid should just drop this field on the floor, not delete it as write-only.
   std::string json_str;
 };
 
-SeededHotEntry SeedHotEntryCapturingJson(memgraph::kvstore::KVStore &kv, std::string_view name) {
+SeededHotEntry SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
   const memgraph::utils::UUID uuid;
   nlohmann::json j;
   j["uuid"] = uuid;
@@ -527,7 +520,7 @@ TEST(DBMS_Handler, SweepReclaimsOrphanedTenantDirectoryButKeepsLiveOne) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    live_uuid = SeedHotEntry(seed_kv, "live");
+    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
   }
 
   const auto live_dir = TenantDataDir(sr, live_uuid);
@@ -569,7 +562,7 @@ TEST(DBMS_Handler, StaleTenantProfileMappingIsPrunedOnStartup) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    live_uuid = SeedHotEntry(seed_kv, "live");
+    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
     // "gone" has NO `database:gone` durability key -- exactly the state a lost DetachFromDatabase leaves.
     SeedProfile(seed_kv, "p", /*memory_limit=*/1000, {"live", "gone"});
   }
@@ -651,7 +644,7 @@ TEST(DBMS_Handler, ExistingV2DurabilityStoreBootsUnchanged) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    live_uuid = SeedHotEntry(seed_kv, "live");
+    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
   }
   fs::create_directories(TenantDataDir(sr, live_uuid));
 
@@ -699,7 +692,7 @@ TEST(DBMS_Handler, DropSucceedsDurablyWhenAttachedProfileJsonIsCorrupt) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    victim_uuid = SeedHotEntry(seed_kv, "victim");
+    victim_uuid = SeedHotEntry(seed_kv, "victim").uuid;
     // Point "victim" at profile "p", but write "p"'s durable record as deliberately broken JSON --
     // NOT via SeedProfile, which would also write a well-formed tenant_profile:p row.
     ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kDbMappingPrefix} + "victim", "p"));
@@ -769,7 +762,7 @@ TEST(DBMS_Handler, RenameSucceedsAndReplicatesWhenAttachedProfileJsonIsCorrupt) 
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    victim_uuid = SeedHotEntry(seed_kv, "victim");
+    victim_uuid = SeedHotEntry(seed_kv, "victim").uuid;
     ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kDbMappingPrefix} + "victim", "p"));
     // Deliberately broken JSON -- NOT via SeedProfile, which would write a well-formed tenant_profile:p row.
     ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kPrefix} + "p", "{not json"));
@@ -850,7 +843,7 @@ TEST(DBMS_Handler, RenameMovesTenantDurabilityRecordVerbatim) {
   auto seeded = [&] {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     seed_kv.Put("version", "V2");
-    return SeedHotEntryCapturingJson(seed_kv, "before");
+    return SeedHotEntry(seed_kv, "before");
   }();
   fs::create_directories(TenantDataDir(sr, seeded.uuid));
 

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -75,10 +75,8 @@ SeededRoot MakeSeededRoot(std::string_view tag) {
 // rel_dir rooted at kMultiTenantDir/<uuid> as New_/UpdateDurability recompute it (dbms_handler.cpp:860).
 struct SeededHotEntry {
   memgraph::utils::UUID uuid;
-  // The exact bytes written for this entry. Needed by RenameMovesTenantDurabilityRecordVerbatim, which
-  // asserts the durability record survives RENAME byte-for-byte (VERBATIM), not merely "still present" --
-  // a parse-and-recompare wouldn't catch a rename that parses, mutates, and re-dumps the record. Callers
-  // that only need the uuid should just drop this field on the floor, not delete it as write-only.
+  // Bytes written for this entry; read back verbatim by RenameMovesTenantDurabilityRecordVerbatim to catch
+  // a rename that parses/mutates/re-dumps the record. Do not delete this field as write-only.
   std::string json_str;
 };
 
@@ -92,11 +90,9 @@ SeededHotEntry SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view nam
   return {uuid, std::move(json_str)};
 }
 
-// Counts how many system actions actually get applied through a Transaction::Commit. Transaction::Commit
-// (system/transaction.hpp) early-returns via Abort() -- without ever calling ApplyAction -- when actions_ is
-// empty, so this is the one observable that discriminates "AddAction<RenameDatabase> ran" (applied == 1)
-// from "it was skipped" (applied == 0). CanReplicateInCommunity() cannot make that distinction: it reads
-// false both for zero actions and for one dbms action.
+// Counts actions applied via Transaction::Commit: Commit's early-return path (empty actions_) calls Abort(),
+// never ApplyAction, so applied==1 vs 0 discriminates "AddAction<RenameDatabase> ran" from "skipped" -- a
+// distinction CanReplicateInCommunity() can't make (false for both zero actions and one dbms action).
 struct CountingReplicationPolicy {
   int *applied;
 

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -30,6 +30,7 @@
 #include "kvstore/kvstore.hpp"
 #include "query/config.hpp"
 #include "query/interpreter.hpp"
+#include "system/system.hpp"
 #include "utils/uuid.hpp"
 
 namespace {
@@ -80,6 +81,42 @@ memgraph::utils::UUID SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_v
   kv.Put(std::string{kDBPrefixLiteral} + std::string{name}, j.dump());
   return uuid;
 }
+
+// Same shape as SeedHotEntry, but also hands back the exact bytes it wrote: needed by tests asserting that
+// a durability record survives an operation VERBATIM (byte-for-byte), not merely "still there".
+struct SeededHotEntry {
+  memgraph::utils::UUID uuid;
+  std::string json_str;
+};
+
+SeededHotEntry SeedHotEntryCapturingJson(memgraph::kvstore::KVStore &kv, std::string_view name) {
+  const memgraph::utils::UUID uuid;
+  nlohmann::json j;
+  j["uuid"] = uuid;
+  j["rel_dir"] = std::filesystem::path(std::string{memgraph::dbms::kMultiTenantDir}) / std::string{uuid};
+  auto json_str = j.dump();
+  kv.Put(std::string{kDBPrefixLiteral} + std::string{name}, json_str);
+  return {uuid, std::move(json_str)};
+}
+
+// Counts how many system actions actually get applied through a Transaction::Commit. Transaction::Commit
+// (system/transaction.hpp) early-returns via Abort() -- without ever calling ApplyAction -- when actions_ is
+// empty, so this is the one observable that discriminates "AddAction<RenameDatabase> ran" (applied == 1)
+// from "it was skipped" (applied == 0). CanReplicateInCommunity() cannot make that distinction: it reads
+// false both for zero actions and for one dbms action.
+struct CountingReplicationPolicy {
+  int *applied;
+
+  auto ApplyAction(const memgraph::system::ISystemAction & /*action*/, const memgraph::system::Transaction & /*txn*/)
+      -> memgraph::system::AllSyncReplicaStatus {
+    ++*applied;
+    return memgraph::system::AllSyncReplicaStatus::AllCommitsConfirmed;
+  }
+
+  auto FinalizeTransaction(const memgraph::system::Transaction & /*txn*/) -> memgraph::system::AllSyncReplicaStatus {
+    return memgraph::system::AllSyncReplicaStatus::AllCommitsConfirmed;
+  }
+};
 
 // Exact shape of Durability::GenColdVal (dbms_handler.cpp:150) minus `cold_stats`, which the restore loop
 // reads under `json.contains("cold_stats")` (dbms_handler.cpp:239) -- omitting it is still faithful.
@@ -709,6 +746,154 @@ TEST(DBMS_Handler, DropSucceedsDurablyWhenAttachedProfileJsonIsCorrupt) {
   EXPECT_FALSE(verify_kv2.Get(std::string{TenantProfiles::kDbMappingPrefix} + "victim").has_value())
       << "boot reconciliation (PruneDatabases) must collect the leftover mapping on the very next boot, "
          "even though the profile it names never parses";
+
+  fs::remove_all(sr.root);
+}
+
+// A corrupt attached tenant-profile record must not turn RENAME into a false failure, nor skip
+// txn->AddAction<RenameDatabase>. TenantProfiles::RenameDatabase used to parse the persisted profile record
+// with an unguarded nlohmann::json::parse, reached *after* DbmsHandler::Rename had already committed the
+// tenant rename both in memory and durably -- so the throw propagated out of Rename, telling the client the
+// RENAME had failed for an operation that had fully succeeded, and skipping AddAction<RenameDatabase>
+// (below the throw site), so the rename was never replicated. MAIN and the replica then permanently
+// disagreed on the tenant's name. Fixed by c4479c893 (catch json::exception in TenantProfiles::RenameDatabase,
+// return DURABILITY_ERROR instead) + 28b1e9046 (surface, but don't propagate, that error in Rename).
+TEST(DBMS_Handler, RenameSucceedsAndReplicatesWhenAttachedProfileJsonIsCorrupt) {
+  namespace fs = std::filesystem;
+  using memgraph::dbms::DbmsHandler;
+  using memgraph::dbms::TenantProfiles;
+
+  auto sr = MakeSeededRoot("rename_corrupt_profile");
+
+  memgraph::utils::UUID victim_uuid;
+  {
+    memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
+    ASSERT_TRUE(seed_kv.Put("version", "V2"));
+    victim_uuid = SeedHotEntry(seed_kv, "victim");
+    ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kDbMappingPrefix} + "victim", "p"));
+    // Deliberately broken JSON -- NOT via SeedProfile, which would write a well-formed tenant_profile:p row.
+    ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kPrefix} + "p", "{not json"));
+  }
+  fs::create_directories(TenantDataDir(sr, victim_uuid));
+
+  auto conf = MakeSeededConfig(sr.root);
+  std::unique_ptr<DbmsHandler> handler;
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
+
+  // Drive the rename through a real system transaction so replication (AddAction<RenameDatabase>) is
+  // directly observable, rather than inferred.
+  memgraph::system::System sys;  // default ctor: no storage, no recovery
+  auto txn = sys.TryCreateTransaction();
+  ASSERT_TRUE(txn.has_value());
+
+  std::optional<DbmsHandler::RenameResult> res;
+  ASSERT_NO_THROW(res = handler->Rename("victim", "renamed", &*txn))
+      << "a corrupt attached tenant-profile record must not be able to throw a JSON exception out of RENAME";
+  ASSERT_TRUE(res.has_value());
+  ASSERT_TRUE(res->has_value())
+      << "RENAME must report SUCCESS even though the attached profile record is corrupt -- reporting failure "
+         "for an operation that fully succeeded is the exact bug";
+
+  int applied = 0;
+  txn->Commit(CountingReplicationPolicy{&applied});
+  EXPECT_EQ(applied, 1)
+      << "the RenameDatabase system action must have been recorded so the rename replicates -- pre-fix this "
+         "was 0 because the throw skipped AddAction, which is what made MAIN and the replica disagree on the "
+         "tenant name permanently";
+
+  const auto all = handler->All();
+  EXPECT_TRUE(std::find(all.begin(), all.end(), "renamed") != all.end()) << "'renamed' must be visible after RENAME";
+  EXPECT_TRUE(std::find(all.begin(), all.end(), "victim") == all.end())
+      << "'victim' must no longer be visible after RENAME";
+  handler.reset();
+
+  {
+    memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
+    EXPECT_TRUE(verify_kv.Get(std::string{kDBPrefixLiteral} + "renamed").has_value())
+        << "database:renamed must exist -- the durability record must have moved to the new name";
+    EXPECT_FALSE(verify_kv.Get(std::string{kDBPrefixLiteral} + "victim").has_value())
+        << "database:victim must no longer exist";
+
+    auto mapping = verify_kv.Get(std::string{TenantProfiles::kDbMappingPrefix} + "victim");
+    EXPECT_TRUE(mapping.has_value())
+        << "the stale db_tenant_profile:victim mapping is deliberately left in place here -- the next boot's "
+           "PruneDatabases collects it, not this call";
+  }
+
+  {
+    std::unique_ptr<DbmsHandler> handler2;
+    ASSERT_NO_THROW(handler2 = std::make_unique<DbmsHandler>(conf));
+    handler2.reset();
+  }
+
+  memgraph::kvstore::KVStore verify_kv2{sr.durability_dir};
+  EXPECT_FALSE(verify_kv2.Get(std::string{TenantProfiles::kDbMappingPrefix} + "victim").has_value())
+      << "boot reconciliation (PruneDatabases) must collect the leftover db_tenant_profile:victim mapping on "
+         "the very next boot, even though the profile it names never parses";
+
+  fs::remove_all(sr.root);
+}
+
+// The tenant's own `database:` durability record must move VERBATIM on RENAME, not be parsed and rewritten.
+// Pre-fix, DbmsHandler::Rename did `json = parse(old_val); json["name"] = new_name; Put(new_key, json.dump())`.
+// Durability::GenVal never writes a "name" field, and nothing in the codebase ever reads one back -- the
+// tenant's name lives in the KEY, and the restore loop derives it via key.substr(kDBPrefix.size()) -- so that
+// write was pure litter added on every rename, and doubled as a second corrupt-record throw site (fixed
+// alongside the profile one by 28b1e9046). This test doubles as the healthy-rename negative control: it
+// proves the fix is not over-broad by checking a plain, non-corrupt rename still behaves.
+TEST(DBMS_Handler, RenameMovesTenantDurabilityRecordVerbatim) {
+  namespace fs = std::filesystem;
+  using memgraph::dbms::DbmsHandler;
+
+  auto sr = MakeSeededRoot("rename_verbatim");
+
+  auto seeded = [&] {
+    memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
+    seed_kv.Put("version", "V2");
+    return SeedHotEntryCapturingJson(seed_kv, "before");
+  }();
+  fs::create_directories(TenantDataDir(sr, seeded.uuid));
+
+  auto conf = MakeSeededConfig(sr.root);
+  std::unique_ptr<DbmsHandler> handler;
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
+
+  auto res = handler->Rename("before", "after");
+  ASSERT_TRUE(res.has_value()) << "a plain, healthy rename must succeed";
+
+  const auto all = handler->All();
+  EXPECT_TRUE(std::find(all.begin(), all.end(), "after") != all.end());
+  EXPECT_TRUE(std::find(all.begin(), all.end(), "before") == all.end());
+  handler.reset();
+
+  {
+    memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
+    auto new_val = verify_kv.Get(std::string{kDBPrefixLiteral} + "after");
+    ASSERT_TRUE(new_val.has_value()) << "database:after must exist";
+    EXPECT_EQ(*new_val, seeded.json_str)
+        << "the moved record must be byte-identical to what was seeded -- parsing and re-dumping it (the "
+           "pre-fix behavior) would not round-trip to the exact same bytes";
+    EXPECT_FALSE(verify_kv.Get(std::string{kDBPrefixLiteral} + "before").has_value())
+        << "database:before must no longer exist";
+
+    const auto entry_json = nlohmann::json::parse(*new_val);
+    EXPECT_FALSE(entry_json.contains("name"))
+        << "the pre-fix code injected a \"name\" field on every rename; Durability::GenVal never writes one "
+           "and nothing reads it back -- it was write-only litter";
+    EXPECT_TRUE(entry_json.contains("uuid"));
+    EXPECT_TRUE(entry_json.contains("rel_dir"));
+  }
+
+  {
+    std::unique_ptr<DbmsHandler> handler2;
+    ASSERT_NO_THROW(handler2 = std::make_unique<DbmsHandler>(conf));
+    const auto all2 = handler2->All();
+    EXPECT_TRUE(std::find(all2.begin(), all2.end(), "after") != all2.end())
+        << "a fresh boot must restore the tenant under its renamed name";
+    handler2.reset();
+  }
+
+  EXPECT_TRUE(fs::exists(TenantDataDir(sr, seeded.uuid))) << "the tenant's data directory must be untouched by RENAME";
 
   fs::remove_all(sr.root);
 }

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -45,13 +45,10 @@ std::set<std::string> GetDirs(auto path) {
   return dirs;
 }
 
-// --- Shared seeding helpers for the startup-reconciliation tests below -------------------------
-// Each of the four tests below builds its OWN isolated root, exactly like MigratesV1DurabilityAndRestoresTenant
-// above: seed a durability kvstore, release it (KVStore forbids two live instances on one directory), construct
-// a DbmsHandler over it, release the handler, then re-open the kvstore to verify.
+// Seeding helpers for the startup-reconciliation tests. Each test seeds its kvstore inside a scope and
+// releases it before constructing the handler: a second live KVStore on one dir throws (kvstore.cpp:38).
 
-// database:<name> -- Durability::kDBPrefix (dbms_handler.cpp) is file-local and not reachable from this test,
-// mirrored here exactly like the two migration tests above already do.
+// Mirrors kDBPrefix (dbms_handler.cpp:46), which is in an anonymous namespace and cannot be named here.
 constexpr std::string_view kDBPrefixLiteral = "database:";
 
 struct SeededRoot {
@@ -60,8 +57,8 @@ struct SeededRoot {
   std::filesystem::path durability_dir;  // <root>/databases/.durability
 };
 
-// A fresh <root>/databases/.durability, mirroring the layout the DbmsHandler ctor creates for itself.
-// `tag` must be unique per test so the tests can run in any order / in parallel without colliding.
+// Layout must match the one the DbmsHandler ctor builds for itself (dbms_handler.cpp:215-219). `tag` must
+// be unique per test: the root is remove_all'd below, so a shared tag would delete a sibling test's data.
 SeededRoot MakeSeededRoot(std::string_view tag) {
   namespace fs = std::filesystem;
   SeededRoot sr;
@@ -73,15 +70,13 @@ SeededRoot MakeSeededRoot(std::string_view tag) {
   return sr;
 }
 
-// The generated uuid plus the exact dumped JSON string that was written, so a caller checking
-// round-trip fidelity across a restart has the original bytes to compare against.
 struct SeededHotEntry {
   memgraph::utils::UUID uuid;
   std::string json_str;
 };
 
-// Exact shape of Durability::GenVal (dbms_handler.cpp): {"uuid": <uuid>, "rel_dir": <path>}, rel_dir
-// rooted at kMultiTenantDir/<uuid> -- the same convention MigratesV1DurabilityAndRestoresTenant uses above.
+// Exact shape of Durability::GenVal (dbms_handler.cpp:114): {"uuid": <uuid>, "rel_dir": <path>}, with
+// rel_dir rooted at kMultiTenantDir/<uuid> as New_/UpdateDurability recompute it (dbms_handler.cpp:860).
 SeededHotEntry SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
   const memgraph::utils::UUID uuid;
   nlohmann::json j;
@@ -92,9 +87,8 @@ SeededHotEntry SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view nam
   return {uuid, std::move(dumped)};
 }
 
-// Exact shape of Durability::GenColdVal (dbms_handler.cpp) minus `cold_stats`: the restore loop reads
-// that field via `json.contains("cold_stats")` and treats it as optional, so an entry without it is a
-// faithful minimal COLD fixture.
+// Exact shape of Durability::GenColdVal (dbms_handler.cpp:150) minus `cold_stats`, which the restore loop
+// reads under `json.contains("cold_stats")` (dbms_handler.cpp:239) -- omitting it is still faithful.
 memgraph::utils::UUID SeedColdEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
   const memgraph::utils::UUID uuid;
   nlohmann::json j;
@@ -105,9 +99,8 @@ memgraph::utils::UUID SeedColdEntry(memgraph::kvstore::KVStore &kv, std::string_
   return uuid;
 }
 
-// Exact shape of TenantProfiles::ProfileToJson (tenant_profiles.cpp): {"memory_limit": <int64>,
-// "databases": [<name>, ...]}. Also writes the db->profile mapping keys under
-// TenantProfiles::kDbMappingPrefix, matching AttachToDatabase's own durability writes.
+// Exact shape of TenantProfiles::ProfileToJson (tenant_profiles.cpp:46): {"memory_limit": <int64>,
+// "databases": [...]}, plus the kDbMappingPrefix rows AttachToDatabase writes (tenant_profiles.cpp:142).
 void SeedProfile(memgraph::kvstore::KVStore &kv, std::string_view profile_name, int64_t memory_limit,
                  const std::set<std::string> &databases) {
   nlohmann::json j;
@@ -119,7 +112,6 @@ void SeedProfile(memgraph::kvstore::KVStore &kv, std::string_view profile_name, 
   }
 }
 
-// <root>/databases/<uuid> -- the on-disk directory a HOT/COLD entry's rel_dir points at.
 std::filesystem::path TenantDataDir(const SeededRoot &sr, const memgraph::utils::UUID &uuid) {
   return sr.db_dir / std::string{uuid};
 }
@@ -492,14 +484,8 @@ TEST(DBMS_Handler, MigratesV0DefaultDbDurabilityAndRestoresTenant) {
   fs::remove_all(root);
 }
 
-// REGRESSION GUARD (pins PRE-EXISTING behavior, predates this branch): the ctor's post-restore
-// "DATABASES CLEAN UP" pass (dbms_handler.cpp) is what makes a lost deferred physical delete benign --
-// if a DROP's durability-key erase lands but the matching directory removal is lost (process dies,
-// remove_all fails, etc.), the orphaned directory is not a permanent leak: the next boot's keep-set is
-// built purely from surviving `database:` keys, so anything on disk that no key points at gets swept.
-// A directory that IS still referenced must be left strictly alone. This branch's PruneDatabases sweep
-// is a sibling reconciliation pass; nothing else in the suite pins the pre-existing directory sweep, so
-// a change to either could silently regress this without any other test noticing.
+// Pins PRE-EXISTING behavior: the ctor's post-restore "DATABASES CLEAN UP" pass (dbms_handler.cpp:345)
+// keeps only dirs a surviving `database:` key names, so a lost physical delete is not a permanent leak.
 TEST(DBMS_Handler, SweepReclaimsOrphanedTenantDirectoryButKeepsLiveOne) {
   namespace fs = std::filesystem;
   using memgraph::dbms::DbmsHandler;
@@ -539,12 +525,8 @@ TEST(DBMS_Handler, SweepReclaimsOrphanedTenantDirectoryButKeepsLiveOne) {
   fs::remove_all(sr.root);
 }
 
-// Positive case for the new startup reconciliation: TenantProfiles::PruneDatabases is wired from the
-// DbmsHandler ctor between constructing TenantProfiles and RestoreTenantProfiles_. A `db_tenant_profile:`
-// mapping (and the matching name inside its Profile's `databases` set) that outlived the tenant it
-// points at -- e.g. a DROP that erased the durability key but crashed before/lost the matching
-// DetachFromDatabase -- has nothing else in the system that ever revisits it; left unpruned, it is
-// permanent.
+// Positive case for the new startup reconciliation: the ctor runs PruneDatabases between constructing
+// TenantProfiles and RestoreTenantProfiles_ (dbms_handler.cpp:368-385); rationale at its declaration.
 TEST(DBMS_Handler, StaleTenantProfileMappingIsPrunedOnStartup) {
   namespace fs = std::filesystem;
   using memgraph::dbms::DbmsHandler;
@@ -583,13 +565,8 @@ TEST(DBMS_Handler, StaleTenantProfileMappingIsPrunedOnStartup) {
   fs::remove_all(sr.root);
 }
 
-// THE NEGATIVE CONTROL for PruneDatabases, and the most important test on this branch: pruning a live
-// SUSPENDED (COLD) tenant's profile attachment would be unrecoverable data loss, not staleness cleanup.
-// The naive way to ask "is this database still alive" is Get_()/db_handler_.All(), but both are
-// HOT-gated -- a COLD tenant looks absent through that lens even though it is a live, resumable tenant.
-// That is exactly why the prune's live-set is built from the raw `database:<name>` durability KEY
-// prefix instead (see the ctor comment immediately above the PruneDatabases call site): the key prefix
-// covers HOT and COLD identically. This test pins that choice against the obvious wrong rewrite.
+// Negative control for PruneDatabases: a COLD tenant looks absent through the HOT-gated Get_/All lens, so
+// pruning its attachment would be data loss. Pins the ctor's raw-`database:`-key live-set (dbms_handler.cpp:371).
 TEST(DBMS_Handler, SuspendedTenantProfileMappingIsNotPrunedOnStartup) {
   namespace fs = std::filesystem;
   using memgraph::dbms::DbmsHandler;
@@ -631,9 +608,8 @@ TEST(DBMS_Handler, SuspendedTenantProfileMappingIsNotPrunedOnStartup) {
   fs::remove_all(sr.root);
 }
 
-// This branch adds a new startup reconciliation pass and reorders two DROP paths, but touches neither
-// Durability::Migrate nor its version chain: a pre-existing V2 store with nothing for the new pass to
-// prune must boot and remain V2, with its `database:` entries left byte-for-byte untouched.
+// This branch adds a startup reconciliation pass and reorders the DROP paths, but touches neither
+// Durability::Migrate nor its version chain: a plain V2 store must still boot, stay V2, and keep its entry.
 TEST(DBMS_Handler, ExistingV2DurabilityStoreBootsUnchanged) {
   namespace fs = std::filesystem;
   using memgraph::dbms::DbmsHandler;
@@ -665,10 +641,8 @@ TEST(DBMS_Handler, ExistingV2DurabilityStoreBootsUnchanged) {
 
   auto entry = verify_kv.Get(std::string{"database:"} + "live");
   ASSERT_TRUE(entry.has_value());
-  // `New_` calls UpdateDurability on every restored HOT tenant, which recomputes rel_dir through
-  // std::filesystem::relative() -- pre-existing rewrite-on-every-boot behavior, so byte-identity would
-  // be a stronger (and flakier, e.g. under a symlinked TMPDIR) claim than this test needs. Asserting the
-  // decoded fields keeps the mutation-sensitivity that matters without depending on exact serialization.
+  // Deliberately not a byte compare: New_ rewrites every restored HOT entry via UpdateDurability, which
+  // recomputes rel_dir through std::filesystem::relative (dbms_handler.cpp:860) -- bytes would be flaky.
   const auto entry_json = nlohmann::json::parse(*entry);
   const auto expected_rel_dir =
       std::filesystem::path(std::string{memgraph::dbms::kMultiTenantDir}) / std::string{live_uuid};
@@ -681,12 +655,8 @@ TEST(DBMS_Handler, ExistingV2DurabilityStoreBootsUnchanged) {
   fs::remove_all(sr.root);
 }
 
-// A corrupt attached tenant-profile record must not be able to turn DROP into a half-done delete
-// that resurrects the tenant on restart (see the try/catch added to TenantProfiles::DetachFromDatabase
-// -- previously an unguarded nlohmann::json::parse there threw past DbmsHandler::TryDelete, aborting
-// after the tenant was removed from the in-memory registry but before its durability key / directory
-// were erased). Leaving the db_tenant_profile: mapping behind afterwards is deliberate: PruneDatabases
-// (boot reconciliation) is what collects it, not this call.
+// A corrupt attached profile record must not turn DROP into a half-done delete: DetachFromDatabase
+// refuses it (DURABILITY_ERROR) and TryDelete must still retire the key + dir (dbms_handler.cpp:479-488).
 TEST(DBMS_Handler, DropSucceedsDurablyWhenAttachedProfileJsonIsCorrupt) {
   namespace fs = std::filesystem;
   using memgraph::dbms::DbmsHandler;

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -70,21 +70,15 @@ SeededRoot MakeSeededRoot(std::string_view tag) {
   return sr;
 }
 
-struct SeededHotEntry {
-  memgraph::utils::UUID uuid;
-  std::string json_str;
-};
-
 // Exact shape of Durability::GenVal (dbms_handler.cpp:114): {"uuid": <uuid>, "rel_dir": <path>}, with
 // rel_dir rooted at kMultiTenantDir/<uuid> as New_/UpdateDurability recompute it (dbms_handler.cpp:860).
-SeededHotEntry SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
+memgraph::utils::UUID SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
   const memgraph::utils::UUID uuid;
   nlohmann::json j;
   j["uuid"] = uuid;
   j["rel_dir"] = std::filesystem::path(std::string{memgraph::dbms::kMultiTenantDir}) / std::string{uuid};
-  auto dumped = j.dump();
-  kv.Put(std::string{kDBPrefixLiteral} + std::string{name}, dumped);
-  return {uuid, std::move(dumped)};
+  kv.Put(std::string{kDBPrefixLiteral} + std::string{name}, j.dump());
+  return uuid;
 }
 
 // Exact shape of Durability::GenColdVal (dbms_handler.cpp:150) minus `cold_stats`, which the restore loop
@@ -496,7 +490,7 @@ TEST(DBMS_Handler, SweepReclaimsOrphanedTenantDirectoryButKeepsLiveOne) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
+    live_uuid = SeedHotEntry(seed_kv, "live");
   }
 
   const auto live_dir = TenantDataDir(sr, live_uuid);
@@ -538,7 +532,7 @@ TEST(DBMS_Handler, StaleTenantProfileMappingIsPrunedOnStartup) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
+    live_uuid = SeedHotEntry(seed_kv, "live");
     // "gone" has NO `database:gone` durability key -- exactly the state a lost DetachFromDatabase leaves.
     SeedProfile(seed_kv, "p", /*memory_limit=*/1000, {"live", "gone"});
   }
@@ -620,7 +614,7 @@ TEST(DBMS_Handler, ExistingV2DurabilityStoreBootsUnchanged) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
+    live_uuid = SeedHotEntry(seed_kv, "live");
   }
   fs::create_directories(TenantDataDir(sr, live_uuid));
 
@@ -668,7 +662,7 @@ TEST(DBMS_Handler, DropSucceedsDurablyWhenAttachedProfileJsonIsCorrupt) {
   {
     memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
     ASSERT_TRUE(seed_kv.Put("version", "V2"));
-    victim_uuid = SeedHotEntry(seed_kv, "victim").uuid;
+    victim_uuid = SeedHotEntry(seed_kv, "victim");
     // Point "victim" at profile "p", but write "p"'s durable record as deliberately broken JSON --
     // NOT via SeedProfile, which would also write a well-formed tenant_profile:p row.
     ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kDbMappingPrefix} + "victim", "p"));
@@ -694,8 +688,8 @@ TEST(DBMS_Handler, DropSucceedsDurablyWhenAttachedProfileJsonIsCorrupt) {
   {
     memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
     EXPECT_FALSE(verify_kv.Get(std::string{kDBPrefixLiteral} + "victim").has_value())
-        << "the tenant's durability key must be erased -- under the pre-fix bug the thrown JSON "
-           "exception aborted TryDelete before this erase ran, so the tenant resurrected on restart";
+        << "a corrupt attached profile record must not stop the tenant's durability key from being erased: a "
+           "surviving key brings the tenant back on the next boot";
     EXPECT_FALSE(fs::exists(TenantDataDir(sr, victim_uuid)))
         << "the tenant's on-disk data directory must also be removed";
 

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -16,6 +16,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <filesystem>
+#include <fstream>
 #include <system_error>
 
 #include <nlohmann/json.hpp>
@@ -23,6 +24,7 @@
 #include "dbms/constants.hpp"
 #include "dbms/dbms_handler.hpp"
 #include "dbms/global.hpp"
+#include "dbms/tenant_profiles.hpp"
 #include "glue/auth_checker.hpp"
 #include "glue/auth_handler.hpp"
 #include "kvstore/kvstore.hpp"
@@ -41,6 +43,93 @@ std::set<std::string> GetDirs(auto path) {
     }
   }
   return dirs;
+}
+
+// --- Shared seeding helpers for the startup-reconciliation tests below -------------------------
+// Each of the four tests below builds its OWN isolated root, exactly like MigratesV1DurabilityAndRestoresTenant
+// above: seed a durability kvstore, release it (KVStore forbids two live instances on one directory), construct
+// a DbmsHandler over it, release the handler, then re-open the kvstore to verify.
+
+// database:<name> -- Durability::kDBPrefix (dbms_handler.cpp) is file-local and not reachable from this test,
+// mirrored here exactly like the two migration tests above already do.
+constexpr std::string_view kDBPrefixLiteral = "database:";
+
+struct SeededRoot {
+  std::filesystem::path root;
+  std::filesystem::path db_dir;          // <root>/databases
+  std::filesystem::path durability_dir;  // <root>/databases/.durability
+};
+
+// A fresh <root>/databases/.durability, mirroring the layout the DbmsHandler ctor creates for itself.
+// `tag` must be unique per test so the tests can run in any order / in parallel without colliding.
+SeededRoot MakeSeededRoot(std::string_view tag) {
+  namespace fs = std::filesystem;
+  SeededRoot sr;
+  sr.root = fs::temp_directory_path() / (std::string{"MG_test_unit_dbms_handler_"} + std::string{tag});
+  fs::remove_all(sr.root);
+  sr.db_dir = sr.root / std::string{memgraph::dbms::kMultiTenantDir};
+  sr.durability_dir = sr.db_dir / ".durability";
+  fs::create_directories(sr.durability_dir);
+  return sr;
+}
+
+// The generated uuid plus the exact dumped JSON string that was written, so a caller checking
+// round-trip fidelity across a restart has the original bytes to compare against.
+struct SeededHotEntry {
+  memgraph::utils::UUID uuid;
+  std::string json_str;
+};
+
+// Exact shape of Durability::GenVal (dbms_handler.cpp): {"uuid": <uuid>, "rel_dir": <path>}, rel_dir
+// rooted at kMultiTenantDir/<uuid> -- the same convention MigratesV1DurabilityAndRestoresTenant uses above.
+SeededHotEntry SeedHotEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
+  const memgraph::utils::UUID uuid;
+  nlohmann::json j;
+  j["uuid"] = uuid;
+  j["rel_dir"] = std::filesystem::path(std::string{memgraph::dbms::kMultiTenantDir}) / std::string{uuid};
+  auto dumped = j.dump();
+  kv.Put(std::string{kDBPrefixLiteral} + std::string{name}, dumped);
+  return {uuid, std::move(dumped)};
+}
+
+// Exact shape of Durability::GenColdVal (dbms_handler.cpp) minus `cold_stats`: the restore loop reads
+// that field via `json.contains("cold_stats")` and treats it as optional, so an entry without it is a
+// faithful minimal COLD fixture.
+memgraph::utils::UUID SeedColdEntry(memgraph::kvstore::KVStore &kv, std::string_view name) {
+  const memgraph::utils::UUID uuid;
+  nlohmann::json j;
+  j["uuid"] = uuid;
+  j["rel_dir"] = std::filesystem::path(std::string{memgraph::dbms::kMultiTenantDir}) / std::string{uuid};
+  j["cold"] = true;
+  kv.Put(std::string{kDBPrefixLiteral} + std::string{name}, j.dump());
+  return uuid;
+}
+
+// Exact shape of TenantProfiles::ProfileToJson (tenant_profiles.cpp): {"memory_limit": <int64>,
+// "databases": [<name>, ...]}. Also writes the db->profile mapping keys under
+// TenantProfiles::kDbMappingPrefix, matching AttachToDatabase's own durability writes.
+void SeedProfile(memgraph::kvstore::KVStore &kv, std::string_view profile_name, int64_t memory_limit,
+                 const std::set<std::string> &databases) {
+  nlohmann::json j;
+  j["memory_limit"] = memory_limit;
+  j["databases"] = databases;
+  kv.Put(std::string{memgraph::dbms::TenantProfiles::kPrefix} + std::string{profile_name}, j.dump());
+  for (const auto &db : databases) {
+    kv.Put(std::string{memgraph::dbms::TenantProfiles::kDbMappingPrefix} + db, std::string{profile_name});
+  }
+}
+
+// <root>/databases/<uuid> -- the on-disk directory a HOT/COLD entry's rel_dir points at.
+std::filesystem::path TenantDataDir(const SeededRoot &sr, const memgraph::utils::UUID &uuid) {
+  return sr.db_dir / std::string{uuid};
+}
+
+memgraph::storage::Config MakeSeededConfig(const std::filesystem::path &root) {
+  memgraph::storage::Config conf;
+  memgraph::storage::UpdatePaths(conf, root);
+  conf.durability.snapshot_wal_mode =
+      memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  return conf;
 }
 }  // namespace
 
@@ -401,6 +490,195 @@ TEST(DBMS_Handler, MigratesV0DefaultDbDurabilityAndRestoresTenant) {
   }
 
   fs::remove_all(root);
+}
+
+// REGRESSION GUARD (pins PRE-EXISTING behavior, predates this branch): the ctor's post-restore
+// "DATABASES CLEAN UP" pass (dbms_handler.cpp) is what makes a lost deferred physical delete benign --
+// if a DROP's durability-key erase lands but the matching directory removal is lost (process dies,
+// remove_all fails, etc.), the orphaned directory is not a permanent leak: the next boot's keep-set is
+// built purely from surviving `database:` keys, so anything on disk that no key points at gets swept.
+// A directory that IS still referenced must be left strictly alone. This branch's PruneDatabases sweep
+// is a sibling reconciliation pass; nothing else in the suite pins the pre-existing directory sweep, so
+// a change to either could silently regress this without any other test noticing.
+TEST(DBMS_Handler, SweepReclaimsOrphanedTenantDirectoryButKeepsLiveOne) {
+  namespace fs = std::filesystem;
+  using memgraph::dbms::DbmsHandler;
+
+  auto sr = MakeSeededRoot("sweep");
+
+  memgraph::utils::UUID live_uuid;
+  {
+    memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
+    ASSERT_TRUE(seed_kv.Put("version", "V2"));
+    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
+  }
+
+  const auto live_dir = TenantDataDir(sr, live_uuid);
+  const memgraph::utils::UUID orphan_uuid;  // deliberately has NO matching `database:` durability key
+  const auto orphan_dir = TenantDataDir(sr, orphan_uuid);
+  fs::create_directories(live_dir);
+  fs::create_directories(orphan_dir);
+  {
+    std::ofstream marker{orphan_dir / "leftover.txt"};
+    marker << "orphaned tenant data";
+  }
+  ASSERT_TRUE(fs::exists(orphan_dir / "leftover.txt")) << "sanity check: the orphan dir must be non-empty";
+
+  auto conf = MakeSeededConfig(sr.root);
+  std::unique_ptr<DbmsHandler> handler;
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
+
+  EXPECT_FALSE(fs::exists(orphan_dir))
+      << "a directory whose durability key is already gone must be swept on boot, non-empty or not";
+  EXPECT_TRUE(fs::exists(live_dir))
+      << "a directory still referenced by a live durability key must survive the sweep untouched";
+  const auto all = handler->All();
+  EXPECT_TRUE(std::find(all.begin(), all.end(), "live") != all.end()) << "the live tenant must still restore HOT";
+
+  handler.reset();
+  fs::remove_all(sr.root);
+}
+
+// Positive case for the new startup reconciliation: TenantProfiles::PruneDatabases is wired from the
+// DbmsHandler ctor between constructing TenantProfiles and RestoreTenantProfiles_. A `db_tenant_profile:`
+// mapping (and the matching name inside its Profile's `databases` set) that outlived the tenant it
+// points at -- e.g. a DROP that erased the durability key but crashed before/lost the matching
+// DetachFromDatabase -- has nothing else in the system that ever revisits it; left unpruned, it is
+// permanent.
+TEST(DBMS_Handler, StaleTenantProfileMappingIsPrunedOnStartup) {
+  namespace fs = std::filesystem;
+  using memgraph::dbms::DbmsHandler;
+  using memgraph::dbms::TenantProfiles;
+
+  auto sr = MakeSeededRoot("prune_stale");
+
+  memgraph::utils::UUID live_uuid;
+  {
+    memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
+    ASSERT_TRUE(seed_kv.Put("version", "V2"));
+    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
+    // "gone" has NO `database:gone` durability key -- exactly the state a lost DetachFromDatabase leaves.
+    SeedProfile(seed_kv, "p", /*memory_limit=*/1000, {"live", "gone"});
+  }
+  fs::create_directories(TenantDataDir(sr, live_uuid));
+
+  auto conf = MakeSeededConfig(sr.root);
+  std::unique_ptr<DbmsHandler> handler;
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
+  handler.reset();
+
+  memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
+  EXPECT_FALSE(verify_kv.Get(std::string{TenantProfiles::kDbMappingPrefix} + "gone").has_value())
+      << "a db_tenant_profile mapping for a database with no durability key must be pruned on startup";
+  auto live_mapping = verify_kv.Get(std::string{TenantProfiles::kDbMappingPrefix} + "live");
+  ASSERT_TRUE(live_mapping.has_value()) << "the mapping for a still-live database must survive the prune";
+  EXPECT_EQ(*live_mapping, "p") << "the surviving mapping's target profile must be unchanged";
+
+  auto profile_json = verify_kv.Get(std::string{TenantProfiles::kPrefix} + "p");
+  ASSERT_TRUE(profile_json.has_value()) << "pruning a stale attachment must not delete the profile itself";
+  const auto dbs = nlohmann::json::parse(*profile_json).at("databases").get<std::set<std::string>>();
+  EXPECT_FALSE(dbs.contains("gone")) << "the stale name must be removed from the profile's databases set too";
+  EXPECT_TRUE(dbs.contains("live")) << "pruning 'gone' must not disturb the profile's still-live attachment";
+
+  fs::remove_all(sr.root);
+}
+
+// THE NEGATIVE CONTROL for PruneDatabases, and the most important test on this branch: pruning a live
+// SUSPENDED (COLD) tenant's profile attachment would be unrecoverable data loss, not staleness cleanup.
+// The naive way to ask "is this database still alive" is Get_()/db_handler_.All(), but both are
+// HOT-gated -- a COLD tenant looks absent through that lens even though it is a live, resumable tenant.
+// That is exactly why the prune's live-set is built from the raw `database:<name>` durability KEY
+// prefix instead (see the ctor comment immediately above the PruneDatabases call site): the key prefix
+// covers HOT and COLD identically. This test pins that choice against the obvious wrong rewrite.
+TEST(DBMS_Handler, SuspendedTenantProfileMappingIsNotPrunedOnStartup) {
+  namespace fs = std::filesystem;
+  using memgraph::dbms::DbmsHandler;
+  using memgraph::dbms::TenantProfiles;
+
+  auto sr = MakeSeededRoot("prune_cold");
+
+  memgraph::utils::UUID cold_uuid;
+  {
+    memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
+    ASSERT_TRUE(seed_kv.Put("version", "V2"));
+    cold_uuid = SeedColdEntry(seed_kv, "cold");
+    SeedProfile(seed_kv, "p", /*memory_limit=*/1000, {"cold"});
+  }
+  const auto cold_dir = TenantDataDir(sr, cold_uuid);
+  fs::create_directories(cold_dir);
+
+  auto conf = MakeSeededConfig(sr.root);
+  std::unique_ptr<DbmsHandler> handler;
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
+  EXPECT_TRUE(handler->IsSuspended("cold"))
+      << "the seeded entry must restore as a live COLD tenant -- otherwise this test would vacuously "
+         "pass by testing an already-absent database instead of a suspended one";
+  handler.reset();
+
+  memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
+  auto mapping = verify_kv.Get(std::string{TenantProfiles::kDbMappingPrefix} + "cold");
+  ASSERT_TRUE(mapping.has_value())
+      << "a COLD tenant's profile attachment must survive startup -- pruning it would be unrecoverable";
+  EXPECT_EQ(*mapping, "p");
+
+  auto profile_json = verify_kv.Get(std::string{TenantProfiles::kPrefix} + "p");
+  ASSERT_TRUE(profile_json.has_value());
+  const auto dbs = nlohmann::json::parse(*profile_json).at("databases").get<std::set<std::string>>();
+  EXPECT_TRUE(dbs.contains("cold")) << "the profile's databases set must still list the suspended tenant";
+
+  EXPECT_TRUE(fs::exists(cold_dir)) << "a COLD tenant's data directory must also survive the unused-directory sweep";
+
+  fs::remove_all(sr.root);
+}
+
+// This branch adds a new startup reconciliation pass and reorders two DROP paths, but touches neither
+// Durability::Migrate nor its version chain: a pre-existing V2 store with nothing for the new pass to
+// prune must boot and remain V2, with its `database:` entries left byte-for-byte untouched.
+TEST(DBMS_Handler, ExistingV2DurabilityStoreBootsUnchanged) {
+  namespace fs = std::filesystem;
+  using memgraph::dbms::DbmsHandler;
+
+  auto sr = MakeSeededRoot("v2_unchanged");
+
+  memgraph::utils::UUID live_uuid;
+  {
+    memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
+    ASSERT_TRUE(seed_kv.Put("version", "V2"));
+    live_uuid = SeedHotEntry(seed_kv, "live").uuid;
+  }
+  fs::create_directories(TenantDataDir(sr, live_uuid));
+
+  auto conf = MakeSeededConfig(sr.root);
+  std::unique_ptr<DbmsHandler> handler;
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf))
+      << "a plain, already-migrated V2 store must boot cleanly";
+
+  const auto all = handler->All();
+  EXPECT_TRUE(std::find(all.begin(), all.end(), "live") != all.end()) << "the V2 HOT entry must restore HOT";
+  EXPECT_FALSE(handler->IsSuspended("live"));
+  handler.reset();
+
+  memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
+  auto version = verify_kv.Get("version");
+  ASSERT_TRUE(version.has_value());
+  EXPECT_EQ(*version, "V2") << "this branch must not introduce a durability version bump";
+
+  auto entry = verify_kv.Get(std::string{"database:"} + "live");
+  ASSERT_TRUE(entry.has_value());
+  // `New_` calls UpdateDurability on every restored HOT tenant, which recomputes rel_dir through
+  // std::filesystem::relative() -- pre-existing rewrite-on-every-boot behavior, so byte-identity would
+  // be a stronger (and flakier, e.g. under a symlinked TMPDIR) claim than this test needs. Asserting the
+  // decoded fields keeps the mutation-sensitivity that matters without depending on exact serialization.
+  const auto entry_json = nlohmann::json::parse(*entry);
+  const auto expected_rel_dir =
+      std::filesystem::path(std::string{memgraph::dbms::kMultiTenantDir}) / std::string{live_uuid};
+  EXPECT_EQ(entry_json.at("uuid").get<memgraph::utils::UUID>(), live_uuid)
+      << "the restored entry's uuid must be unchanged from what was seeded";
+  EXPECT_EQ(entry_json.at("rel_dir").get<std::filesystem::path>(), expected_rel_dir)
+      << "the restored entry's rel_dir must still point at the seeded tenant directory";
+  EXPECT_FALSE(entry_json.value("cold", false)) << "a HOT entry must not acquire a cold marker on restart";
+
+  fs::remove_all(sr.root);
 }
 
 int main(int argc, char *argv[]) {

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -681,6 +681,74 @@ TEST(DBMS_Handler, ExistingV2DurabilityStoreBootsUnchanged) {
   fs::remove_all(sr.root);
 }
 
+// A corrupt attached tenant-profile record must not be able to turn DROP into a half-done delete
+// that resurrects the tenant on restart (see the try/catch added to TenantProfiles::DetachFromDatabase
+// -- previously an unguarded nlohmann::json::parse there threw past DbmsHandler::TryDelete, aborting
+// after the tenant was removed from the in-memory registry but before its durability key / directory
+// were erased). Leaving the db_tenant_profile: mapping behind afterwards is deliberate: PruneDatabases
+// (boot reconciliation) is what collects it, not this call.
+TEST(DBMS_Handler, DropSucceedsDurablyWhenAttachedProfileJsonIsCorrupt) {
+  namespace fs = std::filesystem;
+  using memgraph::dbms::DbmsHandler;
+  using memgraph::dbms::TenantProfiles;
+
+  auto sr = MakeSeededRoot("drop_corrupt_profile");
+
+  memgraph::utils::UUID victim_uuid;
+  {
+    memgraph::kvstore::KVStore seed_kv{sr.durability_dir};
+    ASSERT_TRUE(seed_kv.Put("version", "V2"));
+    victim_uuid = SeedHotEntry(seed_kv, "victim").uuid;
+    // Point "victim" at profile "p", but write "p"'s durable record as deliberately broken JSON --
+    // NOT via SeedProfile, which would also write a well-formed tenant_profile:p row.
+    ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kDbMappingPrefix} + "victim", "p"));
+    ASSERT_TRUE(seed_kv.Put(std::string{TenantProfiles::kPrefix} + "p", "{not json"));
+  }
+  fs::create_directories(TenantDataDir(sr, victim_uuid));
+
+  auto conf = MakeSeededConfig(sr.root);
+  std::unique_ptr<DbmsHandler> handler;
+  ASSERT_NO_THROW(handler = std::make_unique<DbmsHandler>(conf));
+
+  std::optional<DbmsHandler::DeleteResult> del;
+  ASSERT_NO_THROW(del = handler->TryDelete("victim"))
+      << "a corrupt attached tenant-profile record must not be able to throw a JSON exception out of DROP";
+  ASSERT_TRUE(del.has_value());
+  ASSERT_TRUE(del->has_value()) << "DROP must succeed even though the attached profile record is corrupt";
+
+  const auto all = handler->All();
+  EXPECT_TRUE(std::find(all.begin(), all.end(), "victim") == all.end())
+      << "victim must be gone from All() immediately after a successful drop";
+  handler.reset();
+
+  {
+    memgraph::kvstore::KVStore verify_kv{sr.durability_dir};
+    EXPECT_FALSE(verify_kv.Get(std::string{kDBPrefixLiteral} + "victim").has_value())
+        << "the tenant's durability key must be erased -- under the pre-fix bug the thrown JSON "
+           "exception aborted TryDelete before this erase ran, so the tenant resurrected on restart";
+    EXPECT_FALSE(fs::exists(TenantDataDir(sr, victim_uuid)))
+        << "the tenant's on-disk data directory must also be removed";
+
+    auto mapping = verify_kv.Get(std::string{TenantProfiles::kDbMappingPrefix} + "victim");
+    EXPECT_TRUE(mapping.has_value())
+        << "DetachFromDatabase deliberately leaves the mapping in place when the profile it points at is "
+           "corrupt -- PruneDatabases on the next boot is what collects it, not this call";
+  }
+
+  {
+    std::unique_ptr<DbmsHandler> handler2;
+    ASSERT_NO_THROW(handler2 = std::make_unique<DbmsHandler>(conf));
+    handler2.reset();
+  }
+
+  memgraph::kvstore::KVStore verify_kv2{sr.durability_dir};
+  EXPECT_FALSE(verify_kv2.Get(std::string{TenantProfiles::kDbMappingPrefix} + "victim").has_value())
+      << "boot reconciliation (PruneDatabases) must collect the leftover mapping on the very next boot, "
+         "even though the profile it names never parses";
+
+  fs::remove_all(sr.root);
+}
+
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   // gtest takes ownership of the TestEnvironment ptr - we don't delete it.

--- a/tests/unit/tenant_profiles.cpp
+++ b/tests/unit/tenant_profiles.cpp
@@ -11,6 +11,7 @@
 
 #include <unistd.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <string>
 #include <unordered_set>
@@ -126,4 +127,86 @@ TEST_F(TenantProfilesTest, AttachDetachDropLifecycle) {
 
   ASSERT_TRUE(profiles.Drop("p"));
   EXPECT_TRUE(profiles.GetAll().empty());
+}
+
+// Regression guard: before the fix, a corrupt profile record made RenameDatabase throw a raw
+// nlohmann::json::exception instead of returning an error. Its caller, DbmsHandler::Rename, has by
+// that point already committed the tenant rename both in memory and durably -- the throw made the
+// client see RENAME as failed for an operation that had, in fact, fully succeeded, and it also skipped
+// the subsequent txn->AddAction<RenameDatabase>, so the rename was never replicated -- leaving MAIN and
+// its replica permanently disagreeing on the tenant's database name. This writes the durable rows
+// directly through the kvstore (bypassing Create/AttachToDatabase, which would only ever write a
+// well-formed record) so the profile record RenameDatabase reads back is deliberately malformed.
+TEST_F(TenantProfilesTest, RenameDatabaseReportsErrorInsteadOfThrowingOnCorruptProfile) {
+  memgraph::kvstore::KVStore durability{test_folder_ / "rename_corrupt"};
+  memgraph::dbms::TenantProfiles profiles{durability};
+  const auto db_mapping_prefix = std::string{memgraph::dbms::TenantProfiles::kDbMappingPrefix};
+  const auto profile_prefix = std::string{memgraph::dbms::TenantProfiles::kPrefix};
+
+  ASSERT_TRUE(durability.Put(db_mapping_prefix + "db1", "p"));
+  ASSERT_TRUE(durability.Put(profile_prefix + "p", "{not json"));
+
+  std::expected<void, memgraph::dbms::TenantProfiles::RenameError> result;
+  ASSERT_NO_THROW(result = profiles.RenameDatabase("db1", "db2"));
+  ASSERT_FALSE(result);
+  EXPECT_EQ(result.error(), memgraph::dbms::TenantProfiles::RenameError::DURABILITY_ERROR);
+
+  // Deliberate, not an oversight: the caller (DbmsHandler::Rename) still completes and replicates the
+  // rename, and the next boot's PruneDatabases collects the stale mapping once "db1" is no longer live.
+  EXPECT_TRUE(durability.Get(db_mapping_prefix + "db1"))
+      << "old mapping must survive a failed rewrite -- PruneDatabases reconciles it on next boot";
+  // A failure must write neither the profile rewrite nor the new mapping, or "db2" would point at a
+  // profile that never agreed to it.
+  EXPECT_FALSE(durability.Get(db_mapping_prefix + "db2"));
+}
+
+// Regression guard: GetAll is called from the DbmsHandler constructor (RestoreTenantProfiles_) with no
+// enclosing try/catch anywhere up to main(), so an exception escaping it terminates the whole process at
+// startup. Before the fix, Get and GetAll only caught nlohmann::json::parse_error, but a wrong-typed
+// persisted field makes FromJson's `.get<int64_t>()` throw nlohmann::json::type_error -- a SIBLING of
+// parse_error (both derive from nlohmann::detail::exception; neither derives from the other) -- so it
+// slipped past the old catch. The payload below is syntactically valid JSON (parse succeeds); only the
+// later typed .get<int64_t>() throws, so this exercises type_error specifically, not parse_error.
+TEST_F(TenantProfilesTest, WrongTypedProfileFieldDoesNotEscapeGetOrGetAll) {
+  memgraph::kvstore::KVStore durability{test_folder_ / "wrong_typed"};
+  memgraph::dbms::TenantProfiles profiles{durability};
+
+  ASSERT_TRUE(profiles.Create("good", 4096));
+  ASSERT_TRUE(durability.Put(std::string{memgraph::dbms::TenantProfiles::kPrefix} + "typed",
+                             R"({"memory_limit": "not-a-number", "databases": []})"));
+
+  std::optional<memgraph::dbms::TenantProfiles::Profile> get_result;
+  ASSERT_NO_THROW(get_result = profiles.Get("typed"));
+  EXPECT_EQ(get_result, std::nullopt);
+
+  std::vector<memgraph::dbms::TenantProfiles::Profile> all;
+  ASSERT_NO_THROW(all = profiles.GetAll());
+  EXPECT_TRUE(std::ranges::any_of(all, [](const auto &profile) { return profile.name == "good"; }));
+  EXPECT_FALSE(std::ranges::any_of(all, [](const auto &profile) { return profile.name == "typed"; }));
+}
+
+// Negative control: a healthy rename is unchanged by the try/catch restructuring. The existing
+// PersistsProfileAndDatabaseMapping test also calls RenameDatabase, but only ever counts mappings -- it
+// never inspects the profile's own `databases` set, which is exactly what moved around in the fix. This
+// asserts the full expected end state so the fix is provably not over-broad.
+TEST_F(TenantProfilesTest, RenameDatabaseRewritesProfileMembershipOnHealthyRecord) {
+  memgraph::kvstore::KVStore durability{test_folder_ / "rename_healthy"};
+  memgraph::dbms::TenantProfiles profiles{durability};
+  const auto db_mapping_prefix = std::string{memgraph::dbms::TenantProfiles::kDbMappingPrefix};
+
+  ASSERT_TRUE(profiles.Create("p", 2048));
+  ASSERT_EQ(profiles.AttachToDatabase("p", "db1"), 2048);
+
+  ASSERT_TRUE(profiles.RenameDatabase("db1", "db2"));
+
+  const auto new_mapping = durability.Get(db_mapping_prefix + "db2");
+  ASSERT_TRUE(new_mapping);
+  EXPECT_EQ(*new_mapping, "p");
+  EXPECT_FALSE(durability.Get(db_mapping_prefix + "db1"));
+
+  const auto profile = profiles.Get("p");
+  ASSERT_TRUE(profile);
+  EXPECT_TRUE(profile->databases.contains("db2"));
+  EXPECT_FALSE(profile->databases.contains("db1"));
+  EXPECT_EQ(profile->memory_limit, 2048);
 }

--- a/tests/unit/tenant_profiles.cpp
+++ b/tests/unit/tenant_profiles.cpp
@@ -129,14 +129,11 @@ TEST_F(TenantProfilesTest, AttachDetachDropLifecycle) {
   EXPECT_TRUE(profiles.GetAll().empty());
 }
 
-// Regression guard: before the fix, a corrupt profile record made RenameDatabase throw a raw
-// nlohmann::json::exception instead of returning an error. Its caller, DbmsHandler::Rename, has by
-// that point already committed the tenant rename both in memory and durably -- the throw made the
-// client see RENAME as failed for an operation that had, in fact, fully succeeded, and it also skipped
-// the subsequent txn->AddAction<RenameDatabase>, so the rename was never replicated -- leaving MAIN and
-// its replica permanently disagreeing on the tenant's database name. This writes the durable rows
-// directly through the kvstore (bypassing Create/AttachToDatabase, which would only ever write a
-// well-formed record) so the profile record RenameDatabase reads back is deliberately malformed.
+// Regression guard: before the fix, a corrupt profile record made RenameDatabase throw instead of
+// returning an error, after DbmsHandler::Rename had already committed the rename in memory and durably --
+// reporting failure for an operation that had, in fact, succeeded, and skipping the replication
+// AddAction, permanently diverging MAIN and its replica. Rows below are written directly through the
+// kvstore (bypassing Create/AttachToDatabase) to produce this malformed record.
 TEST_F(TenantProfilesTest, RenameDatabaseReportsErrorInsteadOfThrowingOnCorruptProfile) {
   memgraph::kvstore::KVStore durability{test_folder_ / "rename_corrupt"};
   memgraph::dbms::TenantProfiles profiles{durability};
@@ -152,7 +149,7 @@ TEST_F(TenantProfilesTest, RenameDatabaseReportsErrorInsteadOfThrowingOnCorruptP
   EXPECT_EQ(result.error(), memgraph::dbms::TenantProfiles::RenameError::DURABILITY_ERROR);
 
   // Deliberate, not an oversight: the caller (DbmsHandler::Rename) still completes and replicates the
-  // rename, and the next boot's PruneDatabases collects the stale mapping once "db1" is no longer live.
+  // rename even when this profile-membership rewrite fails.
   EXPECT_TRUE(durability.Get(db_mapping_prefix + "db1"))
       << "old mapping must survive a failed rewrite -- PruneDatabases reconciles it on next boot";
   // A failure must write neither the profile rewrite nor the new mapping, or "db2" would point at a
@@ -160,13 +157,12 @@ TEST_F(TenantProfilesTest, RenameDatabaseReportsErrorInsteadOfThrowingOnCorruptP
   EXPECT_FALSE(durability.Get(db_mapping_prefix + "db2"));
 }
 
-// Regression guard: GetAll is called from the DbmsHandler constructor (RestoreTenantProfiles_) with no
-// enclosing try/catch anywhere up to main(), so an exception escaping it terminates the whole process at
-// startup. Before the fix, Get and GetAll only caught nlohmann::json::parse_error, but a wrong-typed
-// persisted field makes FromJson's `.get<int64_t>()` throw nlohmann::json::type_error -- a SIBLING of
-// parse_error (both derive from nlohmann::detail::exception; neither derives from the other) -- so it
-// slipped past the old catch. The payload below is syntactically valid JSON (parse succeeds); only the
-// later typed .get<int64_t>() throws, so this exercises type_error specifically, not parse_error.
+// Regression guard: GetAll runs from the DbmsHandler ctor (RestoreTenantProfiles_) with no enclosing
+// try/catch up to main(), so an escaping exception crashes boot. Before the fix, Get/GetAll only caught
+// parse_error, but a wrong-typed field makes FromJson's .get<int64_t>() throw the sibling type_error
+// (both derive directly from nlohmann::detail::exception), which slipped past. The payload below is
+// syntactically valid JSON, so only the typed .get<int64_t>() throws -- exercising type_error, not
+// parse_error.
 TEST_F(TenantProfilesTest, WrongTypedProfileFieldDoesNotEscapeGetOrGetAll) {
   memgraph::kvstore::KVStore durability{test_folder_ / "wrong_typed"};
   memgraph::dbms::TenantProfiles profiles{durability};
@@ -185,10 +181,8 @@ TEST_F(TenantProfilesTest, WrongTypedProfileFieldDoesNotEscapeGetOrGetAll) {
   EXPECT_FALSE(std::ranges::any_of(all, [](const auto &profile) { return profile.name == "typed"; }));
 }
 
-// Negative control: a healthy rename is unchanged by the try/catch restructuring. The existing
-// PersistsProfileAndDatabaseMapping test also calls RenameDatabase, but only ever counts mappings -- it
-// never inspects the profile's own `databases` set, which is exactly what moved around in the fix. This
-// asserts the full expected end state so the fix is provably not over-broad.
+// Negative control paired with the corrupt-profile test above: a healthy rename must still succeed and
+// rewrite profile membership correctly after the try/catch restructuring in RenameDatabase.
 TEST_F(TenantProfilesTest, RenameDatabaseRewritesProfileMembershipOnHealthyRecord) {
   memgraph::kvstore::KVStore durability{test_folder_ / "rename_healthy"};
   memgraph::dbms::TenantProfiles profiles{durability};


### PR DESCRIPTION
Tenant-profile durability was non-atomic on both DDL paths:

- **DROP** deleted the tenant's `database:<name>` key and detached its profile as two separate writes. A crash between them left the tenant key behind after its attachment was gone, so a later same-named tenant inherited the dead one's memory cap.
- **RENAME** parsed and rewrote the durability record (injecting a bogus `name` field) and could half-apply, leaving MAIN and its replicas disagreeing on the tenant's name. A corrupt profile record also threw out of `Rename` *after* the in-memory rename had committed, skipping replication and diverging the cluster.

## Changes

- **DROP** retires the tenant durability key together with its profile detach in one atomic kvstore batch (`DetachFromDatabase(db_name, extra_keys)`), across all three delete paths.
- **RENAME** moves the durability record verbatim in one atomic batch. If that write fails, the in-memory rename is rolled back and the query fails — a rename MAIN never durably committed is never replicated.
- **Corrupt / wrong-typed profile records** return a durability error instead of throwing: no boot crash (`Get`/`GetAll` widened to catch `json::exception`, letting `bad_alloc` still propagate), no MAIN/replica divergence.
- **Boot-time `PruneDatabases` sweep** reconciles stale `db → profile` mappings left by a corrupt-profile detach or an older non-atomic release. Built from the raw `database:` key set, so suspended (COLD) tenants are not wrongly pruned.
- **`Resume_`** re-applies the profile's memory cap to a resumed tenant's freshly built storage.
