### PR TITLE
feat(dbms): drain DROP DATABASE in three phases off the process-wide lock (DRAINING state)

### DIFF
--- a/src/dbms/database_handler.hpp
+++ b/src/dbms/database_handler.hpp
@@ -48,7 +48,14 @@ class DatabaseHandler : public Handler<Database> {
   ~DatabaseHandler() override {
     for (auto &db : *this) {
       try {
-        if (auto db_acc = db.second.access()) {
+        // utils::drain_bypass: at process shutdown a tenant can still be mid-drain (draining_ ==
+        // true, value_ still HOT, plain access() would refuse). It must not be skipped here --
+        // this loop's job is to proactively StopAllBackgroundTasks() on every live tenant before
+        // the map (and thus every Gatekeeper in it) is destroyed, and a draining tenant is no
+        // exception. Calling it on a tenant whose drop already stopped its tasks is a harmless
+        // no-op: Scheduler::Stop() / ThreadPool::ShutDown() / Streams::Shutdown() all guard on
+        // their own stop/empty state, so a second call is a no-op rather than a double-join.
+        if (auto db_acc = db.second.access(utils::drain_bypass)) {
           (*db_acc)->StopAllBackgroundTasks();
         }
       } catch (std::exception const &e) {
@@ -63,12 +70,26 @@ class DatabaseHandler : public Handler<Database> {
   /// Returns a factory callable that produces a DatabaseProtector for the database named
   /// @p db_name by looking it up in this handler at call time. Used by both New_() and
   /// BuildDetached() so the factory logic lives in exactly one place.
+  ///
+  /// DRAIN GUARANTEE: the only route this closure has to a tenant is `this->Get(db_name)` ->
+  /// `Handler<Database>::Get` -> `Gatekeeper::access()` (the plain, drain-gated overload, never
+  /// utils::drain_bypass). Once a tenant is draining, access() returns nullopt, Get() returns
+  /// nullopt, and this factory returns nullptr. Its two consumers -- storage::ttl::TTL
+  /// (src/storage/v2/ttl.cpp) and the async indexer (src/storage/v2/async_indexer.cpp), both via
+  /// Storage::make_database_protector() -- check the result for null and return/stop rather than
+  /// commit. So no new DatabaseProtector can be armed for a tenant being dropped: a re-armed one
+  /// would hold a live DatabaseAccess and keep the tenant's accessor count above zero indefinitely,
+  /// which would stop the drain from ever converging. This closure deliberately has no other route
+  /// to a tenant (no DbmsHandler pointer, no tenant registry) -- that structural absence is what
+  /// makes the guarantee hold by construction, not by caller discipline.
   auto MakeDatabaseProtectorFactory(std::string db_name) {
     return [this, db_name = std::move(db_name)]() -> storage::DatabaseProtectorPtr {
       if (auto db_gatekeeper_opt = this->Get(db_name)) {
         return std::make_unique<DatabaseProtector>(*db_gatekeeper_opt);
       }
-      // Fallback: return null if database not found (shouldn't happen in normal operation)
+      // A null return here is an expected, load-bearing outcome -- not an anomaly -- for a
+      // database that has been dropped or is currently draining (see the DRAIN GUARANTEE note
+      // above); it is exactly how ttl.cpp / async_indexer.cpp learn to stop re-arming work.
       return nullptr;
     };
   }
@@ -89,7 +110,12 @@ class DatabaseHandler : public Handler<Database> {
           // rebuilds via BuildDetached, never New()), so it cannot collide — skip it. MG_ASSERTing
           // has_value() here would abort whenever New() runs with any tenant suspended (e.g. the
           // replica reconcile materializing an absent COLD tenant, or a plain CREATE DATABASE).
-          auto db_acc = elem.second.access();
+          //
+          // utils::drain_bypass: a draining tenant has not been destroyed yet and still owns its
+          // storage directory, so it must stay visible to this collision check. Safe unlike a
+          // bypassed mint on a path that can win Accessor::try_delete() (see Handler<T>::TryDelete's
+          // comment) -- this scan only reads config(), it never destroys anything.
+          auto db_acc = elem.second.access(utils::drain_bypass);
           if (!db_acc) return false;
           return db_acc->get()->config().durability.storage_directory == config.durability.storage_directory;
         })) {
@@ -139,6 +165,14 @@ class DatabaseHandler : public Handler<Database> {
 
   /**
    * @brief Get the associated storage's configuration
+   *
+   * Deliberately stays gated on the plain, drain-gated Get() -- NOT utils::drain_bypass -- even
+   * though that looks like an omission next to New()'s collision scan above. A draining tenant's
+   * config being unreachable here is intentional and load-bearing: DbmsHandler::TryDelete
+   * (src/dbms/dbms_handler.cpp) uses this lookup as its early existence check for a tenant under
+   * drop, and DbmsHandler::Delete_ resolves the storage directory through it (via StorageDir_) as
+   * the very first thing it does, ahead of everything else it does to the tenant. Nothing
+   * legitimately needs a draining tenant's config afterwards.
    *
    * @param name
    * @return std::optional<storage::Config>

--- a/src/dbms/database_handler.hpp
+++ b/src/dbms/database_handler.hpp
@@ -168,11 +168,14 @@ class DatabaseHandler : public Handler<Database> {
    *
    * Deliberately stays gated on the plain, drain-gated Get() -- NOT utils::drain_bypass -- even
    * though that looks like an omission next to New()'s collision scan above. A draining tenant's
-   * config being unreachable here is intentional and load-bearing: DbmsHandler::TryDelete
-   * (src/dbms/dbms_handler.cpp) uses this lookup as its early existence check for a tenant under
-   * drop, and DbmsHandler::Delete_ resolves the storage directory through it (via StorageDir_) as
-   * the very first thing it does, ahead of everything else it does to the tenant. Nothing
-   * legitimately needs a draining tenant's config afterwards.
+   * config being unreachable by name here is intentional: every remaining caller either only cares
+   * about a HOT tenant (DbmsHandler::GetHotUuid, StorageDir_/SetupDefault_ on the always-HOT default
+   * db) or is a drop-family entry point for which "config not found" is meant to mean "give up on
+   * this name" -- DbmsHandler::TryDelete additionally special-cases an already-draining tenant with
+   * its own is_draining() check *before* reaching this lookup, so it reports the accurate USING
+   * rather than relying on (or being confused by) this refusal. DbmsHandler::Delete_, the drop path
+   * itself, never calls this at all: once it holds the tenant's drain_bypass accessor it reads the
+   * storage directory straight off `database->config()`, so this gate cannot block its own drop.
    *
    * @param name
    * @return std::optional<storage::Config>

--- a/src/dbms/database_handler.hpp
+++ b/src/dbms/database_handler.hpp
@@ -48,13 +48,8 @@ class DatabaseHandler : public Handler<Database> {
   ~DatabaseHandler() override {
     for (auto &db : *this) {
       try {
-        // utils::drain_bypass: at process shutdown a tenant can still be mid-drain (draining_ ==
-        // true, value_ still HOT, plain access() would refuse). It must not be skipped here --
-        // this loop's job is to proactively StopAllBackgroundTasks() on every live tenant before
-        // the map (and thus every Gatekeeper in it) is destroyed, and a draining tenant is no
-        // exception. Calling it on a tenant whose drop already stopped its tasks is a harmless
-        // no-op: Scheduler::Stop() / ThreadPool::ShutDown() / Streams::Shutdown() all guard on
-        // their own stop/empty state, so a second call is a no-op rather than a double-join.
+        // drain_bypass: plain access() refuses a mid-drain tenant; bypass so draining tenants
+        // are not skipped at shutdown (StopAllBackgroundTasks on an already-stopped tenant is a no-op).
         if (auto db_acc = db.second.access(utils::drain_bypass)) {
           (*db_acc)->StopAllBackgroundTasks();
         }
@@ -71,25 +66,14 @@ class DatabaseHandler : public Handler<Database> {
   /// @p db_name by looking it up in this handler at call time. Used by both New_() and
   /// BuildDetached() so the factory logic lives in exactly one place.
   ///
-  /// DRAIN GUARANTEE: the only route this closure has to a tenant is `this->Get(db_name)` ->
-  /// `Handler<Database>::Get` -> `Gatekeeper::access()` (the plain, drain-gated overload, never
-  /// utils::drain_bypass). Once a tenant is draining, access() returns nullopt, Get() returns
-  /// nullopt, and this factory returns nullptr. Its two consumers -- storage::ttl::TTL
-  /// (src/storage/v2/ttl.cpp) and the async indexer (src/storage/v2/async_indexer.cpp), both via
-  /// Storage::make_database_protector() -- check the result for null and return/stop rather than
-  /// commit. So no new DatabaseProtector can be armed for a tenant being dropped: a re-armed one
-  /// would hold a live DatabaseAccess and keep the tenant's accessor count above zero indefinitely,
-  /// which would stop the drain from ever converging. This closure deliberately has no other route
-  /// to a tenant (no DbmsHandler pointer, no tenant registry) -- that structural absence is what
-  /// makes the guarantee hold by construction, not by caller discipline.
+  /// Uses plain Get() (drain-gated) so a draining tenant cannot receive a new DatabaseProtector —
+  /// an armed protector keeps the accessor count > 0 and would prevent the drain from converging.
   auto MakeDatabaseProtectorFactory(std::string db_name) {
     return [this, db_name = std::move(db_name)]() -> storage::DatabaseProtectorPtr {
       if (auto db_gatekeeper_opt = this->Get(db_name)) {
         return std::make_unique<DatabaseProtector>(*db_gatekeeper_opt);
       }
-      // A null return here is an expected, load-bearing outcome -- not an anomaly -- for a
-      // database that has been dropped or is currently draining (see the DRAIN GUARANTEE note
-      // above); it is exactly how ttl.cpp / async_indexer.cpp learn to stop re-arming work.
+      // Expected return for a dropped or draining database — callers check and stop re-arming.
       return nullptr;
     };
   }
@@ -110,11 +94,8 @@ class DatabaseHandler : public Handler<Database> {
           // rebuilds via BuildDetached, never New()), so it cannot collide — skip it. MG_ASSERTing
           // has_value() here would abort whenever New() runs with any tenant suspended (e.g. the
           // replica reconcile materializing an absent COLD tenant, or a plain CREATE DATABASE).
-          //
-          // utils::drain_bypass: a draining tenant has not been destroyed yet and still owns its
-          // storage directory, so it must stay visible to this collision check. Safe unlike a
-          // bypassed mint on a path that can win Accessor::try_delete() (see Handler<T>::TryDelete's
-          // comment) -- this scan only reads config(), it never destroys anything.
+          // drain_bypass: draining tenant still owns its storage directory and must remain
+          // visible to this collision check; this scan only reads config(), never destroys.
           auto db_acc = elem.second.access(utils::drain_bypass);
           if (!db_acc) return false;
           return db_acc->get()->config().durability.storage_directory == config.durability.storage_directory;
@@ -166,16 +147,8 @@ class DatabaseHandler : public Handler<Database> {
   /**
    * @brief Get the associated storage's configuration
    *
-   * Deliberately stays gated on the plain, drain-gated Get() -- NOT utils::drain_bypass -- even
-   * though that looks like an omission next to New()'s collision scan above. A draining tenant's
-   * config being unreachable by name here is intentional: every remaining caller either only cares
-   * about a HOT tenant (DbmsHandler::GetHotUuid, StorageDir_/SetupDefault_ on the always-HOT default
-   * db) or is a drop-family entry point for which "config not found" is meant to mean "give up on
-   * this name" -- DbmsHandler::TryDelete additionally special-cases an already-draining tenant with
-   * its own is_draining() check *before* reaching this lookup, so it reports the accurate USING
-   * rather than relying on (or being confused by) this refusal. DbmsHandler::Delete_, the drop path
-   * itself, never calls this at all: once it holds the tenant's drain_bypass accessor it reads the
-   * storage directory straight off `database->config()`, so this gate cannot block its own drop.
+   * Intentionally drain-gated (no drain_bypass): a draining tenant's config should be unreachable
+   * by name; callers that need a draining tenant's data hold their own drain_bypass accessor.
    *
    * @param name
    * @return std::optional<storage::Config>

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -846,21 +846,22 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
     return std::unexpected{DeleteError::DEFAULT_DB};
   }
 
-  const auto storage_path = StorageDir_(db_name);
-  if (!storage_path) return std::unexpected{DeleteError::NON_EXISTENT};
-
-  // Own the name NOW. Delete(uuid) passes `it->first`, a view into a db_handler_ map key; once `lock`
-  // is released below for Phase 2, that view can dangle if another thread structurally mutates
-  // db_handler_ (heap-UAF). DeleteCold_ documents the identical hazard at cpp:777-779.
+  // Own the name NOW, ahead of every lookup below: Delete(uuid) passes `it->first`, a view into a
+  // db_handler_ map key; once `lock` is released below for Phase 2, that view can dangle if another
+  // thread structurally mutates db_handler_ (heap-UAF). DeleteCold_ documents the identical hazard
+  // at cpp:777-779.
   const std::string name{db_name};
 
   auto *gk = db_handler_.GetGatekeeper(name);
   if (!gk) return std::unexpected{DeleteError::NON_EXISTENT};
 
   // Non-HOT (mid-SUSPEND/RESUME) is retriable USING, never NON_EXISTENT — mirrors the Rename guard
-  // and DeleteCold_'s sibling COLD-only check. This is diagnostic only: begin_drain() below re-checks
-  // the identical HOT condition atomically with setting draining_, and on its own would collapse
-  // "not HOT" and "already draining" into the same bare `false`.
+  // and DeleteCold_'s sibling COLD-only check. Identity (GetGatekeeper) and state MUST be resolved
+  // before anything that depends on the tenant being mintable (StorageDir_/GetConfig, below, is
+  // drain-gated on the plain access() and would itself report NON_EXISTENT for a tenant that is only
+  // mid-SUSPEND, not gone — see Handler<T>::GetConfig's comment). This is diagnostic only:
+  // begin_drain() below re-checks the identical HOT condition atomically with setting draining_, and
+  // on its own would collapse "not HOT" and "already draining" into the same bare `false`.
   if (gk->state() != utils::GatekeeperState::HOT) return std::unexpected{DeleteError::USING};
 
   // Single-flight: false means a concurrent DROP already owns this drain (the state() check above
@@ -877,6 +878,11 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   acc->prepare_for_deletion();
 
   auto *database = acc->get();
+  // Read from the accessor we already hold, not through StorageDir_/GetConfig: those go through the
+  // drain-gated plain access() (Handler<T>::GetConfig), which begin_drain() just above made refuse on
+  // THIS gatekeeper too -- calling StorageDir_(name) here would itself now (mis)report NON_EXISTENT.
+  // `acc` is drain_bypass-minted and live, so this field read cannot race a concurrent teardown.
+  const auto storage_path = database->config().durability.storage_directory;
   const auto tenant_uuid = database->uuid();
   const auto memory_at_detach = database->DbMemoryUsage();
   // Excludes the drop's own drain_bypass accessor, which is live at this point (Phase 1 must hold it
@@ -945,7 +951,7 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   // comment), but the retryability half of that fix still matters. Phase 2's teardown
   // (StopAllBackgroundTasks/streams()->DropAll()) is NOT undone here, exactly as it wasn't before.
   try {
-    db_handler_.DeferDelete(name, [this, tenant_uuid, storage_path = *storage_path, name]() {
+    db_handler_.DeferDelete(name, [this, tenant_uuid, storage_path, name]() {
       ForgetDetached_(tenant_uuid);
       // Delete disk storage
       std::error_code ec;

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -458,6 +458,13 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
     return *cold_res;
   }
 
+  // A tenant already accepted by a concurrent drop is DRAINING: draining_ makes GetConfig's Get()
+  // refuse it, so the GetConfig check just below would otherwise misreport the far more confusing
+  // NON_EXISTENT for a tenant that in fact still exists. Surface the accurate, retriable USING.
+  if (auto *gk = db_handler_.GetGatekeeper(db_name); gk && gk->is_draining()) {
+    return std::unexpected{DeleteError::USING};
+  }
+
   // Get DB config for the UUID and disk clean up
   const auto conf = db_handler_.GetConfig(db_name);
   if (!conf) {
@@ -495,7 +502,7 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
 }
 
 DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name, system::Transaction *transaction) {
-  auto wr = std::lock_guard(lock_);
+  auto wr = std::unique_lock(lock_);
 
   // Cold-tenant fast path.
   if (auto cold_res = TryDeleteColdFastPath_(db_name, transaction)) {
@@ -508,8 +515,10 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name, system::
     return std::unexpected{DeleteError::NON_EXISTENT};
   }
 
-  // Force delete
-  const auto res = Delete_(db_name);
+  // Force delete. `conf` is a BY-VALUE copy (DatabaseHandler::GetConfig), so it stays valid across
+  // Delete_'s internal unlock/relock of `wr` -- unlike a raw pointer/reference into db_handler_, it
+  // cannot dangle even though the map itself may be mutated by another thread while `wr` is released.
+  const auto res = Delete_(db_name, wr);
   if (res) {
     // Success; save delta
     if (transaction) {
@@ -520,15 +529,15 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name, system::
 }
 
 DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name) {
-  auto wr = std::lock_guard(lock_);
+  auto wr = std::unique_lock(lock_);
   if (auto cold_res = TryDeleteColdFastPath_(db_name, /*transaction=*/nullptr)) {
     return *cold_res;
   }
-  return Delete_(db_name);
+  return Delete_(db_name, wr);
 }
 
 DbmsHandler::DeleteResult DbmsHandler::Delete(utils::UUID uuid) {
-  auto wr = std::lock_guard(lock_);
+  auto wr = std::unique_lock(lock_);
   // COLD first, matching the rest of the Delete/TryDelete family (a DROP treats a COLD tenant as an
   // equally valid target, unlike the Get_ read path which privileges HOT to surface a "RESUME it"
   // error). Ordering is correctness-neutral: under lock_ a tenant is HOT xor in suspended_, never both
@@ -541,7 +550,10 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(utils::UUID uuid) {
   }
   auto it = FindHotByUuid_(uuid);
   if (it == db_handler_.end()) return std::unexpected{DeleteError::NON_EXISTENT};
-  return Delete_(it->first);
+  // `it->first` is a view into a db_handler_ map key -- exactly why Delete_'s Phase 1 copies it into
+  // an owned std::string before releasing `wr` for Phase 2. Do not read `it` again after this call:
+  // once `wr` is released internally, a concurrent structural change to db_handler_ can invalidate it.
+  return Delete_(it->first, wr);
 }
 
 DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::string_view new_name,
@@ -571,7 +583,13 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
   // window. Mirrors the DROP sibling DeleteCold_, which likewise refuses a non-HOT gatekeeper under
   // this same exclusive lock_. Safety here is otherwise external (all DDL is serialized by the system
   // transaction) — this makes it local and robust to any future finer-grained DDL locking.
-  if (auto *gk = db_handler_.GetGatekeeper(old_name); gk && gk->state() != utils::GatekeeperState::HOT) {
+  //
+  // DRAINING needs its OWN check: it is HOT-exclusive by construction (begin_drain() requires HOT and
+  // never moves state_), so `state() != HOT` above cannot see it. Not a nicety — Delete_'s Phase 3
+  // resolves the tenant by NAME, and Handler<T>::Rename does items_.erase + items_.emplace, which
+  // invalidates the map node a rename-past-drain would otherwise let happen out from under it.
+  if (auto *gk = db_handler_.GetGatekeeper(old_name);
+      gk && (gk->state() != utils::GatekeeperState::HOT || gk->is_draining())) {
     return std::unexpected{RenameError::USING};
   }
 
@@ -818,7 +836,11 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
   return uuid;
 }
 
-DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
+DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::unique_lock<LockT> &lock) {
+  // ===============================================================================================
+  // PHASE 1 — under `lock`. Brief: in-memory bookkeeping only, no blocking call, no thread join, no
+  // disk I/O below this point until Phase 3.
+  // ===============================================================================================
   if (db_name == kDefaultDB) {
     // MSG cannot delete the default db
     return std::unexpected{DeleteError::DEFAULT_DB};
@@ -827,63 +849,113 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
   const auto storage_path = StorageDir_(db_name);
   if (!storage_path) return std::unexpected{DeleteError::NON_EXISTENT};
 
-  utils::UUID tenant_uuid;
-  int64_t memory_at_detach = 0;
-  {
-    auto db = db_handler_.Get(db_name);
-    if (!db) {
-      // Get() is HOT-gated, so a tenant caught mid-SUSPEND (state SUSPENDING, not yet in `suspended_`)
-      // lands here too. Mirrors the Rename guard: report USING for any non-HOT gatekeeper instead of
-      // misreporting NON_EXISTENT for a tenant that in fact exists.
-      auto *gk = db_handler_.GetGatekeeper(db_name);
-      if (gk && gk->state() != utils::GatekeeperState::HOT) return std::unexpected{DeleteError::USING};
-      return std::unexpected{DeleteError::NON_EXISTENT};
-    }
-    // TODO: ATM we assume REPLICA won't have streams,
-    //       this is a best effort approach just in case they do
-    //       there is still subtle data race we stream manipulation
-    //       can occur while we are dropping the database
-    db->prepare_for_deletion();
-    auto &database = *db->get();
-    database.StopAllBackgroundTasks();
-    database.streams()->DropAll();
-    // Last point this Database is reachable from Delete_: the accessor above is the only thing
-    // keeping it alive, and it goes out of scope at the end of this block.
-    tenant_uuid = database.uuid();
-    memory_at_detach = database.DbMemoryUsage();
-  }
+  // Own the name NOW. Delete(uuid) passes `it->first`, a view into a db_handler_ map key; once `lock`
+  // is released below for Phase 2, that view can dangle if another thread structurally mutates
+  // db_handler_ (heap-UAF). DeleteCold_ documents the identical hazard at cpp:777-779.
+  const std::string name{db_name};
 
-  DetachProfileAndRetireDurabilityKey_(db_name);
+  auto *gk = db_handler_.GetGatekeeper(name);
+  if (!gk) return std::unexpected{DeleteError::NON_EXISTENT};
 
-  // The accessor above is gone, so this read no longer counts it; nullptr is defensive only (we hold
-  // lock_ exclusive and the !db branch above already returned, so the entry is guaranteed present).
-  uint64_t holders = 0;
-  if (auto *gk = db_handler_.GetGatekeeper(db_name)) holders = gk->holder_count();
+  // Non-HOT (mid-SUSPEND/RESUME) is retriable USING, never NON_EXISTENT — mirrors the Rename guard
+  // and DeleteCold_'s sibling COLD-only check. This is diagnostic only: begin_drain() below re-checks
+  // the identical HOT condition atomically with setting draining_, and on its own would collapse
+  // "not HOT" and "already draining" into the same bare `false`.
+  if (gk->state() != utils::GatekeeperState::HOT) return std::unexpected{DeleteError::USING};
 
-  // Publish before DeferDelete: the inline path calls ForgetDetached_ synchronously inside DeferDelete, so publishing
-  // after would orphan the row permanently.
-  RecordDetached_(DetachedTenant{.name = std::string{db_name},
+  // Single-flight: false means a concurrent DROP already owns this drain (the state() check above
+  // cannot see draining_, so this is the only place that particular race is caught).
+  if (!gk->begin_drain()) return std::unexpected{DeleteError::USING};
+
+  // drain_bypass is required, not a convenience: begin_drain() just flipped draining_ true one line
+  // above, so the plain (non-bypass) access() would now refuse on THIS gatekeeper too. begin_drain()
+  // proved HOT, and `lock` is held exclusive so no concurrent Suspend_/Resume_/second-drop can have
+  // moved state_ since (try_begin_suspend() itself refuses once draining_ is set) — access() cannot
+  // legitimately fail here.
+  auto acc = gk->access(utils::drain_bypass);
+  MG_ASSERT(acc, "begin_drain() just confirmed HOT under lock_ held exclusive; access(drain_bypass) cannot fail");
+  acc->prepare_for_deletion();
+
+  auto *database = acc->get();
+  const auto tenant_uuid = database->uuid();
+  const auto memory_at_detach = database->DbMemoryUsage();
+  // Excludes the drop's own drain_bypass accessor, which is live at this point (Phase 1 must hold it
+  // across the off-lock teardown). count_ >= 1 here for that reason, so the subtraction cannot wrap.
+  // Keeps parity with the pre-B4a reading, which happened after the accessor's scope closed, and keeps
+  // the field meaning what DetachedTenant documents: holders OTHER than the dropper.
+  //
+  // Clamped, not just subtracted: holder_count() is its own doc's "INHERENTLY RACY ... Diagnostics
+  // only" -- our confidence that count_ >= 1 rests on `acc` being live, not on the read itself being
+  // stable. This clamp defends a user-visible diagnostic (DETACHED registry / SHOW output) against a
+  // FUTURE edit silently breaking that invariant (e.g. moving this read below acc.reset()) wrapping to
+  // UINT64_MAX instead of reporting a wrong-but-plausible number. It is not evidence the count can
+  // legitimately be zero today -- it always is >= 1 here, by the reasoning above.
+  const auto holders = std::max<uint64_t>(gk->holder_count(), 1) - 1;
+
+  // Publish BEFORE releasing `lock`: visibility must not blink. A reader arriving between
+  // begin_drain() and this line would otherwise see neither a HOT/DRAINING status nor a DETACHED row
+  // for a tenant that has, in fact, already been accepted for deletion.
+  RecordDetached_(DetachedTenant{.name = name,
                                  .uuid = tenant_uuid,
                                  .detached_at = std::chrono::system_clock::now(),
                                  .reason = DetachReason::DROP,
+                                 .phase = TenantPhase::DRAINING,
                                  .holders_at_detach = holders,
                                  .memory_at_detach = memory_at_detach});
 
-  // Check if db exists
-  // Low level handlers
-  // Row is published above; if DeferDelete throws before ForgetDetached_ runs, undo or the row outlives the tenant
-  // forever.
+  // ===============================================================================================
+  // PHASE 2 — `lock` released. The unbounded part: two thread joins that used to run under lock_.
+  // Nothing reachable from here may take `lock` (a non-recursive pthread rwlock) — StopAllBackgroundTasks
+  // and streams()->DropAll() provably don't: they ran under lock_ HELD EXCLUSIVE a moment ago (the code
+  // this replaces), so a self-deadlock there would have already been a live bug, not a latent one.
+  // `gk`/`acc` are the only handles we still trust past this point; `name`/`storage_path` are owned copies.
+  // ===============================================================================================
+  lock.unlock();
+  database->StopAllBackgroundTasks();
+  database->streams()->DropAll();
+  acc.reset();  // release the drop's own accessor so Phase 3's DeferDelete -> try_delete() can win
+  lock.lock();
+
+  // ===============================================================================================
+  // PHASE 3 — under `lock` again.
+  // ===============================================================================================
+  // Re-validate; do not trust the Phase 1 pointer or guards. DeferDelete is void and silently no-ops
+  // on a name miss, so a lost/renamed node here would otherwise let us promote the registry row (and
+  // return success) for a tenant that Phase 2's off-lock window let something else destroy or rename
+  // out from under us.
+  auto *gk3 = db_handler_.GetGatekeeper(name);
+  if (!gk3 || !gk3->is_draining()) {
+    spdlog::error(R"(Lost the drain marker for database "{}" while its teardown ran off-lock; aborting the drop.)",
+                  name);
+    ForgetDetached_(tenant_uuid);
+    return std::unexpected{DeleteError::FAIL};
+  }
+
+  DetachProfileAndRetireDurabilityKey_(name);
+
+  PromoteDetachedPhase_(tenant_uuid);  // DRAINING -> DETACHED
+
+  // The row is already DETACHED; if constructing the deferred closure or DeferDelete itself throws
+  // before the Gatekeeper is actually handed off, undo BOTH the promotion and the drain, or the
+  // tenant's *name* is wedged forever: a fresh CREATE would see EXISTS (still in db_handler_) and a
+  // retried DROP would see USING (begin_drain()'s own draining_ check) — even though DeferDelete never
+  // actually ran. This is the same undo commit 62e2c9711 added, now widened for a second failure mode:
+  // the double-count it was originally guarding against no longer exists (a draining tenant's plain
+  // access() is refused, so TenantMemorySum's HOT half already excludes it — see TenantMemorySum's
+  // comment), but the retryability half of that fix still matters. Phase 2's teardown
+  // (StopAllBackgroundTasks/streams()->DropAll()) is NOT undone here, exactly as it wasn't before.
   try {
-    db_handler_.DeferDelete(
-        db_name, [this, tenant_uuid, storage_path = *storage_path, db_name = std::string{db_name}]() {
-          ForgetDetached_(tenant_uuid);
-          std::error_code ec;
-          (void)std::filesystem::remove_all(storage_path, ec);
-          if (ec) {
-            spdlog::error(R"(Failed to clean disk while deleting database "{}" stored in {})", db_name, storage_path);
-          }
-        });
+    db_handler_.DeferDelete(name, [this, tenant_uuid, storage_path = *storage_path, name]() {
+      ForgetDetached_(tenant_uuid);
+      // Delete disk storage
+      std::error_code ec;
+      (void)std::filesystem::remove_all(storage_path, ec);
+      if (ec) {
+        spdlog::error(R"(Failed to clean disk while deleting database "{}" stored in {})", name, storage_path);
+      }
+    });
   } catch (...) {
+    if (auto *g = db_handler_.GetGatekeeper(name)) g->abort_drain();
     ForgetDetached_(tenant_uuid);
     throw;
   }

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -876,6 +876,40 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   // cannot see draining_, so this is the only place that particular race is caught).
   if (!gk->begin_drain()) return std::unexpected{DeleteError::USING};
 
+  // RAII rollback guard, armed the instant begin_drain() succeeds. Undoes exactly what begin_drain()
+  // did (plus retiring a published DETACHED-registry row) on EVERY exit between here and the single
+  // Disable() at the end of Phase 3 -- an early `return`, or a throw from Phase 2's off-lock teardown
+  // or Phase 3's DetachFromDatabase/DeferDelete. Without it, any of those left draining_ stuck true:
+  // the tenant's *name* wedges forever (fresh CREATE sees EXISTS, retried DROP sees begin_drain()'s
+  // own USING) even though nothing was actually deleted, and -- once RecordDetached_ below has
+  // published a row -- the registry entry is stuck at DRAINING with nothing left to point at a
+  // possibly-already-unlinked-from-durability, possibly-already-teardown on-disk directory.
+  //
+  // `detached_row_uuid` (not `tenant_uuid` directly) because the guard can fire before tenant_uuid is
+  // even read (nothing between here and RecordDetached_ below throws today, but the guard's job is to
+  // hold even if that changes) and before any row has been published. Empty means "nothing to
+  // retire yet" -- ForgetDetached_ on a row that was never recorded would be a harmless no-op erase_if
+  // anyway, but this avoids depending on that and avoids needing a placeholder UUID (utils::UUID's
+  // default constructor calls uuid_generate(), not a cheap sentinel).
+  std::optional<utils::UUID> detached_row_uuid;
+  auto rollback_drain = utils::OnScopeExit{[&] {
+    // Phase 2 below runs with `lock` unlocked. If the throw came from there, `lock` is not held here,
+    // yet db_handler_ (GetGatekeeper) has no internal synchronization of its own -- every access relies
+    // on the caller already holding `lock` (see DatabaseHandler::GetGatekeeper's doc). Re-locking during
+    // unwind is a blocking call on `lock` (a reader-preferring pthread rwlock), same cost any other
+    // writer pays to get in; touching db_handler_ without it would be a data race instead, which is
+    // strictly worse on an already-exceptional path.
+    if (!lock.owns_lock()) lock.lock();
+    // Fresh by-name lookup, never the Phase 1 `gk` pointer above: the off-lock Phase 2 window could
+    // have let a concurrent structural change invalidate it. is_draining() guards abort_drain()'s own
+    // DMG_ASSERT -- load-bearing, not defensive fluff: the Phase 3 re-validation failure path below
+    // (gk3 gone, or found but no longer draining) intentionally does NOT call abort_drain() there
+    // (nothing to abort), and this guard still fires on that path's `return` to retire the registry
+    // row, so it must not blindly re-call abort_drain() into that same non-draining state.
+    if (auto *g = db_handler_.GetGatekeeper(name); g && g->is_draining()) g->abort_drain();
+    if (detached_row_uuid) ForgetDetached_(*detached_row_uuid);
+  }};
+
   // drain_bypass is required, not a convenience: begin_drain() just flipped draining_ true one line
   // above, so the plain (non-bypass) access() would now refuse on THIS gatekeeper too. begin_drain()
   // proved HOT, and `lock` is held exclusive so no concurrent Suspend_/Resume_/second-drop can have
@@ -916,6 +950,11 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
                                  .phase = TenantPhase::DRAINING,
                                  .holders_at_detach = holders,
                                  .memory_at_detach = memory_at_detach});
+  // A row now exists to retire -- arm `rollback_drain`'s ForgetDetached_ half. Placed only after
+  // RecordDetached_ returns (not alongside it): if RecordDetached_ itself throws (push_back growing
+  // detached_'s backing storage is the only fallible step, and even that keeps the vector unchanged
+  // on failure), no row was actually published, so there is nothing for the guard to retire.
+  detached_row_uuid = tenant_uuid;
 
   // ===============================================================================================
   // PHASE 2 — `lock` released. The unbounded part: two thread joins that used to run under lock_.
@@ -941,7 +980,11 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   if (!gk3 || !gk3->is_draining()) {
     spdlog::error(R"(Lost the drain marker for database "{}" while its teardown ran off-lock; aborting the drop.)",
                   name);
-    ForgetDetached_(tenant_uuid);
+    // No explicit ForgetDetached_ here: this `return` runs `rollback_drain`'s destructor, which
+    // retires the row via `detached_row_uuid` on its own. It correctly skips abort_drain() too --
+    // gk3 is already gone or already not draining, and the guard's fresh lookup sees the same
+    // state, so its is_draining() check leaves abort_drain() uncalled here exactly as this comment
+    // requires: there is nothing left to abort.
     return std::unexpected{DeleteError::FAIL};
   }
 
@@ -958,22 +1001,26 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   // access() is refused, so TenantMemorySum's HOT half already excludes it — see TenantMemorySum's
   // comment), but the retryability half of that fix still matters. Phase 2's teardown
   // (StopAllBackgroundTasks/streams()->DropAll()) is NOT undone here, exactly as it wasn't before.
-  try {
-    db_handler_.DeferDelete(name, [this, tenant_uuid, storage_path, name]() {
-      ForgetDetached_(tenant_uuid);
-      // Delete disk storage
-      std::error_code ec;
-      (void)std::filesystem::remove_all(storage_path, ec);
-      if (ec) {
-        spdlog::error(R"(Failed to clean disk while deleting database "{}" stored in {})", name, storage_path);
-      }
-    });
-  } catch (...) {
-    if (auto *g = db_handler_.GetGatekeeper(name)) g->abort_drain();
+  // No local try/catch: `rollback_drain` already does exactly this (fresh-lookup abort_drain guarded
+  // by is_draining(), then ForgetDetached_) on unwind, so a second copy here would just be a duplicate
+  // that runs after it, wastefully, on every throwing path -- not incorrect (both halves are
+  // idempotent/self-guarding), but redundant code with no behavior of its own to justify existing.
+  db_handler_.DeferDelete(name, [this, tenant_uuid, storage_path, name]() {
     ForgetDetached_(tenant_uuid);
-    throw;
-  }
+    // Delete disk storage
+    std::error_code ec;
+    (void)std::filesystem::remove_all(storage_path, ec);
+    if (ec) {
+      spdlog::error(R"(Failed to clean disk while deleting database "{}" stored in {})", name, storage_path);
+    }
+  });
 
+  // Point of no return: DeferDelete has taken ownership of the eventual teardown/ForgetDetached_/
+  // remove_all. Disarm BEFORE returning success -- nothing below can throw, but if it ever did,
+  // rollback_drain firing on a tenant DeferDelete already owns would abort_drain() out from under a
+  // handoff that has already happened, and (once the drain thread's ForgetDetached_ races this one)
+  // double-retire a row whose uuid slot could theoretically already have been reused.
+  rollback_drain.Disable();
   return {};  // Success
 }
 

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -508,8 +508,7 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name, system::
     return *cold_res;
   }
 
-  // Same DRAINING race TryDelete guards above (see its comment) -- just as reachable here on the
-  // FORCE path (DROP DATABASE ... FORCE).
+  // DRAINING before GetConfig: drain-gated GetConfig returns nullopt for a draining tenant — return retriable USING.
   if (auto *gk = db_handler_.GetGatekeeper(db_name); gk && gk->is_draining()) {
     return std::unexpected{DeleteError::USING};
   }
@@ -554,8 +553,8 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(utils::UUID uuid) {
   }
   auto it = FindHotByUuid_(uuid);
   if (it == db_handler_.end()) return std::unexpected{DeleteError::NON_EXISTENT};
-  // `it->first` is a view into a db_handler_ map key (Delete_'s Phase 1 copies it before releasing
-  // `wr` -- see its comment). Do not read `it` again after this call.
+  // `it->first` is a view into a db_handler_ map key copied by Delete_ before releasing `wr`.
+  // Do not use `it` after this call — map nodes may have shifted.
   return Delete_(it->first, wr);
 }
 
@@ -587,10 +586,8 @@ DbmsHandler::RenameResult DbmsHandler::Rename(std::string_view old_name, std::st
   // this same exclusive lock_. Safety here is otherwise external (all DDL is serialized by the system
   // transaction) — this makes it local and robust to any future finer-grained DDL locking.
   //
-  // DRAINING needs its OWN check: it is HOT-exclusive by construction (begin_drain() requires HOT and
-  // never moves state_), so `state() != HOT` above cannot see it. Not a nicety — Delete_'s Phase 3
-  // resolves the tenant by NAME, and Handler<T>::Rename does items_.erase + items_.emplace, which
-  // invalidates the map node a rename-past-drain would otherwise let happen out from under it.
+  // DRAINING also: begin_drain() keeps state_ HOT so `state() != HOT` above misses it — but Rename's
+  // erase+emplace would invalidate the map node a concurrent Delete_ Phase 3 still holds by name.
   if (auto *gk = db_handler_.GetGatekeeper(old_name);
       gk && (gk->state() != utils::GatekeeperState::HOT || gk->is_draining())) {
     return std::unexpected{RenameError::USING};
@@ -840,124 +837,76 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
 }
 
 DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::unique_lock<LockT> &lock) {
-  // PHASE 1 — under `lock`: in-memory bookkeeping only, no blocking call, no thread join, no disk
-  // I/O below this point until Phase 3.
+  // Phase 1 (under lock): in-memory bookkeeping only — no blocking calls, thread joins, or disk I/O until Phase 2.
   if (db_name == kDefaultDB) {
     // MSG cannot delete the default db
     return std::unexpected{DeleteError::DEFAULT_DB};
   }
 
-  // Own the name NOW, ahead of every lookup below: Delete(uuid) passes `it->first`, a view into a
-  // db_handler_ map key; once `lock` is released below for Phase 2, that view can dangle if another
-  // thread structurally mutates db_handler_ (heap-UAF). DeleteCold_ documents the identical hazard
-  // right before its own erase().
+  // Own the name before Phase 2's lock_.unlock(): Delete(uuid) passes `it->first`, a string_view into a
+  // db_handler_ map key; releasing the lock lets another thread mutate the map (heap-UAF).
   const std::string name{db_name};
 
   auto *gk = db_handler_.GetGatekeeper(name);
   if (!gk) return std::unexpected{DeleteError::NON_EXISTENT};
 
-  // Non-HOT (mid-SUSPEND/RESUME) is retriable USING, never NON_EXISTENT — mirrors the Rename guard
-  // and DeleteCold_'s COLD-only check; identity/state must be resolved before anything drain-gated
-  // (see the accessor-read comment below). Diagnostic only: begin_drain() below re-checks the same
-  // HOT condition atomically with draining_, collapsing "not HOT" and "already draining" into one
-  // bare `false`.
+  // Non-HOT (mid-SUSPEND/RESUME) → retriable USING, not NON_EXISTENT: identity/state must be confirmed
+  // before entering the drain sequence (begin_drain() re-checks HOT atomically with draining_).
   if (gk->state() != utils::GatekeeperState::HOT) return std::unexpected{DeleteError::USING};
 
   // Single-flight: false means a concurrent DROP already owns this drain (the state() check above
   // cannot see draining_, so this is the only place that particular race is caught).
   if (!gk->begin_drain()) return std::unexpected{DeleteError::USING};
 
-  // RAII rollback guard, armed the instant begin_drain() succeeds. Undoes exactly what begin_drain()
-  // did (plus retiring a published DETACHED-registry row) on EVERY exit between here and the single
-  // Disable() at the end of Phase 3 -- an early `return`, or a throw from Phase 2's off-lock teardown
-  // or Phase 3's DetachFromDatabase/DeferDelete. Without it, any of those left draining_ stuck true:
-  // the tenant's *name* wedges forever (fresh CREATE sees EXISTS, retried DROP sees begin_drain()'s
-  // own USING) even though nothing was actually deleted, and -- once RecordDetached_ below has
-  // published a row -- the registry entry is stuck at DRAINING with nothing left to point at a
-  // possibly-already-unlinked-from-durability, possibly-already-teardown on-disk directory.
-  //
-  // `detached_row_uuid` (not `tenant_uuid` directly) because the guard can fire before tenant_uuid is
-  // even read (nothing between here and RecordDetached_ below throws today, but the guard's job is to
-  // hold even if that changes) and before any row has been published. Empty means "nothing to
-  // retire yet" -- ForgetDetached_ on a row that was never recorded would be a harmless no-op erase_if
-  // anyway, but this avoids depending on that and avoids needing a placeholder UUID (utils::UUID's
-  // default constructor calls uuid_generate(), not a cheap sentinel).
+  // Rollback guard: undoes begin_drain() + ForgetDetached_ on any early exit (throw or return before
+  // Disable()). Without it, draining_ stays set: the name is wedged and the DETACHED row is orphaned.
   std::optional<utils::UUID> detached_row_uuid;
   auto rollback_drain = utils::OnScopeExit{[&] {
-    // Phase 2 below runs with `lock` unlocked. If the throw came from there, `lock` is not held here,
-    // yet db_handler_'s items_ carries no mutex of its own (unlike defer_lock_ for deferred_) -- every
-    // access relies on the caller already holding `lock`. Re-locking during unwind is a blocking call
-    // on `lock` (a reader-preferring pthread rwlock), same cost any other writer pays to get in;
-    // touching db_handler_ without it would be a data race instead, which is strictly worse on an
-    // already-exceptional path.
+    // lock_ may be unlocked here (Phase 2 threw); db_handler_ has no internal mutex — re-acquire before
+    // touching it. Blocking is acceptable; a data race is not.
     if (!lock.owns_lock()) lock.lock();
-    // Fresh by-name lookup, never the Phase 1 `gk` pointer above: the off-lock Phase 2 window could
-    // have let a concurrent structural change invalidate it. is_draining() guards abort_drain()'s own
-    // DMG_ASSERT -- load-bearing, not defensive fluff: on a throwing unwind the gatekeeper may already
-    // be gone or no longer draining, so this guard must not blindly re-call abort_drain() into a
-    // non-draining state while it retires the registry row.
+    // Fresh lookup — Phase 1's gk may be stale after the off-lock window. is_draining() guards
+    // abort_drain()'s DMG_ASSERT: the gatekeeper may be gone or no longer draining on unwind.
     if (auto *g = db_handler_.GetGatekeeper(name); g && g->is_draining()) g->abort_drain();
     if (detached_row_uuid) ForgetDetached_(*detached_row_uuid);
   }};
 
-  // drain_bypass is required, not a convenience: begin_drain() just flipped draining_ true one line
-  // above, so the plain (non-bypass) access() would now refuse on THIS gatekeeper too. begin_drain()
-  // proved HOT, and `lock` is held exclusive so no concurrent Suspend_/Resume_/second-drop can have
-  // moved state_ since (try_begin_suspend() itself refuses once draining_ is set) — access() cannot
-  // legitimately fail here.
+  // drain_bypass is required: begin_drain() just set draining_, so plain access() now refuses this
+  // gatekeeper too. lock_ is held exclusive, so HOT state is stable; the assert below covers failure.
   auto acc = gk->access(utils::drain_bypass);
   MG_ASSERT(acc, "begin_drain() just confirmed HOT under lock_ held exclusive; access(drain_bypass) cannot fail");
   acc->prepare_for_deletion();
 
   auto *database = acc->get();
-  // Read from the accessor we already hold, not through StorageDir_/GetConfig: those go through the
-  // drain-gated plain access() (DatabaseHandler::GetConfig), which begin_drain() just above made
-  // refuse on THIS gatekeeper too -- calling StorageDir_(name) here would itself now (mis)report
-  // NON_EXISTENT. `acc` is drain_bypass-minted and live, so this field read cannot race a concurrent
-  // teardown.
+  // Read via acc, not StorageDir_/GetConfig: begin_drain() made drain-gated access() refuse this
+  // gatekeeper too — GetConfig would return nullopt here. acc is drain_bypass-minted and live.
   const auto storage_path = database->config().durability.storage_directory;
   const auto tenant_uuid = database->uuid();
   const auto memory_at_detach = database->DbMemoryUsage();
-  // Excludes the drop's own drain_bypass accessor, which is live at this point (Phase 1 must hold it
-  // across the off-lock teardown). count_ >= 1 here for that reason, so the subtraction cannot wrap.
-  // Keeps parity with the pre-B4a reading, which happened after the accessor's scope closed, and keeps
-  // the field meaning what DetachedTenant documents: holders OTHER than the dropper.
-  //
-  // Clamped, not just subtracted: holder_count() is its own doc's "INHERENTLY RACY ... Diagnostics
-  // only" -- our confidence that count_ >= 1 rests on `acc` being live, not on the read itself being
-  // stable. This clamp defends a user-visible diagnostic (DETACHED registry / SHOW output) against a
-  // FUTURE edit silently breaking that invariant (e.g. moving this read below acc.reset()) wrapping to
-  // UINT64_MAX instead of reporting a wrong-but-plausible number. It is not evidence the count can
-  // legitimately be zero today -- it always is >= 1 here, by the reasoning above.
+  // -1 to exclude the dropper's own acc (live here, so count_ >= 1). Clamped: holder_count() is
+  // inherently racy/diagnostic — clamp prevents UINT64_MAX if a future edit moves this below acc.reset().
   const auto holders = std::max<uint64_t>(gk->holder_count(), 1) - 1;
 
-  // Publish BEFORE releasing `lock`: visibility must not blink. A reader arriving between
-  // begin_drain() and this line would otherwise see neither a HOT status nor a DETACHED row
-  // for a tenant that has, in fact, already been accepted for deletion.
+  // Publish before lock_.unlock(): a reader between begin_drain() and here would see neither HOT nor a
+  // DETACHED row for a tenant already accepted for deletion.
   RecordDetached_(DetachedTenant{.name = name,
                                  .uuid = tenant_uuid,
                                  .detached_at = std::chrono::system_clock::now(),
                                  .reason = DetachReason::DROP,
                                  .holders_at_detach = holders,
                                  .memory_at_detach = memory_at_detach});
-  // A row now exists to retire -- arm `rollback_drain`'s ForgetDetached_ half. Placed only after
-  // RecordDetached_ returns (not alongside it): if RecordDetached_ itself throws (push_back growing
-  // detached_'s backing storage is the only fallible step, and even that keeps the vector unchanged
-  // on failure), no row was actually published, so there is nothing for the guard to retire.
+  // Set after RecordDetached_ returns: if RecordDetached_ throws, no row was published and the
+  // guard must not retire a non-existent row.
   detached_row_uuid = tenant_uuid;
 
-  // PHASE 2 — `lock` released. The unbounded part: two thread joins that used to run under lock_.
-  // Nothing reachable from here may take `lock` (a non-recursive pthread rwlock) — StopAllBackgroundTasks
-  // and streams()->DropAll() provably don't: they ran under lock_ HELD EXCLUSIVE a moment ago (the code
-  // this replaces), so a self-deadlock there would have already been a live bug, not a latent one.
-  // `gk`/`acc` are the only handles we still trust past this point; `name`/`storage_path` are owned copies.
+  // Phase 2 (lock_ released): StopAllBackgroundTasks and DropAll use their own internal locks, not lock_.
+  // `gk`/`acc` are the only trusted handles past this point; `name`/`storage_path` are owned copies.
   lock.unlock();
   database->StopAllBackgroundTasks();
   database->streams()->DropAll();
   acc.reset();  // release the drop's own accessor so Phase 3's DeferDelete -> try_delete() can win
   lock.lock();
 
-  // Re-validate the drain marker survived the off-lock window before proceeding.
   auto *gk3 = db_handler_.GetGatekeeper(name);
   MG_ASSERT(gk3 && gk3->is_draining(),
             "drain marker must survive the off-lock window: draining_ has a single clearer (this "
@@ -965,18 +914,9 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
 
   DetachProfileAndRetireDurabilityKey_(name);
 
-  // If constructing the deferred closure or DeferDelete itself throws before the Gatekeeper is
-  // actually handed off, undo the drain, or the tenant's *name* is wedged forever: a fresh CREATE
-  // would see EXISTS (still in db_handler_) and a retried DROP would see USING (begin_drain()'s own
-  // draining_ check) — even though DeferDelete never actually ran. This is the same undo commit
-  // 62e2c9711 added: the double-count it was originally guarding against no longer exists (a draining
-  // tenant's plain access() is refused, so TenantMemorySum's HOT half already excludes it — see
-  // TenantMemorySum's comment), but the retryability half of that fix still matters. Phase 2's teardown
-  // (StopAllBackgroundTasks/streams()->DropAll()) is NOT undone here, exactly as it wasn't before.
-  // No local try/catch: `rollback_drain` already does exactly this (fresh-lookup abort_drain guarded
-  // by is_draining(), then ForgetDetached_) on unwind, so a second copy here would just be a duplicate
-  // that runs after it, wastefully, on every throwing path -- not incorrect (both halves are
-  // idempotent/self-guarding), but redundant code with no behavior of its own to justify existing.
+  // rollback_drain covers DeferDelete failure: if DeferDelete throws, the name would be wedged forever
+  // (CREATE sees EXISTS, DROP sees USING). Phase 2's teardown is intentionally NOT reversed on failure.
+  // No local try/catch: rollback_drain already fires on unwind — a duplicate would be redundant.
   db_handler_.DeferDelete(name, [this, tenant_uuid, storage_path, name]() {
     ForgetDetached_(tenant_uuid);
     std::error_code ec;
@@ -986,11 +926,8 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
     }
   });
 
-  // Point of no return: DeferDelete has taken ownership of the eventual teardown/ForgetDetached_/
-  // remove_all. Disarm BEFORE returning success -- nothing below can throw, but if it ever did,
-  // rollback_drain firing on a tenant DeferDelete already owns would abort_drain() out from under a
-  // handoff that has already happened, and (once the drain thread's ForgetDetached_ races this one)
-  // double-retire a row whose uuid slot could theoretically already have been reused.
+  // DeferDelete owns teardown from here — disable rollback_drain before returning. If it fired, it would
+  // abort_drain() an already-handed-off tenant and double-retire the DETACHED row.
   rollback_drain.Disable();
   return {};  // Success
 }

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -893,10 +893,9 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
     if (!lock.owns_lock()) lock.lock();
     // Fresh by-name lookup, never the Phase 1 `gk` pointer above: the off-lock Phase 2 window could
     // have let a concurrent structural change invalidate it. is_draining() guards abort_drain()'s own
-    // DMG_ASSERT -- load-bearing, not defensive fluff: the Phase 3 re-validation failure path below
-    // (gk3 gone, or found but no longer draining) intentionally does NOT call abort_drain() there
-    // (nothing to abort), and this guard still fires on that path's `return` to retire the registry
-    // row, so it must not blindly re-call abort_drain() into that same non-draining state.
+    // DMG_ASSERT -- load-bearing, not defensive fluff: on a throwing unwind the gatekeeper may already
+    // be gone or no longer draining, so this guard must not blindly re-call abort_drain() into a
+    // non-draining state while it retires the registry row.
     if (auto *g = db_handler_.GetGatekeeper(name); g && g->is_draining()) g->abort_drain();
     if (detached_row_uuid) ForgetDetached_(*detached_row_uuid);
   }};
