### PR TITLE
fix(query): correct which temporal components may be omitted, and what they may hold

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1663,9 +1663,12 @@ bool MapNumericParameters(auto &parameter_mappings, const auto &input_parameters
 }
 
 // Instant components are named from most to least significant, and an omitted
-// one takes its lowest value. That default is only meaningful for a trailing
-// run: naming a component while a more significant one is missing would leave
-// part of the instant to a default the caller was in the middle of replacing.
+// one takes its lowest value. That default only makes sense for a trailing run:
+// naming a component while a more significant one is missing would mix an
+// explicit value with a defaulted one above it.
+//
+// Call this after the components have been mapped, so that an unrecognised name
+// is reported as such rather than as a gap between the ones understood.
 void EnsureNoOmittedSignificantComponent(std::initializer_list<std::string_view> components_by_significance,
                                          const auto &input_parameters) {
   std::string_view first_omitted;
@@ -1719,8 +1722,6 @@ TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ct
                                            std::pair{"month"sv, &date_parameters.month},
                                            std::pair{"day"sv, &date_parameters.day}};
 
-  // After the mapping, so an unrecognised key is reported as such rather than
-  // as a gap between the components that were understood.
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
   EnsureNoOmittedSignificantComponent({"year", "month", "day"}, args[0].ValueMap());
   return TypedValue(utils::Date(date_parameters), ctx.memory);

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1667,20 +1667,29 @@ bool MapNumericParameters(auto &parameter_mappings, const auto &input_parameters
 // naming a component while a more significant one is missing would mix an
 // explicit value with a defaulted one above it.
 //
+// Each level holds the names sharing one significance. The sub-second fields
+// are alternative scales for a single fraction of a second rather than steps of
+// their own, so any combination of them may be given together, and the level
+// counts as supplied when any one of them is.
+//
 // Call this after the components have been mapped, so that an unrecognised name
 // is reported as such rather than as a gap between the ones understood.
-void EnsureNoOmittedSignificantComponent(std::initializer_list<std::string_view> components_by_significance,
+void EnsureNoOmittedSignificantComponent(std::initializer_list<std::initializer_list<std::string_view>> levels,
                                          const auto &input_parameters) {
+  const auto is_supplied = [&input_parameters](const std::string_view component) {
+    return std::ranges::any_of(input_parameters,
+                               [component](const auto &entry) { return std::string_view{entry.first} == component; });
+  };
+
   std::string_view first_omitted;
-  for (const auto component : components_by_significance) {
-    const auto supplied = std::ranges::any_of(
-        input_parameters, [component](const auto &entry) { return std::string_view{entry.first} == component; });
-    if (!supplied) {
-      if (first_omitted.empty()) first_omitted = component;
+  for (const auto level : levels) {
+    const auto *const supplied = std::ranges::find_if(level, is_supplied);
+    if (supplied == level.end()) {
+      if (first_omitted.empty()) first_omitted = *level.begin();
       continue;
     }
     if (!first_omitted.empty()) {
-      throw QueryRuntimeException("'{}' cannot be specified without '{}'.", component, first_omitted);
+      throw QueryRuntimeException("'{}' cannot be specified without '{}'.", *supplied, first_omitted);
     }
   }
 }
@@ -1723,7 +1732,7 @@ TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ct
                                            std::pair{"day"sv, &date_parameters.day}};
 
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
-  EnsureNoOmittedSignificantComponent({"year", "month", "day"}, args[0].ValueMap());
+  EnsureNoOmittedSignificantComponent({{"year"}, {"month"}, {"day"}}, args[0].ValueMap());
   return TypedValue(utils::Date(date_parameters), ctx.memory);
 }
 
@@ -1773,7 +1782,8 @@ TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContex
   };
 
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
-  EnsureNoOmittedSignificantComponent({"hour", "minute", "second", "millisecond", "microsecond"}, args[0].ValueMap());
+  EnsureNoOmittedSignificantComponent({{"hour"}, {"minute"}, {"second"}, {"millisecond", "microsecond"}},
+                                      args[0].ValueMap());
   return TypedValue(utils::LocalTime(local_time_parameters), ctx.memory);
 }
 

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1667,10 +1667,10 @@ bool MapNumericParameters(auto &parameter_mappings, const auto &input_parameters
 // naming a component while a more significant one is missing would mix an
 // explicit value with a defaulted one above it.
 //
-// Each level holds the names sharing one significance. The sub-second fields
-// are alternative scales for a single fraction of a second rather than steps of
-// their own, so any combination of them may be given together, and the level
-// counts as supplied when any one of them is.
+// Each level holds the names sharing one significance, and counts as supplied
+// when any name in it is. The sub-second fields share a level below second:
+// giving the fraction at a finer scale than another is ordinary, so an omission
+// among them does not signal the mistake an omitted hour or minute does.
 //
 // Call this after the components have been mapped, so that an unrecognised name
 // is reported as such rather than as a gap between the ones understood.

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1662,35 +1662,21 @@ bool MapNumericParameters(auto &parameter_mappings, const auto &input_parameters
   return has_mapped_any_field;
 }
 
-// Instant components are named from most to least significant, and an omitted
-// one takes its lowest value. That default only makes sense for a trailing run:
-// naming a component while a more significant one is missing would mix an
-// explicit value with a defaulted one above it.
+// An omitted component takes its lowest value. That default reads naturally for
+// every component but the most significant one, which is what the rest are
+// offsets from: a map naming only lesser components leaves the value anchored
+// nowhere, so it is a mistake rather than a terse spelling.
 //
-// Each level holds the names sharing one significance, and counts as supplied
-// when any name in it is. The sub-second fields share a level below second:
-// giving the fraction at a finer scale than another is ordinary, so an omission
-// among them does not signal the mistake an omitted hour or minute does.
+// Components between the most significant one and those named may be left out,
+// which openCypher does not allow and Neo4j rejects. The gap it forbids is not
+// ambiguous here, and refusing it costs callers more than it saves them.
 //
 // Call this after the components have been mapped, so that an unrecognised name
-// is reported as such rather than as a gap between the ones understood.
-void EnsureNoOmittedSignificantComponent(std::initializer_list<std::initializer_list<std::string_view>> levels,
-                                         const auto &input_parameters) {
-  const auto is_supplied = [&input_parameters](const std::string_view component) {
-    return std::ranges::any_of(input_parameters,
-                               [component](const auto &entry) { return std::string_view{entry.first} == component; });
-  };
-
-  std::string_view first_omitted;
-  for (const auto level : levels) {
-    const auto *const supplied = std::ranges::find_if(level, is_supplied);
-    if (supplied == level.end()) {
-      if (first_omitted.empty()) first_omitted = *level.begin();
-      continue;
-    }
-    if (!first_omitted.empty()) {
-      throw QueryRuntimeException("'{}' cannot be specified without '{}'.", *supplied, first_omitted);
-    }
+// is reported as such rather than as a missing component.
+void EnsureLeadingComponentSupplied(const std::string_view leading, const auto &input_parameters) {
+  const auto supplies_leading = [leading](const auto &entry) { return std::string_view{entry.first} == leading; };
+  if (!std::ranges::any_of(input_parameters, supplies_leading)) {
+    throw QueryRuntimeException("'{}' must be specified.", leading);
   }
 }
 
@@ -1732,7 +1718,7 @@ TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ct
                                            std::pair{"day"sv, &date_parameters.day}};
 
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
-  EnsureNoOmittedSignificantComponent({{"year"}, {"month"}, {"day"}}, args[0].ValueMap());
+  EnsureLeadingComponentSupplied("year", args[0].ValueMap());
   return TypedValue(utils::Date(date_parameters), ctx.memory);
 }
 
@@ -1782,8 +1768,7 @@ TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContex
   };
 
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
-  EnsureNoOmittedSignificantComponent({{"hour"}, {"minute"}, {"second"}, {"millisecond", "microsecond"}},
-                                      args[0].ValueMap());
+  EnsureLeadingComponentSupplied("hour", args[0].ValueMap());
   return TypedValue(utils::LocalTime(local_time_parameters), ctx.memory);
 }
 

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1662,6 +1662,26 @@ bool MapNumericParameters(auto &parameter_mappings, const auto &input_parameters
   return has_mapped_any_field;
 }
 
