### PR TITLE
fix(utils): destroy the managed value after releasing the gatekeeper mtx

### DIFF
--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -129,9 +129,8 @@ struct GKInternals {
   template <typename... Args>
   explicit GKInternals(Args &&...args) : value_{std::make_unique<T>(std::forward<Args>(args)...)} {}
 
-  // COLD-shell construction: value_ stays null, state_ starts COLD. Non-template so it is preferred
-  // over the variadic ctor for an exact cold_shell_t argument (which would otherwise try
-  // make_unique<T>(cold_shell) and fail to compile for managed types with no such constructor).
+  // COLD-shell: value_ stays null, state_ starts COLD. Non-template so it wins over the variadic
+  // ctor for a cold_shell_t arg (otherwise make_unique<T>(cold_shell) fails for managed types).
   explicit GKInternals(cold_shell_t /*tag*/) : state_{GatekeeperState::COLD} {}
 
   std::unique_ptr<T> value_;
@@ -291,30 +290,21 @@ struct Gatekeeper {
     }
 
     // Completely invalidates the accessor if it returns true.
-    //
-    // ~T runs AFTER mutex_ is released (see the pointer move below), never under it: ~T (e.g.
-    // ~Database -> ~InMemoryStorage -> StopAllBackgroundTasks()) joins background threads (async
-    // indexer, TTL scheduler) that re-enter this gatekeeper through access() to mint their own
-    // Accessor. If the destroying thread still held mutex_ here, that mint would block on the very
-    // mutex the joiner is holding while it waits for the join -- an AB-BA deadlock reachable from a
-    // plain, non-FORCE DROP DATABASE. Do NOT move the destruction back under the lock.
+    // ~T runs AFTER mutex_ is released: ~Database->StopAllBackgroundTasks() joins threads that call
+    // access() — holding mutex_ here is an AB-BA deadlock. Do NOT move destruction back under lock.
     template <typename Func = decltype([](T &) { return true; })>
     [[nodiscard]] bool try_delete(std::chrono::milliseconds timeout = std::chrono::milliseconds(100),
                                   Func &&predicate = {}) {
       if (!owner_) return false;
-      std::unique_ptr<T> dying;  // destroyed at scope exit below, AFTER mutex_ is released
+      std::unique_ptr<T> dying;
       {
-        // Prevent new access
         auto guard = std::unique_lock{owner_->mutex_};
         if (!owner_->cv_.wait_for(guard, timeout, [this] { return owner_->count_ == 1; })) {
           return false;
         }
         // Already deleted
         if (!owner_->value_) return true;
-        // Delete value if ok
         if (!predicate(*owner_->value_)) return false;
-        // Pointer move: transfers ownership without running ~T or moving T under the lock. Every
-        // locked observer sees value_ == nullptr the instant this commits.
         dying = std::move(owner_->value_);
         owner_->cv_.notify_all();
       }  // <-- mutex_ released here
@@ -324,10 +314,8 @@ struct Gatekeeper {
       return true;
     }
 
-    // Unlocked, advisory only: reads owner_ and the atomic is_marked_for_deletion without mutex_, so
-    // it must NOT also read the non-atomic value_ (that would race try_delete()'s unlocked move-out).
-    // May report true while get()/operator->() return nullptr — callers that need the value must
-    // check the pointer, not rely on this alone.
+    // Unlocked, advisory: reads only the atomic is_marked_for_deletion (not value_, which would race
+    // try_delete()'s move-out). May report true while get()/operator->() return nullptr.
     explicit operator bool() const {
       return owner_ != nullptr                    // we have access
              && !owner_->is_marked_for_deletion;  // AND we are allowed to use it
@@ -387,9 +375,7 @@ struct Gatekeeper {
   // the managed value, then call finish_suspend().
   bool try_begin_suspend(std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
     auto guard = std::unique_lock{pimpl_->mutex_};
-    // value_ is refused too: try_delete() briefly holds count_ == 1 / state_ == HOT while ~T runs
-    // unlocked after moving value_ out, and a gatekeeper with nothing to suspend must not enter
-    // SUSPENDING.
+    // Also refuse null value_: try_delete()'s unlocked window holds count_==1/HOT with value_ moved out.
     if (!pimpl_->value_ || pimpl_->state_ != GatekeeperState::HOT) return false;
     if (!pimpl_->cv_.wait_for(guard, timeout, [this] { return pimpl_->count_ == 1; })) {
       return false;
@@ -422,24 +408,15 @@ struct Gatekeeper {
     {
       // Opt-in lifetime guard around object destruction (mirrors the dtor).
       [[maybe_unused]] typename GatekeeperGuardFor<T>::type arena_guard;
-      // INTENTIONAL: pimpl_->mutex_ is held across value_.reset() (Database destruction +
-      // WAL finalization).  This is the load-bearing suspend->resume directory handoff:
-      // begin_resume() (which transitions COLD->RESUMING) also runs under pimpl_->mutex_,
-      // so a concurrent Resume_ CANNOT start recovering from the on-disk directory until the
-      // old Database has finished finalizing its WAL and all its files are closed.
-      // Do NOT "optimize" this by releasing the mutex before destruction — doing so would
-      // open a window where a concurrent begin_resume() starts reading the directory while
-      // the old Database is still writing its final WAL segment.
+      // mutex_ held across value_.reset() intentionally — suspend->resume WAL handoff:
+      // begin_resume() also runs under mutex_, so a concurrent Resume_ cannot read the on-disk
+      // directory until the old Database finishes writing its final WAL. Do NOT release early.
       //
-      // INVARIANT (load-bearing, CALLER precondition): ~Database -> ~InMemoryStorage DOES reach a
-      // gatekeeper path -- StopAllBackgroundTasks() joins the TTL scheduler and async indexer, and
-      // those threads call make_database_protector() -> Handler::Get() -> Gatekeeper::access(),
-      // which needs pimpl_->mutex_. Destroying value_ under this non-recursive mutex is safe ONLY
-      // because the suspend caller (Suspend_) has already run StopAllBackgroundTasks() OUTSIDE this
-      // mutex, before finish_suspend(): those two threads are joined by now, so the in-destructor
-      // join is a no-op. (try_delete() destroys the same chain UNLOCKED precisely because it has no
-      // such pre-stop.) If you remove the caller's pre-stop, or add a destruction-time hook that
-      // calls access()/try_*(), this self-deadlocks.
+      // Destroying under the lock is safe ONLY because Suspend_ (dbms_handler.cpp) already ran
+      // StopAllBackgroundTasks() OUTSIDE this mutex before calling finish_suspend(): TTL/
+      // async-indexer threads that call access() (needing mutex_) are already joined — the
+      // in-destructor join is a no-op. try_delete() has no such pre-stop so it destroys UNLOCKED.
+      // Remove the caller's pre-stop and this deadlocks.
       DMG_ASSERT(pimpl_->count_ == 0, "finish_suspend() must not destroy value_ while accessors are live");
       pimpl_->value_.reset();
     }

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -127,14 +127,14 @@ inline constexpr cold_shell_t cold_shell{};
 template <typename T>
 struct GKInternals {
   template <typename... Args>
-  explicit GKInternals(Args &&...args) : value_{std::in_place, std::forward<Args>(args)...} {}
+  explicit GKInternals(Args &&...args) : value_{std::make_unique<T>(std::forward<Args>(args)...)} {}
 
-  // COLD-shell construction: value_ stays nullopt, state_ starts COLD. Non-template so it is preferred
-  // over the variadic ctor for an exact cold_shell_t argument (which would otherwise try value_{in_place,
-  // cold_shell} and fail to compile for managed types with no such constructor).
+  // COLD-shell construction: value_ stays null, state_ starts COLD. Non-template so it is preferred
+  // over the variadic ctor for an exact cold_shell_t argument (which would otherwise try
+  // make_unique<T>(cold_shell) and fail to compile for managed types with no such constructor).
   explicit GKInternals(cold_shell_t /*tag*/) : state_{GatekeeperState::COLD} {}
 
-  std::optional<T> value_;
+  std::unique_ptr<T> value_;
   uint64_t count_ = 0;
   std::atomic_bool is_marked_for_deletion = false;
   std::mutex mutex_;  // TODO change to something cheaper?
@@ -240,22 +240,22 @@ struct Gatekeeper {
 
     auto get() -> T * {
       if (owner_ == nullptr) return nullptr;
-      return std::addressof(*owner_->value_);
+      return owner_->value_.get();
     }
 
     auto get() const -> const T * {
       if (owner_ == nullptr) return nullptr;
-      return std::addressof(*owner_->value_);
+      return owner_->value_.get();
     }
 
     T *operator->() {
       if (owner_ == nullptr) return nullptr;
-      return std::addressof(*owner_->value_);
+      return owner_->value_.get();
     }
 
     const T *operator->() const {
       if (owner_ == nullptr) return nullptr;
-      return std::addressof(*owner_->value_);
+      return owner_->value_.get();
     }
 
     template <typename Func>
@@ -263,8 +263,9 @@ struct Gatekeeper {
       if (!owner_) return {not_run_t{}};
       // Prevent new access
       auto guard = std::unique_lock{owner_->mutex_};
-      // Only invoke if we have exclusive access
-      if (owner_->count_ != 1) {
+      // Only invoke if we have exclusive access and there is still a value (try_delete()'s unlocked
+      // destruction window briefly holds count_ == 1 with value_ == nullptr).
+      if (owner_->count_ != 1 || !owner_->value_) {
         return {not_run_t{}};
       }
       // Invoke and hold result in wrapper type
@@ -289,26 +290,44 @@ struct Gatekeeper {
       return {run_t{}, std::forward<Func>(func), *owner_->value_};
     }
 
-    // Completely invalidated the accessor if return true
+    // Completely invalidates the accessor if it returns true.
+    //
+    // ~T runs AFTER mutex_ is released (see the pointer move below), never under it: ~T (e.g.
+    // ~Database -> ~InMemoryStorage -> StopAllBackgroundTasks()) joins background threads (async
+    // indexer, TTL scheduler) that re-enter this gatekeeper through access() to mint their own
+    // Accessor. If the destroying thread still held mutex_ here, that mint would block on the very
+    // mutex the joiner is holding while it waits for the join -- an AB-BA deadlock reachable from a
+    // plain, non-FORCE DROP DATABASE. Do NOT move the destruction back under the lock.
     template <typename Func = decltype([](T &) { return true; })>
     [[nodiscard]] bool try_delete(std::chrono::milliseconds timeout = std::chrono::milliseconds(100),
                                   Func &&predicate = {}) {
       if (!owner_) return false;
-      // Prevent new access
-      auto guard = std::unique_lock{owner_->mutex_};
-      if (!owner_->cv_.wait_for(guard, timeout, [this] { return owner_->count_ == 1; })) {
-        return false;
-      }
-      // Already deleted
-      if (owner_->value_ == std::nullopt) return true;
-      // Delete value if ok
-      if (!predicate(*owner_->value_)) return false;
+      std::unique_ptr<T> dying;  // destroyed at scope exit below, AFTER mutex_ is released
+      {
+        // Prevent new access
+        auto guard = std::unique_lock{owner_->mutex_};
+        if (!owner_->cv_.wait_for(guard, timeout, [this] { return owner_->count_ == 1; })) {
+          return false;
+        }
+        // Already deleted
+        if (!owner_->value_) return true;
+        // Delete value if ok
+        if (!predicate(*owner_->value_)) return false;
+        // Pointer move: transfers ownership without running ~T or moving T under the lock. Every
+        // locked observer sees value_ == nullptr the instant this commits.
+        dying = std::move(owner_->value_);
+        owner_->cv_.notify_all();
+      }  // <-- mutex_ released here
       // Opt-in lifetime guard around object destruction.
       [[maybe_unused]] typename GatekeeperGuardFor<T>::type arena_guard;
-      owner_->value_ = std::nullopt;
+      dying.reset();  // ~T runs unlocked; its thread joins can now complete
       return true;
     }
 
+    // Unlocked, advisory only: reads owner_ and the atomic is_marked_for_deletion without mutex_, so
+    // it must NOT also read the non-atomic value_ (that would race try_delete()'s unlocked move-out).
+    // May report true while get()/operator->() return nullptr — callers that need the value must
+    // check the pointer, not rely on this alone.
     explicit operator bool() const {
       return owner_ != nullptr                    // we have access
              && !owner_->is_marked_for_deletion;  // AND we are allowed to use it
@@ -368,7 +387,10 @@ struct Gatekeeper {
   // the managed value, then call finish_suspend().
   bool try_begin_suspend(std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
     auto guard = std::unique_lock{pimpl_->mutex_};
-    if (pimpl_->state_ != GatekeeperState::HOT) return false;
+    // value_ is refused too: try_delete() briefly holds count_ == 1 / state_ == HOT while ~T runs
+    // unlocked after moving value_ out, and a gatekeeper with nothing to suspend must not enter
+    // SUSPENDING.
+    if (!pimpl_->value_ || pimpl_->state_ != GatekeeperState::HOT) return false;
     if (!pimpl_->cv_.wait_for(guard, timeout, [this] { return pimpl_->count_ == 1; })) {
       return false;
     }
@@ -415,7 +437,7 @@ struct Gatekeeper {
       // self-deadlock. Verified today: the ~Database/~InMemoryStorage chain takes no gatekeeper
       // path. Anyone adding a destruction-time DBMS callback must preserve this.
       DMG_ASSERT(pimpl_->count_ == 0, "finish_suspend() must not destroy value_ while accessors are live");
-      pimpl_->value_ = std::nullopt;
+      pimpl_->value_.reset();
     }
     pimpl_->state_ = GatekeeperState::COLD;
     pimpl_->cv_.notify_all();

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -431,11 +431,15 @@ struct Gatekeeper {
       // open a window where a concurrent begin_resume() starts reading the directory while
       // the old Database is still writing its final WAL segment.
       //
-      // INVARIANT (load-bearing): T's destructor (here ~Database -> ~InMemoryStorage) MUST NOT
-      // call any Gatekeeper method on the gatekeeper that owns it. pimpl_->mutex_ is non-recursive
-      // and held here, so re-entry (e.g. a pre-destruction hook calling access()/try_*()) would
-      // self-deadlock. Verified today: the ~Database/~InMemoryStorage chain takes no gatekeeper
-      // path. Anyone adding a destruction-time DBMS callback must preserve this.
+      // INVARIANT (load-bearing, CALLER precondition): ~Database -> ~InMemoryStorage DOES reach a
+      // gatekeeper path -- StopAllBackgroundTasks() joins the TTL scheduler and async indexer, and
+      // those threads call make_database_protector() -> Handler::Get() -> Gatekeeper::access(),
+      // which needs pimpl_->mutex_. Destroying value_ under this non-recursive mutex is safe ONLY
+      // because the suspend caller (Suspend_) has already run StopAllBackgroundTasks() OUTSIDE this
+      // mutex, before finish_suspend(): those two threads are joined by now, so the in-destructor
+      // join is a no-op. (try_delete() destroys the same chain UNLOCKED precisely because it has no
+      // such pre-stop.) If you remove the caller's pre-stop, or add a destruction-time hook that
+      // calls access()/try_*(), this self-deadlocks.
       DMG_ASSERT(pimpl_->count_ == 0, "finish_suspend() must not destroy value_ while accessors are live");
       pimpl_->value_.reset();
     }

--- a/tests/unit/hot_cold_gatekeeper.cpp
+++ b/tests/unit/hot_cold_gatekeeper.cpp
@@ -27,6 +27,23 @@ struct Widget {
 using GK = Gatekeeper<Widget>;
 using State = GatekeeperState;
 
+// Regression type for the try_delete() destroy-outside-the-lock invariant:
+// its destructor re-enters the owning gatekeeper via access(), mirroring
+// ~Database -> StopAllBackgroundTasks -> ... -> Gatekeeper::access().
+struct Reentrant {
+  Gatekeeper<Reentrant> *gk = nullptr;
+  bool *dtor_saw_nullopt = nullptr;
+
+  ~Reentrant() {
+    if (gk == nullptr) return;
+    // If ~Reentrant ran while try_delete() still held mutex_, this access()
+    // would self-deadlock on the non-recursive mutex. On the fixed code the
+    // lock is released, so access() returns nullopt (value_ already moved out).
+    auto acc = gk->access();
+    if (dtor_saw_nullopt != nullptr) *dtor_saw_nullopt = !acc.has_value();
+  }
+};
+
 // Helper: construct a HOT gatekeeper holding Widget{42}.
 static GK make_hot() { return GK{42}; }
 
@@ -328,4 +345,25 @@ TEST(HotColdGatekeeper, TryExclusivelyNonBlockingFailsFast) {
   auto result = primary->try_exclusively([](Widget &w) { return w.v; });
   EXPECT_TRUE(static_cast<bool>(result));
   EXPECT_EQ(result.value(), 42);
+}
+
+// ---------------------------------------------------------------------------
+// TryDeleteDestroysValueWithMutexReleased
+// ---------------------------------------------------------------------------
+// try_delete() must destroy ~T with mutex_ released; a ~T that re-enters via
+// access() proves it (self-deadlocks under the old destroy-under-lock code).
+TEST(HotColdGatekeeper, TryDeleteDestroysValueWithMutexReleased) {
+  bool dtor_saw_nullopt = false;
+  Gatekeeper<Reentrant> gk{};
+  {
+    auto acc = gk.access();
+    ASSERT_TRUE(acc.has_value());
+    (*acc)->gk = &gk;
+    (*acc)->dtor_saw_nullopt = &dtor_saw_nullopt;
+  }
+  auto acc = gk.access();
+  ASSERT_TRUE(acc.has_value());
+  EXPECT_TRUE(acc->try_delete());         // completes (no deadlock) on fixed code
+  EXPECT_TRUE(dtor_saw_nullopt);          // access() during ~Reentrant saw value_ gone
+  EXPECT_FALSE(gk.access().has_value());  // value destroyed
 }


### PR DESCRIPTION
Gatekeeper::try_delete() destroyed the value under GKInternals::mutex_, deadlocking against ~InMemoryStorage joining TTL/async-indexer threads that block on that same mutex. value_ becomes a unique_ptr<T> moved out under the mutex and destroyed after release — the deadlock repro goes from a hang to 0 ms.