@@ -933,13 +932,12 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   const auto holders = std::max<uint64_t>(gk->holder_count(), 1) - 1;
 
   // Publish BEFORE releasing `lock`: visibility must not blink. A reader arriving between
-  // begin_drain() and this line would otherwise see neither a HOT/DRAINING status nor a DETACHED row
+  // begin_drain() and this line would otherwise see neither a HOT status nor a DETACHED row
   // for a tenant that has, in fact, already been accepted for deletion.
   RecordDetached_(DetachedTenant{.name = name,
                                  .uuid = tenant_uuid,
                                  .detached_at = std::chrono::system_clock::now(),
                                  .reason = DetachReason::DROP,
-                                 .phase = TenantPhase::DRAINING,
                                  .holders_at_detach = holders,
                                  .memory_at_detach = memory_at_detach});
   // A row now exists to retire -- arm `rollback_drain`'s ForgetDetached_ half. Placed only after
@@ -959,34 +957,21 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   acc.reset();  // release the drop's own accessor so Phase 3's DeferDelete -> try_delete() can win
   lock.lock();
 
-  // Re-validate; do not trust the Phase 1 pointer or guards. DeferDelete is void and silently no-ops
-  // on a name miss, so a lost/renamed node here would otherwise let us promote the registry row (and
-  // return success) for a tenant that Phase 2's off-lock window let something else destroy or rename
-  // out from under us.
+  // Re-validate the drain marker survived the off-lock window before proceeding.
   auto *gk3 = db_handler_.GetGatekeeper(name);
