### PR TITLE
fix: plan an EXISTS body's RETURN instead of discarding it

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3992,6 +3992,12 @@ antlrcpp::Any CypherMainVisitor::visitExistsSubquery(MemgraphCypher::ExistsSubqu
     if (cypher_query->pre_query_directives_.commit_frequency_ != nullptr) {
       throw SyntaxException("EXISTS subqueries cannot have a periodic commit.");
     }
+
+    // 5. No parallel execution. Only the enclosing query's directives are read, so the body's are silently dropped;
+    // and the body is a sub-plan re-executed per outer row, which the parallel cursors' Reset() mishandles.
+    if (cypher_query->pre_query_directives_.parallel_execution_) {
+      throw SyntaxException("EXISTS subqueries cannot use parallel execution.");
+    }
   } else {
     throw SyntaxException("EXISTS supports only a single relation or a subquery as its input.");
   }

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3982,6 +3982,12 @@ antlrcpp::Any CypherMainVisitor::visitExistsSubquery(MemgraphCypher::ExistsSubqu
     if (cypher_query->memory_limit_ != nullptr) {
       throw SyntaxException("EXISTS subqueries cannot have a query memory limit.");
     }
+
+    // 4. No periodic commit. The body is read-only and its rows are only counted, so a commit point inside it has
+    // nothing to commit - but it would run, finalizing the caller's transaction from inside a filter predicate.
+    if (cypher_query->pre_query_directives_.commit_frequency_ != nullptr) {
+      throw SyntaxException("EXISTS subqueries cannot have a periodic commit.");
+    }
   } else {
     throw SyntaxException("EXISTS supports only a single relation or a subquery as its input.");
   }

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3983,8 +3983,8 @@ antlrcpp::Any CypherMainVisitor::visitExistsSubquery(MemgraphCypher::ExistsSubqu
       throw SyntaxException("EXISTS subqueries cannot have a query memory limit.");
     }
 
