### PR TITLE
fix(query): convert whole-number strings to integers exactly

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -684,22 +684,23 @@ TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext 
   }
 }
 
+// int64's maximum is not representable as a double, so the bound is the
+// smallest double above the range, 2^63, and it is exclusive.
+constexpr double kInt64UpperBoundExclusive = 9223372036854775808.0;
+constexpr auto kInt64LowerBoundInclusive = static_cast<double>(std::numeric_limits<int64_t>::min());
+
+// False for NaN, which compares false against both bounds.
+bool IsWithinInt64Range(const double value) {
+  return value >= kInt64LowerBoundInclusive && value < kInt64UpperBoundExclusive;
+}
+
 // Truncates toward zero, saturating at either end of the range and taking NaN
 // to zero. This is how a floating point argument converts: the C++ cast is
 // undefined outside the range, so the bounds are applied before it.
-//
-// The bounds are spelled out rather than taken from boost's range checker,
-// which reports the exact lowest value as an underflow even though it converts,
-// and reports NaN as in range. Both would need working around here, where every
-// input has to yield a number.
-int64_t TruncateToInteger(double value) {
-  // int64's maximum is not representable as a double; the smallest double at or
-  // above the range is 2^63, which is.
-  constexpr double kExclusiveUpperBound = 9223372036854775808.0;
-  constexpr auto kInclusiveLowerBound = static_cast<double>(std::numeric_limits<int64_t>::min());
+int64_t TruncateToInteger(const double value) {
   if (std::isnan(value)) return 0;
-  if (value >= kExclusiveUpperBound) return std::numeric_limits<int64_t>::max();
-  if (value < kInclusiveLowerBound) return std::numeric_limits<int64_t>::min();
+  if (value >= kInt64UpperBoundExclusive) return std::numeric_limits<int64_t>::max();
+  if (value < kInt64LowerBoundInclusive) return std::numeric_limits<int64_t>::min();
   return static_cast<int64_t>(value);
 }
 
@@ -732,11 +733,7 @@ std::pair<StringToInteger, int64_t> ParseInteger(std::string_view text) {
   } catch (const utils::BasicException &) {
     return {StringToInteger::kNotANumber, 0};
   }
-  constexpr double kExclusiveUpperBound = 9223372036854775808.0;
-  constexpr auto kInclusiveLowerBound = static_cast<double>(std::numeric_limits<int64_t>::min());
-  if (std::isnan(as_double) || as_double >= kExclusiveUpperBound || as_double < kInclusiveLowerBound) {
-    return {StringToInteger::kOutOfRange, 0};
-  }
+  if (!IsWithinInt64Range(as_double)) return {StringToInteger::kOutOfRange, 0};
   return {StringToInteger::kOk, static_cast<int64_t>(as_double)};
 }
 

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -684,16 +684,53 @@ TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext 
   }
 }
 
