### PR TITLE
fix(metrics): keep a database's metrics while a registration holds them

### DIFF
--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -95,19 +95,21 @@ memory::ArenaPool &Database::Arena() noexcept { return *db_arena_; }
 
 memory::ArenaPool &Database::Arena() const noexcept { return *db_arena_; }
 
+namespace {
+
+// A coordinator reports no per-database metrics under OpenMetrics, and some databases ask not to be
+// measured at all; both hold an empty registration, which releases nothing.
+auto RegisterMetrics(storage::Config const &config) -> metrics::PrometheusMetrics::Registration {
+  if (!config.register_metrics) return {};
+  if (FLAGS_metrics_format == "OpenMetrics" && flags::CoordinationSetupInstance().IsCoordinator()) return {};
+  return metrics::Metrics().AddDatabase(config.salient.uuid, config.salient.name.str());
+}
+
+}  // namespace
+
 Database::Database(storage::Config config, std::function<storage::DatabaseProtectorPtr()> database_protector_factory)
-    : db_arena_(std::make_unique<memory::ArenaPool>(&db_memory_tracker_)),
-      metrics_(config.salient.uuid, ([&config]() -> metrics::DatabaseMetricHandles {
-                 if (!config.register_metrics) {
-                   return {};
-                 }
-                 auto const should_register =
-                     !(FLAGS_metrics_format == "OpenMetrics" && flags::CoordinationSetupInstance().IsCoordinator());
-                 if (!should_register) {
-                   return {};
-                 }
-                 return metrics::Metrics().AddDatabase(config.salient.uuid, config.salient.name.str());
-               })()),
+    : metrics_(RegisterMetrics(config)),
+      db_arena_(std::make_unique<memory::ArenaPool>(&db_memory_tracker_)),
       after_commit_trigger_pool_{1,
                                  // After-commit triggers run on a dedicated DB worker.
                                  // Keep a DB arena scope alive for the full worker lifetime.
@@ -151,8 +153,6 @@ Database::Database(storage::Config config, std::function<storage::DatabaseProtec
                                            &db_embedding_memory_tracker_);
   }
 }
