### PR TITLE
fix: refuse a subquery body that rebinds a name it can already see

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -519,6 +519,8 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
   } else if (scope.in_pattern && !(scope.in_node_atom || scope.visiting_edge)) {
     // If we are in the pattern, and outside of a node or an edge, the
     // identifier is the pattern name. Shadowed: declare here, as for node and edge atoms below.
+    // A named path assigns a path of its own, so it declares the name rather than referencing it.
+    CheckPathDoesNotShadow(ident.name_, scope);
     symbol = shadows_outer_name ? CreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::PATH)
                                 : GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::PATH);
   } else if (scope.in_pattern && scope.in_pattern_atom_identifier) {
@@ -1136,6 +1138,17 @@ bool SymbolGenerator::ShadowsEnclosingName(const std::string &name, const Scope 
   auto const hi = std::max(lo, *scope.subquery_body_base);
   return std::ranges::any_of(std::views::iota(lo, hi),
                              [&](auto const idx) { return scopes_[idx].symbols.contains(name); });
+}
+
+void SymbolGenerator::CheckPathDoesNotShadow(const std::string &name, const Scope &scope) const {
+  if (scope.call_subquery_imports.contains(name)) {
+    throw SemanticException("Variable '{}' shadows the variable of the same name imported into this subquery.", name);
+  }
+  if (ShadowsEnclosingName(name, scope)) {
+    throw SemanticException("Variable '{}' in {} shadows a variable with the same name from the outer scope.",
+                            name,
+                            SubqueryExpression::FoldName(scope.subquery_fold));
+  }
 }
 
 void SymbolGenerator::CheckDoesNotShadow(const NamedExpression &named_expr, const Scope &scope) const {

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -215,8 +215,8 @@ bool SymbolGenerator::PreVisit(CypherUnion &) {
   // Currently only CALL and EXISTS subqueries can contain complete queries with UNION.
   next_scope.in_call_subquery = prev_scope.in_call_subquery;
   next_scope.in_subquery_body = prev_scope.in_subquery_body;
-  // This replaces the scope at its own index, so a boundary that scope opened has to come with it - a UNION branch
-  // is still the same body, and shadows the same names.
+  // This replaces the scope at its own index, so a boundary that scope opened comes with it: a UNION branch is
+  // still the same body.
   next_scope.boundary = prev_scope.boundary;
   next_scope.subquery_fold = prev_scope.subquery_fold;
   // Carry over explicit `CALL (v1, v2) { ... }` imports so each UNION branch
@@ -1133,8 +1133,8 @@ std::optional<size_t> SymbolGenerator::InnermostBoundary(Scope::Boundary kind) c
 bool SymbolGenerator::ShadowsEnclosingName(const std::string &name) const {
   auto const body = InnermostBoundary(Scope::Boundary::kSubqueryBody);
   if (!body) return false;
-  // A `CALL {}` bounds what the body can see: an un-imported name is out of reach, so redeclaring it shadows nothing.
-  // A `CALL {}` opened *inside* the body starts above it, leaving the range empty - the same conclusion.
+  // A `CALL {}` bounds what the body can see: an un-imported name is out of reach, so redeclaring it shadows
+  // nothing. One opened *inside* the body starts above it, leaving the range empty - the same conclusion.
   auto const lo = InnermostBoundary(Scope::Boundary::kCallImport).value_or(0);
   auto const hi = std::max(lo, *body);
   return std::ranges::any_of(std::views::iota(lo, hi),

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -215,9 +215,9 @@ bool SymbolGenerator::PreVisit(CypherUnion &) {
   // Currently only CALL and EXISTS subqueries can contain complete queries with UNION.
   next_scope.in_call_subquery = prev_scope.in_call_subquery;
   next_scope.in_subquery_body = prev_scope.in_subquery_body;
-  next_scope.call_subquery_base = prev_scope.call_subquery_base;
-  // A UNION branch is still the same subquery body, so it shadows the same names, and names them the same way.
-  next_scope.subquery_body_base = prev_scope.subquery_body_base;
+  // This replaces the scope at its own index, so a boundary that scope opened has to come with it - a UNION branch
+  // is still the same body, and shadows the same names.
+  next_scope.boundary = prev_scope.boundary;
   next_scope.subquery_fold = prev_scope.subquery_fold;
   // Carry over explicit `CALL (v1, v2) { ... }` imports so each UNION branch
   // within the subquery still sees the imported variables.
@@ -286,8 +286,7 @@ bool SymbolGenerator::PostVisit(CallProcedure &call_proc) {
 
 bool SymbolGenerator::PreVisit(CallSubquery &call_sub) {
   Scope new_scope{.in_call_subquery = true};
-  // The scope about to be pushed is the subquery's outermost one; names below it need an explicit import.
-  new_scope.call_subquery_base = scopes_.size();
+  new_scope.boundary = Scope::Boundary::kCallImport;
 
   if (call_sub.has_variable_scope_) {
     // `CALL (...) { ... }`: resolve imports against the current outer scope
@@ -461,10 +460,8 @@ bool SymbolGenerator::PostVisit(Match &) {
 
 bool SymbolGenerator::PreVisit(Foreach &for_each) {
   const auto &name = for_each.named_expression_->name_;
-  auto const call_subquery_base = scopes_.back().call_subquery_base;
   scopes_.emplace_back(Scope());
   scopes_.back().in_foreach = true;
-  scopes_.back().call_subquery_base = call_subquery_base;
   for_each.named_expression_->MapTo(
       CreateSymbol(name, true, Symbol::Type::ANY, for_each.named_expression_->token_position_));
   return true;
@@ -485,7 +482,7 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
 
   // Inside a `CALL {}` subquery only its own scopes outwards are visible. A pattern occurrence of an un-imported
   // outer name declares a fresh variable, rather than writing through the frame slot the caller shares.
-  auto const from = scope.in_pattern ? scope.call_subquery_base.value_or(0) : 0;
+  auto const from = scope.in_pattern ? InnermostBoundary(Scope::Boundary::kCallImport).value_or(0) : 0;
   // Treated as undeclared below: patterns declare it afresh, `exists()` rejects it.
   const bool name_in_scope = HasSymbol(ident.name_, from);
   const bool shadows_outer_name = !name_in_scope && from != 0 && HasSymbol(ident.name_);
@@ -750,14 +747,12 @@ bool SymbolGenerator::PreVisit(SubqueryExpression &subquery) {
 
   // Each form declares only its own variables, so each gets a scope; the pattern form's are named at parse time, so
   // leaving them outside redeclared them wherever one expression is reached twice, as a simple CASE reaches its test.
-  // Carry the subquery boundary in, so a pattern inside cannot reach an un-imported outer name, and the fold name
-  // with it, so a diagnostic raised inside names the construct the user wrote.
+  // Carry the fold name in, so a diagnostic raised inside names the construct the user wrote.
   // NOLINTNEXTLINE(hicpp-use-emplace,modernize-use-emplace)
   scopes_.emplace_back(Scope{.in_subquery_pattern = subquery.HasPattern(),
                              .in_subquery_body = subquery.HasSubquery(),
                              .subquery_fold = subquery.fold_,
-                             .call_subquery_base = scope.call_subquery_base,
-                             .subquery_body_base = scopes_.size()});
+                             .boundary = Scope::Boundary::kSubqueryBody});
 
   return true;
 }
@@ -1063,9 +1058,7 @@ bool SymbolGenerator::PostVisit(EdgeAtom &) {
 }
 
 bool SymbolGenerator::PreVisit(PatternComprehension &pc) {
-  // Carry the subquery boundary in, so a pattern inside cannot reach an un-imported outer name.
-  scopes_.emplace_back(
-      Scope{.in_pattern_comprehension = true, .call_subquery_base = scopes_.back().call_subquery_base});
+  scopes_.emplace_back(Scope{.in_pattern_comprehension = true});
 
   const auto &symbol = CreateAnonymousSymbol();
   pc.MapTo(symbol);
@@ -1130,12 +1123,20 @@ bool SymbolGenerator::HasSymbol(const std::string &name, size_t from) const {
   return std::ranges::any_of(visible, [&name](const auto &scope) { return scope.symbols.contains(name); });
 }
 
-bool SymbolGenerator::ShadowsEnclosingName(const std::string &name, const Scope &scope) const {
-  if (!scope.subquery_body_base) return false;
+std::optional<size_t> SymbolGenerator::InnermostBoundary(Scope::Boundary kind) const {
+  for (auto idx = scopes_.size(); idx > 0; --idx) {
+    if (scopes_[idx - 1].boundary == kind) return idx - 1;
+  }
+  return std::nullopt;
+}
+
+bool SymbolGenerator::ShadowsEnclosingName(const std::string &name) const {
+  auto const body = InnermostBoundary(Scope::Boundary::kSubqueryBody);
+  if (!body) return false;
   // A `CALL {}` bounds what the body can see: an un-imported name is out of reach, so redeclaring it shadows nothing.
   // A `CALL {}` opened *inside* the body starts above it, leaving the range empty - the same conclusion.
-  auto const lo = scope.call_subquery_base.value_or(0);
-  auto const hi = std::max(lo, *scope.subquery_body_base);
+  auto const lo = InnermostBoundary(Scope::Boundary::kCallImport).value_or(0);
+  auto const hi = std::max(lo, *body);
   return std::ranges::any_of(std::views::iota(lo, hi),
                              [&](auto const idx) { return scopes_[idx].symbols.contains(name); });
 }
@@ -1144,7 +1145,7 @@ void SymbolGenerator::CheckPathDoesNotShadow(const std::string &name, const Scop
   if (scope.call_subquery_imports.contains(name)) {
     throw SemanticException("Variable '{}' shadows the variable of the same name imported into this subquery.", name);
   }
-  if (ShadowsEnclosingName(name, scope)) {
+  if (ShadowsEnclosingName(name)) {
     throw SemanticException("Variable '{}' in {} shadows a variable with the same name from the outer scope.",
                             name,
                             SubqueryExpression::FoldName(scope.subquery_fold));
@@ -1164,7 +1165,7 @@ void SymbolGenerator::CheckDoesNotShadow(const NamedExpression &named_expr, cons
     }
     return;
   }
-  if (!ProjectsItself(named_expr) && ShadowsEnclosingName(name, scope)) {
+  if (!ProjectsItself(named_expr) && ShadowsEnclosingName(name)) {
     throw SemanticException("Variable '{}' in {} shadows a variable with the same name from the outer scope.",
                             name,
                             SubqueryExpression::FoldName(scope.subquery_fold));

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -38,6 +38,12 @@ std::unordered_map<std::string, Identifier *> GeneratePredefinedIdentifierMap(
 
   return identifier_map;
 }
+
+// A variable projected straight through under its own name declares nothing new, so it cannot shadow anything.
+bool ProjectsItself(const NamedExpression &named_expr) {
+  auto const *ident = utils::Downcast<Identifier>(named_expr.expression_);
+  return ident != nullptr && ident->name_ == named_expr.name_;
+}
 }  // namespace
 
 SymbolGenerator::SymbolGenerator(SymbolTable *symbol_table, const std::vector<Identifier *> &predefined_identifiers)
@@ -124,6 +130,7 @@ void SymbolGenerator::VisitReturnBody(ReturnBody &body, Where *where) {
     if (!new_names.insert(name).second) {
       throw SemanticException("Multiple results with the same name '{}' are not allowed.", name);
     }
+    CheckDoesNotShadow(*named_expr, scopes_[scope_idx]);
     // An improvement would be to infer the type of the expression, so that the
     // new symbol would have a more specific type.
     named_expr->MapTo(CreateSymbol(name, true, Symbol::Type::ANY, named_expr->token_position_));
@@ -209,6 +216,9 @@ bool SymbolGenerator::PreVisit(CypherUnion &) {
   next_scope.in_call_subquery = prev_scope.in_call_subquery;
   next_scope.in_subquery_body = prev_scope.in_subquery_body;
   next_scope.call_subquery_base = prev_scope.call_subquery_base;
+  // A UNION branch is still the same subquery body, so it shadows the same names, and names them the same way.
+  next_scope.subquery_body_base = prev_scope.subquery_body_base;
+  next_scope.subquery_fold = prev_scope.subquery_fold;
   // Carry over explicit `CALL (v1, v2) { ... }` imports so each UNION branch
   // within the subquery still sees the imported variables.
   next_scope.call_subquery_imports = prev_scope.call_subquery_imports;
@@ -744,7 +754,8 @@ bool SymbolGenerator::PreVisit(SubqueryExpression &subquery) {
   scopes_.emplace_back(Scope{.in_subquery_pattern = subquery.HasPattern(),
                              .in_subquery_body = subquery.HasSubquery(),
                              .subquery_fold = subquery.fold_,
-                             .call_subquery_base = scope.call_subquery_base});
+                             .call_subquery_base = scope.call_subquery_base,
+                             .subquery_body_base = scopes_.size()});
 
   return true;
 }
@@ -1115,6 +1126,36 @@ void SymbolGenerator::VisitWithIdentifiers(std::vector<Expression *> exprs,
 bool SymbolGenerator::HasSymbol(const std::string &name, size_t from) const {
   auto const visible = std::ranges::subrange(scopes_.begin() + static_cast<std::ptrdiff_t>(from), scopes_.end());
   return std::ranges::any_of(visible, [&name](const auto &scope) { return scope.symbols.contains(name); });
+}
+
+bool SymbolGenerator::ShadowsEnclosingName(const std::string &name, const Scope &scope) const {
+  if (!scope.subquery_body_base) return false;
+  // A `CALL {}` bounds what the body can see: an un-imported name is out of reach, so redeclaring it shadows nothing.
+  // A `CALL {}` opened *inside* the body starts above it, leaving the range empty - the same conclusion.
+  auto const lo = scope.call_subquery_base.value_or(0);
+  auto const hi = std::max(lo, *scope.subquery_body_base);
+  return std::ranges::any_of(std::views::iota(lo, hi),
+                             [&](auto const idx) { return scopes_[idx].symbols.contains(name); });
+}
+
+void SymbolGenerator::CheckDoesNotShadow(const NamedExpression &named_expr, const Scope &scope) const {
+  auto const &name = named_expr.name_;
+  if (scope.call_subquery_imports.contains(name)) {
+    // Returning an imported name reintroduces it into the outer scope, which already holds it. An intermediate WITH
+    // may still carry it through, because that name never leaves the body.
+    if (scope.in_return) {
+      throw SemanticException("Variable '{}' in subquery already declared in outer scope!", name);
+    }
+    if (!ProjectsItself(named_expr)) {
+      throw SemanticException("Variable '{}' shadows the variable of the same name imported into this subquery.", name);
+    }
+    return;
+  }
+  if (!ProjectsItself(named_expr) && ShadowsEnclosingName(name, scope)) {
+    throw SemanticException("Variable '{}' in {} shadows a variable with the same name from the outer scope.",
+                            name,
+                            SubqueryExpression::FoldName(scope.subquery_fold));
+  }
 }
 
 bool SymbolGenerator::ConsumePredefinedIdentifier(const std::string &name) {

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -208,6 +208,7 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
 
   // Refuses a WITH/RETURN item whose alias redeclares a name its subquery can already see.
   void CheckDoesNotShadow(const NamedExpression &named_expr, const Scope &scope) const;
+  void CheckPathDoesNotShadow(const std::string &name, const Scope &scope) const;
 
   // @return true if it added a predefined identifier with that name
   bool ConsumePredefinedIdentifier(const std::string &name);

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -174,8 +174,8 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
     std::map<std::string, Symbol> symbols;
     // Symbols imported into a `CALL (v1, v2, ...) { ... }` subquery scope.
     std::map<std::string, Symbol> call_subquery_imports;
-    // Which visibility boundary this scope opens, if any. Both bounds of the shadowing range are derived by walking
-    // outwards, so a scope pushed inside one inherits the answer instead of carrying a copy of it.
+    // Which visibility boundary this scope opens, if any. Both bounds of the shadowing range are found by walking
+    // outwards, so a scope pushed inside one inherits the answer.
     enum class Boundary : uint8_t {
       kNone,
       kCallImport,    ///< a `CALL {}`: a name resolving only outside it needs an explicit import
@@ -205,7 +205,7 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   bool HasSymbol(const std::string &name, size_t from = 0) const;
 
   // Whether @p name belongs to a scope the innermost enclosing subquery expression's body can see but did not
-  // declare - the shadowing Neo4j refuses with 42N07.
+  // declare.
   bool ShadowsEnclosingName(const std::string &name) const;
   // Index of the innermost scope opening @p kind, if any.
   std::optional<size_t> InnermostBoundary(Scope::Boundary kind) const;

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -177,6 +177,9 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
     // Index of the scope that opened the innermost enclosing `CALL {}`. A name resolving only below it belongs to
     // the enclosing query and needs an explicit import.
     std::optional<size_t> call_subquery_base;
+    // Index of the scope that opened the innermost enclosing subquery expression's body. A name resolving between
+    // `call_subquery_base` and it is one the body can already see, so the body may not redeclare it.
+    std::optional<size_t> subquery_body_base;
     // Identifiers found in property maps of patterns or as variable length path
     // bounds in a single Match clause. They need to be checked after visiting
     // Match. Identifiers created by naming vertices, edges and paths are *not*
@@ -198,6 +201,13 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
 
   // Whether @p name resolves in any scope from @p from outwards; pass `call_subquery_base` to ask about a subquery.
   bool HasSymbol(const std::string &name, size_t from = 0) const;
+
+  // Whether @p name belongs to a scope the innermost enclosing subquery expression's body can see but did not
+  // declare - the shadowing Neo4j refuses with 42N07.
+  bool ShadowsEnclosingName(const std::string &name, const Scope &scope) const;
+
+  // Refuses a WITH/RETURN item whose alias redeclares a name its subquery can already see.
+  void CheckDoesNotShadow(const NamedExpression &named_expr, const Scope &scope) const;
 
   // @return true if it added a predefined identifier with that name
   bool ConsumePredefinedIdentifier(const std::string &name);

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -174,12 +174,14 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
     std::map<std::string, Symbol> symbols;
     // Symbols imported into a `CALL (v1, v2, ...) { ... }` subquery scope.
     std::map<std::string, Symbol> call_subquery_imports;
-    // Index of the scope that opened the innermost enclosing `CALL {}`. A name resolving only below it belongs to
-    // the enclosing query and needs an explicit import.
-    std::optional<size_t> call_subquery_base;
-    // Index of the scope that opened the innermost enclosing subquery expression's body. A name resolving between
-    // `call_subquery_base` and it is one the body can already see, so the body may not redeclare it.
-    std::optional<size_t> subquery_body_base;
+    // Which visibility boundary this scope opens, if any. Both bounds of the shadowing range are derived by walking
+    // outwards, so a scope pushed inside one inherits the answer instead of carrying a copy of it.
+    enum class Boundary : uint8_t {
+      kNone,
+      kCallImport,    ///< a `CALL {}`: a name resolving only outside it needs an explicit import
+      kSubqueryBody,  ///< a subquery expression's body: it sees those names, but may not redeclare them
+    };
+    Boundary boundary{Boundary::kNone};
     // Identifiers found in property maps of patterns or as variable length path
     // bounds in a single Match clause. They need to be checked after visiting
     // Match. Identifiers created by naming vertices, edges and paths are *not*
@@ -199,12 +201,14 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   /// unlisted position leaves the frame slot unwritten and the expression reads it without an error.
   static bool IsSupportedSubqueryPosition(const Scope &scope);
 
-  // Whether @p name resolves in any scope from @p from outwards; pass `call_subquery_base` to ask about a subquery.
+  // Whether @p name resolves in any scope from @p from outwards; pass a `kCallImport` index to ask about a subquery.
   bool HasSymbol(const std::string &name, size_t from = 0) const;
 
   // Whether @p name belongs to a scope the innermost enclosing subquery expression's body can see but did not
   // declare - the shadowing Neo4j refuses with 42N07.
-  bool ShadowsEnclosingName(const std::string &name, const Scope &scope) const;
+  bool ShadowsEnclosingName(const std::string &name) const;
+  // Index of the innermost scope opening @p kind, if any.
+  std::optional<size_t> InnermostBoundary(Scope::Boundary kind) const;
 
   // Refuses a WITH/RETURN item whose alias redeclares a name its subquery can already see.
   void CheckDoesNotShadow(const NamedExpression &named_expr, const Scope &scope) const;

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -51,9 +51,9 @@ struct SubqueryBranchPlanner {
   /// WITH/RETURN's output symbols.
   virtual std::unique_ptr<LogicalOperator> Plan(const PatternComprehensionMatching &matching, storage::View view,
                                                 const std::unordered_set<Symbol> &bound_symbols) = 0;
-  /// Builds an EXISTS branch for a forced bool fold, i.e. without the deferred fold's
-  /// `Limit(1) -> EvaluatePatternFilter` tail. Takes @p write_occurred rather than a view, because the branch has to
-  /// pass the fact itself down to its own body, not just the view it resolves to here.
+  /// Builds an EXISTS branch for a forced bool fold, i.e. without the deferred fold's `EvaluatePatternFilter` tail.
+  /// Takes @p write_occurred rather than a view, because the branch has to pass the fact itself down to its own body,
+  /// not just the view it resolves to here.
   virtual std::unique_ptr<LogicalOperator> PlanSubqueryBranch(const SubqueryMatching &matching, bool write_occurred,
                                                               const std::unordered_set<Symbol> &bound_symbols) = 0;
 };
@@ -1755,10 +1755,6 @@ class RuleBasedPlanner : public SubqueryBranchPlanner {
                                                       const std::unordered_set<Symbol> &bound_symbols) {
     // Outside an EXISTS branch the flag is false, which resolves to View::OLD.
     auto last_op = MakeSubqueryBranch(matching, symbol_table, storage, bound_symbols, subquery_branch_after_write_);
-    // Dead weight under the bool fold, whose cursor pulls exactly once - but it would truncate a count's drain.
-    if (matching.fold != SubqueryExpression::Fold::kCount) {
-      last_op = std::make_unique<Limit>(std::move(last_op), storage.Create<PrimitiveLiteral>(1));
-    }
     return std::make_unique<EvaluatePatternFilter>(
         std::move(last_op), matching.symbol.value(), impl::ToOperatorFold(matching.fold));
   }

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -557,6 +557,34 @@ Feature: Subqueries
             | playerName | rating | team                     |
             | 'Player A' | 0.21   | (:Team {name: 'Team A'}) |
 
+    Scenario: Scoped CALL body may not return an imported variable
+        Given graph "subqueries"
+        When executing query:
+            """
+            MATCH (p:Player)
+            CALL (p) {
+              RETURN p LIMIT 1
+            }
+            RETURN p.name AS playerName
+            """
+        Then an error should be raised
+
+    Scenario: Scoped CALL body may return an imported variable under a name of its own
+        Given graph "subqueries"
+        When executing query:
+            """
+            MATCH (p:Player)
+            CALL (p) {
+              RETURN p AS pp LIMIT 1
+            }
+            RETURN pp.name AS playerName
+            ORDER BY playerName
+            LIMIT 1
+            """
+        Then the result should be:
+            | playerName |
+            | 'Player A' |
+
     Scenario: Scoped CALL with star imports every outer variable
         Given graph "subqueries"
         When executing query:

--- a/tests/gql_behave/tests/memgraph_V1/features/subquery_expressions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subquery_expressions.feature
@@ -561,7 +561,7 @@ Feature: Subquery expressions
           | name   |
           | 'John' |
 
-  Scenario: Test EXISTS subquery with WITH clause
+  Scenario: Test EXISTS subquery with a WITH clause shadowing an outer variable
       Given an empty graph
       And having executed:
           """
@@ -572,7 +572,7 @@ Feature: Subquery expressions
           """
           WITH 'Peter' as name MATCH (person:Person {name: name}) WHERE EXISTS { WITH "Ozzy" AS name MATCH (person)-[:HAS_DOG]->(d:Dog) WHERE d.name = name } RETURN person.name AS name;
           """
-      Then the result should be empty
+      Then an error should be raised
 
   Scenario: Test EXISTS subquery with nested WITH
       Given an empty graph
@@ -2748,3 +2748,171 @@ Feature: Subquery expressions
           | star | named | sub |
           | 1    | 1     | 0   |
           | 1    | 1     | 1   |
+
+  Scenario: Test EXISTS subquery body refuses to shadow an outer variable with a WITH alias
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          WITH 'Peter' AS name
+          MATCH (person:Person {name: name})
+          WHERE EXISTS { WITH 'Ozzy' AS name MATCH (person)-[:HAS_DOG]->(d:Dog) WHERE d.name = name }
+          RETURN person.name AS pn;
+          """
+      Then an error should be raised
+
+  Scenario: Test COUNT subquery body refuses to shadow an outer variable with a WITH alias
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          WITH 'Peter' AS name
+          MATCH (person:Person {name: name})
+          WHERE COUNT { WITH 'Ozzy' AS name MATCH (person)-[:HAS_DOG]->(d:Dog) WHERE d.name = name } = 1
+          RETURN person.name AS pn;
+          """
+      Then an error should be raised
+
+  Scenario: Test EXISTS subquery body refuses to shadow an outer variable with a RETURN alias
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE EXISTS { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN d AS person }
+          RETURN person.name AS pn;
+          """
+      Then an error should be raised
+
+  Scenario: Test a nested EXISTS subquery body refuses to shadow the enclosing body's variable
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE EXISTS { MATCH (person)-[:HAS_DOG]->(dog:Dog) WHERE EXISTS { WITH 'Ozzy' AS dog MATCH (z:Dog) WHERE z.name = dog } }
+          RETURN person.name AS pn;
+          """
+      Then an error should be raised
+
+  Scenario: Test EXISTS subquery body may declare a name the outer scope does not hold
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          WITH 'Peter' AS name
+          MATCH (person:Person {name: name})
+          WHERE EXISTS { WITH 'Ozzy' AS dogName MATCH (person)-[:HAS_DOG]->(d:Dog) WHERE d.name = dogName }
+          RETURN person.name AS pn;
+          """
+      Then the result should be:
+          | pn      |
+          | 'Peter' |
+
+  Scenario: Test EXISTS subquery body may project an outer variable through unchanged
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE EXISTS { MATCH (person)-[:HAS_DOG]->(d:Dog) WITH person, d WHERE d.name = 'Ozzy' RETURN d }
+          RETURN person.name AS pn;
+          """
+      Then the result should be:
+          | pn      |
+          | 'Peter' |
+
+  Scenario: Test COUNT subquery body may return an outer variable unchanged
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          WHERE COUNT { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN person } = 1
+          RETURN person.name AS pn;
+          """
+      Then the result should be:
+          | pn      |
+          | 'Peter' |
+
+  Scenario: Test EXISTS subquery body inside a CALL may declare an un-imported outer name
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          WITH 'Peter' AS name
+          MATCH (person:Person {name: name})
+          CALL { MATCH (d:Dog) WHERE EXISTS { WITH 'Ozzy' AS name MATCH (z:Dog) WHERE z.name = name } RETURN d.name AS dn }
+          RETURN person.name AS pn, dn;
+          """
+      Then the result should be:
+          | pn      | dn     |
+          | 'Peter' | 'Ozzy' |
+
+  Scenario: Test a scoped CALL subquery body refuses to shadow an imported variable
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          CALL (person) { WITH 1 AS person MATCH (d:Dog) RETURN d.name AS dn }
+          RETURN dn;
+          """
+      Then an error should be raised
+
+  Scenario: Test a scoped CALL subquery body refuses to return an imported variable's name
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          CALL (person) { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN d.name AS person }
+          RETURN person;
+          """
+      Then an error should be raised
+
+  Scenario: Test a CALL subquery body importing with WITH may redeclare the name afterwards
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          """
+      When executing query:
+          """
+          MATCH (person:Person)
+          CALL { WITH person WITH 1 AS person MATCH (d:Dog) RETURN d.name AS dn }
+          RETURN person.name AS pn, dn;
+          """
+      Then the result should be:
+          | pn      | dn     |
+          | 'Peter' | 'Ozzy' |

--- a/tests/gql_behave/tests/memgraph_V1/features/subquery_expressions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subquery_expressions.feature
@@ -2749,63 +2749,6 @@ Feature: Subquery expressions
           | 1    | 1     | 0   |
           | 1    | 1     | 1   |
 
-  Scenario: Test EXISTS subquery body refuses to shadow an outer variable with a WITH alias
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
-          """
-      When executing query:
-          """
-          WITH 'Peter' AS name
-          MATCH (person:Person {name: name})
-          WHERE EXISTS { WITH 'Ozzy' AS name MATCH (person)-[:HAS_DOG]->(d:Dog) WHERE d.name = name }
-          RETURN person.name AS pn;
-          """
-      Then an error should be raised
-
-  Scenario: Test COUNT subquery body refuses to shadow an outer variable with a WITH alias
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
-          """
-      When executing query:
-          """
-          WITH 'Peter' AS name
-          MATCH (person:Person {name: name})
-          WHERE COUNT { WITH 'Ozzy' AS name MATCH (person)-[:HAS_DOG]->(d:Dog) WHERE d.name = name } = 1
-          RETURN person.name AS pn;
-          """
-      Then an error should be raised
-
-  Scenario: Test EXISTS subquery body refuses to shadow an outer variable with a RETURN alias
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
-          """
-      When executing query:
-          """
-          MATCH (person:Person)
-          WHERE EXISTS { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN d AS person }
-          RETURN person.name AS pn;
-          """
-      Then an error should be raised
-
-  Scenario: Test EXISTS subquery body refuses to shadow an outer named path
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(d:Dog {name: 'Ozzy'})-[:HAS_TOY]->(:Toy {name: 'Ball'})
-          """
-      When executing query:
-          """
-          MATCH pp = (person:Person)-[:HAS_DOG]->(:Dog)
-          RETURN length(pp) AS L, EXISTS { MATCH pp = (a:Person)-[:HAS_DOG]->()-[:HAS_TOY]->(b:Toy) } AS e;
-          """
-      Then an error should be raised
-
   Scenario: Test COUNT subquery body accepts a named path under a name of its own
       Given an empty graph
       And having executed:
@@ -2821,42 +2764,12 @@ Feature: Subquery expressions
           | L | c |
           | 1 | 1 |
 
-  Scenario: Test a nested EXISTS subquery body refuses to shadow the enclosing body's variable
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
-          """
-      When executing query:
-          """
-          MATCH (person:Person)
-          WHERE EXISTS { MATCH (person)-[:HAS_DOG]->(dog:Dog) WHERE EXISTS { WITH 'Ozzy' AS dog MATCH (z:Dog) WHERE z.name = dog } }
-          RETURN person.name AS pn;
-          """
-      Then an error should be raised
-
-  Scenario: Test EXISTS subquery body may declare a name the outer scope does not hold
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
-          """
-      When executing query:
-          """
-          WITH 'Peter' AS name
-          MATCH (person:Person {name: name})
-          WHERE EXISTS { WITH 'Ozzy' AS dogName MATCH (person)-[:HAS_DOG]->(d:Dog) WHERE d.name = dogName }
-          RETURN person.name AS pn;
-          """
-      Then the result should be:
-          | pn      |
-          | 'Peter' |
-
   Scenario: Test EXISTS subquery body may project an outer variable through unchanged
       Given an empty graph
       And having executed:
           """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          CREATE (:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          CREATE (:Person {name: 'Alice'})-[:HAS_DOG]->(:Dog {name: 'Rex'})
           """
       When executing query:
           """
@@ -2872,7 +2785,9 @@ Feature: Subquery expressions
       Given an empty graph
       And having executed:
           """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          CREATE (:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          CREATE (a:Person {name: 'Alice'})-[:HAS_DOG]->(:Dog {name: 'Rex'})
+          CREATE (a)-[:HAS_DOG]->(:Dog {name: 'Bo'})
           """
       When executing query:
           """
@@ -2888,7 +2803,7 @@ Feature: Subquery expressions
       Given an empty graph
       And having executed:
           """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          CREATE (:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
           """
       When executing query:
           """
@@ -2901,39 +2816,11 @@ Feature: Subquery expressions
           | pn      | dn     |
           | 'Peter' | 'Ozzy' |
 
-  Scenario: Test a scoped CALL subquery body refuses to shadow an imported variable
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
-          """
-      When executing query:
-          """
-          MATCH (person:Person)
-          CALL (person) { WITH 1 AS person MATCH (d:Dog) RETURN d.name AS dn }
-          RETURN dn;
-          """
-      Then an error should be raised
-
-  Scenario: Test a scoped CALL subquery body refuses to return an imported variable's name
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
-          """
-      When executing query:
-          """
-          MATCH (person:Person)
-          CALL (person) { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN d.name AS person }
-          RETURN person;
-          """
-      Then an error should be raised
-
   Scenario: Test a CALL subquery body importing with WITH may redeclare the name afterwards
       Given an empty graph
       And having executed:
           """
-          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
+          CREATE (:Person {name: 'Peter'})-[:HAS_DOG]->(:Dog {name: 'Ozzy'})
           """
       When executing query:
           """

--- a/tests/gql_behave/tests/memgraph_V1/features/subquery_expressions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subquery_expressions.feature
@@ -2793,6 +2793,34 @@ Feature: Subquery expressions
           """
       Then an error should be raised
 
+  Scenario: Test EXISTS subquery body refuses to shadow an outer named path
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(d:Dog {name: 'Ozzy'})-[:HAS_TOY]->(:Toy {name: 'Ball'})
+          """
+      When executing query:
+          """
+          MATCH pp = (person:Person)-[:HAS_DOG]->(:Dog)
+          RETURN length(pp) AS L, EXISTS { MATCH pp = (a:Person)-[:HAS_DOG]->()-[:HAS_TOY]->(b:Toy) } AS e;
+          """
+      Then an error should be raised
+
+  Scenario: Test COUNT subquery body accepts a named path under a name of its own
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (p:Person {name: 'Peter'})-[:HAS_DOG]->(d:Dog {name: 'Ozzy'})-[:HAS_TOY]->(:Toy {name: 'Ball'})
+          """
+      When executing query:
+          """
+          MATCH pp = (person:Person)-[:HAS_DOG]->(:Dog)
+          RETURN length(pp) AS L, COUNT { MATCH qq = (a:Person)-[:HAS_DOG]->()-[:HAS_TOY]->(b:Toy) } AS c;
+          """
+      Then the result should be:
+          | L | c |
+          | 1 | 1 |
+
   Scenario: Test a nested EXISTS subquery body refuses to shadow the enclosing body's variable
       Given an empty graph
       And having executed:

--- a/tests/unit/plan_pretty_print.cpp
+++ b/tests/unit/plan_pretty_print.cpp
@@ -1502,9 +1502,8 @@ TYPED_TEST(PrintToJsonTest, SubqueryExpression) {
                                std::vector<memgraph::storage::EdgeTypeId>{this->dba.NameToEdgeType("EdgeType1")},
                                false,
                                memgraph::storage::View::OLD);
-  std::shared_ptr<LogicalOperator> limit = std::make_shared<Limit>(expand, LITERAL(1));
   std::shared_ptr<LogicalOperator> evaluate_pattern_filter =
-      std::make_shared<EvaluatePatternFilter>(limit, output, RollUpApply::Fold::kBool);
+      std::make_shared<EvaluatePatternFilter>(expand, output, RollUpApply::Fold::kBool);
   last_op = std::make_shared<Filter>(last_op,
                                      std::vector<std::shared_ptr<LogicalOperator>>{evaluate_pattern_filter},
                                      EXISTS(PATTERN(NODE("x"),
@@ -1524,22 +1523,18 @@ TYPED_TEST(PrintToJsonTest, SubqueryExpression) {
             "name": "Filter",
             "pattern_filter1": {
               "input": {
-                "expression": "1",
+                "direction": "both",
+                "edge_symbol": "edge",
+                "edge_types": [
+                  "EdgeType1"
+                ],
+                "existing_node": false,
                 "input": {
-                  "direction": "both",
-                  "edge_symbol": "edge",
-                  "edge_types": [
-                    "EdgeType1"
-                  ],
-                  "existing_node": false,
-                  "input": {
-                    "name": "Once"
-                  },
-                  "input_symbol": "x",
-                  "name": "Expand",
-                  "node_symbol": "node"
+                  "name": "Once"
                 },
-                "name": "Limit"
+                "input_symbol": "x",
+                "name": "Expand",
+                "node_symbol": "node"
               },
               "name": "EvaluatePatternFilter",
               "output_symbol": "output_symbol"

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3282,9 +3282,9 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportRestoredAfterNestedLegacySubquery) {
 }
 
 // A named expression may reproject an import under its own name; the import must stay suppressed, not coexist with
-// the new symbol. Plans identically before and after the fix - it guards `GenWith`'s shadow check, without
-// which `WITH *` projects `m` twice. Aliasing a *different* expression to `m` is refused by the symbol generator,
-// so projecting the import through is the only spelling that still reaches the guard.
+// the new symbol. Guards `GenWith`'s shadow check, without which `WITH *` projects `m` twice. Aliasing a *different*
+// expression to `m` is refused by the symbol generator, so projecting the import through is the only spelling that
+// reaches the guard.
 TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjectedTwice) {
   // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a, m WITH * RETURN a } RETURN a
   FakeDbAccessor dba;

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3281,14 +3281,15 @@ TYPED_TEST(TestPlanner, SubqueryScopedImportRestoredAfterNestedLegacySubquery) {
   DeleteListContent(&nested_branch);
 }
 
-// A named expression may redeclare an import's name; the import must stay suppressed, not coexist with
-// the shadow. Plans identically before and after the fix - it guards `GenWith`'s shadow check, without
-// which `WITH *` projects `m` twice.
+// A named expression may reproject an import under its own name; the import must stay suppressed, not coexist with
+// the new symbol. Plans identically before and after the fix - it guards `GenWith`'s shadow check, without
+// which `WITH *` projects `m` twice. Aliasing a *different* expression to `m` is refused by the symbol generator,
+// so projecting the import through is the only spelling that still reaches the guard.
 TYPED_TEST(TestPlanner, SubqueryScopedImportShadowedByNamedExpressionIsNotProjectedTwice) {
-  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a, a AS m WITH * RETURN a } RETURN a
+  // MATCH (m) CALL (m) { MATCH (m)-[r]-(a) WITH a, m WITH * RETURN a } RETURN a
   FakeDbAccessor dba;
   auto *subquery = SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
-                                WITH(NEXPR("a", IDENT("a")), NEXPR("m", IDENT("a"))),
+                                WITH(NEXPR("a", IDENT("a")), NEXPR("m", IDENT("m"))),
                                 WITH("*"),
                                 RETURN("a"));
   auto *query = QUERY(SINGLE_QUERY(

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -1555,8 +1555,7 @@ TYPED_TEST(TestPlanner, MatchFilterWhere) {
                                    AND(NEQ(IDENT("n"), IDENT("n")), NEQ(LITERAL(7), LITERAL(8))))),
                          RETURN("n")));
 
-  std::list<BaseOpChecker *> pattern_filter{
-      new ExpectScanAll(), new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> pattern_filter{new ExpectScanAll(), new ExpectExpand(), new ExpectEvaluatePatternFilter()};
   CheckPlan<TypeParam>(
       query,
       this->storage,
@@ -2739,7 +2738,7 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
 
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
-    std::list<BaseOpChecker *> pattern_filter{new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+    std::list<BaseOpChecker *> pattern_filter{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(planner.plan(),
               symbol_table,
@@ -2762,7 +2761,7 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(planner.plan(),
               symbol_table,
@@ -2788,9 +2787,8 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter_with_types{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
-    std::list<BaseOpChecker *> pattern_filter_without_types{
-        new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
+    std::list<BaseOpChecker *> pattern_filter_without_types{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(
         planner.plan(),
@@ -2817,7 +2815,7 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(planner.plan(),
               symbol_table,
@@ -2843,9 +2841,8 @@ TYPED_TEST(TestPlanner, SubqueryExpression) {
     auto symbol_table = memgraph::query::MakeSymbolTable(query);
     auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
     std::list<BaseOpChecker *> pattern_filter_with_types{
-        new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
-    std::list<BaseOpChecker *> pattern_filter_without_types{
-        new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+        new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
+    std::list<BaseOpChecker *> pattern_filter_without_types{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
     CheckPlan(
         planner.plan(),
@@ -5103,7 +5100,7 @@ TYPED_TEST(TestPlanner, BasicExistsSubquery) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5125,8 +5122,7 @@ TYPED_TEST(TestPlanner, ExistsSubqueryMatchWhere) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{
-      new ExpectExpand(), new ExpectFilter(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5150,11 +5146,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryMatchWherePlansReturn) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectExpand(),
-                                         new ExpectFilter(),
-                                         new ExpectProduce(),
-                                         new ExpectLimit(),
-                                         new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{
+      new ExpectExpand(), new ExpectFilter(), new ExpectProduce(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5176,11 +5169,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithMatchWhere) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectProduce(),
-                                         new ExpectFilter(),
-                                         new ExpectExpand(),
-                                         new ExpectLimit(),
-                                         new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{
+      new ExpectProduce(), new ExpectFilter(), new ExpectExpand(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5202,11 +5192,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithMatchWhereOnVertexPropety) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> filter_tree{new ExpectProduce(),
-                                         new ExpectExpand(),
-                                         new ExpectFilter(),
-                                         new ExpectLimit(),
-                                         new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> filter_tree{
+      new ExpectProduce(), new ExpectExpand(), new ExpectFilter(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5227,11 +5214,9 @@ TYPED_TEST(TestPlanner, ExistsSubqueryNested) {
   auto symbol_table = memgraph::query::MakeSymbolTable(query);
   auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
 
-  std::list<BaseOpChecker *> nested_filter_tree{
-      new ExpectExpand(), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> nested_filter_tree{new ExpectExpand(), new ExpectEvaluatePatternFilter()};
   std::list<BaseOpChecker *> filter_tree{new ExpectExpand(),
                                          new ExpectFilter(std::vector<std::list<BaseOpChecker *>>{nested_filter_tree}),
-                                         new ExpectLimit(),
                                          new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
@@ -5255,10 +5240,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnion) {
 
   std::list<BaseOpChecker *> left_exists_part{new ExpectExpand()};
   std::list<BaseOpChecker *> right_exists_part{new ExpectExpand()};
-  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
-                                               new ExpectDistinct(),
-                                               new ExpectLimit(),
-                                               new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> exists_union_plan{
+      new ExpectUnion(left_exists_part, right_exists_part), new ExpectDistinct(), new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5286,10 +5269,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionOfReturnOnlyBodies) {
 
   std::list<BaseOpChecker *> left_exists_part{new ExpectOnce(), new ExpectProduce()};
   std::list<BaseOpChecker *> right_exists_part{new ExpectOnce(), new ExpectProduce()};
-  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
-                                               new ExpectDistinct(),
-                                               new ExpectLimit(),
-                                               new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> exists_union_plan{
+      new ExpectUnion(left_exists_part, right_exists_part), new ExpectDistinct(), new ExpectEvaluatePatternFilter()};
 
   // The branch correlates to nothing, so the filter is satisfied before the scan and sits below it.
   CheckPlan(planner.plan(),
@@ -5315,8 +5296,8 @@ TYPED_TEST(TestPlanner, ExistsSubqueryWithUnionAllOfReturnOnlyBodies) {
 
   std::list<BaseOpChecker *> left_exists_part{new ExpectOnce(), new ExpectProduce()};
   std::list<BaseOpChecker *> right_exists_part{new ExpectOnce(), new ExpectProduce()};
-  std::list<BaseOpChecker *> exists_union_plan{
-      new ExpectUnion(left_exists_part, right_exists_part), new ExpectLimit(), new ExpectEvaluatePatternFilter()};
+  std::list<BaseOpChecker *> exists_union_plan{new ExpectUnion(left_exists_part, right_exists_part),
+                                               new ExpectEvaluatePatternFilter()};
 
   CheckPlan(planner.plan(),
             symbol_table,
@@ -5382,7 +5363,7 @@ TYPED_TEST(TestPlanner, CountSubqueryInReturnProjection) {
 
 TYPED_TEST(TestPlanner, CountSubqueryInMatchWhereUsesTheDeferredFold) {
   // MATCH (n) WHERE COUNT { MATCH (n)-[r]->(m) } > 1 RETURN n
-  // Deferred, as for EXISTS. No Limit above the branch: it would truncate the drain.
+  // Deferred, as for EXISTS: an untaken disjunct skips the branch, which for a count is a whole drain.
   FakeDbAccessor dba;
 
   auto *count_subquery = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m")))));

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1735,6 +1735,196 @@ TYPED_TEST(TestSymbolGenerator, ExistsAsSimpleCaseTest) {
                                      RETURN(AND(simple_case(pattern_form()), simple_case(pattern_form())), AS("h")))));
 }
 
+// Measured against Neo4j 2026.02.2: a subquery expression's body sees the whole enclosing scope, so declaring a name
+// that scope already holds is refused (42N07) rather than silently answering about the inner binding. Both folds,
+// because they share the one AST node and the one gate.
+TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayNotShadowAnOuterName) {
+  auto expect_message = [](auto *query, std::string_view message) {
+    try {
+      MakeSymbolTable(query);
+      FAIL() << "expected the query to be refused";
+    } catch (const SemanticException &e) {
+      EXPECT_EQ(std::string_view{e.what()}, message);
+    }
+  };
+
+  auto check_folds = [&](auto make_subquery, std::string_view construct) {
+    // MATCH (n) WHERE EXISTS { WITH 1 AS n MATCH (m) } RETURN n - a WITH alias.
+    expect_message(
+        QUERY(SINGLE_QUERY(
+            MATCH(PATTERN(NODE("n"))),
+            WHERE(make_subquery(QUERY(SINGLE_QUERY(WITH(NEXPR("n", LITERAL(1))), MATCH(PATTERN(NODE("m"))))))),
+            RETURN("n"))),
+        fmt::format("Variable 'n' in {} shadows a variable with the same name from the outer scope.", construct));
+
+    // MATCH (n) WHERE EXISTS { MATCH (n)-[r]->(m) RETURN m AS n } RETURN n - a RETURN alias.
+    expect_message(
+        QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                           WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))),
+                                                                  RETURN(IDENT("m"), AS("n")))))),
+                           RETURN("n"))),
+        fmt::format("Variable 'n' in {} shadows a variable with the same name from the outer scope.", construct));
+
+    // The name need not be one the body uses, and the body need not correlate at all:
+    // MATCH (n) WHERE EXISTS { MATCH (m) WITH m, 1 AS n RETURN m } RETURN n
+    expect_message(
+        QUERY(SINGLE_QUERY(
+            MATCH(PATTERN(NODE("n"))),
+            WHERE(make_subquery(QUERY(SINGLE_QUERY(
+                MATCH(PATTERN(NODE("m"))), WITH(NEXPR("m", IDENT("m")), NEXPR("n", LITERAL(1))), RETURN("m"))))),
+            RETURN("n"))),
+        fmt::format("Variable 'n' in {} shadows a variable with the same name from the outer scope.", construct));
+
+    // A name the *enclosing body* declared counts as outer to a nested one:
+    // MATCH (n) WHERE EXISTS { MATCH (n)-[r]->(q) WHERE EXISTS { WITH 1 AS q MATCH (z) } } RETURN n
+    expect_message(
+        QUERY(SINGLE_QUERY(
+            MATCH(PATTERN(NODE("n"))),
+            WHERE(make_subquery(QUERY(SINGLE_QUERY(
+                MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("q"))),
+                WHERE(make_subquery(QUERY(SINGLE_QUERY(WITH(NEXPR("q", LITERAL(1))), MATCH(PATTERN(NODE("z"))))))))))),
+            RETURN("n"))),
+        fmt::format("Variable 'q' in {} shadows a variable with the same name from the outer scope.", construct));
+  };
+
+  check_folds([this](auto *subquery) { return EXISTS_SUBQUERY(subquery); }, "EXISTS");
+  check_folds([this](auto *subquery) { return COUNT_SUBQUERY(subquery); }, "COUNT");
+}
+
+// The accepted half, and the half that carries the regression risk: referencing an outer name is what correlation *is*,
+// and projecting one through under its own name declares nothing new. All measured accepted on Neo4j 2026.02.2.
+TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayStillUseAnOuterName) {
+  auto check_folds = [&](auto make_subquery) {
+    // MATCH (n) WHERE EXISTS { MATCH (n)-[r]->(m) } RETURN n - plain correlation.
+    MakeSymbolTable(
+        QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                           WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))))))),
+                           RETURN("n"))));
+
+    // A declaration of a name that is not outer.
+    MakeSymbolTable(QUERY(SINGLE_QUERY(
+        MATCH(PATTERN(NODE("n"))),
+        WHERE(make_subquery(QUERY(SINGLE_QUERY(WITH(NEXPR("zzz", LITERAL(1))), MATCH(PATTERN(NODE("m"))))))),
+        RETURN("n"))));
+
+    // MATCH (n) WHERE EXISTS { MATCH (n)-[r]->(m) WITH n, m RETURN m } RETURN n - `n` projected through unchanged.
+    MakeSymbolTable(
+        QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                           WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))),
+                                                                  WITH(NEXPR("n", IDENT("n")), NEXPR("m", IDENT("m"))),
+                                                                  RETURN("m"))))),
+                           RETURN("n"))));
+
+    // ... and returned unchanged: EXISTS { MATCH (n)-[r]->(m) RETURN n }
+    MakeSymbolTable(QUERY(SINGLE_QUERY(
+        MATCH(PATTERN(NODE("n"))),
+        WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))), RETURN("n"))))),
+        RETURN("n"))));
+
+    // Renaming an outer name to a fresh one: EXISTS { MATCH (n)-[r]->(m) WITH n AS p2, m RETURN m }
+    MakeSymbolTable(
+        QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))),
+                           WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"), EDGE("r"), NODE("m"))),
+                                                                  WITH(NEXPR("p2", IDENT("n")), NEXPR("m", IDENT("m"))),
+                                                                  RETURN("m"))))),
+                           RETURN("n"))));
+
+    // Re-aliasing a *body-local* name twice: only names visible from outside the body are protected.
+    MakeSymbolTable(QUERY(SINGLE_QUERY(
+        MATCH(PATTERN(NODE("n"))),
+        WHERE(make_subquery(QUERY(SINGLE_QUERY(
+            MATCH(PATTERN(NODE("m"))), WITH(NEXPR("q", IDENT("m"))), WITH(NEXPR("q", LITERAL(1))), RETURN("q"))))),
+        RETURN("n"))));
+
+    // An un-imported outer name is out of reach inside a `CALL {}`, so a body nested in one may declare it freely:
+    // MATCH (n) CALL { MATCH (q) WHERE EXISTS { WITH 1 AS n MATCH (z) } RETURN q AS x } RETURN x
+    MakeSymbolTable(QUERY(SINGLE_QUERY(
+        MATCH(PATTERN(NODE("n"))),
+        CALL_SUBQUERY(QUERY(SINGLE_QUERY(
+            MATCH(PATTERN(NODE("q"))),
+            WHERE(make_subquery(QUERY(SINGLE_QUERY(WITH(NEXPR("n", LITERAL(1))), MATCH(PATTERN(NODE("z"))))))),
+            RETURN(IDENT("q"), AS("x"))))),
+        RETURN("x"))));
+  };
+
+  check_folds([this](auto *subquery) { return EXISTS_SUBQUERY(subquery); });
+  check_folds([this](auto *subquery) { return COUNT_SUBQUERY(subquery); });
+}
+
+// `CALL {}` has a scope of its own, so what it can shadow is exactly what it imported - measured on Neo4j 2026.02.2,
+// where the `CALL { WITH v ... }` spelling shadows nothing at all and only `CALL (v) { ... }` refuses.
+TYPED_TEST(TestSymbolGenerator, ScopedCallBodyMayNotShadowAnImport) {
+  auto expect_message = [](auto *query, std::string_view message) {
+    try {
+      MakeSymbolTable(query);
+      FAIL() << "expected the query to be refused";
+    } catch (const SemanticException &e) {
+      EXPECT_EQ(std::string_view{e.what()}, message);
+    }
+  };
+  auto scoped_on_m = [this](auto *subquery) { return CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}); };
+
+  // MATCH (m) CALL (m) { MATCH (q) WITH 1 AS m RETURN q AS x } RETURN x
+  expect_message(
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
+                         scoped_on_m(QUERY(SINGLE_QUERY(
+                             MATCH(PATTERN(NODE("q"))), WITH(NEXPR("m", LITERAL(1))), RETURN(LITERAL(1), AS("x"))))),
+                         RETURN("x"))),
+      "Variable 'm' shadows the variable of the same name imported into this subquery.");
+
+  // The body's RETURN is refused whatever it projects, because the name it would reintroduce is already outside:
+  // MATCH (m) CALL (m) { MATCH (m)-[r]->(a) RETURN a AS m } RETURN m  - the base answered with the *outer* `m`.
+  expect_message(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
+                                    scoped_on_m(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                                                   RETURN(IDENT("a"), AS("m"))))),
+                                    RETURN("m"))),
+                 "Variable 'm' in subquery already declared in outer scope!");
+
+  // ... including when it projects the import itself: CALL (m) { MATCH (m)-[r]->(a) RETURN m }
+  expect_message(
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
+                         scoped_on_m(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))), RETURN("m")))),
+                         RETURN("m"))),
+      "Variable 'm' in subquery already declared in outer scope!");
+
+  // A subquery expression inside the body measures "outer" against the import, so this is refused:
+  // MATCH (m) CALL (m) { MATCH (m)-[r]->(a) WHERE EXISTS { WITH 1 AS m MATCH (z) } RETURN a AS x } RETURN x
+  expect_message(
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
+                         scoped_on_m(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                                        WHERE(EXISTS_SUBQUERY(QUERY(SINGLE_QUERY(
+                                                            WITH(NEXPR("m", LITERAL(1))), MATCH(PATTERN(NODE("z"))))))),
+                                                        RETURN(IDENT("a"), AS("x"))))),
+                         RETURN("x"))),
+      "Variable 'm' in EXISTS shadows a variable with the same name from the outer scope.");
+
+  // Accepted: an intermediate WITH may carry the import through unchanged.
+  // MATCH (m) CALL (m) { MATCH (m)-[r]->(a) WITH m, a RETURN a AS x } RETURN x
+  MakeSymbolTable(
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
+                         scoped_on_m(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
+                                                        WITH(NEXPR("m", IDENT("m")), NEXPR("a", IDENT("a"))),
+                                                        RETURN(IDENT("a"), AS("x"))))),
+                         RETURN("x"))));
+
+  // Accepted: a name the scope clause did not import is not visible inside, so declaring it shadows nothing.
+  // MATCH (m) MATCH (other) CALL (m) { MATCH (q) WITH 1 AS other RETURN other AS x } RETURN x
+  MakeSymbolTable(QUERY(
+      SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
+                   MATCH(PATTERN(NODE("other"))),
+                   scoped_on_m(QUERY(SINGLE_QUERY(
+                       MATCH(PATTERN(NODE("q"))), WITH(NEXPR("other", LITERAL(1))), RETURN(IDENT("other"), AS("x"))))),
+                   RETURN("x"))));
+
+  // Accepted: the `CALL { WITH v ... }` spelling imports inside the body, so a later clause may redeclare the name.
+  // MATCH (m) CALL { WITH m WITH 1 AS m MATCH (q) RETURN q AS x } RETURN x
+  MakeSymbolTable(QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("m"))),
+      CALL_SUBQUERY(QUERY(SINGLE_QUERY(
+          WITH("m"), WITH(NEXPR("m", LITERAL(1))), MATCH(PATTERN(NODE("q"))), RETURN(IDENT("q"), AS("x"))))),
+      RETURN("x"))));
+}
+
 TYPED_TEST(TestSymbolGenerator, Subqueries) {
   // MATCH (n) CALL { MATCH (n) RETURN n } RETURN n
   // Yields exception because n in subquery is referenced in outer scope

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1735,9 +1735,8 @@ TYPED_TEST(TestSymbolGenerator, ExistsAsSimpleCaseTest) {
                                      RETURN(AND(simple_case(pattern_form()), simple_case(pattern_form())), AS("h")))));
 }
 
-// Measured against Neo4j 2026.02.2: a subquery expression's body sees the whole enclosing scope, so declaring a name
-// that scope already holds is refused (42N07) rather than silently answering about the inner binding. Both folds,
-// because they share the one AST node and the one gate.
+// A body sees the whole enclosing scope, so declaring a name that scope already holds is refused rather than
+// answering about the inner binding. Both folds, because they share the one AST node and the one gate.
 TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayNotShadowAnOuterName) {
   auto expect_message = [](auto *query, std::string_view message) {
     try {
@@ -1826,8 +1825,8 @@ TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayNotShadowAnOuterName) {
   check_folds([this](auto *subquery) { return COUNT_SUBQUERY(subquery); }, "COUNT");
 }
 
-// The accepted half, and the half that carries the regression risk: referencing an outer name is what correlation *is*,
-// and projecting one through under its own name declares nothing new. All measured accepted on Neo4j 2026.02.2.
+// The accepted half, and the half that carries the regression risk: referencing an outer name is what correlation
+// *is*, and projecting one through under its own name declares nothing new.
 TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayStillUseAnOuterName) {
   auto check_folds = [&](auto make_subquery) {
     // MATCH (n) WHERE EXISTS { MATCH (n)-[r]->(m) } RETURN n - plain correlation.
@@ -1918,8 +1917,8 @@ TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayStillUseAnOuterName) {
   check_folds([this](auto *subquery) { return COUNT_SUBQUERY(subquery); });
 }
 
-// `CALL {}` has a scope of its own, so what it can shadow is exactly what it imported - measured on Neo4j 2026.02.2,
-// where the `CALL { WITH v ... }` spelling shadows nothing at all and only `CALL (v) { ... }` refuses.
+// `CALL {}` has a scope of its own, so what it can shadow is exactly what it imported: the `CALL { WITH v ... }`
+// spelling shadows nothing, and only `CALL (v) { ... }` refuses.
 TYPED_TEST(TestSymbolGenerator, ScopedCallBodyMayNotShadowAnImport) {
   auto expect_message = [](auto *query, std::string_view message) {
     try {
@@ -1960,7 +1959,7 @@ TYPED_TEST(TestSymbolGenerator, ScopedCallBodyMayNotShadowAnImport) {
       "Variable 'm' shadows the variable of the same name imported into this subquery.");
 
   // The body's RETURN is refused whatever it projects, because the name it would reintroduce is already outside:
-  // MATCH (m) CALL (m) { MATCH (m)-[r]->(a) RETURN a AS m } RETURN m  - the base answered with the *outer* `m`.
+  // MATCH (m) CALL (m) { MATCH (m)-[r]->(a) RETURN a AS m } RETURN m
   expect_message(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
                                     scoped_on_m(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"), EDGE("r"), NODE("a"))),
                                                                    RETURN(IDENT("a"), AS("m"))))),

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1785,6 +1785,15 @@ TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayNotShadowAnOuterName) {
                 WHERE(make_subquery(QUERY(SINGLE_QUERY(WITH(NEXPR("q", LITERAL(1))), MATCH(PATTERN(NODE("z"))))))))))),
             RETURN("n"))),
         fmt::format("Variable 'q' in {} shadows a variable with the same name from the outer scope.", construct));
+
+    // A named path assigns its own path, so it declares the name:
+    // MATCH p = (n)-[r]->(m) WHERE EXISTS { MATCH p = (a)-[r2]->(b) } RETURN n
+    expect_message(
+        QUERY(SINGLE_QUERY(MATCH(NAMED_PATTERN("p", NODE("n"), EDGE("r"), NODE("m"))),
+                           WHERE(make_subquery(QUERY(SINGLE_QUERY(
+                               MATCH(NAMED_PATTERN("p", NODE("a"), EDGE("r2"), NODE("b"))), RETURN("a"))))),
+                           RETURN("n"))),
+        fmt::format("Variable 'p' in {} shadows a variable with the same name from the outer scope.", construct));
   };
 
   check_folds([this](auto *subquery) { return EXISTS_SUBQUERY(subquery); }, "EXISTS");
@@ -1845,6 +1854,13 @@ TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayStillUseAnOuterName) {
             WHERE(make_subquery(QUERY(SINGLE_QUERY(WITH(NEXPR("n", LITERAL(1))), MATCH(PATTERN(NODE("z"))))))),
             RETURN(IDENT("q"), AS("x"))))),
         RETURN("x"))));
+
+    // A named path under a name the outer query does not hold:
+    // MATCH p = (n)-[r]->(m) WHERE EXISTS { MATCH q = (a)-[r2]->(b) } RETURN n
+    MakeSymbolTable(QUERY(SINGLE_QUERY(MATCH(NAMED_PATTERN("p", NODE("n"), EDGE("r"), NODE("m"))),
+                                       WHERE(make_subquery(QUERY(SINGLE_QUERY(
+                                           MATCH(NAMED_PATTERN("q", NODE("a"), EDGE("r2"), NODE("b"))), RETURN("a"))))),
+                                       RETURN("n"))));
   };
 
   check_folds([this](auto *subquery) { return EXISTS_SUBQUERY(subquery); });

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1794,6 +1794,32 @@ TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayNotShadowAnOuterName) {
                                MATCH(NAMED_PATTERN("p", NODE("a"), EDGE("r2"), NODE("b"))), RETURN("a"))))),
                            RETURN("n"))),
         fmt::format("Variable 'p' in {} shadows a variable with the same name from the outer scope.", construct));
+
+    // A UNION branch is still the same body, so a later branch shadows what the first one does:
+    // MATCH (n) WHERE EXISTS { MATCH (z) RETURN z AS zz UNION MATCH (y) WITH 1 AS n, y RETURN y AS zz } RETURN n
+    // Put in the *second* branch on purpose - the first is already covered by the body scope itself.
+    expect_message(
+        QUERY(SINGLE_QUERY(
+            MATCH(PATTERN(NODE("n"))),
+            WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("z"))), RETURN(IDENT("z"), AS("zz"))),
+                                      UNION(SINGLE_QUERY(MATCH(PATTERN(NODE("y"))),
+                                                         WITH(NEXPR("n", LITERAL(1)), NEXPR("y", IDENT("y"))),
+                                                         RETURN(IDENT("y"), AS("zz"))))))),
+            RETURN("n"))),
+        fmt::format("Variable 'n' in {} shadows a variable with the same name from the outer scope.", construct));
+
+    // A name declared inside an unscoped `CALL {}` body is outer to a subquery body nested in it:
+    // MATCH (q) CALL { WITH 1 AS nm MATCH (d) WHERE EXISTS { WITH 2 AS nm MATCH (z) } RETURN d AS x } RETURN x
+    expect_message(
+        QUERY(SINGLE_QUERY(
+            MATCH(PATTERN(NODE("q"))),
+            CALL_SUBQUERY(QUERY(SINGLE_QUERY(
+                WITH(NEXPR("nm", LITERAL(1))),
+                MATCH(PATTERN(NODE("d"))),
+                WHERE(make_subquery(QUERY(SINGLE_QUERY(WITH(NEXPR("nm", LITERAL(2))), MATCH(PATTERN(NODE("z"))))))),
+                RETURN(IDENT("d"), AS("x"))))),
+            RETURN("x"))),
+        fmt::format("Variable 'nm' in {} shadows a variable with the same name from the outer scope.", construct));
   };
 
   check_folds([this](auto *subquery) { return EXISTS_SUBQUERY(subquery); }, "EXISTS");
@@ -1861,6 +1887,31 @@ TYPED_TEST(TestSymbolGenerator, SubqueryBodyMayStillUseAnOuterName) {
                                        WHERE(make_subquery(QUERY(SINGLE_QUERY(
                                            MATCH(NAMED_PATTERN("q", NODE("a"), EDGE("r2"), NODE("b"))), RETURN("a"))))),
                                        RETURN("n"))));
+
+    // Accepting the spelling is half the rule; the body must still mean the outer variable. A fresh symbol here
+    // would decorrelate silently, which no accept-only check can see.
+    {
+      auto *outer_n = NODE("n");
+      auto *body_n = NODE("n");
+      auto symbol_table = MakeSymbolTable(QUERY(
+          SINGLE_QUERY(MATCH(PATTERN(outer_n)),
+                       WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(body_n, EDGE("r"), NODE("m"))),
+                                                              WITH(NEXPR("n", IDENT("n")), NEXPR("m", IDENT("m"))),
+                                                              RETURN("m"))))),
+                       RETURN("n"))));
+      EXPECT_EQ(symbol_table.at(*outer_n->identifier_), symbol_table.at(*body_n->identifier_))
+          << "an identity projection must not decorrelate the body";
+    }
+    {
+      auto *outer_n = NODE("n");
+      auto *body_n = NODE("n");
+      auto symbol_table = MakeSymbolTable(
+          QUERY(SINGLE_QUERY(MATCH(PATTERN(outer_n)),
+                             WHERE(make_subquery(QUERY(SINGLE_QUERY(MATCH(PATTERN(body_n, EDGE("r"), NODE("m"))))))),
+                             RETURN("n"))));
+      EXPECT_EQ(symbol_table.at(*outer_n->identifier_), symbol_table.at(*body_n->identifier_))
+          << "plain correlation must resolve to the outer symbol";
+    }
   };
 
   check_folds([this](auto *subquery) { return EXISTS_SUBQUERY(subquery); });
@@ -1879,6 +1930,26 @@ TYPED_TEST(TestSymbolGenerator, ScopedCallBodyMayNotShadowAnImport) {
     }
   };
   auto scoped_on_m = [this](auto *subquery) { return CALL_SUBQUERY_SCOPED(subquery, std::vector<std::string>{"m"}); };
+  auto scoped_on_all = [this](auto *subquery) { return CALL_SUBQUERY_SCOPED_ALL(subquery); };
+
+  // `CALL (*) { ... }` imports every outer name, so it shadows the same way `CALL (m) { ... }` does:
+  // MATCH (m) CALL (*) { MATCH (q) WITH 1 AS m RETURN q AS x } RETURN x
+  expect_message(
+      QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))),
+                         scoped_on_all(QUERY(SINGLE_QUERY(
+                             MATCH(PATTERN(NODE("q"))), WITH(NEXPR("m", LITERAL(1))), RETURN(LITERAL(1), AS("x"))))),
+                         RETURN("x"))),
+      "Variable 'm' shadows the variable of the same name imported into this subquery.");
+
+  // A named path declares its name against the import too:
+  // MATCH pp = (m)-[r]->(b) CALL (pp) { MATCH pp = (c)-[r2]->(d) RETURN c AS x } RETURN x
+  expect_message(QUERY(SINGLE_QUERY(MATCH(NAMED_PATTERN("pp", NODE("m"), EDGE("r"), NODE("b"))),
+                                    CALL_SUBQUERY_SCOPED(
+                                        QUERY(SINGLE_QUERY(MATCH(NAMED_PATTERN("pp", NODE("c"), EDGE("r2"), NODE("d"))),
+                                                           RETURN(IDENT("c"), AS("x")))),
+                                        std::vector<std::string>{"pp"}),
+                                    RETURN("x"))),
+                 "Variable 'pp' shadows the variable of the same name imported into this subquery.");
 
   // MATCH (m) CALL (m) { MATCH (q) WITH 1 AS m RETURN q AS x } RETURN x
   expect_message(


### PR DESCRIPTION
**What.** A subquery body that rebinds a name already visible from outside it now raises a query error instead of silently answering about the inner binding. Applies to `EXISTS { … }`, `COUNT { … }`, and to `CALL (v) { … }` / `CALL (*) { … }` bodies rebinding an imported variable. Referencing an outer variable — and projecting one through a body `WITH`/`RETURN` under its own name — is unaffected.

**How.** `src/query/frontend/semantic/symbol_generator.{hpp,cpp}` only. A new `Scope::subquery_body_base` records the index of the scope a subquery body opened, set in `PreVisit(SubqueryExpression&)` and carried across `UNION` branches; it pairs with the existing `call_subquery_base`. `ShadowsEnclosingName` searches only *between* those two indices, and `CheckDoesNotShadow` runs once per named expression in `VisitReturnBody`.

Uses the index-based scope pattern rather than holding a `Scope &` — `scopes_` is capacity-1, so a reference held across an `Accept` dangles.

**Why.** Neo4j refuses this with `42N07`; we accepted it and returned rows computed against the inner binding, so the query silently meant something else. The `CALL (v) { … RETURN <expr> AS v }` case was worse than a missing error — it returned the **outer** `v`, dropping the subquery's own column with no diagnostic.

**The rule is narrower than "may not declare an outer name."** It was derived from measurement, not from the reference text, and the reference wording would have broken working queries. Measured on Neo4j 2026.02.2, 106 queries across `EXISTS` / `COUNT` / `CALL {}`:

| body shape | verdict |
|---|---|
| pattern reuses an outer name — `EXISTS { MATCH (person:Dog) }` | **accepted** — it *correlates*, it does not declare |
| identity projection — `EXISTS { WITH person … }`, `RETURN person`, `WITH person AS person` | **accepted** |
| rebinding to a different value — `EXISTS { WITH 1 AS person … }`, `WITH d AS name` | **refused** |
| body-local name not visible outside | **accepted** |
| `CALL { WITH person WITH 1 AS person … }` (importing `WITH`) | **accepted** — the importing `WITH` is part of the body |
| `CALL (person) { … RETURN … AS person }` (scope clause) | **refused** |

So the rule is "may not bind an outer name to a **different** value". Pattern-position reuse, lambda / list-comprehension / `reduce` variables, body-local re-aliasing, and anything inside a `CALL {}` that the `CALL` did not import are all deliberately left accepted.

**Verification.** 106-query A/B against a pre-change binary: **32 fixed, 0 regressed**, 63 already at parity, 11 pre-existing divergences unrelated to this change. `gql_behave memgraph_V1`: 7 base-only failures (exactly the new refusals), **0 new-only**; `openCypher_M09` byte-identical. `query_semantic` 264, `query_plan` 282, plus `query_variable_start_planner`, `query_parallel_plan`, `plan_pretty_print`, `cypher_main_visitor`, `query_plan_match_filter_return` all pass.

**Known gap.** `UNWIND … AS <outer name>` in a body is refused today only by the coarser clause allow-list, not by this rule. No check was added because it would be unreachable dead code — but whoever widens that allow-list to admit `UNWIND` must add one, or the defect reopens on that spelling.

---

**Stacked PR.** Base is `rung/1-subquery-filter-loss` (#4630) → `feat/count-subquery` (#4598) → `fix/exists-body-return` (#4597) → `master`.
