### PR TITLE
fix(storage): accept a numeric offset in a zoned datetime constraint

### DIFF
--- a/src/storage/v2/constraints/type_constraints_kind.hpp
+++ b/src/storage/v2/constraints/type_constraints_kind.hpp
@@ -16,6 +16,7 @@
 #include "storage/v2/temporal.hpp"
 
 #include <cstdint>
+#include <span>
 #include <string>
 #include <utility>
 
@@ -74,31 +75,48 @@ inline std::string_view TypeConstraintKindToString(TypeConstraintKind type) {
   std::unreachable();
 }
 
-inline PropertyStoreType TypeConstraintsKindToPropertyStoreType(TypeConstraintKind type) {
+/// The stored types a value of this constraint kind may be held as.
+///
+/// One kind can have more than one encoding: a zoned datetime is stored differently depending
+/// on whether its timezone is a name or a numeric offset, and a list is stored out of line when
+/// a vector index holds it. Each is the same type to the user, so each satisfies the constraint.
+inline std::span<PropertyStoreType const> TypeConstraintsKindToPropertyStoreType(TypeConstraintKind type) {
+  static constexpr PropertyStoreType kString[] = {PropertyStoreType::STRING};
+  static constexpr PropertyStoreType kBool[] = {PropertyStoreType::BOOL};
+  static constexpr PropertyStoreType kInt[] = {PropertyStoreType::INT};
+  static constexpr PropertyStoreType kDouble[] = {PropertyStoreType::DOUBLE};
+  static constexpr PropertyStoreType kList[] = {PropertyStoreType::LIST, PropertyStoreType::VECTOR};
+  static constexpr PropertyStoreType kMap[] = {PropertyStoreType::MAP};
+  static constexpr PropertyStoreType kTemporal[] = {PropertyStoreType::TEMPORAL_DATA};
+  static constexpr PropertyStoreType kZonedTemporal[] = {PropertyStoreType::ZONED_TEMPORAL_DATA,
+                                                         PropertyStoreType::OFFSET_ZONED_TEMPORAL_DATA};
+  static constexpr PropertyStoreType kEnum[] = {PropertyStoreType::ENUM};
+  static constexpr PropertyStoreType kPoint[] = {PropertyStoreType::POINT};
+
   switch (type) {
     case TypeConstraintKind::STRING:
-      return PropertyStoreType::STRING;
+      return kString;
     case TypeConstraintKind::BOOLEAN:
-      return PropertyStoreType::BOOL;
+      return kBool;
     case TypeConstraintKind::INTEGER:
-      return PropertyStoreType::INT;
+      return kInt;
     case TypeConstraintKind::FLOAT:
-      return PropertyStoreType::DOUBLE;
+      return kDouble;
     case TypeConstraintKind::LIST:
-      return PropertyStoreType::LIST;
+      return kList;
     case TypeConstraintKind::MAP:
-      return PropertyStoreType::MAP;
+      return kMap;
     case TypeConstraintKind::DURATION:
     case TypeConstraintKind::DATE:
     case TypeConstraintKind::LOCALTIME:
     case TypeConstraintKind::LOCALDATETIME:
-      return PropertyStoreType::TEMPORAL_DATA;
+      return kTemporal;
     case TypeConstraintKind::ZONEDDATETIME:
-      return PropertyStoreType::ZONED_TEMPORAL_DATA;
+      return kZonedTemporal;
     case TypeConstraintKind::ENUM:
-      return PropertyStoreType::ENUM;
+      return kEnum;
     case TypeConstraintKind::POINT:
-      return PropertyStoreType::POINT;
+      return kPoint;
   }
   std::unreachable();
 }

--- a/src/storage/v2/constraints/type_constraints_validator.cpp
+++ b/src/storage/v2/constraints/type_constraints_validator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,6 +13,8 @@
 
 #include "range/v3/all.hpp"
 
+#include <algorithm>
+
 namespace memgraph::storage {
 
 auto TypeConstraintsValidator::validate(PropertyStoreMemberInfo const &member_info) const
@@ -26,7 +28,7 @@ auto TypeConstraintsValidator::validate(PropertyStoreMemberInfo const &member_in
       if (TemporalMatch(*member_info.temporal_type, it->second)) continue;
     } else {
       // coarse grain (broad type class)
-      if (TypeConstraintsKindToPropertyStoreType(it->second) == member_info.type) continue;
+      if (std::ranges::contains(TypeConstraintsKindToPropertyStoreType(it->second), member_info.type)) continue;
     }
     return PropertyStoreConstraintViolation{member_info.prop_id, label, it->second};
   }

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -23,6 +23,7 @@
 #include "storage/v2/disk/unique_constraints.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
+#include "utils/small_vector.hpp"
 
 #include "disk_test_utils.hpp"
 #include "tests/test_commit_args_helper.hpp"
@@ -1518,6 +1519,79 @@ TYPED_TEST(ConstraintsTest, TypeConstraintsSubtypeCheckForTemporalData) {
     ASSERT_THROW((void)vertex1.SetProperty(this->prop1, PropertyValue(TemporalData{TemporalType::LocalDateTime, 0})),
                  memgraph::query::QueryException);
     ASSERT_NO_ERROR(vertex1.SetProperty(this->prop1, PropertyValue(TemporalData{TemporalType::Date, 0})));
+  }
+}
+
+// A zoned datetime is stored one of two ways depending on its timezone: a named zone or a
+// numeric offset. Both are ZonedDateTime values and both satisfy a ZONED DATE TIME constraint.
+TYPED_TEST(ConstraintsTest, TypeConstraintsZonedDateTimeWithOffsetTimezone) {
+  if (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    GTEST_SKIP() << "Type constraints not implemented for on-disk";
+  }
+
+  {
+    auto constraint_acc = this->CreateConstraintAccessor();
+    auto res = constraint_acc->CreateTypeConstraint(this->label1, this->prop1, TypeConstraintKind::ZONEDDATETIME);
+    ASSERT_NO_ERROR(res);
+    ASSERT_NO_ERROR(constraint_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  auto const when = memgraph::utils::AsSysTime(1732145501);
+  auto const zoned = [&](memgraph::utils::Timezone timezone) {
+    return PropertyValue(ZonedTemporalData{ZonedTemporalType::ZonedDateTime, when, timezone});
+  };
+
+  {
+    auto acc1 = this->storage->Access(memgraph::storage::WRITE);
+    auto vertex1 = acc1->CreateVertex();
+
+    ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
+    ASSERT_NO_ERROR(vertex1.SetProperty(this->prop1, zoned(memgraph::utils::Timezone("Etc/UTC"))));
+    ASSERT_NO_ERROR(vertex1.SetProperty(this->prop1, zoned(memgraph::utils::Timezone(std::chrono::minutes{60}))));
+    ASSERT_NO_ERROR(vertex1.SetProperty(this->prop1, zoned(memgraph::utils::Timezone(std::chrono::minutes{-330}))));
+
+    // A value that is not a zoned datetime is still rejected.
+    ASSERT_THROW((void)vertex1.SetProperty(this->prop1, PropertyValue("problem")), memgraph::query::QueryException);
+    ASSERT_THROW((void)vertex1.SetProperty(this->prop1, PropertyValue(TemporalData{TemporalType::LocalDateTime, 0})),
+                 memgraph::query::QueryException);
+  }
+
+  // The same holds when the label arrives after the property.
+  {
+    auto acc1 = this->storage->Access(memgraph::storage::WRITE);
+    auto vertex1 = acc1->CreateVertex();
+
+    ASSERT_NO_ERROR(vertex1.SetProperty(this->prop1, zoned(memgraph::utils::Timezone(std::chrono::minutes{60}))));
+    ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
+  }
+}
+
+// A list is held out of line when a vector index covers it, but it is still a list to the user
+// and still satisfies a LIST constraint. Validation that reads an already-stored record therefore
+// has to accept that encoding as well as the inline one.
+TYPED_TEST(ConstraintsTest, TypeConstraintsListHeldByVectorIndex) {
+  if (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    GTEST_SKIP() << "Type constraints not implemented for on-disk";
+  }
+
+  {
+    auto constraint_acc = this->CreateConstraintAccessor();
+    auto res = constraint_acc->CreateTypeConstraint(this->label1, this->prop1, TypeConstraintKind::LIST);
+    ASSERT_NO_ERROR(res);
+    ASSERT_NO_ERROR(constraint_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  {
+    auto acc1 = this->storage->Access(memgraph::storage::WRITE);
+    auto vertex1 = acc1->CreateVertex();
+    auto const held_by_index = PropertyValue(PropertyValue::VectorIndexIdData{
+        .ids = memgraph::utils::small_vector<uint64_t>{acc1->GetNameIdMapper()->NameToId("a_vector_index")},
+        .vector = memgraph::utils::small_vector<float>{1.0F, 2.0F}});
+
+    // The label arrives last so that the constraint is checked against the stored record rather
+    // than against the value being written.
+    ASSERT_NO_ERROR(vertex1.SetProperty(this->prop1, held_by_index));
+    ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
   }
 }
 


### PR DESCRIPTION
A zoned datetime whose timezone is a numeric UTC offset now satisfies a zoned
datetime type constraint. Such a value is stored in a different encoding from
one whose timezone is a named region, and the check recognised only the named
encoding, so a valid value was rejected. Whether it was rejected depended on
the order the label and the property were written, because only a check against
an already stored record sees the encoding.

A constraint kind can now name more than one stored encoding rather than
exactly one. That also covers a list, which is held out of line when a vector
index is defined over it and is still a list to the user. Values that were
rejected are now accepted, and nothing that was accepted before is rejected now.