-
-Database::DatabaseMetricsRegistration::~DatabaseMetricsRegistration() { metrics::Metrics().RemoveDatabase(uuid_); }
 
 DatabaseInfo Database::GetInfo() const {
   DatabaseInfo info;

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -237,6 +237,10 @@ class Database {
   metrics::DatabaseMetricHandles *metric_handles() { return &metrics_.handles(); }
 
  private:
+  // Declared first so it is released last: the storage's garbage collector writes to these metrics
+  // until it is joined, which happens while the storage is being destroyed.
+  metrics::PrometheusMetrics::Registration metrics_;
+
   // Enforcement-only: caps total per-DB memory (tenant profile limit).
   // No parent — does not roll up to any global. Per-DB domain trackers list this
   // as their second parent so every allocation is counted here AND in the domain global.
@@ -252,30 +256,6 @@ class Database {
   utils::MemoryTracker db_query_memory_tracker_{&db_total_memory_tracker_};
   std::unique_ptr<memory::ArenaPool> db_arena_;  //!< Per-DB jemalloc arena pool with tracking hooks
 
-  // RAII guard that de-registers this database's metric handles from the
-  // global PrometheusMetrics registry on destruction.
-  class DatabaseMetricsRegistration {
-   public:
-    DatabaseMetricsRegistration(utils::UUID uuid, metrics::DatabaseMetricHandles handles)
-        : uuid_(uuid), handles_(std::move(handles)) {}
-
-    ~DatabaseMetricsRegistration();
-
-    DatabaseMetricsRegistration(DatabaseMetricsRegistration const &) = delete;
-    DatabaseMetricsRegistration &operator=(DatabaseMetricsRegistration const &) = delete;
-    DatabaseMetricsRegistration(DatabaseMetricsRegistration &&) = delete;
-    DatabaseMetricsRegistration &operator=(DatabaseMetricsRegistration &&) = delete;
-
-    metrics::DatabaseMetricHandles const &handles() const { return handles_; }
-
-    metrics::DatabaseMetricHandles &handles() { return handles_; }
-
-   private:
-    utils::UUID uuid_;
-    metrics::DatabaseMetricHandles handles_{};
-  };
-
-  DatabaseMetricsRegistration metrics_;                 //!< De-registration guard for this db's prometheus metrics
   std::unique_ptr<storage::Storage> storage_;           //!< Underlying storage
   std::unique_ptr<query::TriggerStore> trigger_store_;  //!< Triggers associated with the storage
   utils::ThreadPool after_commit_trigger_pool_{1};      //!< Thread pool for after commit triggers

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -934,14 +934,24 @@ StorageSnapshot PrometheusMetrics::ResolveStorageSnapshot(utils::UUID const &uui
   return StorageSnapshot{};
 }
 
-DatabaseMetricHandles PrometheusMetrics::AddDatabase(utils::UUID const &uuid, std::string_view name) {
+PrometheusMetrics::Registration PrometheusMetrics::AddDatabase(utils::UUID const &uuid, std::string_view name) {
   std::lock_guard const lock{databases_.mutex};
   if (name == dbms::kDefaultDB) {
     default_db_uuid_ = uuid;
   }
+
+  auto const existing =
+      r::find_if(databases_.entries, [&uuid, name](auto const &e) { return e.uuid == uuid && e.db_name == name; });
+  if (existing != databases_.entries.end()) {
+    ++existing->registrations;
+    return Registration{this, existing->id, existing->handles};
+  }
+
   prometheus::Labels const labels{{"database", std::string(name)}, {"uuid", std::string(uuid)}};
+  auto const entry_id = databases_.next_entry_id++;
   databases_.entries.push_back(
       {
+          .id = entry_id,
           .uuid = uuid,
           .db_name = std::string(name),
           .handles =
@@ -1059,13 +1069,36 @@ DatabaseMetricHandles PrometheusMetrics::AddDatabase(utils::UUID const &uuid, st
                   .gc_index_sweeps = {&gc_index_sweeps_family_.Add(labels)},
               },
       });
-  return databases_.entries.back().handles;
+  return Registration{this, entry_id, databases_.entries.back().handles};
 }
 
-void PrometheusMetrics::RemoveDatabase(utils::UUID const &uuid) {
+PrometheusMetrics::Registration::~Registration() { Release(); }
+
+PrometheusMetrics::Registration::Registration(Registration &&other) noexcept
+    : registry_(std::exchange(other.registry_, nullptr)),
+      entry_id_(std::exchange(other.entry_id_, 0)),
+      handles_(std::exchange(other.handles_, DatabaseMetricHandles{})) {}
+
+auto PrometheusMetrics::Registration::operator=(Registration &&other) noexcept -> Registration & {
+  if (this == &other) return *this;
+  Release();
+  registry_ = std::exchange(other.registry_, nullptr);
+  entry_id_ = std::exchange(other.entry_id_, 0);
+  handles_ = std::exchange(other.handles_, DatabaseMetricHandles{});
+  return *this;
+}
+
+void PrometheusMetrics::Registration::Release() noexcept {
+  if (registry_ == nullptr) return;
+  std::exchange(registry_, nullptr)->ReleaseRegistration(entry_id_);
+  handles_ = {};
+}
+
+void PrometheusMetrics::ReleaseRegistration(uint64_t entry_id) {
   std::lock_guard const lock{databases_.mutex};
-  auto it = r::find_if(databases_.entries, [&uuid](auto const &e) { return e.uuid == uuid; });
+  auto it = r::find_if(databases_.entries, [entry_id](auto const &e) { return e.id == entry_id; });
   if (it == databases_.entries.end()) return;
+  if (--it->registrations != 0) return;
   auto &h = it->handles;
   vertex_count_family_.Remove(h.vertex_count.get());
   edge_count_family_.Remove(h.edge_count.get());
@@ -1170,7 +1203,7 @@ void PrometheusMetrics::RemoveDatabase(utils::UUID const &uuid) {
   gc_latency_family_.Remove(h.gc_latency_seconds.get());
   gc_skiplist_cleanup_latency_family_.Remove(h.gc_skiplist_cleanup_latency_seconds.get());
   gc_index_sweeps_family_.Remove(h.gc_index_sweeps.get());
-  if (default_db_uuid_ && *default_db_uuid_ == uuid) {
+  if (default_db_uuid_ && *default_db_uuid_ == it->uuid) {
     default_db_uuid_.reset();
   }
   databases_.entries.erase(it);

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -186,8 +186,37 @@ class PrometheusMetrics {
   PrometheusMetrics &operator=(PrometheusMetrics &&) = delete;
   ~PrometheusMetrics() = default;
 
-  DatabaseMetricHandles AddDatabase(utils::UUID const &uuid, std::string_view name);
-  void RemoveDatabase(utils::UUID const &uuid);
+  /// Owns one registration of a database's metrics and releases it on destruction. Move-only, so
+  /// exactly one object releases each registration. It releases the entry it registered rather than
+  /// one matching a uuid or a name, so a database that is renamed or rebound still releases its own.
+  class Registration {
+   public:
+    Registration() = default;
+    ~Registration();
+
+    Registration(Registration &&other) noexcept;
+    Registration &operator=(Registration &&other) noexcept;
+    Registration(Registration const &) = delete;
+    Registration &operator=(Registration const &) = delete;
+
+    DatabaseMetricHandles const &handles() const { return handles_; }
+
+    DatabaseMetricHandles &handles() { return handles_; }
+
+   private:
+    friend class PrometheusMetrics;
+
+    Registration(PrometheusMetrics *registry, uint64_t entry_id, DatabaseMetricHandles handles)
+        : registry_(registry), entry_id_(entry_id), handles_(std::move(handles)) {}
+
+    void Release() noexcept;
+
+    PrometheusMetrics *registry_{nullptr};
+    uint64_t entry_id_{0};
+    DatabaseMetricHandles handles_{};
+  };
+
+  [[nodiscard]] Registration AddDatabase(utils::UUID const &uuid, std::string_view name);
   void RebindDefaultDatabaseUUID(utils::UUID const &new_uuid);
   void UpdateGauges();
 
@@ -227,10 +256,19 @@ class PrometheusMetrics {
 
  private:
   struct DatabaseEntry {
+    // Identifies the entry for its whole life, unlike the uuid and the name, either of which can
+    // change while registrations are outstanding.
+    uint64_t id;
     utils::UUID uuid;
     std::string db_name;
     DatabaseMetricHandles handles;
+    // Registrations of one database share every handle, because a family returns the metric it
+    // already holds for a label set. The metrics go when the last registration does.
+    std::size_t registrations{1};
   };
+
+  /// Drops one registration of the entry, and the metrics with the last of them.
+  void ReleaseRegistration(uint64_t entry_id);
 
   StorageSnapshot ResolveStorageSnapshot(utils::UUID const &uuid) const;
 
@@ -239,6 +277,7 @@ class PrometheusMetrics {
   struct {
     mutable std::shared_mutex mutex;
     std::list<DatabaseEntry> entries;
+    uint64_t next_entry_id{1};
   } databases_;
 
   std::unordered_map<std::string, int64_t> legacy_json_prev_ha_counter_values_;

--- a/tests/unit/prometheus_metrics.cpp
+++ b/tests/unit/prometheus_metrics.cpp
@@ -18,6 +18,7 @@
 #include <prometheus/metric_family.h>
 #include <prometheus/registry.h>
 
+#include "dbms/constants.hpp"
 #include "dbms/database.hpp"
 #include "disk_test_utils.hpp"
 #include "flags/general.hpp"
@@ -48,10 +49,10 @@ std::optional<double> FindSample(std::vector<prometheus::MetricFamily> const &fa
 TEST(PrometheusMetrics, GetOrAddDatabaseRegistersMetrics) {
   FLAGS_metrics_format = "OpenMetrics";
   memgraph::metrics::PrometheusMetrics pm;
-  auto handles = pm.AddDatabase(memgraph::utils::UUID{}, "db1");
+  auto reg = pm.AddDatabase(memgraph::utils::UUID{}, "db1");
 
-  handles.vertex_count.Set(42.0);
-  handles.committed_transactions.Increment(5.0);
+  reg.handles().vertex_count.Set(42.0);
+  reg.handles().committed_transactions.Increment(5.0);
 
   auto const families = pm.registry().Collect();
   EXPECT_EQ(FindSample(families, "memgraph_vertex_count", "db1"), 42.0);
@@ -61,11 +62,11 @@ TEST(PrometheusMetrics, GetOrAddDatabaseRegistersMetrics) {
 TEST(PrometheusMetrics, MultipleDatabasesAreIsolated) {
   FLAGS_metrics_format = "OpenMetrics";
   memgraph::metrics::PrometheusMetrics pm;
-  auto h1 = pm.AddDatabase(memgraph::utils::UUID{}, "db1");
-  auto h2 = pm.AddDatabase(memgraph::utils::UUID{}, "db2");
+  auto db1 = pm.AddDatabase(memgraph::utils::UUID{}, "db1");
+  auto db2 = pm.AddDatabase(memgraph::utils::UUID{}, "db2");
 
-  h1.vertex_count.Set(10.0);
-  h2.vertex_count.Set(20.0);
+  db1.handles().vertex_count.Set(10.0);
+  db2.handles().vertex_count.Set(20.0);
 
   auto const families = pm.registry().Collect();
   EXPECT_EQ(FindSample(families, "memgraph_vertex_count", "db1"), 10.0);
@@ -86,7 +87,7 @@ TEST(PrometheusMetrics, UpdateGaugesSetsStorageValues) {
         if (uuid == db1_uuid) return snapshot;
         return std::nullopt;
       });
-  pm.AddDatabase(db1_uuid, "db1");
+  auto const db1 = pm.AddDatabase(db1_uuid, "db1");
 
   pm.UpdateGauges();
 
@@ -101,13 +102,50 @@ TEST(PrometheusMetrics, UpdateGaugesSetsStorageValues) {
 TEST(PrometheusMetrics, RemoveDatabaseRemovesMetrics) {
   memgraph::metrics::PrometheusMetrics pm;
   memgraph::utils::UUID const uuid{};
-  auto handles = pm.AddDatabase(uuid, "db1");
-  handles.vertex_count.Set(99.0);
+  auto reg = pm.AddDatabase(uuid, "db1");
+  reg.handles().vertex_count.Set(99.0);
 
-  pm.RemoveDatabase(uuid);
+  reg = {};
 
   auto const families = pm.registry().Collect();
   EXPECT_EQ(FindSample(families, "memgraph_vertex_count", "db1"), std::nullopt);
+}
+
+// Metrics survive a deregistration while another registration still holds them.
+TEST(PrometheusMetrics, MetricsSurviveWhileAnotherRegistrationHoldsThem) {
+  memgraph::metrics::PrometheusMetrics pm;
+  memgraph::utils::UUID const uuid{};
+
+  auto first = pm.AddDatabase(uuid, "db1");
+  auto second = pm.AddDatabase(uuid, "db1");
+  ASSERT_EQ(first.handles().vertex_count.get(), second.handles().vertex_count.get()) << "one label set, one metric";
+
+  first = {};
+
+  // Checked before the handle is used: writing through a dropped metric is the bug under test.
+  ASSERT_NE(FindSample(pm.registry().Collect(), "memgraph_vertex_count", "db1"), std::nullopt);
+
+  second.handles().vertex_count.Set(7.0);
+  EXPECT_EQ(FindSample(pm.registry().Collect(), "memgraph_vertex_count", "db1"), 7.0);
+
+  second = {};
+  EXPECT_EQ(FindSample(pm.registry().Collect(), "memgraph_vertex_count", "db1"), std::nullopt);
+}
+
+// A database's metrics are identified by the labels it registered under, so deregistering one name
+// must not take the entry a second name registered under the same uuid.
+TEST(PrometheusMetrics, RemovingOneNameLeavesTheOtherRegisteredUnderThatUuid) {
+  memgraph::metrics::PrometheusMetrics pm;
+  memgraph::utils::UUID const uuid{};
+
+  auto under_old_name = pm.AddDatabase(uuid, "old");
+  auto under_new_name = pm.AddDatabase(uuid, "new");
+
+  under_new_name = {};
+
+  under_old_name.handles().vertex_count.Set(5.0);
+  EXPECT_EQ(FindSample(pm.registry().Collect(), "memgraph_vertex_count", "old"), 5.0);
+  EXPECT_EQ(FindSample(pm.registry().Collect(), "memgraph_vertex_count", "new"), std::nullopt);
 }
 
 TEST(DatabaseMetrics, SwitchToOnDiskUpdatesSnapshotCallback) {
@@ -157,7 +195,7 @@ TEST(PrometheusMetrics, UpdateGaugesReturnsZeroAfterDefaultDbUuidChange) {
       });
 
   // Metrics registered with original uuid_a, as happens at startup
-  pm.AddDatabase(uuid_a, "memgraph");
+  auto const registration = pm.AddDatabase(uuid_a, "memgraph");
 
   // Simulate HA UUID realignment on joining cluster: storage now answers to
   // uuid_b
@@ -203,4 +241,87 @@ TEST(MetricHandles, ScopedGaugeNullSafety) {
 
 TEST(MetricHandles, ScopedHistogramTimerNullSafety) {
   EXPECT_NO_FATAL_FAILURE([] { memgraph::metrics::ScopedHistogramTimer timer{nullptr}; }());
+}
+
+namespace {
+
+// Samples carry the labels the database registered under, so a stale series is found by its uuid
+// rather than by the name a later database may reuse.
+std::optional<double> FindSampleByUuid(std::vector<prometheus::MetricFamily> const &families, std::string_view name,
+                                       memgraph::utils::UUID const &uuid) {
+  auto const wanted = std::string{uuid};
+  for (auto const &family : families) {
+    if (family.name != name) continue;
+    for (auto const &metric : family.metric) {
+      auto const has_uuid_label =
+          std::ranges::any_of(metric.label, [&](auto const &l) { return l.name == "uuid" && l.value == wanted; });
+      if (!has_uuid_label) continue;
+      if (family.type == prometheus::MetricType::Gauge) return metric.gauge.value;
+      if (family.type == prometheus::MetricType::Counter) return metric.counter.value;
+    }
+  }
+  return std::nullopt;
+}
+
+auto MakeConfig(std::filesystem::path const &dir, std::string_view name, memgraph::utils::UUID const &uuid)
+    -> memgraph::storage::Config {
+  memgraph::storage::Config config;
+  config.durability.storage_directory = dir;
+  config.salient.name = std::string{name};
+  config.salient.uuid = uuid;
+  return config;
+}
+
+}  // namespace
+
+// Two databases can hold one database's identity at once: a resume that rebuilds a tenant before its
+// predecessor has finished dying gives both the same name and uuid, and so the same metrics. The
+// metrics belong to both until the second one goes.
+TEST(DatabaseMetrics, MetricsOutliveADatabaseWhileAnotherSharesItsIdentity) {
+  auto const root = std::filesystem::temp_directory_path() / "mg_test_metrics_shared_identity";
+  std::filesystem::remove_all(root);
+  memgraph::utils::UUID const uuid{};
+
+  {
+    memgraph::dbms::Database second{MakeConfig(root / "second", "shared_identity", uuid)};
+    {
+      memgraph::dbms::Database first{MakeConfig(root / "first", "shared_identity", uuid)};
+      ASSERT_NE(FindSampleByUuid(memgraph::metrics::Metrics().registry().Collect(), "memgraph_vertex_count", uuid),
+                std::nullopt);
+    }
+
+    // `first` is gone; `second` is still running, and its garbage collector writes to these metrics
+    // every pass, so they must still be registered.
+    EXPECT_NE(FindSampleByUuid(memgraph::metrics::Metrics().registry().Collect(), "memgraph_vertex_count", uuid),
+              std::nullopt)
+        << "the surviving database's metrics were freed with the other's";
+  }
+
+  std::filesystem::remove_all(root);
+}
+
+// A replica joining a cluster realigns its default database onto the main's uuid in place, which is
+// what DbmsHandler::Update does for the default database. The database must still take its metrics
+// with it when it goes.
+TEST(DatabaseMetrics, ARealignedDatabaseStillTakesItsMetricsWithIt) {
+  auto const root = std::filesystem::temp_directory_path() / "mg_test_metrics_realigned";
+  std::filesystem::remove_all(root);
+  memgraph::utils::UUID const registered_uuid{};
+  memgraph::utils::UUID const realigned_uuid{};
+  ASSERT_NE(registered_uuid, realigned_uuid);
+
+  {
+    memgraph::dbms::Database db{MakeConfig(root, memgraph::dbms::kDefaultDB, registered_uuid)};
+    ASSERT_NE(
+        FindSampleByUuid(memgraph::metrics::Metrics().registry().Collect(), "memgraph_vertex_count", registered_uuid),
+        std::nullopt);
+    memgraph::metrics::Metrics().RebindDefaultDatabaseUUID(realigned_uuid);
+  }
+
+  EXPECT_EQ(
+      FindSampleByUuid(memgraph::metrics::Metrics().registry().Collect(), "memgraph_vertex_count", registered_uuid),
+      std::nullopt)
+      << "the realigned database left its metrics behind";
+
+  std::filesystem::remove_all(root);
 }

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -290,7 +290,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithCommittedContributorsAreGa
     // - 2 x CREATE_OBJECT, to create the edges
     // - 2 x ADD_IN_EDGE
     // - 2 x ADD_OUT_EDGE
-    ASSERT_EQ(6, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(6, handles().unreleased_delta_objects.Value());
 
     // Commit in order `acc1` and `acc2`. This means that even though `acc2` does
     // have non-sequential deltas, everything downstream from them is committed
@@ -300,7 +300,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithCommittedContributorsAreGa
     ASSERT_TRUE(acc2->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     acc2.reset();
 
-    ASSERT_EQ(6, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(6, handles().unreleased_delta_objects.Value());
   }
 
   {
@@ -308,7 +308,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithCommittedContributorsAreGa
     storage->FreeMemory(std::move(main_guard), false);
   }
 
-  EXPECT_EQ(0, handles_.unreleased_delta_objects.Value());
+  EXPECT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithAbortedContributorsAreGarbagedCollected) {
@@ -339,7 +339,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithAbortedContributorsAreGarb
     auto edge2_result = acc2->CreateEdge(&*v1_t2, &*v2_t2, acc2->NameToEdgeType("Edge2"));
     ASSERT_TRUE(edge2_result.has_value());
 
-    ASSERT_EQ(6, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(6, handles().unreleased_delta_objects.Value());
 
     ASSERT_TRUE(acc2->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     acc2.reset();
@@ -347,7 +347,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithAbortedContributorsAreGarb
     acc1.reset();
     acc0.reset();
 
-    ASSERT_EQ(6, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(6, handles().unreleased_delta_objects.Value());
   }
 
   // First GC: moves `waiting_gc_deltas_` to `aborted_transactions_` or
@@ -364,7 +364,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithAbortedContributorsAreGarb
     storage->FreeMemory(std::move(main_guard), false);
   }
 
-  EXPECT_EQ(0, handles_.unreleased_delta_objects.Value());
+  EXPECT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithMultipleAbortsAreGarbageCollected) {
@@ -395,7 +395,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithMultipleAbortsAreGarbageCo
     auto edge2_result = acc2->CreateEdge(&*v1_t2, &*v2_t2, acc2->NameToEdgeType("Edge2"));
     ASSERT_TRUE(edge2_result.has_value());
 
-    ASSERT_EQ(6, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(6, handles().unreleased_delta_objects.Value());
 
     // Both transactions abort - all deltas should be cleaned up
     acc2->Abort();
@@ -405,7 +405,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithMultipleAbortsAreGarbageCo
     acc1.reset();
     acc0.reset();
 
-    ASSERT_EQ(6, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(6, handles().unreleased_delta_objects.Value());
   }
 
   // First GC: moves from waiting_gc_deltas_ to aborted_transactions_
@@ -426,7 +426,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithMultipleAbortsAreGarbageCo
     storage->FreeMemory(std::move(main_guard), false);
   }
 
-  EXPECT_EQ(0, handles_.unreleased_delta_objects.Value());
+  EXPECT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST_F(StorageV2GcMetricsTest, DownstreamDeltaChainsAreGarbageCollected) {
@@ -462,7 +462,7 @@ TEST_F(StorageV2GcMetricsTest, DownstreamDeltaChainsAreGarbageCollected) {
     ASSERT_TRUE(v1_t3.has_value() && v2_t3.has_value());
     ASSERT_TRUE(acc3->CreateEdge(&*v1_t3, &*v2_t3, acc3->NameToEdgeType("Edge3")).has_value());
 
-    ASSERT_EQ(9, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(9, handles().unreleased_delta_objects.Value());
 
     // Commit TX1, abort TX2 and TX3
     // TX3's deltas are downstream from TX2, which are downstream from TX1
@@ -474,7 +474,7 @@ TEST_F(StorageV2GcMetricsTest, DownstreamDeltaChainsAreGarbageCollected) {
     acc2.reset();
     acc0.reset();
 
-    ASSERT_EQ(9, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(9, handles().unreleased_delta_objects.Value());
   }
 
   // Multiple GC cycles to process the downstream chain
@@ -483,7 +483,7 @@ TEST_F(StorageV2GcMetricsTest, DownstreamDeltaChainsAreGarbageCollected) {
     storage->FreeMemory(std::move(main_guard), false);
   }
 
-  EXPECT_EQ(0, handles_.unreleased_delta_objects.Value());
+  EXPECT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST_F(StorageV2GcMetricsTest, MixedCommitAbortCommitNonSequentialDeltasAreGarbageCollected) {
@@ -519,7 +519,7 @@ TEST_F(StorageV2GcMetricsTest, MixedCommitAbortCommitNonSequentialDeltasAreGarba
     ASSERT_TRUE(v1_t3.has_value() && v2_t3.has_value());
     ASSERT_TRUE(acc3->CreateEdge(&*v1_t3, &*v2_t3, acc3->NameToEdgeType("Edge3")).has_value());
 
-    ASSERT_EQ(9, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(9, handles().unreleased_delta_objects.Value());
 
     // TX1 commits, TX2 aborts, TX3 commits
     ASSERT_TRUE(acc1->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
@@ -530,7 +530,7 @@ TEST_F(StorageV2GcMetricsTest, MixedCommitAbortCommitNonSequentialDeltasAreGarba
     acc3.reset();
     acc0.reset();
 
-    ASSERT_EQ(9, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(9, handles().unreleased_delta_objects.Value());
   }
 
   // Multiple GC cycles to handle mixed commit/abort
@@ -539,7 +539,7 @@ TEST_F(StorageV2GcMetricsTest, MixedCommitAbortCommitNonSequentialDeltasAreGarba
     storage->FreeMemory(std::move(main_guard), false);
   }
 
-  EXPECT_EQ(0, handles_.unreleased_delta_objects.Value());
+  EXPECT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithTwoContributorsAreGarbagedCollected) {
@@ -577,7 +577,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithTwoContributorsAreGarbaged
     auto edge3_result = acc3->CreateEdge(&*v1_t3, &*v2_t3, acc3->NameToEdgeType("Edge3"));
     ASSERT_TRUE(edge3_result.has_value());
 
-    ASSERT_EQ(9, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(9, handles().unreleased_delta_objects.Value());
 
     ASSERT_TRUE(acc3->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     acc3.reset();
@@ -586,7 +586,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithTwoContributorsAreGarbaged
     ASSERT_TRUE(acc2->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     acc2.reset();
 
-    ASSERT_EQ(9, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(9, handles().unreleased_delta_objects.Value());
   }
 
   {
@@ -594,7 +594,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithTwoContributorsAreGarbaged
     storage->FreeMemory(std::move(main_guard), false);
   }
 
-  EXPECT_EQ(0, handles_.unreleased_delta_objects.Value());
+  EXPECT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAreGarbagedCollected) {
@@ -633,7 +633,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAre
     // - 4 x CREATE_OBJECT, to create the edges
     // - 4 x ADD_IN_EDGE
     // - 4 x ADD_OUT_EDGE
-    ASSERT_EQ(12, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(12, handles().unreleased_delta_objects.Value());
 
     // When acc2 commits, its transaction has non-sequential deltas which are
     // uncommitted, meaning these deltas must sit in the waiting list until
@@ -646,7 +646,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAre
 
     // At this point acc2 committed but acc1 hasn't - deltas should stay in waiting list
     // Wait for GC to run but deltas should remain due to uncommitted acc1
-    ASSERT_EQ(12, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(12, handles().unreleased_delta_objects.Value());
 
     ASSERT_TRUE(acc1->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     acc1.reset();
@@ -654,7 +654,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAre
 
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-  ASSERT_EQ(0, handles_.unreleased_delta_objects.Value());
+  ASSERT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAreGarbagedCollected_SwapCommitOrder) {
@@ -692,7 +692,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAre
     // - 4 x CREATE_OBJECT, to create the edges
     // - 4 x ADD_IN_EDGE
     // - 4 x ADD_OUT_EDGE
-    ASSERT_EQ(12, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(12, handles().unreleased_delta_objects.Value());
 
     // When acc1 commits first, its transaction has non-sequential deltas which are
     // uncommitted, meaning these deltas must sit in the waiting list until
@@ -705,7 +705,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAre
 
     // At this point acc1 committed but acc2 hasn't - deltas should stay in waiting list
     // Wait for GC to run but deltas should remain due to uncommitted acc2
-    ASSERT_EQ(12, handles_.unreleased_delta_objects.Value());
+    ASSERT_EQ(12, handles().unreleased_delta_objects.Value());
 
     ASSERT_TRUE(acc2->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     acc2.reset();
@@ -713,7 +713,7 @@ TEST_F(StorageV2GcMetricsTest, NonSequentialDeltasWithUncommittedContributorsAre
 
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-  ASSERT_EQ(0, handles_.unreleased_delta_objects.Value());
+  ASSERT_EQ(0, handles().unreleased_delta_objects.Value());
 }
 
 TEST(StorageV2Gc, ConcurrentEdgeOperationsAbortDeleteRepeat) {

--- a/tests/unit/storage_v2_gc_index_sweep.cpp
+++ b/tests/unit/storage_v2_gc_index_sweep.cpp
@@ -52,10 +52,10 @@ class StorageV2GcIndexSweepCountTest : public StorageV2GcMetricsTest {
   // eighth family joining the sweep without arming support breaks every expectation below, which
   // is the intent: it should not be possible to add one silently.
   uint64_t SweptByOnePass() {
-    auto const before = handles_.gc_index_sweeps.Value();
+    auto const before = handles().gc_index_sweeps.Value();
     auto *mem_storage = static_cast<ms::InMemoryStorage *>(storage.get());
     mem_storage->FreeMemory(UniqueGuard(storage->main_lock_), false);
-    return static_cast<uint64_t>(handles_.gc_index_sweeps.Value() - before);
+    return static_cast<uint64_t>(handles().gc_index_sweeps.Value() - before);
   }
 
   // Commit helpers come in two halves because one test needs a commit that is expected to fail.

--- a/tests/unit/storage_v2_gc_metrics_fixture.hpp
+++ b/tests/unit/storage_v2_gc_metrics_fixture.hpp
@@ -43,29 +43,21 @@ class StorageV2GcMetricsTest : public testing::Test {
   void TearDown() override {
     memgraph::metrics::Metrics().SetStorageSnapshotResolver({});
     storage.reset();
-    memgraph::metrics::Metrics().RemoveDatabase(uuid_);
-    handles_ = {};
+    registration_ = {};
     uuid_ = {};
-    registered_ = false;
   }
 
   void InitStorage(std::chrono::milliseconds interval) {
-    if (registered_) {
-      memgraph::metrics::Metrics().SetStorageSnapshotResolver({});
-      storage.reset();
-      memgraph::metrics::Metrics().RemoveDatabase(uuid_);
-      handles_ = {};
-      uuid_ = {};
-      registered_ = false;
-    }
+    memgraph::metrics::Metrics().SetStorageSnapshotResolver({});
+    storage.reset();
+    registration_ = {};
     memgraph::storage::Config config;
     config.salient.name = db_name_;
     config.gc = {.type = memgraph::storage::Config::Gc::Type::PERIODIC, .interval = interval};
     uuid_ = memgraph::utils::UUID{};
-    handles_ = memgraph::metrics::Metrics().AddDatabase(uuid_, db_name_);
-    registered_ = true;
+    registration_ = memgraph::metrics::Metrics().AddDatabase(uuid_, db_name_);
     storage = std::make_unique<memgraph::storage::InMemoryStorage>(
-        config, std::nullopt, std::make_unique<memgraph::storage::PlanInvalidatorDefault>(), handles_);
+        config, std::nullopt, std::make_unique<memgraph::storage::PlanInvalidatorDefault>(), registration_.handles());
     memgraph::metrics::Metrics().SetStorageSnapshotResolver(
         [this](memgraph::utils::UUID const &uuid) -> std::optional<memgraph::metrics::StorageSnapshot> {
           if (uuid != uuid_ || !storage) return std::nullopt;
@@ -79,9 +71,11 @@ class StorageV2GcMetricsTest : public testing::Test {
   }
 
   std::unique_ptr<memgraph::storage::Storage> storage;
-  memgraph::metrics::DatabaseMetricHandles handles_{};
+
+  auto handles() -> memgraph::metrics::DatabaseMetricHandles & { return registration_.handles(); }
+
+  memgraph::metrics::PrometheusMetrics::Registration registration_{};
   memgraph::utils::UUID uuid_{};
-  bool registered_{false};
 
  private:
   std::string db_name_;


### PR DESCRIPTION
A prometheus family returns the metric it already holds for a label set rather
than creating a second, so registering a database twice hands back one set of
metrics with two owners. Deregistering either owner removed them from the
families and left the other writing through freed handles: the storage garbage
collector records its latency every pass, and would observe into one.

Registering now yields a move-only Registration that releases on destruction,
so each registration has exactly one owner and the metrics go when the last of
them does. A registration releases the entry it created, identified by a number
fixed for that entry's life, so a database that is renamed or rebound to
another uuid still releases its own and only its own. A database that registers
nothing holds an empty Registration and releases nothing, and a database now
declares its registration before its storage, so it is released only once that
storage is destroyed and the garbage collector writing through its handles has
been joined.
