### PR TITLE
feat: allow EXISTS subqueries inside a CASE expression

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3954,8 +3954,11 @@ antlrcpp::Any CypherMainVisitor::visitExistsSubquery(MemgraphCypher::ExistsSubqu
     // Curly-brace subquery form: { cypherQuery }
     // Set the flag to indicate we are parsing an EXISTS subquery
     auto old_flag = parsing_exists_subquery_;
+    // The body's clauses are its own, so the enclosing WITH's "everything must be aliased" rule does not reach them.
+    auto old_in_with = std::exchange(in_with_, false);
     parsing_exists_subquery_ = true;
     auto *cypher_query = std::any_cast<CypherQuery *>(ctx->cypherQuery()->accept(this));
+    in_with_ = old_in_with;
     parsing_exists_subquery_ = old_flag;
     exists->content_ = cypher_query;
 
@@ -4248,9 +4251,10 @@ antlrcpp::Any CypherMainVisitor::visitCaseAlternatives(MemgraphCypher::CaseAlter
 
 antlrcpp::Any CypherMainVisitor::visitWith(MemgraphCypher::WithContext *ctx) {
   auto *with = storage_->Create<With>();
-  in_with_ = true;
+  // Restored, not cleared: a WITH inside an EXISTS body inside a WITH's own body would otherwise release the outer one.
+  auto old_in_with = std::exchange(in_with_, true);
   with->body_ = std::any_cast<ReturnBody>(ctx->returnBody()->accept(this));
-  in_with_ = false;
+  in_with_ = old_in_with;
   if (ctx->DISTINCT()) {
     with->body_.distinct = true;
   }

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -4251,7 +4251,8 @@ antlrcpp::Any CypherMainVisitor::visitCaseAlternatives(MemgraphCypher::CaseAlter
 
 antlrcpp::Any CypherMainVisitor::visitWith(MemgraphCypher::WithContext *ctx) {
   auto *with = storage_->Create<With>();
-  // Restored, not cleared: a WITH inside an EXISTS body inside a WITH's own body would otherwise release the outer one.
+  // Restored rather than cleared, so the flag is this function's own business. Defensive today: the only way to reach
+  // a nested WITH is through an EXISTS body, and that visit already clears the flag and re-arms it on the way out.
   auto old_in_with = std::exchange(in_with_, true);
   with->body_ = std::any_cast<ReturnBody>(ctx->returnBody()->accept(this));
   in_with_ = old_in_with;

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -725,10 +725,8 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
     throw utils::NotYetImplemented("Exists cannot be used within REDUCE!");
   }
 
-  if (scope.num_if_operators) {
-    throw utils::NotYetImplemented("IF operator cannot be used with exists, but only during matching!");
-  }
-
+  // A CASE is not a position of its own: whichever position holds the CASE decides, so num_if_operators is not
+  // consulted here. It still gates aggregations in PreVisit(Aggregation&).
   if (!IsSupportedExistsPosition(scope)) {
     throw utils::NotYetImplemented("Exists is not supported in this position yet!");
   }

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -725,8 +725,7 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
     throw utils::NotYetImplemented("Exists cannot be used within REDUCE!");
   }
 
-  // A CASE is not a position of its own: whichever position holds the CASE decides, so num_if_operators is not
-  // consulted here. It still gates aggregations in PreVisit(Aggregation&).
+  // A CASE holds no position of its own, so it is not consulted here. num_if_operators still gates aggregations.
   if (!IsSupportedExistsPosition(scope)) {
     throw utils::NotYetImplemented("Exists is not supported in this position yet!");
   }
@@ -734,26 +733,19 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
   const auto &symbol = CreateAnonymousSymbol();
   exists.MapTo(symbol);
 
-  if (exists.HasPattern()) {
-    scope.in_exists_pattern = true;
-  }
-
-  if (exists.HasSubquery()) {
-    // NOLINTNEXTLINE(hicpp-use-emplace,modernize-use-emplace)
-    scopes_.emplace_back(Scope{.in_exists_subquery = true, .call_subquery_base = scope.call_subquery_base});
-  }
+  // Each form declares only its own variables, so each gets a scope; the pattern form's are named at parse time, so
+  // leaving them outside redeclared them wherever one expression is reached twice, as a simple CASE reaches its test.
+  // Carry the subquery boundary in, so a pattern inside cannot reach an un-imported outer name.
+  // NOLINTNEXTLINE(hicpp-use-emplace,modernize-use-emplace)
+  scopes_.emplace_back(Scope{.in_exists_pattern = exists.HasPattern(),
+                             .in_exists_subquery = exists.HasSubquery(),
+                             .call_subquery_base = scope.call_subquery_base});
 
   return true;
 }
 
-bool SymbolGenerator::PostVisit(Exists &exists) {
-  if (exists.HasPattern()) {
-    auto &scope = scopes_.back();
-    scope.in_exists_pattern = false;
-  } else if (exists.HasSubquery()) {
-    scopes_.pop_back();
-  }
-
+bool SymbolGenerator::PostVisit(Exists & /*exists*/) {
+  scopes_.pop_back();
   return true;
 }
 

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -611,7 +611,8 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
 
       // A body whose clauses all dropped plans to nothing, yet still matches one (empty) row. Substituted per query
       // part, not once on the branch root: each UNION branch is its own part, and the combinator below dereferences
-      // both operands.
+      // both operands. `in_exists_subquery` stays set across the recursive `Plan` calls this one makes, so this also
+      // catches a nested `CALL {}` body that plans to nothing - `HandleSubquery` dereferences that one too.
       if (context.in_exists_subquery && !input_op) {
         input_op = std::make_unique<Once>();
       }
@@ -1676,7 +1677,7 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
 
   /// The EXISTS branch, without either fold's tail. The pattern form is rooted at an `Once(bound_symbols)` so the
   /// branch correlates through the shared frame; the subquery form correlates by planning recursively against those
-  /// same bound symbols, and gets a bare `Once` from an operator's null-input guard.
+  /// same bound symbols, and gets a bare `Once` from `Plan` for any query part that plans to nothing.
   std::unique_ptr<LogicalOperator> MakeExistsBranch(const ExistsMatching &matching, const SymbolTable &symbol_table,
                                                     AstStorage &storage,
                                                     const std::unordered_set<Symbol> &bound_symbols,

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -609,6 +609,13 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
         input_op = std::make_unique<EmptyResult>(std::move(input_op));
       }
 
+      // A body whose clauses all dropped plans to nothing, yet still matches one (empty) row. Substituted per query
+      // part, not once on the branch root: each UNION branch is its own part, and the combinator below dereferences
+      // both operands.
+      if (context.in_exists_subquery && !input_op) {
+        input_op = std::make_unique<Once>();
+      }
+
       if (query_part.query_combinator) {
         final_plan = MergeWithCombinator(std::move(input_op), std::move(final_plan), *query_part.query_combinator);
       } else {
@@ -1692,11 +1699,8 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       exists_branch_after_write_ = write_occurred;
       context_->bound_symbols = std::move(branch_bound_symbols);
 
-      std::unique_ptr<LogicalOperator> last_op = Plan(*matching.subquery);
-      // A body whose clauses all dropped plans to nothing, yet still matches one (empty) row - so give the fold a
-      // branch to pull rather than a null it would dereference when making its cursor.
-      if (!last_op) last_op = std::make_unique<Once>();
-      return last_op;
+      // Plan substitutes a Once for a query part that plans to nothing, so this never comes back null.
+      return Plan(*matching.subquery);
     }
 
     std::vector<Symbol> once_symbols(bound_symbols.begin(), bound_symbols.end());

--- a/tests/gql_behave/tests/memgraph_V1/features/case.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/case.feature
@@ -98,14 +98,17 @@ Feature: Case
             |  CASE name WHEN null THEN "doesn't work" WHEN 2 THEN "doesn't work" ELSE 'works' END |
             |  'works'                                                                             |
 
-    Scenario: Test exists does not work in CASE clauses
+    Scenario: Test exists works in CASE clauses
       Given an empty graph
       And having executed:
           """
-          CREATE ()-[:T]->();
+          CREATE (:P {id: 1})-[:T]->(:X)
+          CREATE (:P {id: 2})
           """
       When executing query:
           """
-          MATCH (a) WHERE CASE WHEN TRUE THEN exists(()-[]->()) END RETURN a;
+          MATCH (a:P) WHERE CASE WHEN TRUE THEN exists((a)-[:T]->()) END RETURN a.id AS id;
           """
-      Then an error should be raised
+      Then the result should be:
+          | id |
+          | 1  |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1153,3 +1153,21 @@ Feature: WHERE exists
           | false |
           | true  |
           | true  |
+
+  Scenario: EXISTS subquery body with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WHERE EXISTS {
+              RETURN 1
+          }
+          RETURN n.id as id;
+          """
+      Then the result should be:
+          | id    |
+          | 1     |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1390,17 +1390,17 @@ Feature: WHERE exists
           """
           MATCH (a:P)
           RETURN a.id AS id,
-                 CASE WHEN a.id = 1
+                 CASE WHEN a.id <= 2
                       THEN CASE WHEN EXISTS { MATCH (a)-[:R]->() } THEN 'yes' ELSE 'no' END
                       ELSE 'skip' END AS h
           ORDER BY id;
           """
       Then the result should be, in order:
-          | id | h      |
-          | 1  | 'yes'  |
-          | 2  | 'skip' |
+          | id | h     |
+          | 1  | 'yes' |
+          | 2  | 'no'  |
 
-  Scenario: Test EXISTS subquery in a simple CASE
+  Scenario: Test EXISTS subquery in an arm of a simple CASE
       Given an empty graph
       And having executed:
           """
@@ -1410,7 +1410,7 @@ Feature: WHERE exists
       When executing query:
           """
           MATCH (a:P)
-          RETURN a.id AS id, CASE a.id WHEN 1 THEN EXISTS { MATCH (a)-[:R]->() } ELSE false END AS h
+          RETURN a.id AS id, CASE a.id WHEN 1 THEN EXISTS { MATCH (a)-[:R]->() } ELSE EXISTS { MATCH (:Nope) } END AS h
           ORDER BY id;
           """
       Then the result should be, in order:
@@ -1444,11 +1444,13 @@ Feature: WHERE exists
       When executing query:
           """
           MATCH (a:P)
-          RETURN count(*) AS c, CASE WHEN EXISTS { MATCH (:X) } THEN 'any' ELSE 'none' END AS h;
+          RETURN a.id AS id, count(*) AS c, CASE WHEN EXISTS { MATCH (a)-[:R]->() } THEN 'any' ELSE 'none' END AS h
+          ORDER BY id;
           """
-      Then the result should be:
-          | c | h     |
-          | 2 | 'any' |
+      Then the result should be, in order:
+          | id | c | h      |
+          | 1  | 1 | 'any'  |
+          | 2  | 1 | 'none' |
 
   Scenario: Test EXISTS subquery in a CASE inside ORDER BY
       Given an empty graph
@@ -1478,7 +1480,7 @@ Feature: WHERE exists
       When executing query:
           """
           MATCH (a:P)
-          RETURN a.id AS id, CASE WHEN a.id = 1 THEN EXISTS { RETURN 1 } ELSE false END AS h
+          RETURN a.id AS id, CASE WHEN a.id = 1 THEN EXISTS { RETURN 1 } ELSE EXISTS { MATCH (:Nope) } END AS h
           ORDER BY id;
           """
       Then the result should be, in order:
@@ -1561,7 +1563,10 @@ Feature: WHERE exists
           | 1  | 'yes' |
           | 2  | 'no'  |
 
-  Scenario: Test a simple CASE EXISTS test does not leak its pattern variables
+  # The pattern form takes its own planner path - rooted at an Once over the bound symbols rather than planned
+  # recursively - so each position it can now reach through a CASE is pinned separately from the subquery form.
+
+  Scenario: Test pattern EXISTS in a CASE in a WITH projection
       Given an empty graph
       And having executed:
           """
@@ -1571,10 +1576,126 @@ Feature: WHERE exists
       When executing query:
           """
           MATCH (a:P)
-          WHERE CASE exists((a)-[:R]->()) WHEN true THEN true WHEN false THEN false END
-          MATCH (a)-[r]->(m)
-          RETURN a.id AS id, type(r) AS t;
+          WITH a.id AS id, CASE WHEN exists((a)-[:R]->()) THEN 'yes' ELSE 'no' END AS h
+          RETURN id, h ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | 'yes' |
+          | 2  | 'no'  |
+
+  Scenario: Test pattern EXISTS in a CASE in a WITH's WHERE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          WITH a WHERE CASE WHEN exists((a)-[:R]->()) THEN true ELSE false END
+          RETURN a.id AS id;
           """
       Then the result should be:
-          | id | t   |
-          | 1  | 'R' |
+          | id |
+          | 1  |
+
+  Scenario: Test pattern EXISTS in a CASE in an ORDER BY
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id
+          ORDER BY CASE WHEN exists((a)-[:R]->()) THEN 1 ELSE 0 END;
+          """
+      Then the result should be, in order:
+          | id |
+          | 2  |
+          | 1  |
+
+  Scenario: Test pattern EXISTS in a CASE inside an aggregate argument
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN sum(CASE WHEN exists((a)-[:R]->()) THEN 1 ELSE 0 END) AS c;
+          """
+      Then the result should be:
+          | c |
+          | 1 |
+
+  Scenario: Test both EXISTS forms in one CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id,
+                 CASE exists((a)-[:R]->()) WHEN true THEN EXISTS { MATCH (a)-[:R]->() } ELSE false END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | true  |
+          | 2  | false |
+
+  Scenario: Test an aggregation in an EXISTS body inside a CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id,
+                 CASE WHEN EXISTS { MATCH (a)-[:R]->(x) WITH count(x) AS c WHERE c > 0 RETURN c } THEN 'yes' ELSE 'no' END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | 'yes' |
+          | 2  | 'no'  |
+
+  # An EXISTS inside an EXISTS pattern's property map has no splice point of its own. The refusal is the position
+  # message; before the pattern form had a scope it reached the planner and surfaced an internal error instead.
+
+  Scenario: Test EXISTS inside an EXISTS pattern's property map is refused
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          """
+      When executing query:
+          """
+          MATCH (a:P) RETURN exists((a)-[:R]->({p: EXISTS { MATCH (:X) }})) AS h;
+          """
+      Then an error should be raised
+
+  Scenario: Test a pattern EXISTS inside an EXISTS pattern's property map is refused
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          """
+      When executing query:
+          """
+          MATCH (a:P) RETURN exists((a)-[:R]->({p: exists((a)-[:R]->())})) AS h;
+          """
+      Then an error should be raised

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1323,9 +1323,8 @@ Feature: WHERE exists
           | id    |
           | 1     |
 
-  # CASE holds no position of its own - it carries whichever position it sits in - so the shapes below are really a
-  # check on the bookkeeping: PostVisit(Exists) pushes one has_aggregation entry and IfOperator pops one per arm. The
-  # fixture keeps one P with an outgoing edge and one without, so an all-true or all-false answer is visible.
+  # CASE holds no position of its own; it carries whichever position it sits in. The fixture keeps one P with an
+  # outgoing edge and one without, so an all-true or all-false answer would be visible.
 
   Scenario: Test EXISTS subquery in a CASE condition
       Given an empty graph
@@ -1486,3 +1485,96 @@ Feature: WHERE exists
           | id | h     |
           | 1  | true  |
           | 2  | false |
+
+  # A simple CASE compares one test expression against each alternative, so an EXISTS in the test position is reached
+  # once per arm. The pattern form names its variables at parse time, so an arm past the first used to redeclare them.
+
+  Scenario: Test EXISTS subquery as the test of a simple CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id, CASE EXISTS { MATCH (a)-[:R]->() } WHEN true THEN 'yes' WHEN false THEN 'no' ELSE '?' END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | 'yes' |
+          | 2  | 'no'  |
+
+  Scenario: Test pattern EXISTS as the test of a simple CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id, CASE exists((a)-[:R]->()) WHEN true THEN 'yes' WHEN false THEN 'no' ELSE '?' END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | 'yes' |
+          | 2  | 'no'  |
+
+  Scenario: Test pattern EXISTS as the test of a simple CASE in a WHERE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          WHERE CASE exists((a)-[:R]->()) WHEN true THEN true WHEN false THEN false END
+          RETURN a.id AS id;
+          """
+      Then the result should be:
+          | id |
+          | 1  |
+
+  Scenario: Test pattern EXISTS as the test of a simple CASE with four alternatives
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id,
+                 CASE exists((a)-[:R]->()) WHEN 1 THEN 'one' WHEN 2 THEN 'two' WHEN true THEN 'yes' WHEN false THEN 'no' ELSE '?' END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | 'yes' |
+          | 2  | 'no'  |
+
+  Scenario: Test a simple CASE EXISTS test does not leak its pattern variables
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          WHERE CASE exists((a)-[:R]->()) WHEN true THEN true WHEN false THEN false END
+          MATCH (a)-[r]->(m)
+          RETURN a.id AS id, type(r) AS t;
+          """
+      Then the result should be:
+          | id | t   |
+          | 1  | 'R' |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1229,3 +1229,96 @@ Feature: WHERE exists
       Then the result should be:
           | h    |
           | true |
+
+  Scenario: EXISTS subquery body that is a UNION of a branch with rows and one with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          CREATE (:Node {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              MATCH (x:Node) RETURN x AS c
+              UNION
+              RETURN 2 AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |
+          | true |
+
+  Scenario: EXISTS subquery body that is a UNION of two branches matching nothing
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              MATCH (x:Missing) RETURN x AS c
+              UNION
+              MATCH (y:AlsoMissing) RETURN y AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h     |
+          | false |
+
+  Scenario: EXISTS subquery body with no operators in a projection
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              RETURN 1
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |
+
+  Scenario: EXISTS subquery body with no operators in a WITH projection
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WITH n, EXISTS {
+              RETURN 1
+          } AS e
+          RETURN e;
+          """
+      Then the result should be:
+          | e    |
+          | true |
+
+  Scenario: EXISTS subquery body with no operators in an ORDER BY
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WITH n ORDER BY EXISTS {
+              RETURN 1
+          }
+          RETURN n.id AS id;
+          """
+      Then the result should be:
+          | id    |
+          | 1     |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1322,3 +1322,167 @@ Feature: WHERE exists
       Then the result should be:
           | id    |
           | 1     |
+
+  # CASE holds no position of its own - it carries whichever position it sits in - so the shapes below are really a
+  # check on the bookkeeping: PostVisit(Exists) pushes one has_aggregation entry and IfOperator pops one per arm. The
+  # fixture keeps one P with an outgoing edge and one without, so an all-true or all-false answer is visible.
+
+  Scenario: Test EXISTS subquery in a CASE condition
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id, CASE WHEN EXISTS { MATCH (a)-[:R]->() } THEN 'yes' ELSE 'no' END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | 'yes' |
+          | 2  | 'no'  |
+
+  Scenario: Test EXISTS subquery in a CASE inside a WHERE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P) WHERE CASE WHEN TRUE THEN EXISTS { MATCH (a)-[:R]->() } ELSE false END
+          RETURN a.id AS id;
+          """
+      Then the result should be:
+          | id |
+          | 1  |
+
+  Scenario: Test EXISTS subquery in both arms of a CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id,
+                 CASE WHEN a.id = 1 THEN EXISTS { MATCH (a)-[:R]->() } ELSE EXISTS { MATCH (:Nope) } END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | true  |
+          | 2  | false |
+
+  Scenario: Test EXISTS subquery inside a nested CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id,
+                 CASE WHEN a.id = 1
+                      THEN CASE WHEN EXISTS { MATCH (a)-[:R]->() } THEN 'yes' ELSE 'no' END
+                      ELSE 'skip' END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h      |
+          | 1  | 'yes'  |
+          | 2  | 'skip' |
+
+  Scenario: Test EXISTS subquery in a simple CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id, CASE a.id WHEN 1 THEN EXISTS { MATCH (a)-[:R]->() } ELSE false END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | true  |
+          | 2  | false |
+
+  Scenario: Test EXISTS subquery in a CASE inside an aggregate argument
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN sum(CASE WHEN EXISTS { MATCH (a)-[:R]->() } THEN 1 ELSE 0 END) AS c;
+          """
+      Then the result should be:
+          | c |
+          | 1 |
+
+  Scenario: Test EXISTS subquery in a CASE beside an aggregation
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN count(*) AS c, CASE WHEN EXISTS { MATCH (:X) } THEN 'any' ELSE 'none' END AS h;
+          """
+      Then the result should be:
+          | c | h     |
+          | 2 | 'any' |
+
+  Scenario: Test EXISTS subquery in a CASE inside ORDER BY
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id
+          ORDER BY CASE WHEN EXISTS { MATCH (a)-[:R]->() } THEN 1 ELSE 0 END;
+          """
+      Then the result should be, in order:
+          | id |
+          | 2  |
+          | 1  |
+
+  Scenario: Test EXISTS subquery with a body with no operators inside a CASE
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:P {id: 1})-[:R]->(:X)
+          CREATE (:P {id: 2})
+          """
+      When executing query:
+          """
+          MATCH (a:P)
+          RETURN a.id AS id, CASE WHEN a.id = 1 THEN EXISTS { RETURN 1 } ELSE false END AS h
+          ORDER BY id;
+          """
+      Then the result should be, in order:
+          | id | h     |
+          | 1  | true  |
+          | 2  | false |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1171,3 +1171,61 @@ Feature: WHERE exists
       Then the result should be:
           | id    |
           | 1     |
+
+  Scenario: EXISTS subquery body that is a UNION of bodies with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          WHERE EXISTS {
+              RETURN 1 AS c
+              UNION
+              RETURN 2 AS c
+          }
+          RETURN n.id as id;
+          """
+      Then the result should be:
+          | id    |
+          | 1     |
+
+  Scenario: EXISTS subquery in a projection whose body is a UNION with no operators
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              RETURN 1 AS c
+              UNION ALL
+              RETURN 2 AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |
+
+  Scenario: EXISTS subquery body that is a UNION of one matching and one empty branch
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Node {id: 1})
+          """
+      When executing query:
+          """
+          MATCH (n:Node)
+          RETURN EXISTS {
+              MATCH (x:Missing) RETURN x AS c
+              UNION
+              RETURN 2 AS c
+          } AS h;
+          """
+      Then the result should be:
+          | h    |
+          | true |

--- a/tests/gql_behave/tests/memgraph_V1_on_disk/features/case.feature
+++ b/tests/gql_behave/tests/memgraph_V1_on_disk/features/case.feature
@@ -98,14 +98,17 @@ Feature: Case
             |  CASE name WHEN null THEN "doesn't work" WHEN 2 THEN "doesn't work" ELSE 'works' END |
             |  'works'                                                                             |
 
-    Scenario: Test exists does not work in CASE clauses
+    Scenario: Test exists works in CASE clauses
       Given an empty graph
       And having executed:
           """
-          CREATE ()-[:T]->();
+          CREATE (:P {id: 1})-[:T]->(:X)
+          CREATE (:P {id: 2})
           """
       When executing query:
           """
-          MATCH (a) WHERE CASE WHEN TRUE THEN exists(()-[]->()) END RETURN a;
+          MATCH (a:P) WHERE CASE WHEN TRUE THEN exists((a)-[:T]->()) END RETURN a.id AS id;
           """
-      Then an error should be raised
+      Then the result should be:
+          | id |
+          | 1  |

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8007,6 +8007,31 @@ TEST_P(CypherMainVisitorTest, ExistsThrow) {
                                                "EXISTS supports only a single relation or a subquery as its input.");
 }
 
+TEST_P(CypherMainVisitorTest, ExistsBodyIsNotJudgedByTheEnclosingWith) {
+  auto &ast_generator = *GetParam();
+
+  // `in_with_` gates "only variables can be non-aliased" for a WITH's own return items. An EXISTS body's clauses are
+  // not those items, so the flag must not still be set while they are visited - the body's `RETURN 1` is legal.
+  {
+    const auto *query =
+        dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH (n) WITH n, EXISTS { RETURN 1 } AS e RETURN e;"));
+    ASSERT_TRUE(query);
+    const auto *with = dynamic_cast<With *>(query->single_query_->clauses_[1]);
+    ASSERT_TRUE(with);
+    ASSERT_EQ(with->body_.named_expressions.size(), 2U);
+    EXPECT_TRUE(dynamic_cast<Exists *>(with->body_.named_expressions[1]->expression_));
+  }
+  // A body WITH restores the flag rather than clearing it, so the outer WITH's own items are still checked.
+  {
+    const auto *query = dynamic_cast<CypherQuery *>(
+        ast_generator.ParseQuery("MATCH (n) WITH n, EXISTS { MATCH (m) WITH m AS m RETURN 1 } AS e RETURN e;"));
+    ASSERT_TRUE(query);
+  }
+  TestInvalidQueryWithMessage<SemanticException>("MATCH (n) WITH n, EXISTS { RETURN 1 } AS e, n.prop RETURN e;",
+                                                 ast_generator,
+                                                 "Only variables can be non-aliased in WITH.");
+}
+
 TEST_P(CypherMainVisitorTest, Exists) {
   auto &ast_generator = *GetParam();
   {

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8021,13 +8021,29 @@ TEST_P(CypherMainVisitorTest, ExistsBodyIsNotJudgedByTheEnclosingWith) {
     ASSERT_EQ(with->body_.named_expressions.size(), 2U);
     EXPECT_TRUE(dynamic_cast<Exists *>(with->body_.named_expressions[1]->expression_));
   }
-  // A body WITH restores the flag rather than clearing it, so the outer WITH's own items are still checked.
+  // `visitReturnBody` visits ORDER BY before the return items, both while the flag is set, so the body of an EXISTS
+  // sorted on is judged by the same rule and was refused for the same reason.
+  {
+    const auto *query = dynamic_cast<CypherQuery *>(
+        ast_generator.ParseQuery("MATCH (n) WITH n ORDER BY EXISTS { RETURN 1 } RETURN n;"));
+    ASSERT_TRUE(query);
+    const auto *with = dynamic_cast<With *>(query->single_query_->clauses_[1]);
+    ASSERT_TRUE(with);
+    ASSERT_EQ(with->body_.order_by.size(), 1U);
+    EXPECT_TRUE(dynamic_cast<Exists *>(with->body_.order_by[0].expression));
+  }
+  // Clearing the flag for the body does not disarm it for the body's own WITH, which has return items of its own.
   {
     const auto *query = dynamic_cast<CypherQuery *>(
         ast_generator.ParseQuery("MATCH (n) WITH n, EXISTS { MATCH (m) WITH m AS m RETURN 1 } AS e RETURN e;"));
     ASSERT_TRUE(query);
   }
-  TestInvalidQueryWithMessage<SemanticException>("MATCH (n) WITH n, EXISTS { RETURN 1 } AS e, n.prop RETURN e;",
+  TestInvalidQueryWithMessage<SemanticException>(
+      "MATCH (n) WITH n, EXISTS { MATCH (m) WITH m, m.prop RETURN 1 } AS e RETURN e;",
+      ast_generator,
+      "Only variables can be non-aliased in WITH.");
+  // The outer WITH's own items are still checked. The body is aliased, so this can only be the `n.prop`.
+  TestInvalidQueryWithMessage<SemanticException>("MATCH (n) WITH n, EXISTS { RETURN 1 AS c } AS e, n.prop RETURN e;",
                                                  ast_generator,
                                                  "Only variables can be non-aliased in WITH.");
 }

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5206,6 +5206,85 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
   DeleteListContent(&exists_union_plan);
 }
 
+// A body's RETURN is dropped inside an exists subquery, so a UNION of RETURN-only branches plans both sides to
+// nothing. Each part gets its own Once before the combinator merges them - substituting one on the branch root would
+// come too late, and GenUnion dereferences both operands for their output symbols.
+
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodies) {
+  // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } RETURN n
+  FakeDbAccessor dba;
+
+  auto *exists_subquery =
+      QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("c"))), UNION(SINGLE_QUERY(RETURN(LITERAL(2), AS("c")))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EXISTS_SUBQUERY(exists_subquery)), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
+                                               new ExpectDistinct(),
+                                               new ExpectLimit(),
+                                               new ExpectEvaluatePatternFilter()};
+
+  // The branch correlates to nothing, so the filter is satisfied before the scan and sits below it.
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectFilter(std::vector<std::list<BaseOpChecker *>>{exists_union_plan}),
+            ExpectScanAll(),
+            ExpectProduce());
+
+  DeleteListContent(&left_exists_part);
+  DeleteListContent(&right_exists_part);
+  DeleteListContent(&exists_union_plan);
+}
+
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfEmptyBodies) {
+  // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION ALL RETURN 2 AS c } RETURN n - UNION ALL drops the Distinct.
+  FakeDbAccessor dba;
+
+  auto *exists_subquery =
+      QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("c"))), UNION_ALL(SINGLE_QUERY(RETURN(LITERAL(2), AS("c")))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EXISTS_SUBQUERY(exists_subquery)), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> exists_union_plan{
+      new ExpectUnion(left_exists_part, right_exists_part), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+
+  CheckPlan(planner.plan(),
+            symbol_table,
+            ExpectFilter(std::vector<std::list<BaseOpChecker *>>{exists_union_plan}),
+            ExpectScanAll(),
+            ExpectProduce());
+
+  DeleteListContent(&left_exists_part);
+  DeleteListContent(&right_exists_part);
+  DeleteListContent(&exists_union_plan);
+}
+
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodiesInReturnProjection) {
+  // MATCH (n) RETURN EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } AS h - the projection reaches the same branch
+  // through the forced fold, which has no Limit/EvaluatePatternFilter tail to hide a null root.
+  auto *exists_subquery =
+      QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("c"))), UNION(SINGLE_QUERY(RETURN(LITERAL(2), AS("c")))));
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), RETURN(EXISTS_SUBQUERY(exists_subquery), AS("h"))));
+
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+
+  Checkers input{ExpectOnce{}, ExpectScanAll{}};
+  Checkers branch{ExpectUnion{left_exists_part, right_exists_part}, ExpectDistinct{}};
+
+  CheckPlan<TypeParam>(
+      query, this->storage, ExpectExistsRollUpApply{std::move(input), std::move(branch)}, ExpectProduce());
+
+  DeleteListContent(&left_exists_part);
+  DeleteListContent(&right_exists_part);
+}
+
 // The forced bool fold: an EXISTS in a WITH/RETURN body is spliced onto the main chain as a RollUpApply, because
 // EvaluatePatternFilter is only usable as a Filter side branch.
 

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1479,17 +1479,104 @@ TYPED_TEST(TestSymbolGenerator, ExistsRefusedPositions) {
                          RETURN(REDUCE("acc", LITERAL(false), "x", LIST(LITERAL(1)), exists_subquery()), AS("h")))),
       "Not yet implemented: Exists cannot be used within REDUCE!");
 