-// Truncates toward zero, or reports that no int64 corresponds to the value.
-// Converting out-of-range doubles is undefined behaviour, so the range has to
-// be checked before the cast rather than after.
-std::optional<int64_t> TruncateToInteger(double value) {
+// Truncates toward zero, saturating at either end of the range and taking NaN
+// to zero. This is how a floating point argument converts: the C++ cast is
+// undefined outside the range, so the bounds are applied before it.
+int64_t TruncateToInteger(double value) {
   // int64's maximum is not representable as a double; the smallest double at or
   // above the range is 2^63, which is.
   constexpr double kExclusiveUpperBound = 9223372036854775808.0;
   constexpr auto kInclusiveLowerBound = static_cast<double>(std::numeric_limits<int64_t>::min());
-  if (std::isnan(value) || value < kInclusiveLowerBound || value >= kExclusiveUpperBound) return std::nullopt;
+  if (std::isnan(value)) return 0;
+  if (value >= kExclusiveUpperBound) return std::numeric_limits<int64_t>::max();
+  if (value < kInclusiveLowerBound) return std::numeric_limits<int64_t>::min();
   return static_cast<int64_t>(value);
+}
+
+// A string can fail to yield an integer in two ways that are reported
+// differently: one naming no number at all is null, while one naming a number
+// too large for the type is an error in toInteger and null in toIntegerOrNull.
+enum class StringToInteger : std::uint8_t { kOk, kNotANumber, kOutOfRange };
+
+std::pair<StringToInteger, int64_t> ParseInteger(std::string_view text) {
+  const auto trimmed = utils::Trim(text);
+  // A whole-number string is parsed as an integer directly. A double holds
+  // fewer significant digits than int64, so going through one would round large
+  // values onto a neighbouring integer or off the end of the range.
+  int64_t parsed{};
+  const auto *const begin = trimmed.data();
+  const auto *const end = begin + trimmed.size();
+  if (const auto [stopped_at, ec] = std::from_chars(begin, end, parsed); stopped_at == end) {
+    if (ec == std::errc{}) return {StringToInteger::kOk, parsed};
+    return {StringToInteger::kOutOfRange, 0};
+  }
+
+  // Anything else is only meaningful as a floating point number, and is
+  // truncated toward zero. Unlike a floating point argument it does not
+  // saturate: the text named an exact value, and no integer stands for it.
+  double as_double{};
+  try {
+    as_double = utils::ParseDouble(trimmed);
+  } catch (const utils::BasicException &) {
+    return {StringToInteger::kNotANumber, 0};
+  }
+  constexpr double kExclusiveUpperBound = 9223372036854775808.0;
+  constexpr auto kInclusiveLowerBound = static_cast<double>(std::numeric_limits<int64_t>::min());
+  if (std::isnan(as_double) || as_double >= kExclusiveUpperBound || as_double < kInclusiveLowerBound) {
+    return {StringToInteger::kOutOfRange, 0};
+  }
+  return {StringToInteger::kOk, static_cast<int64_t>(as_double)};
 }
 
 TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
@@ -706,28 +743,16 @@ TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContex
   } else if (value.IsInt()) {
     return TypedValue(value, ctx.memory);
   } else if (value.IsDouble()) {
-    const auto truncated = TruncateToInteger(value.ValueDouble());
-    return truncated ? TypedValue(*truncated, ctx.memory) : TypedValue(ctx.memory);
+    return TypedValue(TruncateToInteger(value.ValueDouble()), ctx.memory);
   } else {
-    const auto trimmed = utils::Trim(value.ValueString());
-    // A whole-number string is parsed as an integer directly. A double holds
-    // fewer significant digits than int64, so going through one would round
-    // large values onto a neighbouring integer or off the end of the range.
-    int64_t parsed{};
-    const auto *const begin = trimmed.data();
-    const auto *const end = begin + trimmed.size();
-    if (const auto [stopped_at, ec] = std::from_chars(begin, end, parsed); stopped_at == end) {
-      if (ec == std::errc{}) return TypedValue(parsed, ctx.memory);
-      // The whole string was digits but named a value outside int64.
-      return TypedValue(ctx.memory);
-    }
-    // Anything else is only meaningful as a floating point number, and is
-    // truncated toward zero once parsed.
-    try {
-      const auto truncated = TruncateToInteger(utils::ParseDouble(trimmed));
-      return truncated ? TypedValue(*truncated, ctx.memory) : TypedValue(ctx.memory);
-    } catch (const utils::BasicException &) {
-      return TypedValue(ctx.memory);
+    const auto [status, parsed] = ParseInteger(value.ValueString());
+    switch (status) {
+      case StringToInteger::kOk:
+        return TypedValue(parsed, ctx.memory);
+      case StringToInteger::kNotANumber:
+        return TypedValue(ctx.memory);
+      case StringToInteger::kOutOfRange:
+        throw QueryRuntimeException("'{}' is outside the range of an integer.", value.ValueString());
     }
   }
 }
@@ -749,7 +774,15 @@ TypedValue ToFloatOrNull(const TypedValue *args, int64_t nargs, const FunctionCo
 }
 
 TypedValue ToIntegerOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  return ConvertOrNull<ToNumericTypes, ToInteger>("toIntegerOrNull", args, nargs, ctx);
