### PR TITLE
fix: keep scoped CALL subquery imports bound across an intermediate WITH

### DIFF
--- a/src/query/plan/planner.hpp
+++ b/src/query/plan/planner.hpp
@@ -122,6 +122,9 @@ class PostProcessor final {
 template <template <class> class TPlanner, class TDbAccessor>
 auto MakeLogicalPlanForSingleQuery(QueryParts query_parts, PlanningContext<TDbAccessor> *context) {
   context->bound_symbols.clear();
+  // Only a subquery body has imports, and `HandleSubquery` restores them; clear anyway so the
+  // invariant holds locally rather than by induction over every planner entry point.
+  context->scoped_call_imports.clear();
   return TPlanner<PlanningContext<TDbAccessor>>(context).Plan(query_parts);
 }
 

--- a/src/query/plan/planner.hpp
+++ b/src/query/plan/planner.hpp
@@ -122,8 +122,7 @@ class PostProcessor final {
 template <template <class> class TPlanner, class TDbAccessor>
 auto MakeLogicalPlanForSingleQuery(QueryParts query_parts, PlanningContext<TDbAccessor> *context) {
   context->bound_symbols.clear();
-  // Only a subquery body has imports, and `HandleSubquery` restores them; clear anyway so the
-  // invariant holds locally rather than by induction over every planner entry point.
+  // Only a subquery body has imports; keep each entry point's start state local.
   context->scoped_call_imports.clear();
   return TPlanner<PlanningContext<TDbAccessor>>(context).Plan(query_parts);
 }

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -968,7 +968,9 @@ std::unordered_set<Symbol> GetSubqueryBoundSymbols(const std::vector<SingleQuery
     std::unordered_map<Symbol, PatternComprehensionMatching> empty_pending;
     PatternComprehensionContext pc_ctx{
         .pending_comprehensions = empty_pending, .planner = nullptr, .view = storage::View::OLD};
-    auto input_op = impl::GenWith(*with, nullptr, symbol_table, false, bound_symbols, storage, pc_ctx, nullptr, false);
+    // No planning context here, hence no scoped `CALL` imports either.
+    auto input_op =
+        impl::GenWith(*with, nullptr, symbol_table, false, bound_symbols, storage, pc_ctx, nullptr, false, {});
     return bound_symbols;
   }
 
@@ -1024,7 +1026,8 @@ std::unique_ptr<LogicalOperator> GenWith(With &with, std::unique_ptr<LogicalOper
                                          SymbolTable &symbol_table, bool is_write,
                                          std::unordered_set<Symbol> &bound_symbols, AstStorage &storage,
                                          PatternComprehensionContext &pc_ctx, Expression *commit_frequency,
-                                         bool in_exists_subquery) {
+                                         bool in_exists_subquery,
+                                         const std::unordered_set<Symbol> &scoped_call_imports) {
   // WITH clause is Accumulate/Aggregate (advance_command) + Produce and
   // optional Filter. In case of update and aggregation, we want to accumulate
   // first, so that when aggregating, we get the latest results. Similar to
@@ -1055,6 +1058,14 @@ std::unique_ptr<LogicalOperator> GenWith(With &with, std::unique_ptr<LogicalOper
     bound_symbols.clear();
     for (const auto &symbol : body.output_symbols()) {
       bound_symbols.insert(symbol);
+    }
+    // Scoped `CALL` imports stay in scope for the whole subquery body, unless a named expression
+    // redeclared the name and shadowed the import.
+    for (const auto &import : scoped_call_imports) {
+      if (std::ranges::none_of(body.output_symbols(),
+                               [&import](const Symbol &out) { return out.name() == import.name(); })) {
+        bound_symbols.insert(import);
+      }
     }
   }
   return last_op;

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -1061,10 +1061,10 @@ std::unique_ptr<LogicalOperator> GenWith(With &with, std::unique_ptr<LogicalOper
     }
     // Imports outlive the narrowing unless a named expression redeclared the name. Comparing names
     // mirrors SymbolGenerator's `new_names`, and is equivalent only because `scopeClause` has no alias form.
-    for (const auto &import : scoped_call_imports) {
+    for (const auto &imported : scoped_call_imports) {
       if (std::ranges::none_of(body.output_symbols(),
-                               [&import](const Symbol &out) { return out.name() == import.name(); })) {
-        bound_symbols.insert(import);
+                               [&imported](const Symbol &out) { return out.name() == imported.name(); })) {
+        bound_symbols.insert(imported);
       }
     }
   }

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -1059,9 +1059,8 @@ std::unique_ptr<LogicalOperator> GenWith(With &with, std::unique_ptr<LogicalOper
     for (const auto &symbol : body.output_symbols()) {
       bound_symbols.insert(symbol);
     }
-    // Scoped `CALL` imports stay in scope for the whole subquery body, unless a named expression
-    // redeclared the name and shadowed the import. Comparing names mirrors SymbolGenerator's own
-    // `new_names` check, and is only equivalent because `scopeClause` has no aliasing form.
+    // Imports outlive the narrowing unless a named expression redeclared the name. Comparing names
+    // mirrors SymbolGenerator's `new_names`, and is equivalent only because `scopeClause` has no alias form.
     for (const auto &import : scoped_call_imports) {
       if (std::ranges::none_of(body.output_symbols(),
                                [&import](const Symbol &out) { return out.name() == import.name(); })) {

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -1060,7 +1060,8 @@ std::unique_ptr<LogicalOperator> GenWith(With &with, std::unique_ptr<LogicalOper
       bound_symbols.insert(symbol);
     }
     // Scoped `CALL` imports stay in scope for the whole subquery body, unless a named expression
-    // redeclared the name and shadowed the import.
+    // redeclared the name and shadowed the import. Comparing names mirrors SymbolGenerator's own
+    // `new_names` check, and is only equivalent because `scopeClause` has no aliasing form.
     for (const auto &import : scoped_call_imports) {
       if (std::ranges::none_of(body.output_symbols(),
                                [&import](const Symbol &out) { return out.name() == import.name(); })) {

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -86,8 +86,9 @@ struct PlanningContext {
   /// written information.
   std::unordered_set<Symbol> bound_symbols{};
   /// @brief Symbols imported by an enclosing `CALL (v1, v2, ...) { ... }` / `CALL (*) { ... }`.
-  /// Unlike ordinary bindings these remain in scope for the whole subquery body, so they survive
-  /// a WITH inside it (mirroring SymbolGenerator) and a later pattern must not re-scan them.
+  /// Unlike ordinary bindings these remain in scope for the whole subquery body, so a later pattern
+  /// must not re-scan them. `GenWith` re-adds them after a WITH narrows, on the non-EXISTS path only
+  /// - the EXISTS branch already keeps every symbol type a pattern could re-scan.
   std::unordered_set<Symbol> scoped_call_imports{};
   bool is_write_query{false};
   bool in_exists_subquery{false};

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -86,9 +86,8 @@ struct PlanningContext {
   /// written information.
   std::unordered_set<Symbol> bound_symbols{};
   /// @brief Symbols imported by an enclosing `CALL (v1, v2, ...) { ... }` / `CALL (*) { ... }`.
-  /// Unlike ordinary bindings these remain in scope for the whole subquery body, so a later pattern
-  /// must not re-scan them. `GenWith` re-adds them after a WITH narrows, on the non-EXISTS path only
-  /// - the EXISTS branch already keeps every symbol type a pattern could re-scan.
+  /// These outlive a WITH inside the body, so a later pattern must not re-scan them. `GenWith`
+  /// re-adds them on the non-EXISTS path; the EXISTS branch already keeps every re-scannable type.
   std::unordered_set<Symbol> scoped_call_imports{};
   bool is_write_query{false};
   bool in_exists_subquery{false};

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -85,6 +85,10 @@ struct PlanningContext {
   /// write) the first `n`, but the latter `n` would only read the already
   /// written information.
   std::unordered_set<Symbol> bound_symbols{};
+  /// @brief Symbols imported by an enclosing `CALL (v1, v2, ...) { ... }` / `CALL (*) { ... }`.
+  /// Unlike ordinary bindings these remain in scope for the whole subquery body, so they survive
+  /// a WITH inside it (mirroring SymbolGenerator) and a later pattern must not re-scan them.
+  std::unordered_set<Symbol> scoped_call_imports{};
   bool is_write_query{false};
   bool in_exists_subquery{false};
 };
@@ -187,7 +191,8 @@ std::unique_ptr<LogicalOperator> GenWith(With &with, std::unique_ptr<LogicalOper
                                          SymbolTable &symbol_table, bool is_write,
                                          std::unordered_set<Symbol> &bound_symbols, AstStorage &storage,
                                          PatternComprehensionContext &pc_ctx, Expression *commit_frequency,
-                                         bool in_exists_subquery);
+                                         bool in_exists_subquery,
+                                         const std::unordered_set<Symbol> &scoped_call_imports);
 
 std::unique_ptr<LogicalOperator> GenUnion(const CypherUnion &cypher_union, std::shared_ptr<LogicalOperator> left_op,
                                           std::shared_ptr<LogicalOperator> right_op, SymbolTable &symbol_table);
@@ -416,7 +421,8 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
                                      *context.ast_storage,
                                      pc_ctx,
                                      nullptr,
-                                     context.in_exists_subquery);
+                                     context.in_exists_subquery,
+                                     context.scoped_call_imports);
             // WITH clause advances the command, so reset the flag.
             context.is_write_query = false;
           } else if (IsWriteClause(clause)) {
@@ -1541,13 +1547,21 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
     outer_scope_bound_symbols.insert(std::make_move_iterator(context_->bound_symbols.begin()),
                                      std::make_move_iterator(context_->bound_symbols.end()));
 
+    // An enclosing subquery's imports do not carry into this body; restored once this body is planned.
+    auto const restore_imports = utils::OnScopeExit{[this, saved = std::move(context_->scoped_call_imports)]() mutable {
+      context_->scoped_call_imports = std::move(saved);
+    }};
+
     if (scoped_variables) {
       // `CALL (v1, v2, ...) { ... }`: seed the subquery planner with exactly
       // the imported outer symbols. The legacy leading-WITH scan is bypassed.
       context_->bound_symbols = *scoped_variables;
+      context_->scoped_call_imports = *scoped_variables;
     } else {
       context_->bound_symbols =
           impl::GetSubqueryBoundSymbols(subquery->query_parts[0].single_query_parts, symbol_table, storage);
+      // The legacy `CALL { WITH v ... }` form imports nothing; standard WITH narrowing applies.
+      context_->scoped_call_imports.clear();
     }
 
     auto subquery_op = Plan(*subquery);

--- a/src/query/plan/variable_start_planner.hpp
+++ b/src/query/plan/variable_start_planner.hpp
@@ -401,6 +401,8 @@ class VariableStartPlanner {
 
           RuleBasedPlanner<TPlanningContext> rule_planner(context);
           context->bound_symbols.clear();
+          // Same reason as in `MakeLogicalPlanForSingleQuery`: keep each alternative's start state local.
+          context->scoped_call_imports.clear();
           return rule_planner.Plan(reconstructed_query_parts);
         },
         VaryQueryMatching(query_parts, *context_->symbol_table));

--- a/src/query/plan/variable_start_planner.hpp
+++ b/src/query/plan/variable_start_planner.hpp
@@ -401,7 +401,6 @@ class VariableStartPlanner {
 
           RuleBasedPlanner<TPlanningContext> rule_planner(context);
           context->bound_symbols.clear();
-          // Same reason as in `MakeLogicalPlanForSingleQuery`: keep each alternative's start state local.
           context->scoped_call_imports.clear();
           return rule_planner.Plan(reconstructed_query_parts);
         },

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -1126,8 +1126,7 @@ Feature: Subqueries
             """
             CREATE (m1:Movie {id: '1'})-[:relatedTo]->(m2:Movie {id: '2'})
             """
-        # The subquery shares the outer frame, so treating `source` as a fresh variable here would
-        # null its slot on the OPTIONAL MATCH miss - visible after the CALL as `outer_after`.
+        # The subquery shares the outer frame, so a miss on a fresh `source` would null `outer_after`.
         When executing query:
             """
             MATCH (source:Movie {id: '1'})
@@ -1149,8 +1148,7 @@ Feature: Subqueries
             """
             CREATE (m1:Movie {id: '1'})-[:relatedTo]->(m2:Movie {id: '2'})
             """
-        # Treating `source` as unbound here makes MERGE's create branch build a fresh node for it, so
-        # the merged edge dangles off a phantom instead of off Movie '1' - a silent extra node.
+        # An unbound `source` makes MERGE create a fresh node, so the edge dangles off a phantom.
         And having executed:
             """
             MATCH (source:Movie {id: '1'})

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -1013,7 +1013,7 @@ Feature: Subqueries
             }
             RETURN DISTINCT des1.id AS d1, collect(DISTINCT des2.id) AS d2
             """
-        Then the result should be:
+        Then the result should be (ignoring element order for lists):
             | d1  | d2           |
             | '2' | ['4', '6']   |
 
@@ -1063,7 +1063,7 @@ Feature: Subqueries
             }
             RETURN DISTINCT des1.id AS d1, collect(DISTINCT des2.id) AS d2
             """
-        Then the result should be:
+        Then the result should be (ignoring element order for lists):
             | d1  | d2           |
             | '2' | ['4', '6']   |
 
@@ -1089,7 +1089,7 @@ Feature: Subqueries
             }
             RETURN DISTINCT des1.id AS d1, collect(DISTINCT des2.id) AS d2
             """
-        Then the result should be:
+        Then the result should be (ignoring element order for lists):
             | d1  | d2                                  |
             | '2' | ['2', '1', '4', '3', '6', '5']      |
 

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -992,3 +992,130 @@ Feature: Subqueries
             | id | c |
             | 1  | 2 |
             | 2  | 2 |
+
+    Scenario: A scoped CALL import stays in scope across an intermediate WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'}), (m2:Movie {id: '2'}), (m3:Movie {id: '3'})
+            CREATE (m4:Movie {id: '4'}), (m5:Movie {id: '5'}), (m6:Movie {id: '6'})
+            CREATE (m1)-[:relatedTo]->(m2), (m3)-[:relatedTo]->(m4), (m5)-[:relatedTo]->(m6)
+            """
+        When executing query:
+            """
+            MATCH (source1:Movie {id: '1'})
+            MATCH (source35:Movie) WHERE source35.id IN ['3', '5']
+            CALL (source1, source35) {
+              MATCH (source1)-[]-(des1)
+              WITH des1
+              MATCH (source35)-[]-(des2)
+              RETURN des1, des2
+            }
+            RETURN DISTINCT des1.id AS d1, collect(DISTINCT des2.id) AS d2
+            """
+        Then the result should be:
+            | d1  | d2           |
+            | '2' | ['4', '6']   |
+
+    Scenario: A scoped CALL import is not clobbered for the outer query either
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'}), (m2:Movie {id: '2'}), (m3:Movie {id: '3'})
+            CREATE (m4:Movie {id: '4'}), (m5:Movie {id: '5'}), (m6:Movie {id: '6'})
+            CREATE (m1)-[:relatedTo]->(m2), (m3)-[:relatedTo]->(m4), (m5)-[:relatedTo]->(m6)
+            """
+        When executing query:
+            """
+            MATCH (source1:Movie {id: '1'})
+            MATCH (source35:Movie) WHERE source35.id IN ['3', '5']
+            CALL (source1, source35) {
+              MATCH (source1)-[]-(des1)
+              WITH des1
+              MATCH (source35)-[]-(des2)
+              RETURN des1, des2
+            }
+            RETURN source35.id AS outer_after, des2.id AS d2
+            ORDER BY outer_after, d2
+            """
+        Then the result should be, in order:
+            | outer_after | d2  |
+            | '3'         | '4' |
+            | '5'         | '6' |
+
+    Scenario: A CALL (*) import stays in scope across an intermediate WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'}), (m2:Movie {id: '2'}), (m3:Movie {id: '3'})
+            CREATE (m4:Movie {id: '4'}), (m5:Movie {id: '5'}), (m6:Movie {id: '6'})
+            CREATE (m1)-[:relatedTo]->(m2), (m3)-[:relatedTo]->(m4), (m5)-[:relatedTo]->(m6)
+            """
+        When executing query:
+            """
+            MATCH (source1:Movie {id: '1'})
+            MATCH (source35:Movie) WHERE source35.id IN ['3', '5']
+            CALL (*) {
+              MATCH (source1)-[]-(des1)
+              WITH des1
+              MATCH (source35)-[]-(des2)
+              RETURN des1, des2
+            }
+            RETURN DISTINCT des1.id AS d1, collect(DISTINCT des2.id) AS d2
+            """
+        Then the result should be:
+            | d1  | d2           |
+            | '2' | ['4', '6']   |
+
+    Scenario: A legacy leading WITH import does not survive an intermediate WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'}), (m2:Movie {id: '2'}), (m3:Movie {id: '3'})
+            CREATE (m4:Movie {id: '4'}), (m5:Movie {id: '5'}), (m6:Movie {id: '6'})
+            CREATE (m1)-[:relatedTo]->(m2), (m3)-[:relatedTo]->(m4), (m5)-[:relatedTo]->(m6)
+            """
+        # `source35` after `WITH des1` is a fresh variable, so the whole graph is scanned.
+        When executing query:
+            """
+            MATCH (source1:Movie {id: '1'})
+            MATCH (source35:Movie) WHERE source35.id IN ['3', '5']
+            CALL {
+              WITH source1, source35
+              MATCH (source1)-[]-(des1)
+              WITH des1
+              MATCH (source35)-[]-(des2)
+              RETURN des1, des2
+            }
+            RETURN DISTINCT des1.id AS d1, collect(DISTINCT des2.id) AS d2
+            """
+        Then the result should be:
+            | d1  | d2                                  |
+            | '2' | ['2', '1', '4', '3', '6', '5']      |
+
+    Scenario: A write clause after an intermediate WITH attaches to the scoped CALL import
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'})-[:relatedTo]->(m2:Movie {id: '2'})
+            """
+        And having executed:
+            """
+            MATCH (s:Movie {id: '1'})
+            CALL (s) {
+              MATCH (s)-[]-(x)
+              WITH x
+              CREATE (s)-[:BAD]->(:Probe)
+              RETURN x
+            }
+            RETURN count(*) AS c
+            """
+        When executing query:
+            """
+            MATCH (n) WITH count(n) AS total
+            MATCH (a)-[:BAD]->(b)
+            RETURN total, a.id AS from_id, labels(b) AS to_labels
+            """
+        Then the result should be:
+            | total | from_id | to_labels   |
+            | 3     | '1'     | ['Probe']   |

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -1119,3 +1119,26 @@ Feature: Subqueries
         Then the result should be:
             | total | from_id | to_labels   |
             | 3     | '1'     | ['Probe']   |
+
+    Scenario: An OPTIONAL MATCH miss on a scoped CALL import does not null the outer variable
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'})-[:relatedTo]->(m2:Movie {id: '2'})
+            """
+        # The subquery shares the outer frame, so treating `source` as a fresh variable here would
+        # null its slot on the OPTIONAL MATCH miss - visible after the CALL as `outer_after`.
+        When executing query:
+            """
+            MATCH (source:Movie {id: '1'})
+            CALL (source) {
+              MATCH (source)-[]-(des1)
+              WITH des1
+              OPTIONAL MATCH (source)-[:noSuchType]-(des2)
+              RETURN des1, des2
+            }
+            RETURN source.id AS outer_after, des1.id AS d1, des2 AS d2
+            """
+        Then the result should be:
+            | outer_after | d1  | d2   |
+            | '1'         | '2' | null |

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -1142,3 +1142,58 @@ Feature: Subqueries
         Then the result should be:
             | outer_after | d1  | d2   |
             | '1'         | '2' | null |
+
+    Scenario: A MERGE after an intermediate WITH attaches to the scoped CALL import
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'})-[:relatedTo]->(m2:Movie {id: '2'})
+            """
+        # Treating `source` as unbound here makes MERGE's create branch build a fresh node for it, so
+        # the merged edge dangles off a phantom instead of off Movie '1' - a silent extra node.
+        And having executed:
+            """
+            MATCH (source:Movie {id: '1'})
+            CALL (source) {
+              MATCH (source)-[]-(des1)
+              WITH des1
+              MERGE (source)-[:mergedTo]->(des1)
+              RETURN des1
+            }
+            RETURN count(*) AS c
+            """
+        When executing query:
+            """
+            MATCH (n) WITH count(n) AS total
+            MATCH (a)-[:mergedTo]->(b)
+            RETURN total, a.id AS from_id, b.id AS to_id
+            """
+        Then the result should be:
+            | total | from_id | to_id |
+            | 2     | '1'     | '2'   |
+
+    Scenario: A scoped CALL import stays in scope in every UNION branch of the body
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (m1:Movie {id: '1'})-[:relatedTo]->(m2:Movie {id: '2'})
+            """
+        When executing query:
+            """
+            MATCH (source:Movie {id: '1'})
+            CALL (source) {
+              MATCH (source)-[]-(des1)
+              WITH des1
+              MATCH (source)-[]-(des2)
+              RETURN des2.id AS d
+              UNION
+              MATCH (source)-[]-(des3)
+              WITH des3
+              MATCH (source)-[]-(des4)
+              RETURN des4.id AS d
+            }
+            RETURN d
+            """
+        Then the result should be:
+            | d   |
+            | '2' |

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -1075,7 +1075,9 @@ Feature: Subqueries
             CREATE (m4:Movie {id: '4'}), (m5:Movie {id: '5'}), (m6:Movie {id: '6'})
             CREATE (m1)-[:relatedTo]->(m2), (m3)-[:relatedTo]->(m4), (m5)-[:relatedTo]->(m6)
             """
-        # `source35` after `WITH des1` is a fresh variable, so the whole graph is scanned.
+        # `source35` after `WITH des1` really is a new variable here, so the whole graph is scanned.
+        # Behaves the same before and after the scoped-import fix: this guards the legacy form, it does
+        # not reproduce the defect.
         When executing query:
             """
             MATCH (source1:Movie {id: '1'})
@@ -1126,7 +1128,8 @@ Feature: Subqueries
             """
             CREATE (m1:Movie {id: '1'})-[:relatedTo]->(m2:Movie {id: '2'})
             """
-        # The subquery shares the outer frame, so a miss on a fresh `source` would null `outer_after`.
+        # `source` keeps its outer symbol here, so if the planner re-scans it the OPTIONAL MATCH miss
+        # null-fills the outer slot itself - visible as `outer_after`. A genuinely new variable would not.
         When executing query:
             """
             MATCH (source:Movie {id: '1'})

--- a/tests/unit/query_common.hpp
+++ b/tests/unit/query_common.hpp
@@ -653,6 +653,15 @@ auto GetCallSubqueryScoped(AstStorage &storage, TSubquery *subquery, const std::
   return call_subquery;
 }
 
+// `CALL (*) { ... }`: imports every user-declared outer variable.
+template <typename TSubquery>
+auto GetCallSubqueryScopedAll(AstStorage &storage, TSubquery *subquery) {
+  auto *call_subquery = GetCallSubquery(storage, subquery);
+  call_subquery->has_variable_scope_ = true;
+  call_subquery->all_variables_scoped_ = true;
+  return call_subquery;
+}
+
 auto GetCallPeriodicSubquery(AstStorage &storage, SingleQuery *subquery, CommitFrequency commit_frequency) {
   auto *periodic_subquery = storage.Create<memgraph::query::CallSubquery>();
 
@@ -869,6 +878,7 @@ auto GetExistsSubquery(AstStorage &storage, CypherQuery *subquery) {
 #define CALL_SUBQUERY(...) memgraph::query::test_common::GetCallSubquery(this->storage, __VA_ARGS__)
 #define CALL_PERIODIC_SUBQUERY(...) memgraph::query::test_common::GetCallPeriodicSubquery(this->storage, __VA_ARGS__)
 #define CALL_SUBQUERY_SCOPED(...) memgraph::query::test_common::GetCallSubqueryScoped(this->storage, __VA_ARGS__)
+#define CALL_SUBQUERY_SCOPED_ALL(...) memgraph::query::test_common::GetCallSubqueryScopedAll(this->storage, __VA_ARGS__)
 #define PATTERN_COMPREHENSION(variable, pattern, filter, resultExpr) \
   this->storage.template Create<memgraph::query::PatternComprehension>(variable, pattern, filter, resultExpr)
 #define ENUM_VALUE(...) this->storage.template Create<memgraph::query::EnumValueAccess>(__VA_ARGS__)

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3122,7 +3122,8 @@ TYPED_TEST(TestPlanner, SubqueryScopedAllImportSurvivesIntermediateWith) {
 }
 
 // The legacy leading-WITH form imports nothing, so ordinary WITH narrowing applies and the name
-// written after it is a fresh variable that must be scanned.
+// written after it is a fresh variable that must be scanned. This plan is identical before and after
+// the fix - the test guards the intended divergence, it does not reproduce the defect.
 TYPED_TEST(TestPlanner, SubqueryLegacyImportDoesNotSurviveIntermediateWith) {
   // MATCH (m) CALL { WITH m MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
   FakeDbAccessor dba;
@@ -3228,6 +3229,8 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportRestoredAfterNestedLegacySubquery) {
 
 // A named expression may redeclare an import's name. The import must then stay suppressed rather than
 // coexist with the shadow symbol, which a later `WITH *` would project as a second column of that name.
+// The plan is identical before and after the fix; this guards the shadow check in `GenWith` itself -
+// without it, `WITH *` projects `m` twice.
 TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjectedTwice) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a, a AS m WITH * RETURN a } RETURN a
   FakeDbAccessor dba;
@@ -3243,6 +3246,23 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjec
 
   std::list<BaseOpChecker *> branch{
       new ExpectExpand(), new ExpectProduce(), new ExpectProduceColumns({"a", "m"}), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+}
+
+// An import no named expression redeclared is still in scope at a trailing `RETURN *`, so the body
+// projects it as a column. Before the fix the intermediate WITH dropped it and `*` was one column.
+TYPED_TEST(TestPlanner, SubqueryScopedImportProjectedByReturnStarAfterWith) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a RETURN * } RETURN a
+  FakeDbAccessor dba;
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))), WITH("a"), RETURN("*"));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}), RETURN("a")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> branch{new ExpectExpand(), new ExpectProduce(), new ExpectProduceColumns({"a", "m"})};
   CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
   DeleteListContent(&branch);
 }

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3082,6 +3082,93 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportSelfReferentialFilterNoIndex) {
   DeleteListContent(&branch);
 }
 