-  // CASE is PR 4. Its message is unchanged in a WHERE and now also fires in a RETURN.
+  // A CASE does not launder an unsupported position: the enclosing position still answers. Pinned so that dropping
+  // the CASE gate cannot be read as widening the position list - SET is still refused, wrapped or not.
+  auto case_expr = [this](Expression *condition, Expression *then_expr, Expression *else_expr) -> Expression * {
+    return this->storage.template Create<memgraph::query::IfOperator>(condition, then_expr, else_expr);
+  };
   expect_message(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
-                                    WHERE(this->storage.template Create<memgraph::query::IfOperator>(
-                                        exists_subquery(), LITERAL(true), LITERAL(false))),
+                                    SET(PROPERTY_LOOKUP(this->dba, "n", prop),
+                                        case_expr(LITERAL(true), exists_subquery(), LITERAL(false))),
                                     RETURN("n"))),
-                 "Not yet implemented: IF operator cannot be used with exists, but only during matching!");
-  expect_message(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
-                                    RETURN(this->storage.template Create<memgraph::query::IfOperator>(
-                                               exists_subquery(), LITERAL(true), LITERAL(false)),
-                                           AS("h")))),
-                 "Not yet implemented: IF operator cannot be used with exists, but only during matching!");
+                 generic);
+}
+
+// CASE used to be refused outright. It is not a position of its own - it carries whatever position holds it - so
+// these belong with the allowed shapes. The interesting axis is bookkeeping, not planning: PostVisit(Exists&) pushes
+// one has_aggregation_ entry per EXISTS and IfOperator pops one per arm, so the shapes below (condition, both arms,
+// nesting, inside and beside an aggregate) are the ones that would leave the stack unbalanced if the two disagreed.
+TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
+  auto exists_subquery = [this] {
+    return EXISTS_SUBQUERY(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))))));
+  };
+  auto case_expr = [this](Expression *condition, Expression *then_expr, Expression *else_expr) -> Expression * {
+    return this->storage.template Create<memgraph::query::IfOperator>(condition, then_expr, else_expr);
+  };
+
+  // MATCH (n) WHERE CASE WHEN true THEN EXISTS { ... } ELSE false END RETURN n
+  MakeSymbolTable(QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n"))), WHERE(case_expr(LITERAL(true), exists_subquery(), LITERAL(false))), RETURN("n"))));
+
+  // MATCH (n) RETURN CASE WHEN EXISTS { ... } THEN true ELSE false END AS h - EXISTS in the condition.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                     RETURN(case_expr(exists_subquery(), LITERAL(true), LITERAL(false)), AS("h")))));
+
+  // The same in a WITH projection and in a WITH's WHERE.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                     WITH(NEXPR("h", case_expr(exists_subquery(), LITERAL(true), LITERAL(false)))),
+                                     RETURN("h"))));
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                     WITH("n"),
+                                     WHERE(case_expr(exists_subquery(), LITERAL(true), LITERAL(false))),
+                                     RETURN("n"))));
+
+  // Both arms hold an EXISTS: two folds are spliced, one per arm, and only the taken one is read.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                     RETURN(case_expr(LITERAL(true), exists_subquery(), exists_subquery()), AS("h")))));
+
+  // A CASE nested inside a CASE arm - num_if_operators reaches two.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n"))),
+      RETURN(case_expr(LITERAL(true), case_expr(exists_subquery(), LITERAL(true), LITERAL(false)), LITERAL(false)),
+             AS("h")))));
+
+  // RETURN collect(CASE WHEN EXISTS { ... } THEN 1 ELSE 0 END) AS c - inside an aggregate's argument. The CASE gate on
+  // aggregations is the other consumer of num_if_operators and stays: it refuses an aggregation *inside* a CASE, not a
+  // CASE inside an aggregation.
+  MakeSymbolTable(
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                         RETURN(COLLECT_LIST(case_expr(exists_subquery(), LITERAL(1), LITERAL(0)), false), AS("c")))));
+
+  // RETURN count(n) AS c, CASE WHEN EXISTS { ... } ... AS h - beside an aggregation, so the EXISTS column must not
+  // inherit the aggregating column's flag.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n"))),
+      RETURN(COUNT(IDENT("n"), false), AS("c"), case_expr(exists_subquery(), LITERAL(1), LITERAL(0)), AS("h")))));
+
+  // ORDER BY a CASE holding an EXISTS.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                     RETURN("n", ORDER_BY(case_expr(exists_subquery(), LITERAL(1), LITERAL(0)))))));
+
+  // The pattern form is gated identically, and it is the form the behave scenario for #1382 pins.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n"))),
+      WHERE(case_expr(
+          LITERAL(true),
+          EXISTS(PATTERN(NODE("n"), EDGE("r", EdgeAtom::Direction::OUT, {}, false), NODE("m", std::nullopt, false))),
+          LITERAL(false))),
+      RETURN("n"))));
+
+  // MATCH (n) WHERE all(x IN [1] WHERE CASE WHEN EXISTS { ... } ... END) RETURN n
+  // A MATCH's WHERE is rung one, so the deferred closure survives the lambda; the CASE inside it changes nothing.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n"))),
+      WHERE(ALL("x", LIST(LITERAL(1)), WHERE(case_expr(exists_subquery(), LITERAL(true), LITERAL(false))))),
+      RETURN("n"))));
+
+  // The same lambda in a RETURN is still refused: the CASE does not give the branch a splice point the lambda lacks.
+  EXPECT_THROW(
+      MakeSymbolTable(QUERY(SINGLE_QUERY(
+          MATCH(PATTERN(NODE("n"))),
+          RETURN(ALL("x", LIST(LITERAL(1)), WHERE(case_expr(exists_subquery(), LITERAL(true), LITERAL(false)))),
+                 AS("h"))))),
+      memgraph::utils::NotYetImplemented);
+
+  // An aggregation inside a CASE is still refused - that gate is untouched, and it fires before the EXISTS in the
+  // other arm is ever reached.
+  EXPECT_THROW(MakeSymbolTable(QUERY(SINGLE_QUERY(
+                   MATCH(PATTERN(NODE("n"))),
+                   RETURN(case_expr(LITERAL(true), COUNT(IDENT("n"), false), exists_subquery()), AS("h"))))),
+               SemanticException);
 }
 
 TYPED_TEST(TestSymbolGenerator, Subqueries) {

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1491,10 +1491,8 @@ TYPED_TEST(TestSymbolGenerator, ExistsRefusedPositions) {
                  generic);
 }
 