-  if (!gk3 || !gk3->is_draining()) {
-    spdlog::error(R"(Lost the drain marker for database "{}" while its teardown ran off-lock; aborting the drop.)",
-                  name);
-    // No explicit ForgetDetached_ here: this `return` runs `rollback_drain`'s destructor, which
-    // retires the row via `detached_row_uuid` on its own. It correctly skips abort_drain() too --
-    // gk3 is already gone or already not draining, and the guard's fresh lookup sees the same
-    // state, so its is_draining() check leaves abort_drain() uncalled here exactly as this comment
-    // requires: there is nothing left to abort.
-    return std::unexpected{DeleteError::FAIL};
-  }
+  MG_ASSERT(gk3 && gk3->is_draining(),
+            "drain marker must survive the off-lock window: draining_ has a single clearer (this "
+            "thread's rollback guard) and every db_handler_ mutation is drain-gated");
 
   DetachProfileAndRetireDurabilityKey_(name);
 
-  PromoteDetachedPhase_(tenant_uuid);  // DRAINING -> DETACHED
-
-  // The row is already DETACHED; if constructing the deferred closure or DeferDelete itself throws
-  // before the Gatekeeper is actually handed off, undo BOTH the promotion and the drain, or the
-  // tenant's *name* is wedged forever: a fresh CREATE would see EXISTS (still in db_handler_) and a
-  // retried DROP would see USING (begin_drain()'s own draining_ check) — even though DeferDelete never
-  // actually ran. This is the same undo commit 62e2c9711 added, now widened for a second failure mode:
-  // the double-count it was originally guarding against no longer exists (a draining tenant's plain
-  // access() is refused, so TenantMemorySum's HOT half already excludes it — see TenantMemorySum's
-  // comment), but the retryability half of that fix still matters. Phase 2's teardown
+  // If constructing the deferred closure or DeferDelete itself throws before the Gatekeeper is
+  // actually handed off, undo the drain, or the tenant's *name* is wedged forever: a fresh CREATE
+  // would see EXISTS (still in db_handler_) and a retried DROP would see USING (begin_drain()'s own
+  // draining_ check) — even though DeferDelete never actually ran. This is the same undo commit
+  // 62e2c9711 added: the double-count it was originally guarding against no longer exists (a draining
+  // tenant's plain access() is refused, so TenantMemorySum's HOT half already excludes it — see
+  // TenantMemorySum's comment), but the retryability half of that fix still matters. Phase 2's teardown
   // (StopAllBackgroundTasks/streams()->DropAll()) is NOT undone here, exactly as it wasn't before.
   // No local try/catch: `rollback_drain` already does exactly this (fresh-lookup abort_drain guarded
   // by is_draining(), then ForgetDetached_) on unwind, so a second copy here would just be a duplicate

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -458,9 +458,8 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
     return *cold_res;
   }
 
-  // A tenant already accepted by a concurrent drop is DRAINING: draining_ makes GetConfig's Get()
-  // refuse it, so the GetConfig check just below would otherwise misreport the far more confusing
-  // NON_EXISTENT for a tenant that in fact still exists. Surface the accurate, retriable USING.
+  // A DRAINING tenant is still real: GetConfig's Get() refuses it, so the check just below would
+  // otherwise misreport NON_EXISTENT. Surface the accurate, retriable USING instead.
   if (auto *gk = db_handler_.GetGatekeeper(db_name); gk && gk->is_draining()) {
     return std::unexpected{DeleteError::USING};
   }
@@ -509,10 +508,8 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name, system::
     return *cold_res;
   }
 
-  // Same DRAINING race TryDelete guards above (see its comment): a concurrent drop already accepted
-  // this tenant, so the GetConfig check just below would otherwise misreport NON_EXISTENT instead of
-  // the accurate, retriable USING. This is the FORCE path (DROP DATABASE ... FORCE), so the race is
-  // just as reachable here as it is through TryDelete's non-FORCE path.
+  // Same DRAINING race TryDelete guards above (see its comment) -- just as reachable here on the
+  // FORCE path (DROP DATABASE ... FORCE).
   if (auto *gk = db_handler_.GetGatekeeper(db_name); gk && gk->is_draining()) {
     return std::unexpected{DeleteError::USING};
   }
@@ -523,9 +520,8 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name, system::
     return std::unexpected{DeleteError::NON_EXISTENT};
   }
 
-  // Force delete. `conf` is a BY-VALUE copy (DatabaseHandler::GetConfig), so it stays valid across
-  // Delete_'s internal unlock/relock of `wr` -- unlike a raw pointer/reference into db_handler_, it
-  // cannot dangle even though the map itself may be mutated by another thread while `wr` is released.
+  // `conf` is a by-value copy (DatabaseHandler::GetConfig), so unlike a pointer/reference into
+  // db_handler_ it stays valid across Delete_'s internal unlock/relock of `wr`.
   const auto res = Delete_(db_name, wr);
   if (res) {
     // Success; save delta
@@ -558,9 +554,8 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(utils::UUID uuid) {
   }
   auto it = FindHotByUuid_(uuid);
   if (it == db_handler_.end()) return std::unexpected{DeleteError::NON_EXISTENT};
-  // `it->first` is a view into a db_handler_ map key -- exactly why Delete_'s Phase 1 copies it into
-  // an owned std::string before releasing `wr` for Phase 2. Do not read `it` again after this call:
-  // once `wr` is released internally, a concurrent structural change to db_handler_ can invalidate it.
+  // `it->first` is a view into a db_handler_ map key (Delete_'s Phase 1 copies it before releasing
+  // `wr` -- see its comment). Do not read `it` again after this call.
   return Delete_(it->first, wr);
 }
 