+// An import stays in scope for the whole subquery body, so a pattern written after an intermediate
+// WITH that drops the name must still expand from the imported vertex instead of re-scanning it.
+TYPED_TEST(TestPlanner, SubqueryScopedImportSurvivesIntermediateWith) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
+  FakeDbAccessor dba;
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                WITH("a"),
+                                MATCH(PATTERN(NODE("m"), EDGE("r2"), NODE("b"))),
+                                RETURN("a", "b"));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}), RETURN("a", "b")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  // No ExpectScanAll before the second ExpectExpand: `m` is still bound.
+  std::list<BaseOpChecker *> branch{new ExpectExpand(), new ExpectProduce(), new ExpectExpand(), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+}
+
+// `CALL (*) { ... }` imports the same way, through all_variables_scoped_.
+TYPED_TEST(TestPlanner, SubqueryScopedAllImportSurvivesIntermediateWith) {
+  // MATCH (m) CALL (*) { MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
+  FakeDbAccessor dba;
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                WITH("a"),
+                                MATCH(PATTERN(NODE("m"), EDGE("r2"), NODE("b"))),
+                                RETURN("a", "b"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED_ALL(subquery), RETURN("a", "b")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> branch{new ExpectExpand(), new ExpectProduce(), new ExpectExpand(), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+}
+
+// The legacy leading-WITH form imports nothing, so ordinary WITH narrowing applies and the name
+// written after it is a fresh variable that must be scanned.
+TYPED_TEST(TestPlanner, SubqueryLegacyImportDoesNotSurviveIntermediateWith) {
+  // MATCH (m) CALL { WITH m MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
+  FakeDbAccessor dba;
+  auto *subquery = SINGLE_QUERY(WITH("m"),
+                                MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                WITH("a"),
+                                MATCH(PATTERN(NODE("m"), EDGE("r2"), NODE("b"))),
+                                RETURN("a", "b"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY(subquery), RETURN("a", "b")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> branch{new ExpectProduce(),
+                                    new ExpectExpand(),
+                                    new ExpectProduce(),
+                                    new ExpectScanAll(),
+                                    new ExpectExpand(),
+                                    new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+}
+
+// A nested `CALL (*) { ... }` after the WITH collects its imports from the bound set, so the
+// preserved import has to reach it.
+TYPED_TEST(TestPlanner, SubqueryScopedImportReachesNestedScopedAllAfterWith) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a CALL (*) { MATCH (m)-[r2]-(b) RETURN b }
+  //                      RETURN a, b } RETURN a, b
+  FakeDbAccessor dba;
+  auto *nested = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r2"), NODE("b"))), RETURN("b"));
+  auto *subquery = SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))), WITH("a"), CALL_SUBQUERY_SCOPED_ALL(nested), RETURN("a", "b"));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}), RETURN("a", "b")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> nested_branch{new ExpectExpand(), new ExpectProduce()};
+  std::list<BaseOpChecker *> branch{
+      new ExpectExpand(), new ExpectProduce(), new ExpectApply(nested_branch), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+  DeleteListContent(&nested_branch);
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInReturn) {
   FakeDbAccessor dba;
   const auto prop = PROPERTY_PAIR(dba, "prop");

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3247,6 +3247,39 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjec
   DeleteListContent(&branch);
 }
 