-    // 4. No periodic commit. The body is read-only and its rows are only counted, so a commit point inside it has
-    // nothing to commit - but it would run, finalizing the caller's transaction from inside a filter predicate.
+    // 4. No periodic commit. The body's rows are only counted, so a commit point inside it has nothing to commit -
+    // but it would run, finalizing the caller's transaction from inside an expression.
     if (cypher_query->pre_query_directives_.commit_frequency_ != nullptr) {
       throw SyntaxException("EXISTS subqueries cannot have a periodic commit.");
     }

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3963,19 +3963,23 @@ antlrcpp::Any CypherMainVisitor::visitExistsSubquery(MemgraphCypher::ExistsSubqu
     parsing_exists_subquery_ = old_flag;
     exists->content_ = cypher_query;
 
-    // 1. There must be at least one clause
-    auto *single_query = cypher_query->single_query_;
-    if (!single_query || single_query->clauses_.empty()) {
-      throw SyntaxException("EXISTS subquery must contain at least one clause.");
-    }
-
-    // 2. Only MATCH, WHERE, WITH, RETURN allowed
-    for (const auto *clause : single_query->clauses_) {
-      const auto &type = clause->GetTypeInfo();
-      if (!(utils::IsSubtype(type, Match::kType) || utils::IsSubtype(type, Where::kType) ||
-            utils::IsSubtype(type, With::kType) || utils::IsSubtype(type, Return::kType))) {
-        throw SyntaxException("Only MATCH, WHERE, WITH, and RETURN clauses are allowed in EXISTS subqueries.");
+    // 1. There must be at least one clause, and 2. only MATCH, WHERE, WITH, RETURN. Per branch: a UNION's
+    // further branches are each their own SingleQuery, and a clause forbidden in the first is not legal in them.
+    auto validate_branch = [](const SingleQuery *single_query) {
+      if (!single_query || single_query->clauses_.empty()) {
+        throw SyntaxException("EXISTS subquery must contain at least one clause.");
       }
+      for (const auto *clause : single_query->clauses_) {
+        const auto &type = clause->GetTypeInfo();
+        if (!(utils::IsSubtype(type, Match::kType) || utils::IsSubtype(type, Where::kType) ||
+              utils::IsSubtype(type, With::kType) || utils::IsSubtype(type, Return::kType))) {
+          throw SyntaxException("Only MATCH, WHERE, WITH, and RETURN clauses are allowed in EXISTS subqueries.");
+        }
+      }
+    };
+    validate_branch(cypher_query->single_query_);
+    for (const auto *cypher_union : cypher_query->cypher_unions_) {
+      validate_branch(cypher_union->single_query_);
     }
 
     // 3. No query memory limit

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -1064,13 +1064,7 @@ std::unique_ptr<LogicalOperator> GenNamedPaths(std::unique_ptr<LogicalOperator> 
 std::unique_ptr<LogicalOperator> GenReturn(Return &ret, std::unique_ptr<LogicalOperator> input_op,
                                            SymbolTable &symbol_table, bool is_write,
                                            const std::unordered_set<Symbol> &bound_symbols, AstStorage &storage,
-                                           SubqueryContext &subquery_ctx, Expression *commit_frequency,
-                                           bool in_exists_subquery) {
-  // In existential subqueries, we should omit any return clauses as per Neo4j documentation
-  if (in_exists_subquery) {
-    return input_op;
-  }
-
+                                           SubqueryContext &subquery_ctx, Expression *commit_frequency) {
   // Similar to WITH clause, but we want to accumulate when the query writes to
   // the database. This way we handle the case when we want to return
   // expressions with the latest updated results. For example, `MATCH (n) -- ()

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -420,9 +420,9 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                        .write_occurred = branch_sees_write()};
 
           if (auto *ret = utils::Downcast<Return>(clause)) {
-            // An EXISTS branch's rows are only counted, so neither operator buys anything here and both hurt: a
-            // PeriodicCommit would finalize the caller's transaction from inside an expression, and an Accumulate
-            // drains the branch below the fold, running a union-hole write once per matched row instead of once.
+            // GenReturn is denied both operators: a PeriodicCommit would finalize the caller's transaction from
+            // inside an expression, and an Accumulate would drain the branch below the fold, multiplying any write
+            // in it. No write can reach a body while every branch is clause-checked, so only the commit can fire.
             input_op = impl::GenReturn(*ret,
                                        std::move(input_op),
                                        *context.symbol_table,
@@ -453,8 +453,8 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                 pending_comprehensions,
                                 wrote_before_merge);
           } else if (auto *with = utils::Downcast<query::With>(clause)) {
-            // Denied Accumulate for the same reason as GenReturn: it drains the branch below the fold. Unreachable
-            // while the allow-list keeps writes out of a body - kept so the planner does not depend on it holding.
+            // GenWith is denied Accumulate for the same reason. Also unreachable, and kept for the same one: the
+            // planner should not depend on a parse-time clause check, which has already had a hole once.
             input_op = impl::GenWith(*with,
                                      std::move(input_op),
                                      *context.symbol_table,

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -453,10 +453,12 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                 pending_comprehensions,
                                 wrote_before_merge);
           } else if (auto *with = utils::Downcast<query::With>(clause)) {
+            // Denied Accumulate for the same reason as GenReturn: it drains the branch below the fold. Unreachable
+            // while the allow-list keeps writes out of a body - kept so the planner does not depend on it holding.
             input_op = impl::GenWith(*with,
                                      std::move(input_op),
                                      *context.symbol_table,
-                                     context.is_write_query,
+                                     context.is_write_query && !context.in_exists_subquery,
                                      context.bound_symbols,
                                      *context.ast_storage,
                                      subquery_ctx,
@@ -1684,7 +1686,7 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       auto branch_bound_symbols = bound_symbols;
       // in_exists_subquery drives four behaviours of the recursive plan: the EmptyResult wrapper is suppressed, a
       // null-planning query part gets a Once, GenWith keeps outer-scope vertex/edge symbols across a body WITH, and
-      // GenReturn is denied Accumulate and PeriodicCommit.
+      // neither GenReturn nor GenWith may build an Accumulate (nor GenReturn a PeriodicCommit).
       auto const restore = utils::OnScopeExit{[this,
                                                old_exists_subquery = context_->in_exists_subquery,
                                                old_after_write = exists_branch_after_write_,

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -420,14 +420,20 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                        .write_occurred = branch_sees_write()};
 
           if (auto *ret = utils::Downcast<Return>(clause)) {
+            // An EXISTS branch is only counted, never returned, so neither of the two operators a RETURN body can
+            // add for a write buys anything there - and both are actively harmful. A PeriodicCommit would finalize
+            // the caller's transaction from inside a filter predicate, and an Accumulate drains its input below the
+            // fold's Limit(1), so a write that reached the body through the union allow-list hole would run once
+            // per matched row instead of once. Both are already refused above, in the parser and the allow-list;
+            // this mirrors what GenWith has always done and keeps the planner from depending on those gates.
             input_op = impl::GenReturn(*ret,
                                        std::move(input_op),
                                        *context.symbol_table,
-                                       context.is_write_query,
+                                       context.is_write_query && !context.in_exists_subquery,
                                        context.bound_symbols,
                                        *context.ast_storage,
                                        subquery_ctx,
-                                       query_parts.commit_frequency);
+                                       context.in_exists_subquery ? nullptr : query_parts.commit_frequency);
           } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
             // ON CREATE / ON MATCH comprehensions originate here too; GenMerge splices each onto the branch that
             // reads it, so this chain must not take them first.
@@ -1684,8 +1690,9 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       // Copy first: bound_symbols may alias context_->bound_symbols, and moving out of it would empty the very set
       // the branch has to correlate against.
       auto branch_bound_symbols = bound_symbols;
-      // in_exists_subquery drives two behaviours of the recursive plan: the EmptyResult wrapper is suppressed, and
-      // GenWith keeps outer-scope vertex/edge symbols across a body WITH.
+      // in_exists_subquery drives four behaviours of the recursive plan: the EmptyResult wrapper is suppressed, a
+      // null-planning query part gets a Once, GenWith keeps outer-scope vertex/edge symbols across a body WITH, and
+      // GenReturn is denied the write-only operators (Accumulate, PeriodicCommit) that make no sense in a branch.
       auto const restore = utils::OnScopeExit{[this,
                                                old_exists_subquery = context_->in_exists_subquery,
                                                old_after_write = exists_branch_after_write_,

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -420,12 +420,9 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                        .write_occurred = branch_sees_write()};
 
           if (auto *ret = utils::Downcast<Return>(clause)) {
-            // An EXISTS branch is only counted, never returned, so neither of the two operators a RETURN body can
-            // add for a write buys anything there - and both are actively harmful. A PeriodicCommit would finalize
-            // the caller's transaction from inside a filter predicate, and an Accumulate drains its input below the
-            // fold's Limit(1), so a write that reached the body through the union allow-list hole would run once
-            // per matched row instead of once. Both are already refused above, in the parser and the allow-list;
-            // this mirrors what GenWith has always done and keeps the planner from depending on those gates.
+            // An EXISTS branch's rows are only counted, so neither operator buys anything here and both hurt: a
+            // PeriodicCommit would finalize the caller's transaction from inside an expression, and an Accumulate
+            // drains the branch below the fold, running a union-hole write once per matched row instead of once.
             input_op = impl::GenReturn(*ret,
                                        std::move(input_op),
                                        *context.symbol_table,
@@ -601,22 +598,17 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
         }
       }
 
-      // Is this the only situation that should be covered
       // An EXISTS branch must keep emitting its rows for the fold to read, so it never gets the EmptyResult wrapper.
-      // The null check is belt-and-braces: no clause sequence is known to plan to nothing.
       if (!context.in_exists_subquery && input_op && input_op->OutputSymbols(*context.symbol_table).empty()) {
         if (has_periodic_commit && is_root_query) {
-          // this periodic commit is from USING PERIODIC COMMIT
           input_op = std::make_unique<PeriodicCommit>(std::move(input_op), query_parts.commit_frequency);
         }
         input_op = std::make_unique<EmptyResult>(std::move(input_op));
       }
 
-      // A body that plans to nothing still matches one (empty) row. Planning the body's RETURN removed the last
-      // clause that dropped one, so a branch's own part no longer reaches this; it stays as defence, and
-      // `in_exists_subquery` survives the recursive `Plan` calls this one makes, so it still covers a nested
-      // `CALL {}` body - `HandleSubquery` dereferences that plan too. Substituted per query part, because each
-      // UNION branch is its own and the combinator below dereferences both operands.
+      // A body that plans to nothing still matches one (empty) row. Defence only: no clause sequence has been found
+      // that plans to nothing, here or in a nested `CALL {}` body, but `HandleSubquery` dereferences that plan
+      // unguarded. Per query part, because each UNION branch is its own and the combinator dereferences both.
       if (context.in_exists_subquery && !input_op) {
         input_op = std::make_unique<Once>();
       }
@@ -1692,7 +1684,7 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       auto branch_bound_symbols = bound_symbols;
       // in_exists_subquery drives four behaviours of the recursive plan: the EmptyResult wrapper is suppressed, a
       // null-planning query part gets a Once, GenWith keeps outer-scope vertex/edge symbols across a body WITH, and
-      // GenReturn is denied the write-only operators (Accumulate, PeriodicCommit) that make no sense in a branch.
+      // GenReturn is denied Accumulate and PeriodicCommit.
       auto const restore = utils::OnScopeExit{[this,
                                                old_exists_subquery = context_->in_exists_subquery,
                                                old_after_write = exists_branch_after_write_,

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -420,17 +420,15 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                        .write_occurred = branch_sees_write()};
 
           if (auto *ret = utils::Downcast<Return>(clause)) {
-            // GenReturn is denied both operators: a PeriodicCommit would finalize the caller's transaction from
-            // inside an expression, and an Accumulate would drain the branch below the fold, multiplying any write
-            // in it. No write can reach a body while every branch is clause-checked, so only the commit can fire.
+            CheckExistsBodyInvariants(context, query_parts.commit_frequency);
             input_op = impl::GenReturn(*ret,
                                        std::move(input_op),
                                        *context.symbol_table,
-                                       context.is_write_query && !context.in_exists_subquery,
+                                       context.is_write_query,
                                        context.bound_symbols,
                                        *context.ast_storage,
                                        subquery_ctx,
-                                       context.in_exists_subquery ? nullptr : query_parts.commit_frequency);
+                                       query_parts.commit_frequency);
           } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
             // ON CREATE / ON MATCH comprehensions originate here too; GenMerge splices each onto the branch that
             // reads it, so this chain must not take them first.
@@ -453,12 +451,11 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                 pending_comprehensions,
                                 wrote_before_merge);
           } else if (auto *with = utils::Downcast<query::With>(clause)) {
-            // GenWith is denied Accumulate for the same reason. Also unreachable, and kept for the same one: the
-            // planner should not depend on a parse-time clause check, which has already had a hole once.
+            CheckExistsBodyInvariants(context, /*commit_frequency=*/nullptr);
             input_op = impl::GenWith(*with,
                                      std::move(input_op),
                                      *context.symbol_table,
-                                     context.is_write_query && !context.in_exists_subquery,
+                                     context.is_write_query,
                                      context.bound_symbols,
                                      *context.ast_storage,
                                      subquery_ctx,
@@ -865,6 +862,23 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
   }
 
   // Check if a clause is a write clause that HandleWriteClause can process.
+  /// An EXISTS body is read-only and carries no periodic commit: `visitExistsSubquery` allows only MATCH, WHERE,
+  /// WITH and RETURN - in every UNION branch - and rejects a body-level commit directive. Reaching either here means
+  /// that validation has a hole. Throws rather than asserts, which would abort the process from an `EXPLAIN` alone.
+  static void CheckExistsBodyInvariants(const TPlanningContext &context, Expression *commit_frequency) {
+    if (!context.in_exists_subquery) return;
+    if (context.is_write_query) {
+      throw QueryException(
+          "A write clause reached the body of an EXISTS subquery, which may only read. Please contact Memgraph "
+          "support or submit a GitHub issue, as this scenario should not happen.");
+    }
+    if (commit_frequency != nullptr) {
+      throw QueryException(
+          "A periodic commit reached the body of an EXISTS subquery, which cannot commit. Please contact Memgraph "
+          "support or submit a GitHub issue, as this scenario should not happen.");
+    }
+  }
+
   static bool IsWriteClause(Clause *clause) {
     return utils::Downcast<Create>(clause) || utils::Downcast<query::Delete>(clause) ||
            utils::Downcast<query::SetProperty>(clause) || utils::Downcast<query::SetProperties>(clause) ||
@@ -1684,9 +1698,9 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       // Copy first: bound_symbols may alias context_->bound_symbols, and moving out of it would empty the very set
       // the branch has to correlate against.
       auto branch_bound_symbols = bound_symbols;
-      // in_exists_subquery drives four behaviours of the recursive plan: the EmptyResult wrapper is suppressed, a
-      // null-planning query part gets a Once, GenWith keeps outer-scope vertex/edge symbols across a body WITH, and
-      // neither GenReturn nor GenWith may build an Accumulate (nor GenReturn a PeriodicCommit).
+      // in_exists_subquery drives three behaviours of the recursive plan: the EmptyResult wrapper is suppressed, a
+      // null-planning query part gets a Once, and GenWith keeps outer-scope vertex/edge symbols across a body WITH.
+      // It also selects the read-only invariants CheckExistsBodyInvariants enforces.
       auto const restore = utils::OnScopeExit{[this,
                                                old_exists_subquery = context_->in_exists_subquery,
                                                old_after_write = exists_branch_after_write_,

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -205,8 +205,7 @@ std::unique_ptr<LogicalOperator> GenNamedPaths(std::unique_ptr<LogicalOperator> 
 std::unique_ptr<LogicalOperator> GenReturn(Return &ret, std::unique_ptr<LogicalOperator> input_op,
                                            SymbolTable &symbol_table, bool is_write,
                                            const std::unordered_set<Symbol> &bound_symbols, AstStorage &storage,
-                                           SubqueryContext &subquery_ctx, Expression *commit_frequency,
-                                           bool in_exists_subquery);
+                                           SubqueryContext &subquery_ctx, Expression *commit_frequency);
 
 std::unique_ptr<LogicalOperator> GenWith(With &with, std::unique_ptr<LogicalOperator> input_op,
                                          SymbolTable &symbol_table, bool is_write,
@@ -428,8 +427,7 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                        context.bound_symbols,
                                        *context.ast_storage,
                                        subquery_ctx,
-                                       query_parts.commit_frequency,
-                                       context.in_exists_subquery);
+                                       query_parts.commit_frequency);
           } else if (auto *merge = utils::Downcast<query::Merge>(clause)) {
             // ON CREATE / ON MATCH comprehensions originate here too; GenMerge splices each onto the branch that
             // reads it, so this chain must not take them first.
@@ -598,9 +596,8 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       }
 
       // Is this the only situation that should be covered
-      // An exists body whose every clause is dropped (`EXISTS { RETURN 1 }`) leaves input_op null, so short-circuit
-      // on `in_exists_subquery` before dereferencing it. The null check after it is belt-and-braces: no other clause
-      // sequence is known to plan to nothing.
+      // An EXISTS branch must keep emitting its rows for the fold to read, so it never gets the EmptyResult wrapper.
+      // The null check is belt-and-braces: no clause sequence is known to plan to nothing.
       if (!context.in_exists_subquery && input_op && input_op->OutputSymbols(*context.symbol_table).empty()) {
         if (has_periodic_commit && is_root_query) {
           // this periodic commit is from USING PERIODIC COMMIT
@@ -609,10 +606,11 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
         input_op = std::make_unique<EmptyResult>(std::move(input_op));
       }
 
-      // A body whose clauses all dropped plans to nothing, yet still matches one (empty) row. Substituted per query
-      // part, not once on the branch root: each UNION branch is its own part, and the combinator below dereferences
-      // both operands. `in_exists_subquery` stays set across the recursive `Plan` calls this one makes, so this also
-      // catches a nested `CALL {}` body that plans to nothing - `HandleSubquery` dereferences that one too.
+      // A body that plans to nothing still matches one (empty) row. Planning the body's RETURN removed the last
+      // clause that dropped one, so a branch's own part no longer reaches this; it stays as defence, and
+      // `in_exists_subquery` survives the recursive `Plan` calls this one makes, so it still covers a nested
+      // `CALL {}` body - `HandleSubquery` dereferences that plan too. Substituted per query part, because each
+      // UNION branch is its own and the combinator below dereferences both operands.
       if (context.in_exists_subquery && !input_op) {
         input_op = std::make_unique<Once>();
       }
@@ -1686,8 +1684,8 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
       // Copy first: bound_symbols may alias context_->bound_symbols, and moving out of it would empty the very set
       // the branch has to correlate against.
       auto branch_bound_symbols = bound_symbols;
-      // in_exists_subquery drives three behaviours of the recursive plan: the body's RETURN is dropped, the
-      // EmptyResult wrapper is suppressed, and GenWith keeps outer-scope vertex/edge symbols across a body WITH.
+      // in_exists_subquery drives two behaviours of the recursive plan: the EmptyResult wrapper is suppressed, and
+      // GenWith keeps outer-scope vertex/edge symbols across a body WITH.
       auto const restore = utils::OnScopeExit{[this,
                                                old_exists_subquery = context_->in_exists_subquery,
                                                old_after_write = exists_branch_after_write_,

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -739,6 +739,24 @@ Feature: WHERE exists
           """
       Then an error should be raised
 
+  Scenario: Test invalid parallel execution inside EXISTS
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Person {name: 'John'})-[:HAS_DOG]->(:Dog {name: 'Rex'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE EXISTS {
+            USING PARALLEL EXECUTION
+            MATCH (person)-[:HAS_DOG]->(dog:Dog)
+            RETURN dog
+          }
+          RETURN person.name AS name;
+          """
+      Then an error should be raised
+
   Scenario: Test invalid SET inside EXISTS
       Given an empty graph
       And having executed:
@@ -1777,7 +1795,6 @@ Feature: WHERE exists
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
           CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
           """
@@ -1800,7 +1817,6 @@ Feature: WHERE exists
           """
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
@@ -1829,7 +1845,6 @@ Feature: WHERE exists
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
           CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
           """
@@ -1851,7 +1866,6 @@ Feature: WHERE exists
           """
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
@@ -1875,7 +1889,6 @@ Feature: WHERE exists
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
           CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
           """
@@ -1891,7 +1904,8 @@ Feature: WHERE exists
           | 'Bob'   | false |
           | 'Carol' | false |
 
-  # Alice is the discriminating row: 3 rows, 2 distinct, so the SKIP clears the table only if DISTINCT was planned.
+  # Alice is the discriminating row: her doubled KNOWS edge to F1 makes 3 rows but 2 distinct, so the SKIP clears
+  # the table only if DISTINCT was planned. It is the one fixture here that needs a parallel edge.
   # Dave, with 3 distinct, keeps a row either way, so an all-false table cannot pass by accident.
   Scenario: Test EXISTS subquery whose body RETURN is DISTINCT
       Given an empty graph
@@ -1927,7 +1941,6 @@ Feature: WHERE exists
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
           CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
           """
@@ -1952,7 +1965,6 @@ Feature: WHERE exists
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
           CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
           """
@@ -1974,7 +1986,6 @@ Feature: WHERE exists
           """
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
@@ -2000,7 +2011,6 @@ Feature: WHERE exists
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
           CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)
           """
@@ -2022,7 +2032,6 @@ Feature: WHERE exists
           """
           CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
           CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
-          CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f1)
           CREATE (a)-[:KNOWS]->(f2)
           CREATE (b)-[:KNOWS]->(f1)

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1719,9 +1719,7 @@ Feature: WHERE exists
       Then an error should be raised
 
   # The body's RETURN decides how many rows reach the fold, so SKIP, LIMIT and aggregation on it change the answer.
-  # DISTINCT alone cannot - it never takes a non-empty table to an empty one - so it only shows up composed with a
-  # SKIP that the reduced row count can no longer clear. The fixture discriminates: Alice has 3 KNOWS rows to only
-  # 2 distinct friends, Bob has 1, Carol has 0.
+  # DISTINCT alone cannot - it never empties a non-empty table - so it appears only composed with a SKIP.
 
   Scenario: Test EXISTS subquery whose body RETURN aggregates
       Given an empty graph
@@ -1746,6 +1744,7 @@ Feature: WHERE exists
           | 'Bob'   | true |
           | 'Carol' | true |
 
+  # Invariance pin: the WITH spelling was always planned, so this agrees either way. It guards the two from diverging.
   Scenario: Test EXISTS subquery whose body RETURN aggregates agrees with the WITH spelling
       Given an empty graph
       And having executed:
@@ -1815,8 +1814,8 @@ Feature: WHERE exists
           | 'Bob'   | false |
           | 'Carol' | false |
 
-  # Alice is the discriminating row: 3 rows but 2 distinct, so the SKIP clears the table only if the DISTINCT was
-  # planned. Dave, with 3 distinct, keeps a row either way, so an all-false table cannot pass by accident.
+  # Alice is the discriminating row: 3 rows, 2 distinct, so the SKIP clears the table only if DISTINCT was planned.
+  # Dave, with 3 distinct, keeps a row either way, so an all-false table cannot pass by accident.
   Scenario: Test EXISTS subquery whose body RETURN is DISTINCT
       Given an empty graph
       And having executed:
@@ -1890,9 +1889,8 @@ Feature: WHERE exists
           | name    |
           | 'Alice' |
 
-  # ORDER BY is the one RETURN body clause that cannot change the answer - a sort permutes the table, and the fold
-  # reads only whether it is empty. These pin that invariance, and that the sort still plans: composed with a SKIP it
-  # must leave the count the SKIP acts on alone, and it may order on a correlated outer symbol.
+  # ORDER BY cannot change the answer - a sort permutes the table and the fold reads only whether it is empty. These
+  # pin that invariance, and that the sort still plans: composed with a SKIP, and ordering on a correlated outer symbol.
 
   Scenario: Test EXISTS subquery whose body RETURN has an ORDER BY
       Given an empty graph
@@ -1963,8 +1961,8 @@ Feature: WHERE exists
           | 'Bob'   | true  |
           | 'Carol' | false |
 
-  # Nesting reaches a second RETURN through the inner body's WHERE. Each LIMIT 0 below turns exactly one of the two
-  # tables empty, so the pair says which RETURN is planned: only Alice knows a friend who likes anything.
+  # Nesting reaches a second RETURN through the inner body's WHERE. Only Alice knows a friend who likes anything.
+  # The first scenario is the baseline; the LIMIT 0 pair below empties one table each and says which RETURN is planned.
 
   Scenario: Test nested EXISTS subqueries with a RETURN in both bodies
       Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -721,6 +721,24 @@ Feature: WHERE exists
           | 'Bob'  | false   |
           | 'John' | true    |
 
+  Scenario: Test invalid periodic commit inside EXISTS
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Person {name: 'John'})-[:HAS_DOG]->(:Dog {name: 'Rex'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE EXISTS {
+            USING PERIODIC COMMIT 1
+            MATCH (person)-[:HAS_DOG]->(dog:Dog)
+            RETURN dog
+          }
+          RETURN person.name AS name;
+          """
+      Then an error should be raised
+
   Scenario: Test invalid SET inside EXISTS
       Given an empty graph
       And having executed:

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1768,6 +1768,34 @@ Feature: WHERE exists
           | 'Bob'   | true |
           | 'Carol' | true |
 
+  # The counterpart to the scenario above, and the reason it is worth pinning: an un-aggregated column becomes a
+  # grouping key, and a grouped aggregate emits no row at all on empty input, so Carol flips to false. The body's
+  # column list therefore decides the row count. Neither of these two answers depends on this change - both hold with
+  # the body's RETURN discarded - so this pair guards a future rewrite that prunes an unread projection column from
+  # silently turning the grouped answer into the ungrouped one. Both measured against the reference engine.
+  Scenario: Test EXISTS subquery whose body RETURN aggregates with a grouping key
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN 1, count(f) } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | true  |
+          | 'Bob'   | true  |
+          | 'Carol' | false |
+
   Scenario: Test EXISTS subquery whose body RETURN has a LIMIT
       Given an empty graph
       And having executed:
@@ -1866,6 +1894,30 @@ Feature: WHERE exists
           | 'Alice' |
           | 'Bob'   |
           | 'Carol' |
+
+  # The grouping key reaches the WHERE fold too, and drops the row the ungrouped spelling above keeps.
+  Scenario: Test EXISTS subquery in a WHERE whose body RETURN aggregates with a grouping key
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          WHERE EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN 1, count(f) }
+          RETURN p.name AS name
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    |
+          | 'Alice' |
+          | 'Bob'   |
 
   Scenario: Test EXISTS subquery in a WHERE whose body RETURN has a SKIP
       Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -823,6 +823,55 @@ Feature: WHERE exists
           """
       Then an error should be raised
 
+  # A UNION's later branches are each their own SingleQuery, so the clause rules above have to be checked on every
+  # one of them, not just the first. Both were accepted before. The earlier branches match nothing on purpose: the
+  # fold stops at the first row, so only then is the writing branch pulled - measured, it created the node.
+
+  Scenario: Test invalid CREATE in a UNION branch inside EXISTS
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Person {name: 'John'})-[:HAS_DOG]->(:Dog {name: 'Rex'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE EXISTS {
+            MATCH (person)-[:HAS_CAT]->(cat:Cat)
+            RETURN cat AS d
+            UNION
+            MATCH (other:Dog)
+            CREATE (:Marker)
+            RETURN other AS d
+          }
+          RETURN person.name AS name;
+          """
+      Then an error should be raised
+
+  Scenario: Test invalid CREATE in the last of three UNION branches inside EXISTS
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:Person {name: 'John'})-[:HAS_DOG]->(:Dog {name: 'Rex'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE EXISTS {
+            MATCH (person)-[:HAS_CAT]->(cat:Cat)
+            RETURN cat AS d
+            UNION
+            MATCH (second:Cat)
+            RETURN second AS d
+            UNION
+            MATCH (third:Dog)
+            CREATE (:Marker)
+            RETURN third AS d
+          }
+          RETURN person.name AS name;
+          """
+      Then an error should be raised
+
   Scenario: Test EXISTS with UNION in RETURN
       Given an empty graph
       And having executed:

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -439,7 +439,7 @@ Feature: WHERE exists
           | n.prop |
           | 1      |
 
-  Scenario: Test exists equal to true
+  Scenario: Test exists equal to false
       Given an empty graph
       And having executed:
           """
@@ -1943,29 +1943,6 @@ Feature: WHERE exists
 
   # ORDER BY cannot change the answer - a sort permutes the table and the fold reads only whether it is empty. These
   # pin that invariance, and that the sort still plans: composed with a SKIP, and ordering on a correlated outer symbol.
-
-  Scenario: Test EXISTS subquery whose body RETURN has an ORDER BY
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
-          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
-          CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f1)
-          CREATE (a)-[:KNOWS]->(f2)
-          CREATE (b)-[:KNOWS]->(f1)
-          """
-      When executing query:
-          """
-          MATCH (p:Person)
-          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN f ORDER BY f.name } AS h
-          ORDER BY name;
-          """
-      Then the result should be, in order:
-          | name    | h     |
-          | 'Alice' | true  |
-          | 'Bob'   | true  |
-          | 'Carol' | false |
 
   Scenario: Test EXISTS subquery whose body RETURN has an ORDER BY and a SKIP
       Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1699,3 +1699,144 @@ Feature: WHERE exists
           MATCH (a:P) RETURN exists((a)-[:R]->({p: exists((a)-[:R]->())})) AS h;
           """
       Then an error should be raised
+
+  # The body's RETURN decides how many rows reach the fold, so every clause on it - DISTINCT, SKIP, LIMIT,
+  # aggregation - changes the answer. The fixture discriminates: Alice has 3 KNOWS rows to only 2 distinct
+  # friends, Bob has 1, Carol has 0.
+
+  Scenario: Test EXISTS subquery whose body RETURN aggregates
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN count(f) } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h    |
+          | 'Alice' | true |
+          | 'Bob'   | true |
+          | 'Carol' | true |
+
+  Scenario: Test EXISTS subquery whose body RETURN aggregates agrees with the WITH spelling
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) WITH count(f) AS c RETURN c } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h    |
+          | 'Alice' | true |
+          | 'Bob'   | true |
+          | 'Carol' | true |
+
+  Scenario: Test EXISTS subquery whose body RETURN has a LIMIT
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN f LIMIT 0 } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | false |
+          | 'Bob'   | false |
+          | 'Carol' | false |
+
+  Scenario: Test EXISTS subquery whose body RETURN has a SKIP
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN f SKIP 1 } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | true  |
+          | 'Bob'   | false |
+          | 'Carol' | false |
+
+  Scenario: Test EXISTS subquery whose body RETURN is DISTINCT
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN DISTINCT f } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | true  |
+          | 'Bob'   | true  |
+          | 'Carol' | false |
+
+  Scenario: Test EXISTS subquery in a WHERE whose body RETURN has a SKIP
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          WHERE EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN f SKIP 1 }
+          RETURN p.name AS name
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    |
+          | 'Alice' |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1889,3 +1889,148 @@ Feature: WHERE exists
       Then the result should be, in order:
           | name    |
           | 'Alice' |
+
+  # ORDER BY is the one RETURN body clause that cannot change the answer - a sort permutes the table, and the fold
+  # reads only whether it is empty. These pin that invariance, and that the sort still plans: composed with a SKIP it
+  # must leave the count the SKIP acts on alone, and it may order on a correlated outer symbol.
+
+  Scenario: Test EXISTS subquery whose body RETURN has an ORDER BY
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN f ORDER BY f.name } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | true  |
+          | 'Bob'   | true  |
+          | 'Carol' | false |
+
+  Scenario: Test EXISTS subquery whose body RETURN has an ORDER BY and a SKIP
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN f ORDER BY f.name SKIP 1 } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | true  |
+          | 'Bob'   | false |
+          | 'Carol' | false |
+
+  Scenario: Test EXISTS subquery whose body RETURN orders on a correlated outer symbol
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN f ORDER BY p.name DESC } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | true  |
+          | 'Bob'   | true  |
+          | 'Carol' | false |
+
+  # Nesting reaches a second RETURN through the inner body's WHERE. Each LIMIT 0 below turns exactly one of the two
+  # tables empty, so the pair says which RETURN is planned: only Alice knows a friend who likes anything.
+
+  Scenario: Test nested EXISTS subqueries with a RETURN in both bodies
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (b)-[:KNOWS]->(f2)
+          CREATE (f1)-[:LIKES]->(:Movie {name: 'M1'})
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name,
+                 EXISTS { MATCH (p)-[:KNOWS]->(f) WHERE EXISTS { MATCH (f)-[:LIKES]->(m) RETURN m } RETURN f } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | true  |
+          | 'Bob'   | false |
+          | 'Carol' | false |
+
+  Scenario: Test nested EXISTS subqueries where the inner body RETURN has a LIMIT
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (b)-[:KNOWS]->(f2)
+          CREATE (f1)-[:LIKES]->(:Movie {name: 'M1'})
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name,
+                 EXISTS { MATCH (p)-[:KNOWS]->(f) WHERE EXISTS { MATCH (f)-[:LIKES]->(m) RETURN m LIMIT 0 } RETURN f } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | false |
+          | 'Bob'   | false |
+          | 'Carol' | false |
+
+  Scenario: Test nested EXISTS subqueries where the outer body RETURN has a LIMIT
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (b)-[:KNOWS]->(f2)
+          CREATE (f1)-[:LIKES]->(:Movie {name: 'M1'})
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name,
+                 EXISTS { MATCH (p)-[:KNOWS]->(f) WHERE EXISTS { MATCH (f)-[:LIKES]->(m) RETURN m } RETURN f LIMIT 0 } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | false |
+          | 'Bob'   | false |
+          | 'Carol' | false |

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1718,9 +1718,10 @@ Feature: WHERE exists
           """
       Then an error should be raised
 
-  # The body's RETURN decides how many rows reach the fold, so every clause on it - DISTINCT, SKIP, LIMIT,
-  # aggregation - changes the answer. The fixture discriminates: Alice has 3 KNOWS rows to only 2 distinct
-  # friends, Bob has 1, Carol has 0.
+  # The body's RETURN decides how many rows reach the fold, so SKIP, LIMIT and aggregation on it change the answer.
+  # DISTINCT alone cannot - it never takes a non-empty table to an empty one - so it only shows up composed with a
+  # SKIP that the reduced row count can no longer clear. The fixture discriminates: Alice has 3 KNOWS rows to only
+  # 2 distinct friends, Bob has 1, Carol has 0.
 
   Scenario: Test EXISTS subquery whose body RETURN aggregates
       Given an empty graph
@@ -1814,7 +1815,36 @@ Feature: WHERE exists
           | 'Bob'   | false |
           | 'Carol' | false |
 
+  # Alice is the discriminating row: 3 rows but 2 distinct, so the SKIP clears the table only if the DISTINCT was
+  # planned. Dave, with 3 distinct, keeps a row either way, so an all-false table cannot pass by accident.
   Scenario: Test EXISTS subquery whose body RETURN is DISTINCT
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'}), (d:Person {name: 'Dave'})
+          CREATE (f1:Friend {name: 'F1'}), (f2:Friend {name: 'F2'}), (f3:Friend {name: 'F3'})
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f1)
+          CREATE (a)-[:KNOWS]->(f2)
+          CREATE (b)-[:KNOWS]->(f1)
+          CREATE (d)-[:KNOWS]->(f1)
+          CREATE (d)-[:KNOWS]->(f2)
+          CREATE (d)-[:KNOWS]->(f3)
+          """
+      When executing query:
+          """
+          MATCH (p:Person)
+          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN DISTINCT f SKIP 2 } AS h
+          ORDER BY name;
+          """
+      Then the result should be, in order:
+          | name    | h     |
+          | 'Alice' | false |
+          | 'Bob'   | false |
+          | 'Carol' | false |
+          | 'Dave'  | true  |
+
+  Scenario: Test EXISTS subquery in a WHERE whose body RETURN aggregates
       Given an empty graph
       And having executed:
           """
@@ -1828,14 +1858,15 @@ Feature: WHERE exists
       When executing query:
           """
           MATCH (p:Person)
-          RETURN p.name AS name, EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN DISTINCT f } AS h
+          WHERE EXISTS { MATCH (p)-[:KNOWS]->(f) RETURN count(f) }
+          RETURN p.name AS name
           ORDER BY name;
           """
       Then the result should be, in order:
-          | name    | h     |
-          | 'Alice' | true  |
-          | 'Bob'   | true  |
-          | 'Carol' | false |
+          | name    |
+          | 'Alice' |
+          | 'Bob'   |
+          | 'Carol' |
 
   Scenario: Test EXISTS subquery in a WHERE whose body RETURN has a SKIP
       Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -1172,7 +1172,7 @@ Feature: WHERE exists
           | true  |
           | true  |
 
-  Scenario: EXISTS subquery body with no operators
+  Scenario: EXISTS subquery body that is only a RETURN
       Given an empty graph
       And having executed:
           """
@@ -1190,7 +1190,7 @@ Feature: WHERE exists
           | id    |
           | 1     |
 
-  Scenario: EXISTS subquery body that is a UNION of bodies with no operators
+  Scenario: EXISTS subquery body that is a UNION of RETURN-only bodies
       Given an empty graph
       And having executed:
           """
@@ -1210,7 +1210,7 @@ Feature: WHERE exists
           | id    |
           | 1     |
 
-  Scenario: EXISTS subquery in a projection whose body is a UNION with no operators
+  Scenario: EXISTS subquery in a projection whose body is a UNION of RETURN-only bodies
       Given an empty graph
       And having executed:
           """
@@ -1248,7 +1248,7 @@ Feature: WHERE exists
           | h    |
           | true |
 
-  Scenario: EXISTS subquery body that is a UNION of a branch with rows and one with no operators
+  Scenario: EXISTS subquery body that is a UNION of a branch with rows and a RETURN-only one
       Given an empty graph
       And having executed:
           """
@@ -1288,7 +1288,7 @@ Feature: WHERE exists
           | h     |
           | false |
 
-  Scenario: EXISTS subquery body with no operators in a projection
+  Scenario: EXISTS subquery body that is only a RETURN in a projection
       Given an empty graph
       And having executed:
           """
@@ -1305,7 +1305,7 @@ Feature: WHERE exists
           | h    |
           | true |
 
-  Scenario: EXISTS subquery body with no operators in a WITH projection
+  Scenario: EXISTS subquery body that is only a RETURN in a WITH projection
       Given an empty graph
       And having executed:
           """
@@ -1323,7 +1323,7 @@ Feature: WHERE exists
           | e    |
           | true |
 
-  Scenario: EXISTS subquery body with no operators in an ORDER BY
+  Scenario: EXISTS subquery body that is only a RETURN in an ORDER BY
       Given an empty graph
       And having executed:
           """
@@ -1488,7 +1488,7 @@ Feature: WHERE exists
           | 2  |
           | 1  |
 
-  Scenario: Test EXISTS subquery with a body with no operators inside a CASE
+  Scenario: Test EXISTS subquery with a RETURN-only body inside a CASE
       Given an empty graph
       And having executed:
           """

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8131,6 +8131,30 @@ TEST_P(CypherMainVisitorTest, ExistsThrow) {
                                                "EXISTS supports only a single relation or a subquery as its input.");
 }
 
+TEST_P(CypherMainVisitorTest, ExistsBodyRefusesPeriodicCommit) {
+  auto &ast_generator = *GetParam();
+
+  // The body parses as a full cypherQuery, so it carries the pre-query directives with it. Planning its RETURN would
+  // otherwise put a PeriodicCommit inside the branch, finalizing the caller's transaction from inside a predicate.
+  TestInvalidQueryWithMessage<SyntaxException>(
+      "MATCH (n) WHERE EXISTS { USING PERIODIC COMMIT 1 MATCH (n)-[]->(m) RETURN m } RETURN n;",
+      ast_generator,
+      "EXISTS subqueries cannot have a periodic commit.");
+  // The projection position reaches the same body check.
+  TestInvalidQueryWithMessage<SyntaxException>(
+      "MATCH (n) RETURN EXISTS { USING PERIODIC COMMIT 1 MATCH (n)-[]->(m) RETURN m } AS h;",
+      ast_generator,
+      "EXISTS subqueries cannot have a periodic commit.");
+  // The outer query may still have one - only the body is refused.
+  {
+    const auto *query = dynamic_cast<CypherQuery *>(
+        ast_generator.ParseQuery("USING PERIODIC COMMIT 1 MATCH (n) WHERE EXISTS { MATCH (n)-[]->(m) RETURN m } "
+                                 "SET n.x = 1 RETURN n;"));
+    ASSERT_TRUE(query);
+    EXPECT_NE(query->pre_query_directives_.commit_frequency_, nullptr);
+  }
+}
+
 TEST_P(CypherMainVisitorTest, ExistsBodyIsNotJudgedByTheEnclosingWith) {
   auto &ast_generator = *GetParam();
 

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8149,6 +8149,26 @@ TEST_P(CypherMainVisitorTest, ExistsBodyRefusesPeriodicCommit) {
   }
 }
 
+TEST_P(CypherMainVisitorTest, ExistsBodyRefusesParallelExecution) {
+  auto &ast_generator = *GetParam();
+
+  TestInvalidQueryWithMessage<SyntaxException>(
+      "MATCH (n) WHERE EXISTS { USING PARALLEL EXECUTION MATCH (n)-[]->(m) RETURN m } RETURN n;",
+      ast_generator,
+      "EXISTS subqueries cannot use parallel execution.");
+  TestInvalidQueryWithMessage<SyntaxException>(
+      "MATCH (n) WHERE EXISTS { USING PARALLEL EXECUTION 4 MATCH (n)-[]->(m) RETURN m } RETURN n;",
+      ast_generator,
+      "EXISTS subqueries cannot use parallel execution.");
+  // The outer query may still have one - only the body is refused.
+  {
+    const auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery(
+        "USING PARALLEL EXECUTION MATCH (n) WHERE EXISTS { MATCH (n)-[]->(m) RETURN m } RETURN n;"));
+    ASSERT_TRUE(query);
+    EXPECT_TRUE(query->pre_query_directives_.parallel_execution_);
+  }
+}
+
 TEST_P(CypherMainVisitorTest, ExistsBodyIsNotJudgedByTheEnclosingWith) {
   auto &ast_generator = *GetParam();
 

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8139,11 +8139,6 @@ TEST_P(CypherMainVisitorTest, ExistsBodyRefusesPeriodicCommit) {
       "MATCH (n) WHERE EXISTS { USING PERIODIC COMMIT 1 MATCH (n)-[]->(m) RETURN m } RETURN n;",
       ast_generator,
       "EXISTS subqueries cannot have a periodic commit.");
-  // The projection position reaches the same body check.
-  TestInvalidQueryWithMessage<SyntaxException>(
-      "MATCH (n) RETURN EXISTS { USING PERIODIC COMMIT 1 MATCH (n)-[]->(m) RETURN m } AS h;",
-      ast_generator,
-      "EXISTS subqueries cannot have a periodic commit.");
   // The outer query may still have one - only the body is refused.
   {
     const auto *query = dynamic_cast<CypherQuery *>(

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -8134,8 +8134,7 @@ TEST_P(CypherMainVisitorTest, ExistsThrow) {
 TEST_P(CypherMainVisitorTest, ExistsBodyRefusesPeriodicCommit) {
   auto &ast_generator = *GetParam();
 
-  // The body parses as a full cypherQuery, so it carries the pre-query directives with it. Planning its RETURN would
-  // otherwise put a PeriodicCommit inside the branch, finalizing the caller's transaction from inside a predicate.
+  // The body parses as a full cypherQuery, so it carries the pre-query directives with it.
   TestInvalidQueryWithMessage<SyntaxException>(
       "MATCH (n) WHERE EXISTS { USING PERIODIC COMMIT 1 MATCH (n)-[]->(m) RETURN m } RETURN n;",
       ast_generator,

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5138,8 +5138,7 @@ TYPED_TEST(TestPlanner, ExistsSubqueryMatchWhere) {
 }
 
 TYPED_TEST(TestPlanner, ExistsSubqueryMatchWherePlansReturn) {
-  // The body's RETURN is planned, not discarded, so the branch gains its Produce. Everything the RETURN body carries
-  // - DISTINCT, SKIP, LIMIT, aggregation - reaches the row count the fold reads.
+  // The body's RETURN is planned, not discarded, so the branch gains its Produce.
   FakeDbAccessor dba;
 
   auto name = dba.Property("name");
@@ -5272,8 +5271,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
   DeleteListContent(&exists_union_plan);
 }
 
-// A RETURN-only branch plans to a Produce over the Once its own constructor substitutes for a null input, so each
-// side of the UNION has real output symbols - GenUnion dereferences both operands to read them.
+// A RETURN-only branch plans to a Produce over the Once its constructor substitutes, so each side of the UNION has
+// the real output symbols GenUnion dereferences both operands to read.
 
 TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfReturnOnlyBodies) {
   // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } RETURN n

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5137,7 +5137,9 @@ TYPED_TEST(TestPlanner, ExistsSubqueryMatchWhere) {
   DeleteListContent(&filter_tree);
 }
 
-TYPED_TEST(TestPlanner, ExistsSubqueryMatchWhereOmitReturn) {
+TYPED_TEST(TestPlanner, ExistsSubqueryMatchWherePlansReturn) {
+  // The body's RETURN is planned, not discarded, so the branch gains its Produce. Everything the RETURN body carries
+  // - DISTINCT, SKIP, LIMIT, aggregation - reaches the row count the fold reads.
   FakeDbAccessor dba;
 
   auto name = dba.Property("name");
@@ -5149,8 +5151,11 @@ TYPED_TEST(TestPlanner, ExistsSubqueryMatchWhereOmitReturn) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{
-      new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(),
+                                         new ExpectFilter(),
+                                         new ExpectProduce(),
+                                         new ExpectLimit(),
+                                         new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5271,7 +5276,7 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
 // nothing. Each part gets its own Once before the combinator merges them - substituting one on the branch root would
 // come too late, and GenUnion dereferences both operands for their output symbols.
 
-TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodies) {
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfReturnOnlyBodies) {
   // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } RETURN n
   FakeDbAccessor dba;
 
@@ -5281,8 +5286,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodies) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
-  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce(), new ExpectProduce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce(), new ExpectProduce()};
   std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
                                                new ExpectDistinct(),
                                                new ExpectLimit(),
@@ -5300,7 +5305,7 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodies) {
   DeleteListContent(&exists_union_plan);
 }
 
-TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfEmptyBodies) {
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfReturnOnlyBodies) {
   // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION ALL RETURN 2 AS c } RETURN n - UNION ALL drops the Distinct.
   FakeDbAccessor dba;
 
@@ -5310,8 +5315,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfEmptyBodies) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
-  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce(), new ExpectProduce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce(), new ExpectProduce()};
   std::list<BaseOpChecker *> exists_union_plan{
       new ExpectUnion(left_exists_part, right_exists_part), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
 
@@ -5326,15 +5331,15 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfEmptyBodies) {
   DeleteListContent(&exists_union_plan);
 }
 
-TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfEmptyBodiesInReturnProjection) {
+TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfReturnOnlyBodiesInReturnProjection) {
   // MATCH (n) RETURN EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } AS h - the projection reaches the same branch
   // through the forced fold, which has no Limit/EvaluatePatternFilter tail to hide a null root.
   auto *exists_subquery =
       QUERY(SINGLE_QUERY(RETURN(LITERAL(1), AS("c"))), UNION(SINGLE_QUERY(RETURN(LITERAL(2), AS("c")))));
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), RETURN(EXISTS_SUBQUERY(exists_subquery), AS("h"))));
 
-  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce()};
-  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce()};
+  std::list<BaseOpChecker *> left_exists_part{new ExpectOnce(), new ExpectProduce()};
+  std::list<BaseOpChecker *> right_exists_part{new ExpectOnce(), new ExpectProduce()};
 
   Checkers input{ExpectOnce{}, ExpectScanAll{}};
   Checkers branch{ExpectUnion{left_exists_part, right_exists_part}, ExpectDistinct{}};

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -5272,9 +5272,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
   DeleteListContent(&exists_union_plan);
 }
 
-// A body's RETURN is dropped inside an exists subquery, so a UNION of RETURN-only branches plans both sides to
-// nothing. Each part gets its own Once before the combinator merges them - substituting one on the branch root would
-// come too late, and GenUnion dereferences both operands for their output symbols.
+// A RETURN-only branch plans to a Produce over the Once its own constructor substitutes for a null input, so each
+// side of the UNION has real output symbols - GenUnion dereferences both operands to read them.
 
 TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfReturnOnlyBodies) {
   // MATCH (n) WHERE EXISTS { RETURN 1 AS c UNION RETURN 2 AS c } RETURN n


### PR DESCRIPTION
> Formerly stacked on #4560 and #4596; both have merged, so this now targets `master` directly. #4598 (`COUNT { }`) stacks on top of it.

Makes an `EXISTS` subquery's body `RETURN` take effect instead of being thrown away.

**What.** `GenReturn` discarded the whole `ReturnBody` inside an exists subquery, so everything on it that decides the row count went with it — `DISTINCT`, `SKIP`, `LIMIT` and aggregation — and the fold answered from a branch that no longer represented the query:

| body | said | should say |
|---|---|---|
| `MATCH (p)-[:KNOWS]->(f) RETURN count(f)` | `false` for a person with no friends | `true` — an ungrouped aggregate emits one row even on empty input |
| `MATCH (p)-[:KNOWS]->(f) RETURN f LIMIT 0` | `true` | `false` — the table is empty |
| `MATCH (p)-[:KNOWS]->(f) RETURN f SKIP 1` | `true` for a one-row table | `false` |

The same query written with a `WITH` always behaved correctly, so the two spellings disagreed on the same graph. A `UNION` arm was wrong the same way: `EXISTS { RETURN 1 AS c SKIP 1 UNION RETURN 2 AS c SKIP 1 }` said `true`, because both arms planned to a bare `Once`.

**How.** Deletes the four-line early return from `GenReturn` (`rule_based_planner.cpp`). The `in_exists_subquery` parameter stays — `GenWith` still reads it to preserve outer-scope variables across a body `WITH` — but `GenReturn` no longer takes it.

Planning the body's `RETURN` means the branch now reaches all of `GenReturnBody`, including two operators that have no business inside a filter predicate: `PeriodicCommit`, which would finalize and re-timestamp the caller's transaction from inside an expression, and `Accumulate`, which drains its input on the first pull, below the fold, turning one write into one per matched row. Neither can reach a body once the clause validation below is closed. So rather than pass narrowed arguments — which would silently turn a write executing N times into a write executing once, if that validation ever regained a hole — `CheckExistsBodyInvariants` states both invariants and throws. A throw and not an assert — an assert would abort the process from an `EXPLAIN` alone.

`USING PERIODIC COMMIT` and `USING PARALLEL EXECUTION` in a body are refused in `visitExistsSubquery`, next to the existing memory-limit check. A body parses as a full `cypherQuery`, so it carries the pre-query directives with it, but only the enclosing query's are ever read — so a body directive was accepted and then silently dropped. Periodic commit was worse than inert: the body's own `QueryParts` picks up `commit_frequency`, so it would have reached the planner.

Also corrects two comments in `rule_based_planner.hpp`. The null-`input_op` guard is now unreachable and kept as defence; the `EmptyResult` suppression stays **load-bearing** — a body with no `RETURN` at all (`EXISTS { MATCH (n:Person) }`) still has empty output symbols, and wrapping it would make it universally false.

**The `UNION` allow-list hole.** `visitExistsSubquery` validated its clause rules against `cypher_query->single_query_` only, so a `UNION`'s later branches — each its own `SingleQuery` — were never checked, and every clause the first branch forbids was legal in the second. On master, a write in a later branch executed from inside a `WHERE` predicate:

```cypher
MATCH (person:Person)
WHERE EXISTS { MATCH (person)-[:HAS_CAT]->(cat:Cat) RETURN cat AS d
               UNION MATCH (other:Dog) CREATE (:Marker) RETURN other AS d }
RETURN person.name;
-- accepted; one :Marker created by the predicate
```

The earlier branch has to match nothing for it to fire, since the fold stops at the first row, so it was intermittent as well as wrong. The clause checks are now factored into one validator applied to `single_query_` and to every `cypher_unions_[i]->single_query_`. The directive checks need no such loop: `memory_limit_` and `pre_query_directives_` live on `CypherQuery`, one per body.

**Why.** Accepted openCypher settles which spelling is right: only the number of rows in the body's result table is relevant, and the `RETURN` is what produces that table. What the spec says to ignore is the *columns*, not the clause — which is what the removed comment had misread. Every dependent construct inherits the bug, so this has to land before `COUNT { … }`, where four of five body shapes would otherwise be wrong.

**Behaviour changes.** None of these is breaking: each either fixes an answer that was already wrong or rejects input that used to produce one.

- A body `RETURN` now takes effect: `EXISTS { … RETURN count(*) }` becomes always-true, and `SKIP`/`LIMIT` in a body start being honoured. Affected queries return different results without raising an error.
- **A body `RETURN`'s expressions are now evaluated**, where the discarded clause used to evaluate nothing. So a body expression can raise where the query previously answered — `EXISTS { MATCH (n)-[]->(m) RETURN 1/0 }` now throws — and it does so data-dependently, since an outer row whose body `MATCH` yields no rows never evaluates. The equivalent `WITH` spelling already threw, so this makes the two agree.
- `USING PERIODIC COMMIT` or `USING PARALLEL EXECUTION` inside an `EXISTS` body is now a syntax error rather than being silently ignored.
- A clause outside `MATCH`/`WHERE`/`WITH`/`RETURN` in a `UNION` branch of an `EXISTS` body is now a syntax error rather than being accepted, with a write there executing inside the predicate.

**Cost.** A body `ORDER BY` now plans a real `OrderBy` inside the branch, and both folds `Reset()` the branch per outer row, so the sort is redone for every one — where the deferred fold's `Limit(1)` previously stopped at the first row. Discardable work, since a sort cannot change whether a table is empty, but removing it is not a one-line change: `GenReturnBody` is shared with `GenWith`, whose `WHERE` is built above `SKIP`/`LIMIT` and is therefore order-sensitive. Left as a follow-up — a rewrite over the branch root, not a flag.