+// Instant components are named from most to least significant, and an omitted
+// one takes its lowest value. That default is only meaningful for a trailing
+// run: naming a component while a more significant one is missing would leave
+// part of the instant to a default the caller was in the middle of replacing.
+void EnsureNoOmittedSignificantComponent(std::initializer_list<std::string_view> components_by_significance,
+                                         const auto &input_parameters) {
+  std::string_view first_omitted;
+  for (const auto component : components_by_significance) {
+    const auto supplied = std::ranges::any_of(
+        input_parameters, [component](const auto &entry) { return std::string_view{entry.first} == component; });
+    if (!supplied) {
+      if (first_omitted.empty()) first_omitted = component;
+      continue;
+    }
+    if (!first_omitted.empty()) {
+      throw QueryRuntimeException("'{}' cannot be specified without '{}'.", component, first_omitted);
+    }
+  }
+}
+
 TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Optional<Or<Null, String, Map, struct Date, LocalDateTime, ZonedDateTime>>>("date", args, nargs);
   if (nargs == 0) {
@@ -1699,6 +1719,7 @@ TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ct
                                            std::pair{"month"sv, &date_parameters.month},
                                            std::pair{"day"sv, &date_parameters.day}};
 
+  EnsureNoOmittedSignificantComponent({"year", "month", "day"}, args[0].ValueMap());
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
   return TypedValue(utils::Date(date_parameters), ctx.memory);
 }
