### PR TITLE
fix(query): reverse strings by code point rather than by byte

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1526,8 +1526,11 @@ TypedValue Trim(const TypedValue *args, int64_t nargs, const FunctionContext &ct
 }
 
 TypedValue Reverse(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  return CallStringFunction(
-      args, nargs, ctx.memory, "reverse", [&](const auto &str) { return utils::Reversed(str, ctx.memory); });
+  return CallStringFunction(args, nargs, ctx.memory, "reverse", [&](const auto &str) {
+    TypedValue::TString res(ctx.memory);
+    utils::ReverseUtf8(&res, str);
+    return res;
+  });
 }
 
 TypedValue ToLower(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -142,24 +142,6 @@ inline TVal First(TIterable &&iterable, TVal &&empty_value) {
 }
 
 /**
- * Return a reversed copy of the given collection.
- * The copy is allocated using the default allocator.
- */
-template <class TCollection>
-TCollection Reversed(const TCollection &collection) {
-  return TCollection(std::rbegin(collection), std::rend(collection));
-}
-
-/**
- * Return a reversed copy of the given collection.
- * The copy is allocated with the given `alloc`.
- */
-template <class TCollection, class TAllocator>
-TCollection Reversed(const TCollection &collection, const TAllocator &alloc) {
-  return TCollection(std::rbegin(collection), std::rend(collection), alloc);
-}
-
-/**
  * Converts a (beginning, end) pair of iterators into an iterable that can be
  * passed on to itertools.
  */

--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -121,9 +121,8 @@ inline std::string ToLowerCase(const std::string_view s) {
 /**
  * Whether `c` continues a UTF-8 sequence rather than starting one.
  *
- * Every code point is introduced by exactly one byte that is not a
- * continuation, which is what makes counting and seeking possible without
- * decoding the values themselves.
+ * Exactly one byte per code point is not a continuation, so code points can be
+ * counted and sought without decoding their values.
  */
 constexpr bool IsUtf8Continuation(const char c) { return (static_cast<unsigned char>(c) & 0xC0U) == 0x80U; }
 
@@ -131,24 +130,19 @@ constexpr bool IsUtf8Continuation(const char c) { return (static_cast<unsigned c
  * Reverse the order of the UTF-8 code points of `s` and store the result in
  * `out`.
  *
- * Multi-byte sequences are copied whole, so the result is valid UTF-8 whenever
- * the input is; reversing the bytes instead would place continuation bytes
- * ahead of the byte that introduces them. A combining mark is a code point of
- * its own and does not travel with the character it follows.
+ * A combining mark is a code point of its own and does not travel with the
+ * character it follows. Bytes that do not introduce a well-formed sequence are
+ * carried across as they are, so malformed input is reordered, not rejected.
  *
- * Bytes that do not introduce a well-formed sequence are carried across as
- * they are, so malformed input is reordered rather than rejected.
- *
- * `out` must not share storage with `s`, which is written while `s` is read.
+ * `out` must not share storage with `s`.
  *
  * @return pointer to `out`.
  */
 template <class TAllocator>
 std::basic_string<char, std::char_traits<char>, TAllocator> *ReverseUtf8(
     std::basic_string<char, std::char_traits<char>, TAllocator> *out, const std::string_view s) {
-  // Read forwards and place each sequence from the back, so the input is
-  // walked once in the direction the prefetcher expects and every byte is
-  // written exactly once, into storage that is never needlessly filled first.
+  // Reading forwards while placing from the back keeps this to one pass over
+  // the input, with each output byte written exactly once.
   out->resize_and_overwrite(s.size(), [s](char *buffer, const size_t size) {
     auto *tail = buffer + size;
     for (const auto *sequence = s.begin(); sequence != s.end();) {

--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -119,6 +119,59 @@ inline std::string ToLowerCase(const std::string_view s) {
 }
 
 /**
+ * Whether `c` continues a UTF-8 sequence rather than starting one.
+ *
+ * Every code point is introduced by exactly one byte that is not a
+ * continuation, which is what makes counting and seeking possible without
+ * decoding the values themselves.
+ */
+constexpr bool IsUtf8Continuation(const char c) { return (static_cast<unsigned char>(c) & 0xC0U) == 0x80U; }
+
+/**
+ * Reverse the order of the UTF-8 code points of `s` and store the result in
+ * `out`.
+ *
+ * Multi-byte sequences are copied whole, so the result is valid UTF-8 whenever
+ * the input is; reversing the bytes instead would place continuation bytes
+ * ahead of the byte that introduces them. A combining mark is a code point of
+ * its own and does not travel with the character it follows.
+ *
+ * Bytes that do not introduce a well-formed sequence are carried across as
+ * they are, so malformed input is reordered rather than rejected.
+ *
+ * `out` must not share storage with `s`, which is written while `s` is read.
+ *
+ * @return pointer to `out`.
+ */
+template <class TAllocator>
+std::basic_string<char, std::char_traits<char>, TAllocator> *ReverseUtf8(
+    std::basic_string<char, std::char_traits<char>, TAllocator> *out, const std::string_view s) {
+  // Read forwards and place each sequence from the back, so the input is
+  // walked once in the direction the prefetcher expects and every byte is
+  // written exactly once, into storage that is never needlessly filled first.
+  out->resize_and_overwrite(s.size(), [s](char *buffer, const size_t size) {
+    auto *tail = buffer + size;
+    for (const auto *sequence = s.begin(); sequence != s.end();) {
+      const auto *const next = std::find_if_not(std::next(sequence), s.end(), IsUtf8Continuation);
+      tail -= std::distance(sequence, next);
+      std::copy(sequence, next, tail);
+      sequence = next;
+    }
+    return size;
+  });
+  return out;
+}
+
+/**
+ * Reverse the order of the UTF-8 code points of `s`.
+ */
+inline std::string ReverseUtf8(const std::string_view s) {
+  std::string res;
+  ReverseUtf8(&res, s);
+  return res;
+}
+
+/**
  * Uppercase all characters of a string and store the result in `out`.
  * Transformation is locale independent.
  * @return pointer to `out`.

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2966,6 +2966,23 @@ TYPED_TEST(FunctionTest, Reverse) {
   EXPECT_THROW(this->EvaluateFunction("REVERSE", "x", "y"), QueryRuntimeException);
 }
 
+TYPED_TEST(FunctionTest, ReverseNonAscii) {
+  // Code points are written as escapes throughout: an accented character typed
+  // directly may reach the compiler either precomposed or as a base plus a
+  // combining mark, and those two forms have different correct answers here.
+  //
+  // Reversal is by code point, so a multi-byte character survives intact
+  // instead of having its bytes turned around into invalid UTF-8.
+  EXPECT_EQ(this->EvaluateFunction("REVERSE", "caf\u00E9").ValueString(), "\u00E9fac");
+  EXPECT_EQ(this->EvaluateFunction("REVERSE", "a\u4E2Db").ValueString(), "b\u4E2Da");
+  EXPECT_EQ(this->EvaluateFunction("REVERSE", "\u00E9").ValueString(), "\u00E9");
+  EXPECT_EQ(this->EvaluateFunction("REVERSE", "ab\u0107").ValueString(), "\u0107ba");
+  // Decomposed: the combining mark is a code point of its own, so it leads the
+  // result rather than staying with the character it followed.
+  EXPECT_EQ(this->EvaluateFunction("REVERSE", "abc\u0301").ValueString(), "\u0301cba");
+  EXPECT_EQ(this->EvaluateFunction("REVERSE", "").ValueString(), "");
+}
+
 TYPED_TEST(FunctionTest, Replace) {
   EXPECT_THROW(this->EvaluateFunction("REPLACE"), QueryRuntimeException);
   EXPECT_TRUE(this->EvaluateFunction("REPLACE", TypedValue(), "l", "w").IsNull());

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2967,12 +2967,9 @@ TYPED_TEST(FunctionTest, Reverse) {
 }
 
 TYPED_TEST(FunctionTest, ReverseNonAscii) {
-  // Code points are written as escapes throughout: an accented character typed
-  // directly may reach the compiler either precomposed or as a base plus a
-  // combining mark, and those two forms have different correct answers here.
-  //
-  // Reversal is by code point, so a multi-byte character survives intact
-  // instead of having its bytes turned around into invalid UTF-8.
+  // Escapes rather than typed characters: an accented character may reach the
+  // compiler precomposed or as a base plus a combining mark, and the two forms
+  // have different correct answers here.
   EXPECT_EQ(this->EvaluateFunction("REVERSE", "caf\u00E9").ValueString(), "\u00E9fac");
   EXPECT_EQ(this->EvaluateFunction("REVERSE", "a\u4E2Db").ValueString(), "b\u4E2Da");
   EXPECT_EQ(this->EvaluateFunction("REVERSE", "\u00E9").ValueString(), "\u00E9");

--- a/tests/unit/utils_algorithm.cpp
+++ b/tests/unit/utils_algorithm.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#include <list>
 #include <map>
 #include <sstream>
 #include <string>
@@ -21,7 +20,6 @@
 
 using vec = std::vector<std::string>;
 
-using namespace std::string_literals;
 using namespace memgraph::utils;
 
 TEST(Algorithm, PrintIterable) {
@@ -54,11 +52,4 @@ TEST(Algorithm, PrintIterable) {
     PrintIterable(&oss, map.begin(), map.end(), ", ", map_streamer);
     EXPECT_EQ(oss.str(), "a: x, b: y");
   }
-}
-
-TEST(Algorithm, Reversed) {
-  EXPECT_EQ(Reversed(""s), ""s);
-  EXPECT_EQ(Reversed("abc"s), "cba"s);
-  EXPECT_EQ(Reversed(std::vector<int>({1, 2, 3, 4})), std::vector<int>({4, 3, 2, 1}));
-  EXPECT_EQ(Reversed(std::list<std::string>({"ab"s, "cd"s})), std::list<std::string>({"cd"s, "ab"s}));
 }

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -53,6 +53,44 @@ TEST(String, ToUpperCase) {
   EXPECT_EQ(ToUpperCase("\u0161memgraph"), "\u0161MEMGRAPH");
 }
 
+TEST(String, ReverseUtf8) {
+  // Code points are written as escapes: a directly typed accented character
+  // may be precomposed or decomposed, and the two have different answers here.
+  EXPECT_EQ(ReverseUtf8(""), "");
+  EXPECT_EQ(ReverseUtf8("abc"), "cba");
+
+  // A multi-byte sequence moves as a unit. Reversing the underlying bytes would
+  // put a continuation byte ahead of its lead byte, which is not valid UTF-8.
+  EXPECT_EQ(ReverseUtf8("caf\u00E9"), "\u00E9fac");
+  EXPECT_EQ(ReverseUtf8("a\u4E2Db"), "b\u4E2Da");
+  EXPECT_EQ(ReverseUtf8("\u00E9"), "\u00E9");
+  EXPECT_EQ(ReverseUtf8("ab\u0107"), "\u0107ba");
+
+  // A combining mark is a code point in its own right, so it leads the result
+  // rather than staying attached to the character it followed.
+  EXPECT_EQ(ReverseUtf8("abc\u0301"), "\u0301cba");
+
+  // Reversing twice is the identity, which byte reversal also satisfies; the
+  // point here is that the intermediate value is well formed.
+  EXPECT_EQ(ReverseUtf8(ReverseUtf8("a\u4E2Db\u00E9")), "a\u4E2Db\u00E9");
+}
+
+TEST(String, ReverseUtf8CountsCodePointsNotBytes) {
+  // The distinguishing property: the result holds as many code points as the
+  // input, each intact. A byte-wise reversal keeps the byte count too, so
+  // comparing lengths alone would not catch the defect.
+  const std::string input = "a\u00E9\u4E2D";
+  const std::string reversed = ReverseUtf8(input);
+  ASSERT_EQ(reversed.size(), input.size());
+
+  auto const lead_bytes = [](std::string_view s) {
+    return std::ranges::count_if(s, [](char c) { return (static_cast<unsigned char>(c) & 0xC0U) != 0x80U; });
+  };
+  EXPECT_EQ(lead_bytes(reversed), 3);
+  EXPECT_EQ(lead_bytes(reversed), lead_bytes(input));
+  EXPECT_EQ(reversed, "\u4E2D\u00E9a");
+}
+
 TEST(String, Join) {
   using namespace std::string_literals;
   EXPECT_EQ(Join(std::array<std::string, 0>{}, " "), "");

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -54,8 +54,8 @@ TEST(String, ToUpperCase) {
 }
 
 TEST(String, ReverseUtf8) {
-  // Code points are written as escapes: a directly typed accented character
-  // may be precomposed or decomposed, and the two have different answers here.
+  // Escapes rather than typed characters: an accented character may reach the
+  // compiler precomposed or decomposed, and the two have different answers here.
   EXPECT_EQ(ReverseUtf8(""), "");
   EXPECT_EQ(ReverseUtf8("abc"), "cba");
 
@@ -70,15 +70,12 @@ TEST(String, ReverseUtf8) {
   // rather than staying attached to the character it followed.
   EXPECT_EQ(ReverseUtf8("abc\u0301"), "\u0301cba");
 
-  // Reversing twice is the identity, which byte reversal also satisfies; the
-  // point here is that the intermediate value is well formed.
   EXPECT_EQ(ReverseUtf8(ReverseUtf8("a\u4E2Db\u00E9")), "a\u4E2Db\u00E9");
 }
 
 TEST(String, ReverseUtf8CountsCodePointsNotBytes) {
-  // The distinguishing property: the result holds as many code points as the
-  // input, each intact. A byte-wise reversal keeps the byte count too, so
-  // comparing lengths alone would not catch the defect.
+  // The result holds as many code points as the input, each intact. Byte-wise
+  // reversal preserves the byte count too, so length alone proves nothing.
   const std::string input = "a\u00E9\u4E2D";
   const std::string reversed = ReverseUtf8(input);
   ASSERT_EQ(reversed.size(), input.size());


### PR DESCRIPTION
Reversing a string now moves whole code points, so a multi-byte character comes
through intact. Reversing the bytes split every such character and left
continuation bytes ahead of the byte that introduces them, so any string
outside ASCII came back as invalid UTF-8 rather than reversed.

A combining mark is a code point of its own and so leads the result rather than
staying with the character it followed. The general purpose collection reverse
is untouched, its other callers working on bytes.