@@ -845,10 +840,8 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
 }
 
 DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::unique_lock<LockT> &lock) {
-  // ===============================================================================================
-  // PHASE 1 — under `lock`. Brief: in-memory bookkeeping only, no blocking call, no thread join, no
-  // disk I/O below this point until Phase 3.
-  // ===============================================================================================
+  // PHASE 1 — under `lock`: in-memory bookkeeping only, no blocking call, no thread join, no disk
+  // I/O below this point until Phase 3.
   if (db_name == kDefaultDB) {
     // MSG cannot delete the default db
     return std::unexpected{DeleteError::DEFAULT_DB};
@@ -857,19 +850,17 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   // Own the name NOW, ahead of every lookup below: Delete(uuid) passes `it->first`, a view into a
   // db_handler_ map key; once `lock` is released below for Phase 2, that view can dangle if another
   // thread structurally mutates db_handler_ (heap-UAF). DeleteCold_ documents the identical hazard
-  // at cpp:777-779.
+  // right before its own erase().
   const std::string name{db_name};
 
   auto *gk = db_handler_.GetGatekeeper(name);
   if (!gk) return std::unexpected{DeleteError::NON_EXISTENT};
 
   // Non-HOT (mid-SUSPEND/RESUME) is retriable USING, never NON_EXISTENT — mirrors the Rename guard
-  // and DeleteCold_'s sibling COLD-only check. Identity (GetGatekeeper) and state MUST be resolved
-  // before anything that depends on the tenant being mintable (StorageDir_/GetConfig, below, is
-  // drain-gated on the plain access() and would itself report NON_EXISTENT for a tenant that is only
-  // mid-SUSPEND, not gone — see Handler<T>::GetConfig's comment). This is diagnostic only:
-  // begin_drain() below re-checks the identical HOT condition atomically with setting draining_, and
-  // on its own would collapse "not HOT" and "already draining" into the same bare `false`.
+  // and DeleteCold_'s COLD-only check; identity/state must be resolved before anything drain-gated
+  // (see the accessor-read comment below). Diagnostic only: begin_drain() below re-checks the same
+  // HOT condition atomically with draining_, collapsing "not HOT" and "already draining" into one
+  // bare `false`.
   if (gk->state() != utils::GatekeeperState::HOT) return std::unexpected{DeleteError::USING};
 
   // Single-flight: false means a concurrent DROP already owns this drain (the state() check above
@@ -894,11 +885,11 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   std::optional<utils::UUID> detached_row_uuid;
   auto rollback_drain = utils::OnScopeExit{[&] {
     // Phase 2 below runs with `lock` unlocked. If the throw came from there, `lock` is not held here,
-    // yet db_handler_ (GetGatekeeper) has no internal synchronization of its own -- every access relies
-    // on the caller already holding `lock` (see DatabaseHandler::GetGatekeeper's doc). Re-locking during
-    // unwind is a blocking call on `lock` (a reader-preferring pthread rwlock), same cost any other
-    // writer pays to get in; touching db_handler_ without it would be a data race instead, which is
-    // strictly worse on an already-exceptional path.
+    // yet db_handler_'s items_ carries no mutex of its own (unlike defer_lock_ for deferred_) -- every
+    // access relies on the caller already holding `lock`. Re-locking during unwind is a blocking call
+    // on `lock` (a reader-preferring pthread rwlock), same cost any other writer pays to get in;
+    // touching db_handler_ without it would be a data race instead, which is strictly worse on an
+    // already-exceptional path.
     if (!lock.owns_lock()) lock.lock();
     // Fresh by-name lookup, never the Phase 1 `gk` pointer above: the off-lock Phase 2 window could
     // have let a concurrent structural change invalidate it. is_draining() guards abort_drain()'s own
@@ -921,9 +912,10 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
 
   auto *database = acc->get();
   // Read from the accessor we already hold, not through StorageDir_/GetConfig: those go through the
-  // drain-gated plain access() (Handler<T>::GetConfig), which begin_drain() just above made refuse on
-  // THIS gatekeeper too -- calling StorageDir_(name) here would itself now (mis)report NON_EXISTENT.
-  // `acc` is drain_bypass-minted and live, so this field read cannot race a concurrent teardown.
+  // drain-gated plain access() (DatabaseHandler::GetConfig), which begin_drain() just above made
+  // refuse on THIS gatekeeper too -- calling StorageDir_(name) here would itself now (mis)report
+  // NON_EXISTENT. `acc` is drain_bypass-minted and live, so this field read cannot race a concurrent
+  // teardown.
   const auto storage_path = database->config().durability.storage_directory;
   const auto tenant_uuid = database->uuid();
   const auto memory_at_detach = database->DbMemoryUsage();
@@ -956,22 +948,17 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   // on failure), no row was actually published, so there is nothing for the guard to retire.
   detached_row_uuid = tenant_uuid;
 
-  // ===============================================================================================
   // PHASE 2 — `lock` released. The unbounded part: two thread joins that used to run under lock_.
   // Nothing reachable from here may take `lock` (a non-recursive pthread rwlock) — StopAllBackgroundTasks
   // and streams()->DropAll() provably don't: they ran under lock_ HELD EXCLUSIVE a moment ago (the code
   // this replaces), so a self-deadlock there would have already been a live bug, not a latent one.
   // `gk`/`acc` are the only handles we still trust past this point; `name`/`storage_path` are owned copies.
-  // ===============================================================================================
   lock.unlock();
   database->StopAllBackgroundTasks();
   database->streams()->DropAll();
   acc.reset();  // release the drop's own accessor so Phase 3's DeferDelete -> try_delete() can win
   lock.lock();
 
-  // ===============================================================================================
-  // PHASE 3 — under `lock` again.
-  // ===============================================================================================
   // Re-validate; do not trust the Phase 1 pointer or guards. DeferDelete is void and silently no-ops
   // on a name miss, so a lost/renamed node here would otherwise let us promote the registry row (and
   // return success) for a tenant that Phase 2's off-lock window let something else destroy or rename
@@ -1007,7 +994,6 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name, std::un
   // idempotent/self-guarding), but redundant code with no behavior of its own to justify existing.
   db_handler_.DeferDelete(name, [this, tenant_uuid, storage_path, name]() {
     ForgetDetached_(tenant_uuid);
-    // Delete disk storage
     std::error_code ec;
     (void)std::filesystem::remove_all(storage_path, ec);
     if (ec) {

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -509,6 +509,14 @@ DbmsHandler::DeleteResult DbmsHandler::Delete(std::string_view db_name, system::
     return *cold_res;
   }
 
+  // Same DRAINING race TryDelete guards above (see its comment): a concurrent drop already accepted
+  // this tenant, so the GetConfig check just below would otherwise misreport NON_EXISTENT instead of
+  // the accurate, retriable USING. This is the FORCE path (DROP DATABASE ... FORCE), so the race is
+  // just as reachable here as it is through TryDelete's non-FORCE path.
+  if (auto *gk = db_handler_.GetGatekeeper(db_name); gk && gk->is_draining()) {
+    return std::unexpected{DeleteError::USING};
+  }
+
   // Get DB config for the UUID and disk clean up
   const auto conf = db_handler_.GetConfig(db_name);
   if (!conf) {

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -555,11 +555,10 @@ class DbmsHandler {
     auto dg = std::lock_guard{detached_lock_};
     for (auto const &[_, d] : detached_) {
       if (std::ranges::none_of(out, [&](auto const &kv) { return kv.first == d.name; })) {
-        // A DRAINING row's gatekeeper is still IN db_handler_, but prepare_for_deletion() already
+        // A detached row's gatekeeper may still be IN db_handler_, but prepare_for_deletion() already
         // marked it, so the HOT loop above never listed it (db_handler_.All() skips a marked-for-
-        // deletion entry) -- this dedup still resolves to exactly one row, just with the phase-
-        // appropriate label instead of always "DETACHED".
-        out.emplace_back(d.name, d.phase == TenantPhase::DRAINING ? "DRAINING" : "DETACHED");
+        // deletion entry) -- this dedup still resolves to exactly one row.
+        out.emplace_back(d.name, "DETACHED");
       }
     }
     return out;
@@ -569,22 +568,13 @@ class DbmsHandler {
   // retires the row immediately (inline delete) or from the drain thread (deferred, accessors still held).
   enum class DetachReason : uint8_t { DROP };
 
-  // Lifecycle phase of a deferred-destruction row (see DetachedTenant below). Delete_ publishes a row
-  // as DRAINING in its Phase 1 (still under lock_, before the off-lock teardown window) and promotes
-  // it to DETACHED in Phase 3, via PromoteDetachedPhase_, once DeferDelete has actually erased the
-  // gatekeeper from db_handler_.
-  //   DRAINING — accepted for deletion, still IN db_handler_ (is_marked_for_deletion + draining_ both
-  //              set, so it's unaddressable for new work but not yet unaddressable by name/iteration).
-  //   DETACHED — handed to a drain thread (or already destroyed inline); erased from db_handler_.
-  enum class TenantPhase : uint8_t { DRAINING, DETACHED };
-
   /**
    * @brief Metadata for a tenant whose destruction is deferred.
    *
-   * Not every row is unaddressable by name: a DRAINING row's gatekeeper is still IN db_handler_ (see
-   * TenantPhase above) — only once it reaches DETACHED has db_handler_ actually erased it (see
-   * Handler<T>::DeferDelete), the point after which its Database — and its bytes in
-   * utils::graph_memory_tracker — stays alive purely via this row until the drain thread's last
+   * Not every row is unaddressable by name: a detached row's gatekeeper may still be IN db_handler_
+   * during the drain window — only once db_handler_ has actually erased it (see
+   * Handler<T>::DeferDelete) does its Database — and its bytes in
+   * utils::graph_memory_tracker — stay alive purely via this row until the drain thread's last
    * accessor releases it.
    *
    * memory_at_detach is an AS-OF-DETACH snapshot, not a live figure: a live read would need a raw
@@ -598,7 +588,6 @@ class DbmsHandler {
     utils::UUID uuid;  //!< identity; unique, survives name reuse
     std::chrono::system_clock::time_point detached_at;
     DetachReason reason;
-    TenantPhase phase;  //!< DRAINING until PromoteDetachedPhase_ runs in Delete_'s Phase 3
     uint64_t holders_at_detach;
     int64_t memory_at_detach;
   };
@@ -627,10 +616,10 @@ class DbmsHandler {
    * db_handler_ the same access()-gated way ForEach does (a COLD shell's access() is nullopt and
    * contributes 0 — a COLD tenant has no in-memory storage, so that is correct, not an omission).
    *
-   * A DRAINING tenant (still IN db_handler_, see TenantPhase) is likewise not double-counted: its
+   * A detached tenant still IN db_handler_ during its drain window is likewise not double-counted: its
    * gatekeeper's plain access() is refused while draining_ is set (Gatekeeper::access()'s hard
    * refusal), so the HOT half contributes 0 for it and its bytes come solely from its detached_ row —
-   * exactly one count, whether the row is DRAINING or DETACHED.
+   * exactly one count.
    */
   TenantMemorySums TenantMemorySum() {  // NOT const: the HOT half mints (and drops) accessors
     auto rd = std::shared_lock{lock_};
@@ -1095,15 +1084,6 @@ class DbmsHandler {
   void ForgetDetached_(const utils::UUID &uuid) {
     auto dg = std::lock_guard{detached_lock_};
     detached_.erase(uuid);
-  }
-
-  /// DRAINING -> DETACHED. Caller MUST hold lock_ exclusive (Delete_'s Phase 3 does, right after
-  /// re-validating the drain is still live); takes ONLY detached_lock_ itself, same contract as
-  /// RecordDetached_/ForgetDetached_. No-op if the row is already gone.
-  void PromoteDetachedPhase_(const utils::UUID &uuid) {
-    auto dg = std::lock_guard{detached_lock_};
-    auto it = std::ranges::find_if(detached_, [&](DetachedTenant const &d) { return d.uuid == uuid; });
-    if (it != detached_.end()) it->phase = TenantPhase::DETACHED;
   }
 
   // Refresh the global cold-databases gauge from the live suspended_ size. Caller MUST hold lock_

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -223,7 +223,7 @@ class DbmsHandler {
    * @return NewResultT context on success, error on failure
    */
   NewResultT Update(const storage::SalientConfig &config) {
-    auto wr = std::lock_guard{lock_};
+    auto wr = std::unique_lock{lock_};
     auto new_db = New_(config);
     if (new_db || new_db.error() != NewError::EXISTS) {
       // NOTE: If db already exists we retry below
@@ -269,8 +269,11 @@ class DbmsHandler {
                   *name_view,
                   std::string(db->uuid()),
                   std::string(config.uuid));
-    // Defer drop
-    (void)Delete_(db->name());
+    // Defer drop. `db` (this function's own live DatabaseAccess) stays held across this call, so the
+    // gatekeeper's count_ is >= 1 throughout every one of Delete_'s three phases -- its Phase 3
+    // DeferDelete -> try_delete() (which needs count_ == 1, only its own accessor) deterministically
+    // takes the defer branch, exactly the outcome this call site relied on before the phases existed.
+    (void)Delete_(db->name(), wr);
     // Second attempt
     return New_(config);
   }
@@ -552,7 +555,11 @@ class DbmsHandler {
     auto dg = std::lock_guard{detached_lock_};
     for (auto const &[_, d] : detached_) {
       if (std::ranges::none_of(out, [&](auto const &kv) { return kv.first == d.name; })) {
-        out.emplace_back(d.name, "DETACHED");
+        // A DRAINING row's gatekeeper is still IN db_handler_, but prepare_for_deletion() already
+        // marked it, so the HOT loop above never listed it (db_handler_.All() skips a marked-for-
+        // deletion entry) -- this dedup still resolves to exactly one row, just with the phase-
+        // appropriate label instead of always "DETACHED".
+        out.emplace_back(d.name, d.phase == TenantPhase::DRAINING ? "DRAINING" : "DETACHED");
       }
     }
     return out;
@@ -562,18 +569,36 @@ class DbmsHandler {
   // retires the row immediately (inline delete) or from the drain thread (deferred, accessors still held).
   enum class DetachReason : uint8_t { DROP };
 
+  // Lifecycle phase of a deferred-destruction row (see DetachedTenant below). Delete_ publishes a row
+  // as DRAINING in its Phase 1 (still under lock_, before the off-lock teardown window) and promotes
+  // it to DETACHED in Phase 3, via PromoteDetachedPhase_, once DeferDelete has actually erased the
+  // gatekeeper from db_handler_.
+  //   DRAINING — accepted for deletion, still IN db_handler_ (is_marked_for_deletion + draining_ both
+  //              set, so it's unaddressable for new work but not yet unaddressable by name/iteration).
+  //   DETACHED — handed to a drain thread (or already destroyed inline); erased from db_handler_.
+  enum class TenantPhase : uint8_t { DRAINING, DETACHED };
+
   /**
-   * @brief Tenant erased from db_handler_ (via DeferDelete) but not yet destroyed: its Database
-   *        stays alive until the drain thread's last accessor releases it.
-   * memory_at_detach is AS-OF-DETACH, not live — a live read would need a raw Database* the drain
-   * thread destroys with no lock held (the UAF class this registry avoids). holders_at_detach is
-   * diagnostic: count at drop time, not necessarily the count that forced the defer.
+   * @brief Metadata for a tenant whose destruction is deferred.
+   *
+   * Not every row is unaddressable by name: a DRAINING row's gatekeeper is still IN db_handler_ (see
+   * TenantPhase above) — only once it reaches DETACHED has db_handler_ actually erased it (see
+   * Handler<T>::DeferDelete), the point after which its Database — and its bytes in
+   * utils::graph_memory_tracker — stays alive purely via this row until the drain thread's last
+   * accessor releases it.
+   *
+   * memory_at_detach is an AS-OF-DETACH snapshot, not a live figure: a live read would need a raw
+   * Database* that the drain thread destroys with no lock held, the UAF class this registry avoids.
+   * holders_at_detach is diagnostic only — the count observed just before the drop attempt, not
+   * necessarily the count that forced the defer, since an Accessor can be minted/released between that
+   * read and DeferDelete's own try_delete() check.
    */
   struct DetachedTenant {
     std::string name;  //!< name at detach; may be re-taken by a new tenant while this one drains
     utils::UUID uuid;  //!< identity; unique, survives name reuse
     std::chrono::system_clock::time_point detached_at;
     DetachReason reason;
+    TenantPhase phase;  //!< DRAINING until PromoteDetachedPhase_ runs in Delete_'s Phase 3
     uint64_t holders_at_detach;
     int64_t memory_at_detach;
   };
@@ -594,10 +619,18 @@ class DbmsHandler {
   };
 
   /**
-   * @brief HOT + detached halves together: db_handler_ alone under-reports because a force-dropped
-   *        tenant's bytes outlive DeferDelete's items_.erase until the last accessor releases.
-   * HOT half is access()-gated like ForEach: a COLD shell's access() is nullopt and contributes
-   * 0 — correct, since a COLD tenant has no in-memory storage.
+   * @brief Sigma tenant memory, split into the addressable (HOT) and detached halves.
+   *
+   * db_handler_ alone under-reports: a force-dropped tenant leaves every by-name surface immediately
+   * (Handler<T>::DeferDelete's unconditional items_.erase), while its bytes stay parented into
+   * utils::graph_memory_tracker until the last accessor is released. The HOT half deliberately walks
+   * db_handler_ the same access()-gated way ForEach does (a COLD shell's access() is nullopt and
+   * contributes 0 — a COLD tenant has no in-memory storage, so that is correct, not an omission).
+   *
+   * A DRAINING tenant (still IN db_handler_, see TenantPhase) is likewise not double-counted: its
+   * gatekeeper's plain access() is refused while draining_ is set (Gatekeeper::access()'s hard
+   * refusal), so the HOT half contributes 0 for it and its bytes come solely from its detached_ row —
+   * exactly one count, whether the row is DRAINING or DETACHED.
    */
   TenantMemorySums TenantMemorySum() {  // NOT const: the HOT half mints (and drops) accessors
     auto rd = std::shared_lock{lock_};
@@ -1013,7 +1046,16 @@ class DbmsHandler {
   DbmsHandler::NewResultT New_(storage::Config storage_config, system::Transaction *txn = nullptr);
 
   // TODO: new overload of Delete_ with DatabaseAccess
-  DeleteResult Delete_(std::string_view db_name);
+  //
+  // Three-phase drop, split around a deliberate off-lock window for the two unbounded thread joins
+  // it runs (StopAllBackgroundTasks / streams()->DropAll()):
+  //   Phase 1 (under `lock`)     — validate, own the name, begin_drain(), publish a DRAINING row.
+  //   Phase 2 (`lock` released) — run the joins; nothing reachable here may take lock_.
+  //   Phase 3 (under `lock`)    — re-validate, promote DRAINING -> DETACHED, hand off via DeferDelete.
+  // CONTRACT: `lock` is held EXCLUSIVE on entry and on every return path, including every error
+  // return. Delete_ unlocks/relocks it internally for Phase 2; the caller's lock object is left in
+  // the SAME (locked) state either way, as if this were one uninterrupted critical section.
+  DeleteResult Delete_(std::string_view db_name, std::unique_lock<LockT> &lock);
 
   // Drop a COLD (suspended) tenant: erases suspended_ entry, durable cold marker, on-disk data dir,
   // cold shell, and tenant-profile attachment. Returns the dropped UUID on success, or DeleteError
@@ -1053,6 +1095,15 @@ class DbmsHandler {
   void ForgetDetached_(const utils::UUID &uuid) {
     auto dg = std::lock_guard{detached_lock_};
     detached_.erase(uuid);
+  }
+
+  /// DRAINING -> DETACHED. Caller MUST hold lock_ exclusive (Delete_'s Phase 3 does, right after
+  /// re-validating the drain is still live); takes ONLY detached_lock_ itself, same contract as
+  /// RecordDetached_/ForgetDetached_. No-op if the row is already gone.
+  void PromoteDetachedPhase_(const utils::UUID &uuid) {
+    auto dg = std::lock_guard{detached_lock_};
+    auto it = std::ranges::find_if(detached_, [&](DetachedTenant const &d) { return d.uuid == uuid; });
+    if (it != detached_.end()) it->phase = TenantPhase::DETACHED;
   }
 
   // Refresh the global cold-databases gauge from the live suspended_ size. Caller MUST hold lock_
@@ -1192,7 +1243,17 @@ class DbmsHandler {
     if (it == db_handler_.end()) {
       throw UnknownDatabaseException("Tried to retrieve an unknown database with UUID \"{}\".", std::string{uuid});
     }
-    return std::move(*it->second.access());
+    // PRE-EXISTING hazard, not introduced here: FindHotByUuid_'s own access() call (above, to test the
+    // uuid match) is a SEPARATE mint from this one, and Get(uuid) only takes lock_ SHARED -- a
+    // concurrent Suspend_ can run try_begin_suspend() (also under only a shared lock_, see
+    // dbms_handler.cpp) and flip HOT -> SUSPENDING in the gap between the two, so this second access()
+    // can legitimately return nullopt. Guard it like the sibling Get_(name) overload instead of
+    // dereferencing an empty optional.
+    auto db = it->second.access();
+    if (!db) {
+      throw UnknownDatabaseException("Tried to retrieve an unknown database with UUID \"{}\".", std::string{uuid});
+    }
+    return std::move(*db);
   }
 #endif
 

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -269,10 +269,7 @@ class DbmsHandler {
                   *name_view,
                   std::string(db->uuid()),
                   std::string(config.uuid));
-    // Defer drop. `db` (this function's own live DatabaseAccess) stays held across this call, so the
-    // gatekeeper's count_ is >= 1 throughout every one of Delete_'s three phases -- its Phase 3
-    // DeferDelete -> try_delete() (which needs count_ == 1, only its own accessor) deterministically
-    // takes the defer branch, exactly the outcome this call site relied on before the phases existed.
+    // Defer drop: db (caller's live accessor) keeps count_ > 1, so Phase 3 DeferDelete->try_delete() always defers.
     (void)Delete_(db->name(), wr);
     // Second attempt
     return New_(config);
@@ -555,9 +552,8 @@ class DbmsHandler {
     auto dg = std::lock_guard{detached_lock_};
     for (auto const &[_, d] : detached_) {
       if (std::ranges::none_of(out, [&](auto const &kv) { return kv.first == d.name; })) {
-        // A detached row's gatekeeper may still be IN db_handler_, but prepare_for_deletion() already
-        // marked it, so the HOT loop above never listed it (db_handler_.All() skips a marked-for-
-        // deletion entry) -- this dedup still resolves to exactly one row.
+        // Between Phase 1 (prepare_for_deletion) and Phase 3 (DeferDelete/erase), the gatekeeper is
+        // still in db_handler_ — but All() skips marked-for-deletion entries, so the HOT loop missed it.
         out.emplace_back(d.name, "DETACHED");
       }
     }
@@ -569,19 +565,9 @@ class DbmsHandler {
   enum class DetachReason : uint8_t { DROP };
 
   /**
-   * @brief Metadata for a tenant whose destruction is deferred.
-   *
-   * Not every row is unaddressable by name: a detached row's gatekeeper may still be IN db_handler_
-   * during the drain window — only once db_handler_ has actually erased it (see
-   * Handler<T>::DeferDelete) does its Database — and its bytes in
-   * utils::graph_memory_tracker — stay alive purely via this row until the drain thread's last
-   * accessor releases it.
-   *
-   * memory_at_detach is an AS-OF-DETACH snapshot, not a live figure: a live read would need a raw
-   * Database* that the drain thread destroys with no lock held, the UAF class this registry avoids.
-   * holders_at_detach is diagnostic only — the count observed just before the drop attempt, not
-   * necessarily the count that forced the defer, since an Accessor can be minted/released between that
-   * read and DeferDelete's own try_delete() check.
+   * @brief Deferred-destruction metadata; gatekeeper may still be in db_handler_ until Phase 3 erases it.
+   * memory_at_detach is AS-OF-DETACH only — a live read would race the drain thread's lock-free destroy.
+   * holders_at_detach is diagnostic: count just before the drop attempt, racy — not the count that forced deferral.
    */
   struct DetachedTenant {
     std::string name;  //!< name at detach; may be re-taken by a new tenant while this one drains
@@ -608,18 +594,9 @@ class DbmsHandler {
   };
 
   /**
-   * @brief Sigma tenant memory, split into the addressable (HOT) and detached halves.
-   *
-   * db_handler_ alone under-reports: a force-dropped tenant leaves every by-name surface immediately
-   * (Handler<T>::DeferDelete's unconditional items_.erase), while its bytes stay parented into
-   * utils::graph_memory_tracker until the last accessor is released. The HOT half deliberately walks
-   * db_handler_ the same access()-gated way ForEach does (a COLD shell's access() is nullopt and
-   * contributes 0 — a COLD tenant has no in-memory storage, so that is correct, not an omission).
-   *
-   * A detached tenant still IN db_handler_ during its drain window is likewise not double-counted: its
-   * gatekeeper's plain access() is refused while draining_ is set (Gatekeeper::access()'s hard
-   * refusal), so the HOT half contributes 0 for it and its bytes come solely from its detached_ row —
-   * exactly one count.
+   * @brief HOT + detached halves: db_handler_ alone under-reports — dropped bytes outlive items_.erase until last
+   * accessor. COLD shells contribute 0 to the HOT half (access() refuses non-HOT). Draining tenants also contribute 0
+   * to HOT (access() hard-refuses draining_) and appear once in detached_ — no double-count.
    */
   TenantMemorySums TenantMemorySum() {  // NOT const: the HOT half mints (and drops) accessors
     auto rd = std::shared_lock{lock_};
@@ -1034,16 +1011,8 @@ class DbmsHandler {
    */
   DbmsHandler::NewResultT New_(storage::Config storage_config, system::Transaction *txn = nullptr);
 
-  // TODO: new overload of Delete_ with DatabaseAccess
-  //
-  // Three-phase drop, split around a deliberate off-lock window for the two unbounded thread joins
-  // it runs (StopAllBackgroundTasks / streams()->DropAll()):
-  //   Phase 1 (under `lock`)     — validate, own the name, begin_drain(), publish a DRAINING row.
-  //   Phase 2 (`lock` released) — run the joins; nothing reachable here may take lock_.
-  //   Phase 3 (under `lock`)    — re-validate, promote DRAINING -> DETACHED, hand off via DeferDelete.
-  // CONTRACT: `lock` is held EXCLUSIVE on entry and on every return path, including every error
-  // return. Delete_ unlocks/relocks it internally for Phase 2; the caller's lock object is left in
-  // the SAME (locked) state either way, as if this were one uninterrupted critical section.
+  // Three-phase drop: Phase 2 releases lock for two unbounded joins (StopAllBackgroundTasks / streams()->DropAll()).
+  // CONTRACT: `lock` is held EXCLUSIVE on entry and every return path; Delete_ unlocks/relocks for Phase 2.
   DeleteResult Delete_(std::string_view db_name, std::unique_lock<LockT> &lock);
 
   // Drop a COLD (suspended) tenant: erases suspended_ entry, durable cold marker, on-disk data dir,
@@ -1223,12 +1192,8 @@ class DbmsHandler {
     if (it == db_handler_.end()) {
       throw UnknownDatabaseException("Tried to retrieve an unknown database with UUID \"{}\".", std::string{uuid});
     }
-    // PRE-EXISTING hazard, not introduced here: FindHotByUuid_'s own access() call (above, to test the
-    // uuid match) is a SEPARATE mint from this one, and Get(uuid) only takes lock_ SHARED -- a
-    // concurrent Suspend_ can run try_begin_suspend() (also under only a shared lock_, see
-    // dbms_handler.cpp) and flip HOT -> SUSPENDING in the gap between the two, so this second access()
-    // can legitimately return nullopt. Guard it like the sibling Get_(name) overload instead of
-    // dereferencing an empty optional.
+    // FindHotByUuid_'s access() is a separate mint: a concurrent Suspend_ (also under shared lock_)
+    // can flip HOT -> SUSPENDING between the two, so this second access() can legitimately be nullopt.
     auto db = it->second.access();
     if (!db) {
       throw UnknownDatabaseException("Tried to retrieve an unknown database with UUID \"{}\".", std::string{uuid});

--- a/src/dbms/handler.hpp
+++ b/src/dbms/handler.hpp
@@ -323,10 +323,23 @@ class Handler {
     metrics::ScopedGauge pending;                      //!< holds the pending-destructions gauge up while queued
     utils::Gatekeeper<T> gk;                           //!< the tenant awaiting its last accessor's release
 
-    // Called OFF defer_lock_ (value teardown must not run under the list mutex). Zero-timeout try_delete:
-    // succeeds only if sole holder (value destroyed → true). Nullopt from access() is a dead-state backstop.
+    // Non-blocking trylock, called OFF defer_lock_ (so the value teardown never runs under the list
+    // mutex). Mints an accessor and try_delete()s it with a zero timeout: succeeds only if this is the
+    // sole live accessor RIGHT NOW (all external holders
+    // released), in which case the managed value is destroyed here and true is returned so the tick
+    // splices this node out. Otherwise the accessor is released and false leaves the node for the next
+    // tick -- a tenant nobody releases is retried forever but never blocks the others (round-robin).
+    // Mints with utils::drain_bypass, exactly like DeferDelete's own access() above: a dropped tenant
+    // has been begin_drain()'d, and plain access() refuses a draining tenant. Bypassing is mandatory,
+    // not a convenience -- plain access() would return nullopt for every pending (hence draining)
+    // tenant, so `if (!acc) return true` would splice a still-live tenant out and RunCallback()'s
+    // blocking ~Gatekeeper would wait, under this single worker, for that tenant's last accessor. One
+    // pinned tenant would then head-of-line-block every other tenant's deferred destruction -- the
+    // exact starvation this round-robin worker exists to prevent. The nullopt branch is now only a
+    // dead-state backstop: value_ already gone (state no longer HOT), which try_delete() reports as
+    // done.
     bool TryReserve() {
-      auto acc = gk.access();
+      auto acc = gk.access(utils::drain_bypass);
       if (!acc) return true;
       if (!acc->try_delete(kDeferTryTimeout)) {
         acc->reset();

--- a/src/dbms/handler.hpp
+++ b/src/dbms/handler.hpp
@@ -184,6 +184,14 @@ class Handler {
    */
   bool TryDelete(std::string_view name) {
     if (auto itr = items_.find(name); itr != items_.end()) {
+      // Deliberately the plain, drain-gated access() -- NOT utils::drain_bypass. This does not
+      // participate in the drain protocol at all: its only caller (DbmsHandler::TryDelete) already
+      // fails earlier at its own GetConfig lookup for a tenant under drop. More importantly, a
+      // bypassed mint here could win Accessor::try_delete() behind an in-flight FORCE drop's back --
+      // during that drop's off-lock phase its own accessor is released, so count_ can be exactly 1,
+      // letting this path destroy value_ and erase the entry out from under the drop, which would
+      // then falsely promote its registry row and roll back a drain on a gatekeeper that no longer
+      // exists.
       auto db_acc = itr->second.access();
       if (db_acc && db_acc->try_delete()) {
         db_acc->reset();
@@ -207,7 +215,13 @@ class Handler {
     auto itr = items_.find(name);
     if (itr == items_.end()) return;
 
-    auto db_acc = itr->second.access();
+    // utils::drain_bypass is mandatory here, not a convenience: DeferDelete is the drop path itself,
+    // so it owns whatever drain it (or its caller) already declared on this gatekeeper -- and
+    // items_.erase(itr) below is unconditional, reached whether the accessor mints or not. A
+    // drain-gated access() failing here would `return` before that erase, stranding the tenant in
+    // items_ forever: unreachable by name (its own access() refuses), never destroyed, its name
+    // permanently unusable.
+    auto db_acc = itr->second.access(utils::drain_bypass);
     if (!db_acc) return;
 
     if (db_acc->try_delete()) {

--- a/src/dbms/handler.hpp
+++ b/src/dbms/handler.hpp
@@ -184,14 +184,8 @@ class Handler {
    */
   bool TryDelete(std::string_view name) {
     if (auto itr = items_.find(name); itr != items_.end()) {
-      // Deliberately the plain, drain-gated access() -- NOT utils::drain_bypass. This does not
-      // participate in the drain protocol at all: its only caller (DbmsHandler::TryDelete) already
-      // fails earlier at its own GetConfig lookup for a tenant under drop. More importantly, a
-      // bypassed mint here could win Accessor::try_delete() behind an in-flight FORCE drop's back --
-      // during that drop's off-lock phase its own accessor is released, so count_ can be exactly 1,
-      // letting this path destroy value_ and erase the entry out from under the drop, which would
-      // then falsely promote its registry row and roll back a drain on a gatekeeper that no longer
-      // exists.
+      // Deliberately plain, drain-gated access() -- NOT drain_bypass: a bypassed mint could race a
+      // FORCE drop's off-lock phase (count_==1), destroying value_ from under the drop.
       auto db_acc = itr->second.access();
       if (db_acc && db_acc->try_delete()) {
         db_acc->reset();
@@ -215,12 +209,8 @@ class Handler {
     auto itr = items_.find(name);
     if (itr == items_.end()) return;
 
-    // utils::drain_bypass is mandatory here, not a convenience: DeferDelete is the drop path itself,
-    // so it owns whatever drain it (or its caller) already declared on this gatekeeper -- and
-    // items_.erase(itr) below is unconditional, reached whether the accessor mints or not. A
-    // drain-gated access() failing here would `return` before that erase, stranding the tenant in
-    // items_ forever: unreachable by name (its own access() refuses), never destroyed, its name
-    // permanently unusable.
+    // drain_bypass mandatory: DeferDelete owns the drain, so plain access() returns nullopt here,
+    // triggering early return before items_.erase(itr) and stranding the tenant in items_ forever.
     auto db_acc = itr->second.access(utils::drain_bypass);
     if (!db_acc) return;
 
@@ -323,21 +313,9 @@ class Handler {
     metrics::ScopedGauge pending;                      //!< holds the pending-destructions gauge up while queued
     utils::Gatekeeper<T> gk;                           //!< the tenant awaiting its last accessor's release
 
-    // Non-blocking trylock, called OFF defer_lock_ (so the value teardown never runs under the list
-    // mutex). Mints an accessor and try_delete()s it with a zero timeout: succeeds only if this is the
-    // sole live accessor RIGHT NOW (all external holders
-    // released), in which case the managed value is destroyed here and true is returned so the tick
-    // splices this node out. Otherwise the accessor is released and false leaves the node for the next
-    // tick -- a tenant nobody releases is retried forever but never blocks the others (round-robin).
-    // Mints with utils::drain_bypass, exactly like DeferDelete's own access() above: a dropped tenant
-    // has been begin_drain()'d, and plain access() refuses a draining tenant. Bypassing is mandatory,
-    // not a convenience -- plain access() would return nullopt for every pending (hence draining)
-    // tenant, so `if (!acc) return true` would splice a still-live tenant out and RunCallback()'s
-    // blocking ~Gatekeeper would wait, under this single worker, for that tenant's last accessor. One
-    // pinned tenant would then head-of-line-block every other tenant's deferred destruction -- the
-    // exact starvation this round-robin worker exists to prevent. The nullopt branch is now only a
-    // dead-state backstop: value_ already gone (state no longer HOT), which try_delete() reports as
-    // done.
+    // Called OFF defer_lock_ (value teardown must not run under the list mutex).
+    // drain_bypass mandatory: plain access() refuses every pending (draining) tenant, so `if (!acc) return true`
+    // splices live tenants and head-of-line-blocks the worker on ~Gatekeeper.
     bool TryReserve() {
       auto acc = gk.access(utils::drain_bypass);
       if (!acc) return true;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -515,8 +515,10 @@ class Storage {
   std::function<std::unique_ptr<DatabaseProtector>()> database_protector_factory_;
 
   /// Creates a database protector for async operations
-  /// @return DatabaseProtector instance for committing async transactions
-  /// @note Never returns nullptr - always provides a valid protector
+  /// @return DatabaseProtector instance for committing async transactions, or nullptr if this
+  ///         database is no longer available for async work (dropped, or draining toward drop).
+  /// @note A nullptr return is expected, not an error: callers (storage::ttl::TTL,
+  ///       storage::async_indexer) must check for it and stop rather than commit.
   auto make_database_protector() const -> std::unique_ptr<DatabaseProtector> { return database_protector_factory_(); }
 
   /// Gets the database protector factory for copying to new storage instances

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -515,10 +515,7 @@ class Storage {
   std::function<std::unique_ptr<DatabaseProtector>()> database_protector_factory_;
 
   /// Creates a database protector for async operations
-  /// @return DatabaseProtector instance for committing async transactions, or nullptr if this
-  ///         database is no longer available for async work (dropped, or draining toward drop).
-  /// @note A nullptr return is expected, not an error: callers (storage::ttl::TTL,
-  ///       storage::async_indexer) must check for it and stop rather than commit.
+  /// @return nullptr when the database is dropped or draining; callers must check and stop.
   auto make_database_protector() const -> std::unique_ptr<DatabaseProtector> { return database_protector_factory_(); }
 
   /// Gets the database protector factory for copying to new storage instances

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -148,9 +148,8 @@ struct GKInternals {
   std::unique_ptr<T> value_;
   uint64_t count_ = 0;
   std::atomic_bool is_marked_for_deletion = false;
-  // Plain bool, NOT atomic: every access happens under mutex_ already, and begin_drain() needs the
-  // HOT check and the set to be one indivisible step — an atomic<bool> gives atomicity to each
-  // access individually but not to "check state_ == HOT, then set draining_" as a single unit.
+  // Plain bool, not atomic: every access already happens under mutex_, and begin_drain() needs the
+  // HOT check plus the set to be one indivisible step, which a bare atomic<bool> would not give.
   bool draining_ = false;
   std::mutex mutex_;  // TODO change to something cheaper?
   std::condition_variable cv_;
@@ -382,11 +381,13 @@ struct Gatekeeper {
   }
 
   // Bypasses the draining_ refusal above. Restricted to deletion/teardown machinery:
-  // Handler<T>::DeferDelete, and DatabaseHandler's destructor / its New() directory-collision scan.
+  // DbmsHandler::Delete_'s own accessor right after begin_drain(), Handler<T>::DeferDelete, and
+  // DatabaseHandler's destructor / its New() directory-collision scan.
   // Mandatory, not a convenience: Handler<T>::DeferDelete does
-  //   auto db_acc = itr->second.access(); if (!db_acc) return;
-  // *before* its unconditional items_.erase(itr) — a drain-gated mint there would strand the tenant
-  // in items_ forever: unreachable by name, never destroyed, its name permanently unusable.
+  //   auto db_acc = itr->second.access(utils::drain_bypass); if (!db_acc) return;
+  // *before* its unconditional items_.erase(itr) — minting via the plain (non-bypass) overload
+  // there would strand the tenant in items_ forever: unreachable by name, never destroyed, its
+  // name permanently unusable.
   // Do NOT use this from anything that could win Accessor::try_delete() behind the drop's back —
   // that is exactly why Handler<T>::TryDelete stays gated on the non-bypass overload above.
   std::optional<Accessor> access(drain_bypass_t /*tag*/) {
@@ -509,9 +510,8 @@ struct Gatekeeper {
     pimpl_->cv_.notify_all();
   }
 
-  // HOT -> HOT, draining_: false -> true. Deliberately NOT a GatekeeperState transition — see the
-  // note on GatekeeperState above and on draining_ in GKInternals for why a fifth state value would
-  // hang ~Gatekeeper's terminal predicate forever.
+  // HOT -> HOT, draining_: false -> true — an orthogonal flag, not a GatekeeperState transition
+  // (see the note on GatekeeperState above).
   //
   // Single-flight CAS *and* the concurrent-SUSPEND/RESUME guard in one atomic step: requires
   // state_ == HOT (refuses an in-flight SUSPENDING/RESUMING gatekeeper, and a COLD one) AND
@@ -555,10 +555,8 @@ struct Gatekeeper {
     {
       auto lock = std::unique_lock{pimpl_->mutex_};
       auto const terminal_and_drained = [this] {
-        // Deliberately tests state_ and count_ only — draining_ is an orthogonal flag (see
-        // GatekeeperState's comment above), not a state, so it never enters this predicate and a
-        // draining HOT/COLD gatekeeper stays destructible. Anyone adding a new GatekeeperState value
-        // must extend this predicate too, or a Gatekeeper stuck in that state waits here forever.
+        // draining_ deliberately excluded (orthogonal flag, not a state — see GatekeeperState above),
+        // so a draining HOT/COLD gatekeeper stays destructible; a new GatekeeperState value must be added here too.
         return (pimpl_->state_ == GatekeeperState::HOT || pimpl_->state_ == GatekeeperState::COLD) &&
                pimpl_->count_ == 0;
       };

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -109,9 +109,8 @@ struct GatekeeperGuardFor<T, std::void_t<typename T::GatekeeperGuard>> {
 //   RESUMING -> HOT    : move-assign a fresh HOT Gatekeeper over the shell
 // INVARIANT: Gatekeeper::access() mints Accessors only in HOT.
 //
-// DRAINING (GKInternals::draining_, set by Gatekeeper::begin_drain()) is an orthogonal flag layered
-// on top of HOT, NOT a fifth state: it is set/cleared without moving state_, so it never appears in
-// the transition table above and cannot desynchronize from it.
+// draining_ is an orthogonal flag on top of HOT, NOT a fifth state: set/cleared without
+// touching state_, so it never appears in the transition table above.
 //
 // Declared at namespace scope so headers that forward-declare the managed type
 // T can use GatekeeperState without forcing T to be complete.
@@ -128,8 +127,6 @@ struct cold_shell_t {
 
 inline constexpr cold_shell_t cold_shell{};
 
-// Tag to bypass the DRAINING refusal in access() below (see Gatekeeper::access(drain_bypass_t)'s
-// doc comment for exactly who may pass it and why).
 struct drain_bypass_t {
   explicit drain_bypass_t() = default;
 };
@@ -354,8 +351,7 @@ struct Gatekeeper {
   };
 
  private:
-  // Shared mint condition for both access() overloads below; caller must hold pimpl_->mutex_.
-  // Factored out so the plain and drain_bypass_t overloads cannot drift apart.
+  // Caller must hold pimpl_->mutex_; shared mint condition keeps both access() overloads in sync.
   std::optional<Accessor> access_locked(bool bypass_drain) {
     if (pimpl_->value_ && pimpl_->state_ == GatekeeperState::HOT && (bypass_drain || !pimpl_->draining_)) {
       return Accessor{this};
@@ -372,24 +368,14 @@ struct Gatekeeper {
     // Accessor's operator bool is false, so callers won't use it, and the count returns to 0 so a
     // waiting ~Gatekeeper proceeds. Adding a marked check here is NOT a correctness requirement.
     //
-    // draining_ is different: it IS a hard refusal, not advisory. It is the single choke point that
-    // stops the database-protector factory (dbms::DatabaseHandler::MakeDatabaseProtectorFactory ->
-    // Handler::Get -> here) from re-arming TTL and async-index work on a tenant that is being dropped
-    // — without this refusal the drain would never converge, because freshly-minted work would keep
-    // the tenant HOT and its own Accessor count above the drop's single-flight expectations forever.
+    // draining_ IS a hard refusal (unlike is_marked_for_deletion): new accessors re-arming TTL and
+    // async-index work would prevent the drain from converging.
     return access_locked(/*bypass_drain=*/false);
   }
 
-  // Bypasses the draining_ refusal above. Restricted to deletion/teardown machinery:
-  // DbmsHandler::Delete_'s own accessor right after begin_drain(), Handler<T>::DeferDelete, and
-  // DatabaseHandler's destructor / its New() directory-collision scan.
-  // Mandatory, not a convenience: Handler<T>::DeferDelete does
-  //   auto db_acc = itr->second.access(utils::drain_bypass); if (!db_acc) return;
-  // *before* its unconditional items_.erase(itr) — minting via the plain (non-bypass) overload
-  // there would strand the tenant in items_ forever: unreachable by name, never destroyed, its
-  // name permanently unusable.
-  // Do NOT use this from anything that could win Accessor::try_delete() behind the drop's back —
-  // that is exactly why Handler<T>::TryDelete stays gated on the non-bypass overload above.
+  // Bypasses draining_ for deletion/teardown machinery only. Mandatory: using plain access() here
+  // would return nullopt (draining tenant), triggering early-return before items_.erase(itr) and
+  // stranding the tenant forever. Do NOT use from TryDelete paths.
   std::optional<Accessor> access(drain_bypass_t /*tag*/) {
     auto guard = std::unique_lock{pimpl_->mutex_};
     return access_locked(/*bypass_drain=*/true);
@@ -427,11 +413,8 @@ struct Gatekeeper {
   // the managed value, then call finish_suspend().
   bool try_begin_suspend(std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
     auto guard = std::unique_lock{pimpl_->mutex_};
-    // draining_ is refused upfront, alongside the HOT check, NOT folded into the wait_for predicate
-    // below (which must stay count_ == 1 only): a tenant already accepted for deletion must not be
-    // frozen out from under the drop by a competing suspend. value_ is refused too: try_delete()
-    // briefly holds count_ == 1 / state_ == HOT / draining_ == false while ~T runs unlocked after
-    // moving value_ out, and a gatekeeper with nothing to suspend must not enter SUSPENDING.
+    // Refuse draining_ upfront (not in the predicate): a drop-in-flight must not be frozen by a
+    // competing suspend. Refuse null value_: try_delete() briefly exposes HOT/count_==1/value_==null.
     if (!pimpl_->value_ || pimpl_->state_ != GatekeeperState::HOT || pimpl_->draining_) return false;
     if (!pimpl_->cv_.wait_for(guard, timeout, [this] { return pimpl_->count_ == 1; })) {
       return false;
@@ -510,29 +493,18 @@ struct Gatekeeper {
     pimpl_->cv_.notify_all();
   }
 
-  // HOT -> HOT, draining_: false -> true — an orthogonal flag, not a GatekeeperState transition
-  // (see the note on GatekeeperState above).
-  //
-  // Single-flight CAS *and* the concurrent-SUSPEND/RESUME guard in one atomic step: requires
-  // state_ == HOT (refuses an in-flight SUSPENDING/RESUMING gatekeeper, and a COLD one) AND
-  // !draining_ (a second concurrent DROP loses). Because draining_ can only ever be set here, from
-  // HOT, it is HOT-exclusive for its entire life — that is exactly why ~Gatekeeper's terminal
-  // predicate, begin_resume() (COLD-only), and EraseColdShell/DeleteCold_ (COLD-only) all stay valid
-  // unchanged: none of them can ever observe draining_ == true.
-  //
-  // Returning false is a normal, non-asserting outcome (unlike abort_drain() below): a concurrent
-  // drop or a mid-transition tenant is a legal race that the caller turns into a retriable error.
+  // HOT -> HOT, draining_ false -> true. Single-flight under mutex_: requires HOT + !draining_,
+  // so draining_ is HOT-exclusive for its entire life (harmless to ~Gatekeeper, begin_resume, etc.).
+  // Returning false is a normal race outcome; cf. abort_drain(), which asserts (single caller).
   bool begin_drain() {
     auto guard = std::unique_lock{pimpl_->mutex_};
-    // value_ term: see try_begin_suspend() above -- you cannot drain a gatekeeper that holds nothing.
     if (!pimpl_->value_ || pimpl_->state_ != GatekeeperState::HOT || pimpl_->draining_) return false;
     pimpl_->draining_ = true;
     pimpl_->cv_.notify_all();
     return true;
   }
 
-  // Rolls back begin_drain(). Single disciplined caller (unlike begin_drain()'s legal-race false), so
-  // a DMG_ASSERT tripwire, matching abort_suspend()/abort_resume() above.
+  // Single disciplined caller → DMG_ASSERT tripwire, unlike begin_drain()'s legal-race false return.
   void abort_drain() {
     auto guard = std::unique_lock{pimpl_->mutex_};
     DMG_ASSERT(pimpl_->draining_, "abort_drain() called while not draining");

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -109,6 +109,10 @@ struct GatekeeperGuardFor<T, std::void_t<typename T::GatekeeperGuard>> {
 //   RESUMING -> HOT    : move-assign a fresh HOT Gatekeeper over the shell
 // INVARIANT: Gatekeeper::access() mints Accessors only in HOT.
 //
+// DRAINING (GKInternals::draining_, set by Gatekeeper::begin_drain()) is an orthogonal flag layered
+// on top of HOT, NOT a fifth state: it is set/cleared without moving state_, so it never appears in
+// the transition table above and cannot desynchronize from it.
+//
 // Declared at namespace scope so headers that forward-declare the managed type
 // T can use GatekeeperState without forcing T to be complete.
 enum class GatekeeperState : uint8_t { HOT, SUSPENDING, COLD, RESUMING };
@@ -124,6 +128,14 @@ struct cold_shell_t {
 
 inline constexpr cold_shell_t cold_shell{};
 
+// Tag to bypass the DRAINING refusal in access() below (see Gatekeeper::access(drain_bypass_t)'s
+// doc comment for exactly who may pass it and why).
+struct drain_bypass_t {
+  explicit drain_bypass_t() = default;
+};
+
+inline constexpr drain_bypass_t drain_bypass{};
+
 template <typename T>
 struct GKInternals {
   template <typename... Args>
@@ -136,6 +148,10 @@ struct GKInternals {
   std::unique_ptr<T> value_;
   uint64_t count_ = 0;
   std::atomic_bool is_marked_for_deletion = false;
+  // Plain bool, NOT atomic: every access happens under mutex_ already, and begin_drain() needs the
+  // HOT check and the set to be one indivisible step — an atomic<bool> gives atomicity to each
+  // access individually but not to "check state_ == HOT, then set draining_" as a single unit.
+  bool draining_ = false;
   std::mutex mutex_;  // TODO change to something cheaper?
   std::condition_variable cv_;
   GatekeeperState state_ = GatekeeperState::HOT;
@@ -338,6 +354,17 @@ struct Gatekeeper {
     GKInternals<T> *owner_ = nullptr;
   };
 
+ private:
+  // Shared mint condition for both access() overloads below; caller must hold pimpl_->mutex_.
+  // Factored out so the plain and drain_bypass_t overloads cannot drift apart.
+  std::optional<Accessor> access_locked(bool bypass_drain) {
+    if (pimpl_->value_ && pimpl_->state_ == GatekeeperState::HOT && (bypass_drain || !pimpl_->draining_)) {
+      return Accessor{this};
+    }
+    return std::nullopt;
+  }
+
+ public:
   std::optional<Accessor> access() {
     auto guard = std::unique_lock{pimpl_->mutex_};
     // Intentionally gated ONLY on state_ == HOT, NOT on is_marked_for_deletion: a tenant being deleted
@@ -345,10 +372,26 @@ struct Gatekeeper {
     // caller checks it and releases). access() minting on a marked-but-HOT shell is benign — the minted
     // Accessor's operator bool is false, so callers won't use it, and the count returns to 0 so a
     // waiting ~Gatekeeper proceeds. Adding a marked check here is NOT a correctness requirement.
-    if (pimpl_->value_ && pimpl_->state_ == GatekeeperState::HOT) {
-      return Accessor{this};
-    }
-    return std::nullopt;
+    //
+    // draining_ is different: it IS a hard refusal, not advisory. It is the single choke point that
+    // stops the database-protector factory (dbms::DatabaseHandler::MakeDatabaseProtectorFactory ->
+    // Handler::Get -> here) from re-arming TTL and async-index work on a tenant that is being dropped
+    // — without this refusal the drain would never converge, because freshly-minted work would keep
+    // the tenant HOT and its own Accessor count above the drop's single-flight expectations forever.
+    return access_locked(/*bypass_drain=*/false);
+  }
+
+  // Bypasses the draining_ refusal above. Restricted to deletion/teardown machinery:
+  // Handler<T>::DeferDelete, and DatabaseHandler's destructor / its New() directory-collision scan.
+  // Mandatory, not a convenience: Handler<T>::DeferDelete does
+  //   auto db_acc = itr->second.access(); if (!db_acc) return;
+  // *before* its unconditional items_.erase(itr) — a drain-gated mint there would strand the tenant
+  // in items_ forever: unreachable by name, never destroyed, its name permanently unusable.
+  // Do NOT use this from anything that could win Accessor::try_delete() behind the drop's back —
+  // that is exactly why Handler<T>::TryDelete stays gated on the non-bypass overload above.
+  std::optional<Accessor> access(drain_bypass_t /*tag*/) {
+    auto guard = std::unique_lock{pimpl_->mutex_};
+    return access_locked(/*bypass_drain=*/true);
   }
 
   std::optional<bool> is_marked_for_deletion() const {
@@ -383,8 +426,12 @@ struct Gatekeeper {
   // the managed value, then call finish_suspend().
   bool try_begin_suspend(std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
     auto guard = std::unique_lock{pimpl_->mutex_};
-    // Also refuse null value_: try_delete()'s unlocked window holds count_==1/HOT with value_ moved out.
-    if (!pimpl_->value_ || pimpl_->state_ != GatekeeperState::HOT) return false;
+    // draining_ is refused upfront, alongside the HOT check, NOT folded into the wait_for predicate
+    // below (which must stay count_ == 1 only): a tenant already accepted for deletion must not be
+    // frozen out from under the drop by a competing suspend. value_ is refused too: try_delete()
+    // briefly holds count_ == 1 / state_ == HOT / draining_ == false while ~T runs unlocked after
+    // moving value_ out, and a gatekeeper with nothing to suspend must not enter SUSPENDING.
+    if (!pimpl_->value_ || pimpl_->state_ != GatekeeperState::HOT || pimpl_->draining_) return false;
     if (!pimpl_->cv_.wait_for(guard, timeout, [this] { return pimpl_->count_ == 1; })) {
       return false;
     }
@@ -462,6 +509,41 @@ struct Gatekeeper {
     pimpl_->cv_.notify_all();
   }
 
+  // HOT -> HOT, draining_: false -> true. Deliberately NOT a GatekeeperState transition — see the
+  // note on GatekeeperState above and on draining_ in GKInternals for why a fifth state value would
+  // hang ~Gatekeeper's terminal predicate forever.
+  //
+  // Single-flight CAS *and* the concurrent-SUSPEND/RESUME guard in one atomic step: requires
+  // state_ == HOT (refuses an in-flight SUSPENDING/RESUMING gatekeeper, and a COLD one) AND
+  // !draining_ (a second concurrent DROP loses). Because draining_ can only ever be set here, from
+  // HOT, it is HOT-exclusive for its entire life — that is exactly why ~Gatekeeper's terminal
+  // predicate, begin_resume() (COLD-only), and EraseColdShell/DeleteCold_ (COLD-only) all stay valid
+  // unchanged: none of them can ever observe draining_ == true.
+  //
+  // Returning false is a normal, non-asserting outcome (unlike abort_drain() below): a concurrent
+  // drop or a mid-transition tenant is a legal race that the caller turns into a retriable error.
+  bool begin_drain() {
+    auto guard = std::unique_lock{pimpl_->mutex_};
+    if (pimpl_->state_ != GatekeeperState::HOT || pimpl_->draining_) return false;
+    pimpl_->draining_ = true;
+    pimpl_->cv_.notify_all();
+    return true;
+  }
+
+  // Rolls back begin_drain(). Single disciplined caller (unlike begin_drain()'s legal-race false), so
+  // a DMG_ASSERT tripwire, matching abort_suspend()/abort_resume() above.
+  void abort_drain() {
+    auto guard = std::unique_lock{pimpl_->mutex_};
+    DMG_ASSERT(pimpl_->draining_, "abort_drain() called while not draining");
+    pimpl_->draining_ = false;
+    pimpl_->cv_.notify_all();
+  }
+
+  bool is_draining() const {
+    auto guard = std::unique_lock{pimpl_->mutex_};
+    return pimpl_->draining_;
+  }
+
   ~Gatekeeper() {
     if (!pimpl_) return;  // Moved out, nothing to do
     pimpl_->is_marked_for_deletion = true;
@@ -473,6 +555,10 @@ struct Gatekeeper {
     {
       auto lock = std::unique_lock{pimpl_->mutex_};
       auto const terminal_and_drained = [this] {
+        // Deliberately tests state_ and count_ only — draining_ is an orthogonal flag (see
+        // GatekeeperState's comment above), not a state, so it never enters this predicate and a
+        // draining HOT/COLD gatekeeper stays destructible. Anyone adding a new GatekeeperState value
+        // must extend this predicate too, or a Gatekeeper stuck in that state waits here forever.
         return (pimpl_->state_ == GatekeeperState::HOT || pimpl_->state_ == GatekeeperState::COLD) &&
                pimpl_->count_ == 0;
       };

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -524,7 +524,8 @@ struct Gatekeeper {
   // drop or a mid-transition tenant is a legal race that the caller turns into a retriable error.
   bool begin_drain() {
     auto guard = std::unique_lock{pimpl_->mutex_};
-    if (pimpl_->state_ != GatekeeperState::HOT || pimpl_->draining_) return false;
+    // value_ term: see try_begin_suspend() above -- you cannot drain a gatekeeper that holds nothing.
+    if (!pimpl_->value_ || pimpl_->state_ != GatekeeperState::HOT || pimpl_->draining_) return false;
     pimpl_->draining_ = true;
     pimpl_->cv_.notify_all();
     return true;

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -1692,6 +1692,78 @@ TEST(DBMS_Handler, IdleTenantDropReportsNoForeignHolders) {
   EXPECT_TRUE(del_fut.get().has_value()) << "the drop itself must still succeed once its stall is released";
 }
 
+// PINS 1a82eb021: the FORCE-drop overload (DbmsHandler::Delete(std::string_view, system::Transaction *)
+// -- the two-argument form DROP DATABASE ... FORCE calls, interpreter.cpp) must see a concurrently
+// DRAINING tenant as retriable USING, not NON_EXISTENT. Deleting the is_draining() guard immediately
+// above the GetConfig pre-check in that overload (dbms_handler.cpp) would make this call fall through
+// to GetConfig's !conf branch and reintroduce the "does not exist" misreport for a tenant that plainly
+// does.
+TEST(DBMS_Handler, ForceDropOfADrainingTenantIsRetriableNotMissing) {
+  auto &dbms = *TestEnvironment::get();
+
+  auto new_t = dbms.New("force_drop_race");
+  ASSERT_TRUE(new_t.has_value()) << (int)new_t.error();
+  memgraph::dbms::DatabaseAccess acc = std::move(new_t.value());
+
+  PhaseTwoStall stall{acc};
+  ASSERT_TRUE(stall.WaitUntilRunning()) << "the stalling task must start before the first drop begins";
+  acc.reset();  // not needed as an external holder; the stall alone parks Phase 2
+
+  // First drop: any overload's Phase 1 (begin_drain()) puts the tenant into the same DRAINING state,
+  // so the plain single-argument overload is enough to manufacture the race this test needs.
+  auto del_prom = std::make_shared<std::promise<memgraph::dbms::DbmsHandler::DeleteResult>>();
+  auto del_fut = del_prom->get_future();
+  std::thread dropper([&dbms, del_prom] { del_prom->set_value(dbms.Delete("force_drop_race")); });
+
+  bool cleaned_up = false;
+  auto cleanup = memgraph::utils::OnScopeExit{[&] {
+    if (cleaned_up) return;
+    stall.Release();
+    if (del_fut.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+      dropper.join();
+    } else {
+      dropper.detach();
+    }
+  }};
+
+  const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
+    const auto statuses = dbms.AllWithHotColdStatus();
+    return std::ranges::any_of(statuses,
+                               [](auto const &kv) { return kv.first == "force_drop_race" && kv.second == "DRAINING"; });
+  });
+  ASSERT_TRUE(draining_seen) << "the first drop never reached the DRAINING window this test needs to probe";
+
+  // The call under test: the TWO-argument overload, Delete(std::string_view, system::Transaction *) --
+  // the one DROP DATABASE ... FORCE binds to. The single-argument Delete(std::string_view) used for the
+  // first drop above never had this bug (its Delete_ Phase 1 begin_drain() already returns USING), so
+  // calling it here instead would pass this assertion for the wrong reason. The explicit
+  // system::Transaction* cast on the second argument is belt-and-suspenders: Delete(utils::UUID) and
+  // Delete(std::string_view) both take exactly one argument, so a plain `nullptr` would already bind
+  // unambiguously to this two-argument overload -- the cast just makes that binding visible in the diff.
+  auto [force_ready, force_result] = RunBounded(std::chrono::seconds(2), [&] {
+    return dbms.Delete("force_drop_race", static_cast<memgraph::system::Transaction *>(nullptr));
+  });
+  ASSERT_TRUE(force_ready) << "a FORCE drop racing a DRAINING tenant must return promptly (the is_draining() "
+                              "check runs before Phase 2's lock_-released teardown), not block";
+  ASSERT_TRUE(force_result.has_value());
+  ASSERT_FALSE(force_result->has_value())
+      << "a FORCE drop racing a DRAINING tenant must fail, not silently succeed a second time";
+  EXPECT_EQ(force_result->error(), memgraph::dbms::DeleteError::USING)
+      << "regression: a DRAINING tenant reported via the FORCE-path Delete(name, transaction) overload must "
+         "be USING (retriable), not NON_EXISTENT (the pre-1a82eb021 misreport)";
+
+  stall.Release();
+  const auto del_status = del_fut.wait_for(std::chrono::seconds(5));
+  if (del_status == std::future_status::ready) {
+    dropper.join();
+  } else {
+    dropper.detach();
+  }
+  cleaned_up = true;
+  ASSERT_EQ(del_status, std::future_status::ready) << "the first drop must complete once the stall is released";
+  EXPECT_TRUE(del_fut.get().has_value()) << "the first drop itself must still succeed once its stall is released";
+}
+
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   // gtest takes ownership of the TestEnvironment ptr - we don't delete it.

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -201,8 +201,8 @@ auto RunBounded(std::chrono::milliseconds timeout, F f) -> std::pair<bool, std::
 // (Database::StopAllBackgroundTasks() -> ThreadPool::ShutDown() -> its jthread vector's destructor;
 // see dbms_handler.cpp's Delete_ Phase 2, database.cpp's StopAllBackgroundTasks, and
 // thread_pool.cpp's ShutDown/~ThreadPool) blocks on that jthread join for a bounded, test-controlled
-// window. This gives DRAINING (the window between Delete_'s Phase 1 RecordDetached_ and Phase 3's
-// PromoteDetachedPhase_ -- see the TenantPhase doc in dbms_handler.hpp) an actual, observable witness
+// window. This gives the drain window (between Delete_'s Phase 1 RecordDetached_ and the DeferDelete
+// handoff that erases the gatekeeper from db_handler_) an actual, observable witness
 // instead of inferring it from sleep durations. AddTask()/thread_pool() are public Database API
 // (database.hpp), not a test-only seam.
 class PhaseTwoStall {
@@ -1362,7 +1362,7 @@ TEST(DBMS_Handler, DrainingTenantIsRefusedToTheProtectorFactory) {
   const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
     const auto statuses = dbms.AllWithHotColdStatus();
     return std::ranges::any_of(statuses,
-                               [](auto const &kv) { return kv.first == "protector_seam" && kv.second == "DRAINING"; });
+                               [](auto const &kv) { return kv.first == "protector_seam" && kv.second == "DETACHED"; });
   });
   ASSERT_TRUE(draining_seen) << "the drop never reached the DRAINING window this test needs to probe";
 
@@ -1423,7 +1423,7 @@ TEST(DBMS_Handler, DropDoesNotHoldTheHandlerLockDuringTeardown) {
   const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
     const auto statuses = dbms.AllWithHotColdStatus();
     return std::ranges::any_of(
-        statuses, [](auto const &kv) { return kv.first == "lock_teardown_target" && kv.second == "DRAINING"; });
+        statuses, [](auto const &kv) { return kv.first == "lock_teardown_target" && kv.second == "DETACHED"; });
   });
   ASSERT_TRUE(draining_seen) << "the drop never reached the DRAINING window this test needs to probe";
 
@@ -1526,8 +1526,9 @@ TEST(DBMS_Handler, ConcurrentSuspendAgainstADrainingDropDoesNotDeadlock) {
   }
 }
 
-// PINS the visibility/accounting guarantee AllWithHotColdStatus/TenantMemorySum/AllDetached give during
-// Phase 2 specifically (DRAINING) -- not just after full DETACHED, which
+// PINS the visibility/accounting guarantee AllWithHotColdStatus/TenantMemorySum/AllDetached give while
+// the tenant is still draining (Phase 2, draining_ set, gatekeeper still IN db_handler_) -- not just
+// after db_handler_ has erased it, which
 // DetachedTenantMemoryStaysAttributableWhileUnaddressable above already covers. A regression that let a
 // draining tenant's plain access() succeed (see TenantMemorySum's comment, dbms_handler.hpp) would
 // double-count it here (once HOT, once detached) or drop it from both totals.
@@ -1582,17 +1583,15 @@ TEST(DBMS_Handler, DrainingTenantIsVisibleAndCountedExactlyOnce) {
 
   const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
     const auto all_detached = dbms.AllDetached();
-    return std::ranges::any_of(all_detached, [&](auto const &d) {
-      return d.uuid == tenant_uuid && d.phase == memgraph::dbms::DbmsHandler::TenantPhase::DRAINING;
-    });
+    return std::ranges::any_of(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });
   });
   ASSERT_TRUE(draining_seen) << "the drop never reached the DRAINING window this test needs to probe";
 
   {
     const auto statuses = dbms.AllWithHotColdStatus();
     const auto draining_count = std::ranges::count_if(
-        statuses, [](auto const &kv) { return kv.first == "draining_visibility_probe" && kv.second == "DRAINING"; });
-    EXPECT_EQ(draining_count, 1) << "a draining tenant must be listed exactly once, as DRAINING";
+        statuses, [](auto const &kv) { return kv.first == "draining_visibility_probe" && kv.second == "DETACHED"; });
+    EXPECT_EQ(draining_count, 1) << "a draining tenant must be listed exactly once, as DETACHED";
     EXPECT_TRUE(std::ranges::none_of(statuses, [](auto const &kv) {
       return kv.first == "draining_visibility_probe" && kv.second == "HOT";
     })) << "a draining tenant must not ALSO be reported HOT";
@@ -1609,8 +1608,6 @@ TEST(DBMS_Handler, DrainingTenantIsVisibleAndCountedExactlyOnce) {
     const auto all_detached = dbms.AllDetached();
     const auto matches = std::ranges::count_if(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });
     ASSERT_EQ(matches, 1) << "exactly one detached row must exist for this tenant while it drains";
-    const auto it = std::ranges::find_if(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });
-    EXPECT_EQ(it->phase, memgraph::dbms::DbmsHandler::TenantPhase::DRAINING);
   }
 
   stall.Release();
@@ -1667,9 +1664,7 @@ TEST(DBMS_Handler, IdleTenantDropReportsNoForeignHolders) {
   std::optional<uint64_t> holders_at_detach;
   const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
     const auto all_detached = dbms.AllDetached();
-    const auto it = std::ranges::find_if(all_detached, [&](auto const &d) {
-      return d.uuid == tenant_uuid && d.phase == memgraph::dbms::DbmsHandler::TenantPhase::DRAINING;
-    });
+    const auto it = std::ranges::find_if(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });
     if (it == all_detached.end()) return false;
     holders_at_detach = it->holders_at_detach;
     return true;
@@ -1729,7 +1724,7 @@ TEST(DBMS_Handler, ForceDropOfADrainingTenantIsRetriableNotMissing) {
   const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
     const auto statuses = dbms.AllWithHotColdStatus();
     return std::ranges::any_of(statuses,
-                               [](auto const &kv) { return kv.first == "force_drop_race" && kv.second == "DRAINING"; });
+                               [](auto const &kv) { return kv.first == "force_drop_race" && kv.second == "DETACHED"; });
   });
   ASSERT_TRUE(draining_seen) << "the first drop never reached the DRAINING window this test needs to probe";
 

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -16,11 +16,17 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <future>
+#include <latch>
+#include <mutex>
+#include <optional>
 #include <system_error>
 #include <thread>
+#include <utility>
 
 #include <nlohmann/json.hpp>
 
@@ -37,6 +43,7 @@
 #include "system/system.hpp"
 #include "tests/test_commit_args_helper.hpp"
 #include "utils/memory_tracker.hpp"
+#include "utils/on_scope_exit.hpp"
 #include "utils/uuid.hpp"
 
 namespace {
@@ -169,6 +176,72 @@ bool WaitUntil(std::chrono::milliseconds timeout, Pred &&pred) {
   } while (std::chrono::steady_clock::now() < deadline);
   return pred();
 }
+
+// Runs `f` on its own thread and waits up to `timeout`. Returns {true, f()'s result} if it finished in
+// time. On timeout it detaches instead of joining -- the promise is heap-owned via shared_ptr, so a
+// detached thread finishing later (or never, e.g. it is itself wedged) is safe, not a dangling
+// reference -- and returns {false, std::nullopt}, so a hang FAILs only the calling assertion, never
+// the whole binary. Mirrors hot_cold_gatekeeper.cpp's DtorOfDrainingGatekeeperReturnsPromptly.
+template <typename F>
+auto RunBounded(std::chrono::milliseconds timeout, F f) -> std::pair<bool, std::optional<std::invoke_result_t<F>>> {
+  using T = std::invoke_result_t<F>;
+  auto prom = std::make_shared<std::promise<T>>();
+  auto fut = prom->get_future();
+  std::thread worker([f = std::move(f), prom]() mutable { prom->set_value(f()); });
+  const auto status = fut.wait_for(timeout);
+  if (status == std::future_status::ready) {
+    worker.join();
+    return {true, fut.get()};
+  }
+  worker.detach();
+  return {false, std::nullopt};
+}
+
+// Wedges a tenant's after-commit-trigger thread pool mid-task so a concurrent Delete()'s Phase 2
+// (Database::StopAllBackgroundTasks() -> ThreadPool::ShutDown() -> its jthread vector's destructor;
+// see dbms_handler.cpp's Delete_ Phase 2, database.cpp's StopAllBackgroundTasks, and
+// thread_pool.cpp's ShutDown/~ThreadPool) blocks on that jthread join for a bounded, test-controlled
+// window. This gives DRAINING (the window between Delete_'s Phase 1 RecordDetached_ and Phase 3's
+// PromoteDetachedPhase_ -- see the TenantPhase doc in dbms_handler.hpp) an actual, observable witness
+// instead of inferring it from sleep durations. AddTask()/thread_pool() are public Database API
+// (database.hpp), not a test-only seam.
+class PhaseTwoStall {
+ public:
+  explicit PhaseTwoStall(memgraph::dbms::DatabaseAccess &acc) {
+    acc->AddTask([this] {
+      {
+        std::lock_guard<std::mutex> set_running(mtx_);
+        running_ = true;
+      }
+      running_cv_.notify_all();
+      std::unique_lock<std::mutex> wait_lock(mtx_);
+      // 10s is a safety net only, in case a test forgets to call Release() (e.g. an early ASSERT
+      // return): every caller below releases well inside that bound.
+      released_cv_.wait_for(wait_lock, std::chrono::seconds(10), [this] { return released_; });
+    });
+  }
+
+  // False (not a hang) if the pool's single worker never dequeues the stalling task within `timeout`.
+  bool WaitUntilRunning(std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+    std::unique_lock<std::mutex> lock(mtx_);
+    return running_cv_.wait_for(lock, timeout, [this] { return running_; });
+  }
+
+  void Release() {
+    {
+      std::lock_guard<std::mutex> lock(mtx_);
+      released_ = true;
+    }
+    released_cv_.notify_all();
+  }
+
+ private:
+  std::mutex mtx_;
+  std::condition_variable running_cv_;
+  std::condition_variable released_cv_;
+  bool running_ = false;
+  bool released_ = false;
+};
 }  // namespace
 
 // Global
@@ -1246,6 +1319,377 @@ TEST(DBMS_Handler, TwoDetachedTenantsCanShareANameAndAreCountedByUuid) {
 
   const auto statuses_after_drain = dbms.AllWithHotColdStatus();
   EXPECT_TRUE(std::ranges::none_of(statuses_after_drain, [](auto const &kv) { return kv.first == "detached_reuse"; }));
+}
+
+// PINS: MakeDatabaseProtectorFactory's DRAIN GUARANTEE (database_handler.hpp) -- TTL (ttl.cpp) and the
+// async indexer (async_indexer.cpp) both re-mint a DatabaseProtector via Storage::make_database_protector()
+// per work item; if a draining tenant stayed reachable through that factory, either could hold a live
+// DatabaseAccess indefinitely and the drain would never converge. Exercises the real seam
+// (Storage::make_database_protector(), storage.hpp) rather than a hand-rolled lookup.
+TEST(DBMS_Handler, DrainingTenantIsRefusedToTheProtectorFactory) {
+  auto &dbms = *TestEnvironment::get();
+
+  auto new_t = dbms.New("protector_seam");
+  ASSERT_TRUE(new_t.has_value()) << (int)new_t.error();
+  // Held for the whole test: `storage` (and the Database it belongs to) stays alive across the drop
+  // below only because this accessor keeps DeferDelete's destruction deferred (count > 0).
+  memgraph::dbms::DatabaseAccess acc = std::move(new_t.value());
+  auto *storage = acc->storage();
+
+  {
+    auto protector = storage->make_database_protector();
+    EXPECT_NE(protector, nullptr) << "a HOT tenant must still be protectable (TTL/async-indexer re-arm)";
+  }
+
+  PhaseTwoStall stall{acc};
+  ASSERT_TRUE(stall.WaitUntilRunning()) << "the stalling task must start before the drop begins";
+
+  auto del_prom = std::make_shared<std::promise<memgraph::dbms::DbmsHandler::DeleteResult>>();
+  auto del_fut = del_prom->get_future();
+  std::thread dropper([&dbms, del_prom] { del_prom->set_value(dbms.Delete("protector_seam")); });
+
+  bool cleaned_up = false;
+  auto cleanup = memgraph::utils::OnScopeExit{[&] {
+    if (cleaned_up) return;
+    stall.Release();
+    if (del_fut.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+      dropper.join();
+    } else {
+      dropper.detach();
+    }
+  }};
+
+  const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
+    const auto statuses = dbms.AllWithHotColdStatus();
+    return std::ranges::any_of(statuses,
+                               [](auto const &kv) { return kv.first == "protector_seam" && kv.second == "DRAINING"; });
+  });
+  ASSERT_TRUE(draining_seen) << "the drop never reached the DRAINING window this test needs to probe";
+
+  auto protector_while_draining = storage->make_database_protector();
+  EXPECT_EQ(protector_while_draining, nullptr)
+      << "a draining tenant must not be re-armable via the protector factory -- TTL/the async indexer "
+         "would otherwise keep minting accessors and the drain would never converge";
+
+  stall.Release();
+  const auto del_status = del_fut.wait_for(std::chrono::seconds(5));
+  if (del_status == std::future_status::ready) {
+    dropper.join();
+  } else {
+    dropper.detach();
+  }
+  cleaned_up = true;
+  ASSERT_EQ(del_status, std::future_status::ready) << "the drop must complete once the stall is released";
+  EXPECT_TRUE(del_fut.get().has_value()) << "the drop itself must still succeed once its stall is released";
+
+  acc.reset();
+  const bool retired = WaitUntil(std::chrono::seconds(10), [&] {
+    const auto all_detached = dbms.AllDetached();
+    return std::ranges::none_of(all_detached, [](auto const &d) { return d.name == "protector_seam"; });
+  });
+  EXPECT_TRUE(retired) << "protector_seam's row must retire once its accessor is released";
+}
+
+// PINS constraint C8 -- Delete_'s Phase 2 (StopAllBackgroundTasks/streams()->DropAll()) must run with
+// lock_ released, so an unrelated tenant's own exclusive-lock_ operation is never blocked behind this
+// drop's teardown. This is the reason the three-phase split (dbms_handler.cpp's Delete_ doc comment)
+// exists at all.
+TEST(DBMS_Handler, DropDoesNotHoldTheHandlerLockDuringTeardown) {
+  auto &dbms = *TestEnvironment::get();
+
+  auto new_t = dbms.New("lock_teardown_target");
+  ASSERT_TRUE(new_t.has_value()) << (int)new_t.error();
+  memgraph::dbms::DatabaseAccess acc = std::move(new_t.value());
+
+  PhaseTwoStall stall{acc};
+  ASSERT_TRUE(stall.WaitUntilRunning()) << "the stalling task must start before the drop begins";
+  acc.reset();  // not needed as an external holder; the stall alone parks Phase 2
+
+  auto del_prom = std::make_shared<std::promise<memgraph::dbms::DbmsHandler::DeleteResult>>();
+  auto del_fut = del_prom->get_future();
+  std::thread dropper([&dbms, del_prom] { del_prom->set_value(dbms.Delete("lock_teardown_target")); });
+
+  bool cleaned_up = false;
+  auto cleanup = memgraph::utils::OnScopeExit{[&] {
+    if (cleaned_up) return;
+    stall.Release();
+    if (del_fut.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+      dropper.join();
+    } else {
+      dropper.detach();
+    }
+  }};
+
+  const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
+    const auto statuses = dbms.AllWithHotColdStatus();
+    return std::ranges::any_of(
+        statuses, [](auto const &kv) { return kv.first == "lock_teardown_target" && kv.second == "DRAINING"; });
+  });
+  ASSERT_TRUE(draining_seen) << "the drop never reached the DRAINING window this test needs to probe";
+
+  // Prove -- not infer from timing -- that lock_ is free: New() (std::lock_guard{lock_}, exclusive) for
+  // a DIFFERENT tenant must complete well inside the stall's window while this drop sits in Phase 2.
+  auto [other_ready, other_result] =
+      RunBounded(std::chrono::seconds(2), [&] { return dbms.New("lock_teardown_other"); });
+  EXPECT_TRUE(other_ready) << "a different tenant's New() must not block on lock_ while this drop's Phase 2 "
+                              "(off-lock teardown) is in flight -- a regression re-holding lock_ across the "
+                              "teardown would hang this call instead of returning";
+  if (other_ready) {
+    ASSERT_TRUE(other_result.has_value());
+    EXPECT_TRUE(other_result->has_value()) << "the other tenant's creation must actually succeed";
+  }
+
+  stall.Release();
+  const auto del_status = del_fut.wait_for(std::chrono::seconds(5));
+  if (del_status == std::future_status::ready) {
+    dropper.join();
+  } else {
+    dropper.detach();
+  }
+  cleaned_up = true;
+  ASSERT_EQ(del_status, std::future_status::ready) << "the drop must complete once the stall is released";
+  EXPECT_TRUE(del_fut.get().has_value()) << "the drop itself must still succeed once its stall is released";
+}
+
+// PINS the ad88a52fe class of regression against the new three-phase drop: a concurrent SUSPEND and
+// DROP racing on the SAME tenant must never deadlock. Suspend_'s shared-lock_ phases and Delete_'s
+// exclusive-lock_ Phase 1 are mutually exclusive under lock_, so exactly one side must observe the
+// other's already-committed state and fail cleanly and retriably -- never block forever.
+TEST(DBMS_Handler, ConcurrentSuspendAgainstADrainingDropDoesNotDeadlock) {
+  auto &dbms = *TestEnvironment::get();
+
+  auto new_t = dbms.New("suspend_drop_race");
+  ASSERT_TRUE(new_t.has_value()) << (int)new_t.error();
+  memgraph::dbms::DatabaseAccess acc = std::move(new_t.value());
+  // Release: an outstanding accessor would make Suspend_'s try_begin_suspend() fail
+  // ACTIVE_CONNECTIONS regardless of the drop, which would defeat the race this test wants to force.
+  acc.reset();
+
+  std::latch start_gate{2};
+  auto del_prom = std::make_shared<std::promise<memgraph::dbms::DbmsHandler::DeleteResult>>();
+  auto susp_prom = std::make_shared<std::promise<memgraph::dbms::DbmsHandler::SuspendResult>>();
+  auto del_fut = del_prom->get_future();
+  auto susp_fut = susp_prom->get_future();
+
+  std::thread dropper([&dbms, &start_gate, del_prom] {
+    start_gate.arrive_and_wait();
+    del_prom->set_value(dbms.Delete("suspend_drop_race"));
+  });
+  std::thread suspender([&dbms, &start_gate, susp_prom] {
+    start_gate.arrive_and_wait();
+    susp_prom->set_value(dbms.Suspend("suspend_drop_race"));
+  });
+
+  constexpr auto kBound = std::chrono::seconds(5);
+  const auto del_status = del_fut.wait_for(kBound);
+  const auto susp_status = susp_fut.wait_for(kBound);
+
+  if (del_status == std::future_status::ready) {
+    dropper.join();
+  } else {
+    dropper.detach();
+  }
+  if (susp_status == std::future_status::ready) {
+    suspender.join();
+  } else {
+    suspender.detach();
+  }
+
+  ASSERT_EQ(del_status, std::future_status::ready)
+      << "DROP must return within " << kBound.count() << "s even racing a concurrent SUSPEND, not deadlock";
+  ASSERT_EQ(susp_status, std::future_status::ready)
+      << "SUSPEND must return within " << kBound.count() << "s even racing a concurrent DROP, not deadlock";
+
+  const auto del_result = del_fut.get();
+  const auto susp_result = susp_fut.get();
+  const bool del_won = del_result.has_value();
+  const bool susp_won = susp_result.has_value();
+
+  EXPECT_TRUE(del_won != susp_won) << "exactly one of DROP/SUSPEND must win the race for the same tenant (del="
+                                   << del_won << " susp=" << susp_won << ")";
+
+  if (!del_won) {
+    EXPECT_EQ(del_result.error(), memgraph::dbms::DeleteError::USING)
+        << "a DROP that loses to a concurrent SUSPEND must be retriable USING, not a hard failure";
+  }
+  if (!susp_won) {
+    EXPECT_EQ(susp_result.error(), memgraph::dbms::DbmsHandler::SuspendError::NON_EXISTENT)
+        << "a SUSPEND that loses to a concurrent DROP must see the (now-draining) tenant as gone "
+           "(NON_EXISTENT, drain-gated Get()), not deadlock or observe torn state";
+  }
+
+  // Whichever won, clean up so later tests are unaffected: a winning SUSPEND leaves a COLD shell
+  // (drop it here); a winning DROP with no external holder already retired inline (nothing to do).
+  if (susp_won) {
+    auto cold_drop = dbms.Delete("suspend_drop_race");
+    EXPECT_TRUE(cold_drop.has_value()) << "cleanup: dropping the now-COLD tenant must succeed";
+  }
+}
+
+// PINS the visibility/accounting guarantee AllWithHotColdStatus/TenantMemorySum/AllDetached give during
+// Phase 2 specifically (DRAINING) -- not just after full DETACHED, which
+// DetachedTenantMemoryStaysAttributableWhileUnaddressable above already covers. A regression that let a
+// draining tenant's plain access() succeed (see TenantMemorySum's comment, dbms_handler.hpp) would
+// double-count it here (once HOT, once detached) or drop it from both totals.
+TEST(DBMS_Handler, DrainingTenantIsVisibleAndCountedExactlyOnce) {
+  auto &dbms = *TestEnvironment::get();
+
+  auto new_t = dbms.New("draining_visibility_probe");
+  ASSERT_TRUE(new_t.has_value()) << (int)new_t.error();
+  memgraph::dbms::DatabaseAccess acc = std::move(new_t.value());
+  const auto tenant_uuid = acc->uuid();
+
+  constexpr size_t kNumVertices = 3000;
+  constexpr size_t kPropertyBytes = 1024;
+  const std::string blob(kPropertyBytes, 'd');
+  {
+    // DbArenaScope required -- see StuckOrphanDoesNotStarveAnotherTenantsDeferredDelete above.
+    memgraph::memory::DbArenaScope db_arena_scope{acc.get()};
+    auto storage_acc = acc->Access();
+    ASSERT_TRUE(storage_acc);
+    const auto property = storage_acc->NameToProperty("payload");
+    for (size_t i = 0; i < kNumVertices; ++i) {
+      auto vertex = storage_acc->CreateVertex();
+      ASSERT_TRUE(vertex.SetProperty(property, memgraph::storage::PropertyValue(blob)).has_value());
+    }
+    ASSERT_TRUE(storage_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  const int64_t footprint = acc->DbMemoryUsage();
+  ASSERT_GT(footprint, static_cast<int64_t>(kNumVertices * kPropertyBytes))
+      << "the footprint must be unambiguous before it is used as a tolerance baseline below";
+  const auto before = dbms.TenantMemorySum();
+  ASSERT_GE(before.hot, footprint);
+
+  PhaseTwoStall stall{acc};
+  ASSERT_TRUE(stall.WaitUntilRunning()) << "the stalling task must start before the drop begins";
+  acc.reset();
+
+  auto del_prom = std::make_shared<std::promise<memgraph::dbms::DbmsHandler::DeleteResult>>();
+  auto del_fut = del_prom->get_future();
+  std::thread dropper([&dbms, del_prom] { del_prom->set_value(dbms.Delete("draining_visibility_probe")); });
+
+  bool cleaned_up = false;
+  auto cleanup = memgraph::utils::OnScopeExit{[&] {
+    if (cleaned_up) return;
+    stall.Release();
+    if (del_fut.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+      dropper.join();
+    } else {
+      dropper.detach();
+    }
+  }};
+
+  const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
+    const auto all_detached = dbms.AllDetached();
+    return std::ranges::any_of(all_detached, [&](auto const &d) {
+      return d.uuid == tenant_uuid && d.phase == memgraph::dbms::DbmsHandler::TenantPhase::DRAINING;
+    });
+  });
+  ASSERT_TRUE(draining_seen) << "the drop never reached the DRAINING window this test needs to probe";
+
+  {
+    const auto statuses = dbms.AllWithHotColdStatus();
+    const auto draining_count = std::ranges::count_if(
+        statuses, [](auto const &kv) { return kv.first == "draining_visibility_probe" && kv.second == "DRAINING"; });
+    EXPECT_EQ(draining_count, 1) << "a draining tenant must be listed exactly once, as DRAINING";
+    EXPECT_TRUE(std::ranges::none_of(statuses, [](auto const &kv) {
+      return kv.first == "draining_visibility_probe" && kv.second == "HOT";
+    })) << "a draining tenant must not ALSO be reported HOT";
+  }
+  {
+    const auto during = dbms.TenantMemorySum();
+    const int64_t tolerance = footprint / 10;
+    EXPECT_LE(during.hot, before.hot - (footprint - tolerance))
+        << "a draining tenant's plain access() must be refused, so it must NOT contribute to the HOT half";
+    EXPECT_GE(during.detached, footprint - tolerance)
+        << "its bytes must be attributed via the detached half while draining, or they vanish from every total";
+  }
+  {
+    const auto all_detached = dbms.AllDetached();
+    const auto matches = std::ranges::count_if(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });
+    ASSERT_EQ(matches, 1) << "exactly one detached row must exist for this tenant while it drains";
+    const auto it = std::ranges::find_if(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });
+    EXPECT_EQ(it->phase, memgraph::dbms::DbmsHandler::TenantPhase::DRAINING);
+  }
+
+  stall.Release();
+  const auto del_status = del_fut.wait_for(std::chrono::seconds(5));
+  if (del_status == std::future_status::ready) {
+    dropper.join();
+  } else {
+    dropper.detach();
+  }
+  cleaned_up = true;
+  ASSERT_EQ(del_status, std::future_status::ready) << "the drop must complete once the stall is released";
+  EXPECT_TRUE(del_fut.get().has_value()) << "the drop itself must still succeed once its stall is released";
+
+  const bool retired = WaitUntil(std::chrono::seconds(10), [&] {
+    const auto all_detached = dbms.AllDetached();
+    return std::ranges::none_of(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });
+  });
+  EXPECT_TRUE(retired) << "draining_visibility_probe's row must retire once the drop completes";
+}
+
+// PINS holders_at_detach's documented meaning ("holders OTHER than the dropper", DetachedTenant's doc
+// in dbms_handler.hpp) for the common idle case: an otherwise-unheld tenant's own drop must record 0,
+// not 1 (the drop's own drain_bypass mint counted as if it were a foreign holder) and not UINT64_MAX
+// (the saturating-clamp underflow the "holders" comment in Delete_, dbms_handler.cpp, guards against).
+TEST(DBMS_Handler, IdleTenantDropReportsNoForeignHolders) {
+  auto &dbms = *TestEnvironment::get();
+
+  auto new_t = dbms.New("idle_holders_probe");
+  ASSERT_TRUE(new_t.has_value()) << (int)new_t.error();
+  memgraph::dbms::DatabaseAccess acc = std::move(new_t.value());
+  const auto tenant_uuid = acc->uuid();
+
+  PhaseTwoStall stall{acc};
+  ASSERT_TRUE(stall.WaitUntilRunning()) << "the stalling task must start before the drop begins";
+  // Idle: release our OWN accessor before dropping, so the only live accessor when Delete_'s Phase 1
+  // reads holder_count() is its own drain_bypass mint -- the case the "holders" subtraction documents.
+  acc.reset();
+
+  auto del_prom = std::make_shared<std::promise<memgraph::dbms::DbmsHandler::DeleteResult>>();
+  auto del_fut = del_prom->get_future();
+  std::thread dropper([&dbms, del_prom] { del_prom->set_value(dbms.Delete("idle_holders_probe")); });
+
+  bool cleaned_up = false;
+  auto cleanup = memgraph::utils::OnScopeExit{[&] {
+    if (cleaned_up) return;
+    stall.Release();
+    if (del_fut.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+      dropper.join();
+    } else {
+      dropper.detach();
+    }
+  }};
+
+  std::optional<uint64_t> holders_at_detach;
+  const bool draining_seen = WaitUntil(std::chrono::seconds(5), [&] {
+    const auto all_detached = dbms.AllDetached();
+    const auto it = std::ranges::find_if(all_detached, [&](auto const &d) {
+      return d.uuid == tenant_uuid && d.phase == memgraph::dbms::DbmsHandler::TenantPhase::DRAINING;
+    });
+    if (it == all_detached.end()) return false;
+    holders_at_detach = it->holders_at_detach;
+    return true;
+  });
+  ASSERT_TRUE(draining_seen) << "the drop never reached the DRAINING window this test needs to probe";
+  ASSERT_TRUE(holders_at_detach.has_value()) << "the row must have been observed to record a value at all";
+  EXPECT_EQ(*holders_at_detach, 0u)
+      << "an idle tenant (no accessor besides the drop's own drain_bypass mint) must record zero foreign "
+         "holders, not 1 (the dropper's own accessor left uncorrected) and not UINT64_MAX (a clamp underflow)";
+
+  stall.Release();
+  const auto del_status = del_fut.wait_for(std::chrono::seconds(5));
+  if (del_status == std::future_status::ready) {
+    dropper.join();
+  } else {
+    dropper.detach();
+  }
+  cleaned_up = true;
+  ASSERT_EQ(del_status, std::future_status::ready) << "the drop must complete once the stall is released";
+  EXPECT_TRUE(del_fut.get().has_value()) << "the drop itself must still succeed once its stall is released";
 }
 
 int main(int argc, char *argv[]) {

--- a/tests/unit/dbms_handler.cpp
+++ b/tests/unit/dbms_handler.cpp
@@ -1556,11 +1556,13 @@ TEST(DBMS_Handler, DrainingTenantIsVisibleAndCountedExactlyOnce) {
     ASSERT_TRUE(storage_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 
+#if USE_JEMALLOC
   const int64_t footprint = acc->DbMemoryUsage();
   ASSERT_GT(footprint, static_cast<int64_t>(kNumVertices * kPropertyBytes))
       << "the footprint must be unambiguous before it is used as a tolerance baseline below";
   const auto before = dbms.TenantMemorySum();
   ASSERT_GE(before.hot, footprint);
+#endif
 
   PhaseTwoStall stall{acc};
   ASSERT_TRUE(stall.WaitUntilRunning()) << "the stalling task must start before the drop begins";
@@ -1596,6 +1598,7 @@ TEST(DBMS_Handler, DrainingTenantIsVisibleAndCountedExactlyOnce) {
       return kv.first == "draining_visibility_probe" && kv.second == "HOT";
     })) << "a draining tenant must not ALSO be reported HOT";
   }
+#if USE_JEMALLOC
   {
     const auto during = dbms.TenantMemorySum();
     const int64_t tolerance = footprint / 10;
@@ -1604,6 +1607,7 @@ TEST(DBMS_Handler, DrainingTenantIsVisibleAndCountedExactlyOnce) {
     EXPECT_GE(during.detached, footprint - tolerance)
         << "its bytes must be attributed via the detached half while draining, or they vanish from every total";
   }
+#endif
   {
     const auto all_detached = dbms.AllDetached();
     const auto matches = std::ranges::count_if(all_detached, [&](auto const &d) { return d.uuid == tenant_uuid; });

--- a/tests/unit/hot_cold_gatekeeper.cpp
+++ b/tests/unit/hot_cold_gatekeeper.cpp
@@ -11,6 +11,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <future>
+#include <memory>
 #include <optional>
 #include <thread>
 
@@ -496,4 +498,199 @@ TEST(HotColdGatekeeper, DeferDeleteDoesNotHeadOfLineBlockAnotherEntry) {
     ASSERT_LT(std::chrono::steady_clock::now(), drain_deadline) << "\"stuck\" was not destroyed after being released";
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
+}
+
+// ---------------------------------------------------------------------------
+// DrainingRefusesNewAccessButNotTheDropPath
+// ---------------------------------------------------------------------------
+// PINS: draining_ gates minting, not use. begin_drain() must flip plain access() to nullopt while
+// leaving access(drain_bypass) minting and leaving an already-live Accessor (taken before the
+// drain started) fully usable and still counted.
+TEST(HotColdGatekeeper, DrainingRefusesNewAccessButNotTheDropPath) {
+  auto gk = make_hot();
+
+  // Minted BEFORE the drain starts.
+  auto pre_existing = gk.access();
+  ASSERT_TRUE(pre_existing.has_value());
+  EXPECT_EQ(gk.holder_count(), 1u);
+
+  ASSERT_TRUE(gk.begin_drain());
+  EXPECT_TRUE(gk.is_draining());
+
+  // New plain access() must now be refused.
+  EXPECT_FALSE(gk.access().has_value());
+
+  // The drop path's bypass overload still mints.
+  auto bypass_acc = gk.access(drain_bypass);
+  ASSERT_TRUE(bypass_acc.has_value());
+  EXPECT_EQ(gk.holder_count(), 2u);
+
+  // The accessor minted before the drain remains usable and still contributes to the count -- the
+  // flag gates minting, not use of an already-live accessor.
+  EXPECT_EQ((*pre_existing)->v, 42);
+  EXPECT_TRUE(static_cast<bool>(*pre_existing));
+
+  bypass_acc->reset();
+  pre_existing->reset();
+  gk.abort_drain();
+}
+
+// ---------------------------------------------------------------------------
+// BeginDrainIsSingleFlightAndHotGated
+// ---------------------------------------------------------------------------
+// PINS: begin_drain() is a single-flight CAS gated on state_ == HOT: a second concurrent drain must
+// lose, abort_drain() must let a later drain win again, and a COLD shell or a SUSPENDING gatekeeper
+// (in-flight transition) must refuse the drain outright.
+TEST(HotColdGatekeeper, BeginDrainIsSingleFlightAndHotGated) {
+  auto gk = make_hot();
+
+  // First begin_drain() wins the single-flight token.
+  EXPECT_TRUE(gk.begin_drain());
+  EXPECT_TRUE(gk.is_draining());
+
+  // A concurrent second begin_drain() must see draining_ already set and lose.
+  EXPECT_FALSE(gk.begin_drain());
+
+  // abort_drain() rolls the flag back; access() and a fresh begin_drain() both work again.
+  gk.abort_drain();
+  EXPECT_FALSE(gk.is_draining());
+  auto acc = gk.access();
+  ASSERT_TRUE(acc.has_value());
+  acc->reset();
+
+  EXPECT_TRUE(gk.begin_drain());
+  gk.abort_drain();
+
+  // HOT-gated: a COLD shell must refuse begin_drain() outright.
+  auto cold = GK{cold_shell};
+  ASSERT_EQ(cold.state(), State::COLD);
+  EXPECT_FALSE(cold.begin_drain());
+
+  // Also refused while a suspend is in flight (SUSPENDING) -- reachable with the existing
+  // try_begin_suspend() helper, no new scaffolding needed.
+  auto gk2 = make_hot();
+  auto suspend_acc = gk2.access();
+  ASSERT_TRUE(suspend_acc.has_value());
+  ASSERT_TRUE(gk2.try_begin_suspend(std::chrono::milliseconds(200)));
+  ASSERT_EQ(gk2.state(), State::SUSPENDING);
+  EXPECT_FALSE(gk2.begin_drain());
+  suspend_acc->reset();
+  gk2.abort_suspend();
+}
+
+// ---------------------------------------------------------------------------
+// DtorOfDrainingGatekeeperReturnsPromptly
+// ---------------------------------------------------------------------------
+// The wedge regression. PINS: ~Gatekeeper waits on (state_ == HOT || state_ == COLD) && count_ == 0.
+// draining_ is deliberately a flag layered on top of HOT, NOT a fifth GatekeeperState value -- had
+// begin_drain() instead flipped state_ to some DRAINING enumerator, that predicate would never
+// recognize it as terminal and this destructor would block forever.
+TEST(HotColdGatekeeper, DtorOfDrainingGatekeeperReturnsPromptly) {
+  auto gk = std::make_unique<GK>(7);
+  ASSERT_TRUE(gk->begin_drain());
+  EXPECT_TRUE(gk->is_draining());
+  // No live accessors: count_ is already 0, so the terminal-state half of the wait predicate is the
+  // only thing in question here.
+  EXPECT_EQ(gk->holder_count(), 0u);
+
+  auto done = std::make_shared<std::promise<void>>();
+  auto done_future = done->get_future();
+  // `gk` and a copy of the shared_ptr `done` are moved/copied into the thread's closure so both stay
+  // alive even if this test has to detach the thread below (a hung ~Gatekeeper must not dangle-deref
+  // a stack-local promise).
+  std::thread destroyer([gk = std::move(gk), done]() mutable {
+    gk.reset();  // Runs ~Gatekeeper() with draining_ == true and count_ == 0.
+    done->set_value();
+  });
+
+  constexpr auto kBound = std::chrono::seconds(2);
+  auto const status = done_future.wait_for(kBound);
+  if (status == std::future_status::ready) {
+    destroyer.join();
+  } else {
+    // A hung ~Gatekeeper must not wedge the whole test binary: detach and let the ASSERT below fail
+    // the test instead of blocking join() forever.
+    destroyer.detach();
+  }
+  ASSERT_EQ(status, std::future_status::ready)
+      << "~Gatekeeper did not return within " << kBound.count() << "s while draining_ was set.";
+}
+
+// ---------------------------------------------------------------------------
+// DeferDeleteOfADrainingEntryStillErasesIt
+// ---------------------------------------------------------------------------
+// The strand-forever hazard. PINS: Handler<T>::DeferDelete must mint its own accessor via
+// access(drain_bypass), not the plain drain-gated access() -- otherwise it would `return` before its
+// unconditional items_.erase(itr), and a draining entry would stay in the map forever: unreachable
+// by name, never destroyed.
+TEST(HotColdGatekeeper, DeferDeleteOfADrainingEntryStillErasesIt) {
+  std::atomic<bool> destroyed{false};
+  std::atomic<bool> callback_fired{false};
+  memgraph::dbms::Handler<DeferDeleteProbe> handler;
+
+  auto new_result = handler.New(std::piecewise_construct, "draining_probe", &destroyed, std::chrono::milliseconds(0));
+  ASSERT_TRUE(new_result.has_value());
+  auto held_acc = std::move(*new_result);
+  ASSERT_TRUE(held_acc);
+
+  // Drain the in-map gatekeeper directly, the way the drop path does before calling DeferDelete.
+  auto *gk = handler.GetGatekeeper("draining_probe");
+  ASSERT_NE(gk, nullptr);
+  ASSERT_TRUE(gk->begin_drain());
+
+  // held_acc + DeferDelete's own drain_bypass mint push count_ to 2, so try_delete()'s count_==1
+  // check times out and this takes the deferred path.
+  handler.DeferDelete("draining_probe", [&callback_fired] { callback_fired.store(true, std::memory_order_release); });
+
+  // Erased from the map immediately even though access() itself now refuses (draining_) and
+  // held_acc keeps the object alive.
+  EXPECT_FALSE(handler.Has("draining_probe"));
+  EXPECT_FALSE(destroyed.load(std::memory_order_acquire));
+
+  // Dropping held_acc's count to 0 lets the already-blocked deferred ~Gatekeeper proceed.
+  held_acc.reset();
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!destroyed.load(std::memory_order_acquire) || !callback_fired.load(std::memory_order_acquire)) {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+        << "draining entry's deferred destruction never completed after its last accessor was released";
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_TRUE(destroyed.load(std::memory_order_acquire));
+  EXPECT_TRUE(callback_fired.load(std::memory_order_acquire));
+}
+
+// ---------------------------------------------------------------------------
+// DrainingTenantRefusesSuspend
+// ---------------------------------------------------------------------------
+// PINS: try_begin_suspend()'s upfront refusal checks draining_ directly, alongside (not folded into)
+// the count_==1 wait -- a tenant already accepted for deletion must not be frozen out from under the
+// drop by a competing suspend.
+TEST(HotColdGatekeeper, DrainingTenantRefusesSuspend) {
+  // Control: on a non-draining gatekeeper, a sole accessor is sufficient for try_begin_suspend() to
+  // succeed. Without this, a `false` from the draining case below would be ambiguous -- it could
+  // just be the count_==1 check failing for an unrelated reason.
+  {
+    auto control = make_hot();
+    auto acc = control.access();
+    ASSERT_TRUE(acc.has_value());
+    EXPECT_TRUE(control.try_begin_suspend(std::chrono::milliseconds(200)));
+    ASSERT_EQ(control.state(), State::SUSPENDING);
+    acc->reset();
+    control.abort_suspend();
+  }
+
+  auto gk = make_hot();
+  auto acc = gk.access();
+  ASSERT_TRUE(acc.has_value());
+  EXPECT_EQ(gk.holder_count(), 1u);
+
+  ASSERT_TRUE(gk.begin_drain());
+
+  // count_==1 precondition is satisfied (only `acc` is live); the refusal must be the drain check.
+  EXPECT_FALSE(gk.try_begin_suspend(std::chrono::milliseconds(50)));
+  EXPECT_EQ(gk.state(), State::HOT);
+
+  acc->reset();
+  gk.abort_drain();
 }

--- a/tests/unit/hot_cold_gatekeeper.cpp
+++ b/tests/unit/hot_cold_gatekeeper.cpp
@@ -688,9 +688,24 @@ TEST(HotColdGatekeeper, DrainingTenantRefusesSuspend) {
   ASSERT_TRUE(gk.begin_drain());
 
   // count_==1 precondition is satisfied (only `acc` is live); the refusal must be the drain check.
-  EXPECT_FALSE(gk.try_begin_suspend(std::chrono::milliseconds(50)));
+  // Captured into a local (not asserted on directly): if the draining_ check regresses, this call
+  // succeeds and leaves state_ == SUSPENDING. SUSPENDING is not terminal for ~Gatekeeper's wait
+  // predicate, so asserting first and returning early would destruct `gk` mid-transition and wedge
+  // the destructor forever -- turning a named test failure into an opaque CI job timeout instead.
+  const bool suspend_began = gk.try_begin_suspend(std::chrono::milliseconds(50));
+
+  // Release the accessor before acting on the result: on the expected-false path state_ is still
+  // HOT and this is a no-op ordering-wise; on the regressed-true path count_ must reach 0 before
+  // abort_suspend() below hands the gatekeeper back a clean HOT state to destruct from.
+  acc->reset();
+
+  if (suspend_began) {
+    // Roll the transition back before the assertion below can return early.
+    gk.abort_suspend();
+  }
+  EXPECT_FALSE(suspend_began)
+      << "try_begin_suspend() succeeded on a draining gatekeeper -- the draining_ upfront check regressed";
   EXPECT_EQ(gk.state(), State::HOT);
 
-  acc->reset();
   gk.abort_drain();
 }


### PR DESCRIPTION
`DbmsHandler::Delete_` held the process-wide `lock_` across the entire FORCE-drop teardown — including two unbounded thread joins (`StopAllBackgroundTasks`, `streams()->DropAll()`) — so a slow drop stalled every other tenant on the instance. This splits the drop into three phases and runs the blocking part holding nothing.

### What this PR delivers on its own
- **Teardown no longer holds `lock_`.** Phase 1 does in-memory bookkeeping under the lock; Phase 2 releases it, runs the two joins, and drops the operation's own accessor; Phase 3 re-locks to hand off to `DeferDelete`. From the caller's side the lock contract is unchanged: `lock` is held exclusive on entry and on every return, including error paths.
- **A tenant mid-drop is visible, not vanished.** It shows `DETACHED` for the whole drain window (published once, in Phase 1) instead of silently disappearing from `SHOW DATABASES`.
- **Honest errors on a racing drop.** `TryDelete` / `Delete` / `Delete_` / `Rename` report retriable `USING` for a tenant that is draining or mid-suspend, instead of a misleading `NON_EXISTENT`.

### What `DRAINING` is here — and what it is not
`draining_` is an orthogonal flag on the HOT gatekeeper state (not a fifth state), set by a single-flight `begin_drain()` and rolled back by `abort_drain()`. Its role in **this** PR is narrow and load-bearing: once Phase 2 releases `lock_`, `access()` must refuse **new** accessors, or a fresh query would re-arm the background work the joins just stopped. `drain_bypass` lets only the teardown itself still mint.

It is deliberately **not** an active drain here. This PR does not force existing holders off, does not wait for the tenant to become sole-held, and does not close the clone-based re-arm path. That policy — cooperative cancel, a bounded off-lock wait, and the recovery re-arm gate — is **#4575**, which builds directly on the phase split and the marker introduced here.

### Not in scope
- Forcing existing sessions / transactions off the tenant → **#4575** (FORCE ABORT), **#4577** (session eviction).
- Any change to interpreter DROP dispatch or grammar.

Stacked on **#4573**.