@@ -1748,6 +1769,7 @@ TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContex
       std::pair{"microsecond"sv, &local_time_parameters.microsecond},
   };
 
+  EnsureNoOmittedSignificantComponent({"hour", "minute", "second", "millisecond", "microsecond"}, args[0].ValueMap());
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
   return TypedValue(utils::LocalTime(local_time_parameters), ctx.memory);
 }

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1719,8 +1719,10 @@ TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ct
                                            std::pair{"month"sv, &date_parameters.month},
                                            std::pair{"day"sv, &date_parameters.day}};
 
-  EnsureNoOmittedSignificantComponent({"year", "month", "day"}, args[0].ValueMap());
+  // After the mapping, so an unrecognised key is reported as such rather than
+  // as a gap between the components that were understood.
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
+  EnsureNoOmittedSignificantComponent({"year", "month", "day"}, args[0].ValueMap());
   return TypedValue(utils::Date(date_parameters), ctx.memory);
 }
 
@@ -1769,8 +1771,8 @@ TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContex
       std::pair{"microsecond"sv, &local_time_parameters.microsecond},
   };
 
-  EnsureNoOmittedSignificantComponent({"hour", "minute", "second", "millisecond", "microsecond"}, args[0].ValueMap());
   MapNumericParameters<Integer>(parameter_mappings, args[0].ValueMap());
+  EnsureNoOmittedSignificantComponent({"hour", "minute", "second", "millisecond", "microsecond"}, args[0].ValueMap());
   return TypedValue(utils::LocalTime(local_time_parameters), ctx.memory);
 }
 

--- a/src/utils/temporal.cpp
+++ b/src/utils/temporal.cpp
@@ -403,7 +403,7 @@ LocalTime::LocalTime(const LocalTimeParameters &local_time_parameters) {
     throw temporal::InvalidArgumentException("Creating a LocalTime with a negative or overlarge sub-second parameter.");
   }
   const auto fraction =