+// The active import set is not reset per query part, so every UNION branch of the body keeps it -
+// mirroring SymbolGenerator, which carries the imports into each branch's scope.
+TYPED_TEST(TestPlanner, SubqueryScopedImportSurvivesIntermediateWithInEveryUnionBranch) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN b
+  //                      UNION ALL
+  //                      MATCH (m)-[r3]-(c) WITH c MATCH (m)-[r4]-(d) RETURN d AS b } RETURN b
+  FakeDbAccessor dba;
+  auto *subquery = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                      WITH("a"),
+                                      MATCH(PATTERN(NODE("m"), EDGE("r2"), NODE("b"))),
+                                      RETURN("b")),
+                         UNION_ALL(SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r3"), NODE("c"))),
+                                                WITH("c"),
+                                                MATCH(PATTERN(NODE("m"), EDGE("r4"), NODE("d"))),
+                                                RETURN(NEXPR("b", IDENT("d"))))));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}), RETURN("b")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  // Neither branch re-scans `m`.
+  std::list<BaseOpChecker *> left_branch{
+      new ExpectExpand(), new ExpectProduce(), new ExpectExpand(), new ExpectProduce()};
+  std::list<BaseOpChecker *> right_branch{
+      new ExpectExpand(), new ExpectProduce(), new ExpectExpand(), new ExpectProduce()};
+  std::list<BaseOpChecker *> branch{new ExpectUnion(left_branch, right_branch)};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+  DeleteListContent(&left_branch);
+  DeleteListContent(&right_branch);
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInReturn) {
   FakeDbAccessor dba;
   const auto prop = PROPERTY_PAIR(dba, "prop");

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3167,7 +3167,8 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportReachesNestedScopedAllAfterWith) {
   DeleteListContent(&nested_branch);
 }
 