-// CASE used to be refused outright. It is not a position of its own - it carries whatever position holds it - so
-// these belong with the allowed shapes. The interesting axis is bookkeeping, not planning: PostVisit(Exists&) pushes
-// one has_aggregation_ entry per EXISTS and IfOperator pops one per arm, so the shapes below (condition, both arms,
-// nesting, inside and beside an aggregate) are the ones that would leave the stack unbalanced if the two disagreed.
+// A CASE carries whichever position holds it, so these belong with the allowed shapes. They pin what the symbol
+// generator accepts and nothing more - the planner side is the behave suite's.
 TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
   auto exists_subquery = [this] {
     return EXISTS_SUBQUERY(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))))));
@@ -1520,25 +1518,23 @@ TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
                                      WHERE(case_expr(exists_subquery(), LITERAL(true), LITERAL(false))),
                                      RETURN("n"))));
 
-  // Both arms hold an EXISTS: two folds are spliced, one per arm, and only the taken one is read.
+  // An EXISTS in both arms.
   MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
                                      RETURN(case_expr(LITERAL(true), exists_subquery(), exists_subquery()), AS("h")))));
 
-  // A CASE nested inside a CASE arm - num_if_operators reaches two.
+  // Nested CASE, so num_if_operators reaches two.
   MakeSymbolTable(QUERY(SINGLE_QUERY(
       MATCH(PATTERN(NODE("n"))),
       RETURN(case_expr(LITERAL(true), case_expr(exists_subquery(), LITERAL(true), LITERAL(false)), LITERAL(false)),
              AS("h")))));
 