-      local_time_parameters.millisecond * kMicrosecondsPerMillisecond + local_time_parameters.microsecond;
+      (local_time_parameters.millisecond * kMicrosecondsPerMillisecond) + local_time_parameters.microsecond;
   if (fraction >= kMicrosecondsPerSecond) {
     throw temporal::InvalidArgumentException(
         "Creating a LocalTime whose milliseconds and microseconds reach a whole second.");

--- a/src/utils/temporal.cpp
+++ b/src/utils/temporal.cpp
@@ -391,19 +391,29 @@ LocalTime::LocalTime(const LocalTimeParameters &local_time_parameters) {
     throw temporal::InvalidArgumentException("Creating a LocalTime with invalid seconds parameter.");
   }
 
-  if (!IsInBounds(0, 999, local_time_parameters.millisecond)) {
-    throw temporal::InvalidArgumentException("Creating a LocalTime with invalid milliseconds parameter.");
+  // The sub-second fields are scales of one fraction of a second, so a value
+  // beyond its own scale carries into the coarser field: 1500 microseconds is a
+  // millisecond and a half. Storing the fraction canonically keeps one
+  // representation per instant, which the field-wise comparison and the hash
+  // both rely on.
+  constexpr int64_t kMicrosecondsPerMillisecond = 1000;
+  constexpr int64_t kMicrosecondsPerSecond = 1'000'000;
+  if (!IsInBounds(0, kMicrosecondsPerSecond, local_time_parameters.millisecond) ||
+      !IsInBounds(0, kMicrosecondsPerSecond, local_time_parameters.microsecond)) {
+    throw temporal::InvalidArgumentException("Creating a LocalTime with a negative or overlarge sub-second parameter.");
   }
-
-  if (!IsInBounds(0, 999, local_time_parameters.microsecond)) {
-    throw temporal::InvalidArgumentException("Creating a LocalTime with invalid microseconds parameter.");
+  const auto fraction =
+      local_time_parameters.millisecond * kMicrosecondsPerMillisecond + local_time_parameters.microsecond;
+  if (fraction >= kMicrosecondsPerSecond) {
+    throw temporal::InvalidArgumentException(
+        "Creating a LocalTime whose milliseconds and microseconds reach a whole second.");
   }
 
   hour = local_time_parameters.hour;
   minute = local_time_parameters.minute;
   second = local_time_parameters.second;
-  millisecond = local_time_parameters.millisecond;
-  microsecond = local_time_parameters.microsecond;
+  millisecond = fraction / kMicrosecondsPerMillisecond;
+  microsecond = fraction % kMicrosecondsPerMillisecond;
 }
 
 std::chrono::microseconds LocalTime::SumLocalTimeParts() const {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -3184,6 +3184,29 @@ TYPED_TEST(FunctionTest, LocalTimeSubSecondComponentsShareOneLevel) {
                QueryRuntimeException);
 }
 
+TYPED_TEST(FunctionTest, LocalTimeSubSecondFieldsCarry) {
+  // A fraction may be written at whichever scale the caller has it in, so a
+  // count of microseconds beyond a millisecond is read as the time it names
+  // rather than refused.
+  EXPECT_EQ(this->EvaluateFunction("LOCALTIME",
+                                   TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
+                                                                                {"minute", TypedValue(2)},
+                                                                                {"second", TypedValue(3)},
+                                                                                {"microsecond", TypedValue(1500)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({1, 2, 3, 1, 500}));
+
+  // The fraction stops short of a whole second, which would otherwise carry
+  // into the second the caller gave.
+  EXPECT_THROW(
+      this->EvaluateFunction("LOCALTIME",
+                             TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
+                                                                          {"minute", TypedValue(2)},
+                                                                          {"second", TypedValue(3)},
+                                                                          {"microsecond", TypedValue(1'000'000)}})),
+      memgraph::utils::temporal::InvalidArgumentException);
+}
+
 TYPED_TEST(FunctionTest, LocalTime) {
   const auto local_time = memgraph::utils::LocalTime({13, 3, 2, 0, 0});
   EXPECT_EQ(this->EvaluateFunction("LOCALTIME", "130302").ValueLocalTime(), local_time);

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -3106,20 +3106,16 @@ TYPED_TEST(FunctionTest, Date) {
   EXPECT_TRUE(this->EvaluateFunction("DATE", TypedValue()).IsNull());
 }
 
-TYPED_TEST(FunctionTest, DateRejectsOmittedSignificantComponent) {
-  // Components are given from most to least significant, so naming one fixes
-  // every component above it. Leaving one of those out would let a default
-  // decide part of the value the caller was in the middle of spelling out.
-  EXPECT_THROW(
-      this->EvaluateFunction(
-          "DATE", TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1984)}, {"day", TypedValue(5)}})),
-      QueryRuntimeException);
+TYPED_TEST(FunctionTest, DateRequiresTheYear) {
+  // Every other component is an offset within the year, so naming one without
+  // it leaves the value anchored nowhere.
   EXPECT_THROW(this->EvaluateFunction("DATE", TypedValue(std::map<std::string, TypedValue>{{"month", TypedValue(10)}})),
                QueryRuntimeException);
   EXPECT_THROW(this->EvaluateFunction("DATE", TypedValue(std::map<std::string, TypedValue>{{"day", TypedValue(5)}})),
                QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction("DATE", TypedValue(std::map<std::string, TypedValue>{})), QueryRuntimeException);
 
-  // A trailing run may still be omitted, and takes its lowest value.
+  // Any component below the year may be left out, and takes its lowest value.
   EXPECT_EQ(this->EvaluateFunction("DATE", TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1984)}}))
                 .ValueDate(),
             memgraph::utils::Date({1984, 1, 1}));