-// `Apply` shares the frame, so treating the import as a new symbol would null the outer slot on a miss.
+// The import keeps its outer symbol, so listing it in `optional_symbols_` would null the outer slot on a
+// miss - `Apply` shares the frame. Hence the assertion that only the edge and far node are listed.
 TYPED_TEST(TestPlanner, SubqueryScopedImportNotNulledByOptionalMatchAfterWith) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a OPTIONAL MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
   FakeDbAccessor dba;

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3169,6 +3169,84 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportReachesNestedScopedAllAfterWith) {
   DeleteListContent(&nested_branch);
 }
 
+// An OPTIONAL MATCH on the import after the WITH must not treat it as a new symbol: `Apply` shares the
+// frame, so a miss would null-fill the outer query's slot.
+TYPED_TEST(TestPlanner, SubqueryScopedImportNotNulledByOptionalMatchAfterWith) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a OPTIONAL MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
+  FakeDbAccessor dba;
+  auto *opt_edge = EDGE("r2");
+  auto *opt_node = NODE("b");
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                WITH("a"),
+                                OPTIONAL_MATCH(PATTERN(NODE("m"), opt_edge, opt_node)),
+                                RETURN("a", "b"));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}), RETURN("a", "b")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  // Only the edge and the far node are new; `m` stays bound, so it is never null-filled.
+  std::vector<Symbol> optional_symbols{symbol_table.at(*opt_edge->identifier_),
+                                       symbol_table.at(*opt_node->identifier_)};
+  std::list<BaseOpChecker *> optional_branch{new ExpectExpand()};
+  std::list<BaseOpChecker *> branch{new ExpectExpand(),
+                                    new ExpectProduce(),
+                                    new ExpectOptional(optional_symbols, optional_branch),
+                                    new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+  DeleteListContent(&optional_branch);
+}
+
+// A nested legacy `CALL { WITH ... }` clears the active import set; it has to be restored for the rest
+// of the enclosing body, or the WITH after it drops the import again.
+TYPED_TEST(TestPlanner, SubqueryScopedImportRestoredAfterNestedLegacySubquery) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) CALL { WITH a MATCH (a)-[r3]-(c) RETURN c }
+  //                      WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
+  FakeDbAccessor dba;
+  auto *nested = SINGLE_QUERY(WITH("a"), MATCH(PATTERN(NODE("a"), EDGE("r3"), NODE("c"))), RETURN("c"));
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                CALL_SUBQUERY(nested),
+                                WITH("a"),
+                                MATCH(PATTERN(NODE("m"), EDGE("r2"), NODE("b"))),
+                                RETURN("a", "b"));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}), RETURN("a", "b")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  // No ExpectScanAll before the last ExpectExpand: `m` is bound again once the nested body is planned.
+  std::list<BaseOpChecker *> nested_branch{new ExpectProduce(), new ExpectExpand(), new ExpectProduce()};
+  std::list<BaseOpChecker *> branch{
+      new ExpectExpand(), new ExpectApply(nested_branch), new ExpectProduce(), new ExpectExpand(), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+  DeleteListContent(&nested_branch);
+}
+
+// A named expression may redeclare an import's name. The import must then stay suppressed rather than
+// coexist with the shadow symbol, which a later `WITH *` would project as a second column of that name.
+TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjectedTwice) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a, a AS m WITH * RETURN a } RETURN a
+  FakeDbAccessor dba;
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                WITH(NEXPR("a", IDENT("a")), NEXPR("m", IDENT("a"))),
+                                WITH("*"),
+                                RETURN("a"));
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))), CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}), RETURN("a")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> branch{
+      new ExpectExpand(), new ExpectProduce(), new ExpectProduceColumns({"a", "m"}), new ExpectProduce()};
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectApply(branch), ExpectProduce());
+  DeleteListContent(&branch);
+}
+
 TYPED_TEST(TestPlanner, PatternComprehensionInReturn) {
   FakeDbAccessor dba;
   const auto prop = PROPERTY_PAIR(dba, "prop");

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3082,8 +3082,7 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportSelfReferentialFilterNoIndex) {
   DeleteListContent(&branch);
 }
 