-  // RETURN collect(CASE WHEN EXISTS { ... } THEN 1 ELSE 0 END) AS c - inside an aggregate's argument. The CASE gate on
-  // aggregations is the other consumer of num_if_operators and stays: it refuses an aggregation *inside* a CASE, not a
-  // CASE inside an aggregation.
+  // Inside an aggregate's argument. The other consumer of num_if_operators stays: it refuses an aggregation inside a
+  // CASE, not a CASE inside an aggregation.
   MakeSymbolTable(
       QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
                          RETURN(COLLECT_LIST(case_expr(exists_subquery(), LITERAL(1), LITERAL(0)), false), AS("c")))));
 
-  // RETURN count(n) AS c, CASE WHEN EXISTS { ... } ... AS h - beside an aggregation, so the EXISTS column must not
-  // inherit the aggregating column's flag.
+  // Beside an aggregation.
   MakeSymbolTable(QUERY(SINGLE_QUERY(
       MATCH(PATTERN(NODE("n"))),
       RETURN(COUNT(IDENT("n"), false), AS("c"), case_expr(exists_subquery(), LITERAL(1), LITERAL(0)), AS("h")))));
@@ -1547,7 +1543,7 @@ TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
   MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
                                      RETURN("n", ORDER_BY(case_expr(exists_subquery(), LITERAL(1), LITERAL(0)))))));
 