@@ -3128,18 +3124,23 @@ TYPED_TEST(FunctionTest, DateRejectsOmittedSignificantComponent) {
                                                                                 {"month", TypedValue(10)}}))
                 .ValueDate(),
             memgraph::utils::Date({1984, 10, 1}));
+
+  // Including one with a gap above it, which openCypher and Neo4j refuse.
+  EXPECT_EQ(
+      this->EvaluateFunction(
+              "DATE", TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1984)}, {"day", TypedValue(5)}}))
+          .ValueDate(),
+      memgraph::utils::Date({1984, 1, 5}));
 }
 
-TYPED_TEST(FunctionTest, LocalTimeRejectsOmittedSignificantComponent) {
+TYPED_TEST(FunctionTest, LocalTimeRequiresTheHour) {
   EXPECT_THROW(
       this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{{"minute", TypedValue(30)}})),
       QueryRuntimeException);
   EXPECT_THROW(
       this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{{"second", TypedValue(30)}})),
       QueryRuntimeException);
-  EXPECT_THROW(this->EvaluateFunction(
-                   "LOCALTIME",
-                   TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)}, {"second", TypedValue(3)}})),
+  EXPECT_THROW(this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{})),
                QueryRuntimeException);
 
   EXPECT_EQ(this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(10)}}))
@@ -3152,10 +3153,30 @@ TYPED_TEST(FunctionTest, LocalTimeRejectsOmittedSignificantComponent) {
             memgraph::utils::LocalTime({10, 5, 0, 0, 0}));
 }
 
