### PR TITLE
fix(query): return null from single() when a predicate is null

### DIFF
--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1006,8 +1006,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (non_empty_list && !has_value) {
       return TypedValue(ctx_->memory);
     } else if (has_null_elements) {
-      // An unknown could be the second match, so with fewer than two definite
-      // matches the count is not settled. Two or more already returned false.
+      // Two matches already returned false above, so at most one definite match
+      // reached here and a null element could have been a second one.
       return TypedValue(ctx_->memory);
     } else {
       return TypedValue(predicate_satisfied, ctx_->memory);

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1005,7 +1005,9 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     }
     if (non_empty_list && !has_value) {
       return TypedValue(ctx_->memory);
-    } else if (has_null_elements && !predicate_satisfied) {
+    } else if (has_null_elements) {
+      // An unknown could be the second match, so with fewer than two definite
+      // matches the count is not settled. Two or more already returned false.
       return TypedValue(ctx_->memory);
     } else {
       return TypedValue(predicate_satisfied, ctx_->memory);

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -883,7 +883,7 @@ Feature: Functions
             """
         Then the result should be:
             | a    |
-            | true |
+            | null |
 
     Scenario: Single test 06:
         When executing query:
@@ -910,7 +910,7 @@ Feature: Functions
             """
         Then the result should be:
             | a     |
-            | true  |
+            | null  |
 
     Scenario: Single test 09:
         When executing query:

--- a/tests/gql_behave/tests/memgraph_V1_on_disk/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1_on_disk/features/functions.feature
@@ -777,7 +777,7 @@ Feature: Functions
             """
         Then the result should be:
             | a    |
-            | true |
+            | null |
 
     Scenario: Single test 06:
         When executing query:
@@ -804,7 +804,7 @@ Feature: Functions
             """
         Then the result should be:
             | a     |
-            | true  |
+            | null  |
 
     Scenario: Single test 09:
         When executing query:

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1155,8 +1155,8 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullList) {
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList1) {
-  // One definite match alongside an unknown: the total is either one or two, so
-  // whether exactly one element matches is itself unknown.
+  // One definite match alongside a null: the match count is either one or two,
+  // so the result is null rather than true.
   AstStorage storage;
   auto *ident_x = IDENT("x");
   auto *single = SINGLE("x", LIST(LITERAL(true), LITERAL(memgraph::storage::ExternalPropertyValue())), WHERE(ident_x));
@@ -1168,8 +1168,7 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList1) {
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementBeforeMatch) {
-  // Same as above with the unknown first: element order must not change the
-  // result.
+  // Same as above with the null first: element order must not change the result.
   AstStorage storage;
   auto *ident_x = IDENT("x");
   auto *single = SINGLE("x", LIST(LITERAL(memgraph::storage::ExternalPropertyValue()), LITERAL(true)), WHERE(ident_x));
@@ -1181,8 +1180,7 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementBeforeMatch) {
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleTwoMatchesWithNullIsFalse) {
-  // Two definite matches settle the answer no matter what the unknown resolves
-  // to, so an unknown alongside them does not make the result unknown.
+  // Two definite matches settle the answer whatever the null turns out to be.
   AstStorage storage;
   auto *ident_x = IDENT("x");
   auto *single = SINGLE(

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1155,6 +1155,8 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullList) {
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList1) {
+  // One definite match alongside an unknown: the total is either one or two, so
+  // whether exactly one element matches is itself unknown.
   AstStorage storage;
   auto *ident_x = IDENT("x");
   auto *single = SINGLE("x", LIST(LITERAL(true), LITERAL(memgraph::storage::ExternalPropertyValue())), WHERE(ident_x));
@@ -1162,8 +1164,35 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList1) {
   single->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
   auto value = this->Eval(single);
+  EXPECT_TRUE(value.IsNull());
+}
+
+TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementBeforeMatch) {
+  // Same as above with the unknown first: element order must not change the
+  // result.
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *single = SINGLE("x", LIST(LITERAL(memgraph::storage::ExternalPropertyValue()), LITERAL(true)), WHERE(ident_x));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  single->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(single);
+  EXPECT_TRUE(value.IsNull());
+}
+
+TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleTwoMatchesWithNullIsFalse) {
+  // Two definite matches settle the answer no matter what the unknown resolves
+  // to, so an unknown alongside them does not make the result unknown.
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *single = SINGLE(
+      "x", LIST(LITERAL(memgraph::storage::ExternalPropertyValue()), LITERAL(true), LITERAL(true)), WHERE(ident_x));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  single->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(single);
   ASSERT_TRUE(value.IsBool());
-  EXPECT_TRUE(value.ValueBool());
+  EXPECT_FALSE(value.ValueBool());
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList2) {


### PR DESCRIPTION
single() now returns null whenever the predicate evaluates to null for any
element. One element matching for certain alongside one that may match means the
count is either one or two, so the previous answer of true claimed a certainty
it did not have.

Two or more definite matches still return false, that being the only case where
the null elements cannot change the result whichever way they resolve.