-  // The pattern form is gated identically, and it is the form the behave scenario for #1382 pins.
+  // The pattern form is gated identically.
   MakeSymbolTable(QUERY(SINGLE_QUERY(
       MATCH(PATTERN(NODE("n"))),
       WHERE(case_expr(
@@ -1556,14 +1552,13 @@ TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
           LITERAL(false))),
       RETURN("n"))));
 
-  // MATCH (n) WHERE all(x IN [1] WHERE CASE WHEN EXISTS { ... } ... END) RETURN n
-  // A MATCH's WHERE is rung one, so the deferred closure survives the lambda; the CASE inside it changes nothing.
+  // A MATCH's WHERE defers, so the lambda is fine there.
   MakeSymbolTable(QUERY(SINGLE_QUERY(
       MATCH(PATTERN(NODE("n"))),
       WHERE(ALL("x", LIST(LITERAL(1)), WHERE(case_expr(exists_subquery(), LITERAL(true), LITERAL(false))))),
       RETURN("n"))));
 
-  // The same lambda in a RETURN is still refused: the CASE does not give the branch a splice point the lambda lacks.
+  // The same lambda in a RETURN is still refused: a CASE gives the branch no splice point the lambda lacks.
   EXPECT_THROW(
       MakeSymbolTable(QUERY(SINGLE_QUERY(
           MATCH(PATTERN(NODE("n"))),
@@ -1571,12 +1566,53 @@ TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
                  AS("h"))))),
       memgraph::utils::NotYetImplemented);
 