+TYPED_TEST(FunctionTest, LocalTimeFillsComponentsLeftOutBelowTheHour) {
+  // A component may be named with coarser ones missing between it and the
+  // hour, each of those taking zero.
+  EXPECT_EQ(this->EvaluateFunction(
+                    "LOCALTIME",
+                    TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(5)}, {"second", TypedValue(32)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({5, 0, 32, 0, 0}));
+  EXPECT_EQ(
+      this->EvaluateFunction("LOCALTIME",
+                             TypedValue(std::map<std::string, TypedValue>{
+                                 {"hour", TypedValue(1)}, {"minute", TypedValue(2)}, {"microsecond", TypedValue(5)}}))
+          .ValueLocalTime(),
+      memgraph::utils::LocalTime({1, 2, 0, 0, 5}));
+  EXPECT_EQ(this->EvaluateFunction("LOCALTIME",
+                                   TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
+                                                                                {"millisecond", TypedValue(4)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({1, 0, 0, 4, 0}));
+}
+
 TYPED_TEST(FunctionTest, LocalTimeSubSecondComponentsShareOneLevel) {
-  // The sub-second fields share one level, so either may be given without the
-  // other. A microsecond given alone still counts as microseconds, the coarser
-  // scale defaulting to zero.
+  // Either sub-second field may be given without the other. A microsecond
+  // given alone still counts as microseconds, the coarser scale taking zero.
   EXPECT_EQ(this->EvaluateFunction("LOCALTIME",
                                    TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
                                                                                 {"minute", TypedValue(2)},
@@ -3170,18 +3191,6 @@ TYPED_TEST(FunctionTest, LocalTimeSubSecondComponentsShareOneLevel) {
                                                                                 {"millisecond", TypedValue(4)}}))
                 .ValueLocalTime(),
             memgraph::utils::LocalTime({1, 2, 3, 4, 0}));
-
-  // The level still sits below second, so the fraction cannot be given while
-  // the second it divides is missing.
-  EXPECT_THROW(
-      this->EvaluateFunction("LOCALTIME",
-                             TypedValue(std::map<std::string, TypedValue>{
-                                 {"hour", TypedValue(1)}, {"minute", TypedValue(2)}, {"microsecond", TypedValue(5)}})),
-      QueryRuntimeException);
-  EXPECT_THROW(this->EvaluateFunction("LOCALTIME",
-                                      TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
-                                                                                   {"millisecond", TypedValue(4)}})),
-               QueryRuntimeException);
 }
 
 TYPED_TEST(FunctionTest, LocalTimeSubSecondFieldsCarry) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -3153,8 +3153,9 @@ TYPED_TEST(FunctionTest, LocalTimeRejectsOmittedSignificantComponent) {
 }
 
 TYPED_TEST(FunctionTest, LocalTimeSubSecondComponentsShareOneLevel) {
-  // The sub-second fields are scales of a single fraction of a second, not
-  // steps of the sequence, so either may be given without the other.
+  // The sub-second fields share one level, so either may be given without the
+  // other. A microsecond given alone still counts as microseconds, the coarser
+  // scale defaulting to zero.
   EXPECT_EQ(this->EvaluateFunction("LOCALTIME",
                                    TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
                                                                                 {"minute", TypedValue(2)},

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -3106,6 +3106,52 @@ TYPED_TEST(FunctionTest, Date) {
   EXPECT_TRUE(this->EvaluateFunction("DATE", TypedValue()).IsNull());
 }
 
+TYPED_TEST(FunctionTest, DateRejectsOmittedSignificantComponent) {
+  // Components are given from most to least significant, so naming one fixes
+  // every component above it. Leaving one of those out would let a default
+  // decide part of the value the caller was in the middle of spelling out.
+  EXPECT_THROW(
+      this->EvaluateFunction(
+          "DATE", TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1984)}, {"day", TypedValue(5)}})),
+      QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction("DATE", TypedValue(std::map<std::string, TypedValue>{{"month", TypedValue(10)}})),
+               QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction("DATE", TypedValue(std::map<std::string, TypedValue>{{"day", TypedValue(5)}})),
+               QueryRuntimeException);
+
+  // A trailing run may still be omitted, and takes its lowest value.
+  EXPECT_EQ(this->EvaluateFunction("DATE", TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1984)}}))
+                .ValueDate(),
+            memgraph::utils::Date({1984, 1, 1}));
+  EXPECT_EQ(this->EvaluateFunction("DATE",
+                                   TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1984)},
+                                                                                {"month", TypedValue(10)}}))
+                .ValueDate(),
+            memgraph::utils::Date({1984, 10, 1}));
+}
+
+TYPED_TEST(FunctionTest, LocalTimeRejectsOmittedSignificantComponent) {
+  EXPECT_THROW(
+      this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{{"minute", TypedValue(30)}})),
+      QueryRuntimeException);
+  EXPECT_THROW(
+      this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{{"second", TypedValue(30)}})),
+      QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction(
+                   "LOCALTIME",
+                   TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)}, {"second", TypedValue(3)}})),
+               QueryRuntimeException);
+
+  EXPECT_EQ(this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(10)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({10, 0, 0, 0, 0}));
+  EXPECT_EQ(this->EvaluateFunction(
+                    "LOCALTIME",
+                    TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(10)}, {"minute", TypedValue(5)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({10, 5, 0, 0, 0}));
+}
+
 TYPED_TEST(FunctionTest, LocalTime) {
   const auto local_time = memgraph::utils::LocalTime({13, 3, 2, 0, 0});
   EXPECT_EQ(this->EvaluateFunction("LOCALTIME", "130302").ValueLocalTime(), local_time);

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -3152,6 +3152,37 @@ TYPED_TEST(FunctionTest, LocalTimeRejectsOmittedSignificantComponent) {
             memgraph::utils::LocalTime({10, 5, 0, 0, 0}));
 }
 
