### PR TITLE
fix(query): report an unusable timezone as an argument error

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1829,7 +1829,7 @@ utils::Timezone GetTimezone(const memgraph::query::TypedValue::TMap &input_param
   }
   const auto &value = input_parameters.at(timezone);
   if (value.IsString()) {
-    return utils::Timezone(value.ValueString());
+    return utils::ParseTimezoneFromUserString(value.ValueString());
   }
   if (value.IsInt()) {
     return utils::Timezone(std::chrono::minutes{value.ValueInt()});

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -316,7 +316,8 @@ struct mgp_zoned_date_time {
             MapDateParameters(parameters->date_parameters),
             MapLocalTimeParameters(parameters->local_time_parameters),
             parameters->is_named_timezone
-                ? memgraph::utils::Timezone{std::string_view{parameters->timezone_info.timezone_name}}
+                ? memgraph::utils::ParseTimezoneFromUserString(
+                      std::string_view{parameters->timezone_info.timezone_name})
                 : memgraph::utils::Timezone{std::chrono::minutes{parameters->timezone_info.offset_in_minutes}}}) {}
 
   mgp_zoned_date_time(const mgp_zoned_date_time &other, allocator_type alloc) noexcept

--- a/src/utils/temporal.cpp
+++ b/src/utils/temporal.cpp
@@ -778,8 +778,8 @@ Timezone ParseTimezoneFromUserString(std::string_view timezone) {
   try {
     return Timezone{std::chrono::locate_zone(timezone)};
   } catch (const std::runtime_error &) {
-    // The only failure locate_zone reports, and narrow on purpose: catching
-    // everything would report a failed allocation as an unknown zone name.
+    // The only failure locate_zone reports. Catching everything here would
+    // report a failed allocation as an unknown zone name.
     throw temporal::InvalidArgumentException("Timezone name is not in the IANA time zone database.");
   }
 }

--- a/src/utils/temporal.cpp
+++ b/src/utils/temporal.cpp
@@ -756,6 +756,31 @@ std::pair<Timezone, uint64_t> ParseTimezoneFromOffset(std::string_view timezone_
   return {Timezone(compute_offset(sign, maybe_hours.value(), maybe_minutes.value())), timezone_offset_string.length()};
 }
 
+Timezone ParseTimezoneFromUserString(std::string_view timezone) {
+  if (timezone.empty()) {
+    throw temporal::InvalidArgumentException("The timezone must not be empty.");
+  }
+
+  if (timezone == "Z" || timezone == "z") {
+    return Timezone{std::chrono::minutes{0}};
+  }
+
+  if (timezone.front() == '+' || timezone.front() == '-') {
+    const auto [parsed, unconsumed_length] = ParseTimezoneFromOffset(timezone);
+    if (unconsumed_length != 0) {
+      throw temporal::InvalidArgumentException("Extra characters after the timezone offset. {}",
+                                               kSupportedZonedDateTimeFormatsHelpMessage);
+    }
+    return parsed;
+  }
+
+  try {
+    return Timezone{std::chrono::locate_zone(timezone)};
+  } catch (...) {
+    throw temporal::InvalidArgumentException("Timezone name is not in the IANA time zone database.");
+  }
+}
+
 ZonedDateTimeParameters ParseZonedDateTimeParameters(std::string_view string) {
   // https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
 

--- a/src/utils/temporal.cpp
+++ b/src/utils/temporal.cpp
@@ -19,6 +19,7 @@
 #include <ctime>
 #include <format>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -776,7 +777,9 @@ Timezone ParseTimezoneFromUserString(std::string_view timezone) {
 
   try {
     return Timezone{std::chrono::locate_zone(timezone)};
-  } catch (...) {
+  } catch (const std::runtime_error &) {
+    // The only failure locate_zone reports, and narrow on purpose: catching
+    // everything would report a failed allocation as an unknown zone name.
     throw temporal::InvalidArgumentException("Timezone name is not in the IANA time zone database.");
   }
 }