-  // An aggregation inside a CASE is still refused - that gate is untouched, and it fires before the EXISTS in the
-  // other arm is ever reached.
+  // An aggregation inside a CASE is still refused; that gate is untouched.
   EXPECT_THROW(MakeSymbolTable(QUERY(SINGLE_QUERY(
                    MATCH(PATTERN(NODE("n"))),
                    RETURN(case_expr(LITERAL(true), COUNT(IDENT("n"), false), exists_subquery()), AS("h"))))),
                SemanticException);
+}
+
+// A simple CASE compares one test expression against every alternative, so the generator reaches it once per arm.
+// An EXISTS names its pattern variables at parse time, so each arm past the first redeclares them unless the EXISTS
+// scopes them. The searched form above cannot reach this: an IfOperator built directly holds a distinct condition.
+TYPED_TEST(TestSymbolGenerator, ExistsAsSimpleCaseTest) {
+  auto case_expr = [this](Expression *condition, Expression *then_expr, Expression *else_expr) -> Expression * {
+    return this->storage.template Create<memgraph::query::IfOperator>(condition, then_expr, else_expr);
+  };
+  // `CASE <test> WHEN true THEN 1 WHEN false THEN 2 ELSE 3 END`, desugared as the parser desugars it.
+  auto simple_case = [&](Expression *test) {
+    return case_expr(EQ(test, LITERAL(true)), LITERAL(1), case_expr(EQ(test, LITERAL(false)), LITERAL(2), LITERAL(3)));
+  };
+
+  auto pattern_form = [this] {
+    return EXISTS(PATTERN(NODE("n"), EDGE("r", EdgeAtom::Direction::OUT, {}, false), NODE("m", std::nullopt, false)));
+  };
+  auto subquery_form = [this] {
+    return EXISTS_SUBQUERY(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))))));
+  };
+
+  // The pattern form is the one that broke: its anonymous edge kept its parse-time name.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), RETURN(simple_case(pattern_form()), AS("h")))));
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(simple_case(pattern_form())), RETURN("n"))));
+
+  // The subquery form always had a scope; pinned so the two cannot drift apart again.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), RETURN(simple_case(subquery_form()), AS("h")))));
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(simple_case(subquery_form())), RETURN("n"))));
+
+  // Four arms, so the test is reached four times.
+  auto *test = pattern_form();
+  auto *four_arms = case_expr(
+      EQ(test, LITERAL(1)),
+      LITERAL(1),
+      case_expr(EQ(test, LITERAL(2)),
+                LITERAL(2),
+                case_expr(EQ(test, LITERAL(3)), LITERAL(3), case_expr(EQ(test, LITERAL(4)), LITERAL(4), LITERAL(0)))));
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), RETURN(four_arms, AS("h")))));
+
+  // Two side by side, each reached twice: the first's variables must be gone before the second declares its own.
+  MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                                     RETURN(AND(simple_case(pattern_form()), simple_case(pattern_form())), AS("h")))));
 }
 
 TYPED_TEST(TestSymbolGenerator, Subqueries) {

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1500,6 +1500,24 @@ TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
   auto case_expr = [this](Expression *condition, Expression *then_expr, Expression *else_expr) -> Expression * {
     return this->storage.template Create<memgraph::query::IfOperator>(condition, then_expr, else_expr);
   };
+  // The refusals below are pinned by message, not by type: at the base every one of these threw the CASE message
+  // instead, so a type-only assertion would pass with this change reverted.
+  auto expect_message = [](auto *query, std::string_view message) {
+    try {
+      MakeSymbolTable(query);
+      FAIL() << "expected the query to be refused";
+    } catch (const memgraph::utils::NotYetImplemented &e) {
+      EXPECT_EQ(std::string_view{e.what()}, message);
+    }
+  };
+  auto expect_semantic_message = [](auto *query, std::string_view message) {
+    try {
+      MakeSymbolTable(query);
+      FAIL() << "expected the query to be refused";
+    } catch (const SemanticException &e) {
+      EXPECT_EQ(std::string_view{e.what()}, message);
+    }
+  };
 
   // MATCH (n) WHERE CASE WHEN true THEN EXISTS { ... } ELSE false END RETURN n
   MakeSymbolTable(QUERY(SINGLE_QUERY(
@@ -1559,18 +1577,18 @@ TYPED_TEST(TestSymbolGenerator, ExistsInsideCase) {
       RETURN("n"))));
 
   // The same lambda in a RETURN is still refused: a CASE gives the branch no splice point the lambda lacks.
-  EXPECT_THROW(
-      MakeSymbolTable(QUERY(SINGLE_QUERY(
+  expect_message(
+      QUERY(SINGLE_QUERY(
           MATCH(PATTERN(NODE("n"))),
           RETURN(ALL("x", LIST(LITERAL(1)), WHERE(case_expr(exists_subquery(), LITERAL(true), LITERAL(false)))),
-                 AS("h"))))),
-      memgraph::utils::NotYetImplemented);
+                 AS("h")))),
+      "Not yet implemented: Exists is not supported in this position yet!");
 
   // An aggregation inside a CASE is still refused; that gate is untouched.
-  EXPECT_THROW(MakeSymbolTable(QUERY(SINGLE_QUERY(
-                   MATCH(PATTERN(NODE("n"))),
-                   RETURN(case_expr(LITERAL(true), COUNT(IDENT("n"), false), exists_subquery()), AS("h"))))),
-               SemanticException);
+  expect_semantic_message(
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                         RETURN(case_expr(LITERAL(true), COUNT(IDENT("n"), false), exists_subquery()), AS("h")))),
+      "Using aggregation functions inside of CASE is not allowed.");
 }
 
 // A simple CASE compares one test expression against every alternative, so the generator reaches it once per arm.


