### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/tests/e2e/streams/kafka/docker-compose.yml
+++ b/tests/e2e/streams/kafka/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zookeeper:
-    image: 'bitnami/zookeeper:3.9.1'
+    image: 'soldevelo/zookeeper:3.9.5'
     ports:
       - '2181:2181'
     environment:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/zookeeper:3.9.1` → [`soldevelo/zookeeper:3.9.5`](https://hub.docker.com/r/soldevelo/zookeeper)