--- a/src/utils/temporal.hpp
+++ b/src/utils/temporal.hpp
@@ -628,6 +628,14 @@ LocalTime CurrentLocalTime();
 LocalDateTime CurrentLocalDateTime();
 ZonedDateTime CurrentZonedDateTime();
 Timezone DefaultTimezone();
+
+/// Interpret a user-supplied timezone as either a UTC offset (`+01:00`,
+/// `+0100`, `+01`, or `Z`) or a name from the IANA time zone database.
+///
+/// Throws temporal::InvalidArgumentException for anything else. Constructing a
+/// Timezone from a name directly reports an unknown name by throwing out of the
+/// standard library instead, which callers handling user input cannot present.
+Timezone ParseTimezoneFromUserString(std::string_view timezone);
 }  // namespace memgraph::utils
 
 namespace std {

--- a/src/utils/temporal.hpp
+++ b/src/utils/temporal.hpp
@@ -633,8 +633,8 @@ Timezone DefaultTimezone();
 /// `+0100`, `+01`, or `Z`) or a name from the IANA time zone database.
 ///
 /// Throws temporal::InvalidArgumentException for anything else. Constructing a
-/// Timezone from a name directly reports an unknown name by throwing out of the
-/// standard library instead, which callers handling user input cannot present.
+/// Timezone from a name directly throws out of the standard library instead,
+/// which is not an error a query can report.
 Timezone ParseTimezoneFromUserString(std::string_view timezone);
 }  // namespace memgraph::utils
 

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -3255,6 +3255,29 @@ TYPED_TEST(FunctionTest, ZonedDateTime) {
                                                                       {"timezone", TypedValue("America/Los_Angeles")}});
   EXPECT_EQ(this->EvaluateFunction("DATETIME", map_param).ValueZonedDateTime(), zdt);
 
+  // A UTC offset is accepted for the timezone field, in the same forms the
+  // string constructor takes.
+  auto with_offset = [&](const char *timezone) {
+    return this
+        ->EvaluateFunction("DATETIME",
+                           TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(2024)},
+                                                                        {"month", TypedValue(6)},
+                                                                        {"day", TypedValue(22)},
+                                                                        {"hour", TypedValue(12)},
+                                                                        {"timezone", TypedValue(timezone)}}))
+        .ValueZonedDateTime();
+  };
+  EXPECT_EQ(with_offset("+01:00").GetTimezone(), memgraph::utils::Timezone(std::chrono::minutes{60}));
+  EXPECT_EQ(with_offset("-05:30").GetTimezone(), memgraph::utils::Timezone(std::chrono::minutes{-330}));
+  EXPECT_EQ(with_offset("+0100").GetTimezone(), memgraph::utils::Timezone(std::chrono::minutes{60}));
+  EXPECT_EQ(with_offset("Z").GetTimezone(), memgraph::utils::Timezone(std::chrono::minutes{0}));
+
+  // A timezone that cannot be understood is a problem with the argument, so it
+  // has to be reported as one rather than escaping as an internal error.
+  EXPECT_THROW(with_offset("not/a/zone"), memgraph::utils::BasicException);
+  EXPECT_THROW(with_offset("+99:00"), memgraph::utils::BasicException);
+  EXPECT_THROW(with_offset(""), memgraph::utils::BasicException);
+
   const auto one_sec_in_microseconds = 1'000'000;
   const auto today = memgraph::utils::CurrentZonedDateTime();
   EXPECT_NEAR(this->EvaluateFunction("DATETIME").ValueZonedDateTime().SysMicrosecondsSinceEpoch().count(),


### PR DESCRIPTION
A timezone that cannot be understood is now reported as a problem with the
argument. The field was handed to the constructor that looks a name up in the
time zone database, which reports an unknown name by throwing out of the
standard library, so a bad argument reached the caller as an internal error
naming no cause.

A UTC offset is accepted as well, in the forms the string constructor already
takes. The same construction in the module interface reports an invalid
argument now too, which is what its own documentation promises for a parameter
it cannot parse.