### PR DESCRIPTION
> **Stacked PR.** Base is `fix/exists-empty-body-segv` (#4560), which is itself stacked on `feat/exists-in-projection` (#4504). Review only the two commits above the base; merge the stack bottom-up.

Lets an `EXISTS` subquery appear inside a `CASE` expression.

**What.** `CASE WHEN cond THEN EXISTS { ... } ELSE ... END`, and `EXISTS` in the `CASE` condition itself, are now planned and evaluated. They previously threw `IF operator cannot be used with exists, but only during matching!` in any position, including ones where a bare `EXISTS` was already accepted.

**How.** The whole production change is deleting that refusal from `SymbolGenerator::PreVisit(Exists&)` (`symbol_generator.cpp`). A `CASE` holds no position of its own — it carries whichever position it sits in — so the position allow-list (`IsSupportedExistsPosition`) added later already answers for every shape the `num_if_operators` gate used to catch, and still refuses the ones with no splice point, `CASE`-wrapped or not. No planner change is needed: the planner's collectors are expression-tree visitors that already descend through `IfOperator`.

The counter itself stays. `PreVisit(Aggregation&)` reads it to refuse an aggregation inside a `CASE`, which is untouched, and a `CASE`-wrapped `SET` stays in the refused set — so the two gates remain distinguishable now that the `CASE` message is gone.

**Why.** The gate predates the position allow-list and was added with no planner change and no recorded hazard; it had nothing left to protect. It made `CASE` an unexplained hole in `EXISTS` support — the same subquery was accepted directly in a `RETURN` but refused one `CASE` deeper.

