### PR TITLE
feat(query): tenant DB in SHOW TRANSACTIONS / SHOW ACTIVE USERS + foreign-read UAF fix + precise stuck-drain diagnostics

### DIFF
--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -108,11 +108,8 @@ class Database {
 
   utils::SafeString::ConstSafeWrapper name_view() const;
 
-  // Opt-in customization point that utils::GatekeeperLabelFor<Database> detects, so that
-  // ~Gatekeeper's teardown-stall warning can name the tenant that is failing to drain instead of
-  // logging an anonymous "~Gatekeeper" line. This direction of dependency is deliberate: utils/
-  // stays free of tenant vocabulary, and Database contributes the label instead. Only read on the
-  // cold, already-stalled (>5min) teardown path, so returning std::string by value is fine here.
+  // Opt-in customization point utils::GatekeeperLabelFor<Database> detects via SFINAE (see
+  // gatekeeper.hpp) so ~Gatekeeper's stall warning can name the tenant — looks unused otherwise.
   std::string gatekeeper_label() const { return name(); }
 
   /**

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -108,6 +108,13 @@ class Database {
 
   utils::SafeString::ConstSafeWrapper name_view() const;
 
+  // Opt-in customization point that utils::GatekeeperLabelFor<Database> detects, so that
+  // ~Gatekeeper's teardown-stall warning can name the tenant that is failing to drain instead of
+  // logging an anonymous "~Gatekeeper" line. This direction of dependency is deliberate: utils/
+  // stays free of tenant vocabulary, and Database contributes the label instead. Only read on the
+  // cold, already-stalled (>5min) teardown path, so returning std::string by value is fine here.
+  std::string gatekeeper_label() const { return name(); }
+
   /**
    * @brief Unique storage identified (uuid)
    *

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6637,10 +6637,8 @@ bool ActiveTransactionsExist(InterpreterContext *interpreter_context) {
   return exists_active_transaction;
 }
 
-// SessionInfo plus the session's current database, snapshotted through the only cross-thread-safe view
-// CurrentDB offers (foreign_db_view()). marked_for_deletion is the authoritative Gatekeeper flag, not an
-// inference from a handler-map lookup: a session pinning a force-dropped tenant keeps that tenant's memory
-// alive after the tenant is no longer listed by name anywhere else, and this is exactly the flag DROP sets.
+// foreign_db_view(), not name(), is required: this runs on a foreign thread with no verifier held.
+// db_marked_for_deletion is the authoritative Gatekeeper flag, not inferred from a handler-map lookup.
 struct ActiveUserInfo {
   Interpreter::SessionInfo session_info;
   std::string db_name;
@@ -7406,8 +7404,7 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
       if (lv && rv) return *lv == *rv;
       return false;
     };
-    // Read once: current_db_.name() is safe here because the verifier CAS above is held, and the value
-    // feeds both the privilege check and the "database" column below.
+    // current_db_.name() is safe here because the verifier CAS above is held (see CurrentDB::name()'s contract).
     auto const db_name = interpreter->current_db_.name();
     if (!same_user(interpreter->user_or_role_, user_or_role) && !privilege_checker(user_or_role, db_name)) continue;
     auto const runtime_status = verifier->status();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6637,17 +6637,27 @@ bool ActiveTransactionsExist(InterpreterContext *interpreter_context) {
   return exists_active_transaction;
 }
 
-std::vector<Interpreter::SessionInfo> GetActiveUsersInfo(InterpreterContext *interpreter_context) {
-  std::vector<Interpreter::SessionInfo> active_users =
-      interpreter_context->interpreters.WithLock([](const auto &interpreters_) {
-        std::vector<Interpreter::SessionInfo> info;
-        info.reserve(interpreters_.size());
-        for (const auto &interpreter : interpreters_) {
-          info.push_back(interpreter->session_info_);
-        }
+// SessionInfo plus the session's current database, snapshotted through the only cross-thread-safe view
+// CurrentDB offers (foreign_db_view()). marked_for_deletion is the authoritative Gatekeeper flag, not an
+// inference from a handler-map lookup: a session pinning a force-dropped tenant keeps that tenant's memory
+// alive after the tenant is no longer listed by name anywhere else, and this is exactly the flag DROP sets.
+struct ActiveUserInfo {
+  Interpreter::SessionInfo session_info;
+  std::string db_name;
+  bool db_marked_for_deletion{false};
+};
 
-        return info;
-      });
+std::vector<ActiveUserInfo> GetActiveUsersInfo(InterpreterContext *interpreter_context) {
+  std::vector<ActiveUserInfo> active_users = interpreter_context->interpreters.WithLock([](const auto &interpreters_) {
+    std::vector<ActiveUserInfo> info;
+    info.reserve(interpreters_.size());
+    for (const auto &interpreter : interpreters_) {
+      auto db_view = interpreter->current_db_.foreign_db_view();
+      info.push_back({interpreter->session_info_, std::move(db_view.name), db_view.marked_for_deletion});
+    }
+
+    return info;
+  });
 
   return active_users;
 }
@@ -8173,11 +8183,15 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
       };
     } break;
     case SystemInfoQuery::InfoType::ACTIVE_USERS: {
-      header = {"username", "session uuid", "login timestamp"};
+      header = {"username", "session uuid", "login timestamp", "database", "database marked for deletion"};
       handler = [interpreter_context] {
         std::vector<std::vector<TypedValue>> results;
         for (const auto &result : GetActiveUsersInfo(interpreter_context)) {
-          results.push_back({TypedValue(result.username), TypedValue(result.uuid), TypedValue(result.login_timestamp)});
+          results.push_back({TypedValue(result.session_info.username),
+                             TypedValue(result.session_info.uuid),
+                             TypedValue(result.session_info.login_timestamp),
+                             TypedValue(result.db_name),
+                             TypedValue(result.db_marked_for_deletion)});
         }
         return std::pair{results, QueryHandlerResult::NOTHING};
       };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7404,8 +7404,11 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
       if (lv && rv) return *lv == *rv;
       return false;
     };
-    // current_db_.name() is safe here because the verifier CAS above is held (see CurrentDB::name()'s contract).
-    auto const db_name = interpreter->current_db_.name();
+    // Route through foreign_db_view(): this is a foreign thread. The verifier CAS above does NOT order
+    // against SetCurrentDB (the Pull path never consults transaction_status_), so an unlocked db_acc_ read
+    // could tear against a concurrent USE DATABASE. foreign_db_view() takes db_acc_mutex_ and returns the
+    // same name string CurrentDB::name() would ("" when the session holds no database).
+    auto db_name = interpreter->current_db_.foreign_db_view().name;
     if (!same_user(interpreter->user_or_role_, user_or_role) && !privilege_checker(user_or_role, db_name)) continue;
     auto const runtime_status = verifier->status();
     if (!status_filter.empty()) {
@@ -7433,7 +7436,7 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
         StartTimeAndElapsedMs(interpreter->transaction_start_time_, interpreter->transaction_start_steady_);
     results.back().emplace_back(std::move(start_tv));
     results.back().emplace_back(elapsed_ms);
-    results.back().emplace_back(db_name);
+    results.back().emplace_back(std::move(db_name));
   }
   return results;
 }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7390,52 +7390,52 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
       continue;
     }
     std::optional<uint64_t> transaction_id = interpreter->GetTransactionId();
-    auto get_interpreter_db_name = [&]() -> std::string {
-      return interpreter->current_db_.db_acc_ ? interpreter->current_db_.db_acc_->get()->name() : "";
-    };
+    if (!transaction_id.has_value()) continue;
     auto same_user = [](const auto &lv, const auto &rv) {
       if (lv.get() == rv) return true;
       if (lv && rv) return *lv == *rv;
       return false;
     };
-    if (transaction_id.has_value() && (same_user(interpreter->user_or_role_, user_or_role) ||
-                                       privilege_checker(user_or_role, get_interpreter_db_name()))) {
-      auto const runtime_status = verifier->status();
-      if (!status_filter.empty()) {
-        auto const sf = ToStatusFilter(runtime_status);
-        if (!sf || !std::ranges::contains(status_filter, *sf)) continue;
-      }
-      const auto &typed_queries = interpreter->GetQueries();
-      results.push_back(
-          {TypedValue(interpreter->user_or_role_
-                          ? (interpreter->user_or_role_->username() ? *interpreter->user_or_role_->username() : "")
-                          : ""),
-           TypedValue(std::to_string(transaction_id.value())),
-           TypedValue(typed_queries),
-           TypedValue(std::string_view{TransactionStatusToString(runtime_status)})});
-      // metadata_ is safe to read - we hold CAS protection (status is VERIFYING,
-      // cleanup paths spin-wait before modifying fields)
-      std::map<std::string, TypedValue> metadata_tv;
-      if (interpreter->metadata_) {
-        for (const auto &md : *(interpreter->metadata_)) {
-          metadata_tv.emplace(md.first, TypedValue(md.second));
-        }
-      }
-      results.back().emplace_back(metadata_tv);
-      auto [start_tv, elapsed_ms] =
-          StartTimeAndElapsedMs(interpreter->transaction_start_time_, interpreter->transaction_start_steady_);
-      results.back().emplace_back(std::move(start_tv));
-      results.back().emplace_back(elapsed_ms);
+    // Read once: current_db_.name() is safe here because the verifier CAS above is held, and the value
+    // feeds both the privilege check and the "database" column below.
+    auto const db_name = interpreter->current_db_.name();
+    if (!same_user(interpreter->user_or_role_, user_or_role) && !privilege_checker(user_or_role, db_name)) continue;
+    auto const runtime_status = verifier->status();
+    if (!status_filter.empty()) {
+      auto const sf = ToStatusFilter(runtime_status);
+      if (!sf || !std::ranges::contains(status_filter, *sf)) continue;
     }
+    const auto &typed_queries = interpreter->GetQueries();
+    results.push_back(
+        {TypedValue(interpreter->user_or_role_
+                        ? (interpreter->user_or_role_->username() ? *interpreter->user_or_role_->username() : "")
+                        : ""),
+         TypedValue(std::to_string(transaction_id.value())),
+         TypedValue(typed_queries),
+         TypedValue(std::string_view{TransactionStatusToString(runtime_status)})});
+    // metadata_ is safe to read - we hold CAS protection (status is VERIFYING,
+    // cleanup paths spin-wait before modifying fields)
+    std::map<std::string, TypedValue> metadata_tv;
+    if (interpreter->metadata_) {
+      for (const auto &md : *(interpreter->metadata_)) {
+        metadata_tv.emplace(md.first, TypedValue(md.second));
+      }
+    }
+    results.back().emplace_back(metadata_tv);
+    auto [start_tv, elapsed_ms] =
+        StartTimeAndElapsedMs(interpreter->transaction_start_time_, interpreter->transaction_start_steady_);
+    results.back().emplace_back(std::move(start_tv));
+    results.back().emplace_back(elapsed_ms);
+    results.back().emplace_back(db_name);
   }
   return results;
 }
 
 // Synthetic SHOW TRANSACTIONS row for a background task (snapshot, GC): same
-// 7-column "running" shape, differing only in id, query text, and metadata.
+// 8-column "running" shape, differing only in id, query text, metadata, and db name.
 std::vector<TypedValue> BuildBackgroundTaskRow(std::string_view transaction_id, std::string_view query_text,
                                                std::map<std::string, TypedValue> metadata, int64_t start_time_us,
-                                               int64_t start_steady_ms) {
+                                               int64_t start_steady_ms, std::string_view db_name) {
   // start_time_us == 0 means "not started yet": leave start_time null, elapsed 0.
   auto [start_tv, elapsed_ms] = [&]() -> std::pair<TypedValue, int64_t> {
     if (start_time_us <= 0) return {TypedValue{}, 0};
@@ -7444,7 +7444,7 @@ std::vector<TypedValue> BuildBackgroundTaskRow(std::string_view transaction_id, 
     return StartTimeAndElapsedMs(start_tp, steady_start);
   }();
   std::vector<TypedValue> row;
-  row.reserve(7);
+  row.reserve(8);
   row.emplace_back("");
   row.emplace_back(transaction_id);
   row.emplace_back(std::vector<TypedValue>{TypedValue(query_text)});
@@ -7452,6 +7452,7 @@ std::vector<TypedValue> BuildBackgroundTaskRow(std::string_view transaction_id, 
   row.emplace_back(std::move(metadata));
   row.emplace_back(std::move(start_tv));
   row.emplace_back(elapsed_ms);
+  row.emplace_back(db_name);
   return row;
 }
 
@@ -7463,7 +7464,7 @@ std::vector<TypedValue> BuildSnapshotTransactionRow(storage::SnapshotProgressVie
   metadata.emplace("items_total", static_cast<int64_t>(progress.items_total));
   metadata.emplace("db_name", std::string{db_name});
   return BuildBackgroundTaskRow(
-      "snapshot", "CREATE SNAPSHOT", std::move(metadata), progress.start_time_us, progress.start_steady_ms);
+      "snapshot", "CREATE SNAPSHOT", std::move(metadata), progress.start_time_us, progress.start_steady_ms, db_name);
 }
 
 std::vector<TypedValue> BuildGcTransactionRow(storage::GcRunInfoView const &info, std::string_view db_name) {
@@ -7473,7 +7474,7 @@ std::vector<TypedValue> BuildGcTransactionRow(storage::GcRunInfoView const &info
   metadata.emplace("exclusive_lock", TypedValue(info.exclusive_lock));
   metadata.emplace("db_name", std::string{db_name});
   return BuildBackgroundTaskRow(
-      "gc", "GARBAGE COLLECTION", std::move(metadata), info.start_time_us, info.start_steady_ms);
+      "gc", "GARBAGE COLLECTION", std::move(metadata), info.start_time_us, info.start_steady_ms, db_name);
 }
 
 namespace {
@@ -7519,7 +7520,8 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                                 status_filter = transaction_query->status_filter_](const auto &interpreters) {
         return ShowTransactions(interpreters, user_or_role.get(), privilege_checker, status_filter);
       };
-      callback.header = {"username", "transaction_id", "query", "status", "metadata", "start_time", "elapsed_ms"};
+      callback.header = {
+          "username", "transaction_id", "query", "status", "metadata", "start_time", "elapsed_ms", "database"};
       // Background-task rows are always "running"; skip them when a status filter
       // excludes RUNNING.
       const bool include_background_tasks =

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6650,8 +6650,10 @@ std::vector<ActiveUserInfo> GetActiveUsersInfo(InterpreterContext *interpreter_c
     std::vector<ActiveUserInfo> info;
     info.reserve(interpreters_.size());
     for (const auto &interpreter : interpreters_) {
+      // Not an atomic snapshot: db and user come from separate locked reads, so they may skew -- ok here.
       auto db_view = interpreter->current_db_.foreign_db_view();
-      info.push_back({interpreter->session_info_, std::move(db_view.name), db_view.marked_for_deletion});
+      auto session_info = interpreter->GetSessionInfoSnapshot();
+      info.push_back({std::move(session_info), std::move(db_view.name), db_view.marked_for_deletion});
     }
 
     return info;
@@ -11847,6 +11849,7 @@ void Interpreter::SetUser(std::shared_ptr<QueryUserOrRole> user_or_role) {
 
 void Interpreter::SetSessionInfo(std::string uuid, std::string username, std::string login_timestamp) {
   session_log_ctx_.SetSessionUuid(uuid);
+  std::lock_guard lock{session_info_mutex_};
   session_info_ = {
       .uuid = std::move(uuid), .username = std::move(username), .login_timestamp = std::move(login_timestamp)};
 }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7418,13 +7418,12 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
       if (!sf || !std::ranges::contains(status_filter, *sf)) continue;
     }
     const auto &typed_queries = interpreter->GetQueries();
-    results.push_back(
-        {TypedValue(interpreter->user_or_role_
-                        ? (interpreter->user_or_role_->username() ? *interpreter->user_or_role_->username() : "")
-                        : ""),
-         TypedValue(std::to_string(transaction_id.value())),
-         TypedValue(typed_queries),
-         TypedValue(std::string_view{TransactionStatusToString(runtime_status)})});
+    results.push_back({TypedValue((interpreter->user_or_role_ && interpreter->user_or_role_->username())
+                                      ? *interpreter->user_or_role_->username()
+                                      : ""),
+                       TypedValue(std::to_string(transaction_id.value())),
+                       TypedValue(typed_queries),
+                       TypedValue(std::string_view{TransactionStatusToString(runtime_status)})});
     // metadata_ is safe to read - we hold CAS protection (status is VERIFYING,
     // cleanup paths spin-wait before modifying fields)
     std::map<std::string, TypedValue> metadata_tv;
@@ -11849,7 +11848,7 @@ void Interpreter::SetUser(std::shared_ptr<QueryUserOrRole> user_or_role) {
 
 void Interpreter::SetSessionInfo(std::string uuid, std::string username, std::string login_timestamp) {
   session_log_ctx_.SetSessionUuid(uuid);
-  std::lock_guard lock{session_info_mutex_};
+  const std::scoped_lock lock{session_info_mutex_};
   session_info_ = {
       .uuid = std::move(uuid), .username = std::move(username), .login_timestamp = std::move(login_timestamp)};
 }

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -311,11 +311,11 @@ struct CurrentDB {
     }
   }
 
-  // Owning-thread-only (or under the verifier's ACTIVE->VERIFYING CAS). Reads db_acc_ with no
-  // synchronization, which is safe only because every db_acc_ writer runs on this same owning thread, so a
-  // read/write pair is never concurrent -- adding a writer on any other thread invalidates this contract and
-  // every unlocked read in interpreter.cpp. A foreign thread -- including one observing an IDLE session --
-  // must use foreign_db_view() instead.
+  // Owning-thread-only (or under the verifier's ACTIVE->VERIFYING CAS). Reads db_acc_ with no synchronization,
+  // safe because a session's queries are serialized -- Bolt's worker pool never runs two for one session at
+  // once, so a writer and this read never overlap regardless of which thread runs each -- adding a concurrent
+  // writer invalidates this contract and every unlocked read in interpreter.cpp. A foreign thread -- including
+  // one observing an IDLE session -- must use foreign_db_view() instead.
   std::string name() const { return db_acc_ ? db_acc_->get()->name() : ""; }
 
   // Safe from any thread: unlike name(), it needs no verifier CAS, which can never succeed on IDLE anyway.
@@ -341,8 +341,8 @@ struct CurrentDB {
   bool in_explicit_db_{false};
   metrics::ScopedGauge transaction_gauge_;
 
-  // Guards mutation of db_acc_ only; owning-thread reads (name(), ~100 direct db_acc_ reads in
-  // interpreter.cpp) skip it because they run on the same thread as every writer and so can never race one.
+  // Guards mutation of db_acc_ only; owning-thread reads (name(), ~100 direct db_acc_ reads in interpreter.cpp) skip
+  // it because a session's queries are serialized, so a reader and writer for the same session never overlap.
   // Must NOT be a spinlock: foreign_db_view() calls Storage::name(), which blocks on a shared_mutex inside
   // utils::SafeString.
   //

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -259,9 +259,8 @@ struct CurrentDB {
                           //       ATM: it is provided by the DatabaseAccess
                           //       future: should be a name + ptr to dbms_handler, lazy fetch when needed
 
-  // No lock needed here: db_acc_ is set in the member-init list, and this CurrentDB is only reachable
-  // (e.g. via InterpreterContext::interpreters) once construction has completed, so no other thread can
-  // observe it beforehand.
+  // No lock needed: db_acc_ is set via the member-init list, before this CurrentDB becomes reachable
+  // (e.g. via InterpreterContext::interpreters), so no other thread can observe it mid-construction.
   explicit CurrentDB(memgraph::dbms::DatabaseAccess db_acc) : db_acc_{std::move(db_acc)} {}
 
   CurrentDB(CurrentDB const &) = delete;
@@ -272,19 +271,16 @@ struct CurrentDB {
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {
-    // Locked: db_acc_mutex_ guards this mutation so a foreign thread (SHOW ACTIVE USERS) can observe it via
-    // foreign_db_view(). Note the assignment below destroys the previous Accessor, which decrements
-    // GKInternals::count_ under GKInternals::mutex_ -- so the lock order here is db_acc_mutex_ ->
-    // GKInternals::mutex_. utils/gatekeeper.hpp has no knowledge of CurrentDB, so there is no reverse edge.
+    // Locked (see db_acc_mutex_). Destroying the previous Accessor here takes GKInternals::mutex_, so the
+    // lock order is db_acc_mutex_ -> GKInternals::mutex_, never the reverse.
     std::lock_guard lock{db_acc_mutex_};
     db_acc_ = std::move(new_db);
     in_explicit_db_ = in_explicit_db;
   }
 
   void ResetDB() {
-    // Narrowed to just db_acc_: it's the only member observed cross-thread (foreign_db_view()).
-    // db_transactional_accessor_'s ~Storage::Accessor can abort a txn and take storage locks, which would
-    // stall foreign_db_view() and add a needless db_acc_mutex_ -> storage-lock edge.
+    // Narrowed to db_acc_ only: db_transactional_accessor_'s dtor can abort a txn and take storage locks,
+    // which would stall a concurrent foreign_db_view() if held under the same lock.
     {
       std::lock_guard lock{db_acc_mutex_};
       db_acc_.reset();
@@ -294,9 +290,8 @@ struct CurrentDB {
     trigger_context_collector_.reset();
   }
 
-  // Mirrors the conditional reset in Interpreter::ResetInterpreter(): releases db_acc_ only when a database
-  // is held AND it is marked for deletion. Does not touch db_transactional_accessor_/execution_db_accessor_/
-  // trigger_context_collector_ -- that is ResetDB()'s job, not this one's.
+  // Releases db_acc_ only if held and marked for deletion; db_transactional_accessor_/execution_db_accessor_/
+  // trigger_context_collector_ are untouched -- that's ResetDB()'s job.
   void ReleaseDbIfMarked() {
     std::lock_guard lock{db_acc_mutex_};
     if (db_acc_ && db_acc_->is_marked_for_deletion()) {
@@ -304,18 +299,15 @@ struct CurrentDB {
     }
   }
 
-  // Owning-thread-only (or under the transaction verifier's ACTIVE->VERIFYING CAS). Reads the live accessor
-  // without synchronization -- safe because every db_acc_ writer runs on this same owning thread, so a
-  // same-thread read/write pair is never concurrent. An IDLE session (no verifier window) is NOT covered by
-  // this contract; cross-thread callers (e.g. SHOW ACTIVE USERS, which must also see IDLE sessions) must use
-  // foreign_db_view() instead.
+  // Owning-thread-only (or under the verifier's ACTIVE->VERIFYING CAS). Reads db_acc_ with no
+  // synchronization, which is safe only because every db_acc_ writer runs on this same owning thread, so a
+  // read/write pair is never concurrent -- adding a writer on any other thread invalidates this contract and
+  // every unlocked read in interpreter.cpp. A foreign thread -- including one observing an IDLE session --
+  // must use foreign_db_view() instead.
   std::string name() const { return db_acc_ ? db_acc_->get()->name() : ""; }
 
-  // A snapshot of the current database as seen from a thread that is NOT the owning session thread. This is
-  // the ONLY member of CurrentDB safe to call from any thread; it needs no transaction verifier, which is the
-  // point -- the verifier CAS can never succeed on an IDLE session, so it cannot cover the sessions that
-  // silently pin a dropped tenant's memory. Deliberately reads db_acc_ live (no cached name): DbmsHandler::Rename
-  // rewrites a live storage's name in place without touching db_acc_, so a cache would go stale.
+  // Safe from any thread: unlike name(), it needs no verifier CAS, which can never succeed on IDLE anyway.
+  // Reads db_acc_ live, not cached -- DbmsHandler::Rename mutates storage's name in place, not db_acc_.
   struct ForeignDbView {
     std::string name;                 // "" when the session holds no database
     bool marked_for_deletion{false};  // false when there is no database
@@ -337,11 +329,10 @@ struct CurrentDB {
   bool in_explicit_db_{false};
   metrics::ScopedGauge transaction_gauge_;
 
-  // Guards MUTATION of db_acc_ only, so a foreign thread (SHOW ACTIVE USERS) can observe an IDLE session's
-  // database via foreign_db_view(). Owning-thread reads (name(), and ~100 direct db_acc_ reads in
-  // interpreter.cpp) deliberately do NOT take this lock -- they run on the same thread as every writer, so
-  // they can never race one. Must NOT be a spinlock: foreign_db_view() calls Storage::name(), which takes a
-  // shared_mutex inside utils::SafeString, so the holder can block.
+  // Guards mutation of db_acc_ only; owning-thread reads (name(), ~100 direct db_acc_ reads in
+  // interpreter.cpp) skip it because they run on the same thread as every writer and so can never race one.
+  // Must NOT be a spinlock: foreign_db_view() calls Storage::name(), which blocks on a shared_mutex inside
+  // utils::SafeString.
   mutable std::mutex db_acc_mutex_;
 };
 

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -14,6 +14,7 @@
 #include <gflags/gflags.h>
 #include <chrono>
 #include <functional>
+#include <mutex>
 #include <optional>
 
 #include "dbms/database.hpp"
@@ -258,6 +259,9 @@ struct CurrentDB {
                           //       ATM: it is provided by the DatabaseAccess
                           //       future: should be a name + ptr to dbms_handler, lazy fetch when needed
 
+  // No lock needed here: db_acc_ is set in the member-init list, and this CurrentDB is only reachable
+  // (e.g. via InterpreterContext::interpreters) once construction has completed, so no other thread can
+  // observe it beforehand.
   explicit CurrentDB(memgraph::dbms::DatabaseAccess db_acc) : db_acc_{std::move(db_acc)} {}
 
   CurrentDB(CurrentDB const &) = delete;
@@ -268,19 +272,60 @@ struct CurrentDB {
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {
-    // do we lock here?
+    // Locked: db_acc_mutex_ guards this mutation so a foreign thread (SHOW ACTIVE USERS) can observe it via
+    // foreign_db_view(). Note the assignment below destroys the previous Accessor, which decrements
+    // GKInternals::count_ under GKInternals::mutex_ -- so the lock order here is db_acc_mutex_ ->
+    // GKInternals::mutex_. utils/gatekeeper.hpp has no knowledge of CurrentDB, so there is no reverse edge.
+    std::lock_guard lock{db_acc_mutex_};
     db_acc_ = std::move(new_db);
     in_explicit_db_ = in_explicit_db;
   }
 
   void ResetDB() {
-    db_acc_.reset();
+    // Narrowed to just db_acc_: it's the only member observed cross-thread (foreign_db_view()).
+    // db_transactional_accessor_'s ~Storage::Accessor can abort a txn and take storage locks, which would
+    // stall foreign_db_view() and add a needless db_acc_mutex_ -> storage-lock edge.
+    {
+      std::lock_guard lock{db_acc_mutex_};
+      db_acc_.reset();
+    }
     db_transactional_accessor_.reset();
     execution_db_accessor_.reset();
     trigger_context_collector_.reset();
   }
 
+  // Mirrors the conditional reset in Interpreter::ResetInterpreter(): releases db_acc_ only when a database
+  // is held AND it is marked for deletion. Does not touch db_transactional_accessor_/execution_db_accessor_/
+  // trigger_context_collector_ -- that is ResetDB()'s job, not this one's.
+  void ReleaseDbIfMarked() {
+    std::lock_guard lock{db_acc_mutex_};
+    if (db_acc_ && db_acc_->is_marked_for_deletion()) {
+      db_acc_.reset();
+    }
+  }
+
+  // Owning-thread-only (or under the transaction verifier's ACTIVE->VERIFYING CAS). Reads the live accessor
+  // without synchronization -- safe because every db_acc_ writer runs on this same owning thread, so a
+  // same-thread read/write pair is never concurrent. An IDLE session (no verifier window) is NOT covered by
+  // this contract; cross-thread callers (e.g. SHOW ACTIVE USERS, which must also see IDLE sessions) must use
+  // foreign_db_view() instead.
   std::string name() const { return db_acc_ ? db_acc_->get()->name() : ""; }
+
+  // A snapshot of the current database as seen from a thread that is NOT the owning session thread. This is
+  // the ONLY member of CurrentDB safe to call from any thread; it needs no transaction verifier, which is the
+  // point -- the verifier CAS can never succeed on an IDLE session, so it cannot cover the sessions that
+  // silently pin a dropped tenant's memory. Deliberately reads db_acc_ live (no cached name): DbmsHandler::Rename
+  // rewrites a live storage's name in place without touching db_acc_, so a cache would go stale.
+  struct ForeignDbView {
+    std::string name;                 // "" when the session holds no database
+    bool marked_for_deletion{false};  // false when there is no database
+  };
+
+  [[nodiscard]] ForeignDbView foreign_db_view() const {
+    std::lock_guard lock{db_acc_mutex_};
+    if (!db_acc_) return {};
+    return {db_acc_->get()->name(), db_acc_->is_marked_for_deletion()};
+  }
 
   // TODO: don't provide explicitly via constructor, instead have a lazy way of getting the current/default
   // DatabaseAccess
@@ -291,6 +336,13 @@ struct CurrentDB {
   std::optional<TriggerContextCollector> trigger_context_collector_;
   bool in_explicit_db_{false};
   metrics::ScopedGauge transaction_gauge_;
+
+  // Guards MUTATION of db_acc_ only, so a foreign thread (SHOW ACTIVE USERS) can observe an IDLE session's
+  // database via foreign_db_view(). Owning-thread reads (name(), and ~100 direct db_acc_ reads in
+  // interpreter.cpp) deliberately do NOT take this lock -- they run on the same thread as every writer, so
+  // they can never race one. Must NOT be a spinlock: foreign_db_view() calls Storage::name(), which takes a
+  // shared_mutex inside utils::SafeString, so the holder can block.
+  mutable std::mutex db_acc_mutex_;
 };
 
 using UserParameters_fn = std::function<UserParameters(storage::Storage const *)>;
@@ -586,9 +638,7 @@ class Interpreter final {
     system_transaction_.reset();
     transaction_queries_->clear();
     commit_notification_.reset();
-    if (current_db_.db_acc_ && current_db_.db_acc_->is_marked_for_deletion()) {
-      current_db_.db_acc_.reset();
-    }
+    current_db_.ReleaseDbIfMarked();
   }
 
   struct QueryExecution {

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <mutex>
 #include <optional>
+#include <utility>
 
 #include "dbms/database.hpp"
 #include "dbms/database_protector.hpp"
@@ -271,31 +272,42 @@ struct CurrentDB {
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {
-    // Locked (see db_acc_mutex_). Destroying the previous Accessor here takes GKInternals::mutex_, so the
-    // lock order is db_acc_mutex_ -> GKInternals::mutex_, never the reverse.
-    std::lock_guard lock{db_acc_mutex_};
-    db_acc_ = std::move(new_db);
-    in_explicit_db_ = in_explicit_db;
+    // Move the outgoing Accessor out of db_acc_ under the lock, then let it destruct AFTER the lock is
+    // released (see db_acc_mutex_ for why: its dtor can block on a foreign GKInternals::mutex_).
+    std::optional<memgraph::dbms::DatabaseAccess> old_db;
+    {
+      std::lock_guard lock{db_acc_mutex_};
+      old_db = std::exchange(db_acc_, std::move(new_db));
+      in_explicit_db_ = in_explicit_db;
+    }
   }
 
   void ResetDB() {
     // Narrowed to db_acc_ only: db_transactional_accessor_'s dtor can abort a txn and take storage locks,
-    // which would stall a concurrent foreign_db_view() if held under the same lock.
+    // which would stall a concurrent foreign_db_view() if held under the same lock. old_db is swapped out
+    // under the lock and destructed below, outside it (see db_acc_mutex_).
+    std::optional<memgraph::dbms::DatabaseAccess> old_db;
     {
       std::lock_guard lock{db_acc_mutex_};
-      db_acc_.reset();
+      old_db.swap(db_acc_);
     }
+    old_db.reset();  // release db access before the accessors below, as before
     db_transactional_accessor_.reset();
     execution_db_accessor_.reset();
     trigger_context_collector_.reset();
   }
 
   // Releases db_acc_ only if held and marked for deletion; db_transactional_accessor_/execution_db_accessor_/
-  // trigger_context_collector_ are untouched -- that's ResetDB()'s job.
+  // trigger_context_collector_ are untouched -- that's ResetDB()'s job. is_marked_for_deletion() only reads
+  // an atomic_bool (no GKInternals::mutex_), so it's safe to call under db_acc_mutex_; the swapped-out
+  // Accessor itself is destructed after the lock is released (see db_acc_mutex_).
   void ReleaseDbIfMarked() {
-    std::lock_guard lock{db_acc_mutex_};
-    if (db_acc_ && db_acc_->is_marked_for_deletion()) {
-      db_acc_.reset();
+    std::optional<memgraph::dbms::DatabaseAccess> old_db;
+    {
+      std::lock_guard lock{db_acc_mutex_};
+      if (db_acc_ && db_acc_->is_marked_for_deletion()) {
+        old_db.swap(db_acc_);
+      }
     }
   }
 
@@ -333,6 +345,17 @@ struct CurrentDB {
   // interpreter.cpp) skip it because they run on the same thread as every writer and so can never race one.
   // Must NOT be a spinlock: foreign_db_view() calls Storage::name(), which blocks on a shared_mutex inside
   // utils::SafeString.
+  //
+  // LEAF LOCK: every writer above swaps the outgoing Accessor out under this lock and destroys it only
+  // after releasing it -- no Accessor may be destroyed while this lock is held. An Accessor's dtor takes
+  // its GKInternals::mutex_, which finish_suspend() holds across the whole ~Database + WAL finalization,
+  // and GetActiveUsersInfo() takes this lock (via foreign_db_view()) while holding the interpreters
+  // SpinLock -- so nesting the two would put a busy-wait spinlock over the entire session table behind a
+  // tenant suspend. That pile-up is NOT reachable today: try_begin_suspend() waits for count_ == 1 before
+  // entering SUSPENDING, so a session holding this accessor keeps its tenant out of the suspend path
+  // entirely. Keeping this a leaf lock means correctness here does not depend on that remote invariant
+  // holding -- note finish_suspend()'s own count_ precondition is only a DMG_ASSERT, which compiles out
+  // under NDEBUG.
   mutable std::mutex db_acc_mutex_;
 };
 

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -353,16 +353,12 @@ struct CurrentDB {
   // Must NOT be a spinlock: foreign_db_view() calls Storage::name(), which blocks on a shared_mutex inside
   // utils::SafeString.
   //
-  // LEAF LOCK: every writer above swaps the outgoing Accessor out under this lock and destroys it only
-  // after releasing it -- no Accessor may be destroyed while this lock is held. An Accessor's dtor takes
-  // its GKInternals::mutex_, which finish_suspend() holds across the whole ~Database + WAL finalization,
-  // and GetActiveUsersInfo() takes this lock (via foreign_db_view()) while holding the interpreters
-  // SpinLock -- so nesting the two would put a busy-wait spinlock over the entire session table behind a
-  // tenant suspend. That pile-up is NOT reachable today: try_begin_suspend() waits for count_ == 1 before
-  // entering SUSPENDING, so a session holding this accessor keeps its tenant out of the suspend path
-  // entirely. Keeping this a leaf lock means correctness here does not depend on that remote invariant
-  // holding -- note finish_suspend()'s own count_ precondition is only a DMG_ASSERT, which compiles out
-  // under NDEBUG.
+  // GKInternals-MUTEX-FREE (not a textbook leaf lock -- it does take SafeString's shared_mutex via name()
+  // above): every writer swaps the outgoing Accessor out under this lock and destroys it after releasing, so
+  // no Accessor dtor -- and thus no GKInternals::mutex_ -- ever runs beneath it. That matters because
+  // GetActiveUsersInfo holds the interpreters SpinLock across this lock, and an Accessor dtor can block on a
+  // GKInternals::mutex_ that finish_suspend() holds across a whole ~Database; nesting them would stall the
+  // session table behind a tenant suspend.
   mutable std::mutex db_acc_mutex_;
 };
 
@@ -421,6 +417,8 @@ class Interpreter final {
 #endif
   std::unique_ptr<CachedFineGrainedAuth> cached_fga_;
   SessionInfo session_info_;
+  // Leaf lock for session_info_; only the foreign GetActiveUsersInfo reader locks (owning-thread reads serialized).
+  mutable std::mutex session_info_mutex_;
   bool in_explicit_transaction_{false};
   CurrentDB current_db_;
 
@@ -623,6 +621,11 @@ class Interpreter final {
 #endif
 
   void SetSessionInfo(std::string uuid, std::string username, std::string login_timestamp);
+
+  SessionInfo GetSessionInfoSnapshot() const {
+    std::lock_guard lock{session_info_mutex_};
+    return session_info_;
+  }
 
   std::optional<memgraph::system::Transaction> system_transaction_{};
 

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -311,11 +311,13 @@ struct CurrentDB {
     }
   }
 
-  // Owning-thread-only (or under the verifier's ACTIVE->VERIFYING CAS). Reads db_acc_ with no synchronization,
-  // safe because a session's queries are serialized -- Bolt's worker pool never runs two for one session at
-  // once, so a writer and this read never overlap regardless of which thread runs each -- adding a concurrent
-  // writer invalidates this contract and every unlocked read in interpreter.cpp. A foreign thread -- including
-  // one observing an IDLE session -- must use foreign_db_view() instead.
+  // Owning-thread-only. Reads db_acc_ with no synchronization, safe only because a session's queries are
+  // serialized -- Bolt's worker pool never runs two for one session at once, so the owning thread's read
+  // never overlaps that session's own SetCurrentDB writer. The verifier's ACTIVE->VERIFYING CAS does NOT
+  // make this safe for a foreign thread: the Pull/write path never consults transaction_status_, so the CAS
+  // establishes no happens-before against SetCurrentDB's db_acc_ swap -- a foreign unlocked read here would
+  // tear against a concurrent USE DATABASE. A foreign thread -- including one observing an IDLE session --
+  // must use foreign_db_view() instead.
   std::string name() const { return db_acc_ ? db_acc_->get()->name() : ""; }
 
   // Safe from any thread: unlike name(), it needs no verifier CAS, which can never succeed on IDLE anyway.
@@ -328,6 +330,11 @@ struct CurrentDB {
   [[nodiscard]] ForeignDbView foreign_db_view() const {
     std::lock_guard lock{db_acc_mutex_};
     if (!db_acc_) return {};
+    // is_marked_for_deletion() MUST resolve to Accessor::is_marked_for_deletion() (the plain atomic_bool
+    // read in gatekeeper.hpp) -- NOT Gatekeeper::is_marked_for_deletion(), which locks GKInternals::mutex_.
+    // db_acc_ is optional<DatabaseAccess = Gatekeeper<Database>::Accessor>, so db_acc_-> yields an Accessor
+    // and this resolves to the lockless overload. Taking the gatekeeper mutex here would add a
+    // db_acc_mutex_ -> gatekeeper-mutex edge and break db_acc_mutex_'s leaf-lock property.
     return {db_acc_->get()->name(), db_acc_->is_marked_for_deletion()};
   }
 

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -101,9 +101,10 @@ bool MayTerminate(Interpreter const *interpreter, QueryUserOrRole *user_or_role,
   };
   if (same_user(interpreter->user_or_role_, user_or_role)) return true;
 
-  // Route through CurrentDB::name() -- the single definition of "this session's database" --
-  // so a later change to what that means can't miss this site.
-  auto const db_name = interpreter->current_db_.name();
+  // Foreign thread: route through foreign_db_view() (takes db_acc_mutex_). The VERIFYING CAS in
+  // TryTerminateInterpreter does NOT order against SetCurrentDB, so an unlocked name() could tear
+  // against a concurrent USE DATABASE -- a use-after-free of the swapped-out DatabaseAccess.
+  auto const db_name = interpreter->current_db_.foreign_db_view().name;
   return privilege_checker(user_or_role, db_name);
 }
 
@@ -189,10 +190,13 @@ std::vector<uint64_t> InterpreterContext::ShowTransactionsUsingDBName(
     if (!verifier) {
       continue;
     }
-    // Transaction is running, so cannot change the underlying db
-    // No current DB (db_acc_ null) deliberately passes this filter: the caller uses this list as a
+    // Foreign thread: route through foreign_db_view() (takes db_acc_mutex_). The verifier CAS does NOT
+    // order against SetCurrentDB, so the unlocked db_acc_/name() read could tear against USE DATABASE.
+    // A no-DB interpreter (empty view name) deliberately passes this filter: the caller uses this list as a
     // DROP DATABASE ... FORCE kill-list, and a no-DB interpreter must stay a termination candidate.
-    if (interpreter->current_db_.db_acc_ && interpreter->current_db_.name() != db_name) {
+    // db_name is always a real, non-empty database name, so an empty view name means "no current DB".
+    auto const view = interpreter->current_db_.foreign_db_view();
+    if (!view.name.empty() && view.name != db_name) {
       continue;
     }
     std::optional<uint64_t> transaction_id = interpreter->GetTransactionId();

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -101,7 +101,9 @@ bool MayTerminate(Interpreter const *interpreter, QueryUserOrRole *user_or_role,
   };
   if (same_user(interpreter->user_or_role_, user_or_role)) return true;
 
-  auto const db_name = interpreter->current_db_.db_acc_ ? interpreter->current_db_.db_acc_->get()->name() : "";
+  // Route through CurrentDB::name() -- the single definition of "this session's database" --
+  // so a later change to what that means can't miss this site.
+  auto const db_name = interpreter->current_db_.name();
   return privilege_checker(user_or_role, db_name);
 }
 
@@ -188,7 +190,9 @@ std::vector<uint64_t> InterpreterContext::ShowTransactionsUsingDBName(
       continue;
     }
     // Transaction is running, so cannot change the underlying db
-    if (interpreter->current_db_.db_acc_ && interpreter->current_db_.db_acc_->get()->name() != db_name) {
+    // db_acc_ guard is deliberate (short-circuit &&): an interpreter with no current DB is
+    // intentionally NOT filtered out here.
+    if (interpreter->current_db_.db_acc_ && interpreter->current_db_.name() != db_name) {
       continue;
     }
     std::optional<uint64_t> transaction_id = interpreter->GetTransactionId();

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -190,8 +190,8 @@ std::vector<uint64_t> InterpreterContext::ShowTransactionsUsingDBName(
       continue;
     }
     // Transaction is running, so cannot change the underlying db
-    // db_acc_ guard is deliberate (short-circuit &&): an interpreter with no current DB is
-    // intentionally NOT filtered out here.
+    // No current DB (db_acc_ null) deliberately passes this filter: the caller uses this list as a
+    // DROP DATABASE ... FORCE kill-list, and a no-DB interpreter must stay a termination candidate.
     if (interpreter->current_db_.db_acc_ && interpreter->current_db_.name() != db_name) {
       continue;
     }

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -101,10 +101,8 @@ struct GatekeeperGuardFor<T, std::void_t<typename T::GatekeeperGuard>> {
   using type = typename T::GatekeeperGuard;
 };
 
-// Opt-in identity label for the stall diagnostic in ~Gatekeeper: a generic container has no name for
-// what it holds, but a log line that cannot say WHICH object is stuck is far less useful. Mirrors
-// GatekeeperGuardFor above — T contributes the label by declaring `gatekeeper_label()`; Gatekeeper
-// itself must stay free of any tenant/dbms vocabulary. Types that do not opt in pay nothing.
+// Opt-in identity label for the stall diagnostic in ~Gatekeeper (mirrors GatekeeperGuardFor above): T
+// declares `gatekeeper_label()` to contribute a name; Gatekeeper itself stays free of tenant/dbms vocabulary.
 template <typename T, typename = void>
 struct GatekeeperLabelFor {
   static std::string get(T const &) { return {}; }
@@ -145,11 +143,10 @@ constexpr std::string_view GatekeeperStateName(GatekeeperState state) {
   std::unreachable();
 }
 
-// HOT and COLD are the terminal states of the state machine documented on the enum above; SUSPENDING
-// and RESUMING are in-flight transitions. ~Gatekeeper's teardown wait (below) blocks until a terminal
-// state is reached, which is the sole reason this predicate exists.
-// Exhaustive on purpose (no `default:`): -Werror=switch turns a future 5th enumerator into a compile
-// error instead of silently classifying it as terminal or not.
+// HOT and COLD (see the enum above) are the terminal states; SUSPENDING/RESUMING are in-flight —
+// ~Gatekeeper's teardown wait (below) blocks on this predicate, the sole reason it exists.
+// Exhaustive on purpose (no `default:`): -Werror=switch (CMakeLists.txt:303) turns a future 5th
+// enumerator into a compile error instead of silently classifying it as terminal or not.
 constexpr bool IsTerminalGatekeeperState(GatekeeperState state) noexcept {
   switch (state) {
     case GatekeeperState::HOT:
@@ -485,11 +482,9 @@ struct Gatekeeper {
   ~Gatekeeper() {
     if (!pimpl_) return;  // Moved out, nothing to do
     pimpl_->is_marked_for_deletion = true;
-    // Wait for a terminal state (HOT or COLD) AND a drained accessor count — two independent halves.
-    // Every transition above calls notify_all(), so this wait cannot lose a wakeup; it stays unbounded
-    // because a slow accessor drain on shutdown is legitimate. Past kDiagInterval, though, it is no
-    // longer a benign drain — it is a stuck holder or a caller ordering error, and an operator needs to
-    // see it, so the periodic breadcrumb below branches on which half is unsatisfied and logs at WARN.
+    // Every transition above calls notify_all(), so this wait cannot lose a wakeup. It stays unbounded
+    // (a slow accessor drain on shutdown is legitimate) but logs at WARN past kDiagInterval, since by then it's no
+    // longer benign.
     {
       auto lock = std::unique_lock{pimpl_->mutex_};
       auto const terminal_and_drained = [this] {
@@ -500,15 +495,12 @@ struct Gatekeeper {
         auto const state = pimpl_->state_;
         auto const count = pimpl_->count_;
         bool const non_terminal = !IsTerminalGatekeeperState(state);
-        // Everything below — the label/prefix strings, fmt::format, spdlog — can allocate or throw
-        // (bad_alloc, formatting, sink I/O), and a destructor is implicitly noexcept, so any of it
-        // escaping would call std::terminate. Swallow it all - the wait condition above is what
-        // matters here, not this breadcrumb.
+        // Everything below (label/prefix strings, fmt::format, spdlog) can allocate or throw; ~Gatekeeper
+        // is implicitly noexcept, so an escaping exception would call std::terminate — swallow it all.
         try {
-          // value_ is empty in COLD and RESUMING (see finish_suspend/begin_resume), both reachable here —
-          // RESUMING is a legitimately long in-flight recovery, and COLD-with-count>0 is reachable in
-          // release builds because finish_suspend's count_==0 invariant is only a DMG_ASSERT (a no-op
-          // under NDEBUG). Guard on has_value() so the label is opt-in twice over, not a SIGSEGV.
+          // value_ is empty in COLD and RESUMING (finish_suspend/begin_resume); guard on has_value() to
+          // avoid a null deref — COLD-with-count>0 is reachable in release since finish_suspend's DMG_ASSERT is a no-op
+          // under NDEBUG.
           auto const label = pimpl_->value_ ? GatekeeperLabelFor<T>::get(*pimpl_->value_) : std::string{};
           auto const prefix = label.empty() ? std::string{"~Gatekeeper"} : "~Gatekeeper[" + label + "]";
           std::string reason;

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -145,7 +145,7 @@ constexpr std::string_view GatekeeperStateName(GatekeeperState state) {
 
 // HOT and COLD (see the enum above) are the terminal states; SUSPENDING/RESUMING are in-flight —
 // ~Gatekeeper's teardown wait (below) blocks on this predicate, the sole reason it exists.
-// Exhaustive on purpose (no `default:`): -Werror=switch (CMakeLists.txt:303) turns a future 5th
+// Exhaustive on purpose (no `default:`): -Werror=switch turns a future 5th
 // enumerator into a compile error instead of silently classifying it as terminal or not.
 constexpr bool IsTerminalGatekeeperState(GatekeeperState state) noexcept {
   switch (state) {
@@ -491,6 +491,7 @@ struct Gatekeeper {
         return IsTerminalGatekeeperState(pimpl_->state_) && pimpl_->count_ == 0;
       };
       constexpr auto kDiagInterval = std::chrono::minutes{5};
+      auto const teardown_start = std::chrono::steady_clock::now();
       while (!pimpl_->cv_.wait_for(lock, kDiagInterval, terminal_and_drained)) {
         auto const state = pimpl_->state_;
         auto const count = pimpl_->count_;
@@ -498,9 +499,14 @@ struct Gatekeeper {
         // Everything below (label/prefix strings, fmt::format, spdlog) can allocate or throw; ~Gatekeeper
         // is implicitly noexcept, so an escaping exception would call std::terminate — swallow it all.
         try {
+          auto const elapsed_min =
+              std::chrono::duration_cast<std::chrono::minutes>(std::chrono::steady_clock::now() - teardown_start)
+                  .count();
           // value_ is empty in COLD and RESUMING (finish_suspend/begin_resume); guard on has_value() to
           // avoid a null deref — COLD-with-count>0 is reachable in release since finish_suspend's DMG_ASSERT is a no-op
           // under NDEBUG.
+          // name() takes SafeString's shared_mutex under mutex_ (held here); no cycle -- Rename's name write
+          // sits between its Accessor's two brief mutex_ windows (mint, dtor), never under either.
           auto const label = pimpl_->value_ ? GatekeeperLabelFor<T>::get(*pimpl_->value_) : std::string{};
           auto const prefix = label.empty() ? std::string{"~Gatekeeper"} : "~Gatekeeper[" + label + "]";
           std::string reason;
@@ -517,15 +523,21 @@ struct Gatekeeper {
                 "destruction during SUSPENDING/RESUMING is a caller ordering error - in-flight transitions "
                 "must be quiesced before destroying.",
                 GatekeeperStateName(state));
-          } else {
+          } else if (state == GatekeeperState::HOT) {
             reason = fmt::format(
-                "state is {} (terminal, so this is not a state-transition problem) but {} accessor(s) are "
+                "state is HOT (terminal, so this is not a state-transition problem) but {} accessor(s) are "
                 "still outstanding. A holder has not released - either a leaked accessor or a long-running "
                 "operation.",
-                GatekeeperStateName(state),
+                count);
+          } else {
+            // COLD means finish_suspend() already cleared value_, so a live accessor here is a UAF, not a drain.
+            reason = fmt::format(
+                "state is COLD (terminal) with {} outstanding accessor(s), but value_ has already been "
+                "destroyed by finish_suspend(). A live accessor dereference at this point is undefined "
+                "behaviour / use-after-free — a lifetime ordering violation.",
                 count);
           }
-          spdlog::warn("{} has waited >{} min for teardown: {}", prefix, kDiagInterval.count(), reason);
+          spdlog::warn("{} has waited >{} min for teardown: {}", prefix, elapsed_min, reason);
         } catch (...) {  // NOLINT(bugprone-empty-catch)
         }
       }

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -19,6 +19,8 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -99,6 +101,20 @@ struct GatekeeperGuardFor<T, std::void_t<typename T::GatekeeperGuard>> {
   using type = typename T::GatekeeperGuard;
 };
 
+// Opt-in identity label for the stall diagnostic in ~Gatekeeper: a generic container has no name for
+// what it holds, but a log line that cannot say WHICH object is stuck is far less useful. Mirrors
+// GatekeeperGuardFor above — T contributes the label by declaring `gatekeeper_label()`; Gatekeeper
+// itself must stay free of any tenant/dbms vocabulary. Types that do not opt in pay nothing.
+template <typename T, typename = void>
+struct GatekeeperLabelFor {
+  static std::string get(T const &) { return {}; }
+};
+
+template <typename T>
+struct GatekeeperLabelFor<T, std::void_t<decltype(std::declval<T const &>().gatekeeper_label())>> {
+  static std::string get(T const &v) { return v.gatekeeper_label(); }
+};
+
 // 4-state lifecycle for hot/cold tenant management.
 // Transitions (all under GKInternals::mutex_):
 //   HOT -> SUSPENDING  : Gatekeeper::try_begin_suspend()   — sole-accessor gate
@@ -112,6 +128,39 @@ struct GatekeeperGuardFor<T, std::void_t<typename T::GatekeeperGuard>> {
 // Declared at namespace scope so headers that forward-declare the managed type
 // T can use GatekeeperState without forcing T to be complete.
 enum class GatekeeperState : uint8_t { HOT, SUSPENDING, COLD, RESUMING };
+
+// Exhaustive on purpose (no `default:`): -Werror=switch turns a future 5th enumerator into a compile
+// error instead of a silently wrong name.
+constexpr std::string_view GatekeeperStateName(GatekeeperState state) {
+  switch (state) {
+    case GatekeeperState::HOT:
+      return "HOT";
+    case GatekeeperState::SUSPENDING:
+      return "SUSPENDING";
+    case GatekeeperState::COLD:
+      return "COLD";
+    case GatekeeperState::RESUMING:
+      return "RESUMING";
+  }
+  std::unreachable();
+}
+
+// HOT and COLD are the terminal states of the state machine documented on the enum above; SUSPENDING
+// and RESUMING are in-flight transitions. ~Gatekeeper's teardown wait (below) blocks until a terminal
+// state is reached, which is the sole reason this predicate exists.
+// Exhaustive on purpose (no `default:`): -Werror=switch turns a future 5th enumerator into a compile
+// error instead of silently classifying it as terminal or not.
+constexpr bool IsTerminalGatekeeperState(GatekeeperState state) noexcept {
+  switch (state) {
+    case GatekeeperState::HOT:
+    case GatekeeperState::COLD:
+      return true;
+    case GatekeeperState::SUSPENDING:
+    case GatekeeperState::RESUMING:
+      return false;
+  }
+  std::unreachable();
+}
 
 // Tag to construct a Gatekeeper directly as a COLD shell (no managed value): used by hot/cold
 // cross-restart recovery to bring a previously-suspended tenant back COLD without building its
@@ -436,30 +485,55 @@ struct Gatekeeper {
   ~Gatekeeper() {
     if (!pimpl_) return;  // Moved out, nothing to do
     pimpl_->is_marked_for_deletion = true;
-    // Wait for a terminal state (HOT or COLD) AND a drained accessor count.
-    // A graceful destruction during SUSPENDING or RESUMING is a caller
-    // ordering error — the owner must quiesce in-flight transitions before
-    // destroying. The terminal-state guard is the backstop: every transition
-    // above calls notify_all() so this wait cannot lose a wakeup.
+    // Wait for a terminal state (HOT or COLD) AND a drained accessor count — two independent halves.
+    // Every transition above calls notify_all(), so this wait cannot lose a wakeup; it stays unbounded
+    // because a slow accessor drain on shutdown is legitimate. Past kDiagInterval, though, it is no
+    // longer a benign drain — it is a stuck holder or a caller ordering error, and an operator needs to
+    // see it, so the periodic breadcrumb below branches on which half is unsatisfied and logs at WARN.
     {
       auto lock = std::unique_lock{pimpl_->mutex_};
       auto const terminal_and_drained = [this] {
-        return (pimpl_->state_ == GatekeeperState::HOT || pimpl_->state_ == GatekeeperState::COLD) &&
-               pimpl_->count_ == 0;
+        return IsTerminalGatekeeperState(pimpl_->state_) && pimpl_->count_ == 0;
       };
-      // The wait stays unbounded (a slow accessor drain on shutdown is legitimate); TRACE + a 5min
-      // cadence is a quiet breadcrumb for a trace-enabled hang debug, not an alarming WARN for a benign drain.
       constexpr auto kDiagInterval = std::chrono::minutes{5};
       while (!pimpl_->cv_.wait_for(lock, kDiagInterval, terminal_and_drained)) {
-        // spdlog can throw (formatting, sink I/O); a destructor is implicitly noexcept, so an escaping
-        // exception would call std::terminate. Swallow it — the wait condition is what matters here.
+        auto const state = pimpl_->state_;
+        auto const count = pimpl_->count_;
+        bool const non_terminal = !IsTerminalGatekeeperState(state);
+        // Everything below — the label/prefix strings, fmt::format, spdlog — can allocate or throw
+        // (bad_alloc, formatting, sink I/O), and a destructor is implicitly noexcept, so any of it
+        // escaping would call std::terminate. Swallow it all - the wait condition above is what
+        // matters here, not this breadcrumb.
         try {
-          spdlog::trace(
-              "~Gatekeeper has waited >5min for a terminal state and a drained accessor count (state={}, "
-              "count={}). A graceful destruction during SUSPENDING/RESUMING is a caller ordering error — "
-              "in-flight transitions must be quiesced before destroying.",
-              static_cast<int>(pimpl_->state_),
-              pimpl_->count_);
+          // value_ is empty in COLD and RESUMING (see finish_suspend/begin_resume), both reachable here —
+          // RESUMING is a legitimately long in-flight recovery, and COLD-with-count>0 is reachable in
+          // release builds because finish_suspend's count_==0 invariant is only a DMG_ASSERT (a no-op
+          // under NDEBUG). Guard on has_value() so the label is opt-in twice over, not a SIGSEGV.
+          auto const label = pimpl_->value_ ? GatekeeperLabelFor<T>::get(*pimpl_->value_) : std::string{};
+          auto const prefix = label.empty() ? std::string{"~Gatekeeper"} : "~Gatekeeper[" + label + "]";
+          std::string reason;
+          if (non_terminal && count != 0) {
+            reason = fmt::format(
+                "state is {} (not a terminal HOT/COLD state) AND {} accessor(s) are still outstanding. The "
+                "non-terminal state is a caller ordering error - in-flight suspend/resume transitions must be "
+                "quiesced before destroying. The outstanding accessors mean a holder has not released.",
+                GatekeeperStateName(state),
+                count);
+          } else if (non_terminal) {
+            reason = fmt::format(
+                "accessors are drained but state is {}, which is not a terminal HOT/COLD state. A graceful "
+                "destruction during SUSPENDING/RESUMING is a caller ordering error - in-flight transitions "
+                "must be quiesced before destroying.",
+                GatekeeperStateName(state));
+          } else {
+            reason = fmt::format(
+                "state is {} (terminal, so this is not a state-transition problem) but {} accessor(s) are "
+                "still outstanding. A holder has not released - either a leaked accessor or a long-running "
+                "operation.",
+                GatekeeperStateName(state),
+                count);
+          }
+          spdlog::warn("{} has waited >{} min for teardown: {}", prefix, kDiagInterval.count(), reason);
         } catch (...) {  // NOLINT(bugprone-empty-catch)
         }
       }

--- a/tests/e2e/show_active_users_info/test_show_active_users_info.py
+++ b/tests/e2e/show_active_users_info/test_show_active_users_info.py
@@ -9,6 +9,7 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
+import os
 import sys
 
 import pytest
@@ -22,6 +23,36 @@ def test_empty_show_active_users_info(memgraph):
     assert len(results[0]["username"]) == 0
     assert len(results[0]["session uuid"]) > 0
     assert len(results[0]["login timestamp"]) > 0
+
+    # Cross-check against SHOW DATABASE instead of hardcoding "memgraph", so the assertion still
+    # holds if the default database name is ever reconfigured.
+    current_database = list(memgraph.execute_and_fetch("SHOW DATABASE"))
+    assert len(current_database) == 1
+    expected_db_name = current_database[0]["Current"]
+
+    assert results[0]["database"] == expected_db_name
+    assert results[0]["database marked for deletion"] is False
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("MEMGRAPH_ENTERPRISE_LICENSE") and os.environ.get("MEMGRAPH_ORGANIZATION_NAME")),
+    reason="Needs an enterprise license (MEMGRAPH_ENTERPRISE_LICENSE + MEMGRAPH_ORGANIZATION_NAME) to exercise "
+    "CREATE DATABASE / USE DATABASE",
+)
+def test_show_active_users_info_database_follows_use_database(memgraph):
+    TENANT_DB = "tenant_show_active_users_info"
+
+    memgraph.execute(f"CREATE DATABASE {TENANT_DB};")
+    try:
+        memgraph.execute(f"USE DATABASE {TENANT_DB};")
+
+        results = list(memgraph.execute_and_fetch("SHOW ACTIVE USERS INFO"))
+        assert len(results) == 1
+        assert results[0]["database"] == TENANT_DB
+        assert results[0]["database marked for deletion"] is False
+    finally:
+        memgraph.execute("USE DATABASE memgraph;")
+        memgraph.execute(f"DROP DATABASE {TENANT_DB};")
 
 
 def test_active_show_users_info_with_2_users(provide_user):

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -97,6 +97,26 @@ def test_self_transaction():
     assert len(results) == 1
 
 
+def test_show_transactions_database_column():
+    """Tests that the last column of SHOW TRANSACTIONS reports the connection's real
+    current database, not a placeholder. The unit test fixture leaves the storage name
+    empty, so a non-empty value here can only be checked in e2e."""
+    cursor = connect().cursor()
+    # No USE DATABASE was issued on this connection, so it is on the default database;
+    # ask the server for its name instead of hardcoding it.
+    db_name = execute_and_fetch_all(cursor, "SHOW DATABASE")[0][0]
+    assert db_name == "memgraph"
+    results = execute_and_fetch_all(cursor, "SHOW TRANSACTIONS")
+    assert len(results) == 1
+    row = results[0]
+    # 8-wide header: username, transaction_id, query, status, metadata, start_time, elapsed_ms, database.
+    # A reverted header (or a dropped emplace_back(db_name)) surfaces as an IndexError here,
+    # not a silently-passing comparison.
+    assert len(row) == 8
+    assert row[2] == ["SHOW TRANSACTIONS"]
+    assert row[7] == db_name
+
+
 def test_multitenant_transactions():
     """Tests that show transactions work on another database"""
     test_cursor = connect().cursor()

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -435,7 +435,7 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
   // Verify the SHOW TRANSACTIONS header includes the status column
   auto [stream, qid] = this->main_interpreter.Prepare("SHOW TRANSACTIONS");
   auto header = stream.GetHeader();
-  ASSERT_EQ(header.size(), 7U);
+  ASSERT_EQ(header.size(), 8U);
   EXPECT_EQ(header[0], "username");
   EXPECT_EQ(header[1], "transaction_id");
   EXPECT_EQ(header[2], "query");
@@ -443,6 +443,26 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
   EXPECT_EQ(header[4], "metadata");
   EXPECT_EQ(header[5], "start_time");
   EXPECT_EQ(header[6], "elapsed_ms");
+  EXPECT_EQ(header[7], "database");
+}
+
+TYPED_TEST(TransactionQueueSimpleTest, DatabaseColumnPresentWithCorrectArity) {
+  // Pins the "database" column: it must exist at index 7, and the row must stay 8 wide --
+  // that's what actually breaks on a revert. This fixture never sets config.salient.name, so
+  // this->db->name() is the empty string; the EXPECT_EQ below therefore only proves the column
+  // carries the fixture's (empty) name, not that ShowTransactions reports a real, non-empty
+  // per-session database name. That value-level check lives in
+  // tests/e2e/transaction_queue/test_transaction_queue.py::test_show_transactions_database_column.
+  //
+  // The column is the last one appended by ShowTransactions, sourced from CurrentDB::name().
+  auto show_stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
+  ASSERT_EQ(show_stream.GetResults().size(), 1U);
+
+  auto &row = show_stream.GetResults()[0];
+  ASSERT_EQ(row.size(), 8U);
+  EXPECT_EQ(row[2].ValueList().at(0).ValueString(), "SHOW TRANSACTIONS");
+  ASSERT_TRUE(row[7].IsString());
+  EXPECT_EQ(row[7].ValueString(), this->db->name());
 }
 
 TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -537,3 +537,64 @@ TYPED_TEST(TransactionQueueSimpleTest, ShowFilteredTransactionsExcludesNonMatchi
 }
 
 // ShowFilteredTransactionsWithTerminated removed
+
+// Regression test for the db_acc_mutex_ leaf-lock invariant in query::CurrentDB (interpreter.hpp):
+// SetCurrentDB/ResetDB/ReleaseDbIfMarked must swap the outgoing DatabaseAccess out from under
+// db_acc_mutex_ and destroy it only after releasing that lock -- never while the lock is held. If that
+// invariant regressed (e.g. back to `db_acc_ = std::move(new_db);` under the lock), the outgoing
+// Accessor's dtor -- which takes the (unrelated, per-tenant) GKInternals::mutex_ -- would run nested
+// under db_acc_mutex_, and GetActiveUsersInfo takes db_acc_mutex_ (via foreign_db_view()) while holding
+// the interpreters SpinLock, so a slow-to-release GKInternals::mutex_ elsewhere would stall that spinlock
+// across the whole session table.
+//
+// What this test does NOT cover: it cannot reproduce that exact cross-tenant stall. Every Gatekeeper API
+// that holds GKInternals::mutex_ for a non-trivial duration (finish_suspend(), try_delete(),
+// try_exclusively()) requires sole ownership (count_==1) as a precondition, which a live CurrentDB
+// accessor on the same Database structurally rules out -- and GKInternals itself is a private
+// implementation detail of Gatekeeper<T>, not reachable from a test for direct instrumentation. So this
+// is a structural/API-level regression test, not a reproduction of the originally-hypothesized deadlock.
+// What it DOES cover: heavy concurrent SetCurrentDB/ResetDB/ReleaseDbIfMarked churn on the "owning" thread
+// against concurrent foreign_db_view() reads from a second thread (a) completes within a bounded time
+// (no hang), and (b) never observes a torn/inconsistent {name, marked_for_deletion} pair -- which is what
+// a broken swap (e.g. destroying db_acc_ mid-read) would produce.
+TYPED_TEST(TransactionQueueSimpleTest, CurrentDBChurnVsForeignDbViewNoTornReads) {
+  memgraph::query::CurrentDB current_db{std::move(this->db_gk.access().value())};
+  auto const expected_name = this->db->name();
+
+  constexpr int kIters = 20000;
+  std::atomic<int> churn_count{0};
+
+  std::jthread churn_thread([&] {
+    for (int i = 0; i < kIters; ++i) {
+      auto acc = this->db_gk.access();
+      ASSERT_TRUE(acc.has_value());
+      current_db.SetCurrentDB(std::move(*acc), i % 2 == 0);
+      current_db.ReleaseDbIfMarked();  // never marked in this test; exercises the third writer's lock path
+      current_db.ResetDB();
+      churn_count.fetch_add(1, std::memory_order_relaxed);
+    }
+  });
+
+  std::atomic<int> read_count{0};
+  std::jthread reader_thread([&](std::stop_token st) {
+    while (!st.stop_requested()) {
+      auto view = current_db.foreign_db_view();
+      // Either no db is currently held (ResetDB() won the race for that instant) or it's exactly this
+      // fixture's db -- never a partial/garbage string, which is what a torn read across the swap would
+      // produce.
+      EXPECT_TRUE(view.name.empty() || view.name == expected_name) << "torn read: '" << view.name << "'";
+      EXPECT_FALSE(view.marked_for_deletion);
+      read_count.fetch_add(1, std::memory_order_relaxed);
+    }
+  });
+
+  // Bounded by construction: churn_thread runs a fixed kIters loop (no wait/backoff), so this join cannot
+  // hang unless the leaf-lock invariant is broken and something blocks db_acc_mutex_ indefinitely.
+  churn_thread.join();
+  reader_thread.request_stop();
+  reader_thread.join();
+
+  EXPECT_EQ(churn_count.load(), kIters);
+  EXPECT_GT(read_count.load(), 0);
+  current_db.ResetDB();
+}

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -538,25 +538,12 @@ TYPED_TEST(TransactionQueueSimpleTest, ShowFilteredTransactionsExcludesNonMatchi
 
 // ShowFilteredTransactionsWithTerminated removed
 
-// Regression test for the db_acc_mutex_ leaf-lock invariant in query::CurrentDB (interpreter.hpp):
-// SetCurrentDB/ResetDB/ReleaseDbIfMarked must swap the outgoing DatabaseAccess out from under
-// db_acc_mutex_ and destroy it only after releasing that lock -- never while the lock is held. If that
-// invariant regressed (e.g. back to `db_acc_ = std::move(new_db);` under the lock), the outgoing
-// Accessor's dtor -- which takes the (unrelated, per-tenant) GKInternals::mutex_ -- would run nested
-// under db_acc_mutex_, and GetActiveUsersInfo takes db_acc_mutex_ (via foreign_db_view()) while holding
-// the interpreters SpinLock, so a slow-to-release GKInternals::mutex_ elsewhere would stall that spinlock
-// across the whole session table.
-//
-// What this test does NOT cover: it cannot reproduce that exact cross-tenant stall. Every Gatekeeper API
-// that holds GKInternals::mutex_ for a non-trivial duration (finish_suspend(), try_delete(),
-// try_exclusively()) requires sole ownership (count_==1) as a precondition, which a live CurrentDB
-// accessor on the same Database structurally rules out -- and GKInternals itself is a private
-// implementation detail of Gatekeeper<T>, not reachable from a test for direct instrumentation. So this
-// is a structural/API-level regression test, not a reproduction of the originally-hypothesized deadlock.
-// What it DOES cover: heavy concurrent SetCurrentDB/ResetDB/ReleaseDbIfMarked churn on the "owning" thread
-// against concurrent foreign_db_view() reads from a second thread (a) completes within a bounded time
-// (no hang), and (b) never observes a torn/inconsistent {name, marked_for_deletion} pair -- which is what
-// a broken swap (e.g. destroying db_acc_ mid-read) would produce.
+// Structural regression test for the db_acc_mutex_ leaf-lock invariant (see CurrentDB::db_acc_mutex_ in
+// interpreter.hpp). Does NOT reproduce the originally-hypothesized cross-tenant stall: every long-hold
+// Gatekeeper API requires sole ownership (count_==1), which a live CurrentDB accessor rules out, and
+// GKInternals is private to Gatekeeper<T> -- not reachable for direct instrumentation from a test. What it
+// DOES assert: heavy SetCurrentDB/ResetDB/ReleaseDbIfMarked churn against concurrent foreign_db_view()
+// reads completes within bounded time and never observes a torn {name, marked_for_deletion} pair.
 TYPED_TEST(TransactionQueueSimpleTest, CurrentDBChurnVsForeignDbViewNoTornReads) {
   memgraph::query::CurrentDB current_db{std::move(this->db_gk.access().value())};
   auto const expected_name = this->db->name();
@@ -579,17 +566,14 @@ TYPED_TEST(TransactionQueueSimpleTest, CurrentDBChurnVsForeignDbViewNoTornReads)
   std::jthread reader_thread([&](std::stop_token st) {
     while (!st.stop_requested()) {
       auto view = current_db.foreign_db_view();
-      // Either no db is currently held (ResetDB() won the race for that instant) or it's exactly this
-      // fixture's db -- never a partial/garbage string, which is what a torn read across the swap would
-      // produce.
+      // No db held, or exactly this fixture's db -- never a partial/garbage name from a torn read.
       EXPECT_TRUE(view.name.empty() || view.name == expected_name) << "torn read: '" << view.name << "'";
       EXPECT_FALSE(view.marked_for_deletion);
       read_count.fetch_add(1, std::memory_order_relaxed);
     }
   });
 
-  // Bounded by construction: churn_thread runs a fixed kIters loop (no wait/backoff), so this join cannot
-  // hang unless the leaf-lock invariant is broken and something blocks db_acc_mutex_ indefinitely.
+  // churn_thread runs a fixed kIters loop with no wait/backoff, so this join is bounded by construction.
   churn_thread.join();
   reader_thread.request_stop();
   reader_thread.join();


### PR DESCRIPTION
On a multi-tenant instance, `SHOW TRANSACTIONS` and `SHOW ACTIVE USERS INFO` didn't report which tenant a session was on, and a stuck tenant teardown logged the wrong cause.

### Observability
- `SHOW TRANSACTIONS` gains a `database` column (including the background snapshot/GC rows).
- `SHOW ACTIVE USERS INFO` gains `database` and `database marked for deletion` columns.

### Concurrency fix (why this isn't a one-liner)
These reports run on a **foreign thread** and read another session's current database — which that session's own thread can swap under `USE DATABASE`. That is a torn read / use-after-free of the swapped-out `DatabaseAccess`. It already existed on the `MayTerminate` / `ShowTransactionsUsingDBName` (`DROP DATABASE ... FORCE`) paths and is widened by the new columns. Fixed by:

- A per-`CurrentDB` **leaf mutex** + `foreign_db_view()`: every foreign reader takes a race-free snapshot of the session's DB (name + marked-for-deletion); owning-thread reads stay lock-free (Bolt serializes a session's own queries).
- A per-interpreter **leaf mutex** guarding `session_info_` (uuid / user / login), snapshotted the same way for `SHOW ACTIVE USERS INFO` (previously an unsynchronized foreign read racing mid-session re-auth).

Both mutexes are leaves — no gatekeeper mutex and no `Accessor` destruction happen beneath them — so the lock graph stays acyclic.

### Diagnostics
`~Gatekeeper`'s stuck-teardown warning now names **which half** of its terminal-drain predicate is unsatisfied plus the tenant, distinguishes a benign `HOT` drain from a `COLD` lifetime violation (a live accessor after `value_` was destroyed — a UAF), and reports elapsed wait time.
