### PR TITLE
fix(query): measure and cut strings in code points

### DIFF
--- a/ADRs/008_string_functions_operate_on_code_points.md
+++ b/ADRs/008_string_functions_operate_on_code_points.md
@@ -1,0 +1,74 @@
+# String Functions Operate On Code Points ADR
+
+**Author**
+Gareth Andrew Lloyd (github.com/Ignition)
+
+**Status**
+PROPOSED
+
+**Date**
+August 15, 2026
+
+**Problem**
+
+Every Cypher string function that measures or cuts a string has to agree on
+what one "character" is. Memgraph stores strings as UTF-8 and, until now, used
+the byte as that unit: `size` returned the buffer length, and `substring`,
+`left` and `right` cut at byte offsets. Two things follow. Results depend on
+how the string happens to be stored rather than on what it says, so the same
+text measures differently under a different encoding. And a cut can land inside
+a character and return a fragment of one, which is not valid UTF-8 at all, so
+the engine can hand a client bytes it cannot decode.
+
+There are four candidate units, and the choice is a language-semantics decision
+rather than an implementation detail: bytes, UTF-16 code units, Unicode code
+points, and extended grapheme clusters (what a reader would call a character,
+defined by UAX #29).
+
+**Criteria**
+
+- *Independence from how a string is stored* (highest weight). A length that
+  changes when the storage encoding changes is not a property of the value, and
+  these results are returned to clients, compared, and used in predicates.
+- *Stability over time* (high). The same bytes must measure the same after an
+  upgrade. These values are stored in properties, used in `WHERE`, and can sit
+  behind an index, so a length that shifts underneath is a correctness problem
+  rather than an inconvenience.
+- *Agreement with the reference implementation* (medium). Divergence here is
+  silent: both engines return a number, and only the numbers differ.
+- *Cost* (low, but real). Anything needing Unicode tables is a dependency
+  decision, not a patch.
+
+**Decision**
+
+String functions operate on **Unicode code points**.
+
+Bytes and UTF-16 code units both fail the first criterion, being properties of
+the encoding rather than of the text. It is worth noting that the reference
+implementation runs on a platform whose natural string unit is the UTF-16 code
+unit and deliberately does not use it: its manual says `size()` of a character
+is 1 "even if the character does not fit in the 16 bits of one char". So this
+is not an artefact of that platform, and matching it costs us nothing that we
+would not have chosen anyway.
+
+Grapheme clusters are the honest answer to "how many characters does a reader
+see", and we are not choosing them. Their definition lives in Unicode data
+files that change between versions: new joining behaviour makes sequences that
+counted as several clusters count as one. A stored property's length, and a
+predicate over it, would then change meaning on an upgrade with no write to the
+database. They also need the tables, which means an ICU-class dependency that
+Memgraph does not currently carry. Code points, by contrast, are fixed forever
+for a given sequence of bytes.
+
+The cost of this decision is real and should be stated plainly. A combining
+mark counts on its own, so `e` followed by an acute accent has length two. A
+cut can still separate a mark from its base character, or split an emoji built
+from joined code points, even though it can no longer split a character's
+bytes. The reference implementation behaves identically in each of these cases,
+which was verified rather than assumed, and our UTF-8 implementation was
+checked to give the same answers as its UTF-16 one on the inputs that
+distinguish the four units.
+
+Should grapheme-aware behaviour be wanted later, it should arrive as separate
+functions. Redefining these would be a second breaking change, and would make
+results depend on the Unicode version the server was built against.

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1488,7 +1488,7 @@ TypedValue Timestamp(const TypedValue *args, int64_t nargs, const FunctionContex
 TypedValue Left(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, String>, Or<Null, NonNegativeInteger>>("left", args, nargs);
   if (args[0].IsNull() || args[1].IsNull()) return TypedValue(ctx.memory);
-  return TypedValue(utils::Substr(args[0].ValueString(), 0, args[1].ValueInt()), ctx.memory);
+  return TypedValue(utils::SubstrUtf8(args[0].ValueString(), 0, args[1].ValueInt()), ctx.memory);
 }
 
 TypedValue Right(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
@@ -1496,8 +1496,7 @@ TypedValue Right(const TypedValue *args, int64_t nargs, const FunctionContext &c
   if (args[0].IsNull() || args[1].IsNull()) return TypedValue(ctx.memory);
   const auto &str = args[0].ValueString();
   auto len = args[1].ValueInt();
-  return len <= str.size() ? TypedValue(utils::Substr(str, str.size() - len, len), ctx.memory)
-                           : TypedValue(str, ctx.memory);
+  return TypedValue(std::string_view{str}.substr(utils::Utf8OffsetOfLastCodePoints(str, len)), ctx.memory);
 }
 
 TypedValue CallStringFunction(const TypedValue *args, int64_t nargs, utils::MemoryResource *memory, const char *name,
@@ -1581,9 +1580,9 @@ TypedValue Substring(const TypedValue *args, int64_t nargs, const FunctionContex
   if (args[0].IsNull()) return TypedValue(ctx.memory);
   const auto &str = args[0].ValueString();
   auto start = args[1].ValueInt();
-  if (nargs == 2) return TypedValue(utils::Substr(str, start), ctx.memory);
+  if (nargs == 2) return TypedValue(utils::SubstrUtf8(str, start), ctx.memory);
   auto len = args[2].ValueInt();
-  return TypedValue(utils::Substr(str, start, len), ctx.memory);
+  return TypedValue(utils::SubstrUtf8(str, start, len), ctx.memory);
 }
 
 TypedValue ToByteString(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -536,7 +536,7 @@ TypedValue Size(const TypedValue *args, int64_t nargs, const FunctionContext &ct
   } else if (value.IsList()) {
     return TypedValue(static_cast<int64_t>(value.ValueList().size()), ctx.memory);
   } else if (value.IsString()) {
-    return TypedValue(static_cast<int64_t>(value.ValueString().size()), ctx.memory);
+    return TypedValue(static_cast<int64_t>(utils::CountUtf8CodePoints(value.ValueString())), ctx.memory);
   } else if (value.IsMap()) {
     // neo4j doesn't implement size for map, but I don't see a good reason not
     // to do it.

--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -166,6 +166,21 @@ inline std::string ReverseUtf8(const std::string_view s) {
 }
 
 /**
+ * Count the UTF-8 code points of `s`.
+ *
+ * A code point counts once however many bytes encode it, so this is the length
+ * a reader would give the text rather than the size of its buffer. Note that a
+ * combining mark is a code point of its own, so a decomposed character counts
+ * as more than one.
+ *
+ * Bytes that do not introduce a well-formed sequence each count once, so a
+ * malformed string still yields a length rather than an error.
+ */
+inline size_t CountUtf8CodePoints(const std::string_view s) {
+  return static_cast<size_t>(std::ranges::count_if(s, std::not_fn(IsUtf8Continuation)));
+}
+
+/**
  * Uppercase all characters of a string and store the result in `out`.
  * Transformation is locale independent.
  * @return pointer to `out`.

--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -168,10 +168,8 @@ inline std::string ReverseUtf8(const std::string_view s) {
 /**
  * Count the UTF-8 code points of `s`.
  *
- * A code point counts once however many bytes encode it, so this is the length
- * a reader would give the text rather than the size of its buffer. Note that a
- * combining mark is a code point of its own, so a decomposed character counts
- * as more than one.
+ * A code point counts once however many bytes encode it. A combining mark is a
+ * code point of its own, so a decomposed character counts as more than one.
  *
  * Bytes that do not introduce a well-formed sequence each count once, so a
  * malformed string still yields a length rather than an error.
@@ -184,26 +182,19 @@ inline size_t CountUtf8CodePoints(const std::string_view s) {
  * Byte offset at which the code point numbered `index` starts, or the size of
  * `s` when it holds fewer than `index + 1` of them.
  *
- * Counting from the front is linear, which is inherent to a variable-width
- * encoding: there is no way to reach the n-th code point without reading what
- * precedes it.
+ * Reaching the n-th code point means reading what precedes it, which a
+ * variable-width encoding leaves no way around.
  */
 inline size_t Utf8OffsetOfCodePoint(const std::string_view s, const size_t index) {
   size_t seen = 0;
   for (size_t offset = 0; offset != s.size(); ++offset) {
-    if ((static_cast<unsigned char>(s[offset]) & 0xC0U) == 0x80U) continue;
+    if (IsUtf8Continuation(s[offset])) continue;
     if (seen == index) return offset;
     ++seen;
   }
   return s.size();
 }
 
-/**
- * Substring of `s` starting at code point `pos` and running for at most `count`
- * code points, so a multi-byte character is never cut in half.
- *
- * Out-of-range positions and lengths clamp rather than throw, as `Substr` does.
- */
 /**
  * Byte offset at which the last `count` code points of `s` begin, or 0 when it
  * holds no more than that many.
@@ -223,6 +214,12 @@ inline size_t Utf8OffsetOfLastCodePoints(const std::string_view s, const size_t 
   return 0;
 }
 
+/**
+ * Substring of `s` starting at code point `pos` and running for at most `count`
+ * code points, so a multi-byte character is never cut in half.
+ *
+ * Out-of-range positions and lengths clamp rather than throw.
+ */
 inline std::string_view SubstrUtf8(const std::string_view s, const size_t pos,
                                    const size_t count = std::string_view::npos) {
   const auto begin = Utf8OffsetOfCodePoint(s, pos);

--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -177,7 +177,58 @@ inline std::string ReverseUtf8(const std::string_view s) {
  * malformed string still yields a length rather than an error.
  */
 inline size_t CountUtf8CodePoints(const std::string_view s) {
-  return static_cast<size_t>(std::ranges::count_if(s, std::not_fn(IsUtf8Continuation)));
+  return static_cast<size_t>(std::ranges::count_if(s, [](char c) { return !IsUtf8Continuation(c); }));
+}
+
+/**
+ * Byte offset at which the code point numbered `index` starts, or the size of
+ * `s` when it holds fewer than `index + 1` of them.
+ *
+ * Counting from the front is linear, which is inherent to a variable-width
+ * encoding: there is no way to reach the n-th code point without reading what
+ * precedes it.
+ */
+inline size_t Utf8OffsetOfCodePoint(const std::string_view s, const size_t index) {
+  size_t seen = 0;
+  for (size_t offset = 0; offset != s.size(); ++offset) {
+    if ((static_cast<unsigned char>(s[offset]) & 0xC0U) == 0x80U) continue;
+    if (seen == index) return offset;
+    ++seen;
+  }
+  return s.size();
+}
+
+/**
+ * Substring of `s` starting at code point `pos` and running for at most `count`
+ * code points, so a multi-byte character is never cut in half.
+ *
+ * Out-of-range positions and lengths clamp rather than throw, as `Substr` does.
+ */
+/**
+ * Byte offset at which the last `count` code points of `s` begin, or 0 when it
+ * holds no more than that many.
+ *
+ * Walking back from the end costs only what it returns, where counting the
+ * whole string and subtracting would cost its whole length.
+ */
+inline size_t Utf8OffsetOfLastCodePoints(const std::string_view s, const size_t count) {
+  if (count == 0) return s.size();
+  size_t seen = 0;
+  size_t offset = s.size();
+  while (offset != 0) {
+    --offset;
+    if (IsUtf8Continuation(s[offset])) continue;
+    if (++seen == count) return offset;
+  }
+  return 0;
+}
+
+inline std::string_view SubstrUtf8(const std::string_view s, const size_t pos,
+                                   const size_t count = std::string_view::npos) {
+  const auto begin = Utf8OffsetOfCodePoint(s, pos);
+  if (count == std::string_view::npos) return s.substr(begin);
+  const auto rest = s.substr(begin);
+  return rest.substr(0, Utf8OffsetOfCodePoint(rest, count));
 }
 
 /**

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1955,42 +1955,6 @@ TYPED_TEST(FunctionTest, Last) {
   ASSERT_THROW(this->EvaluateFunction("LAST", 5), QueryRuntimeException);
 }
 
-TYPED_TEST(FunctionTest, SizeCountsCodePoints) {
-  // size() of a string is its length in code points, not the size of its UTF-8
-  // buffer. Escapes keep the normalisation of the input explicit.
-  EXPECT_EQ(this->EvaluateFunction("SIZE", "\u00E9").ValueInt(), 1);
-  EXPECT_EQ(this->EvaluateFunction("SIZE", "\u4E2D").ValueInt(), 1);
-  EXPECT_EQ(this->EvaluateFunction("SIZE", "a\u00E9b").ValueInt(), 3);
-  EXPECT_EQ(this->EvaluateFunction("SIZE", "\U0001F600").ValueInt(), 1);
-  EXPECT_EQ(this->EvaluateFunction("SIZE", "").ValueInt(), 0);
-
-  // A decomposed character is two code points, so it counts as two.
-  EXPECT_EQ(this->EvaluateFunction("SIZE", "e\u0301").ValueInt(), 2);
-
-  // ASCII is unaffected.
-  EXPECT_EQ(this->EvaluateFunction("SIZE", "john").ValueInt(), 4);
-}
-
-TYPED_TEST(FunctionTest, SubstringLeftRightCountCodePoints) {
-  // Positions and lengths follow size(): a multi-byte character is one unit,
-  // and is never cut in half into invalid UTF-8 as byte offsets would do.
-  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "a\u4E2Db", 1, 1).ValueString(), "\u4E2D");
-  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\U0001F600\U0001F600", 0, 1).ValueString(), "\U0001F600");
-  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u00E9\u4E2D", 1).ValueString(), "\u4E2D");
-  EXPECT_EQ(this->EvaluateFunction("LEFT", "\U0001F600\U0001F600", 1).ValueString(), "\U0001F600");
-  EXPECT_EQ(this->EvaluateFunction("RIGHT", "\U0001F600\U0001F600", 1).ValueString(), "\U0001F600");
-  EXPECT_EQ(this->EvaluateFunction("RIGHT", "a\u4E2Db", 2).ValueString(), "\u4E2Db");
-  EXPECT_EQ(this->EvaluateFunction("LEFT", "a\u4E2Db", 2).ValueString(), "a\u4E2D");
-
-  // Asking for more than there is yields the whole string, not a broken one.
-  EXPECT_EQ(this->EvaluateFunction("RIGHT", "\u4E2D", 5).ValueString(), "\u4E2D");
-  EXPECT_EQ(this->EvaluateFunction("LEFT", "\u4E2D", 5).ValueString(), "\u4E2D");
-  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u4E2D", 5).ValueString(), "");
-
-  // The functions agree with each other on what one unit is.
-  EXPECT_EQ(this->EvaluateFunction("SIZE", this->EvaluateFunction("LEFT", "\U0001F600\U0001F600", 1)).ValueInt(), 1);
-}
-
 TYPED_TEST(FunctionTest, Size) {
   ASSERT_THROW(this->EvaluateFunction("SIZE"), QueryRuntimeException);
   ASSERT_TRUE(this->EvaluateFunction("SIZE", TypedValue()).IsNull());
@@ -2013,6 +1977,22 @@ TYPED_TEST(FunctionTest, Size) {
   path.Expand(*edge);
   path.Expand(v1);
   EXPECT_EQ(this->EvaluateFunction("SIZE", path).ValueInt(), 1);
+}
+
+TYPED_TEST(FunctionTest, SizeCountsCodePoints) {
+  // size() of a string is its length in code points, not the size of its UTF-8
+  // buffer. Escapes keep the normalisation of the input explicit.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "\u00E9").ValueInt(), 1);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "\u4E2D").ValueInt(), 1);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "a\u00E9b").ValueInt(), 3);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "\U0001F600").ValueInt(), 1);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "").ValueInt(), 0);
+
+  // A decomposed character is two code points, so it counts as two.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "e\u0301").ValueInt(), 2);
+
+  // ASCII is unaffected.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "john").ValueInt(), 4);
 }
 
 TYPED_TEST(FunctionTest, StartNode) {
@@ -3084,6 +3064,26 @@ TYPED_TEST(FunctionTest, Substring) {
   EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "hello", 1, 3).ValueString(), "ell");
   EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "hello", 1, 4).ValueString(), "ello");
   EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "hello", 1, 10).ValueString(), "ello");
+}
+
+TYPED_TEST(FunctionTest, SubstringLeftRightCountCodePoints) {
+  // Positions and lengths follow size(): a multi-byte character is one unit,
+  // and is never cut in half into invalid UTF-8 as byte offsets would do.
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "a\u4E2Db", 1, 1).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\U0001F600\U0001F600", 0, 1).ValueString(), "\U0001F600");
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u00E9\u4E2D", 1).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("LEFT", "\U0001F600\U0001F600", 1).ValueString(), "\U0001F600");
+  EXPECT_EQ(this->EvaluateFunction("RIGHT", "\U0001F600\U0001F600", 1).ValueString(), "\U0001F600");
+  EXPECT_EQ(this->EvaluateFunction("RIGHT", "a\u4E2Db", 2).ValueString(), "\u4E2Db");
+  EXPECT_EQ(this->EvaluateFunction("LEFT", "a\u4E2Db", 2).ValueString(), "a\u4E2D");
+
+  // Asking for more than there is yields the whole string, not a broken one.
+  EXPECT_EQ(this->EvaluateFunction("RIGHT", "\u4E2D", 5).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("LEFT", "\u4E2D", 5).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u4E2D", 5).ValueString(), "");
+
+  // The functions agree with each other on what one unit is.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", this->EvaluateFunction("LEFT", "\U0001F600\U0001F600", 1)).ValueInt(), 1);
 }
 
 TYPED_TEST(FunctionTest, ToLower) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1971,6 +1971,26 @@ TYPED_TEST(FunctionTest, SizeCountsCodePoints) {
   EXPECT_EQ(this->EvaluateFunction("SIZE", "john").ValueInt(), 4);
 }
 
+TYPED_TEST(FunctionTest, SubstringLeftRightCountCodePoints) {
+  // Positions and lengths follow size(): a multi-byte character is one unit and
+  // is never cut in half, which byte offsets would do and produce invalid UTF-8.
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "a\u4E2Db", 1, 1).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\U0001F600\U0001F600", 0, 1).ValueString(), "\U0001F600");
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u00E9\u4E2D", 1).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("LEFT", "\U0001F600\U0001F600", 1).ValueString(), "\U0001F600");
+  EXPECT_EQ(this->EvaluateFunction("RIGHT", "\U0001F600\U0001F600", 1).ValueString(), "\U0001F600");
+  EXPECT_EQ(this->EvaluateFunction("RIGHT", "a\u4E2Db", 2).ValueString(), "\u4E2Db");
+  EXPECT_EQ(this->EvaluateFunction("LEFT", "a\u4E2Db", 2).ValueString(), "a\u4E2D");
+
+  // Asking for more than there is yields the whole string, not a broken one.
+  EXPECT_EQ(this->EvaluateFunction("RIGHT", "\u4E2D", 5).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("LEFT", "\u4E2D", 5).ValueString(), "\u4E2D");
+  EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u4E2D", 5).ValueString(), "");
+
+  // Every result is a whole number of characters.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", this->EvaluateFunction("LEFT", "\U0001F600\U0001F600", 1)).ValueInt(), 1);
+}
+
 TYPED_TEST(FunctionTest, Size) {
   ASSERT_THROW(this->EvaluateFunction("SIZE"), QueryRuntimeException);
   ASSERT_TRUE(this->EvaluateFunction("SIZE", TypedValue()).IsNull());

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1956,8 +1956,8 @@ TYPED_TEST(FunctionTest, Last) {
 }
 
 TYPED_TEST(FunctionTest, SizeCountsCodePoints) {
-  // size() of a string is its length in characters, not the size of its UTF-8
-  // buffer. Escapes are used so the normalisation of the input is explicit.
+  // size() of a string is its length in code points, not the size of its UTF-8
+  // buffer. Escapes keep the normalisation of the input explicit.
   EXPECT_EQ(this->EvaluateFunction("SIZE", "\u00E9").ValueInt(), 1);
   EXPECT_EQ(this->EvaluateFunction("SIZE", "\u4E2D").ValueInt(), 1);
   EXPECT_EQ(this->EvaluateFunction("SIZE", "a\u00E9b").ValueInt(), 3);
@@ -1967,13 +1967,13 @@ TYPED_TEST(FunctionTest, SizeCountsCodePoints) {
   // A decomposed character is two code points, so it counts as two.
   EXPECT_EQ(this->EvaluateFunction("SIZE", "e\u0301").ValueInt(), 2);
 
-  // ASCII is unaffected, and lists and maps still count their elements.
+  // ASCII is unaffected.
   EXPECT_EQ(this->EvaluateFunction("SIZE", "john").ValueInt(), 4);
 }
 
 TYPED_TEST(FunctionTest, SubstringLeftRightCountCodePoints) {
-  // Positions and lengths follow size(): a multi-byte character is one unit and
-  // is never cut in half, which byte offsets would do and produce invalid UTF-8.
+  // Positions and lengths follow size(): a multi-byte character is one unit,
+  // and is never cut in half into invalid UTF-8 as byte offsets would do.
   EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "a\u4E2Db", 1, 1).ValueString(), "\u4E2D");
   EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\U0001F600\U0001F600", 0, 1).ValueString(), "\U0001F600");
   EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u00E9\u4E2D", 1).ValueString(), "\u4E2D");
@@ -1987,7 +1987,7 @@ TYPED_TEST(FunctionTest, SubstringLeftRightCountCodePoints) {
   EXPECT_EQ(this->EvaluateFunction("LEFT", "\u4E2D", 5).ValueString(), "\u4E2D");
   EXPECT_EQ(this->EvaluateFunction("SUBSTRING", "\u4E2D", 5).ValueString(), "");
 
-  // Every result is a whole number of characters.
+  // The functions agree with each other on what one unit is.
   EXPECT_EQ(this->EvaluateFunction("SIZE", this->EvaluateFunction("LEFT", "\U0001F600\U0001F600", 1)).ValueInt(), 1);
 }
 

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1955,6 +1955,22 @@ TYPED_TEST(FunctionTest, Last) {
   ASSERT_THROW(this->EvaluateFunction("LAST", 5), QueryRuntimeException);
 }
 
+TYPED_TEST(FunctionTest, SizeCountsCodePoints) {
+  // size() of a string is its length in characters, not the size of its UTF-8
+  // buffer. Escapes are used so the normalisation of the input is explicit.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "\u00E9").ValueInt(), 1);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "\u4E2D").ValueInt(), 1);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "a\u00E9b").ValueInt(), 3);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "\U0001F600").ValueInt(), 1);
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "").ValueInt(), 0);
+
+  // A decomposed character is two code points, so it counts as two.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "e\u0301").ValueInt(), 2);
+
+  // ASCII is unaffected, and lists and maps still count their elements.
+  EXPECT_EQ(this->EvaluateFunction("SIZE", "john").ValueInt(), 4);
+}
+
 TYPED_TEST(FunctionTest, Size) {
   ASSERT_THROW(this->EvaluateFunction("SIZE"), QueryRuntimeException);
   ASSERT_TRUE(this->EvaluateFunction("SIZE", TypedValue()).IsNull());

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -89,8 +89,6 @@ TEST(String, ReverseUtf8CountsCodePointsNotBytes) {
 }
 
 TEST(String, CountUtf8CodePoints) {
-  // Code points are written as escapes: a directly typed accented character
-  // may arrive precomposed or decomposed, and those have different counts.
   EXPECT_EQ(CountUtf8CodePoints(""), 0);
   EXPECT_EQ(CountUtf8CodePoints("abc"), 3);
 
@@ -100,8 +98,7 @@ TEST(String, CountUtf8CodePoints) {
   EXPECT_EQ(CountUtf8CodePoints("\U0001F600"), 1);
   EXPECT_EQ(CountUtf8CodePoints("a\u00E9b"), 3);
 
-  // The count is not the buffer size: these differ precisely because the
-  // characters are multi-byte.
+  // The count is not the buffer size.
   EXPECT_EQ(std::string_view("a\u00E9b").size(), 4);
   EXPECT_EQ(CountUtf8CodePoints("a\u00E9b"), 3);
 
@@ -112,7 +109,7 @@ TEST(String, CountUtf8CodePoints) {
 
 TEST(String, SubstrUtf8) {
   // Positions and lengths are in code points, so a multi-byte character is
-  // never split. Escapes keep the input bytes unambiguous.
+  // never split.
   EXPECT_EQ(SubstrUtf8("abc", 1), "bc");
   EXPECT_EQ(SubstrUtf8("abc", 1, 1), "b");
 
@@ -122,7 +119,7 @@ TEST(String, SubstrUtf8) {
   EXPECT_EQ(SubstrUtf8("\U0001F600\U0001F600", 0, 1), "\U0001F600");
   EXPECT_EQ(SubstrUtf8("\U0001F600\U0001F600", 1, 1), "\U0001F600");
 
-  // Out of range clamps rather than throwing, as the byte-wise Substr does.
+  // Out of range clamps rather than throwing.
   EXPECT_EQ(SubstrUtf8("a\u4E2Db", 9), "");
   EXPECT_EQ(SubstrUtf8("a\u4E2Db", 1, 99), "\u4E2Db");
   EXPECT_EQ(SubstrUtf8("a\u4E2Db", 0, 0), "");
@@ -142,8 +139,6 @@ TEST(String, Utf8OffsetOfCodePoint) {
 }
 
 TEST(String, Utf8OffsetOfLastCodePoints) {
-  // The tail is found by walking back, so asking for a few characters of a long
-  // string reads only those characters rather than all of it.
   EXPECT_EQ(Utf8OffsetOfLastCodePoints("abc", 1), 2);
   EXPECT_EQ(Utf8OffsetOfLastCodePoints("a\u4E2Db", 2), 1);
   EXPECT_EQ(Utf8OffsetOfLastCodePoints("\U0001F600\U0001F600", 1), 4);

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -86,6 +86,27 @@ TEST(String, ReverseUtf8CountsCodePointsNotBytes) {
   EXPECT_EQ(lead_bytes(reversed), 3);
   EXPECT_EQ(lead_bytes(reversed), lead_bytes(input));
   EXPECT_EQ(reversed, "\u4E2D\u00E9a");
+
+TEST(String, CountUtf8CodePoints) {
+  // Code points are written as escapes: a directly typed accented character
+  // may arrive precomposed or decomposed, and those have different counts.
+  EXPECT_EQ(CountUtf8CodePoints(""), 0);
+  EXPECT_EQ(CountUtf8CodePoints("abc"), 3);
+
+  // One code point however many bytes encode it.
+  EXPECT_EQ(CountUtf8CodePoints("\u00E9"), 1);
+  EXPECT_EQ(CountUtf8CodePoints("\u4E2D"), 1);
+  EXPECT_EQ(CountUtf8CodePoints("\U0001F600"), 1);
+  EXPECT_EQ(CountUtf8CodePoints("a\u00E9b"), 3);
+
+  // The count is not the buffer size: these differ precisely because the
+  // characters are multi-byte.
+  EXPECT_EQ(std::string_view("a\u00E9b").size(), 4);
+  EXPECT_EQ(CountUtf8CodePoints("a\u00E9b"), 3);
+
+  // A combining mark is a code point of its own, so a decomposed character
+  // counts as two. This is code points, not grapheme clusters.
+  EXPECT_EQ(CountUtf8CodePoints("e\u0301"), 2);
 }
 
 TEST(String, Join) {

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -86,6 +86,7 @@ TEST(String, ReverseUtf8CountsCodePointsNotBytes) {
   EXPECT_EQ(lead_bytes(reversed), 3);
   EXPECT_EQ(lead_bytes(reversed), lead_bytes(input));
   EXPECT_EQ(reversed, "\u4E2D\u00E9a");
+}
 
 TEST(String, CountUtf8CodePoints) {
   // Code points are written as escapes: a directly typed accented character
@@ -107,6 +108,51 @@ TEST(String, CountUtf8CodePoints) {
   // A combining mark is a code point of its own, so a decomposed character
   // counts as two. This is code points, not grapheme clusters.
   EXPECT_EQ(CountUtf8CodePoints("e\u0301"), 2);
+}
+
+TEST(String, SubstrUtf8) {
+  // Positions and lengths are in code points, so a multi-byte character is
+  // never split. Escapes keep the input bytes unambiguous.
+  EXPECT_EQ(SubstrUtf8("abc", 1), "bc");
+  EXPECT_EQ(SubstrUtf8("abc", 1, 1), "b");
+
+  EXPECT_EQ(SubstrUtf8("a\u4E2Db", 1, 1), "\u4E2D");
+  EXPECT_EQ(SubstrUtf8("a\u4E2Db", 1), "\u4E2Db");
+  EXPECT_EQ(SubstrUtf8("\u00E9\u4E2D\U0001F600", 1, 1), "\u4E2D");
+  EXPECT_EQ(SubstrUtf8("\U0001F600\U0001F600", 0, 1), "\U0001F600");
+  EXPECT_EQ(SubstrUtf8("\U0001F600\U0001F600", 1, 1), "\U0001F600");
+
+  // Out of range clamps rather than throwing, as the byte-wise Substr does.
+  EXPECT_EQ(SubstrUtf8("a\u4E2Db", 9), "");
+  EXPECT_EQ(SubstrUtf8("a\u4E2Db", 1, 99), "\u4E2Db");
+  EXPECT_EQ(SubstrUtf8("a\u4E2Db", 0, 0), "");
+  EXPECT_EQ(SubstrUtf8("", 0, 3), "");
+}
+
+TEST(String, Utf8OffsetOfCodePoint) {
+  // Offsets are in bytes, indices in code points; the two only coincide while
+  // the text stays in ASCII.
+  EXPECT_EQ(Utf8OffsetOfCodePoint("abc", 0), 0);
+  EXPECT_EQ(Utf8OffsetOfCodePoint("abc", 2), 2);
+  EXPECT_EQ(Utf8OffsetOfCodePoint("a\u4E2Db", 1), 1);
+  EXPECT_EQ(Utf8OffsetOfCodePoint("a\u4E2Db", 2), 4);
+  // Past the end yields the size, which makes a clamped substring empty.
+  EXPECT_EQ(Utf8OffsetOfCodePoint("a\u4E2Db", 3), 5);
+  EXPECT_EQ(Utf8OffsetOfCodePoint("a\u4E2Db", 99), 5);
+}
+
+TEST(String, Utf8OffsetOfLastCodePoints) {
+  // The tail is found by walking back, so asking for a few characters of a long
+  // string reads only those characters rather than all of it.
+  EXPECT_EQ(Utf8OffsetOfLastCodePoints("abc", 1), 2);
+  EXPECT_EQ(Utf8OffsetOfLastCodePoints("a\u4E2Db", 2), 1);
+  EXPECT_EQ(Utf8OffsetOfLastCodePoints("\U0001F600\U0001F600", 1), 4);
+
+  // Nothing requested is the empty tail; more than there is, is all of it.
+  EXPECT_EQ(Utf8OffsetOfLastCodePoints("a\u4E2Db", 0), 5);
+  EXPECT_EQ(Utf8OffsetOfLastCodePoints("a\u4E2Db", 3), 0);
+  EXPECT_EQ(Utf8OffsetOfLastCodePoints("a\u4E2Db", 99), 0);
+  EXPECT_EQ(Utf8OffsetOfLastCodePoints("", 3), 0);
 }
 
 TEST(String, Join) {


### PR DESCRIPTION
Length, substring, left and right now work in code points, so a position and a
length mean the same number of characters throughout and a result is always
whole characters. Length reported the size of the buffer, and the other three
cut at byte offsets, so a position landing inside a character split it and
returned a fragment that is not valid UTF-8.

The unit is the code point rather than the grapheme cluster: a combining mark
counts on its own, and a cut can still separate one from the character it
follows. Clusters are defined by data that changes between Unicode versions,
which would let the length of a stored value change under an upgrade. Results
change for text outside ASCII.
