### PR TITLE
Use full job name in fail-fast action

### DIFF
--- a/.github/actions/cancel-on-failure-in-merge-queue/action.yml
+++ b/.github/actions/cancel-on-failure-in-merge-queue/action.yml
@@ -1,6 +1,12 @@
 name: 'Cancel run on merge_group failure'
 description: 'Emits an error annotation naming the failing job, then cancels the current workflow run via the GitHub API to fail fast. The annotation makes the real culprit identifiable in the run summary even though cancellation marks every job as cancelled. The caller must gate this with `if: failure() && github.event_name == ''merge_group''` because composite actions cannot read the calling job''s runtime status.'
 
+inputs:
+  job-name:
+    description: 'Name used to identify the failing job in the annotation. Defaults to `github.job`, the job id, which is ambiguous when several reusable workflows in the same run share an id (e.g. the `core` job of every `diff_*` workflow) — pass a qualified name such as "Release / Core tests" in that case.'
+    required: false
+    default: ''
+
 runs:
   using: 'composite'
   steps:
@@ -10,7 +16,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
-        JOB: ${{ github.job }}
+        JOB: ${{ inputs.job-name != '' && inputs.job-name || github.job }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         set -euo pipefail

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -162,3 +162,5 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Community / Core tests"

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -227,6 +227,8 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Coverage / Core tests"
 
   clang-tidy-community:
     if: ${{ inputs.run_clang_tidy == 'true' }}
@@ -318,6 +320,8 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Coverage / Clang tidy community"
 
   clang-tidy-enterprise:
     if: ${{ inputs.run_clang_tidy == 'true' }}
@@ -409,3 +413,5 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Coverage / Clang tidy enterprise"

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -222,6 +222,8 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Debug / Core tests"
 
   integration:
     if: ${{ inputs.run_integration == 'true' }}
@@ -338,3 +340,5 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Debug / Integration test"

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -212,3 +212,5 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Jepsen / Core tests"

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -141,3 +141,5 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Malloc / Build"

--- a/.github/workflows/diff_mgcxx.yml
+++ b/.github/workflows/diff_mgcxx.yml
@@ -43,3 +43,5 @@ jobs:
     - name: Cancel run on merge_group failure
       if: ${{ failure() && github.event_name == 'merge_group' }}
       uses: ./.github/actions/cancel-on-failure-in-merge-queue
+      with:
+        job-name: "MGCXX / Test MGCXX"

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -244,6 +244,8 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Release / Core tests"
 
   benchmark:
     if: ${{ inputs.run_benchmark == 'true' }}
@@ -512,6 +514,8 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Release / Benchmark"
 
   e2e:
     if: ${{ inputs.run_e2e == 'true' }}
@@ -673,6 +677,8 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Release / End to end tests"
 
   stress:
     if: ${{ inputs.run_stress == 'true' }}
@@ -853,6 +859,8 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Release / Stress tests"
 
   query_modules:
     if: ${{ inputs.run_query_modules == 'true' }}
@@ -989,3 +997,5 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Release / Query modules tests"

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -108,12 +108,6 @@ jobs:
           --arch $ARCH \
           run --custom-mirror $USE_CUSTOM_MIRROR
 
-      # TEMPORARY (revert before merging): forces "Release / Core tests" to fail
-      # right after the build container is up, so the merge-queue fail-fast
-      # annotation can be verified in CI.
-      - name: TEMPORARY fail-fast test
-        run: exit 1
-
       - name: Check core dump support
         run: |
           ./release/package/mgbuild.sh \
@@ -248,9 +242,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMPORARY (revert before merging): merge_group gate dropped so the
-        # fail-fast path also runs on pull_request/push events.
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Release / Core tests"

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -108,6 +108,12 @@ jobs:
           --arch $ARCH \
           run --custom-mirror $USE_CUSTOM_MIRROR
 
+      # TEMPORARY (revert before merging): forces "Release / Core tests" to fail
+      # right after the build container is up, so the merge-queue fail-fast
+      # annotation can be verified in CI.
+      - name: TEMPORARY fail-fast test
+        run: exit 1
+
       - name: Check core dump support
         run: |
           ./release/package/mgbuild.sh \
@@ -242,7 +248,9 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMPORARY (revert before merging): merge_group gate dropped so the
+        # fail-fast path also runs on pull_request/push events.
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Release / Core tests"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -1187,3 +1187,5 @@ jobs:
       - name: Cancel run on merge_group failure
         if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
+        with:
+          job-name: "Build and Test MAGE (${{ inputs.arch }}${{ inputs.cuda && ', cuda' || '' }})"


### PR DESCRIPTION
Added an optional input to the `cancel-on-failure-in-merge-queue` action to define the name of the job that causes the cancellation.