### PR TITLE
fix(query): plan a row source for an EXISTS body that reads nothing

### DIFF
--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -552,6 +552,15 @@ class RuleBasedPlanner : public PatternComprehensionPlanner {
         }
       }
 
+      // An EXISTS body whose clauses produce no operator, as in
+      // `exists { RETURN 1 }`, leaves nothing planned: the subquery's RETURN is
+      // dropped and there is no reading clause to plan in its place. The
+      // predicate still needs a row to observe, which is what Once yields.
+      if (!input_op) {
+        input_op =
+            std::make_unique<Once>(std::vector<Symbol>(context.bound_symbols.begin(), context.bound_symbols.end()));
+      }
+
       // Is this the only situation that should be covered
       if (input_op->OutputSymbols(*context.symbol_table).empty() && !context.in_exists_subquery) {
         if (has_periodic_commit && is_root_query) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -192,6 +192,30 @@ TYPED_TEST(InterpreterTest, ExistsSubqueryWithoutReadingClause) {
     ASSERT_EQ(stream.GetResults().size(), 1U);
     EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
   }
+  {
+    // Negated, so the predicate holding for every row means no rows survive.
+    auto stream = this->Interpret("MATCH (n) WHERE NOT exists { RETURN 1 } RETURN n");
+    EXPECT_EQ(stream.GetResults().size(), 0U);
+  }
+  {
+    // Nested: the inner body is the one with nothing to read.
+    auto stream =
+        this->Interpret("MATCH (n) WHERE exists { MATCH (m) WHERE exists { RETURN 1 } RETURN m } RETURN count(n) AS c");
+    ASSERT_EQ(stream.GetResults().size(), 1U);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  }
+  {
+    // Each branch of a union in the body needs its own row source.
+    auto stream = this->Interpret("MATCH (n) WHERE exists { RETURN 1 UNION RETURN 2 } RETURN count(n) AS c");
+    ASSERT_EQ(stream.GetResults().size(), 1U);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  }
+  {
+    // A body that does read something was never affected, and still is not.
+    auto stream = this->Interpret("MATCH (n) WHERE exists { WITH 1 AS x RETURN x } RETURN count(n) AS c");
+    ASSERT_EQ(stream.GetResults().size(), 1U);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  }
 }
 
 // Run query with different ast twice to see if query executes correctly when

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -175,6 +175,25 @@ TYPED_TEST(InterpreterTest, MultiplePulls) {
   }
 }
 
+TYPED_TEST(InterpreterTest, ExistsSubqueryWithoutReadingClause) {
+  // An EXISTS body whose only clause is a RETURN plans no operator of its own,
+  // because the subquery's RETURN is dropped. It still has to yield a row, so
+  // the predicate holds for every input row.
+  this->Interpret("CREATE (:Node {id: 1}), (:Node {id: 2})");
+  {
+    auto stream = this->Interpret("MATCH (n) WHERE exists { RETURN n } RETURN n.id AS id ORDER BY id");
+    ASSERT_EQ(stream.GetResults().size(), 2U);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 1);
+    EXPECT_EQ(stream.GetResults()[1][0].ValueInt(), 2);
+  }
+  {
+    // The same shape with no correlation to the outer row.
+    auto stream = this->Interpret("MATCH (n) WHERE exists { RETURN 1 } RETURN count(n) AS cnt");
+    ASSERT_EQ(stream.GetResults().size(), 1U);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), 2);
+  }
+}
+
 // Run query with different ast twice to see if query executes correctly when
 // ast is read from cache.
 TYPED_TEST(InterpreterTest, AstCache) {


### PR DESCRIPTION
An existential subquery whose body holds no reading clause now plans a row
source of its own. The body's RETURN is dropped, since the predicate only asks
whether a row arrives, so a body with nothing else in it produced no operator
and the planner then read from an empty plan, ending the process.

A body with nothing to read matches once for every row it is evaluated
against, which is what the planned operator yields. The new path is reached
only where the plan was previously empty, so no plan that could be produced
before changes shape.