-// An import stays in scope for the whole subquery body, so a pattern written after an intermediate
-// WITH that drops the name must still expand from the imported vertex instead of re-scanning it.
+// An import outlives a WITH that drops its name, so the next pattern expands from it, never re-scans.
 TYPED_TEST(TestPlanner, SubqueryScopedImportSurvivesIntermediateWith) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
   FakeDbAccessor dba;
@@ -3121,9 +3120,8 @@ TYPED_TEST(TestPlanner, SubqueryScopedAllImportSurvivesIntermediateWith) {
   DeleteListContent(&branch);
 }
 
-// The legacy leading-WITH form imports nothing, so ordinary WITH narrowing applies and the name
-// written after it is a fresh variable that must be scanned. This plan is identical before and after
-// the fix - the test guards the intended divergence, it does not reproduce the defect.
+// The legacy leading-WITH form imports nothing, so the name after the WITH is fresh and gets scanned.
+// Plans identically before and after the fix: this guards the intended divergence, not the defect.
 TYPED_TEST(TestPlanner, SubqueryLegacyImportDoesNotSurviveIntermediateWith) {
   // MATCH (m) CALL { WITH m MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
   FakeDbAccessor dba;
@@ -3147,8 +3145,7 @@ TYPED_TEST(TestPlanner, SubqueryLegacyImportDoesNotSurviveIntermediateWith) {
   DeleteListContent(&branch);
 }
 
-// A nested `CALL (*) { ... }` after the WITH collects its imports from the bound set, so the
-// preserved import has to reach it.
+// A nested `CALL (*) { ... }` builds its imports from the bound set, so the preserved one must reach it.
 TYPED_TEST(TestPlanner, SubqueryScopedImportReachesNestedScopedAllAfterWith) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a CALL (*) { MATCH (m)-[r2]-(b) RETURN b }
   //                      RETURN a, b } RETURN a, b
@@ -3170,8 +3167,7 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportReachesNestedScopedAllAfterWith) {
   DeleteListContent(&nested_branch);
 }
 
