### PR TITLE
refactor: drop the Limit the subquery branch never needed

### DIFF
--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -51,9 +51,9 @@ struct SubqueryBranchPlanner {
   /// WITH/RETURN's output symbols.
   virtual std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
                                                 const std::unordered_set<Symbol> &bound_symbols) = 0;
-  /// Builds an EXISTS branch for a forced bool fold, i.e. without the deferred fold's
-  /// `Limit(1) -> EvaluatePatternFilter` tail. Takes @p write_occurred rather than a view, because the branch has to
-  /// pass the fact itself down to its own body, not just the view it resolves to here.
+  /// Builds an EXISTS branch for a forced bool fold, i.e. without the deferred fold's `EvaluatePatternFilter` tail.
+  /// Takes @p write_occurred rather than a view, because the branch has to pass the fact itself down to its own body,
+  /// not just the view it resolves to here.
   virtual std::unique_ptr<LogicalOperator> PlanSubqueryBranch(const SubqueryMatching &matching, bool write_occurred,
                                                               const std::unordered_set<Symbol> &bound_symbols) = 0;
 };
@@ -1755,10 +1755,6 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                                       const std::unordered_set<Symbol> &bound_symbols) {
     // Outside an EXISTS branch the flag is false, which resolves to View::OLD.
     auto last_op = MakeSubqueryBranch(matching, symbol_table, storage, bound_symbols, subquery_branch_after_write_);
-    // Dead weight under the bool fold, whose cursor pulls exactly once - but it would truncate a count's drain.
-    if (matching.fold != SubqueryExpression::Fold::kCount) {
-      last_op = std::make_unique<Limit>(std::move(last_op), storage.Create<PrimitiveLiteral>(1));
-    }
     return std::make_unique<EvaluatePatternFilter>(
         std::move(last_op), matching.symbol.value(), impl::ToOperatorFold(matching.fold));
   }

--- a/tests/unit/plan_pretty_print.cpp
+++ b/tests/unit/plan_pretty_print.cpp
@@ -1502,9 +1502,8 @@ TYPED_TEST(PrintToJsonTest, SubqueryExpression) {
                                std::vector<memgraph::storage::EdgeTypeId>{this->dba.NameToEdgeType("EdgeType1")},
                                false,
                                memgraph::storage::View::OLD);
-  std::shared_ptr<LogicalOperator> limit = std::make_shared<Limit>(expand, LITERAL(1));
   std::shared_ptr<LogicalOperator> evaluate_pattern_filter =
