### PR TITLE
feat(query): idle-session reaper — release an idle session's DB accessor so idle-pinned tenants drain

### DIFF
--- a/specs/hot-cold-databases.md
+++ b/specs/hot-cold-databases.md
@@ -160,6 +160,18 @@ visibility (`SHOW DATABASES`, stats, metrics); the policy belongs to the operato
 external control plane. Keeping every state change explicit also keeps the feature small
 enough to reason about and free of an entire class of eviction races.
 
+*Releasing an idle accessor is not eviction.* The experimental idle-session reaper
+(`--experimental-enabled=idle-session-reaper`, off by default) is **not** the automatic
+evictor this decision rejects. It never changes a database's hot/cold state and never
+removes it from memory: it only releases the **database accessor** held by a
+*connected-but-idle* session, once that session has been idle past
+`--session-idle-accessor-release-sec`, so a tenant pinned only by idle (e.g. pooled)
+connections drops to zero holders. State still changes only when an operator explicitly
+runs `SUSPEND` / `RESUME` / `DROP`; the reaper merely stops an idle connection from
+blocking that operator action, and the connection stays open so its next query
+transparently re-acquires the database. This is the mechanism, not a policy — the engine
+still never picks a tenant to evict on its own. See D6.
+
 ### D2 — Suspending fully destroys the in-memory representation.
 
 On suspend, *all* of the database's in-memory state and background activity is torn
@@ -242,6 +254,18 @@ and destructive thing to do silently. The safe, predictable contract is: suspend
 only when the database is genuinely idle, and otherwise tells the operator why it
 couldn't. The operator (or their control plane) drains the database and retries. This also
 sidesteps an entire category of mid-transaction teardown hazards.
