### PR TITLE
feat(storage): create indices under read-only access in analytical mode

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10434,15 +10434,16 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 
     using enum storage::StorageAccessType;
     mode_dependent_ = true;
-    auto const creating = index_query.action_ == IndexQuery::Action::CREATE;
     if (storage_mode_ == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
-      accessor_type_ = creating ? READ_ONLY : READ;
+      accessor_type_ = (index_query.action_ == IndexQuery::Action::CREATE) ? READ_ONLY : READ;
     } else if (storage_mode_ == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
-      // Creation only has to exclude writers, so reads run alongside it; unlike transactional the
-      // hold is kept for the whole population (see DowngradeToReadIfValid). Dropping stays unique.
-      accessor_type_ = creating ? READ_ONLY : UNIQUE;
+      // Read-only either way, so reads run alongside: creation needs writers out for the whole
+      // population (see DowngradeToReadIfValid), and a drop takes effect at once but is undone by
+      // restoring the index exactly as captured, so a writer admitted before the commit would leave
+      // the restored index missing whatever it wrote.
+      accessor_type_ = READ_ONLY;
     } else {
       // ON_DISK_TRANSACTIONAL requires unique access
       accessor_type_ = UNIQUE;
@@ -10456,13 +10457,12 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 
     using enum storage::StorageAccessType;
     mode_dependent_ = true;
-    auto const creating = edge_index_query.action_ == EdgeIndexQuery::Action::CREATE;
     if (storage_mode_ == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
-      accessor_type_ = creating ? READ_ONLY : READ;
+      accessor_type_ = (edge_index_query.action_ == EdgeIndexQuery::Action::CREATE) ? READ_ONLY : READ;
     } else if (storage_mode_ == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
-      accessor_type_ = creating ? READ_ONLY : UNIQUE;
+      accessor_type_ = READ_ONLY;
     } else {
       // ON_DISK_TRANSACTIONAL requires unique access
       accessor_type_ = UNIQUE;
@@ -10727,7 +10727,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
 
         // SET STORAGE MODE can land between the unlocked read of `storage_mode` and the accessor
         // taking its hold, leaving the access type chosen for a mode no longer in force: an index
-        // drop planned as transactional holds READ where analytical wants UNIQUE. Retrying
+        // drop planned as transactional holds READ where analytical wants READ_ONLY. Retrying
         // replans against the pinned mode. The throw unwinds into the catch below, releasing the
         // hold.
         if (transaction_requirements.mode_dependent_ &&

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10434,12 +10434,17 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 
     using enum storage::StorageAccessType;
     mode_dependent_ = true;
+    auto const creating = index_query.action_ == IndexQuery::Action::CREATE;
     if (storage_mode_ == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
-      accessor_type_ = (index_query.action_ == IndexQuery::Action::CREATE) ? READ_ONLY : READ;
+      accessor_type_ = creating ? READ_ONLY : READ;
+    } else if (storage_mode_ == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
+      // Creation only has to exclude writers, so reads run alongside it; unlike transactional the
+      // hold is kept for the whole population (see DowngradeToReadIfValid). Dropping stays unique.
+      accessor_type_ = creating ? READ_ONLY : UNIQUE;
     } else {
-      // IN_MEMORY_ANALYTICAL and ON_DISK_TRANSACTIONAL require unique access
+      // ON_DISK_TRANSACTIONAL requires unique access
       accessor_type_ = UNIQUE;
     }
   }
@@ -10451,12 +10456,15 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
 
     using enum storage::StorageAccessType;
     mode_dependent_ = true;
+    auto const creating = edge_index_query.action_ == EdgeIndexQuery::Action::CREATE;
     if (storage_mode_ == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
-      accessor_type_ = (edge_index_query.action_ == EdgeIndexQuery::Action::CREATE) ? READ_ONLY : READ;
+      accessor_type_ = creating ? READ_ONLY : READ;
+    } else if (storage_mode_ == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
+      accessor_type_ = creating ? READ_ONLY : UNIQUE;
     } else {
-      // IN_MEMORY_ANALYTICAL and ON_DISK_TRANSACTIONAL require unique access
+      // ON_DISK_TRANSACTIONAL requires unique access
       accessor_type_ = UNIQUE;
     }
   }
@@ -10719,7 +10727,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
 
         // SET STORAGE MODE can land between the unlocked read of `storage_mode` and the accessor
         // taking its hold, leaving the access type chosen for a mode no longer in force: an index
-        // create planned as transactional holds READ_ONLY where analytical wants UNIQUE. Retrying
+        // drop planned as transactional holds READ where analytical wants UNIQUE. Retrying
         // replans against the pinned mode. The throw unwinds into the catch below, releasing the
         // hold.
         if (transaction_requirements.mode_dependent_ &&

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2061,8 +2061,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(LabelId label) {
   // UNIQUE access will be done only through schema.assert
-  MG_ASSERT(type() == UNIQUE || type() == READ,
-            "Dropping label index requires a unique or read access to the storage!");
+  MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
+            "Dropping label index requires a unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_label_index = static_cast<InMemoryLabelIndex *>(in_memory->indices_.label_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
@@ -2090,8 +2090,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(
     LabelId label, std::vector<storage::PropertyPath> &&properties, std::optional<IndexOrder> order) {
   // UNIQUE access will be done only through schema.assert
-  MG_ASSERT(type() == UNIQUE || type() == READ,
-            "Dropping label-property index requires a unique or read access to the storage!");
+  MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
+            "Dropping label-property index requires a unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_label_property_index =
       static_cast<InMemoryLabelPropertyIndex *>(in_memory->indices_.label_property_index_.get());
@@ -2141,8 +2141,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(EdgeTypeId edge_type) {
   // UNIQUE access will be done only through schema.assert
-  MG_ASSERT(type() == UNIQUE || type() == READ,
-            "Dropping edge-type index requires a unique or read access to the storage!");
+  MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
+            "Dropping edge-type index requires a unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(in_memory->indices_.edge_type_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
@@ -2165,8 +2165,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(EdgeTypeId edge_type,
                                                                                               PropertyId property) {
   // UNIQUE access will be done only through schema.assert
-  MG_ASSERT(type() == UNIQUE || type() == READ,
-            "Dropping edge-type property index requires a unique or read access to the storage!");
+  MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
+            "Dropping edge-type property index requires a unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   if (!in_memory->config_.salient.items.properties_on_edges) {
     // Not possible to drop the index, no properties on edges
@@ -2194,8 +2194,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropGlobalEdgeIndex(
     PropertyId property) {
   // UNIQUE access will be done only through schema.assert
-  MG_ASSERT(type() == UNIQUE || type() == READ,
-            "Dropping global edge property index requires unique or read access to the storage!");
+  MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
+            "Dropping global edge property index requires unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   if (!in_memory->config_.salient.items.properties_on_edges) {
     // Not possible to create the index, no properties on edges
@@ -2223,8 +2223,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropGlobalVertexIndex(
     PropertyId property) {
-  MG_ASSERT(type() == UNIQUE || type() == READ,
-            "Dropping global vertex property index requires unique or read access to the storage!");
+  MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
+            "Dropping global vertex property index requires unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_vertex_property_index =
       static_cast<InMemoryVertexPropertyIndex *>(in_memory->indices_.vertex_property_index_.get());

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1915,6 +1915,12 @@ auto InMemoryStorage::InMemoryAccessor::CreateIndex(LabelId label, PropertiesPat
 }
 
 void InMemoryStorage::InMemoryAccessor::DowngradeToReadIfValid() {
+  // Only transactional can let writers in for the population: they record deltas, so the populating
+  // scan still reads its own snapshot, and their stale index entries wait for GC. Analytical writes
+  // in place with no deltas to read past, and its index maintenance erases entries eagerly (see
+  // ActiveIndices::UpdateOnRemoveLabel), which would race the scan that is still filling the same
+  // skip list. Keep the READ_ONLY hold, which excludes writers and analytical GC alike.
+  if (transaction_.storage_mode != StorageMode::IN_MEMORY_TRANSACTIONAL) return;
   if (guard_.owns_lock() && guard_.type() == utils::ResourceLockGuard::READ_ONLY) {
     guard_.downgrade_to_read();
   }

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -5614,3 +5614,47 @@ TEST_F(NestedIndexAnalytical, NestedValueOverwrittenByANewNestedValue) {
   EXPECT_THAT(IndexedVertices(pvr::Equal(PropertyValue{6})), UnorderedElementsAre(gid));
   EXPECT_THAT(IndexedVertices(pvr::Equal(PropertyValue{5})), IsEmpty());
 }
+
+// Index creation is granted READ_ONLY access, which excludes writers. Transactional hands it back
+// as READ for the population, letting writers in; analytical keeps it, because its populating scan
+// has no deltas to read a snapshot through and its writers erase index entries eagerly.
+class IndexCreationHold : public testing::TestWithParam<StorageMode> {
+ protected:
+  void SetUp() override {
+    storage = std::make_unique<InMemoryStorage>(Config{});
+    storage->SetStorageMode(GetParam());
+    label = storage->NameToLabel("L");
+  }
+
+  std::unique_ptr<InMemoryStorage> storage;
+  LabelId label;
+};
+
+TEST_P(IndexCreationHold, ReadersAreAdmittedDuringPopulation) {
+  auto reader = storage->Access(READ);
+
+  auto creator = storage->ReadOnlyAccess();
+  ASSERT_NO_ERROR(creator->CreateIndex(label));
+  ASSERT_NO_ERROR(creator->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  reader->Abort();
+
+  auto acc = storage->Access(READ);
+  EXPECT_THAT(acc->ListAllIndices().label, UnorderedElementsAre(label));
+  acc->Abort();
+}
+
+TEST_P(IndexCreationHold, WritersOnlyDuringTransactionalPopulation) {
+  auto creator = storage->ReadOnlyAccess();
+  ASSERT_NO_ERROR(creator->CreateIndex(label));
+
+  auto const transactional = GetParam() == StorageMode::IN_MEMORY_TRANSACTIONAL;
+  EXPECT_EQ(creator->type(), transactional ? READ : READ_ONLY);
+  auto writer = storage->TryAccess(WRITE);
+  EXPECT_EQ(writer != nullptr, transactional);
+
+  if (writer) writer->Abort();
+  ASSERT_NO_ERROR(creator->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+}
+
+INSTANTIATE_TEST_SUITE_P(InMemoryModes, IndexCreationHold,
+                         ::testing::Values(StorageMode::IN_MEMORY_TRANSACTIONAL, StorageMode::IN_MEMORY_ANALYTICAL));

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -205,6 +205,30 @@ TEST_F(StorageModeMultiTxTest, AnalyticalIndexCreationAccess) {
   }
 }
 
+// Dropping asks for read-only access too: an aborted drop restores the index as it was captured, so
+// no writer may run between the drop and the commit.
+TEST_F(StorageModeMultiTxTest, AnalyticalIndexDropAccess) {
+  main_interpreter.Interpret("STORAGE MODE IN_MEMORY_ANALYTICAL");
+  ASSERT_EQ(db->GetStorageMode(), memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+  main_interpreter.Interpret("CREATE INDEX ON :Label1");
+
+  {
+    auto writer = db->storage()->Access(memgraph::storage::WRITE);
+    ASSERT_THROW(running_interpreter.Interpret("DROP INDEX ON :Label1"), memgraph::storage::ReadOnlyAccessTimeout);
+    writer->Abort();
+  }
+
+  {
+    auto reader = db->storage()->Access(memgraph::storage::READ);
+    running_interpreter.Interpret("DROP INDEX ON :Label1");
+    reader->Abort();
+  }
+
+  auto acc = db->storage()->Access(memgraph::storage::READ);
+  ASSERT_EQ(acc->ListAllIndices().label.size(), 0);
+  acc->Abort();
+}
+
 // nlohmann ADL hooks for StorageMode (storage_mode.hpp): integer wire encoding + range-checked read.
 // These back the durable hot/cold cold_stats JSON and SalientConfig, which both rely on plain
 // integer encoding — switching to a string form would break read-back of existing entries.

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -182,6 +182,29 @@ TEST_F(StorageModeMultiTxTest, ErrorChangeIsolationLevel) {
                memgraph::query::IsolationLevelModificationInAnalyticsException);
 }
 
+// Analytical index creation asks for read-only access, so it waits for writers but not for readers.
+TEST_F(StorageModeMultiTxTest, AnalyticalIndexCreationAccess) {
+  main_interpreter.Interpret("STORAGE MODE IN_MEMORY_ANALYTICAL");
+  ASSERT_EQ(db->GetStorageMode(), memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+
+  {
+    auto reader = db->storage()->Access(memgraph::storage::READ);
+    running_interpreter.Interpret("CREATE INDEX ON :Label1");
+    reader->Abort();
+  }
+  {
+    auto acc = db->storage()->Access(memgraph::storage::READ);
+    ASSERT_EQ(acc->ListAllIndices().label.size(), 1);
+    acc->Abort();
+  }
+
+  {
+    auto writer = db->storage()->Access(memgraph::storage::WRITE);
+    ASSERT_THROW(running_interpreter.Interpret("CREATE INDEX ON :Label2"), memgraph::storage::ReadOnlyAccessTimeout);
+    writer->Abort();
+  }
+}
+
 // nlohmann ADL hooks for StorageMode (storage_mode.hpp): integer wire encoding + range-checked read.
 // These back the durable hot/cold cold_stats JSON and SalientConfig, which both rely on plain
 // integer encoding — switching to a string form would break read-back of existing entries.


### PR DESCRIPTION
### What

In `IN_MEMORY_ANALYTICAL`, index DDL now takes **read-only** storage access instead of **unique** access:

- `CREATE INDEX` — read-only excludes writers, which is all population needs. Unique additionally excluded readers, so a build and any concurrent read query held each other off for the whole population. Readers and other index builds now run alongside.
- `DROP INDEX` — a copy-on-write erase plus a plan-cache invalidation, so unique access bought nothing except holding readers off.

Applies to label, label-property, edge-type, edge-type-property and global property indices. Point/vector/text index DDL is unchanged (still unique; text is unsupported in analytical). Transactional and on-disk paths are untouched.

### Why the hold is kept for the population

`DowngradeToReadIfValid()` is now transactional-only. Transactional can safely admit writers mid-population — they record deltas, so the populating scan still reads its own snapshot, and their stale index entries wait for GC. Analytical cannot:

- analytical writes in place and records no deltas, so the scan has nothing to read a consistent view through;
- analytical index maintenance erases entries eagerly (`ActiveIndices::UpdateOnRemoveLabel`, `UpdateOnSetProperty`) instead of leaving them to the GC sweep, so a concurrent writer would be erasing from the very skip list the scan is still filling;
- analytical vertex deletion defers index cleanup to a GC full scan, and analytical GC takes `WRITE` on `main_lock_` — which the retained read-only hold excludes.

Downgrading in analytical is the one thing that would make the access change unsound, hence the two go together.

### Why drop is read-only rather than read

Transactional drops under `READ`. Analytical must not: the drop takes effect immediately (`invalidate_now`) while the transaction commits later, and an abort restores the captured index **verbatim** — `RestoreIndex` does no repopulation. A writer admitted into that window takes an `ActiveIndices` snapshot without the index, so it does not maintain it, and a restored index would silently be missing those writes. Analytical has no deltas to reconstruct them from. `READ_ONLY` keeps writers out for the whole transaction, exactly as `UNIQUE` did.

The six `DropIndex`/`DropGlobal*Index` asserts were widened to accept `READ_ONLY`; without that the first analytical drop would `MG_ASSERT`-abort.

### Safety notes

- **GC**: analytical `CollectGarbage` takes `WRITE` (or `UNIQUE` under aggressive GC), both excluded by the retained read-only hold. The unguarded tail of `free_memory_func_` (index `RunGC`, `vertices_/edges_.run_gc()`, graveyard drain) does overlap the population, and is safe: skip-list GC is epoch-based against live accessors, and `CleanupAllIndices` only reaps entries at `use_count() == 1`, which a registered index never is. That overlap is not new — transactional populates under `READ`, which excludes nothing either.
- **`FreeMemory`**: its three callers (periodic GC, `FREE MEMORY` query, `SetStorageMode`) all either hold nothing or hold their own `UNIQUE`, so none can deadlock against a build; they wait. Nothing calls `FreeMemory` from inside index creation, which matters because a same-thread call would now block on our own read-only hold.
- **No WAL/replication impact**: analytical writes no WAL and refuses to run with registered replicas, so the access type a replica would replay under is unaffected.
- **Liveness**: index builds defer analytical GC while they hold access. They did under `UNIQUE` too, but overlapping builds can now keep `ro_count > 0` continuously, so a bulk import issuing many `CREATE INDEX` statements back-to-back defers GC for longer. `FREE MEMORY` afterwards is the escape hatch.
- Analytical constraint creation already worked exactly this way (read-only, hold retained), so this aligns index DDL with it.

### Tests

- `tests/unit/storage_v2_indices.cpp` — `IndexCreationHold`, parameterized over both in-memory modes: readers are admitted during population in either mode; after `CreateIndex` the hold is `READ` with `TryAccess(WRITE)` granted in transactional, versus `READ_ONLY` with it refused in analytical.
- `tests/unit/storage_v2_storage_mode.cpp` — `AnalyticalIndexCreationAccess` and `AnalyticalIndexDropAccess`, through the interpreter: with a `READ` accessor held, create/drop complete; with a `WRITE` accessor held, both fail with `ReadOnlyAccessTimeout`. Each fails on regression in either direction.