+  if (nargs != 1) throw QueryRuntimeException("'{}' requires exactly 1 argument.", "toIntegerOrNull");
+  if (!ToNumericTypes::Check(args[0])) return TypedValue(ctx.memory);
+  // A string naming a value out of range is an error in the strict form but
+  // null here, so the string case cannot delegate the way the rest can.
+  if (args[0].IsString()) {
+    const auto [status, parsed] = ParseInteger(args[0].ValueString());
+    return status == StringToInteger::kOk ? TypedValue(parsed, ctx.memory) : TypedValue(ctx.memory);
+  }
+  return ToInteger(args, nargs, ctx);
 }
 
 TypedValue ToBooleanList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -713,7 +713,9 @@ std::pair<StringToInteger, int64_t> ParseInteger(std::string_view text) {
   const auto *const end = begin + trimmed.size();
   if (const auto [stopped_at, ec] = std::from_chars(begin, end, parsed); stopped_at == end) {
     if (ec == std::errc{}) return {StringToInteger::kOk, parsed};
-    return {StringToInteger::kOutOfRange, 0};
+    if (ec == std::errc::result_out_of_range) return {StringToInteger::kOutOfRange, 0};
+    // Empty text consumes nothing, which leaves the cursor at the end as well,
+    // so reaching it is not on its own a sign that a number was read.
   }
 
   // Anything else is only meaningful as a floating point number, and is

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -12,12 +12,14 @@
 #include "query/interpret/awesome_memgraph_functions.hpp"
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <random>
 #include <ranges>
@@ -682,6 +684,18 @@ TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext 
   }
 }
 
+// Truncates toward zero, or reports that no int64 corresponds to the value.
+// Converting out-of-range doubles is undefined behaviour, so the range has to
+// be checked before the cast rather than after.
+std::optional<int64_t> TruncateToInteger(double value) {
+  // int64's maximum is not representable as a double; the smallest double at or
+  // above the range is 2^63, which is.
+  constexpr double kExclusiveUpperBound = 9223372036854775808.0;
+  constexpr auto kInclusiveLowerBound = static_cast<double>(std::numeric_limits<int64_t>::min());
+  if (std::isnan(value) || value < kInclusiveLowerBound || value >= kExclusiveUpperBound) return std::nullopt;
+  return static_cast<int64_t>(value);
+}
+
 TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<ToNumericTypes>("toInteger", args, nargs);
   const auto &value = args[0];
@@ -692,12 +706,26 @@ TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContex
   } else if (value.IsInt()) {
     return TypedValue(value, ctx.memory);
   } else if (value.IsDouble()) {
-    return TypedValue(static_cast<int64_t>(value.ValueDouble()), ctx.memory);
+    const auto truncated = TruncateToInteger(value.ValueDouble());
+    return truncated ? TypedValue(*truncated, ctx.memory) : TypedValue(ctx.memory);
   } else {
+    const auto trimmed = utils::Trim(value.ValueString());
+    // A whole-number string is parsed as an integer directly. A double holds
+    // fewer significant digits than int64, so going through one would round
+    // large values onto a neighbouring integer or off the end of the range.
+    int64_t parsed{};
+    const auto *const begin = trimmed.data();
+    const auto *const end = begin + trimmed.size();
+    if (const auto [stopped_at, ec] = std::from_chars(begin, end, parsed); stopped_at == end) {
+      if (ec == std::errc{}) return TypedValue(parsed, ctx.memory);
+      // The whole string was digits but named a value outside int64.
+      return TypedValue(ctx.memory);
+    }
+    // Anything else is only meaningful as a floating point number, and is
+    // truncated toward zero once parsed.
     try {
-      // Yup, this is correct. String is valid if it has floating point
-      // number, then it is parsed and converted to int.
-      return TypedValue(static_cast<int64_t>(utils::ParseDouble(utils::Trim(value.ValueString()))), ctx.memory);
+      const auto truncated = TruncateToInteger(utils::ParseDouble(trimmed));
+      return truncated ? TypedValue(*truncated, ctx.memory) : TypedValue(ctx.memory);
     } catch (const utils::BasicException &) {
       return TypedValue(ctx.memory);
     }

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -687,6 +687,11 @@ TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext 
 // Truncates toward zero, saturating at either end of the range and taking NaN
 // to zero. This is how a floating point argument converts: the C++ cast is
 // undefined outside the range, so the bounds are applied before it.
+//
+// The bounds are spelled out rather than taken from boost's range checker,
+// which reports the exact lowest value as an underflow even though it converts,
+// and reports NaN as in range. Both would need working around here, where every
+// input has to yield a number.
 int64_t TruncateToInteger(double value) {
   // int64's maximum is not representable as a double; the smallest double at or
   // above the range is 2^63, which is.

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2107,9 +2107,8 @@ TYPED_TEST(FunctionTest, ToInteger) {
 }
 
 TYPED_TEST(FunctionTest, ToIntegerPreservesFullInt64Range) {
-  // Every int64 must survive the conversion. Routing the string through a
-  // double first cannot represent the values near the limits, so they round
-  // onto a different integer and adjacent inputs collapse together.
+  // Every int64 survives the conversion, including values near the limits that
+  // a double cannot represent, and adjacent inputs stay distinct.
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "9223372036854775807").ValueInt(), std::numeric_limits<int64_t>::max());
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "9223372036854775806").ValueInt(),
             std::numeric_limits<int64_t>::max() - 1);