-// An OPTIONAL MATCH on the import after the WITH must not treat it as a new symbol: `Apply` shares the
-// frame, so a miss would null-fill the outer query's slot.
+// `Apply` shares the frame, so treating the import as a new symbol would null the outer slot on a miss.
 TYPED_TEST(TestPlanner, SubqueryScopedImportNotNulledByOptionalMatchAfterWith) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a OPTIONAL MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
   FakeDbAccessor dba;
@@ -3200,8 +3196,7 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportNotNulledByOptionalMatchAfterWith) {
   DeleteListContent(&optional_branch);
 }
 
-// A nested legacy `CALL { WITH ... }` clears the active import set; it has to be restored for the rest
-// of the enclosing body, or the WITH after it drops the import again.
+// A nested legacy `CALL { WITH ... }` clears the import set; without the restore the next WITH drops it.
 TYPED_TEST(TestPlanner, SubqueryScopedImportRestoredAfterNestedLegacySubquery) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) CALL { WITH a MATCH (a)-[r3]-(c) RETURN c }
   //                      WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
@@ -3227,10 +3222,9 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportRestoredAfterNestedLegacySubquery) {
   DeleteListContent(&nested_branch);
 }
 
-// A named expression may redeclare an import's name. The import must then stay suppressed rather than
-// coexist with the shadow symbol, which a later `WITH *` would project as a second column of that name.
-// The plan is identical before and after the fix; this guards the shadow check in `GenWith` itself -
-// without it, `WITH *` projects `m` twice.
+// A named expression may redeclare an import's name; the import must stay suppressed, not coexist with
+// the shadow. Plans identically before and after the fix - it guards `GenWith`'s shadow check, without
+// which `WITH *` projects `m` twice.
 TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjectedTwice) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a, a AS m WITH * RETURN a } RETURN a
   FakeDbAccessor dba;
