### PR TITLE
fix: pin git ref on daily build and flakiness diff

### DIFF
--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -108,6 +108,7 @@ jobs:
       os: 'ubuntu-24.04'
       run_core: ${{ needs.DiffSetup.outputs.run_community_core }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit
 
   Coverage:
@@ -124,6 +125,7 @@ jobs:
       run_core: ${{ needs.DiffSetup.outputs.run_coverage_core }}
       run_clang_tidy: ${{ needs.DiffSetup.outputs.run_coverage_core }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit
 
   Debug:
@@ -140,6 +142,7 @@ jobs:
       run_core: ${{ needs.DiffSetup.outputs.run_debug_core }}
       run_integration: ${{ needs.DiffSetup.outputs.run_debug_integration }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit
 
   Jepsen:
@@ -153,6 +156,7 @@ jobs:
     with:
       run_core: ${{ needs.DiffSetup.outputs.run_jepsen_core }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit
 
   Release:
@@ -172,6 +176,7 @@ jobs:
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
       run_query_modules: ${{ needs.DiffSetup.outputs.run_release_query_modules }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit
 
   Malloc:
@@ -187,6 +192,7 @@ jobs:
       os: 'ubuntu-24.04'
       run_build: ${{ needs.DiffSetup.outputs.run_malloc_build }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit
 
   Mage:
@@ -202,6 +208,7 @@ jobs:
       run_arm: ${{ needs.DiffSetup.outputs.run_mage_arm == 'true' }}
       run_cuda: ${{ needs.DiffSetup.outputs.run_mage_cuda == 'true' }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit
 
   MGCXX:
@@ -215,4 +222,5 @@ jobs:
     with:
       run_test: ${{ needs.DiffSetup.outputs.run_mgcxx_unit == 'true' }}
       run_id: "${{ matrix.run_no }}"
+      ref: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/reusable_issu_test.yaml
+++ b/.github/workflows/reusable_issu_test.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0 # Required because of release/get_version.py
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: "Checkout infra repository"
         # SBOM generation uses the scripts from the memgraph/infra repo.

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -165,7 +165,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: "Checkout infra repository"
         # SBOM generation uses the scripts from the memgraph/infra repo.

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -173,7 +173,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -301,7 +301,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -458,7 +458,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -570,7 +570,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -713,7 +713,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -864,7 +864,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref:  ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref:  ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -1000,7 +1000,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -1140,7 +1140,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -1310,7 +1310,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -1489,7 +1489,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -1617,7 +1617,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()

--- a/.github/workflows/reusable_smoke_test_docker.yml
+++ b/.github/workflows/reusable_smoke_test_docker.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()

--- a/.github/workflows/reusable_stress_tests.yaml
+++ b/.github/workflows/reusable_stress_tests.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -193,7 +193,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -322,7 +322,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()
@@ -440,7 +440,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Clean up Docker
         if: always()


### PR DESCRIPTION
Bug in the daily build and check diff for flakiness workflows mean that scheduled runs on `master` do not pin an exact SHA - so merging PRs between the workflow start time and the jobs it spawns can cause breakages, particularly if those PRs change the workflow logic.

