### PR TITLE
fix(utils): carry sub-second values into the coarser field

### DIFF
--- a/src/utils/temporal.cpp
+++ b/src/utils/temporal.cpp
@@ -391,19 +391,29 @@ LocalTime::LocalTime(const LocalTimeParameters &local_time_parameters) {
     throw temporal::InvalidArgumentException("Creating a LocalTime with invalid seconds parameter.");
   }
 
-  if (!IsInBounds(0, 999, local_time_parameters.millisecond)) {
-    throw temporal::InvalidArgumentException("Creating a LocalTime with invalid milliseconds parameter.");
+  // The sub-second fields are scales of one fraction of a second, so a value
+  // beyond its own scale carries into the coarser field: 1500 microseconds is a
+  // millisecond and a half. Storing the fraction canonically keeps one
+  // representation per instant, which the field-wise comparison and the hash
+  // both rely on.
+  constexpr int64_t kMicrosecondsPerMillisecond = 1000;
+  constexpr int64_t kMicrosecondsPerSecond = 1'000'000;
+  if (!IsInBounds(0, kMicrosecondsPerSecond, local_time_parameters.millisecond) ||
+      !IsInBounds(0, kMicrosecondsPerSecond, local_time_parameters.microsecond)) {
+    throw temporal::InvalidArgumentException("Creating a LocalTime with a negative or overlarge sub-second parameter.");
   }
-
-  if (!IsInBounds(0, 999, local_time_parameters.microsecond)) {
-    throw temporal::InvalidArgumentException("Creating a LocalTime with invalid microseconds parameter.");
+  const auto fraction =
+      local_time_parameters.millisecond * kMicrosecondsPerMillisecond + local_time_parameters.microsecond;
+  if (fraction >= kMicrosecondsPerSecond) {
+    throw temporal::InvalidArgumentException(
+        "Creating a LocalTime whose milliseconds and microseconds reach a whole second.");
   }
 
   hour = local_time_parameters.hour;
   minute = local_time_parameters.minute;
   second = local_time_parameters.second;
-  millisecond = local_time_parameters.millisecond;
-  microsecond = local_time_parameters.microsecond;
+  millisecond = fraction / kMicrosecondsPerMillisecond;
+  microsecond = fraction % kMicrosecondsPerMillisecond;
 }
 
 std::chrono::microseconds LocalTime::SumLocalTimeParts() const {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -3011,6 +3011,27 @@ TYPED_TEST(FunctionTest, Date) {
   EXPECT_TRUE(this->EvaluateFunction("DATE", TypedValue()).IsNull());
 }
 
+TYPED_TEST(FunctionTest, LocalTimeSubSecondFieldsCarry) {
+  // A fraction may be written at whichever scale the caller has it in, so a
+  // count of microseconds beyond a millisecond is read as the time it names
+  // rather than refused.
+  EXPECT_EQ(this->EvaluateFunction("LOCALTIME",
+                                   TypedValue(std::map<std::string, TypedValue>{{"hour", TypedValue(1)},
+                                                                                {"minute", TypedValue(2)},
+                                                                                {"second", TypedValue(3)},
+                                                                                {"microsecond", TypedValue(1500)}}))
+                .ValueLocalTime(),
+            memgraph::utils::LocalTime({1, 2, 3, 1, 500}));
+
+  // The fraction stops short of a whole second, which would otherwise carry
+  // into the second the caller gave.
+  EXPECT_THROW(this->EvaluateFunction(
+                   "LOCALTIME",
+                   TypedValue(std::map<std::string, TypedValue>{
+                       {"hour", TypedValue(1)}, {"second", TypedValue(3)}, {"microsecond", TypedValue(1'000'000)}})),
+               memgraph::utils::temporal::InvalidArgumentException);
+}
+
 TYPED_TEST(FunctionTest, LocalTime) {
   const auto local_time = memgraph::utils::LocalTime({13, 3, 2, 0, 0});
   EXPECT_EQ(this->EvaluateFunction("LOCALTIME", "130302").ValueLocalTime(), local_time);

--- a/tests/unit/utils_temporal.cpp
+++ b/tests/unit/utils_temporal.cpp
@@ -64,7 +64,12 @@ inline constexpr std::array test_local_times{TestLocalTimeParameters{{.hour = 24
                                              TestLocalTimeParameters{{.millisecond = -1}, true},
                                              TestLocalTimeParameters{{.millisecond = 1000}, true},
                                              TestLocalTimeParameters{{.microsecond = -1}, true},
-                                             TestLocalTimeParameters{{.microsecond = 1000}, true},
+                                             TestLocalTimeParameters{{.microsecond = 1'000'000}, true},
+                                             TestLocalTimeParameters{{.millisecond = 999, .microsecond = 1000}, true},
+                                             TestLocalTimeParameters{{.microsecond = 1000}, false},
+                                             TestLocalTimeParameters{{.microsecond = 1500}, false},
+                                             TestLocalTimeParameters{{.microsecond = 999'999}, false},
+                                             TestLocalTimeParameters{{.millisecond = 4, .microsecond = 1500}, false},
                                              TestLocalTimeParameters{{23, 59, 59, 999, 999}, false},
                                              TestLocalTimeParameters{{0, 0, 0, 0, 0}, false}};
 
@@ -174,6 +179,35 @@ TEST(TemporalTest, LocalTimeConstruction) {
       ASSERT_NO_THROW(test_local_time.emplace(local_time_parameters));
     }
   }
+}
+
+TEST(TemporalTest, LocalTimeSubSecondFieldsCarry) {
+  using memgraph::utils::LocalTime;
+  using memgraph::utils::LocalTimeParameters;
+
+  // A value finer than its own scale carries into the coarser field, so 1500
+  // microseconds is a millisecond and a half however it is written.
+  EXPECT_EQ(LocalTime(LocalTimeParameters{.microsecond = 1500}),
+            LocalTime(LocalTimeParameters{.millisecond = 1, .microsecond = 500}));
+  EXPECT_EQ(LocalTime(LocalTimeParameters{.millisecond = 4, .microsecond = 1500}),
+            LocalTime(LocalTimeParameters{.millisecond = 5, .microsecond = 500}));
+  EXPECT_EQ(LocalTime(LocalTimeParameters{.microsecond = 999'999}),
+            LocalTime(LocalTimeParameters{.millisecond = 999, .microsecond = 999}));
+
+  // Equal instants must be one value, which the field-wise comparison and the
+  // hash both depend on.
+  const LocalTime written_as_micro{LocalTimeParameters{.microsecond = 1500}};
+  const LocalTime written_as_milli{LocalTimeParameters{.millisecond = 1, .microsecond = 500}};
+  EXPECT_EQ(written_as_micro, written_as_milli);
+  EXPECT_EQ(memgraph::utils::LocalTimeHash{}(written_as_micro), memgraph::utils::LocalTimeHash{}(written_as_milli));
+  EXPECT_EQ(written_as_micro.MicrosecondsSinceEpoch(), 1500);
+  EXPECT_EQ(written_as_micro.ToString(), "00:00:00.001500");
+
+  // The fraction stops short of a whole second, which would otherwise carry
+  // into the second the caller gave.
+  EXPECT_THROW(LocalTime(LocalTimeParameters{.microsecond = 1'000'000}), memgraph::utils::BasicException);
+  EXPECT_THROW(LocalTime(LocalTimeParameters{.millisecond = 999, .microsecond = 1000}),
+               memgraph::utils::BasicException);
 }
 
 TEST(TemporalTest, LocalTimeMicrosecondsSinceEpochConversion) {


### PR DESCRIPTION
A local time built from components now reads a sub-second field beyond its own
scale as the time it names rather than refusing it, so 1500 microseconds is a
millisecond and a half. Requiring each field to fill only its own three digits
made the caller convert a measurement they already held, for no gain.

The fraction is stored canonically, one representation per instant, which the
field-wise comparison and the hash both depend on. It must still stop short of a
whole second, since carrying into the second would silently change a component
the caller gave.
