### PR TITLE
fix(query): match a real literal only with a fraction or exponent

### DIFF
--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -457,12 +457,11 @@ int StrippedQuery::MatchReal(int start) const {
   enum class State { START, BEFORE_DOT, DOT, AFTER_DOT, E, E_MINUS, AFTER_E };
   State state = State::START;
   auto i = start;
-  // A real literal needs a fractional part or an exponent. A bare run of digits
-  // is an integer literal, and matching it here too would hand it to the real
-  // parser under the longest-match rule: the decimal-integer matcher stops
-  // after a leading zero, so `09` would be longer as a real than as an integer.
-  // Recording where the last complete real ended also drops a trailing partial
-  // exponent, as in `1.5e`.
+  // A real literal needs a fractional part or an exponent, so tracking where
+  // the last complete one ended keeps a bare run of digits out of the real
+  // parser. Longest match would otherwise hand it over: the decimal-integer
+  // matcher stops at a leading zero, making `09` longer as a real than as an
+  // integer. It also drops a partial trailing exponent, as in `1.5e`.
   auto end_of_real = start;
   while (i < static_cast<int>(original_.size())) {
     if (original_[i] == '.') {

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -457,6 +457,13 @@ int StrippedQuery::MatchReal(int start) const {
   enum class State { START, BEFORE_DOT, DOT, AFTER_DOT, E, E_MINUS, AFTER_E };
   State state = State::START;
   auto i = start;
+  // A real literal needs a fractional part or an exponent. A bare run of digits
+  // is an integer literal, and matching it here too would hand it to the real
+  // parser under the longest-match rule: the decimal-integer matcher stops
+  // after a leading zero, so `09` would be longer as a real than as an integer.
+  // Recording where the last complete real ended also drops a trailing partial
+  // exponent, as in `1.5e`.
+  auto end_of_real = start;
   while (i < static_cast<int>(original_.size())) {
     if (original_[i] == '.') {
       if (state != State::BEFORE_DOT && state != State::START) break;
@@ -479,11 +486,9 @@ int StrippedQuery::MatchReal(int start) const {
       break;
     }
     ++i;
+    if (state == State::AFTER_DOT || state == State::AFTER_E) end_of_real = i;
   }
-  if (state == State::DOT) --i;
-  if (state == State::E) --i;
-  if (state == State::E_MINUS) i -= 2;
-  return i - start;
+  return end_of_real - start;
 }
 
 int StrippedQuery::MatchParameter(int start) const {

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1282,6 +1282,67 @@ TEST_P(CypherMainVisitorTest, StringLiteralEscapedUtf32) {
   CheckRWType(query, kRead);
 }
 
+TEST_P(CypherMainVisitorTest, NumericLiteralForms) {
+  // Literals are lexed twice, once by the grammar and once by the query
+  // stripper, and this suite runs every case through both. Each form below is
+  // therefore an assertion that the two agree as well as that the value is
+  // right.
+  auto &ast_generator = *GetParam();
+
+  auto literal_of = [&ast_generator](const std::string &query_string) {
+    auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery(query_string));
+    EXPECT_TRUE(query) << query_string;
+    auto *return_clause = dynamic_cast<Return *>(query->single_query_->clauses_[0]);
+    return return_clause->body_.named_expressions[0]->expression_;
+  };
+
+  // Integers, in each base the grammar accepts.
+  ast_generator.CheckLiteral(literal_of("RETURN 0"), 0, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 42"), 42, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 9223372036854775807"), 9223372036854775807L, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 010"), 8, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 0177"), 127, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 0x1f"), 31, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 0xFF"), 255, 1);
+
+  // Reals need a fractional part or an exponent, and every arrangement of
+  // those has to keep working.
+  ast_generator.CheckLiteral(literal_of("RETURN 3.5"), 3.5, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 0.5"), 0.5, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN .5"), 0.5, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 1e5"), 1e5, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 1E5"), 1e5, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 1e-5"), 1e-5, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 1E-5"), 1e-5, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 1.5e3"), 1.5e3, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 1.5e-3"), 1.5e-3, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN 0.1e-2"), 0.1e-2, 1);
+  ast_generator.CheckLiteral(literal_of("RETURN .1e-2"), 0.1e-2, 1);
+}
+
+TEST_P(CypherMainVisitorTest, NumbersAdjacentToDots) {
+  // A dot after digits belongs to the range operator or to member access, not
+  // to a real literal, so the matcher must not swallow it.
+  auto &ast_generator = *GetParam();
+
+  auto *slice = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN [1, 2, 3][1..2]"));
+  ASSERT_TRUE(slice);
+  auto *range = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH ()-[*1..2]-() RETURN 1"));
+  ASSERT_TRUE(range);
+  auto *lower_only = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH ()-[*2..]-() RETURN 1"));
+  ASSERT_TRUE(lower_only);
+  auto *upper_only = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH ()-[*..3]-() RETURN 1"));
+  ASSERT_TRUE(upper_only);
+  auto *exact = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH ()-[*2]-() RETURN 1"));
+  ASSERT_TRUE(exact);
+
+  // A real as a bound, and a map value, both sit next to punctuation too.
+  auto *decimal_bound = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN [1, 2, 3][0..1]"));
+  ASSERT_TRUE(decimal_bound);
+  auto *in_map = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN {a: 1.5, b: 2, c: .5}"));
+  ASSERT_TRUE(in_map);
+}
+
 TEST_P(CypherMainVisitorTest, DoubleLiteral) {
   auto &ast_generator = *GetParam();
   auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 3.5"));

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1322,8 +1322,7 @@ TEST_P(CypherMainVisitorTest, NumericLiteralForms) {
 
 TEST_P(CypherMainVisitorTest, LeadingZeroWithNonOctalDigitIsRejected) {
   // A leading zero introduces an octal literal, and 8 and 9 are not octal
-  // digits, so these name no number the grammar accepts. Reading them as reals
-  // is what let them through before.
+  // digits, so these name no number the grammar accepts.
   auto &ast_generator = *GetParam();
   EXPECT_THROW(ast_generator.ParseQuery("RETURN 09"), SyntaxException);
   EXPECT_THROW(ast_generator.ParseQuery("RETURN 018"), SyntaxException);

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1320,6 +1320,26 @@ TEST_P(CypherMainVisitorTest, NumericLiteralForms) {
   ast_generator.CheckLiteral(literal_of("RETURN .1e-2"), 0.1e-2, 1);
 }
 
+TEST_P(CypherMainVisitorTest, LeadingZeroWithNonOctalDigitIsRejected) {
+  // A leading zero introduces an octal literal, and 8 and 9 are not octal
+  // digits, so these name no number the grammar accepts. Reading them as reals
+  // is what let them through before.
+  auto &ast_generator = *GetParam();
+  EXPECT_THROW(ast_generator.ParseQuery("RETURN 09"), SyntaxException);
+  EXPECT_THROW(ast_generator.ParseQuery("RETURN 018"), SyntaxException);
+  EXPECT_THROW(ast_generator.ParseQuery("RETURN 0098"), SyntaxException);
+
+  // A value too large for an integer is rejected as one rather than kept as an
+  // approximation, with or without the leading zero.
+  EXPECT_THROW(ast_generator.ParseQuery("RETURN 9223372036854775808"), SemanticException);
+
+  // Octal itself is unchanged.
+  auto *octal = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 010"));
+  ASSERT_TRUE(octal);
+  auto *ret = dynamic_cast<Return *>(octal->single_query_->clauses_[0]);
+  ast_generator.CheckLiteral(ret->body_.named_expressions[0]->expression_, 8, 1);
+}
+
 TEST_P(CypherMainVisitorTest, NumbersAdjacentToDots) {
   // A dot after digits belongs to the range operator or to member access, not
   // to a real literal, so the matcher must not swallow it.

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -82,6 +82,34 @@ TEST(QueryStripper, HexInteger) {
   EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
+TEST(QueryStripper, LeadingZeroDigitRunIsNotReal) {
+  // A run of digits carries neither a fraction nor an exponent, so it is not a
+  // real literal whatever it starts with. `09` is not a valid octal integer
+  // either, and reclassifying it as a real would change the arithmetic its
+  // value takes part in.
+  StrippedQuery stripped("RETURN 09");
+  for (const auto &[position, literal] : stripped.literals()) {
+    EXPECT_TRUE(literal.IsInt());
+  }
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken + " " + kStrippedIntToken);
+}
+
+TEST(QueryStripper, LeadingZeroDigitRunKeepsIntegerRangeCheck) {
+  // Routing a digit run to a real literal also skipped the 64-bit range check
+  // that integer literals get, so an out-of-range value silently became an
+  // approximate double. The same digits without the leading zero are rejected,
+  // and adding one must not change that.
+  EXPECT_THROW(StrippedQuery("RETURN 9223372036854775808"), SemanticException);
+  EXPECT_THROW(StrippedQuery("RETURN 009223372036854775808"), SemanticException);
+}
+
+TEST(QueryStripper, DigitRunWithEightOrNineIsNotReal) {
+  StrippedQuery stripped("RETURN 018");
+  for (const auto &[position, literal] : stripped.literals()) {
+    EXPECT_TRUE(literal.IsInt());
+  }
+}
+
 TEST(QueryStripper, RegularDecimal) {
   StrippedQuery stripped("RETURN 42.3");
   EXPECT_EQ(stripped.literals().size(), 1);

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -84,9 +84,7 @@ TEST(QueryStripper, HexInteger) {
 
 TEST(QueryStripper, LeadingZeroDigitRunIsNotReal) {
   // A run of digits carries neither a fraction nor an exponent, so it is not a
-  // real literal whatever it starts with. `09` is not a valid octal integer
-  // either, and reclassifying it as a real would change the arithmetic its
-  // value takes part in.
+  // real literal whatever it starts with.
   StrippedQuery stripped("RETURN 09");
   for (const auto &[position, literal] : stripped.literals()) {
     EXPECT_TRUE(literal.IsInt());
@@ -95,10 +93,9 @@ TEST(QueryStripper, LeadingZeroDigitRunIsNotReal) {
 }
 
 TEST(QueryStripper, LeadingZeroDigitRunKeepsIntegerRangeCheck) {
-  // Routing a digit run to a real literal also skipped the 64-bit range check
-  // that integer literals get, so an out-of-range value silently became an
-  // approximate double. The same digits without the leading zero are rejected,
-  // and adding one must not change that.
+  // A digit run is checked against the 64-bit integer range whether or not it
+  // has a leading zero, so an out-of-range value is an error rather than an
+  // approximate double.
   EXPECT_THROW(StrippedQuery("RETURN 9223372036854775808"), SemanticException);
   EXPECT_THROW(StrippedQuery("RETURN 009223372036854775808"), SemanticException);
 }

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -110,6 +110,34 @@ TEST(QueryStripper, DigitRunWithEightOrNineIsNotReal) {
   }
 }
 
+TEST(QueryStripper, RealLiteralStopsAtAnIncompleteExponent) {
+  // The match has to end where the last complete real ended: `1.5e` is the real
+  // `1.5` followed by a name, and taking the trailing `e` would misread both.
+  {
+    StrippedQuery stripped("RETURN 1.5e");
+    EXPECT_EQ(SingleLiteral(stripped).ValueDouble(), 1.5);
+    EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken + " e");
+  }
+  {
+    StrippedQuery stripped("RETURN 1.5e-");
+    EXPECT_EQ(SingleLiteral(stripped).ValueDouble(), 1.5);
+  }
+}
+
+TEST(QueryStripper, TrailingDotIsNotPartOfAnIntegerLiteral) {
+  // `42.` has no fractional part, so it is the integer `42` and a separate dot
+  // rather than a real literal.
+  StrippedQuery stripped("RETURN 42.foo");
+  EXPECT_EQ(SingleLiteral(stripped).ValueInt(), 42);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken + " . foo");
+}
+
+TEST(QueryStripper, LeadingDotIsStillAReal) {
+  StrippedQuery stripped("RETURN .5");
+  EXPECT_EQ(SingleLiteral(stripped).ValueDouble(), 0.5);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
+}
+
 TEST(QueryStripper, RegularDecimal) {
   StrippedQuery stripped("RETURN 42.3");
   EXPECT_EQ(stripped.literals().size(), 1);


### PR DESCRIPTION
A run of digits is no longer matched as a real literal, leaving it to the
integer matchers. Literals are lexed both by the grammar and by the query
stripper, and the stripper's real matcher accepted a bare run of digits, which
under longest match beat the decimal matcher whenever a leading zero cut that
one short. A value written with a leading zero therefore became a double,
taking part in floating point arithmetic, and skipped the range check an
integer literal gets, so a number too large for an integer was kept as an
approximation.

Recording where the last complete real ended keeps a trailing partial exponent
out of the match, as the previous back-off did by stepping over it.