@@ -2138,10 +2137,9 @@ TYPED_TEST(FunctionTest, ToIntegerPreservesFullInt64Range) {
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", -1.0e30).ValueInt(), std::numeric_limits<int64_t>::min());
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", std::nan("")).ValueInt(), 0);
 
-  // The bottom of the range is exactly representable as a double and belongs
-  // to it, so it converts rather than saturating into place by luck, and the
-  // string naming it is a value rather than an error. The top is not
-  // representable, which is why the bound above it is the one tested.
+  // The bottom of the range is exactly representable as a double and belongs to
+  // it, so it converts rather than saturating into place by luck. The top is
+  // not representable, which is why the bound above it is the one tested.
   const auto lowest = static_cast<double>(std::numeric_limits<int64_t>::min());
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", lowest).ValueInt(), std::numeric_limits<int64_t>::min());
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "-9223372036854775808.0").ValueInt(),

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2138,6 +2138,15 @@ TYPED_TEST(FunctionTest, ToIntegerPreservesFullInt64Range) {
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", -1.0e30).ValueInt(), std::numeric_limits<int64_t>::min());
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", std::nan("")).ValueInt(), 0);
 
+  // The bottom of the range is exactly representable as a double and belongs
+  // to it, so it converts rather than saturating into place by luck, and the
+  // string naming it is a value rather than an error. The top is not
+  // representable, which is why the bound above it is the one tested.
+  const auto lowest = static_cast<double>(std::numeric_limits<int64_t>::min());
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", lowest).ValueInt(), std::numeric_limits<int64_t>::min());
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "-9223372036854775808.0").ValueInt(),
+            std::numeric_limits<int64_t>::min());
+
   // Forms that only a floating-point parse accepts keep working.
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", " -3.5 \n\t").ValueInt(), -3);
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "1e3").ValueInt(), 1000);

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2118,15 +2118,37 @@ TYPED_TEST(FunctionTest, ToIntegerPreservesFullInt64Range) {
   ASSERT_NE(this->EvaluateFunction("TOINTEGER", "9223372036854775807").ValueInt(),
             this->EvaluateFunction("TOINTEGER", "9223372036854775806").ValueInt());
 
-  // Outside the range there is no integer to return.
-  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "9223372036854775808").IsNull());
-  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "99999999999999999999").IsNull());
-  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", 1.0e30).IsNull());
+  // A string naming a value with no integer counterpart is an error: it named
+  // a number exactly, and silently returning some other one would be worse
+  // than saying so. This holds however the number is written.
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "9223372036854775808"), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "99999999999999999999"), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "1e30"), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "-99999999999999999999"), QueryRuntimeException);
+
+  // A floating point argument saturates instead, and NaN converts to zero.
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", 1.0e30).ValueInt(), std::numeric_limits<int64_t>::max());
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", -1.0e30).ValueInt(), std::numeric_limits<int64_t>::min());
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", std::nan("")).ValueInt(), 0);
 
   // Forms that only a floating-point parse accepts keep working.
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", " -3.5 \n\t").ValueInt(), -3);
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "1e3").ValueInt(), 1000);
   ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "\n\t3X ").IsNull());
