### PR TITLE
fix: limit link threads in CI to avoid OOM

### DIFF
--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -95,12 +95,15 @@ jobs:
 
       - name: Build community binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph --community \
+          --link-threads $LINK_THREADS \
           --split-debug \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -102,6 +102,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph --community \
           --link-threads $LINK_THREADS \
           --split-debug \

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -147,6 +147,7 @@ jobs:
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           --no-ccache \
+          --threads 12 \
           build-memgraph --coverage --asan --ubsan \
           --link-threads $LINK_THREADS \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -112,6 +112,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph \
           --link-threads $LINK_THREADS \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
@@ -277,6 +278,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph \
           --link-threads $LINK_THREADS \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -90,6 +90,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph \
           --link-threads $LINK_THREADS \
           --conan-remote $CONAN_REMOTE \

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -83,12 +83,15 @@ jobs:
 
       - name: Build release binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
           --conan-password $CONAN_PASSWORD

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -87,12 +87,15 @@ jobs:
 
       - name: Build release binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph --disable-jemalloc --split-debug \
+          --link-threads $LINK_THREADS \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \
           --conan-remote $CONAN_REMOTE \

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -94,6 +94,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph --disable-jemalloc --split-debug \
           --link-threads $LINK_THREADS \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -118,12 +118,15 @@ jobs:
 
       - name: Build release binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --split-debug \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \
@@ -292,12 +295,15 @@ jobs:
 
       - name: Build release binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --split-debug \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \
@@ -560,12 +566,15 @@ jobs:
 
       - name: Build release binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --split-debug \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \
@@ -721,12 +730,15 @@ jobs:
 
       - name: Build release binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --split-debug \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \
@@ -901,12 +913,15 @@ jobs:
 
       - name: Build release binary
         run: |
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --split-debug \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -125,6 +125,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph \
           --link-threads $LINK_THREADS \
           --split-debug \
@@ -295,15 +296,12 @@ jobs:
 
       - name: Build release binary
         run: |
-          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
-          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           build-memgraph \
-          --link-threads $LINK_THREADS \
           --split-debug \
           ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
           ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \
@@ -573,6 +571,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph \
           --link-threads $LINK_THREADS \
           --split-debug \
@@ -737,6 +736,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph \
           --link-threads $LINK_THREADS \
           --split-debug \
@@ -920,6 +920,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads 12 \
           build-memgraph \
           --link-threads $LINK_THREADS \
           --split-debug \


### PR DESCRIPTION
Too many linker threads == too much memory usage in CI, so we limit them to reduce the chance of future OOM kills.