+TYPED_TEST(FunctionTest, LocalTimeSubSecondComponentsShareOneLevel) {
+  // The sub-second fields are scales of a single fraction of a second, not
+  // steps of the sequence, so either may be given without the other.
+  EXPECT_EQ(this->EvaluateFunction("LOCALTIME",
+                                   TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
+                                                                                {"minute", TypedValue(2)},
+                                                                                {"second", TypedValue(3)},
+                                                                                {"microsecond", TypedValue(5)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({1, 2, 3, 0, 5}));
+  EXPECT_EQ(this->EvaluateFunction("LOCALTIME",
+                                   TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
+                                                                                {"minute", TypedValue(2)},
+                                                                                {"second", TypedValue(3)},
+                                                                                {"millisecond", TypedValue(4)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({1, 2, 3, 4, 0}));
+
+  // The level still sits below second, so the fraction cannot be given while
+  // the second it divides is missing.
+  EXPECT_THROW(
+      this->EvaluateFunction("LOCALTIME",
+                             TypedValue(std::map<std::string, TypedValue>{
+                                 {"hour", TypedValue(1)}, {"minute", TypedValue(2)}, {"microsecond", TypedValue(5)}})),
+      QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction("LOCALTIME",
+                                      TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
+                                                                                   {"millisecond", TypedValue(4)}})),
+               QueryRuntimeException);
+}
+
 TYPED_TEST(FunctionTest, LocalTime) {
   const auto local_time = memgraph::utils::LocalTime({13, 3, 2, 0, 0});
   EXPECT_EQ(this->EvaluateFunction("LOCALTIME", "130302").ValueLocalTime(), local_time);

--- a/tests/unit/utils_temporal.cpp
+++ b/tests/unit/utils_temporal.cpp
@@ -64,7 +64,12 @@ inline constexpr std::array test_local_times{TestLocalTimeParameters{{.hour = 24
                                              TestLocalTimeParameters{{.millisecond = -1}, true},
                                              TestLocalTimeParameters{{.millisecond = 1000}, true},
                                              TestLocalTimeParameters{{.microsecond = -1}, true},
-                                             TestLocalTimeParameters{{.microsecond = 1000}, true},
+                                             TestLocalTimeParameters{{.microsecond = 1'000'000}, true},
+                                             TestLocalTimeParameters{{.millisecond = 999, .microsecond = 1000}, true},
+                                             TestLocalTimeParameters{{.microsecond = 1000}, false},
+                                             TestLocalTimeParameters{{.microsecond = 1500}, false},
+                                             TestLocalTimeParameters{{.microsecond = 999'999}, false},
+                                             TestLocalTimeParameters{{.millisecond = 4, .microsecond = 1500}, false},
                                              TestLocalTimeParameters{{23, 59, 59, 999, 999}, false},
                                              TestLocalTimeParameters{{0, 0, 0, 0, 0}, false}};
 
@@ -174,6 +179,35 @@ TEST(TemporalTest, LocalTimeConstruction) {
       ASSERT_NO_THROW(test_local_time.emplace(local_time_parameters));
     }
   }
+}
+
+TEST(TemporalTest, LocalTimeSubSecondFieldsCarry) {
+  using memgraph::utils::LocalTime;
+  using memgraph::utils::LocalTimeParameters;
+
+  // A value finer than its own scale carries into the coarser field, so 1500
+  // microseconds is a millisecond and a half however it is written.
+  EXPECT_EQ(LocalTime(LocalTimeParameters{.microsecond = 1500}),
+            LocalTime(LocalTimeParameters{.millisecond = 1, .microsecond = 500}));
+  EXPECT_EQ(LocalTime(LocalTimeParameters{.millisecond = 4, .microsecond = 1500}),
+            LocalTime(LocalTimeParameters{.millisecond = 5, .microsecond = 500}));
+  EXPECT_EQ(LocalTime(LocalTimeParameters{.microsecond = 999'999}),
+            LocalTime(LocalTimeParameters{.millisecond = 999, .microsecond = 999}));
+
+  // Equal instants must be one value, which the field-wise comparison and the
+  // hash both depend on.
+  const LocalTime written_as_micro{LocalTimeParameters{.microsecond = 1500}};
+  const LocalTime written_as_milli{LocalTimeParameters{.millisecond = 1, .microsecond = 500}};
+  EXPECT_EQ(written_as_micro, written_as_milli);
+  EXPECT_EQ(memgraph::utils::LocalTimeHash{}(written_as_micro), memgraph::utils::LocalTimeHash{}(written_as_milli));
+  EXPECT_EQ(written_as_micro.MicrosecondsSinceEpoch(), 1500);
+  EXPECT_EQ(written_as_micro.ToString(), "00:00:00.001500");
+
+  // The fraction stops short of a whole second, which would otherwise carry
+  // into the second the caller gave.
+  EXPECT_THROW(LocalTime(LocalTimeParameters{.microsecond = 1'000'000}), memgraph::utils::BasicException);
+  EXPECT_THROW(LocalTime(LocalTimeParameters{.millisecond = 999, .microsecond = 1000}),
+               memgraph::utils::BasicException);
 }
 
 TEST(TemporalTest, LocalTimeMicrosecondsSinceEpochConversion) {


### PR DESCRIPTION
Building a date or a local time from a map now requires the leading component,
the year or the hour respectively. Every other component is an offset within
that one, so a map naming only lesser components leaves the value anchored
nowhere; it used to be accepted silently, taking 1970 or midnight.

Components below the leading one may be left out in any combination and take
their lowest value, so `localtime({hour: 5, second: 32})` is five o'clock
exactly. openCypher forbids omitting a component more significant than one that
has been specified, and Neo4j rejects that query, but the gap is unambiguous and
refusing it only makes callers pad the map with zeroes. The difference is
deliberate, and it leaves `date({year: 1984, day: 5})` accepted where the
reference engine reports an error.

The error is raised after the components are read, so an unrecognised name is
still reported as one rather than as a missing component.

A sub-second value beyond its own scale now carries into the coarser field,
making 1500 microseconds a millisecond and a half rather than an error, since
requiring each field to fill only its own three digits made the caller convert a
measurement they already held. The fraction is stored canonically, one
representation per instant, which the field-wise comparison and the hash both
depend on, and it must still stop short of a whole second.