@@ -3250,8 +3244,7 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjec
   DeleteListContent(&branch);
 }
 
-// An import no named expression redeclared is still in scope at a trailing `RETURN *`, so the body
-// projects it as a column. Before the fix the intermediate WITH dropped it and `*` was one column.
+// An unshadowed import is still in scope at a trailing `RETURN *`, so `*` projects it as a column.
 TYPED_TEST(TestPlanner, SubqueryScopedImportProjectedByReturnStarAfterWith) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a RETURN * } RETURN a
   FakeDbAccessor dba;
@@ -3267,8 +3260,7 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportProjectedByReturnStarAfterWith) {
   DeleteListContent(&branch);
 }
 
-// The active import set is not reset per query part, so every UNION branch of the body keeps it -
-// mirroring SymbolGenerator, which carries the imports into each branch's scope.
+// The import set is not reset per query part, so every UNION branch keeps it, as SymbolGenerator does.
 TYPED_TEST(TestPlanner, SubqueryScopedImportSurvivesIntermediateWithInEveryUnionBranch) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN b
   //                      UNION ALL

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -296,6 +296,25 @@ class ExpectScanAllById : public OpChecker<ScanAllById> {
 using ExpectExpand = OpChecker<Expand>;
 using ExpectConstructNamedPath = OpChecker<ConstructNamedPath>;
 using ExpectProduce = OpChecker<Produce>;
+
+// Asserts which columns a Produce projects, for cases where the plan shape alone does not discriminate.
+class ExpectProduceColumns : public OpChecker<Produce> {
+ public:
+  explicit ExpectProduceColumns(std::vector<std::string> names) : names_(std::move(names)) {}
+
+  void ExpectOp(Produce &produce, const SymbolTable &) override {
+    std::vector<std::string> actual;
+    actual.reserve(produce.named_expressions_.size());
+    for (auto *named_expr : produce.named_expressions_) {
+      actual.emplace_back(named_expr->name_);
+    }
+    EXPECT_THAT(actual, testing::UnorderedElementsAreArray(names_));
+  }
+
+ private:
+  std::vector<std::string> names_;
+};
+
 using ExpectEmptyResult = OpChecker<EmptyResult>;
 using ExpectSetProperty = OpChecker<SetProperty>;
 using ExpectSetProperties = OpChecker<SetProperties>;

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -297,7 +297,7 @@ using ExpectExpand = OpChecker<Expand>;
 using ExpectConstructNamedPath = OpChecker<ConstructNamedPath>;
 using ExpectProduce = OpChecker<Produce>;
 
-// Asserts which columns a Produce projects, for cases where the plan shape alone does not discriminate.
+// Asserts which columns a Produce projects, where plan shape alone does not discriminate.
 class ExpectProduceColumns : public OpChecker<Produce> {
  public:
   explicit ExpectProduceColumns(std::vector<std::string> names) : names_(std::move(names)) {}

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1720,6 +1720,46 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesItsOwnSc
       << "a name declared inside the subquery is in scope there, so shadowing must not fire";
 }
 
+// The planner keeps scoped `CALL` imports bound across an intermediate WITH because the symbol generator
+// re-injects them (VisitReturnBody). Pin that premise: narrowing the scope must not mint a new symbol.
+TYPED_TEST(TestSymbolGenerator, ScopedCallImportKeepsItsSymbolAcrossIntermediateWith) {
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
+  auto *outer_m = NODE("m");
+  auto *post_with_m = NODE("m");
+  auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                WITH("a"),
+                                MATCH(PATTERN(post_with_m, EDGE("r2"), NODE("b"))),
+                                RETURN("a", "b"));
+  auto *call_sub = CALL_SUBQUERY(subquery);
+  call_sub->has_variable_scope_ = true;
+  call_sub->scoped_variables_.push_back(NEXPR("m", IDENT("m")));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_m)), call_sub, RETURN("a", "b")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_EQ(symbol_table.at(*outer_m->identifier_), symbol_table.at(*post_with_m->identifier_))
+      << "the import survives the WITH as the same symbol, so it names the outer frame slot";
+}
+
+// The same narrowing with no import: the legacy form declares a fresh symbol, which is why the planner
+// must clear its import set there rather than inherit one.
+TYPED_TEST(TestSymbolGenerator, LegacyCallImportDoesNotKeepItsSymbolAcrossIntermediateWith) {
+  // MATCH (m) CALL { WITH m MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
+  auto *outer_m = NODE("m");
+  auto *post_with_m = NODE("m");
+  auto *subquery = SINGLE_QUERY(WITH("m"),
+                                MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                WITH("a"),
+                                MATCH(PATTERN(post_with_m, EDGE("r2"), NODE("b"))),
+                                RETURN("a", "b"));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_m)), CALL_SUBQUERY(subquery), RETURN("a", "b")));
+
+  auto symbol_table = MakeSymbolTable(query);
+
+  EXPECT_NE(symbol_table.at(*outer_m->identifier_), symbol_table.at(*post_with_m->identifier_))
+      << "the legacy form imports nothing, so the name after the WITH is declared afresh";
+}
+
 TYPED_TEST(TestSymbolGenerator, PatternComprehensionAtTopLevelCorrelatesToABoundName) {
   // MATCH (zz) RETURN [(zz)-->() | 1] AS k
   // Outside a subquery there is no boundary to shadow against, so a bound name in a comprehension pattern must resolve

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1720,8 +1720,8 @@ TYPED_TEST(TestSymbolGenerator, PatternComprehensionInSubqueryCorrelatesItsOwnSc
       << "a name declared inside the subquery is in scope there, so shadowing must not fire";
 }
 
-// The planner keeps scoped `CALL` imports bound across an intermediate WITH because the symbol generator
-// re-injects them (VisitReturnBody). Pin that premise: narrowing the scope must not mint a new symbol.
+// Pins the premise the planner fix rests on: `VisitReturnBody` re-injects the import rather than
+// minting a new symbol for it.
 TYPED_TEST(TestSymbolGenerator, ScopedCallImportKeepsItsSymbolAcrossIntermediateWith) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
   auto *outer_m = NODE("m");
@@ -1741,8 +1741,7 @@ TYPED_TEST(TestSymbolGenerator, ScopedCallImportKeepsItsSymbolAcrossIntermediate
       << "the import survives the WITH as the same symbol, so it names the outer frame slot";
 }
 
-// The same narrowing with no import: the legacy form declares a fresh symbol, which is why the planner
-// must clear its import set there rather than inherit one.
+// The legacy form declares a fresh symbol instead, which is why the planner clears its import set there.
 TYPED_TEST(TestSymbolGenerator, LegacyCallImportDoesNotKeepItsSymbolAcrossIntermediateWith) {
   // MATCH (m) CALL { WITH m MATCH (m)-[r]-(a) WITH a MATCH (m)-[r2]-(b) RETURN a, b } RETURN a, b
   auto *outer_m = NODE("m");


### PR DESCRIPTION
Variables imported by `CALL (v1, v2) { ... }` and `CALL (*) { ... }` stay in scope for the whole
subquery body, so a `WITH` inside the body that does not mention them must not drop them. The
planner dropped them anyway, and planned a fresh scan for a variable that was already bound:

```cypher
MATCH (a:Movie {id: "1"})
MATCH (b:Movie) WHERE b.id IN ["3", "5"]
CALL (a, b) {
  MATCH (a)--(x)
  WITH x            // does not mention b
  MATCH (b)--(y)    // planned as ScanAll (b), not an expand from the imported b
  RETURN x, y
}
RETURN DISTINCT x.id, collect(DISTINCT y.id);
```

**What.** Because `Apply` shares the frame with the outer chain, that spurious `ScanAll` overwrote
the slot the outer chain had filled. Three consequences, all silent — no error, no warning:

- wrong rows (the query above collected every node id instead of the two reachable ones);
- the corruption escaped the subquery, so the outer query read the scanned node after the `CALL`;
- `CREATE`/`MERGE` on an import fabricated a brand-new node instead of attaching to the bound one,
  diverging the graph.

`OPTIONAL MATCH` was affected like `MATCH`. Expression-position reads of an import were always
correct, which is why this stayed hidden.

**How.** `PlanningContext` now carries the active import set. `HandleSubquery` seeds it from the
scoped variables it already computes, clears it on the legacy `CALL { WITH v ... }` path, and
saves/restores it around the nested plan so nested subqueries cannot leak imports either way.
`impl::GenWith` re-adds those imports after narrowing `bound_symbols`, skipping any whose name a
named expression redeclared — mirroring the equivalent guard in `SymbolGenerator::VisitReturnBody`,
so `WITH x AS b` still shadows correctly.

The legacy leading-`WITH` import form is deliberately unchanged: it imports nothing, so ordinary
`WITH` narrowing still applies there and the name written afterwards is a fresh variable.

**Why.** Semantic analysis has modelled this scoping rule since the feature landed
(`50aa3fcd6`, #4073); the planner never learned it, so scoped `CALL` has never worked across an
intermediate `WITH`. Affects v3.10.0 onwards.

Covered by four plan-shape unit tests in `tests/unit/query_plan.cpp` (including the legacy form as
a guard against over-broad preservation) and five `subqueries.feature` scenarios for the rows, the
outer-scope leak and the `CREATE` divergence.