-      std::make_shared<EvaluatePatternFilter>(limit, output, RollUpApply::Fold::kBool);
+      std::make_shared<EvaluatePatternFilter>(expand, output, RollUpApply::Fold::kBool);
   last_op = std::make_shared<Filter>(last_op,
                                      std::vector<std::shared_ptr<LogicalOperator>>{evaluate_pattern_filter},
                                      EXISTS(PATTERN(NODE("x"),
@@ -1524,22 +1523,18 @@ TYPED_TEST(PrintToJsonTest, SubqueryExpression) {
             "name": "Filter",
             "pattern_filter1": {
               "input": {
-                "expression": "1",
+                "direction": "both",
+                "edge_symbol": "edge",
+                "edge_types": [
+                  "EdgeType1"
+                ],
+                "existing_node": false,
                 "input": {
-                  "direction": "both",
-                  "edge_symbol": "edge",
-                  "edge_types": [
-                    "EdgeType1"
-                  ],
-                  "existing_node": false,
-                  "input": {
-                    "name": "Once"
-                  },
-                  "input_symbol": "x",
-                  "name": "Expand",
-                  "node_symbol": "node"
+                  "name": "Once"
                 },
-                "name": "Limit"
+                "input_symbol": "x",
+                "name": "Expand",
+                "node_symbol": "node"
               },
               "name": "EvaluatePatternFilter",
               "output_symbol": "output_symbol"

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -1556,8 +1556,7 @@ TYPED_TEST(TestPlanner, MatchFilterWhere) {
                                    AND(NEQ(IDENT("n"), IDENT("n")), NEQ(LITERAL(7), LITERAL(8))))),
                          RETURN("n")));
 
-  std::list<BaseOpChecker *> pattern_filter{
-      new ExpectScanAll(), new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> pattern_filter{new ExpectScanAll(), new ExpectExpand(), new ExpectEvaluatePatternFilter()};
   CheckPlan<TypeParam>(
       query,
       this->storage,
@@ -2740,7 +2739,7 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
 
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
-    std::list<BaseOpChecker *> pattern_filter{new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+    std::list<BaseOpChecker *> pattern_filter{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(planner.plan(),
               symbol_table,
@@ -2763,7 +2762,7 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(planner.plan(),
               symbol_table,
@@ -2789,9 +2788,8 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter_with_types{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
-    std::list<BaseOpChecker *> pattern_filter_without_types{
-        new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
+    std::list<BaseOpChecker *> pattern_filter_without_types{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(
         planner.plan(),
@@ -2818,7 +2816,7 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(planner.plan(),
               symbol_table,
@@ -2844,9 +2842,8 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter_with_types{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
-    std::list<BaseOpChecker *> pattern_filter_without_types{
-        new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
+    std::list<BaseOpChecker *> pattern_filter_without_types{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(
         planner.plan(),
@@ -5168,7 +5165,7 @@ TYPED_TEST(TestPlanner, BasicExistsSubquery) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5190,8 +5187,7 @@ TYPED_TEST(TestPlanner, ExistsSubqueryMatchWhere) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{
-      new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5215,11 +5211,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryMatchWherePlansReturn) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(),
-                                         new ExpectFilter(),
-                                         new ExpectProduce(),
-                                         new ExpectLimit(),
-                                         new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{
+      new ExpectExpand(), new ExpectFilter(), new ExpectProduce(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5241,11 +5234,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithMatchWhere) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectProduce(),
-                                         new ExpectFilter(),
-                                         new ExpectExpand(),
-                                         new ExpectLimit(),
-                                         new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{
+      new ExpectProduce(), new ExpectFilter(), new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5267,11 +5257,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithMatchWhereOnVertexPropety) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectProduce(),
-                                         new ExpectExpand(),
-                                         new ExpectFilter(),
-                                         new ExpectLimit(),
-                                         new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{
+      new ExpectProduce(), new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5292,11 +5279,9 @@ TYPED_TEST(TestPlanner, ExistsSubqueryNested) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> nested_filter_tree{
-      new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> nested_filter_tree{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
   std::list<BaseOpChecker *> filter_tree{new ExpectExpand(),
                                          new ExpectFilter(std::vector<std::list<BaseOpChecker *>>{nested_filter_tree}),
-                                         new ExpectLimit(),
                                          new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
@@ -5320,10 +5305,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
 
   std::list<BaseOpChecker *> left_exists_part{new ExpectExpand()};
   std::list<BaseOpChecker *> right_exists_part{new ExpectExpand()};
-  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
-                                               new ExpectDistinct(),
-                                               new ExpectLimit(),
-                                               new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> exists_union_plan{
+      new ExpectUnion(left_exists_part, right_exists_part), new ExpectDistinct(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5351,10 +5334,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfReturnOnlyBodies) {
 
   std::list<BaseOpChecker *> left_exists_part{new ExpectOnce(), new ExpectProduce()};
   std::list<BaseOpChecker *> right_exists_part{new ExpectOnce(), new ExpectProduce()};
-  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
-                                               new ExpectDistinct(),
-                                               new ExpectLimit(),
-                                               new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> exists_union_plan{
+      new ExpectUnion(left_exists_part, right_exists_part), new ExpectDistinct(), new ExpectEvaluatePatternFilter()};
 
   // The branch correlates to nothing, so the filter is satisfied before the scan and sits below it.
   CheckPlan(planner.plan(),
@@ -5380,8 +5361,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfReturnOnlyBodies) {
 
   std::list<BaseOpChecker *> left_exists_part{new ExpectOnce(), new ExpectProduce()};
   std::list<BaseOpChecker *> right_exists_part{new ExpectOnce(), new ExpectProduce()};
-  std::list<BaseOpChecker *> exists_union_plan{
-      new ExpectUnion(left_exists_part, right_exists_part), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
+                                               new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5447,7 +5428,7 @@ TYPED_TEST(TestPlanner, CountSubqueryInReturnProjection) {
 
 TYPED_TEST(TestPlanner, CountSubqueryInMatchWhereUsesTheDeferredFold) {
   // MATCH (n) WHERE COUNT { MATCH (n)-[r]->(m) } > 1 RETURN n
-  // Deferred, as for EXISTS. No Limit above the branch: it would truncate the drain.
+  // Deferred, as for EXISTS: an untaken disjunct skips the branch, which for a count is a whole drain.
   FakeDbAccessor dba;
 
   auto *count_subquery = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m")))));


### PR DESCRIPTION
**What.** Removes the `Limit(1)` that `MakeSubqueryFilter` planted above a deferred `EXISTS { … }` / `COUNT { … }` branch, together with the `if (matching.fold != SubqueryExpression::Fold::kCount)` guard that #4598 wrapped it in. No semantic change; `EXPLAIN` loses one line per deferred subquery branch.

**How.** `src/query/plan/rule_based_planner.hpp` — `MakeSubqueryFilter` now returns `EvaluatePatternFilter(branch)` directly.

The `Limit` bounded nothing for either fold. `EvaluatePatternFilterCursor::Pull` installs a closure that does one `Reset()` and then, for `kBool`, exactly one `Pull` — there is no second pull for a `Limit(1)` to stop. For `kCount` it drains, which is precisely why #4598 had to exclude that fold. And anything below the branch that drains on its first pull (`OrderBy`, `Aggregate`, `Accumulate`) defeated it regardless, so a body that sorts or aggregates was never bounded even under the bool fold.

It was not free either: `LimitCursor::Reset()` sets `limit_ = -1`, so every evaluation re-entered the `limit_ == -1` arm to construct a fresh `ExpressionEvaluator` for the literal `1`, plus a profile scope and an `AbortCheck` — per row, per subquery expression. Treat that as clarity rather than measured perf; it was not benchmarked.

Test side: 18 `new ExpectLimit()` entries inside **pattern-filter** trees in `tests/unit/query_plan.cpp` and the one hand-built tree in `tests/unit/plan_pretty_print.cpp` go, and `ExistsSubqueryInMatchWhereKeepsItsLimit` is deleted rather than updated — it existed only to record that the bool fold still planted a `Limit`, which is the misconception. The 6 remaining `ExpectLimit` in `query_plan.cpp` and both in `query_parallel_plan.cpp` are real `LIMIT` clauses and are untouched.

**Why.** The operator was dead weight carrying a false implication — that the bool fold's branch is bounded by it — and the `kCount` guard made that implication look load-bearing. A list fold (`COLLECT { … }`, stacked above) wants the branch unbounded, so removing it here means that PR never has to touch the conditional.

**Verification.** `EXPLAIN` diff before/after; 5 `EXISTS`/`COUNT` queries A/B'd against a base binary with byte-identical answers; `memgraph__unit__query_plan` (282) and `memgraph__unit__plan_pretty_print` (92) pass.

---

**Stacked PR.** Base is `feat/count-subquery` (#4598), not `master`. Review after #4597 and #4598.