+}
+
+TYPED_TEST(FunctionTest, ToIntegerOrNullOnOutOfRange) {
+  // The OrNull form reports every failure the same way, so a value out of
+  // range is null here rather than the error the strict form raises.
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", "99999999999999999999").IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", "9223372036854775808").IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", "1e30").IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", "not a number").IsNull());
+
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGERORNULL", "9223372036854775807").ValueInt(),
+            std::numeric_limits<int64_t>::max());
+  // A floating point argument still saturates rather than going null.
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGERORNULL", 1.0e30).ValueInt(), std::numeric_limits<int64_t>::max());
 }
 
 TYPED_TEST(FunctionTest, ToBooleanOrNull) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2125,6 +2125,13 @@ TYPED_TEST(FunctionTest, ToIntegerPreservesFullInt64Range) {
   ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "99999999999999999999"), QueryRuntimeException);
   ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "1e30"), QueryRuntimeException);
   ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "-99999999999999999999"), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGER", "9223372036854775808.5"), QueryRuntimeException);
+
+  // Text naming no number at all is null rather than an error: nothing was
+  // asked for that could not be given.
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "banana").IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "").IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "   ").IsNull());
 
   // A floating point argument saturates instead, and NaN converts to zero.
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", 1.0e30).ValueInt(), std::numeric_limits<int64_t>::max());

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <cmath>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <unordered_map>
@@ -2103,6 +2104,29 @@ TYPED_TEST(FunctionTest, ToInteger) {
   ASSERT_THROW(this->EvaluateFunction("TOINTEGER", MakeTypedValueList(1, 2, 3)), QueryRuntimeException);
   ASSERT_THROW(this->EvaluateFunction("TOINTEGER", TypedValue(std::map<std::string, TypedValue>{})),
                QueryRuntimeException);
+}
+
+TYPED_TEST(FunctionTest, ToIntegerPreservesFullInt64Range) {
+  // Every int64 must survive the conversion. Routing the string through a
+  // double first cannot represent the values near the limits, so they round
+  // onto a different integer and adjacent inputs collapse together.
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "9223372036854775807").ValueInt(), std::numeric_limits<int64_t>::max());
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "9223372036854775806").ValueInt(),
+            std::numeric_limits<int64_t>::max() - 1);
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "-9223372036854775808").ValueInt(),
+            std::numeric_limits<int64_t>::min());
+  ASSERT_NE(this->EvaluateFunction("TOINTEGER", "9223372036854775807").ValueInt(),
+            this->EvaluateFunction("TOINTEGER", "9223372036854775806").ValueInt());
+
+  // Outside the range there is no integer to return.
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "9223372036854775808").IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "99999999999999999999").IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", 1.0e30).IsNull());
+
+  // Forms that only a floating-point parse accepts keep working.
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", " -3.5 \n\t").ValueInt(), -3);
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGER", "1e3").ValueInt(), 1000);
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "\n\t3X ").IsNull());
 }
 
 TYPED_TEST(FunctionTest, ToBooleanOrNull) {


### PR DESCRIPTION
Whole-number strings now convert to integers directly rather than through a
double. A double carries fewer significant digits than an integer, so a value
near the limits rounded onto a neighbouring integer: the largest came back as
the smallest, and neighbouring inputs collapsed onto one value.

Text naming no number converts to null, while text naming a number outside the
range is an error quoting it, since returning some other number would be worse
than saying so. A floating point argument saturates at the nearest end instead,
and NaN converts to zero. The range is checked before every conversion, so none
of them is undefined.

The bounds are written out rather than taken from boost's range checker, which
reports the exact lowest value as an underflow even though it converts, and
reports NaN as in range. Both would need working around here, where every input
has to yield an answer.