+
+*Idle connections vs. active use.* "In use" means a session holding a **live database
+accessor** or an in-flight transaction — not merely an open socket. With the experimental
+idle-session reaper enabled (see D1), a session idle past
+`--session-idle-accessor-release-sec` releases its accessor while its connection stays
+open (the next query re-acquires the database by name). Such a session no longer counts as
+"in use", so an operator's `SUSPEND` / `DROP` on that otherwise-idle tenant can succeed.
+This preserves D6's guarantees — an **active** session or in-flight transaction still makes
+`SUSPEND` fail fast, and no query is ever killed or torn down — while letting an idle
+pooled connection stop pinning an otherwise-idle tenant. The reaper is off by default
+(`--session-idle-accessor-release-sec=0`), so the strict "any connected session blocks
+suspend" behavior is unchanged unless an operator opts in.
 
 ### D7 — On failover/promotion, cold databases stay cold.
 

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -135,9 +135,13 @@ class Session {
         case State::Idle:
         case State::Result:
           at_least_one_run_ = true;
+          // idle-session reaper: hold the reaper-exclusion gate for the whole handler span (no-op when
+          // the flag is off). Cleared below once the session parks back to Idle (or closes).
+          impl.SetMessageInFlight();
           state_ = StateExecutingRun(impl, state_);
           break;
         case State::Error:
+          impl.SetMessageInFlight();
           state_ = StateErrorRun(impl, state_);
           break;
         default:
@@ -155,6 +159,12 @@ class Session {
         // Try to not break from Prepare till the end of the execution as this will lead to worse performance.
         // Last pull will set the state to State::Idle
         return true;  // more data to process
+      }
+
+      if (state_ == State::Idle || state_ == State::Close) {
+        // The Bolt message span is over: the session has parked back to Idle (or is closing). Release
+        // the reaper-exclusion gate so an idle session becomes reapable again (no-op when flag off).
+        impl.ClearMessageInFlight();
       }
 
       if (state_ == State::Close) [[unlikely]] {

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -130,9 +130,8 @@ class Session {
 
       switch (state_) {
         case State::Init:
-          // idle-session reaper: arm the reaper-exclusion gate across the HELLO/LOGON handshake too (no-op
-          // when the flag is off). Without this, a slow authentication leaves db_acc_ writable by the
-          // handshake while the reaper could release it. Cleared below when the session parks to Idle/Close.
+          // Reaper exclusion: HELLO/LOGON authentication writes db_acc_ via TryDefaultDB; without this gate
+          // the reaper can concurrently release the same accessor. No-op when flag off; cleared below.
           impl.SetMessageInFlight();
           state_ = StateInitRun(impl);
           break;

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -130,6 +130,10 @@ class Session {
 
       switch (state_) {
         case State::Init:
+          // idle-session reaper: arm the reaper-exclusion gate across the HELLO/LOGON handshake too (no-op
+          // when the flag is off). Without this, a slow authentication leaves db_acc_ writable by the
+          // handshake while the reaper could release it. Cleared below when the session parks to Idle/Close.
+          impl.SetMessageInFlight();
           state_ = StateInitRun(impl);
           break;
         case State::Idle:

--- a/src/flags/experimental.cpp
+++ b/src/flags/experimental.cpp
@@ -49,9 +49,11 @@ namespace memgraph::flags {
 
 auto const mapping = std::map{
     std::pair{"planner-v2"sv, Experiments::PLANNER_V2},
+    std::pair{"idle-session-reaper"sv, Experiments::IDLE_SESSION_REAPER},
 };
 auto const reverse_mapping = std::map{
     std::pair{Experiments::PLANNER_V2, "planner-v2"sv},
+    std::pair{Experiments::IDLE_SESSION_REAPER, "idle-session-reaper"sv},
 };
 auto const config_mapping = std::map<std::string_view, Experiments>{};
 

--- a/src/flags/experimental.hpp
+++ b/src/flags/experimental.hpp
@@ -32,6 +32,7 @@ namespace memgraph::flags {
 enum class Experiments : uint8_t {
   NONE = 0,
   PLANNER_V2 = 1 << 0,
+  IDLE_SESSION_REAPER = 1 << 1,
 };
 
 bool AreExperimentsEnabled(Experiments experiments);

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -107,6 +107,13 @@ DEFINE_VALIDATED_uint64(storage_gc_cycle_sec, 30, "Storage garbage collector int
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_VALIDATED_uint64(storage_python_gc_cycle_sec, 180,
                         "Storage python full garbage collection interval (in seconds).", FLAG_IN_RANGE(1, 24UL * 3600));
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_VALIDATED_uint64(session_idle_accessor_release_sec, 0,
+                        "After this many seconds of inactivity, a Bolt session releases its database "
+                        "accessor so an idle tenant stops being pinned; the connection stays open and the "
+                        "next query re-acquires it. 0 disables. Requires "
+                        "--experimental-enabled=idle-session-reaper.",
+                        FLAG_IN_RANGE(0, 24UL * 3600));
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(storage_properties_on_edges, false, "Controls whether edges have properties.");

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -67,6 +67,8 @@ DECLARE_bool(fips_mode);
 DECLARE_uint64(storage_gc_cycle_sec);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint64(storage_python_gc_cycle_sec);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_uint64(session_idle_accessor_release_sec);
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_properties_on_edges);

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -743,6 +743,10 @@ SessionHL::SessionHL(Context context, memgraph::communication::v2::InputStream *
     auto &user_or_role = interpreter_.user_or_role_;
     MultiDatabaseAuth(user_or_role.get(), db_name);
   });
+  // Mark this Bolt-session interpreter as reapable by the idle-session reaper BEFORE it is registered
+  // below -- the registration lock publishes the flag to the reaper thread. Stream-consumer and internal
+  // interpreters never call this, so the reaper never releases their accessor.
+  interpreter_.MarkReapable();
 #endif
   interpreter_context_->interpreters.WithLock([this](auto &interpreters) { interpreters.insert(&interpreter_); });
 }

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -141,6 +141,12 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   inline bool Execute() { return Execute_(*this); }
 
+  // Idle-session-reaper message-in-flight exclusion gate. Forwarded from the Bolt Execute_ pump so the
+  // gate is held for the whole span of a Bolt message. Flag-off: both are no-ops.
+  void SetMessageInFlight() { interpreter_.SetMessageInFlight(); }
+
+  void ClearMessageInFlight() { interpreter_.ClearMessageInFlight(); }
+
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }
 
   metrics::DatabaseMetricHandles *GetMetricHandles() {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -366,7 +366,12 @@ int main(int argc, char **argv) {
 
 #ifdef MG_PYTHON_SUPPORT
   std::optional<memgraph::utils::Scheduler> python_gc_scheduler{std::nullopt};
+#ifdef MG_ENTERPRISE
+  // Enterprise-only: every use of this scheduler (arm/run/stop) is under MG_ENTERPRISE, so the
+  // declaration must be too -- otherwise a community build has an untouched optional that
+  // clang-tidy's misc-const-correctness (rightly) flags as const-able.
   std::optional<memgraph::utils::Scheduler> idle_reaper_scheduler{std::nullopt};
+#endif
   wchar_t *program_name{nullptr};
   PyThreadState *python_thread_state{nullptr};
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -423,9 +423,8 @@ int main(int argc, char **argv) {
 #endif
 
 #ifdef MG_ENTERPRISE
-  // Enterprise-only idle-session reaper scheduler. Declared here at function scope -- NOT inside the
-  // MG_PYTHON_SUPPORT block -- so it exists in an enterprise build compiled without Python. Every use
-  // (arm/run/stop, below) is under #ifdef MG_ENTERPRISE.
+  // Declared outside MG_PYTHON_SUPPORT so it exists when enterprise is built without Python;
+  // arm/run/stop below are each under their own #ifdef MG_ENTERPRISE.
   std::optional<memgraph::utils::Scheduler> idle_reaper_scheduler{std::nullopt};
 #endif
 
@@ -1045,11 +1044,8 @@ int main(int argc, char **argv) {
 #endif
 
 #ifdef MG_ENTERPRISE
-  // Idle-session reaper. Periodically releases the database accessor held by a connected-but-idle Bolt
-  // session once that session has been idle past --session-idle-accessor-release-sec, so a tenant pinned
-  // only by idle (e.g. pooled) connections drops to sole-accessor. The connection stays open; the next
-  // query re-acquires the accessor. Experiment-gated: flag-off sessions never claim db_acc_ ownership at
-  // query entry, so they are not reapable and the reaper must not run for them.
+  // Experiment gate is correctness-critical: flag-off sessions skip EnsureDbAccessForQuery at query
+  // entry and cannot safely recover from a released accessor — the reaper must not run for them.
   if (!is_coordinator_instance && dbms_handler.has_value() && FLAGS_session_idle_accessor_release_sec > 0 &&
       memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::IDLE_SESSION_REAPER)) {
     idle_reaper_scheduler.emplace();
@@ -1063,10 +1059,8 @@ int main(int argc, char **argv) {
       // steady_clock pairs with the interpreter's steady-clock last_activity_ns_.
       const auto now_ns = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
       uint64_t reaped = 0;
-      // Hold the interpreters lock for the sweep (mirrors ShowTransactions iteration). Each
-      // TryReapIdleDbAccessor call is non-blocking — a single CAS plus, at most, an accessor reset
-      // (a refcount decrement, no I/O) — so the critical section is short, and holding the lock
-      // prevents a session's SessionHL destructor from erasing+destroying an interpreter mid-reap.
+      // Lock held for the full sweep: SessionHL's destructor erases under the same lock (SessionHL.cpp:755),
+      // so it cannot destroy an interpreter while we iterate; each TryReapIdleDbAccessor call is non-blocking.
       interpreter_context_.interpreters.WithLock([&](auto &interpreters) {
         for (auto *interpreter : interpreters) {
           if (interpreter->TryReapIdleDbAccessor(now_ns, timeout_ns)) ++reaped;
@@ -1080,7 +1074,7 @@ int main(int argc, char **argv) {
                  FLAGS_session_idle_accessor_release_sec,
                  sweep_sec);
   }
-#endif  // MG_ENTERPRISE (idle-session reaper)
+#endif
 
 #ifdef MG_ENTERPRISE
   // MAIN or REPLICA instance

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -366,6 +366,7 @@ int main(int argc, char **argv) {
 
 #ifdef MG_PYTHON_SUPPORT
   std::optional<memgraph::utils::Scheduler> python_gc_scheduler{std::nullopt};
+  std::optional<memgraph::utils::Scheduler> idle_reaper_scheduler{std::nullopt};
   wchar_t *program_name{nullptr};
   PyThreadState *python_thread_state{nullptr};
 
@@ -1038,6 +1039,44 @@ int main(int argc, char **argv) {
 #endif
 
 #ifdef MG_ENTERPRISE
+  // Idle-session reaper. Periodically releases the database accessor held by a connected-but-idle Bolt
+  // session once that session has been idle past --session-idle-accessor-release-sec, so a tenant pinned
+  // only by idle (e.g. pooled) connections drops to sole-accessor. The connection stays open; the next
+  // query re-acquires the accessor. Experiment-gated: flag-off sessions never claim db_acc_ ownership at
+  // query entry, so they are not reapable and the reaper must not run for them.
+  if (!is_coordinator_instance && dbms_handler.has_value() && FLAGS_session_idle_accessor_release_sec > 0 &&
+      memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::IDLE_SESSION_REAPER)) {
+    idle_reaper_scheduler.emplace();
+    // Sweep at half the idle timeout (bounded to at least 1s) so a newly-idle session is reaped within
+    // roughly one-and-a-half timeout windows.
+    const auto sweep_sec = std::max<uint64_t>(1, FLAGS_session_idle_accessor_release_sec / 2);
+    idle_reaper_scheduler->SetInterval(std::chrono::seconds(sweep_sec));
+    idle_reaper_scheduler->Run("IdleReaper", [&interpreter_context_]() {
+      if (!memgraph::license::global_license_checker.IsEnterpriseValidFast()) return;
+      const uint64_t timeout_ns = FLAGS_session_idle_accessor_release_sec * 1'000'000'000ULL;
+      // steady_clock pairs with the interpreter's steady-clock last_activity_ns_.
+      const auto now_ns = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+      uint64_t reaped = 0;
+      // Hold the interpreters lock for the sweep (mirrors ShowTransactions iteration). Each
+      // TryReapIdleDbAccessor call is non-blocking — a single CAS plus, at most, an accessor reset
+      // (a refcount decrement, no I/O) — so the critical section is short, and holding the lock
+      // prevents a session's SessionHL destructor from erasing+destroying an interpreter mid-reap.
+      interpreter_context_.interpreters.WithLock([&](auto &interpreters) {
+        for (auto *interpreter : interpreters) {
+          if (interpreter->TryReapIdleDbAccessor(now_ns, timeout_ns)) ++reaped;
+        }
+      });
+      if (reaped > 0) {
+        spdlog::info("Idle-session reaper: released {} idle session accessor(s).", reaped);
+      }
+    });
+    spdlog::info("Idle-session reaper started (idle timeout {}s, sweep {}s).",
+                 FLAGS_session_idle_accessor_release_sec,
+                 sweep_sec);
+  }
+#endif  // MG_ENTERPRISE (idle-session reaper)
+
+#ifdef MG_ENTERPRISE
   // MAIN or REPLICA instance
   // Needs to start after dbms_handler.RestoreTriggers has been run. Otherwise we have a deadlock:
   // This thread takes unique lock on dbms handler and waits for storage write access
@@ -1147,6 +1186,7 @@ int main(int argc, char **argv) {
 #ifdef MG_ENTERPRISE
                       &coordinator_state,
                       &metrics_server,
+                      &idle_reaper_scheduler,
 #endif
                       is_coordinator_instance,
                       &websocket_server,
@@ -1195,6 +1235,13 @@ int main(int argc, char **argv) {
         locked_repl_state->Shutdown();
       }
     }
+
+#ifdef MG_ENTERPRISE
+    if (idle_reaper_scheduler) {
+      spdlog::trace("Stopping idle-session reaper");
+      idle_reaper_scheduler->Stop();
+    }
+#endif
 
     if (dbms_handler.has_value()) {
       dbms_handler->ForEach([](memgraph::dbms::DatabaseAccess acc) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -366,12 +366,6 @@ int main(int argc, char **argv) {
 
 #ifdef MG_PYTHON_SUPPORT
   std::optional<memgraph::utils::Scheduler> python_gc_scheduler{std::nullopt};
-#ifdef MG_ENTERPRISE
-  // Enterprise-only: every use of this scheduler (arm/run/stop) is under MG_ENTERPRISE, so the
-  // declaration must be too -- otherwise a community build has an untouched optional that
-  // clang-tidy's misc-const-correctness (rightly) flags as const-able.
-  std::optional<memgraph::utils::Scheduler> idle_reaper_scheduler{std::nullopt};
-#endif
   wchar_t *program_name{nullptr};
   PyThreadState *python_thread_state{nullptr};
 
@@ -426,6 +420,13 @@ int main(int argc, char **argv) {
     python_gc_scheduler->SetInterval(std::chrono::seconds(FLAGS_storage_python_gc_cycle_sec));
     python_gc_scheduler->Run("Python GC", [] { memgraph::query::procedure::PyCollectGarbage(); });
   }
+#endif
+
+#ifdef MG_ENTERPRISE
+  // Enterprise-only idle-session reaper scheduler. Declared here at function scope -- NOT inside the
+  // MG_PYTHON_SUPPORT block -- so it exists in an enterprise build compiled without Python. Every use
+  // (arm/run/stop, below) is under #ifdef MG_ENTERPRISE.
+  std::optional<memgraph::utils::Scheduler> idle_reaper_scheduler{std::nullopt};
 #endif
 
   // Initialize the communication library.

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -50,9 +50,8 @@ enum class TransactionStatus {
   TERMINATED,
   STARTED_COMMITTING,
   STARTED_ROLLBACK,
-  // Transient exclusive-ownership state entered by the idle-session reaper (from IDLE only) while it
-  // releases this interpreter's connection-scoped db_acc_. The session honors it by spin-waiting at
-  // query entry. Reached only when the idle-session-reaper experiment is enabled.
+  // Transient exclusive-ownership state: the idle-session reaper CAS(IDLE→REAPING) while releasing
+  // db_acc_; the session spin-waits on it inside SetMessageInFlight. Requires IDLE_SESSION_REAPER.
   REAPING,
 };
 

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -50,6 +50,16 @@ enum class TransactionStatus {
   TERMINATED,
   STARTED_COMMITTING,
   STARTED_ROLLBACK,
+  // Query-entry claim state (idle-session reaper only): the session CAS-es IDLE->PREPARING at the top
+  // of Prepare, before it touches current_db_.db_acc_, then SetupInterpreterTransaction transitions
+  // PREPARING->ACTIVE once current_transaction_ is published. Distinct from ACTIVE so a concurrent
+  // SHOW TRANSACTIONS (TryAcquireForVerification) does NOT engage the interpreter while it is still
+  // writing current_transaction_/start-time. Excludes the reaper too (it claims REAPING only from IDLE).
+  PREPARING,
+  // Transient exclusive-ownership state entered by the idle-session reaper (from IDLE only) while it
+  // releases this interpreter's connection-scoped db_acc_. The session honors it by spin-waiting at
+  // query entry. Reached only when the idle-session-reaper experiment is enabled.
+  REAPING,
 };
 
 struct Scope {

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -50,12 +50,6 @@ enum class TransactionStatus {
   TERMINATED,
   STARTED_COMMITTING,
   STARTED_ROLLBACK,
-  // Query-entry claim state (idle-session reaper only): the session CAS-es IDLE->PREPARING at the top
-  // of Prepare, before it touches current_db_.db_acc_, then SetupInterpreterTransaction transitions
-  // PREPARING->ACTIVE once current_transaction_ is published. Distinct from ACTIVE so a concurrent
-  // SHOW TRANSACTIONS (TryAcquireForVerification) does NOT engage the interpreter while it is still
-  // writing current_transaction_/start-time. Excludes the reaper too (it claims REAPING only from IDLE).
-  PREPARING,
   // Transient exclusive-ownership state entered by the idle-session reaper (from IDLE only) while it
   // releases this interpreter's connection-scoped db_acc_. The session honors it by spin-waiting at
   // query entry. Reached only when the idle-session-reaper experiment is enabled.

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -11470,7 +11470,7 @@ void Interpreter::EnsureDbAccessForQuery() {
       current_db_.ResetDB();
       return;
     }
-    current_db_.db_acc_ = std::move(reacquired);
+    current_db_.ReacquireDbAccessor(std::move(reacquired));
   } catch (const dbms::UnknownDatabaseException &) {
     // Dropped / suspended / draining out from under the session. Same db-less fallback rather than wedge.
     spdlog::trace("Session database '{}' no longer available; falling back to a db-less session.",
@@ -11512,7 +11512,7 @@ bool Interpreter::TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_n
     if (db->name() != dbms::kDefaultDB && now_ns > last_used_ns && (now_ns - last_used_ns) >= idle_timeout_ns) {
       // Release the accessor (drops the gatekeeper count). current_db_name_ is kept so the next query
       // transparently re-acquires via EnsureDbAccessForQuery.
-      current_db_.db_acc_.reset();
+      current_db_.ReleaseDbAccessor();
       reaped = true;
     }
   }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10249,6 +10249,12 @@ bool Interpreter::IsCurrentTransactionEmpty() const {
 
 void Interpreter::BeginTransaction(QueryExtras const &extras) {
   ResetInterpreter();
+#ifdef MG_ENTERPRISE
+  // Native Bolt BEGIN bypasses Prepare(), so re-acquire db_acc_ here too if the reaper released it
+  // while this pooled session was parked -- otherwise the BEGIN handler throws on a null db_acc_ for a
+  // healthy tenant. Falls back to a db-less session on drop/suspend/recycle, exactly like Prepare().
+  if (flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) EnsureDbAccessForQuery();
+#endif
   auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras);
   prepared_query.query_handler(nullptr, {});
 }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -11464,6 +11464,14 @@ void Interpreter::EnsureDbAccessForQuery() {
   if (!current_db_.current_db_name_) return;  // already db-less
   try {
     auto reacquired = interpreter_context_->dbms_handler->Get(*current_db_.current_db_name_);
+    // The tenant is being dropped (HOT but marked for deletion — the gatekeeper still grants its
+    // accessor). Do not re-pin it; go db-less so the drop can complete.
+    if (reacquired.is_marked_for_deletion()) {
+      spdlog::trace("Session database '{}' is being dropped; falling back to a db-less session.",
+                    *current_db_.current_db_name_);
+      current_db_.ResetDB();
+      return;
+    }
     // Recycle guard: the tenant name may have been recycled (dropped+recreated under the same name);
     // UUID mismatch means we would attach to the wrong tenant — fall back to db-less instead.
     if (current_db_.current_db_uuid_ && reacquired->uuid() != *current_db_.current_db_uuid_) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7369,6 +7369,10 @@ auto TransactionStatusToString(TransactionStatus status) -> char const * {
       return "committing";
     case TransactionStatus::STARTED_ROLLBACK:
       return "aborting";
+    case TransactionStatus::PREPARING:
+      return "preparing";
+    case TransactionStatus::REAPING:
+      return "reaping";
   }
   return "unknown";
 }
@@ -10336,12 +10340,18 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
   const auto trimmed_query = utils::Trim(upper_case_query);
   const bool is_begin = trimmed_query == "BEGIN";
 
+  // Parse runs before the IDLE->PREPARING claim in Prepare, so the idle-session reaper may reset
+  // db_acc_ concurrently (see TryReapIdleDbAccessor). Read the reaper-stable persistent identity
+  // (current_db_name_), never the live accessor, on this pre-claim path. current_db_name_ is kept in
+  // sync with db_acc_ by SetCurrentDB; falling back to name() is safe (it too prefers the persistent
+  // identity when db_acc_ is absent).
+  const std::string log_db_name = current_db_.current_db_name_ ? *current_db_.current_db_name_ : current_db_.name();
   // Explicit transactions define the metadata at the beginning and reuse it
   spdlog::debug("{}",
                 QueryLogWrapper{.query = query_string,
                                 .metadata = (in_explicit_transaction_ && metadata_ && !is_begin) ? &*metadata_
                                                                                                  : &extras.metadata_pv,
-                                .db_name = current_db_.name()});
+                                .db_name = log_db_name});
 
   if (is_begin) {
     return TransactionQuery::BEGIN;
@@ -10361,8 +10371,15 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
     // NOTE: query_string is not BEGIN, COMMIT or ROLLBACK
     const utils::Timer parsing_timer;
     memgraph::logging::EmitSessionTraceEvent("Query parsing started.");
+    // Same reaper-safety as the log above: prefer the reaper-stable current_db_uuid_ over the live
+    // accessor, which the reaper may reset during this pre-claim Parse. (This uuid is only an
+    // AST-cache-key hint; parameters are re-resolved with the real uuid after Prepare re-acquires.)
     std::string database_uuid;
-    if (current_db_.db_acc_) database_uuid = std::string{current_db_.db_acc_->get()->uuid()};
+    if (current_db_.current_db_uuid_) {
+      database_uuid = std::string{*current_db_.current_db_uuid_};
+    } else if (current_db_.db_acc_) {  // reaper off / db-less: db_acc_ is stable
+      database_uuid = std::string{current_db_.db_acc_->get()->uuid()};
+    }
     ParsedQuery parsed_query = ParseQuery(query_string,
                                           params_getter(nullptr),
                                           &interpreter_context_->ast_cache,
@@ -10606,6 +10623,18 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 
 Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParameters_fn params_getter,
                                                 QueryExtras const &extras) {
+#ifdef MG_ENTERPRISE
+  // Idle-session reaper sync (IDLE_SESSION_REAPER only): claim exclusive ownership of db_acc_ for the
+  // IDLE window of Prepare BEFORE the first db_acc_ read below, so the background reaper cannot
+  // release db_acc_ out from under us. TryClaimForQueryEntry spin-waits on REAPING and CAS-es
+  // IDLE->PREPARING (no-op when already inside an explicit transaction). The OnScopeExit restores
+  // IDLE only if we claimed and no transaction was set up (parse error / early return). Flag-off:
+  // no claim, byte-identical to master.
+  const bool reaper_armed = flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER);
+  const bool entry_claimed = reaper_armed && TryClaimForQueryEntry();
+  utils::OnScopeExit release_entry_claim{[this, entry_claimed]() { ReleaseEntryClaimIfUnused(entry_claimed); }};
+  if (reaper_armed) EnsureDbAccessForQuery();  // re-acquire db_acc_ if the reaper released it while idle
+#endif
   std::optional<memory::DbArenaScope> db_arena_scope;
   if (current_db_.db_acc_) {
     db_arena_scope.emplace(current_db_.db_acc_->get());
@@ -11411,6 +11440,145 @@ std::optional<Interpreter::TxVerifier> Interpreter::TryAcquireForVerification() 
   // CAS failed, return to avoid busy loops
   return std::nullopt;
 }
+
+void Interpreter::SetMessageInFlight() noexcept {
+  if (!flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) return;
+  message_in_flight_.store(true, std::memory_order_seq_cst);
+  // Dekker StoreLoad: the seq_cst store above is globally ordered before this seq_cst load, so it
+  // pairs with TryReapIdleDbAccessor's seq_cst store(REAPING)+load(message_in_flight_). If a reaper
+  // currently owns REAPING, wait it out (it will restore IDLE and — seeing our gate on its re-check —
+  // decline to reap). Our db_acc_ touches then happen after the reap window; EnsureDbAccessForQuery
+  // re-acquires the accessor as usual on the next query.
+  while (transaction_status_.load(std::memory_order_seq_cst) == TransactionStatus::REAPING) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+void Interpreter::ClearMessageInFlight() noexcept {
+  if (!flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) return;
+  message_in_flight_.store(false, std::memory_order_seq_cst);
+  // Session is parking back to Idle: stamp the idle clock so the reaper measures the idle window from
+  // this moment (not from the last query start), and never from epoch 0 for a session that only ever
+  // ran db-independent commands.
+  last_activity_ns_.store(SteadyNowNs(), std::memory_order_relaxed);
+}
+
+#ifdef MG_ENTERPRISE
+bool Interpreter::TryClaimForQueryEntry() {
+  // Session thread, top of Prepare. Claim exclusive ownership of db_acc_ for the IDLE window by
+  // moving IDLE -> PREPARING. Spin-wait while the reaper owns REAPING. If status is already ACTIVE
+  // (a statement inside an explicit transaction) we already own it -> not a fresh claim.
+  TransactionStatus st = transaction_status_.load(std::memory_order_acquire);
+  for (;;) {
+    if (st == TransactionStatus::REAPING) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      st = transaction_status_.load(std::memory_order_acquire);
+      continue;
+    }
+    if (st != TransactionStatus::IDLE) return false;  // already owned (e.g. explicit-txn ACTIVE)
+    if (transaction_status_.compare_exchange_weak(
+            st, TransactionStatus::PREPARING, std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return true;  // claimed IDLE -> PREPARING
+    }
+    // CAS failed: compare_exchange_weak refreshed `st`; loop.
+  }
+}
+
+void Interpreter::ReleaseEntryClaimIfUnused(bool claimed) noexcept {
+  if (!claimed) return;
+  // If a transaction was set up, SetupInterpreterTransaction already moved PREPARING -> ACTIVE and
+  // engaged current_transaction_; ownership is handed to the normal commit/abort lifecycle.
+  if (current_transaction_.has_value()) return;
+  // No transaction set up (parse error / early return / exception before SetupInterpreterTransaction).
+  // Restore IDLE only if we still hold the claim (status == PREPARING). A CAS, not a blind store: on an
+  // error path Abort() may already have driven the status to IDLE (and reset current_transaction_), after
+  // which the reaper can win its own CAS IDLE->REAPING. A blind store would clobber that REAPING window;
+  // the CAS instead fails and leaves whoever now owns the transition untouched. Verifiers and the reaper
+  // both ignore PREPARING, so when status really is still PREPARING this thread is its only writer.
+  TransactionStatus expected = TransactionStatus::PREPARING;
+  transaction_status_.compare_exchange_strong(
+      expected, TransactionStatus::IDLE, std::memory_order_acq_rel, std::memory_order_relaxed);
+}
+
+void Interpreter::EnsureDbAccessForQuery() {
+  if (current_db_.db_acc_) {
+    // Connection-scoped: the accessor is already held (acquired at connect / USE / SetCurrentDB).
+    return;
+  }
+  // Defensive: a session DB name is set but the accessor was released (e.g. by the idle-session reaper,
+  // or because its DB was marked for deletion mid-session via ResetInterpreter). Re-acquire via the
+  // gatekeeper; Get throws UnknownDatabaseException (incl. its SuspendedDatabaseException subtype) if
+  // the tenant is genuinely gone / suspended / draining.
+  if (!current_db_.current_db_name_) return;  // already db-less
+  try {
+    auto reacquired = interpreter_context_->dbms_handler->Get(*current_db_.current_db_name_);
+    // Recycle guard: the name may have been dropped and a DIFFERENT tenant recreated under it while the
+    // accessor was released. Re-acquiring by name would silently attach to that different tenant. The
+    // reaper only reaps non-default tenants, whose UUID is a stable identity, so a UUID mismatch here is
+    // unambiguously a recycle. (Safe where a name-only guard was not: the default DB, whose UUID mutates
+    // in place, is never reaped, so its accessor is never re-acquired through this path.) Rather than
+    // wedge the session, fall back to a db-less connection -- the client can USE another database (or run
+    // a db-independent command) in the SAME session; a db-requiring query gets the normal "no current
+    // database" error, recoverable without a reconnect.
+    if (current_db_.current_db_uuid_ && reacquired->uuid() != *current_db_.current_db_uuid_) {
+      spdlog::trace("Session database '{}' was recreated; falling back to a db-less session.",
+                    *current_db_.current_db_name_);
+      current_db_.ResetDB();
+      return;
+    }
+    current_db_.db_acc_ = std::move(reacquired);
+  } catch (const dbms::UnknownDatabaseException &) {
+    // The database was dropped / suspended / draining out from under the session. Same fallback: become
+    // db-less rather than wedge, so the session can USE another database in place instead of being forced
+    // to reconnect.
+    spdlog::trace("Session database '{}' no longer available; falling back to a db-less session.",
+                  *current_db_.current_db_name_);
+    current_db_.ResetDB();
+  }
+}
+
+bool Interpreter::TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_ns) {
+  if (!reapable_) return false;
+  // Message-in-flight gate pre-check (Dekker StoreLoad, seq_cst). If a Bolt message is being handled,
+  // the session may touch db_acc_ at any moment — never reap. Cheap and catches the common case.
+  if (message_in_flight_.load(std::memory_order_seq_cst)) return false;
+  // Cheap pre-check: only an IDLE session is a candidate. No spin — if it is busy we catch it next tick.
+  if (transaction_status_.load(std::memory_order_seq_cst) != TransactionStatus::IDLE) return false;
+  // Single CAS IDLE -> REAPING. On failure the session just became active (or a verifier ran) — skip.
+  // Success ordering is seq_cst so the CAS totally-orders against SetMessageInFlight's seq_cst store.
+  TransactionStatus expected = TransactionStatus::IDLE;
+  if (!transaction_status_.compare_exchange_strong(
+          expected, TransactionStatus::REAPING, std::memory_order_seq_cst, std::memory_order_acquire)) {
+    return false;
+  }
+  // Re-check the gate now that we own REAPING, before touching db_acc_. This closes the TOCTOU with
+  // SetMessageInFlight: if the session set message_in_flight_ (seq_cst store) and then observed our
+  // status as not-yet-REAPING (so it did NOT spin-wait), its store is globally ordered either before
+  // our re-check load (we see it here and back out) or after our store(REAPING) (it spins in
+  // SetMessageInFlight until we restore IDLE). Either way one side yields — no torn reap.
+  if (message_in_flight_.load(std::memory_order_seq_cst)) {
+    transaction_status_.store(TransactionStatus::IDLE, std::memory_order_release);
+    return false;
+  }
+  // We now own REAPING: the session cannot enter Prepare (it spin-waits on REAPING), so db_acc_ and
+  // in_explicit_transaction_ are stable. Decide whether to actually release, then always restore IDLE.
+  bool reaped = false;
+  // Belt-and-suspenders: never reap an explicit transaction (cannot occur from IDLE, but cheap).
+  // Only release a held accessor whose tenant is non-default and has been idle past the timeout.
+  if (!in_explicit_transaction_ && current_db_.db_acc_.has_value()) {
+    auto *db = current_db_.db_acc_->get();
+    const auto last_used_ns = last_activity_ns_.load(std::memory_order_relaxed);
+    if (db->name() != dbms::kDefaultDB && now_ns > last_used_ns && (now_ns - last_used_ns) >= idle_timeout_ns) {
+      // Release the accessor (drops the gatekeeper count). current_db_name_ is kept so the next query
+      // transparently re-acquires via EnsureDbAccessForQuery.
+      current_db_.db_acc_.reset();
+      reaped = true;
+    }
+  }
+  transaction_status_.store(TransactionStatus::IDLE, std::memory_order_release);
+  return reaped;
+}
+#endif
 
 namespace {
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -54,6 +54,7 @@
 #include "dbms/coordinator_handler.hpp"
 #include "dbms/dbms_handler.hpp"
 #include "dbms/global.hpp"
+#include "flags/experimental.hpp"
 #include "flags/general.hpp"
 #include "flags/isolation_level.hpp"
 #include "flags/run_time_configurable.hpp"
@@ -10250,9 +10251,8 @@ bool Interpreter::IsCurrentTransactionEmpty() const {
 void Interpreter::BeginTransaction(QueryExtras const &extras) {
   ResetInterpreter();
 #ifdef MG_ENTERPRISE
-  // Native Bolt BEGIN bypasses Prepare(), so re-acquire db_acc_ here too if the reaper released it
-  // while this pooled session was parked -- otherwise the BEGIN handler throws on a null db_acc_ for a
-  // healthy tenant. Falls back to a db-less session on drop/suspend/recycle, exactly like Prepare().
+  // Native Bolt BEGIN bypasses Prepare(), so re-acquire db_acc_ here if the reaper released it while
+  // this pooled session was parked — the BEGIN handler would throw on a null db_acc_ for a live tenant.
   if (flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) EnsureDbAccessForQuery();
 #endif
   auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras);
@@ -10372,9 +10372,8 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
     // NOTE: query_string is not BEGIN, COMMIT or ROLLBACK
     const utils::Timer parsing_timer;
     memgraph::logging::EmitSessionTraceEvent("Query parsing started.");
-    // db_acc_ may be null here after a prior idle reap (Parse runs before EnsureDbAccessForQuery
-    // re-acquires); use current_db_uuid_ as the cache key to avoid a null db_acc_->get()->uuid().
-    // Only an AST-cache-key hint; params are re-resolved with the real uuid after Prepare re-acquires.
+    // db_acc_ may be null post-reap; use current_db_uuid_ as the cache key instead of db_acc_->uuid().
+    // AST-cache-key hint only — params are re-resolved with the live uuid after EnsureDbAccessForQuery.
     std::string database_uuid;
     if (current_db_.current_db_uuid_) {
       database_uuid = std::string{*current_db_.current_db_uuid_};
@@ -11439,9 +11438,8 @@ std::optional<Interpreter::TxVerifier> Interpreter::TryAcquireForVerification() 
 void Interpreter::SetMessageInFlight() noexcept {
   if (!flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) return;
   message_in_flight_.store(true, std::memory_order_seq_cst);
-  // Dekker StoreLoad: the seq_cst store is globally ordered before this seq_cst load, pairing with
-  // TryReapIdleDbAccessor's seq_cst store(REAPING)+load(message_in_flight_). If a reaper owns REAPING,
-  // wait it out; it will restore IDLE and, seeing our gate on its re-check, decline to reap.
+  // Dekker StoreLoad: seq_cst store/load pairs with TryReapIdleDbAccessor's CAS(REAPING)+load(message_in_flight_).
+  // If the reaper already owns REAPING, spin; it restores IDLE and its re-check will see our gate and back out.
   while (transaction_status_.load(std::memory_order_seq_cst) == TransactionStatus::REAPING) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
@@ -11450,8 +11448,8 @@ void Interpreter::SetMessageInFlight() noexcept {
 void Interpreter::ClearMessageInFlight() noexcept {
   if (!flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) return;
   message_in_flight_.store(false, std::memory_order_seq_cst);
-  // Parking back to Idle: stamp the idle clock so the reaper measures the idle window from now (not
-  // from last query start, and never from epoch 0 for a session that only ran db-independent commands).
+  // Parking back to Idle: stamp the idle clock so the reaper measures idle from last message
+  // completion, not from connect time (MarkReapable stamps once at connect, not per message).
   last_activity_ns_.store(SteadyNowNs(), std::memory_order_relaxed);
 }
 
@@ -11466,10 +11464,8 @@ void Interpreter::EnsureDbAccessForQuery() {
   if (!current_db_.current_db_name_) return;  // already db-less
   try {
     auto reacquired = interpreter_context_->dbms_handler->Get(*current_db_.current_db_name_);
-    // Recycle guard: the name may have been dropped and a DIFFERENT tenant recreated under it, which a
-    // name-only re-acquire would silently attach to. Reaped tenants are non-default, so their UUID is a
-    // stable identity and a mismatch is unambiguously a recycle -> fall back to a db-less session rather
-    // than wedge (the client can USE another database in the same session).
+    // Recycle guard: the tenant name may have been recycled (dropped+recreated under the same name);
+    // UUID mismatch means we would attach to the wrong tenant — fall back to db-less instead.
     if (current_db_.current_db_uuid_ && reacquired->uuid() != *current_db_.current_db_uuid_) {
       spdlog::trace("Session database '{}' was recreated; falling back to a db-less session.",
                     *current_db_.current_db_name_);
@@ -11490,7 +11486,7 @@ bool Interpreter::TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_n
   // Message-in-flight gate pre-check (Dekker StoreLoad, seq_cst). If a Bolt message is being handled,
   // the session may touch db_acc_ at any moment — never reap. Cheap and catches the common case.
   if (message_in_flight_.load(std::memory_order_seq_cst)) return false;
-  // Cheap pre-check: only an IDLE session is a candidate. No spin — if it is busy we catch it next tick.
+  // No spin: a non-IDLE session is skipped; the reaper catches it on the next tick.
   if (transaction_status_.load(std::memory_order_seq_cst) != TransactionStatus::IDLE) return false;
   // Single CAS IDLE -> REAPING. On failure the session just became active (or a verifier ran) — skip.
   // Success ordering is seq_cst so the CAS totally-orders against SetMessageInFlight's seq_cst store.
@@ -11499,10 +11495,8 @@ bool Interpreter::TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_n
           expected, TransactionStatus::REAPING, std::memory_order_seq_cst, std::memory_order_acquire)) {
     return false;
   }
-  // Re-check the gate now that we own REAPING, closing the TOCTOU with SetMessageInFlight: if the session
-  // stored message_in_flight_ but observed our status as not-yet-REAPING (so did NOT spin-wait), its
-  // seq_cst store is globally ordered either before this load (we see it and back out) or after our
-  // store(REAPING) (it spins until we restore IDLE). Either way one side yields -- no torn reap.
+  // Re-check closes the TOCTOU with SetMessageInFlight: seq_cst total order ensures one side yields —
+  // either we see message_in_flight_=true here and back out, or SetMessageInFlight sees REAPING and spins.
   if (message_in_flight_.load(std::memory_order_seq_cst)) {
     transaction_status_.store(TransactionStatus::IDLE, std::memory_order_release);
     return false;
@@ -11516,8 +11510,7 @@ bool Interpreter::TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_n
     auto *db = current_db_.db_acc_->get();
     const auto last_used_ns = last_activity_ns_.load(std::memory_order_relaxed);
     if (db->name() != dbms::kDefaultDB && now_ns > last_used_ns && (now_ns - last_used_ns) >= idle_timeout_ns) {
-      // Release the accessor (drops the gatekeeper count). current_db_name_ is kept so the next query
-      // transparently re-acquires via EnsureDbAccessForQuery.
+      // current_db_name_ is kept so the next query transparently re-acquires via EnsureDbAccessForQuery.
       current_db_.ReleaseDbAccessor();
       reaped = true;
     }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7369,8 +7369,6 @@ auto TransactionStatusToString(TransactionStatus status) -> char const * {
       return "committing";
     case TransactionStatus::STARTED_ROLLBACK:
       return "aborting";
-    case TransactionStatus::PREPARING:
-      return "preparing";
     case TransactionStatus::REAPING:
       return "reaping";
   }
@@ -10340,8 +10338,8 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
   const auto trimmed_query = utils::Trim(upper_case_query);
   const bool is_begin = trimmed_query == "BEGIN";
 
-  // Pre-claim path: the reaper may reset db_acc_ concurrently (TryReapIdleDbAccessor), so read the
-  // reaper-stable current_db_name_, never the live accessor.
+  // db_acc_ may be null here after a prior idle reap (Parse runs before EnsureDbAccessForQuery
+  // re-acquires); read the reaper-stable current_db_name_, never the live accessor.
   const std::string log_db_name = current_db_.current_db_name_ ? *current_db_.current_db_name_ : current_db_.name();
   // Explicit transactions define the metadata at the beginning and reuse it
   spdlog::debug("{}",
@@ -10368,7 +10366,8 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
     // NOTE: query_string is not BEGIN, COMMIT or ROLLBACK
     const utils::Timer parsing_timer;
     memgraph::logging::EmitSessionTraceEvent("Query parsing started.");
-    // Same pre-claim reaper-safety: prefer the reaper-stable current_db_uuid_ over the live accessor.
+    // db_acc_ may be null here after a prior idle reap (Parse runs before EnsureDbAccessForQuery
+    // re-acquires); use current_db_uuid_ as the cache key to avoid a null db_acc_->get()->uuid().
     // Only an AST-cache-key hint; params are re-resolved with the real uuid after Prepare re-acquires.
     std::string database_uuid;
     if (current_db_.current_db_uuid_) {
@@ -10620,11 +10619,9 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParameters_fn params_getter,
                                                 QueryExtras const &extras) {
 #ifdef MG_ENTERPRISE
-  // Claim exclusive ownership of db_acc_ (IDLE->PREPARING) BEFORE the first db_acc_ read below, so the
-  // background reaper cannot release it out from under us; OnScopeExit restores IDLE on an unused claim.
+  // Re-acquire db_acc_ if the reaper released it while this session was parked, before the first
+  // db_acc_ read below. message_in_flight_ (set before Parse) already fences the whole read window.
   const bool reaper_armed = flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER);
-  const bool entry_claimed = reaper_armed && TryClaimForQueryEntry();
-  utils::OnScopeExit release_entry_claim{[this, entry_claimed]() { ReleaseEntryClaimIfUnused(entry_claimed); }};
   if (reaper_armed) EnsureDbAccessForQuery();
 #endif
   std::optional<memory::DbArenaScope> db_arena_scope;
@@ -11453,38 +11450,6 @@ void Interpreter::ClearMessageInFlight() noexcept {
 }
 
 #ifdef MG_ENTERPRISE
-bool Interpreter::TryClaimForQueryEntry() {
-  // Claim db_acc_ ownership by CAS IDLE -> PREPARING, spin-waiting while the reaper owns REAPING. A
-  // non-IDLE status (e.g. ACTIVE inside an explicit transaction) means we already own it -> no claim.
-  TransactionStatus st = transaction_status_.load(std::memory_order_acquire);
-  for (;;) {
-    if (st == TransactionStatus::REAPING) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      st = transaction_status_.load(std::memory_order_acquire);
-      continue;
-    }
-    if (st != TransactionStatus::IDLE) return false;  // already owned (e.g. explicit-txn ACTIVE)
-    if (transaction_status_.compare_exchange_weak(
-            st, TransactionStatus::PREPARING, std::memory_order_acq_rel, std::memory_order_acquire)) {
-      return true;
-    }
-  }
-}
-
-void Interpreter::ReleaseEntryClaimIfUnused(bool claimed) noexcept {
-  if (!claimed) return;
-  // If a transaction was set up, SetupInterpreterTransaction already moved PREPARING -> ACTIVE and
-  // engaged current_transaction_; ownership is handed to the normal commit/abort lifecycle.
-  if (current_transaction_.has_value()) return;
-  // No transaction set up (parse error / early return). Restore IDLE via CAS, not a blind store: an
-  // error-path Abort() may have already driven status to IDLE and let the reaper win its own CAS
-  // IDLE->REAPING; a blind store would clobber that REAPING window. Verifiers and the reaper both ignore
-  // PREPARING, so when status really is still PREPARING this thread is its only writer.
-  TransactionStatus expected = TransactionStatus::PREPARING;
-  transaction_status_.compare_exchange_strong(
-      expected, TransactionStatus::IDLE, std::memory_order_acq_rel, std::memory_order_relaxed);
-}
-
 void Interpreter::EnsureDbAccessForQuery() {
   if (current_db_.db_acc_) {
     // Connection-scoped: the accessor is already held (acquired at connect / USE / SetCurrentDB).

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10340,11 +10340,8 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
   const auto trimmed_query = utils::Trim(upper_case_query);
   const bool is_begin = trimmed_query == "BEGIN";
 
-  // Parse runs before the IDLE->PREPARING claim in Prepare, so the idle-session reaper may reset
-  // db_acc_ concurrently (see TryReapIdleDbAccessor). Read the reaper-stable persistent identity
-  // (current_db_name_), never the live accessor, on this pre-claim path. current_db_name_ is kept in
-  // sync with db_acc_ by SetCurrentDB; falling back to name() is safe (it too prefers the persistent
-  // identity when db_acc_ is absent).
+  // Pre-claim path: the reaper may reset db_acc_ concurrently (TryReapIdleDbAccessor), so read the
+  // reaper-stable current_db_name_, never the live accessor.
   const std::string log_db_name = current_db_.current_db_name_ ? *current_db_.current_db_name_ : current_db_.name();
   // Explicit transactions define the metadata at the beginning and reuse it
   spdlog::debug("{}",
@@ -10371,9 +10368,8 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
     // NOTE: query_string is not BEGIN, COMMIT or ROLLBACK
     const utils::Timer parsing_timer;
     memgraph::logging::EmitSessionTraceEvent("Query parsing started.");
-    // Same reaper-safety as the log above: prefer the reaper-stable current_db_uuid_ over the live
-    // accessor, which the reaper may reset during this pre-claim Parse. (This uuid is only an
-    // AST-cache-key hint; parameters are re-resolved with the real uuid after Prepare re-acquires.)
+    // Same pre-claim reaper-safety: prefer the reaper-stable current_db_uuid_ over the live accessor.
+    // Only an AST-cache-key hint; params are re-resolved with the real uuid after Prepare re-acquires.
     std::string database_uuid;
     if (current_db_.current_db_uuid_) {
       database_uuid = std::string{*current_db_.current_db_uuid_};
@@ -10624,16 +10620,12 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParameters_fn params_getter,
                                                 QueryExtras const &extras) {
 #ifdef MG_ENTERPRISE
-  // Idle-session reaper sync (IDLE_SESSION_REAPER only): claim exclusive ownership of db_acc_ for the
-  // IDLE window of Prepare BEFORE the first db_acc_ read below, so the background reaper cannot
-  // release db_acc_ out from under us. TryClaimForQueryEntry spin-waits on REAPING and CAS-es
-  // IDLE->PREPARING (no-op when already inside an explicit transaction). The OnScopeExit restores
-  // IDLE only if we claimed and no transaction was set up (parse error / early return). Flag-off:
-  // no claim, byte-identical to master.
+  // Claim exclusive ownership of db_acc_ (IDLE->PREPARING) BEFORE the first db_acc_ read below, so the
+  // background reaper cannot release it out from under us; OnScopeExit restores IDLE on an unused claim.
   const bool reaper_armed = flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER);
   const bool entry_claimed = reaper_armed && TryClaimForQueryEntry();
   utils::OnScopeExit release_entry_claim{[this, entry_claimed]() { ReleaseEntryClaimIfUnused(entry_claimed); }};
-  if (reaper_armed) EnsureDbAccessForQuery();  // re-acquire db_acc_ if the reaper released it while idle
+  if (reaper_armed) EnsureDbAccessForQuery();
 #endif
   std::optional<memory::DbArenaScope> db_arena_scope;
   if (current_db_.db_acc_) {
@@ -11444,11 +11436,9 @@ std::optional<Interpreter::TxVerifier> Interpreter::TryAcquireForVerification() 
 void Interpreter::SetMessageInFlight() noexcept {
   if (!flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) return;
   message_in_flight_.store(true, std::memory_order_seq_cst);
-  // Dekker StoreLoad: the seq_cst store above is globally ordered before this seq_cst load, so it
-  // pairs with TryReapIdleDbAccessor's seq_cst store(REAPING)+load(message_in_flight_). If a reaper
-  // currently owns REAPING, wait it out (it will restore IDLE and — seeing our gate on its re-check —
-  // decline to reap). Our db_acc_ touches then happen after the reap window; EnsureDbAccessForQuery
-  // re-acquires the accessor as usual on the next query.
+  // Dekker StoreLoad: the seq_cst store is globally ordered before this seq_cst load, pairing with
+  // TryReapIdleDbAccessor's seq_cst store(REAPING)+load(message_in_flight_). If a reaper owns REAPING,
+  // wait it out; it will restore IDLE and, seeing our gate on its re-check, decline to reap.
   while (transaction_status_.load(std::memory_order_seq_cst) == TransactionStatus::REAPING) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
@@ -11457,17 +11447,15 @@ void Interpreter::SetMessageInFlight() noexcept {
 void Interpreter::ClearMessageInFlight() noexcept {
   if (!flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER)) return;
   message_in_flight_.store(false, std::memory_order_seq_cst);
-  // Session is parking back to Idle: stamp the idle clock so the reaper measures the idle window from
-  // this moment (not from the last query start), and never from epoch 0 for a session that only ever
-  // ran db-independent commands.
+  // Parking back to Idle: stamp the idle clock so the reaper measures the idle window from now (not
+  // from last query start, and never from epoch 0 for a session that only ran db-independent commands).
   last_activity_ns_.store(SteadyNowNs(), std::memory_order_relaxed);
 }
 
 #ifdef MG_ENTERPRISE
 bool Interpreter::TryClaimForQueryEntry() {
-  // Session thread, top of Prepare. Claim exclusive ownership of db_acc_ for the IDLE window by
-  // moving IDLE -> PREPARING. Spin-wait while the reaper owns REAPING. If status is already ACTIVE
-  // (a statement inside an explicit transaction) we already own it -> not a fresh claim.
+  // Claim db_acc_ ownership by CAS IDLE -> PREPARING, spin-waiting while the reaper owns REAPING. A
+  // non-IDLE status (e.g. ACTIVE inside an explicit transaction) means we already own it -> no claim.
   TransactionStatus st = transaction_status_.load(std::memory_order_acquire);
   for (;;) {
     if (st == TransactionStatus::REAPING) {
@@ -11478,9 +11466,8 @@ bool Interpreter::TryClaimForQueryEntry() {
     if (st != TransactionStatus::IDLE) return false;  // already owned (e.g. explicit-txn ACTIVE)
     if (transaction_status_.compare_exchange_weak(
             st, TransactionStatus::PREPARING, std::memory_order_acq_rel, std::memory_order_acquire)) {
-      return true;  // claimed IDLE -> PREPARING
+      return true;
     }
-    // CAS failed: compare_exchange_weak refreshed `st`; loop.
   }
 }
 
@@ -11489,12 +11476,10 @@ void Interpreter::ReleaseEntryClaimIfUnused(bool claimed) noexcept {
   // If a transaction was set up, SetupInterpreterTransaction already moved PREPARING -> ACTIVE and
   // engaged current_transaction_; ownership is handed to the normal commit/abort lifecycle.
   if (current_transaction_.has_value()) return;
-  // No transaction set up (parse error / early return / exception before SetupInterpreterTransaction).
-  // Restore IDLE only if we still hold the claim (status == PREPARING). A CAS, not a blind store: on an
-  // error path Abort() may already have driven the status to IDLE (and reset current_transaction_), after
-  // which the reaper can win its own CAS IDLE->REAPING. A blind store would clobber that REAPING window;
-  // the CAS instead fails and leaves whoever now owns the transition untouched. Verifiers and the reaper
-  // both ignore PREPARING, so when status really is still PREPARING this thread is its only writer.
+  // No transaction set up (parse error / early return). Restore IDLE via CAS, not a blind store: an
+  // error-path Abort() may have already driven status to IDLE and let the reaper win its own CAS
+  // IDLE->REAPING; a blind store would clobber that REAPING window. Verifiers and the reaper both ignore
+  // PREPARING, so when status really is still PREPARING this thread is its only writer.
   TransactionStatus expected = TransactionStatus::PREPARING;
   transaction_status_.compare_exchange_strong(
       expected, TransactionStatus::IDLE, std::memory_order_acq_rel, std::memory_order_relaxed);
@@ -11505,21 +11490,15 @@ void Interpreter::EnsureDbAccessForQuery() {
     // Connection-scoped: the accessor is already held (acquired at connect / USE / SetCurrentDB).
     return;
   }
-  // Defensive: a session DB name is set but the accessor was released (e.g. by the idle-session reaper,
-  // or because its DB was marked for deletion mid-session via ResetInterpreter). Re-acquire via the
-  // gatekeeper; Get throws UnknownDatabaseException (incl. its SuspendedDatabaseException subtype) if
-  // the tenant is genuinely gone / suspended / draining.
+  // A session DB name is set but the accessor was released (reaper, or DB marked for deletion). Re-acquire
+  // via the gatekeeper; Get throws UnknownDatabaseException if the tenant is gone / suspended / draining.
   if (!current_db_.current_db_name_) return;  // already db-less
   try {
     auto reacquired = interpreter_context_->dbms_handler->Get(*current_db_.current_db_name_);
-    // Recycle guard: the name may have been dropped and a DIFFERENT tenant recreated under it while the
-    // accessor was released. Re-acquiring by name would silently attach to that different tenant. The
-    // reaper only reaps non-default tenants, whose UUID is a stable identity, so a UUID mismatch here is
-    // unambiguously a recycle. (Safe where a name-only guard was not: the default DB, whose UUID mutates
-    // in place, is never reaped, so its accessor is never re-acquired through this path.) Rather than
-    // wedge the session, fall back to a db-less connection -- the client can USE another database (or run
-    // a db-independent command) in the SAME session; a db-requiring query gets the normal "no current
-    // database" error, recoverable without a reconnect.
+    // Recycle guard: the name may have been dropped and a DIFFERENT tenant recreated under it, which a
+    // name-only re-acquire would silently attach to. Reaped tenants are non-default, so their UUID is a
+    // stable identity and a mismatch is unambiguously a recycle -> fall back to a db-less session rather
+    // than wedge (the client can USE another database in the same session).
     if (current_db_.current_db_uuid_ && reacquired->uuid() != *current_db_.current_db_uuid_) {
       spdlog::trace("Session database '{}' was recreated; falling back to a db-less session.",
                     *current_db_.current_db_name_);
@@ -11528,9 +11507,7 @@ void Interpreter::EnsureDbAccessForQuery() {
     }
     current_db_.db_acc_ = std::move(reacquired);
   } catch (const dbms::UnknownDatabaseException &) {
-    // The database was dropped / suspended / draining out from under the session. Same fallback: become
-    // db-less rather than wedge, so the session can USE another database in place instead of being forced
-    // to reconnect.
+    // Dropped / suspended / draining out from under the session. Same db-less fallback rather than wedge.
     spdlog::trace("Session database '{}' no longer available; falling back to a db-less session.",
                   *current_db_.current_db_name_);
     current_db_.ResetDB();
@@ -11551,11 +11528,10 @@ bool Interpreter::TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_n
           expected, TransactionStatus::REAPING, std::memory_order_seq_cst, std::memory_order_acquire)) {
     return false;
   }
-  // Re-check the gate now that we own REAPING, before touching db_acc_. This closes the TOCTOU with
-  // SetMessageInFlight: if the session set message_in_flight_ (seq_cst store) and then observed our
-  // status as not-yet-REAPING (so it did NOT spin-wait), its store is globally ordered either before
-  // our re-check load (we see it here and back out) or after our store(REAPING) (it spins in
-  // SetMessageInFlight until we restore IDLE). Either way one side yields — no torn reap.
+  // Re-check the gate now that we own REAPING, closing the TOCTOU with SetMessageInFlight: if the session
+  // stored message_in_flight_ but observed our status as not-yet-REAPING (so did NOT spin-wait), its
+  // seq_cst store is globally ordered either before this load (we see it and back out) or after our
+  // store(REAPING) (it spins until we restore IDLE). Either way one side yields -- no torn reap.
   if (message_in_flight_.load(std::memory_order_seq_cst)) {
     transaction_status_.store(TransactionStatus::IDLE, std::memory_order_release);
     return false;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -620,14 +620,6 @@ class Interpreter final {
   // Returns true iff it reaped.
   bool TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_ns);
 
-  // Session thread, top of Prepare. Claims the IDLE window (CAS IDLE->PREPARING) to exclude the reaper.
-  // Returns true iff it claimed; false if already owned (ACTIVE, e.g. inside an explicit transaction).
-  bool TryClaimForQueryEntry();
-
-  // Prepare-exit counterpart: if we claimed but no transaction was set up, restore IDLE so the session
-  // does not leak the claim (Bolt's HandleFailure does not Abort()). No-op once a transaction is ACTIVE.
-  void ReleaseEntryClaimIfUnused(bool claimed) noexcept;
-
   // Re-acquire db_acc_ if the reaper released it while parked. No-op if held or db-less; on a
   // recycled/dropped tenant falls back to a db-less session.
   void EnsureDbAccessForQuery();
@@ -856,14 +848,6 @@ class Interpreter final {
 template <typename TStream>
 std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std::optional<int> n,
                                                     std::optional<int> qid) {
-#ifdef MG_ENTERPRISE
-  // On the explicit-BEGIN path SetupInterpreterTransaction is deferred to Pull time, so status is still
-  // IDLE when we read db_acc_ below — the reaper's release window. Claim it out first. Any other query
-  // is already ACTIVE here so the claim is a no-op.
-  const bool reaper_armed = flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER);
-  const bool entry_claimed = reaper_armed && TryClaimForQueryEntry();
-  utils::OnScopeExit release_entry_claim{[this, entry_claimed]() { ReleaseEntryClaimIfUnused(entry_claimed); }};
-#endif
   // Update the TLS arena index used to route allocations to the correct database arena.
   // The previous arena is restored on scope exit so pool threads are unaffected.
   std::optional<memory::DbArenaScope> plan_cache_db_arena_scope;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -320,6 +320,12 @@ struct CurrentDB {
         old_db.swap(db_acc_);
       }
     }
+    if (old_db) {
+      // Released a marked-for-deletion tenant: drop the identity cache so EnsureDbAccessForQuery
+      // goes db-less rather than re-pinning the dying tenant (its accessor is still grantable while HOT).
+      current_db_name_.reset();
+      current_db_uuid_.reset();
+    }
   }
 
   // Releases db_acc_ under the lock (tear-safe for concurrent foreign_db_view); called by the idle-session

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -20,6 +20,7 @@
 
 #include "dbms/database.hpp"
 #include "dbms/database_protector.hpp"
+#include "flags/experimental.hpp"
 #include "flags/run_time_configurable.hpp"
 #include "memory/db_arena_fwd.hpp"
 #include "query/context.hpp"
@@ -31,10 +32,12 @@
 #include "system/transaction.hpp"
 #include "utils/event_trigger.hpp"
 #include "utils/memory.hpp"
+#include "utils/on_scope_exit.hpp"
 #include "utils/priorities.hpp"
 #include "utils/session_context.hpp"
 #include "utils/spin_lock.hpp"
 #include "utils/synchronized.hpp"
+#include "utils/uuid.hpp"
 
 #ifdef MG_ENTERPRISE
 #include "coordination/instance_status.hpp"
@@ -262,7 +265,11 @@ struct CurrentDB {
 
   // No lock needed: db_acc_ is set via the member-init list, before this CurrentDB becomes reachable
   // (e.g. via InterpreterContext::interpreters), so no other thread can observe it mid-construction.
-  explicit CurrentDB(memgraph::dbms::DatabaseAccess db_acc) : db_acc_{std::move(db_acc)} {}
+  explicit CurrentDB(memgraph::dbms::DatabaseAccess db_acc) : db_acc_{std::move(db_acc)} {
+    // Stash identity like SetCurrentDB (the other fresh-accessor entry) so it survives a reaper release.
+    current_db_name_ = db_acc_->get()->name();
+    current_db_uuid_ = db_acc_->get()->uuid();
+  }
 
   CurrentDB(CurrentDB const &) = delete;
   CurrentDB &operator=(CurrentDB const &) = delete;
@@ -272,6 +279,10 @@ struct CurrentDB {
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {
+    // Stash the session DB identity (name + uuid) before moving the accessor in, so it survives a
+    // reaper release of db_acc_. Owning-thread-only, like name() -- no lock needed for the cache.
+    current_db_name_ = new_db->name();
+    current_db_uuid_ = new_db->uuid();
     // Move the outgoing Accessor out of db_acc_ under the lock, then let it destruct AFTER the lock is
     // released (see db_acc_mutex_ for why: its dtor can block on a foreign GKInternals::mutex_).
     std::optional<memgraph::dbms::DatabaseAccess> old_db;
@@ -292,6 +303,8 @@ struct CurrentDB {
       old_db.swap(db_acc_);
     }
     old_db.reset();  // release db access before the accessors below, as before
+    current_db_name_.reset();
+    current_db_uuid_.reset();
     db_transactional_accessor_.reset();
     execution_db_accessor_.reset();
     trigger_context_collector_.reset();
@@ -318,7 +331,7 @@ struct CurrentDB {
   // establishes no happens-before against SetCurrentDB's db_acc_ swap -- a foreign unlocked read here would
   // tear against a concurrent USE DATABASE. A foreign thread -- including one observing an IDLE session --
   // must use foreign_db_view() instead.
-  std::string name() const { return db_acc_ ? db_acc_->get()->name() : ""; }
+  std::string name() const { return db_acc_ ? db_acc_->get()->name() : current_db_name_.value_or(""); }
 
   // Safe from any thread: unlike name(), it needs no verifier CAS, which can never succeed on IDLE anyway.
   // Reads db_acc_ live, not cached -- DbmsHandler::Rename mutates storage's name in place, not db_acc_.
@@ -342,6 +355,17 @@ struct CurrentDB {
   // DatabaseAccess
   //       hence, explict bolt "use DB" in metadata wouldn't necessarily get access unless query required it.
   std::optional<memgraph::dbms::DatabaseAccess> db_acc_;  // Current db (TODO: expand to support multiple)
+  // Persistent session DB identity (kept in sync with db_acc_ by SetCurrentDB) so name() stays robust
+  // and the idle-session reaper can release db_acc_ while a query-less session is parked, then have the
+  // next query re-acquire it by name. db_acc_ is connection-scoped (held for the whole session) when the
+  // reaper is off.
+  std::optional<std::string> current_db_name_;
+  // Tenant UUID captured alongside current_db_name_, so a re-acquire after the idle reaper released
+  // db_acc_ can verify it is the SAME tenant. The reaper only reaps non-default tenants, whose UUID is
+  // a stable identity (the in-place UUID mutation exists only for the default DB, which is never
+  // reaped) -- so a mismatch here means the name was recycled (DROP+CREATE) under us: fail closed
+  // rather than silently attach to a different tenant. See Interpreter::EnsureDbAccessForQuery.
+  std::optional<utils::UUID> current_db_uuid_;
   std::unique_ptr<storage::Storage::Accessor> db_transactional_accessor_;
   std::optional<DbAccessor> execution_db_accessor_;
   std::optional<TriggerContextCollector> trigger_context_collector_;
@@ -586,7 +610,63 @@ class Interpreter final {
    */
   std::optional<TxVerifier> TryAcquireForVerification();
 
+#ifdef MG_ENTERPRISE
+  // --- Idle-session reaper support (IDLE_SESSION_REAPER only) ---------------------------------
+  // Mark this interpreter as a reapable Bolt session. Set once by SessionHL BEFORE the interpreter
+  // is registered in InterpreterContext::interpreters (the registration's lock publishes it). Also
+  // stamps the idle clock so a never-queried session's idle window starts at connect, not epoch 0.
+  // Stream consumers and internal interpreters leave this false so the reaper never touches their
+  // accessor.
+  void MarkReapable() noexcept {
+    reapable_ = true;
+    last_activity_ns_.store(SteadyNowNs(), std::memory_order_relaxed);
+  }
+
+  // Reaper entry point — called ONLY from the background reaper sweep, never the session thread.
+  // If this is a reapable session whose bound tenant has been idle (last_activity_ns_ older than
+  // idle_timeout_ns) and is not the default DB, atomically claim REAPING from IDLE, release
+  // current_db_.db_acc_ (dropping the gatekeeper count so the tenant can suspend/drain), and restore
+  // IDLE. Reads the idle clock only AFTER winning the CAS (so db_acc_ is stable). Returns true iff it
+  // reaped. Single CAS, never spins; never reaps a session that is mid-query or in an explicit
+  // transaction.
+  bool TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_ns);
+
+  // Query-entry claim (session thread, top of Prepare). Spin-waits while the reaper owns REAPING,
+  // then CAS IDLE->PREPARING. Returns true iff it performed the IDLE->PREPARING claim (false if
+  // status was already ACTIVE, e.g. a statement inside an explicit transaction — already owned).
+  // PREPARING (not ACTIVE) is used so a concurrent verifier cannot race current_transaction_ writes;
+  // SetupInterpreterTransaction's store(ACTIVE) later transitions PREPARING->ACTIVE.
+  bool TryClaimForQueryEntry();
+
+  // Counterpart to TryClaimForQueryEntry, run on Prepare exit (success or exception). If we claimed
+  // PREPARING at entry but no transaction was actually set up (early return / parse error before
+  // SetupInterpreterTransaction left status at PREPARING), restore IDLE so the session does not leak
+  // the claim — Bolt's HandleFailure does NOT call Abort(), so without this an unparseable query
+  // would wedge the session in PREPARING until the client sends RESET. If a transaction WAS set up
+  // (status is now ACTIVE, current_transaction_ engaged), leaves it to the normal commit/abort path.
+  void ReleaseEntryClaimIfUnused(bool claimed) noexcept;
+
+  // Re-acquire current_db_.db_acc_ if the idle reaper released it while the session was parked. Called
+  // at the top of Prepare after the IDLE window is claimed. No-op if the accessor is still held or the
+  // session is db-less; on a recycled/dropped tenant it falls back to a db-less session.
+  void EnsureDbAccessForQuery();
+#endif
+
+  // --- Message-in-flight reaper-exclusion gate (IDLE_SESSION_REAPER only) -----------------------
+  // Held for the WHOLE span of a Bolt message (set at message dispatch, cleared once the session
+  // parks back to Idle) so the idle-session reaper only reaps a genuinely parked session. The gate
+  // pairs with transaction_status_ via a Dekker StoreLoad (both seq_cst) against TryReapIdleDbAccessor
+  // — see interpreter.cpp. Flag-off (IDLE_SESSION_REAPER disabled): both setters are strict no-ops and
+  // the reaper never consults the gate, so behaviour is byte-identical to today.
+  void SetMessageInFlight() noexcept;    // set gate + Dekker StoreLoad spin
+  void ClearMessageInFlight() noexcept;  // clear gate + stamp idle clock
+
   std::atomic<TransactionStatus> transaction_status_{TransactionStatus::IDLE};
+  // IDLE_SESSION_REAPER: true for the whole Bolt-message handling span (see Set/ClearMessageInFlight).
+  std::atomic<bool> message_in_flight_{false};
+  // steady_clock ns of the end of this session's last Bolt message; the reaper's idle clock. Stamped at
+  // connect (MarkReapable) and every time the session parks back to Idle (ClearMessageInFlight).
+  std::atomic<uint64_t> last_activity_ns_{0};
   // current_transaction_ is protected by the transaction_status_ atomic.
   // When transaction_status_ is VERIFYING, current_transaction_ is stable.
   // When transaction_status_ is IDLE, current_transaction_ is nullopt.
@@ -596,6 +676,18 @@ class Interpreter final {
   // is used for start_time; steady_clock for elapsed_ms (immune to NTP / manual clock jumps).
   std::chrono::system_clock::time_point transaction_start_time_{};
   std::chrono::steady_clock::time_point transaction_start_steady_{};
+
+  // steady_clock ns since epoch — the idle clock's monotone time source (immune to NTP / clock jumps).
+  static uint64_t SteadyNowNs() noexcept {
+    return static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+  }
+
+#ifdef MG_ENTERPRISE
+  // True => reapable Bolt session (see MarkReapable). Written once before registration, then const;
+  // the registration lock on InterpreterContext::interpreters publishes it to the reaper thread.
+  // Idle duration is measured via last_activity_ns_, read by the reaper under REAPING ownership.
+  bool reapable_{false};
+#endif
 
   void ResetUser();
 
@@ -787,6 +879,17 @@ class Interpreter final {
 template <typename TStream>
 std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std::optional<int> n,
                                                     std::optional<int> qid) {
+#ifdef MG_ENTERPRISE
+  // Idle-session reaper sync (IDLE_SESSION_REAPER only): the BEGIN handler defers SetupInterpreterTransaction
+  // to Pull time, so on the explicit-BEGIN path transaction_status_ is still IDLE when we read db_acc_
+  // below — exactly the window in which the background reaper may release it. Claim the IDLE window
+  // (IDLE->PREPARING) before that read so the reaper is excluded; SetupInterpreterTransaction then
+  // transitions PREPARING->ACTIVE inside the handler. For every other query the status is already ACTIVE
+  // here, so the CAS is a no-op (returns false) and this is byte-identical to before. Flag-off: no claim.
+  const bool reaper_armed = flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER);
+  const bool entry_claimed = reaper_armed && TryClaimForQueryEntry();
+  utils::OnScopeExit release_entry_claim{[this, entry_claimed]() { ReleaseEntryClaimIfUnused(entry_claimed); }};
+#endif
   // Update the TLS arena index used to route allocations to the correct database arena.
   // The previous arena is restored on scope exit so pool threads are unaffected.
   std::optional<memory::DbArenaScope> plan_cache_db_arena_scope;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -355,16 +355,12 @@ struct CurrentDB {
   // DatabaseAccess
   //       hence, explict bolt "use DB" in metadata wouldn't necessarily get access unless query required it.
   std::optional<memgraph::dbms::DatabaseAccess> db_acc_;  // Current db (TODO: expand to support multiple)
-  // Persistent session DB identity (kept in sync with db_acc_ by SetCurrentDB) so name() stays robust
-  // and the idle-session reaper can release db_acc_ while a query-less session is parked, then have the
-  // next query re-acquire it by name. db_acc_ is connection-scoped (held for the whole session) when the
-  // reaper is off.
+  // Session DB identity (kept in sync with db_acc_ by SetCurrentDB) so name() survives the idle reaper
+  // releasing db_acc_ on a parked session; the next query re-acquires by name.
   std::optional<std::string> current_db_name_;
-  // Tenant UUID captured alongside current_db_name_, so a re-acquire after the idle reaper released
-  // db_acc_ can verify it is the SAME tenant. The reaper only reaps non-default tenants, whose UUID is
-  // a stable identity (the in-place UUID mutation exists only for the default DB, which is never
-  // reaped) -- so a mismatch here means the name was recycled (DROP+CREATE) under us: fail closed
-  // rather than silently attach to a different tenant. See Interpreter::EnsureDbAccessForQuery.
+  // Tenant UUID captured alongside current_db_name_ so a re-acquire can reject a recycled name. Safe
+  // because reaped tenants (non-default) have a stable UUID; the default DB's UUID mutates in place but
+  // is never reaped. See Interpreter::EnsureDbAccessForQuery.
   std::optional<utils::UUID> current_db_uuid_;
   std::unique_ptr<storage::Storage::Accessor> db_transactional_accessor_;
   std::optional<DbAccessor> execution_db_accessor_;
@@ -611,55 +607,37 @@ class Interpreter final {
   std::optional<TxVerifier> TryAcquireForVerification();
 
 #ifdef MG_ENTERPRISE
-  // --- Idle-session reaper support (IDLE_SESSION_REAPER only) ---------------------------------
-  // Mark this interpreter as a reapable Bolt session. Set once by SessionHL BEFORE the interpreter
-  // is registered in InterpreterContext::interpreters (the registration's lock publishes it). Also
-  // stamps the idle clock so a never-queried session's idle window starts at connect, not epoch 0.
-  // Stream consumers and internal interpreters leave this false so the reaper never touches their
-  // accessor.
+  // Mark this a reapable Bolt session. Set once by SessionHL BEFORE registration in
+  // InterpreterContext::interpreters (that lock publishes it); stream/internal interpreters stay false
+  // so the reaper never touches them. Also stamps the idle clock so the window starts at connect.
   void MarkReapable() noexcept {
     reapable_ = true;
     last_activity_ns_.store(SteadyNowNs(), std::memory_order_relaxed);
   }
 
-  // Reaper entry point — called ONLY from the background reaper sweep, never the session thread.
-  // If this is a reapable session whose bound tenant has been idle (last_activity_ns_ older than
-  // idle_timeout_ns) and is not the default DB, atomically claim REAPING from IDLE, release
-  // current_db_.db_acc_ (dropping the gatekeeper count so the tenant can suspend/drain), and restore
-  // IDLE. Reads the idle clock only AFTER winning the CAS (so db_acc_ is stable). Returns true iff it
-  // reaped. Single CAS, never spins; never reaps a session that is mid-query or in an explicit
-  // transaction.
+  // Called ONLY from the background reaper sweep. Releases db_acc_ (dropping the gatekeeper count) iff
+  // this is a reapable, non-explicit-txn session on a non-default tenant idle past idle_timeout_ns.
+  // Returns true iff it reaped.
   bool TryReapIdleDbAccessor(uint64_t now_ns, uint64_t idle_timeout_ns);
 
-  // Query-entry claim (session thread, top of Prepare). Spin-waits while the reaper owns REAPING,
-  // then CAS IDLE->PREPARING. Returns true iff it performed the IDLE->PREPARING claim (false if
-  // status was already ACTIVE, e.g. a statement inside an explicit transaction — already owned).
-  // PREPARING (not ACTIVE) is used so a concurrent verifier cannot race current_transaction_ writes;
-  // SetupInterpreterTransaction's store(ACTIVE) later transitions PREPARING->ACTIVE.
+  // Session thread, top of Prepare. Claims the IDLE window (CAS IDLE->PREPARING) to exclude the reaper.
+  // Returns true iff it claimed; false if already owned (ACTIVE, e.g. inside an explicit transaction).
   bool TryClaimForQueryEntry();
 
-  // Counterpart to TryClaimForQueryEntry, run on Prepare exit (success or exception). If we claimed
-  // PREPARING at entry but no transaction was actually set up (early return / parse error before
-  // SetupInterpreterTransaction left status at PREPARING), restore IDLE so the session does not leak
-  // the claim — Bolt's HandleFailure does NOT call Abort(), so without this an unparseable query
-  // would wedge the session in PREPARING until the client sends RESET. If a transaction WAS set up
-  // (status is now ACTIVE, current_transaction_ engaged), leaves it to the normal commit/abort path.
+  // Prepare-exit counterpart: if we claimed but no transaction was set up, restore IDLE so the session
+  // does not leak the claim (Bolt's HandleFailure does not Abort()). No-op once a transaction is ACTIVE.
   void ReleaseEntryClaimIfUnused(bool claimed) noexcept;
 
-  // Re-acquire current_db_.db_acc_ if the idle reaper released it while the session was parked. Called
-  // at the top of Prepare after the IDLE window is claimed. No-op if the accessor is still held or the
-  // session is db-less; on a recycled/dropped tenant it falls back to a db-less session.
+  // Re-acquire db_acc_ if the reaper released it while parked. No-op if held or db-less; on a
+  // recycled/dropped tenant falls back to a db-less session.
   void EnsureDbAccessForQuery();
 #endif
 
-  // --- Message-in-flight reaper-exclusion gate (IDLE_SESSION_REAPER only) -----------------------
-  // Held for the WHOLE span of a Bolt message (set at message dispatch, cleared once the session
-  // parks back to Idle) so the idle-session reaper only reaps a genuinely parked session. The gate
-  // pairs with transaction_status_ via a Dekker StoreLoad (both seq_cst) against TryReapIdleDbAccessor
-  // — see interpreter.cpp. Flag-off (IDLE_SESSION_REAPER disabled): both setters are strict no-ops and
-  // the reaper never consults the gate, so behaviour is byte-identical to today.
-  void SetMessageInFlight() noexcept;    // set gate + Dekker StoreLoad spin
-  void ClearMessageInFlight() noexcept;  // clear gate + stamp idle clock
+  // Held for the whole span of a Bolt message so the reaper only reaps a genuinely parked session.
+  // Pairs with transaction_status_ via a Dekker StoreLoad (both seq_cst) against TryReapIdleDbAccessor.
+  // Flag-off: both are no-ops and the reaper never reads the gate, so behaviour is byte-identical.
+  void SetMessageInFlight() noexcept;
+  void ClearMessageInFlight() noexcept;
 
   std::atomic<TransactionStatus> transaction_status_{TransactionStatus::IDLE};
   // IDLE_SESSION_REAPER: true for the whole Bolt-message handling span (see Set/ClearMessageInFlight).
@@ -685,7 +663,6 @@ class Interpreter final {
 #ifdef MG_ENTERPRISE
   // True => reapable Bolt session (see MarkReapable). Written once before registration, then const;
   // the registration lock on InterpreterContext::interpreters publishes it to the reaper thread.
-  // Idle duration is measured via last_activity_ns_, read by the reaper under REAPING ownership.
   bool reapable_{false};
 #endif
 
@@ -880,12 +857,9 @@ template <typename TStream>
 std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std::optional<int> n,
                                                     std::optional<int> qid) {
 #ifdef MG_ENTERPRISE
-  // Idle-session reaper sync (IDLE_SESSION_REAPER only): the BEGIN handler defers SetupInterpreterTransaction
-  // to Pull time, so on the explicit-BEGIN path transaction_status_ is still IDLE when we read db_acc_
-  // below — exactly the window in which the background reaper may release it. Claim the IDLE window
-  // (IDLE->PREPARING) before that read so the reaper is excluded; SetupInterpreterTransaction then
-  // transitions PREPARING->ACTIVE inside the handler. For every other query the status is already ACTIVE
-  // here, so the CAS is a no-op (returns false) and this is byte-identical to before. Flag-off: no claim.
+  // On the explicit-BEGIN path SetupInterpreterTransaction is deferred to Pull time, so status is still
+  // IDLE when we read db_acc_ below — the reaper's release window. Claim it out first. Any other query
+  // is already ACTIVE here so the claim is a no-op.
   const bool reaper_armed = flags::AreExperimentsEnabled(flags::Experiments::IDLE_SESSION_REAPER);
   const bool entry_claimed = reaper_armed && TryClaimForQueryEntry();
   utils::OnScopeExit release_entry_claim{[this, entry_claimed]() { ReleaseEntryClaimIfUnused(entry_claimed); }};

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -324,6 +324,28 @@ struct CurrentDB {
     }
   }
 
+  // Unconditionally release db_acc_ (drops the gatekeeper count) under the lock, so a concurrent
+  // foreign_db_view() never tears against the null-ing. Called by the idle-session reaper from its
+  // background sweep thread. The identity cache (current_db_name_/current_db_uuid_) is deliberately
+  // KEPT so the session's next query re-acquires the same tenant by name. Same swap-out-under-lock /
+  // destruct-outside-lock discipline as ReleaseDbIfMarked (Accessor dtor can block on GKInternals::mutex_).
+  void ReleaseDbAccessor() {
+    std::optional<memgraph::dbms::DatabaseAccess> old_db;
+    {
+      std::lock_guard lock{db_acc_mutex_};
+      old_db.swap(db_acc_);
+    }
+  }
+
+  // Re-attach a freshly-acquired accessor under the lock so a concurrent foreign_db_view() sees a
+  // consistent (fully-constructed) optional, not a torn write. Precondition: db_acc_ is currently empty
+  // (the reaper released it); callers guarantee this, so there is no outgoing Accessor to destruct.
+  // in_explicit_db_ and the identity cache are unchanged (same tenant is being re-attached).
+  void ReacquireDbAccessor(memgraph::dbms::DatabaseAccess db) {
+    std::lock_guard lock{db_acc_mutex_};
+    db_acc_ = std::move(db);
+  }
+
   // Owning-thread-only. Reads db_acc_ with no synchronization, safe only because a session's queries are
   // serialized -- Bolt's worker pool never runs two for one session at once, so the owning thread's read
   // never overlaps that session's own SetCurrentDB writer. The verifier's ACTIVE->VERIFYING CAS does NOT

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -20,7 +20,6 @@
 
 #include "dbms/database.hpp"
 #include "dbms/database_protector.hpp"
-#include "flags/experimental.hpp"
 #include "flags/run_time_configurable.hpp"
 #include "memory/db_arena_fwd.hpp"
 #include "query/context.hpp"
@@ -32,7 +31,6 @@
 #include "system/transaction.hpp"
 #include "utils/event_trigger.hpp"
 #include "utils/memory.hpp"
-#include "utils/on_scope_exit.hpp"
 #include "utils/priorities.hpp"
 #include "utils/session_context.hpp"
 #include "utils/spin_lock.hpp"
@@ -266,7 +264,7 @@ struct CurrentDB {
   // No lock needed: db_acc_ is set via the member-init list, before this CurrentDB becomes reachable
   // (e.g. via InterpreterContext::interpreters), so no other thread can observe it mid-construction.
   explicit CurrentDB(memgraph::dbms::DatabaseAccess db_acc) : db_acc_{std::move(db_acc)} {
-    // Stash identity like SetCurrentDB (the other fresh-accessor entry) so it survives a reaper release.
+    // Stash identity so it survives an idle-reaper release.
     current_db_name_ = db_acc_->get()->name();
     current_db_uuid_ = db_acc_->get()->uuid();
   }
@@ -324,11 +322,8 @@ struct CurrentDB {
     }
   }
 
-  // Unconditionally release db_acc_ (drops the gatekeeper count) under the lock, so a concurrent
-  // foreign_db_view() never tears against the null-ing. Called by the idle-session reaper from its
-  // background sweep thread. The identity cache (current_db_name_/current_db_uuid_) is deliberately
-  // KEPT so the session's next query re-acquires the same tenant by name. Same swap-out-under-lock /
-  // destruct-outside-lock discipline as ReleaseDbIfMarked (Accessor dtor can block on GKInternals::mutex_).
+  // Releases db_acc_ under the lock (tear-safe for concurrent foreign_db_view); called by the idle-session
+  // reaper. Identity cache kept so the session re-acquires by name. Swap-out-under-lock / destruct-outside.
   void ReleaseDbAccessor() {
     std::optional<memgraph::dbms::DatabaseAccess> old_db;
     {
@@ -337,10 +332,8 @@ struct CurrentDB {
     }
   }
 
-  // Re-attach a freshly-acquired accessor under the lock so a concurrent foreign_db_view() sees a
-  // consistent (fully-constructed) optional, not a torn write. Precondition: db_acc_ is currently empty
-  // (the reaper released it); callers guarantee this, so there is no outgoing Accessor to destruct.
-  // in_explicit_db_ and the identity cache are unchanged (same tenant is being re-attached).
+  // Re-attach a freshly-acquired accessor under the lock (consistent optional for concurrent foreign_db_view).
+  // Precondition: db_acc_ is empty (reaper released it). in_explicit_db_ and identity cache unchanged.
   void ReacquireDbAccessor(memgraph::dbms::DatabaseAccess db) {
     std::lock_guard lock{db_acc_mutex_};
     db_acc_ = std::move(db);
@@ -380,9 +373,8 @@ struct CurrentDB {
   // Session DB identity (kept in sync with db_acc_ by SetCurrentDB) so name() survives the idle reaper
   // releasing db_acc_ on a parked session; the next query re-acquires by name.
   std::optional<std::string> current_db_name_;
-  // Tenant UUID captured alongside current_db_name_ so a re-acquire can reject a recycled name. Safe
-  // because reaped tenants (non-default) have a stable UUID; the default DB's UUID mutates in place but
-  // is never reaped. See Interpreter::EnsureDbAccessForQuery.
+  // Tenant UUID so a re-acquire can reject a recycled name. Safe: non-default tenants have stable UUIDs;
+  // the default DB's UUID can change but is never reaped.
   std::optional<utils::UUID> current_db_uuid_;
   std::unique_ptr<storage::Storage::Accessor> db_transactional_accessor_;
   std::optional<DbAccessor> execution_db_accessor_;
@@ -649,12 +641,12 @@ class Interpreter final {
 
   // Held for the whole span of a Bolt message so the reaper only reaps a genuinely parked session.
   // Pairs with transaction_status_ via a Dekker StoreLoad (both seq_cst) against TryReapIdleDbAccessor.
-  // Flag-off: both are no-ops and the reaper never reads the gate, so behaviour is byte-identical.
+  // Flag-off: both are no-ops and the reaper never runs, so existing code paths are behaviourally unchanged.
   void SetMessageInFlight() noexcept;
   void ClearMessageInFlight() noexcept;
 
   std::atomic<TransactionStatus> transaction_status_{TransactionStatus::IDLE};
-  // IDLE_SESSION_REAPER: true for the whole Bolt-message handling span (see Set/ClearMessageInFlight).
+  // true for the whole Bolt-message handling span; the reaper checks this before releasing db_acc_.
   std::atomic<bool> message_in_flight_{false};
   // steady_clock ns of the end of this session's last Bolt message; the reaper's idle clock. Stamped at
   // connect (MarkReapable) and every time the session parks back to Idle (ClearMessageInFlight).

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -239,6 +239,13 @@ startup_config_dict = {
         "Controls whether .old dir will be used to store latest snapshot and WAL files.",
     ),
     "strict_flag_check": ("true", "true", "If true, error and exit when suspicious positional arguments are detected."),
+    "session_idle_accessor_release_sec": (
+        "0",
+        "0",
+        "After this many seconds of inactivity, a Bolt session releases its database accessor so an idle tenant "
+        "stops being pinned; the connection stays open and the next query re-acquires it. 0 disables. Requires "
+        "--experimental-enabled=idle-session-reaper.",
+    ),
     "storage_access_timeout_sec": ("1", "1", "Query's storage level access timeout in seconds."),
     "storage_gc_aggressive": ("false", "false", "Enable aggressive garbage collection."),
     "storage_omit_vector_index_properties_on_return": (

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -379,7 +379,7 @@ startup_config_dict = {
     "experimental_enabled": (
         "",
         "",
-        "Experimental features to be used, comma-separated. Options [planner-v2]",
+        "Experimental features to be used, comma-separated. Options [idle-session-reaper, planner-v2]",
     ),
     "experimental_config": (
         "",

--- a/tests/stress/standalone/native/workloads/config_small.yaml
+++ b/tests/stress/standalone/native/workloads/config_small.yaml
@@ -171,3 +171,20 @@ customWorkloads:
       script_args:
         ["--endpoint", "127.0.0.1:7687", "--parallelism", "4", "--num-tenants", "3", "--duration-sec", "90"]
       timeout_min: 12
+    # Copied from workloads/idle_session_reaper/workload.yaml
+    - name: idle-session-reaper-stress
+      memgraph_args:
+        - "--experimental-enabled=idle-session-reaper"
+        - "--session-idle-accessor-release-sec=2"
+        - "--storage-wal-enabled=true"
+        - "--storage-snapshot-interval-sec=300"
+        - "--data-recovery-on-startup=true"
+      querying:
+        host: "localhost"
+        port: 7687
+      import:
+        queries: []
+      script: standalone/native/workloads/idle_session_reaper/workload.py
+      script_args:
+        ["--endpoint", "127.0.0.1:7687", "--parallelism", "8", "--num-tenants", "6", "--duration-sec", "120", "--idle-timeout-sec", "2"]
+      timeout_min: 15

--- a/tests/stress/standalone/native/workloads/idle_session_reaper/workload.py
+++ b/tests/stress/standalone/native/workloads/idle_session_reaper/workload.py
@@ -1,0 +1,736 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+"""
+Idle-Session Reaper Concurrency Stress Workload.
+
+Exercises the generic *idle-session accessor reaper* (server launched with
+``--experimental-enabled=idle-session-reaper
+--session-idle-accessor-release-sec=N``). When a Bolt session sits idle longer
+than N seconds a background sweep releases that session's DB accessor WITHOUT
+closing the socket. The next query on the session transparently re-acquires the
+accessor; if the session's current DB was dropped/suspended meanwhile it falls
+back to db-less and a db-requiring query then errors cleanly (NOT a crash, NOT a
+hang). The reaper only reaps NON-default tenants.
+
+Four concurrent worker groups race against the reaper for --duration-sec:
+
+  1. idle_holders     — USE a stable keep_db (seeded with a known count, never
+                        dropped), run one query, then sit IDLE. Every ~(2*N +
+                        margin) seconds re-query and ASSERT the count is still
+                        the seeded value. This proves TRANSPARENT RE-ACQUIRE
+                        after the reaper released the accessor. keep_db is never
+                        dropped/suspended, so ANY error here is a hard failure.
+  2. query_churn      — pick a random churn tenant (create-on-miss), USE it, do a
+                        few reads/writes, sometimes go idle > N then re-query.
+                        Tolerate server-side errors from a concurrent
+                        drop/suspend/recreate by rebinding to keep_db.
+  3. tenant_lifecycle — CREATE / SUSPEND+RESUME / DROP DATABASE churn_x FORCE on
+                        random churn tenants from a default-DB admin connection,
+                        racing the churn/holders.
+  4. reconnect_churn  — connect -> USE random tenant -> 1 query -> close, tight
+                        loop (exercises connection setup/teardown vs. the sweep).
+
+ERROR CLASSIFICATION is TYPE-BASED, not substring-based: for the
+churn/lifecycle/reconnect workers a server-side query error (neo4j ``Neo4jError``
+and its subclasses ``ClientError``/``DatabaseError``/``TransientError`` — the
+server was alive and rejected the query because a tenant was concurrently
+dropped/suspended/recreated, or the session fell back to db-less) is EXPECTED. A
+connection-level failure (``ServiceUnavailable``/``SessionExpired``/broken
+socket) or any crash is UNEXPECTED and fails the run.
+
+REAPER-FIRED NON-VACUITY: after the stress groups stop, a dedicated prober_db
+holder connects, USE prober_db, runs a single query, then stays idle with its
+socket OPEN. After waiting > (N + sweep + margin) an admin connection issues
+SUSPEND DATABASE prober_db, which MUST succeed — if the reaper had NOT released
+the idle holder's accessor, prober_db would still be pinned and SUSPEND would
+fail with an active-connections error. A failing SUSPEND here means the reaper
+never fired and the whole test is vacuous, so we exit nonzero.
+
+Run directly (smoke test):
+
+  python3 workload.py --endpoint 127.0.0.1:7687 \\
+      --parallelism 8 --num-tenants 6 --duration-sec 20 --idle-timeout-sec 2
+
+The stress runner invokes it via the workload.yaml script_args.
+
+NOTE: Designed to run against ASan / TSan builds.  The idle windows are the
+feature under test (the reaper only fires on genuinely-idle sessions), so the
+deliberate sleeps here are load-bearing, not flakiness; all waits are sized
+generously above the reaper timeout so a sweep is guaranteed to fire even under
+sanitizer slowdown.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Driver import: mirror hot_cold/workload.py — use the neo4j driver via the
+# shared hot_cold_common helpers. Allow running from the source tree (the stress
+# runner sets cwd/PYTHONPATH); climb to tests/stress/ where hot_cold_common.py
+# lives (workloads/<name>/workload.py -> workloads -> native -> standalone ->
+# stress, four levels up — identical depth to the hot_cold workloads).
+# ---------------------------------------------------------------------------
+_STRESS_ROOT = str(Path(__file__).resolve().parents[4])
+if _STRESS_ROOT not in sys.path:
+    sys.path.insert(0, _STRESS_ROOT)
+
+from hot_cold_common import (  # noqa: E402  (import after sys.path bootstrap)
+    assert_server_alive,
+    build_base_arg_parser,
+    count_nodes_on_tenant,
+    create_tenants,
+    make_driver,
+    run_query,
+    wait_for_server,
+)
+
+try:
+    # Server-side vs. connection-level split drives the whole error classifier.
+    # hot_cold_common only re-exports ClientError/TransientError, so pull the
+    # base classes (Neo4jError, DriverError, SessionExpired) directly.
+    from neo4j.exceptions import DriverError, Neo4jError, ServiceUnavailable, SessionExpired
+except ImportError as exc:  # pragma: no cover - environment guard
+    sys.exit(f"FATAL: neo4j Python driver not installed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Stable tenant that must survive the whole run intact (idle_holders re-check it).
+KEEP_DB = "keep_db"
+KEEP_COUNT = 500
+
+# Dedicated tenant used ONLY by the reaper-fired non-vacuity assertion. Kept
+# disjoint from the churn pool so nothing else ever pins/drops it.
+PROBER_DB = "prober_db"
+
+# Pause between reconnect/lifecycle loop iterations (avoid a tight spin).
+LOOP_SLEEP = 0.05
+
+# Upper bound (seconds) the prober assertion keeps re-trying SUSPEND after the
+# deterministic idle wait. The wait alone should suffice; this only absorbs
+# sanitizer/CI timing jitter. If SUSPEND never lands in this window the accessor
+# was never released -> the reaper is broken (vacuous test).
+PROBER_SUSPEND_POLL_SEC = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Per-worker result record (aggregated by main after the pool drains)
+# ---------------------------------------------------------------------------
+
+
+class WorkerResult(NamedTuple):
+    """Tally returned by every worker; main sums these across the pool."""
+
+    ok: int  # successful query cycles
+    expected: int  # server-side rejections tolerated as churn races
+    unexpected: list[str]  # non-transient / connection-level errors (bugs)
+    holder_failures: list[str]  # transparent-re-acquire failures on keep_db
+
+
+# ---------------------------------------------------------------------------
+# Error classification (TYPE-based — see module docstring)
+# ---------------------------------------------------------------------------
+
+
+def is_expected_server_error(exc: BaseException) -> bool:
+    """
+    Classify *exc* raised in the churn/lifecycle/reconnect workers, which
+    DELIBERATELY race DROP/SUSPEND/CREATE against USE/query.
+
+    EXPECTED (True): a server-side rejection — the server was alive and answered
+    with an error because the target tenant was concurrently dropped, suspended,
+    or recreated, or the session fell back to db-less. In the neo4j driver every
+    such error is a ``Neo4jError`` (``ClientError``/``DatabaseError``/
+    ``TransientError``), so we classify by TYPE rather than chasing individual
+    message wordings.
+
+    UNEXPECTED (False): anything that is NOT a clean server-side rejection — a
+    broken/refused connection (``ServiceUnavailable``/``SessionExpired``, or any
+    other ``DriverError``) or a crash. Those mean the server or the reaper
+    actually misbehaved. Idle-holders on keep_db (never dropped) use a stricter
+    check: ANY error there is a failure.
+    """
+    # Connection-level failures are fatal even though they are not Neo4jError
+    # (explicit for intent; ServiceUnavailable/SessionExpired are DriverError).
+    if isinstance(exc, (ServiceUnavailable, SessionExpired, DriverError)):
+        return False
+    return isinstance(exc, Neo4jError)
+
+
+def _ensure_db(admin_sess, name: str) -> None:
+    """Create *name* if missing (create-on-miss); swallow the already-exists race."""
+    try:
+        run_query(admin_sess, f"CREATE DATABASE {name}")
+    except Neo4jError as exc:
+        if "already exists" in str(exc).lower():
+            return
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Worker groups (run in the ThreadPoolExecutor)
+# ---------------------------------------------------------------------------
+
+
+def idle_holder_worker(
+    worker_id: int,
+    endpoint: str,
+    username: str,
+    password: str,
+    check_interval: float,
+    stop: threading.Event,
+) -> WorkerResult:
+    """
+    Parked/pooled connection: USE keep_db, run one query, then sit IDLE for the
+    whole run on ONE long-lived session (the socket stays open so the reaper
+    releases the accessor between checks). Every *check_interval* seconds
+    (> reaper timeout) re-query and assert the count is still KEEP_COUNT — the
+    transparent-re-acquire proof. keep_db is never dropped/suspended, so ANY
+    error here is a holder failure.
+    """
+    holder_failures: list[str] = []
+    drv = make_driver(endpoint, username, password)
+    sess = drv.session()
+    try:
+        run_query(sess, f"USE DATABASE {KEEP_DB}")
+        rows = run_query(sess, "MATCH (n) RETURN count(n) AS c")
+        cnt = rows[0]["c"] if rows else None
+        if cnt != KEEP_COUNT:
+            holder_failures.append(f"holder{worker_id}: initial count {cnt} != {KEEP_COUNT}")
+
+        last_check = time.monotonic()
+        while not stop.is_set():
+            # Stay genuinely idle between checks so the reaper releases us.
+            stop.wait(0.5)
+            if time.monotonic() - last_check < check_interval:
+                continue
+            last_check = time.monotonic()
+            try:
+                rows = run_query(sess, "MATCH (n) RETURN count(n) AS c")
+                cnt = rows[0]["c"] if rows else None
+                if cnt != KEEP_COUNT:
+                    holder_failures.append(f"holder{worker_id}: re-acquire count {cnt} != {KEEP_COUNT}")
+            except Exception as exc:  # noqa: BLE001 - keep_db never churns -> any error is the bug we hunt
+                holder_failures.append(f"holder{worker_id}: transparent re-acquire FAILED: {exc!r}")
+    except (ServiceUnavailable, SessionExpired) as exc:
+        # Connection-level death on a stable tenant is always a failure.
+        holder_failures.append(f"holder{worker_id}: fatal connection error: {exc!r}")
+    finally:
+        try:
+            sess.close()
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+        drv.close()
+    return WorkerResult(ok=0, expected=0, unexpected=[], holder_failures=holder_failures)
+
+
+def query_churn_worker(
+    worker_id: int,
+    endpoint: str,
+    username: str,
+    password: str,
+    churn_names: list[str],
+    idle_timeout: float,
+    stop: threading.Event,
+    rng_seed: int,
+) -> WorkerResult:
+    """
+    Loop: pick a random churn tenant (create-on-miss), USE it, do a few
+    reads/writes, and sometimes go idle > N then query again (transparent
+    re-acquire, OR a clean server-side error if the tenant was dropped/suspended
+    meanwhile). Tolerate expected churn errors by rebinding to keep_db.
+    """
+    rng = random.Random(rng_seed)
+    ok = 0
+    expected = 0
+    unexpected: list[str] = []
+    reap_min = idle_timeout + 1.0
+    reap_max = idle_timeout + 3.0
+
+    drv = make_driver(endpoint, username, password)
+    admin_drv = make_driver(endpoint, username, password)
+    sess = drv.session()
+    admin_sess = admin_drv.session()
+    try:
+        run_query(sess, f"USE DATABASE {KEEP_DB}")
+        while not stop.is_set():
+            name = rng.choice(churn_names)
+            try:
+                _ensure_db(admin_sess, name)
+                run_query(sess, f"USE DATABASE {name}")
+                for _ in range(rng.randint(1, 3)):
+                    run_query(sess, "CREATE (:Churn)")
+                run_query(sess, "MATCH (n) RETURN count(n) AS c")
+                ok += 1
+
+                if rng.random() < 0.15:
+                    # Deliberately go idle past the reaper timeout, then query.
+                    if stop.wait(rng.uniform(reap_min, reap_max)):
+                        break
+                    run_query(sess, "MATCH (n) RETURN count(n) AS c")
+                    ok += 1
+            except (ServiceUnavailable, SessionExpired):
+                raise  # connection-level -> fatal, propagate to the collector
+            except Neo4jError as exc:
+                if is_expected_server_error(exc):
+                    expected += 1
+                    # Recover: rebind to the stable tenant and continue.
+                    try:
+                        run_query(sess, f"USE DATABASE {KEEP_DB}")
+                    except (ServiceUnavailable, SessionExpired):
+                        raise
+                    except Neo4jError as exc2:
+                        if not is_expected_server_error(exc2):
+                            unexpected.append(f"churn{worker_id} recover: {exc2!r}")
+                else:
+                    unexpected.append(f"churn{worker_id}: {exc!r}")
+            except Exception as exc:  # noqa: BLE001 - unknown type is not a clean rejection -> unexpected
+                unexpected.append(f"churn{worker_id} unknown: {exc!r}")
+    finally:
+        for closeable in (sess, admin_sess):
+            try:
+                closeable.close()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
+        drv.close()
+        admin_drv.close()
+    return WorkerResult(ok=ok, expected=expected, unexpected=unexpected, holder_failures=[])
+
+
+def tenant_lifecycle_worker(
+    worker_id: int,
+    endpoint: str,
+    username: str,
+    password: str,
+    churn_names: list[str],
+    stop: threading.Event,
+    rng_seed: int,
+) -> WorkerResult:
+    """
+    Loop CREATE DATABASE churn_x; optionally SUSPEND then RESUME; then
+    DROP DATABASE churn_x FORCE — all from a default-DB admin connection while
+    other workers use those tenants. SUSPEND may legitimately fail with
+    ACTIVE_CONNECTIONS (a live session pins the tenant until the reaper releases
+    it) — an expected server-side error, not a failure.
+    """
+    rng = random.Random(rng_seed)
+    ok = 0
+    expected = 0
+    unexpected: list[str] = []
+
+    admin_drv = make_driver(endpoint, username, password)
+    admin_sess = admin_drv.session()
+    try:
+        while not stop.is_set():
+            name = rng.choice(churn_names)
+            roll = rng.random()
+            try:
+                _ensure_db(admin_sess, name)
+                if stop.wait(rng.uniform(0.2, 1.0)):
+                    break
+
+                if roll < 0.4:
+                    # Suspend/resume round-trip.
+                    run_query(admin_sess, f"SUSPEND DATABASE {name}")
+                    if stop.wait(rng.uniform(0.5, 2.0)):
+                        break
+                    run_query(admin_sess, f"RESUME DATABASE {name}")
+                    ok += 1
+                else:
+                    run_query(admin_sess, f"DROP DATABASE {name} FORCE")
+                    ok += 1
+            except (ServiceUnavailable, SessionExpired):
+                raise  # connection-level -> fatal, propagate to the collector
+            except Neo4jError as exc:
+                if is_expected_server_error(exc):
+                    expected += 1
+                else:
+                    unexpected.append(f"lifecycle{worker_id}: {exc!r}")
+            except Exception as exc:  # noqa: BLE001 - unknown type is not a clean rejection -> unexpected
+                unexpected.append(f"lifecycle{worker_id} unknown: {exc!r}")
+    finally:
+        try:
+            admin_sess.close()
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+        admin_drv.close()
+    return WorkerResult(ok=ok, expected=expected, unexpected=unexpected, holder_failures=[])
+
+
+def reconnect_churn_worker(
+    worker_id: int,
+    endpoint: str,
+    username: str,
+    password: str,
+    churn_names: list[str],
+    stop: threading.Event,
+    rng_seed: int,
+) -> WorkerResult:
+    """Tight loop: connect -> USE random tenant -> 1 query -> close."""
+    rng = random.Random(rng_seed)
+    ok = 0
+    expected = 0
+    unexpected: list[str] = []
+    targets = churn_names + [KEEP_DB]
+    try:
+        while not stop.is_set():
+            drv = make_driver(endpoint, username, password)
+            try:
+                with drv.session() as sess:
+                    name = rng.choice(targets)
+                    run_query(sess, f"USE DATABASE {name}")
+                    run_query(sess, "MATCH (n) RETURN count(n) AS c")
+                ok += 1
+            except (ServiceUnavailable, SessionExpired):
+                raise  # connection-level -> fatal, propagate to the collector
+            except Neo4jError as exc:
+                if is_expected_server_error(exc):
+                    expected += 1
+                else:
+                    unexpected.append(f"reconnect{worker_id}: {exc!r}")
+            except Exception as exc:  # noqa: BLE001 - unknown type is not a clean rejection -> unexpected
+                unexpected.append(f"reconnect{worker_id} unknown: {exc!r}")
+            finally:
+                drv.close()
+            stop.wait(LOOP_SLEEP)
+    finally:
+        pass
+    return WorkerResult(ok=ok, expected=expected, unexpected=unexpected, holder_failures=[])
+
+
+# ---------------------------------------------------------------------------
+# Setup / assertions
+# ---------------------------------------------------------------------------
+
+
+def seed_tenant(endpoint: str, username: str, password: str, name: str, count: int) -> None:
+    """USE *name* and create exactly *count* labelled nodes; verify the count."""
+    drv = make_driver(endpoint, username, password)
+    try:
+        with drv.session() as sess:
+            run_query(sess, f"USE DATABASE {name}")
+            run_query(sess, "MATCH (n) DETACH DELETE n")
+            run_query(sess, f"UNWIND range(1, {count}) AS i CREATE (:Keep {{i: i}})")
+            rows = run_query(sess, "MATCH (n) RETURN count(n) AS c")
+            seeded = rows[0]["c"] if rows else None
+        if seeded != count:
+            sys.exit(f"FATAL: seed of {name} failed — has {seeded} nodes, expected {count}")
+    finally:
+        drv.close()
+
+
+def prober_reaper_assertion(
+    endpoint: str,
+    username: str,
+    password: str,
+    idle_timeout: float,
+) -> None:
+    """
+    Reaper-fired NON-VACUITY assertion.
+
+    ONE connection connects, USE prober_db, runs a single query, then stays IDLE
+    with its socket OPEN (the holder session/driver are kept alive across the
+    wait so the pin is real). After waiting > (N + sweep + margin) a SEPARATE
+    admin connection issues SUSPEND DATABASE prober_db, which MUST succeed: if the
+    reaper had NOT released the idle holder's accessor, prober_db would still be
+    pinned and SUSPEND would fail with an active-connections error. A SUSPEND that
+    never lands means the reaper never fired -> the whole test is vacuous -> exit
+    nonzero.
+    """
+    sweep = max(1.0, idle_timeout / 2.0)
+    margin = max(5.0, 3.0 * idle_timeout)
+    wait_sec = idle_timeout + sweep + margin
+
+    hold_drv = make_driver(endpoint, username, password)
+    hold_sess = hold_drv.session()
+    try:
+        # Acquire prober_db's accessor on the holder session, then go idle.
+        run_query(hold_sess, f"USE DATABASE {PROBER_DB}")
+        run_query(hold_sess, "MATCH (n) RETURN count(n) AS c")
+        print(
+            f"  prober: holder pinned {PROBER_DB}; staying idle for {wait_sec:.1f}s "
+            f"(N={idle_timeout} + sweep={sweep} + margin={margin})...",
+            flush=True,
+        )
+        # Keep hold_sess / hold_drv ALIVE and OPEN across this wait — do not run
+        # any query on them — so the pin is genuine and the reaper must release it.
+        time.sleep(wait_sec)
+
+        admin_drv = make_driver(endpoint, username, password)
+        suspended = False
+        last_exc: Exception | None = None
+        deadline = time.monotonic() + PROBER_SUSPEND_POLL_SEC
+        try:
+            while time.monotonic() < deadline:
+                try:
+                    with admin_drv.session() as asess:
+                        run_query(asess, f"SUSPEND DATABASE {PROBER_DB}")
+                    suspended = True
+                    break
+                except (ServiceUnavailable, SessionExpired):
+                    raise  # connection-level failure — server likely crashed
+                except Neo4jError as exc:
+                    # Still pinned (active connections) or a transient system-tx
+                    # collision — keep polling until the deadline.
+                    last_exc = exc
+                    time.sleep(0.25)
+        finally:
+            admin_drv.close()
+
+        if not suspended:
+            sys.exit(
+                "FAIL: reaper did not release the idle pin (vacuous) — "
+                f"SUSPEND DATABASE {PROBER_DB} never succeeded within "
+                f"{PROBER_SUSPEND_POLL_SEC:.0f}s after a {wait_sec:.1f}s idle wait; "
+                f"last error: {last_exc!r}"
+            )
+        print(f"  prober: SUSPEND {PROBER_DB} succeeded — reaper released the idle accessor: OK", flush=True)
+    finally:
+        try:
+            hold_sess.close()
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+        hold_drv.close()
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = build_base_arg_parser(
+        description=__doc__,
+        default_parallelism=8,
+        default_num_tenants=6,
+        default_duration_sec=20,
+    )
+    parser.add_argument(
+        "--idle-timeout-sec",
+        type=float,
+        default=2.0,
+        help="Reaper idle timeout N (MUST match --session-idle-accessor-release-sec on the server)",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Main orchestration
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    args = parse_args()
+
+    endpoint: str = args.endpoint
+    username: str = args.username
+    password: str = args.password
+    parallelism: int = max(1, args.parallelism)
+    num_tenants: int = max(1, args.num_tenants)
+    duration_sec: float = args.duration_sec
+    idle_timeout: float = args.idle_timeout_sec
+
+    churn_names = [f"churn_{i}" for i in range(num_tenants)]
+    # Holders re-check on a cadence comfortably above the reaper timeout so the
+    # accessor is definitely reaped-and-re-acquired between checks.
+    holder_check_interval = 2.0 * idle_timeout + 4.0
+
+    n_holders = parallelism
+    n_churn = parallelism
+    n_lifecycle = max(1, parallelism // 4)
+    n_reconnect = max(1, parallelism // 2)
+
+    print("==> Idle-session reaper concurrency stress", flush=True)
+    print(f"    endpoint        : {endpoint}", flush=True)
+    print(f"    idle timeout N  : {idle_timeout}s (server --session-idle-accessor-release-sec)", flush=True)
+    print(f"    churn tenants   : {churn_names}", flush=True)
+    print(f"    stable tenants  : {KEEP_DB} (seeded {KEEP_COUNT}), {PROBER_DB} (reaper prober)", flush=True)
+    print(
+        f"    worker groups   : {n_holders} idle_holders + {n_churn} query_churn + "
+        f"{n_lifecycle} tenant_lifecycle + {n_reconnect} reconnect_churn",
+        flush=True,
+    )
+    print(f"    duration        : {duration_sec}s", flush=True)
+
+    # Phase 1: server readiness + stable-tenant setup. Churn tenants are created
+    # on-miss by the workers, so the CREATE path is exercised from t=0.
+    print("\n==> Phase 1: server readiness + tenant setup", flush=True)
+    wait_for_server(endpoint, username, password)
+    create_tenants(endpoint, username, password, [KEEP_DB, PROBER_DB])
+    seed_tenant(endpoint, username, password, KEEP_DB, KEEP_COUNT)
+    print(f"  seeded {KEEP_DB} with {KEEP_COUNT} nodes", flush=True)
+
+    # Phase 2: concurrent stress run.
+    print(f"\n==> Phase 2: concurrent stress for {duration_sec}s", flush=True)
+    stop = threading.Event()
+    base_seed = int(time.time())
+    futures: list[tuple[str, int, object]] = []
+
+    total_workers = n_holders + n_churn + n_lifecycle + n_reconnect
+    with ThreadPoolExecutor(max_workers=total_workers) as pool:
+        for i in range(n_holders):
+            futures.append(
+                (
+                    "holder",
+                    i,
+                    pool.submit(idle_holder_worker, i, endpoint, username, password, holder_check_interval, stop),
+                )
+            )
+        for i in range(n_churn):
+            futures.append(
+                (
+                    "churn",
+                    i,
+                    pool.submit(
+                        query_churn_worker,
+                        i,
+                        endpoint,
+                        username,
+                        password,
+                        churn_names,
+                        idle_timeout,
+                        stop,
+                        base_seed + 100 + i,
+                    ),
+                )
+            )
+        for i in range(n_lifecycle):
+            futures.append(
+                (
+                    "lifecycle",
+                    i,
+                    pool.submit(
+                        tenant_lifecycle_worker,
+                        i,
+                        endpoint,
+                        username,
+                        password,
+                        churn_names,
+                        stop,
+                        base_seed + 200 + i,
+                    ),
+                )
+            )
+        for i in range(n_reconnect):
+            futures.append(
+                (
+                    "reconnect",
+                    i,
+                    pool.submit(
+                        reconnect_churn_worker,
+                        i,
+                        endpoint,
+                        username,
+                        password,
+                        churn_names,
+                        stop,
+                        base_seed + 300 + i,
+                    ),
+                )
+            )
+
+        time.sleep(duration_sec)
+        stop.set()
+        print("  stop signal sent, waiting for workers...", flush=True)
+
+        # Collect results; a propagated connection-level exception = real bug.
+        total_ok = 0
+        total_expected = 0
+        all_unexpected: list[str] = []
+        all_holder_failures: list[str] = []
+        worker_exceptions: list[tuple[str, int, Exception]] = []
+        for role, wid, f in futures:
+            try:
+                res: WorkerResult = f.result(timeout=120.0)
+                total_ok += res.ok
+                total_expected += res.expected
+                all_unexpected.extend(res.unexpected)
+                all_holder_failures.extend(res.holder_failures)
+            except Exception as exc:  # noqa: BLE001 - surface any worker crash as a run failure
+                worker_exceptions.append((role, wid, exc))
+
+    if worker_exceptions:
+        for role, wid, exc in worker_exceptions:
+            print(f"  WORKER FAILURE [{role}-{wid}]: {exc!r}", file=sys.stderr, flush=True)
+        sys.exit("FAIL: one or more workers raised a connection-level / non-transient exception")
+
+    print(
+        f"  workers done: ok={total_ok} expected_err={total_expected} "
+        f"unexpected={len(all_unexpected)} holder_fail={len(all_holder_failures)}",
+        flush=True,
+    )
+
+    # Phase 3: reaper-fired non-vacuity assertion (exits nonzero if reaper never fired).
+    print("\n==> Phase 3: reaper-fired non-vacuity assertion", flush=True)
+    prober_reaper_assertion(endpoint, username, password, idle_timeout)
+
+    # Phase 4: keep_db integrity — the stable tenant must be untouched.
+    print("\n==> Phase 4: keep_db integrity verification", flush=True)
+    keep_actual = count_nodes_on_tenant(endpoint, username, password, KEEP_DB)
+    keep_ok = keep_actual == KEEP_COUNT
+    if keep_ok:
+        print(f"  OK   {KEEP_DB}: {keep_actual} nodes", flush=True)
+    else:
+        print(f"  FAIL {KEEP_DB}: actual={keep_actual} expected={KEEP_COUNT}", flush=True)
+
+    # Phase 5: server liveness check.
+    print("\n==> Phase 5: server liveness check", flush=True)
+    assert_server_alive(endpoint, username, password)
+
+    # Phase 6: non-vacuity summary + final verdict.
+    print("\n==> Phase 6: non-vacuity summary", flush=True)
+    print("  reaps proven    : YES (prober SUSPEND succeeded — an idle pin was released)", flush=True)
+    print(f"  ok ops          : {total_ok}", flush=True)
+    print(f"  expected races  : {total_expected}", flush=True)
+    print(f"  keep_db intact  : {keep_ok} ({keep_actual}/{KEEP_COUNT})", flush=True)
+
+    failures: list[str] = []
+    if all_holder_failures:
+        failures.append(
+            f"{len(all_holder_failures)} idle-holder re-acquire failure(s); first: {all_holder_failures[0]}"
+        )
+    if all_unexpected:
+        distinct = sorted({str(e) for e in all_unexpected})
+        print(f"  {len(all_unexpected)} UNEXPECTED error(s), {len(distinct)} distinct:", flush=True)
+        for d in distinct[:20]:
+            print(f"    - {d}", flush=True)
+        failures.append(f"{len(all_unexpected)} unexpected worker error(s); first: {all_unexpected[0]}")
+    if not keep_ok:
+        failures.append(f"keep_db integrity: actual={keep_actual} expected={KEEP_COUNT}")
+
+    print("\n" + "=" * 60, flush=True)
+    if failures:
+        print("RESULT: FAIL — idle-session reaper stress detected an error", flush=True)
+        for reason in failures:
+            print(f"  {reason}", flush=True)
+        print("=" * 60, flush=True)
+        sys.exit(1)
+    print("RESULT: PASS — reaper proven live, keep_db intact, no unexpected errors", flush=True)
+    print(f"  {total_ok} ok ops, {total_expected} expected races tolerated", flush=True)
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stress/standalone/native/workloads/idle_session_reaper/workload.yaml
+++ b/tests/stress/standalone/native/workloads/idle_session_reaper/workload.yaml
@@ -1,0 +1,67 @@
+# Idle-Session Reaper Concurrency Stress Workload
+#
+# Exercises the generic idle-session accessor reaper. The server is launched with
+# --experimental-enabled=idle-session-reaper and --session-idle-accessor-release-sec=N:
+# after a Bolt session is idle > N seconds a background sweep releases its DB
+# accessor (the socket stays open); the next query transparently re-acquires it,
+# and if the tenant was dropped/suspended meanwhile the session falls back
+# db-less and the query errors cleanly (no crash, no hang). The reaper only reaps
+# NON-default tenants.
+#
+# Four concurrent worker groups race the reaper:
+#   1. idle_holders: USE a stable keep_db (seeded, never dropped), then sit idle;
+#      periodically re-query and assert the count is unchanged (transparent
+#      re-acquire proof).
+#   2. query_churn: create-on-miss churn tenants, read/write, sometimes go idle
+#      > N then re-query; tolerate server-side drop/suspend races.
+#   3. tenant_lifecycle: CREATE / SUSPEND+RESUME / DROP DATABASE churn_x FORCE.
+#   4. reconnect_churn: connect -> USE random tenant -> 1 query -> close loop.
+#
+# Non-vacuity gate: a dedicated prober_db holder stays idle with its socket open;
+# after > (N + sweep + margin) an admin SUSPEND DATABASE prober_db MUST succeed —
+# proving the reaper actually released the idle pin (else the run is vacuous and
+# exits non-zero).
+#
+# NOTE: Run against an ASan or TSan build for sanitizer coverage of the reaper
+# sweep and the transparent re-acquire path. The idle windows are the feature
+# under test, sized generously above N so a sweep is guaranteed even under the
+# 3-5x slowdown of sanitizer builds.
+
+memgraph:
+  deployment:
+    externally_managed: false
+  args:
+    - "--experimental-enabled=idle-session-reaper"
+    - "--session-idle-accessor-release-sec=2"
+    - "--storage-wal-enabled=true"
+    - "--storage-snapshot-interval-sec=300"
+    - "--data-recovery-on-startup=true"
+
+general:
+  verbose: false
+  use_ssl: false
+
+dataset:
+  tests: []
+
+customWorkloads:
+  tests:
+    - name: idle-session-reaper-stress
+      querying:
+        host: "localhost"
+        port: 7687
+      import:
+        queries: []
+      script: standalone/native/workloads/idle_session_reaper/workload.py
+      script_args:
+        - "--endpoint"
+        - "127.0.0.1:7687"
+        - "--parallelism"
+        - "8"
+        - "--num-tenants"
+        - "6"
+        - "--duration-sec"
+        - "120"
+        - "--idle-timeout-sec"
+        - "2"
+      timeout_min: 15

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -467,6 +467,12 @@ add_unit_test(hot_cold_resume
     LINK_TARGETS mg-query mg-auth mg-glue mg-dbms
 )
 
+# Hot/cold tenants: idle session accessor reaper (interpreter-level)
+add_unit_test(idle_session_reaper
+    SOURCES idle_session_reaper.cpp
+    LINK_TARGETS mg-query mg-auth mg-glue mg-dbms
+)
+
 
 add_unit_test(utils_aws
     SOURCES utils_aws.cpp

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -53,6 +53,12 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
   // No trace stream needed; nullptr opts out of the per-message guard.
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return nullptr; }
 
+  // Idle-session-reaper message-in-flight gate hooks. No-ops in this protocol-level unit test: there is
+  // no interpreter behind TestSession, so there is nothing for the reaper to exclude.
+  void SetMessageInFlight() {}
+
+  void ClearMessageInFlight() {}
+
   void InterpretParse(const std::string &query, bolt_map_t params, const bolt_map_t &extra) {
     if (extra.contains("tx_metadata")) {
       auto const &metadata = extra.at("tx_metadata").ValueMap();

--- a/tests/unit/idle_session_reaper.cpp
+++ b/tests/unit/idle_session_reaper.cpp
@@ -1,0 +1,397 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Unit tests for the idle-session reaper (Interpreter::TryReapIdleDbAccessor) under IDLE_SESSION_REAPER.
+// The reaper releases a connected-but-idle Bolt session's db_acc_ so a tenant pinned only by idle
+// connections drops its gatekeeper count; the connection stays open and the next query transparently
+// re-acquires the accessor by name via Get(). These tests drive TryReapIdleDbAccessor directly
+// (white-box), standing in for the background sweep in src/memgraph.cpp.
+
+#include "gtest/gtest.h"
+
+#ifdef MG_ENTERPRISE
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <optional>
+#include <string>
+#include <thread>
+
+#include "auth/auth.hpp"
+#include "communication/result_stream_faker.hpp"
+#include "dbms/constants.hpp"
+#include "dbms/dbms_handler.hpp"
+#include "flags/experimental.hpp"
+#include "flags/general.hpp"
+#include "flags/run_time_configurable.hpp"
+#include "interpreter_faker.hpp"
+#include "license/license.hpp"
+#include "parameters/parameters.hpp"
+#include "query/auth_checker.hpp"
+#include "query/config.hpp"
+#include "query/exceptions.hpp"
+#include "query/interpreter.hpp"
+#include "query/interpreter_context.hpp"
+#include "query/typed_value.hpp"
+#include "replication/state.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/view.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/logging.hpp"
+#include "utils/on_scope_exit.hpp"
+#include "utils/synchronized.hpp"
+
+namespace {
+
+constexpr uint64_t kHugeNs = std::numeric_limits<uint64_t>::max() / 2;  // "now" far in the future
+constexpr uint64_t kOneHourNs = 3'600ULL * 1'000'000'000ULL;
+
+memgraph::storage::Config MakeConfig(const std::filesystem::path &dir) {
+  memgraph::storage::Config cfg{};
+  memgraph::storage::UpdatePaths(cfg, dir);
+  cfg.durability.snapshot_wal_mode = memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  cfg.durability.recover_on_startup = false;
+  cfg.durability.snapshot_on_exit = false;
+  return cfg;
+}
+
+struct MinMemgraph {
+  explicit MinMemgraph(const memgraph::storage::Config &conf)
+      : settings{conf.durability.storage_directory / "settings"},
+        auth{conf.durability.storage_directory / "auth", memgraph::auth::Auth::Config{}},
+        parameters{conf.durability.storage_directory},
+        repl_state{ReplicationStateRootPath(conf)},
+        dbms{conf},
+        interpreter_context{{}, &settings, &parameters, &dbms, &repl_state, system, nullptr, nullptr, nullptr} {
+    memgraph::license::RegisterLicenseSettings(memgraph::license::global_license_checker, settings);
+    memgraph::flags::run_time::Initialize(settings);
+    memgraph::license::global_license_checker.CheckEnvLicense(settings);
+  }
+
+  auto NewInterpreter() { return InterpreterFaker{&interpreter_context, dbms.Get()}; }
+
+  memgraph::utils::Settings settings;
+  memgraph::auth::SynchedAuth auth;
+  memgraph::system::System system;
+  memgraph::parameters::Parameters parameters;
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state;
+  memgraph::dbms::DbmsHandler dbms;
+  memgraph::query::InterpreterContext interpreter_context;
+};
+
+}  // namespace
+
+class IdleSessionReaperTest : public ::testing::Test {
+ public:
+  std::filesystem::path data_directory = std::filesystem::temp_directory_path() / "MG_tests_unit_idle_session_reaper";
+
+  void SetUp() override {
+    TearDown();
+    memgraph::flags::SetExperimental(memgraph::flags::Experiments::IDLE_SESSION_REAPER);
+    min_mg.emplace(MakeConfig(data_directory));
+  }
+
+  void TearDown() override {
+    min_mg.reset();
+    memgraph::flags::SetExperimental(memgraph::flags::Experiments{});
+    if (std::filesystem::exists(data_directory)) std::filesystem::remove_all(data_directory);
+  }
+
+  auto &DBMS() { return min_mg->dbms; }
+
+  void CreateAndPopulate(const std::string &name, int n) {
+    ASSERT_TRUE(DBMS().New(name).has_value());
+    auto db_acc = DBMS().Get(name);
+    auto storage_acc = db_acc->Access(memgraph::storage::WRITE);
+    for (int i = 0; i < n; ++i) storage_acc->CreateVertex();
+    ASSERT_TRUE(storage_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  std::optional<MinMemgraph> min_mg;
+};
+
+// R1: a reapable idle session's accessor is released; the tenant (no other holders) then suspends.
+TEST_F(IdleSessionReaperTest, ReapsIdleSessionAndTenantBecomesSuspendable) {
+  const std::string db_name = "reap_r1";
+  CreateAndPopulate(db_name, 2);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+  ASSERT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  // Held accessor blocks suspend.
+  EXPECT_FALSE(DBMS().Suspend(db_name).has_value());
+
+  // Reap (idle far past the timeout): releases db_acc_.
+  EXPECT_TRUE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, /*idle_timeout_ns=*/0));
+  EXPECT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value())
+      << "reaper must release the idle session's accessor";
+
+  // Tenant now has zero holders -> suspendable.
+  EXPECT_TRUE(DBMS().Suspend(db_name).has_value()) << "tenant must be suspendable after its sessions are reaped";
+}
+
+// R2: after a reap, the next query re-acquires the (still-HOT) accessor via Get() and reads data.
+TEST_F(IdleSessionReaperTest, ReapedSessionReacquiresOnNextQuery) {
+  const std::string db_name = "reap_r2";
+  CreateAndPopulate(db_name, 3);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+
+  ASSERT_TRUE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0));
+  ASSERT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  {
+    auto [stream, qid] = interpreter.Prepare("MATCH (n) RETURN count(n) AS c");
+    EXPECT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value()) << "next query must re-acquire the accessor";
+    interpreter.Pull(&stream);
+    const auto &results = stream.GetResults();
+    ASSERT_EQ(results.size(), 1U);
+    EXPECT_EQ(results[0][0].ValueInt(), 3) << "reheated tenant must expose the original 3 nodes";
+  }
+}
+
+// R3: a session whose tenant was used within the timeout is NOT reaped.
+TEST_F(IdleSessionReaperTest, DoesNotReapRecentlyUsedTenant) {
+  const std::string db_name = "reap_r3";
+  CreateAndPopulate(db_name, 1);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+
+  // Run a GATED query so last_activity_ns_ is stamped to "now" (ClearMessageInFlight stamps it; the
+  // faker bypasses the Bolt Execute_ layer that normally does this, so arm/clear it here).
+  {
+    interpreter.interpreter.SetMessageInFlight();
+    memgraph::utils::OnScopeExit clear_gate{[&] { interpreter.interpreter.ClearMessageInFlight(); }};
+    auto [stream, qid] = interpreter.Prepare("RETURN 1");
+    interpreter.Pull(&stream);
+  }
+  ASSERT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  const auto now_ns = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+  EXPECT_FALSE(interpreter.interpreter.TryReapIdleDbAccessor(now_ns, /*idle_timeout_ns=*/kOneHourNs))
+      << "a tenant used within the idle timeout must not be reaped";
+  EXPECT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+}
+
+// R4: a non-reapable interpreter (e.g. a stream consumer / internal interpreter) is never reaped.
+TEST_F(IdleSessionReaperTest, DoesNotReapNonReapableInterpreter) {
+  const std::string db_name = "reap_r4";
+  CreateAndPopulate(db_name, 1);
+
+  auto interpreter = min_mg->NewInterpreter();  // NOT marked reapable
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+  ASSERT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  EXPECT_FALSE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0))
+      << "non-reapable interpreters must never be reaped";
+  EXPECT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+}
+
+// R5: a session in an explicit transaction (status != IDLE) is never reaped.
+TEST_F(IdleSessionReaperTest, DoesNotReapMidExplicitTransaction) {
+  const std::string db_name = "reap_r5";
+  CreateAndPopulate(db_name, 2);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+
+  {
+    auto [stream, qid] = interpreter.Prepare("BEGIN");
+    interpreter.Pull(&stream);
+  }
+  // Inside an explicit transaction transaction_status_ is ACTIVE, so the reaper's IDLE pre-check fails.
+  EXPECT_FALSE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0))
+      << "must not reap a session that is in an explicit transaction";
+  EXPECT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  {
+    auto [stream, qid] = interpreter.Prepare("COMMIT");
+    interpreter.Pull(&stream);
+  }
+}
+
+// R6: the default database is never reaped (it is never suspendable anyway).
+TEST_F(IdleSessionReaperTest, DoesNotReapDefaultDatabase) {
+  auto interpreter = min_mg->NewInterpreter();  // stays on the default DB
+  interpreter.interpreter.MarkReapable();
+  // Run a query on the default DB so it has an engaged accessor.
+  {
+    auto [stream, qid] = interpreter.Prepare("RETURN 1");
+    interpreter.Pull(&stream);
+  }
+  ASSERT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+  EXPECT_EQ(interpreter.interpreter.current_db_.db_acc_->get()->name(), memgraph::dbms::kDefaultDB);
+
+  EXPECT_FALSE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0))
+      << "the default database must never be reaped";
+  EXPECT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value());
+}
+
+// R8: recycle safety. After a reap releases the accessor, if the tenant's NAME is dropped and a
+// DIFFERENT tenant is recreated under it, the next query must NOT silently attach to the new tenant.
+// The UUID captured when the session bound the database no longer matches, so re-acquire fails closed.
+TEST_F(IdleSessionReaperTest, ReacquireFallsBackToDbLessWhenTenantRecycled) {
+  const std::string db_name = "reap_r8";
+  CreateAndPopulate(db_name, 5);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+  ASSERT_TRUE(interpreter.interpreter.current_db_.current_db_uuid_.has_value());
+  const auto original_uuid = *interpreter.interpreter.current_db_.current_db_uuid_;
+
+  // Reap: release the idle accessor (current_db_name_ + current_db_uuid_ are kept).
+  ASSERT_TRUE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0));
+  ASSERT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  // Recycle the NAME: drop it (no holders after the reap) and recreate a different tenant under it.
+  ASSERT_TRUE(DBMS().Delete(db_name).has_value());
+  ASSERT_TRUE(DBMS().New(db_name).has_value());
+  ASSERT_NE(DBMS().Get(db_name)->uuid(), original_uuid) << "the recreated tenant must have a fresh UUID";
+
+  // Next query: the re-acquire detects the recycle (UUID mismatch) and falls back to a db-less session
+  // rather than silently attaching to the new tenant or wedging. A db-requiring query then errors with
+  // the normal "no current database", NOT the recycled tenant's (empty) data.
+  try {
+    auto [stream, qid] = interpreter.Prepare("MATCH (n) RETURN count(n)");
+    interpreter.Pull(&stream);
+    FAIL() << "a db-requiring query on a recycled/db-less session must not succeed";
+  } catch (const memgraph::query::QueryException &) {
+  }
+  EXPECT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value()) << "must not attach to the recycled tenant";
+  EXPECT_FALSE(interpreter.interpreter.current_db_.current_db_name_.has_value())
+      << "session must fall back to db-less, not stay wedged on the recycled name";
+
+  // In-session recovery: USE rebinds identity to the new tenant and works (no reconnect needed).
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+  {
+    auto [stream, qid] = interpreter.Prepare("MATCH (n) RETURN count(n) AS c");
+    interpreter.Pull(&stream);
+    ASSERT_EQ(stream.GetResults().size(), 1U);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 0) << "the recreated tenant is empty";
+  }
+}
+
+// R9: the current DB is DROPPED out from under the session (not recreated) -> db-less fallback,
+// recoverable in-session (USE another database) rather than a forced reconnect.
+TEST_F(IdleSessionReaperTest, ReacquireFallsBackToDbLessWhenTenantDropped) {
+  const std::string db_name = "reap_r9";
+  CreateAndPopulate(db_name, 2);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+  ASSERT_TRUE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0));  // release the accessor
+  ASSERT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  ASSERT_TRUE(DBMS().Delete(db_name).has_value());  // drop it: the tenant is gone
+
+  // Next query: the re-acquire finds the tenant gone (UnknownDatabaseException) and falls back to db-less.
+  try {
+    auto [stream, qid] = interpreter.Prepare("MATCH (n) RETURN count(n)");
+    interpreter.Pull(&stream);
+    FAIL() << "a db-requiring query on a dropped/db-less session must not succeed";
+  } catch (const memgraph::query::QueryException &) {
+  }
+  EXPECT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value());
+  EXPECT_FALSE(interpreter.interpreter.current_db_.current_db_name_.has_value())
+      << "session must fall back to db-less after its current DB is dropped";
+
+  // In-session recovery: create another DB and USE it on the same session.
+  ASSERT_TRUE(DBMS().New("reap_r9b").has_value());
+  interpreter.interpreter.SetCurrentDB("reap_r9b", /*in_explicit_db=*/false);
+  {
+    auto [stream, qid] = interpreter.Prepare("RETURN 1 AS x");
+    interpreter.Pull(&stream);
+    ASSERT_EQ(stream.GetResults().size(), 1U);
+  }
+}
+
+// R7: a background reaper sweep thread races a session that is continuously running queries on the
+// same interpreter (autocommit + explicit BEGIN/COMMIT). This drives the real sync protocol: the
+// reaper CAS-es IDLE->REAPING and resets db_acc_ in the gaps between queries, while the session
+// CAS-es IDLE->PREPARING at Prepare/Pull entry and re-acquires via EnsureDbAccessForQuery. With
+// idle_timeout_ns == 0 the reaper is maximally aggressive. The query results must stay correct
+// (the tenant transparently re-acquires every time) and nothing may crash. This is the test worth
+// running under ThreadSanitizer; it is the only multi-threaded exercise of TryReapIdleDbAccessor
+// against a live Prepare/Pull path (including the deferred-setup BEGIN-Pull window).
+TEST_F(IdleSessionReaperTest, ConcurrentReaperVsSessionQueries) {
+  const std::string db_name = "reap_r7";
+  constexpr int kNodes = 5;
+  CreateAndPopulate(db_name, kNodes);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+
+  std::atomic<bool> stop{false};
+  std::atomic<uint64_t> reaps{0};
+  std::thread reaper([&] {
+    while (!stop.load(std::memory_order_acquire)) {
+      // now far in the future, timeout 0 => any IDLE window with a held non-default accessor is reaped.
+      if (interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, /*idle_timeout_ns=*/0)) {
+        reaps.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+  });
+
+  constexpr int kIterations = 400;
+  // A production reapable session is a SessionHL, and every Bolt message flows through Execute_, which
+  // arms the reaper-exclusion gate (SetMessageInFlight) for the whole message and clears it when the
+  // session parks. The InterpreterFaker drives Prepare/Pull directly, bypassing that layer, so the test
+  // MUST arm the gate itself around each query -- otherwise it models an impossible "reapable session
+  // whose queries never arm the gate", which no real client can produce. Each query below is one
+  // gated Bolt message; the gate clears between messages so the reaper still reaps in the idle gaps.
+  auto gated_run = [&](const char *query) {
+    interpreter.interpreter.SetMessageInFlight();
+    memgraph::utils::OnScopeExit clear_gate{[&] { interpreter.interpreter.ClearMessageInFlight(); }};
+    auto [stream, qid] = interpreter.Prepare(query);
+    interpreter.Pull(&stream);
+    const auto &results = stream.GetResults();
+    return results.empty() || results[0].empty() ? int64_t{-1} : results[0][0].ValueInt();
+  };
+  for (int i = 0; i < kIterations; ++i) {
+    // Autocommit read: must observe the original node count after any re-acquire.
+    ASSERT_EQ(gated_run("MATCH (n) RETURN count(n) AS c"), kNodes) << "autocommit read saw wrong count at iter " << i;
+    // Explicit transaction: exercises the deferred-setup BEGIN-Pull claim window vs the reaper.
+    gated_run("BEGIN");
+    ASSERT_EQ(gated_run("MATCH (n) RETURN count(n) AS c"), kNodes) << "explicit-tx read saw wrong count at iter " << i;
+    gated_run("COMMIT");
+  }
+
+  stop.store(true, std::memory_order_release);
+  reaper.join();
+
+  // Sanity: the reaper genuinely contended (otherwise the test would pass trivially).
+  EXPECT_GT(reaps.load(std::memory_order_relaxed), 0U)
+      << "reaper never won a single IDLE window — test is not exercising the race";
+
+  // The session is left consistent and queryable after the storm.
+  {
+    auto [stream, qid] = interpreter.Prepare("MATCH (n) RETURN count(n) AS c");
+    interpreter.Pull(&stream);
+    const auto &results = stream.GetResults();
+    ASSERT_EQ(results.size(), 1U);
+    EXPECT_EQ(results[0][0].ValueInt(), kNodes);
+  }
+}
+
+#endif  // MG_ENTERPRISE

--- a/tests/unit/idle_session_reaper.cpp
+++ b/tests/unit/idle_session_reaper.cpp
@@ -228,6 +228,42 @@ TEST_F(IdleSessionReaperTest, DoesNotReapMidExplicitTransaction) {
   }
 }
 
+// R10: after a reap, the native Bolt BeginTransaction() path re-acquires the accessor and opens an
+// explicit transaction successfully. Prior to the B3 fix, BeginTransaction() bypassed
+// EnsureDbAccessForQuery() and threw because db_acc_ was null for a healthy (HOT) tenant.
+TEST_F(IdleSessionReaperTest, ReapedSessionReacquiresOnBoltBegin) {
+  const std::string db_name = "reap_r10";
+  CreateAndPopulate(db_name, 4);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+
+  // Release the accessor, leaving the session db-less while the tenant stays HOT.
+  ASSERT_TRUE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0));
+  ASSERT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  // Native Bolt BEGIN (the B3 fix path): must not throw even with a null db_acc_.
+  // IDLE_SESSION_REAPER is enabled by SetUp(), so BeginTransaction() calls EnsureDbAccessForQuery().
+  ASSERT_NO_THROW(interpreter.interpreter.BeginTransaction(memgraph::query::QueryExtras{}));
+
+  // EnsureDbAccessForQuery() inside BeginTransaction() must have re-acquired the accessor.
+  EXPECT_TRUE(interpreter.interpreter.current_db_.db_acc_.has_value())
+      << "BeginTransaction must re-acquire the db_acc_ for the named HOT tenant";
+
+  // Inside the open explicit transaction, a read must see the data written before the reap.
+  {
+    auto [stream, qid] = interpreter.Prepare("MATCH (n) RETURN count(n) AS c");
+    interpreter.Pull(&stream);
+    const auto &results = stream.GetResults();
+    ASSERT_EQ(results.size(), 1U);
+    EXPECT_EQ(results[0][0].ValueInt(), 4) << "re-acquired tenant must expose the original 4 nodes";
+  }
+
+  // Commit to leave the interpreter in a clean IDLE state.
+  ASSERT_NO_THROW(interpreter.interpreter.CommitTransaction());
+}
+
 // R6: the default database is never reaped (it is never suspendable anyway).
 TEST_F(IdleSessionReaperTest, DoesNotReapDefaultDatabase) {
   auto interpreter = min_mg->NewInterpreter();  // stays on the default DB

--- a/tests/unit/idle_session_reaper.cpp
+++ b/tests/unit/idle_session_reaper.cpp
@@ -361,6 +361,55 @@ TEST_F(IdleSessionReaperTest, ReacquireFallsBackToDbLessWhenTenantDropped) {
   }
 }
 
+// R11: EnsureDbAccessForQuery must not re-pin a tenant whose in-map gatekeeper has been marked for
+// deletion. The fix: after the reaper releases db_acc_, re-acquisition via Get() can still grant an
+// Accessor (the gatekeeper remains HOT in the map during the Delete_() critical section), but
+// is_marked_for_deletion() detects the drop in progress; ResetDB() is called and the session falls
+// back to db-less rather than re-pinning the dying tenant and delaying the drop.
+//
+// The simulation: call prepare_for_deletion() on a helper DatabaseAccess obtained from the same
+// gatekeeper while it is still in the handler's map. This sets the shared pimpl's
+// is_marked_for_deletion flag — exactly what Delete_() does between its prepare_for_deletion() call
+// and DeferDelete(). The helper accessor is then released (out of scope); the flag persists on the
+// pimpl, and the gatekeeper remains in the map. Any subsequent Get() for that name grants an
+// accessor with is_marked_for_deletion() == true, which is the condition the fix detects.
+TEST_F(IdleSessionReaperTest, DoesNotRepinMarkedForDeletionTenant) {
+  const std::string db_name = "reap_r11";
+  CreateAndPopulate(db_name, 2);
+
+  auto interpreter = min_mg->NewInterpreter();
+  interpreter.interpreter.MarkReapable();
+  interpreter.interpreter.SetCurrentDB(db_name, /*in_explicit_db=*/false);
+
+  // Release the accessor: keeps current_db_name_ + current_db_uuid_ so the next query re-acquires.
+  ASSERT_TRUE(interpreter.interpreter.TryReapIdleDbAccessor(kHugeNs, 0));
+  ASSERT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value());
+
+  // Mark the in-map gatekeeper for deletion without DeferDelete (simulates Delete_()'s critical
+  // section). The gatekeeper stays HOT in the map, so Get() will grant an accessor, but the
+  // accessor's is_marked_for_deletion() will be true.
+  {
+    auto dying_acc = DBMS().Get(db_name);
+    dying_acc.prepare_for_deletion();
+    // dying_acc released here; is_marked_for_deletion persists on the shared pimpl.
+  }
+
+  // Next query: EnsureDbAccessForQuery acquires via Get() and detects is_marked_for_deletion().
+  // It calls ResetDB(), leaving the session db-less. SetupDatabaseTransaction then throws because
+  // db_acc_ is null.
+  try {
+    auto [stream, qid] = interpreter.Prepare("MATCH (n) RETURN count(n)");
+    interpreter.Pull(&stream);
+    FAIL() << "a db-requiring query on a db-less session must not succeed";
+  } catch (const memgraph::query::QueryException &) {
+  }
+
+  EXPECT_FALSE(interpreter.interpreter.current_db_.db_acc_.has_value())
+      << "must not re-pin the marked-for-deletion tenant";
+  EXPECT_FALSE(interpreter.interpreter.current_db_.current_db_name_.has_value())
+      << "session must fall back to db-less after the marked-for-deletion detection";
+}
+
 // R7: a background reaper sweep thread races a session that is continuously running queries on the
 // same interpreter (autocommit + explicit BEGIN/COMMIT). This drives the real sync protocol: the
 // reaper CAS-es IDLE->REAPING and resets db_acc_ in the gaps between queries, while the session


### PR DESCRIPTION
Adds a background reaper that releases the database accessor held by a
**connected-but-idle** Bolt session once it has been idle past
`--session-idle-accessor-release-sec`, so a tenant pinned only by idle
(e.g. pooled) connections drops to zero holders and becomes
**droppable/suspendable**. The **connection stays open**; the next query
transparently re-acquires the accessor by name, falling back to a **db-less**
session — not an error or a wedge — if the tenant was dropped, suspended, or
recycled meanwhile (uuid identity guard).

Generic and **decoupled from hot/cold** — gated behind its own experiment
`--experimental-enabled=idle-session-reaper` (+ enterprise); the default
`--session-idle-accessor-release-sec=0` is **byte-identical to before**. The
background release is race-free against the session thread via a **seq_cst
message-in-flight gate** (Dekker handshake) plus an `IDLE→PREPARING` /
`IDLE→REAPING` transaction-status claim — **TSan-clean** (9/9 unit incl. a 20×
contention race case), with a concurrent drop / suspend / force-abort /
reconnect / idle stress workload under `tests/stress`.