### PR TITLE
fix(query): split an empty string into one empty field

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1496,8 +1496,15 @@ TypedValue Split(const TypedValue *args, int64_t nargs, const FunctionContext &c
   if (args[0].IsNull() || args[1].IsNull()) {
     return TypedValue(ctx.memory);
   }
+  const auto &input = args[0].ValueString();
   TypedValue::TVector result(ctx.memory);
-  utils::Split(&result, args[0].ValueString(), args[1].ValueString());
+  if (input.empty()) {
+    // utils::Split yields no fields at all for an empty input, but splitting a
+    // non-null string must always produce at least one field.
+    result.emplace_back("");
+  } else {
+    utils::Split(&result, input, args[1].ValueString());
+  }
   return TypedValue(std::move(result));
 }
 

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2924,6 +2924,28 @@ TYPED_TEST(FunctionTest, Split) {
   EXPECT_EQ(result.ValueList()[1].ValueString(), "two");
 }
 
+TYPED_TEST(FunctionTest, SplitEmptyString) {
+  // Splitting a non-null string always yields at least one element, so the
+  // empty string splits to a single empty field rather than to no fields.
+  auto empty_input = this->EvaluateFunction("SPLIT", "", ",");
+  ASSERT_TRUE(empty_input.IsList());
+  ASSERT_EQ(empty_input.ValueList().size(), 1);
+  EXPECT_EQ(empty_input.ValueList()[0].ValueString(), "");
+
+  // A delimiter with nothing either side of it already produced empty fields;
+  // the empty input is the same rule applied to a string with no delimiter.
+  auto lone_delimiter = this->EvaluateFunction("SPLIT", ",", ",");
+  ASSERT_TRUE(lone_delimiter.IsList());
+  ASSERT_EQ(lone_delimiter.ValueList().size(), 2);
+  EXPECT_EQ(lone_delimiter.ValueList()[0].ValueString(), "");
+  EXPECT_EQ(lone_delimiter.ValueList()[1].ValueString(), "");
+
+  auto no_delimiter_present = this->EvaluateFunction("SPLIT", "abc", ",");
+  ASSERT_TRUE(no_delimiter_present.IsList());
+  ASSERT_EQ(no_delimiter_present.ValueList().size(), 1);
+  EXPECT_EQ(no_delimiter_present.ValueList()[0].ValueString(), "abc");
+}
+
 TYPED_TEST(FunctionTest, Substring) {
   EXPECT_THROW(this->EvaluateFunction("SUBSTRING"), QueryRuntimeException);
 


### PR DESCRIPTION
Splitting a non-null string now always yields at least one field, so the empty
string splits to a single empty field rather than to none at all. The cases
either side of a delimiter already produced empty fields, and an empty input is
that same rule applied to a string containing no delimiter.

The general purpose split still returns no fields for an empty input, since
configuration and delimited file parsing rely on that. Only the language
function carries the rule.
