### PR TITLE
feat(storage): keep reads running while leaving analytical mode

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -920,8 +920,20 @@ void InMemoryReplicationHandlers::WalFilesHandler(
       storage->Clear(record_progress);
     }
 
-    // Read here because we don't know names of new WAL files
-    old_wal_files = utils::GetFilesFromDir(current_wal_directory);
+    // Read here because we don't know names of new WAL files. This listing names the stale
+    // pre-reset WALs the end-of-handler cleanup removes; proceeding with an incomplete one would
+    // report success while leaving them to corrupt the replica's next restart. Fail the RPC
+    // instead, so the main re-drives recovery.
+    auto maybe_old_wal_files = utils::TryGetFilesFromDir(current_wal_directory);
+    if (!maybe_old_wal_files) {
+      spdlog::error("Couldn't list the old WAL files of db {}; failing the recovery for MAIN to retry.",
+                    storage->name());
+      heartbeat.Stop();
+      rpc::SendFinalResponse(
+          storage::replication::WalFilesRes{std::nullopt, 0}, request_version, res_builder, storage->name());
+      return;
+    }
+    old_wal_files = *std::move(maybe_old_wal_files);
   }
 
   const auto wal_file_number = req.file_number;
@@ -1079,8 +1091,19 @@ void InMemoryReplicationHandlers::CurrentWalHandler(
       storage->Clear(record_progress);
     }
 
-    // Read here because we don't know the name of the new WAL file
-    old_wal_files = utils::GetFilesFromDir(current_wal_directory);
+    // Read here because we don't know the name of the new WAL file. This listing names the stale
+    // pre-reset WALs the end-of-handler cleanup removes; proceeding with an incomplete one would
+    // report success while leaving them to corrupt the replica's next restart. Fail the RPC
+    // instead, so the main re-drives recovery.
+    auto maybe_old_wal_files = utils::TryGetFilesFromDir(current_wal_directory);
+    if (!maybe_old_wal_files) {
+      spdlog::error("Couldn't list the old WAL files of db {}; failing the recovery for MAIN to retry.",
+                    storage->name());
+      heartbeat.Stop();
+      rpc::SendFinalResponse(storage::replication::CurrentWalRes{std::nullopt, 0}, request_version, res_builder);
+      return;
+    }
+    old_wal_files = *std::move(maybe_old_wal_files);
   }
 
   // Even if loading wal file failed, we return last_durable_timestamp to the main because it is not a fatal error

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -71,6 +71,7 @@
 #include "utils/scheduler.hpp"
 #include "utils/stat.hpp"
 #include "utils/temporal.hpp"
+#include "utils/thread.hpp"
 #include "utils/variant_helpers.hpp"
 
 import memgraph.utils.aws;
@@ -546,6 +547,19 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
 }
 
 InMemoryStorage::~InMemoryStorage() {
+  // A pending analytical -> transactional flip runs on mode_switch_thread_ and touches members torn
+  // down below (snapshot runner, WAL machinery, replication state); let it finish before any of that.
+  {
+    auto thread_guard = std::scoped_lock{mode_switch_thread_mutex_};
+    if (mode_switch_thread_.joinable()) {
+      // The flip cannot be completed at any cost here: it may be parked behind unbounded in-flight
+      // readers, and joining without the stop request would hold shutdown hostage to them. The
+      // thread abandons the switch on the next slice instead.
+      mode_switch_thread_.request_stop();
+      mode_switch_thread_.join();
+    }
+  }
+
   flags::run_time::SnapshotPeriodicDetach(snapshot_periodic_observer_);
 
   stop_source.request_stop();
@@ -2908,138 +2922,357 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
           metric_handles_.unreleased_delta_objects};
 }
 
+namespace {
+
+/// The index families whose analytical-mode DDL runs under READ_ONLY access, extracted through the
+/// accessor's transaction-pinned view and sorted so two captures compare by content. READ_ONLY is
+/// compatible with the READ_ONLY hold the mode-change exit snapshot is written under, so only these
+/// families can change concurrently with that snapshot; every other index kind (text, point,
+/// vector) still requires UNIQUE access, which the transaction-id check covers.
+IndicesInfo SortedIndexDefinitions(Storage::Accessor &accessor) {
+  auto info = accessor.ListAllIndices();
+  std::ranges::sort(info.label);
+  std::ranges::sort(info.label_properties);
+  std::ranges::sort(info.edge_type);
+  std::ranges::sort(info.edge_type_property);
+  std::ranges::sort(info.edge_property);
+  std::ranges::sort(info.vertex_property);
+  return info;
+}
+
+bool ReadOnlyMutableIndexDefinitionsEqual(IndicesInfo const &lhs, IndicesInfo const &rhs) {
+  return lhs.label == rhs.label && lhs.label_properties == rhs.label_properties && lhs.edge_type == rhs.edge_type &&
+         lhs.edge_type_property == rhs.edge_type_property && lhs.edge_property == rhs.edge_property &&
+         lhs.vertex_property == rhs.vertex_property;
+}
+
+}  // namespace
+
 void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
-  // Drain before UNIQUE: worker holds AsyncIndexer::mutex_ while waiting on
-  // main_lock_, so draining under UNIQUE would deadlock.
-  if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL && storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) {
+  MG_ASSERT(new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL ||
+            new_storage_mode == StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+  // One transition at a time, waiting rather than failing, so back-to-back calls keep behaving as
+  // if executed one by one: the analytical -> transactional direction can still be finishing on a
+  // background thread when the next call arrives.
+  storage_mode_transition_permit_.acquire();
+  bool handed_off = false;
+  const utils::OnScopeExit release_permit{[&] {
+    if (!handed_off) storage_mode_transition_permit_.release();
+  }};
+
+  // Pinned while the permit is held (the holder owns the only path that writes it), so this read
+  // cannot go stale.
+  const auto current_mode = storage_mode_.load();
+  MG_ASSERT(current_mode == StorageMode::IN_MEMORY_ANALYTICAL || current_mode == StorageMode::IN_MEMORY_TRANSACTIONAL);
+  if (current_mode == new_storage_mode) return;
+
+  if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL) {
+    // Drain before UNIQUE: worker holds AsyncIndexer::mutex_ while waiting on
+    // main_lock_, so draining under UNIQUE would deadlock.
     spdlog::info("SetStorageMode: draining async indexer before transition to IN_MEMORY_ANALYTICAL");
     async_indexer_.CompleteRemaining();
     spdlog::info("SetStorageMode: async indexer drained");
-  }
 
-  auto unique_accessor = UniqueAccess();
-  MG_ASSERT(
-      (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL || storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) &&
-      (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL ||
-       new_storage_mode == StorageMode::IN_MEMORY_TRANSACTIONAL));
-  if (storage_mode_ != new_storage_mode) {
-    // Snapshot thread is already running, but setup periodic execution only if enabled
-    if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL) {
-      auto active_constraints = GetActiveConstraints();
-      // Constraints violation require deltas so we can abort. Hence in analytical can not support any constraint
-      if (active_constraints && !active_constraints->empty()) {
-        throw utils::BasicException(
-            "Constraints are not supported in analytical storage mode. Please drop them before "
-            "changing storage mode to analytical or use transactional mode.");
-      }
-      // Anything enqueued in the gap between drain and UNIQUE can't be drained here without deadlock.
-      if (!async_indexer_.IsIdle()) {
-        throw utils::BasicException(
-            "Cannot switch to IN_MEMORY_ANALYTICAL: an async index creation task (from CREATE INDEX "
-            "or ENABLE TTL) was enqueued concurrently with the storage mode change. Wait for pending "
-            "index creation to finish and retry.");
-      }
-      // Analytical writes are never appended to the WAL, so a replica attached across the switch would
-      // silently miss the whole episode. Refuse and store the mode under the clients' own lock, which is
-      // the same lock replica registration inserts under: "analytical with a live client" is then
-      // unrepresentable rather than merely a narrow race.
-      repl_storage_state_.replication_storage_clients_.WithLock([this](auto const &clients) {
-        if (!clients.empty()) {
-          throw utils::BasicException(
-              "Cannot switch to IN_MEMORY_ANALYTICAL while {} replica(s) replicate from this database. Analytical "
-              "writes are not replicated; unregister every replica first.",
-              clients.size());
-        }
-        storage_mode_ = StorageMode::IN_MEMORY_ANALYTICAL;
-      });
-
-      // Finalize the WAL so the episode leaves a file-level signature: the pre-import file's [from, to]
-      // range then ends before the switch-back snapshot's timestamp, which is how GetRecoverySteps
-      // detects that no WAL can reproduce the imported data. Placed after every check that throws, so a
-      // rejected switch has no side effect, and under engine_lock_ because GetRecoverySteps holds that
-      // lock specifically to read wal_file_. Lock order main_lock_ -> engine_lock_ is respected, since
-      // the UNIQUE hold above is on main_lock_.
-      {
-        std::unique_lock const engine_guard(engine_lock_);
-        if (wal_file_) {
-          wal_file_->FinalizeWal();
-          wal_file_.reset();
-          wal_unsynced_transactions_ = 0;
-        }
-      }
-      snapshot_runner_.Pause();
-    } else {
-      // No need to resume async indexer, it is always running.
-      // As IN_MEMORY_TRANSACTIONAL we will now start giving it new work.
-      // The txn's last_durable_ts_ was captured at unique-acc construction
-      // from the pre-analytical-mode ldt; analytical-mode writes don't bump
-      // ldt, so without this the snapshot's durable_timestamp would lag its
-      // contents and consumers would skip it as "not newer".
-      auto *txn = unique_accessor->GetTransaction();
-      txn->last_durable_ts_ = txn->start_timestamp;
-      const auto snapshot_path = durability::CreateSnapshot(this,
-                                                            txn,
-                                                            recovery_.snapshot_directory_,
-                                                            recovery_.wal_directory_,
-                                                            &vertices_,
-                                                            &edges_,
-                                                            uuid(),
-                                                            repl_storage_state_.epoch_.id(),
-                                                            repl_storage_state_.history,
-                                                            &file_retainer_,
-                                                            &abort_snapshot_,
-                                                            &snapshot_progress_,
-                                                            "storage_mode_change");
-      if (!snapshot_path) {
-        // Analytical writes never reached a WAL, so this snapshot is the only durable record the episode
-        // will ever have. Completing the switch without it would leave the data live in memory but absent
-        // from durability, and the next recovery would silently drop it. Stay analytical instead: the
-        // mode, the cached ldt and every durability file are still untouched at this point, so the user
-        // can fix the cause and retry. CreateSnapshot has already removed whatever partial file it wrote.
-        throw utils::BasicException(
-            "Failed to create the snapshot required to leave IN_MEMORY_ANALYTICAL. The database is still in "
-            "analytical mode and its data is unchanged; check the logs for the cause and retry.");
-      }
-
-      // Publish the snapshot's timestamp as the cached ldt. Analytical writes never reach
-      // FinalizeCommitPhase, so without this main keeps advertising the pre-analytical ldt and a replica
-      // registered afterwards is judged up to date by the heartbeat comparison -- recovery would never
-      // run and the imported data would never reach it. num_committed_txns_ is deliberately left alone:
-      // the snapshot records the same unchanged counter, so main and a recovering replica stay
-      // consistent. Advance-only, since concurrent commits are barred by the UNIQUE main_lock_ hold but
-      // the field is shared with the replication clients.
-      atomic_struct_update<CommitTsInfo>(repl_storage_state_.commit_ts_info_,
-                                         [ldt = *txn->last_durable_ts_](CommitTsInfo const &old_info) {
-                                           return CommitTsInfo{.ldt_ = std::max(old_info.ldt_, ldt),
-                                                               .num_committed_txns_ = old_info.num_committed_txns_};
-                                         });
-
-      // The switch-back snapshot is a new durability base, not an increment on the old one: an analytical
-      // episode leaves a timestamp hole no WAL can fill, so nothing written before it can be chained onto
-      // it. Archive the superseded files and restart the WAL numbering at 0 -- the two go together.
-      // Wiping alone would break recovery, since a chain whose first file has a non-zero sequence number
-      // is accepted only when some WAL predates the snapshot, and every such WAL is what was just wiped.
-      // Restarting alone would be worse: the surviving files carry this same UUID, so the new numbers
-      // would collide with theirs, and a duplicate sequence number is caught by no check anywhere.
-      DMG_ASSERT(!wal_file_, "Analytical mode must not leave an open WAL file.");
-      if (ArchiveSupersededDurabilityFiles(*snapshot_path)) {
-        wal_seq_num_ = 0;
-      } else {
-        spdlog::warn(
-            "Superseded WAL files could not be archived, so WAL sequence numbering continues from {} to stay "
-            "collision-free.",
-            wal_seq_num_);
-      }
-      snapshot_runner_.Resume();
-      // Under the clients' lock for symmetry with the analytical store above, so replica registration's
-      // in-lock read of storage_mode_ is serialized against every mode change, not just one direction.
-      repl_storage_state_.replication_storage_clients_.WithLock(
-          [this](auto const & /*clients*/) { storage_mode_ = StorageMode::IN_MEMORY_TRANSACTIONAL; });
+    auto unique_accessor = UniqueAccess();
+    auto active_constraints = GetActiveConstraints();
+    // Constraints violation require deltas so we can abort. Hence in analytical can not support any constraint
+    if (active_constraints && !active_constraints->empty()) {
+      throw utils::BasicException(
+          "Constraints are not supported in analytical storage mode. Please drop them before "
+          "changing storage mode to analytical or use transactional mode.");
     }
+    // Anything enqueued in the gap between drain and UNIQUE can't be drained here without deadlock.
+    if (!async_indexer_.IsIdle()) {
+      throw utils::BasicException(
+          "Cannot switch to IN_MEMORY_ANALYTICAL: an async index creation task (from CREATE INDEX "
+          "or ENABLE TTL) was enqueued concurrently with the storage mode change. Wait for pending "
+          "index creation to finish and retry.");
+    }
+    // Analytical writes are never appended to the WAL, so a replica attached across the switch would
+    // silently miss the whole episode. Refuse and store the mode under the clients' own lock, which is
+    // the same lock replica registration inserts under: "analytical with a live client" is then
+    // unrepresentable rather than merely a narrow race.
+    repl_storage_state_.replication_storage_clients_.WithLock([this](auto const &clients) {
+      if (!clients.empty()) {
+        throw utils::BasicException(
+            "Cannot switch to IN_MEMORY_ANALYTICAL while {} replica(s) replicate from this database. Analytical "
+            "writes are not replicated; unregister every replica first.",
+            clients.size());
+      }
+      storage_mode_ = StorageMode::IN_MEMORY_ANALYTICAL;
+    });
+
+    // Finalize the WAL so the episode leaves a file-level signature: the pre-import file's [from, to]
+    // range then ends before the switch-back snapshot's timestamp, which is how GetRecoverySteps
+    // detects that no WAL can reproduce the imported data. Placed after every check that throws, so a
+    // rejected switch has no side effect, and under engine_lock_ because GetRecoverySteps holds that
+    // lock specifically to read wal_file_. Lock order main_lock_ -> engine_lock_ is respected, since
+    // the UNIQUE hold above is on main_lock_.
+    {
+      std::unique_lock const engine_guard(engine_lock_);
+      if (wal_file_) {
+        wal_file_->FinalizeWal();
+        wal_file_.reset();
+        wal_unsynced_transactions_ = 0;
+      }
+    }
+    snapshot_runner_.Pause();
     // Hand off the same lock unique_accessor already holds; adopting main_lock_ into a second
     // lock would give the one hold two owners and release it twice.
     FreeMemory(unique_accessor->ReleaseGuard(), false);
+    return;
   }
+
+  // IN_MEMORY_ANALYTICAL -> IN_MEMORY_TRANSACTIONAL. The exit snapshot dominates the switch, so it
+  // is written under READ_ONLY -- writers stay excluded but readers keep running -- instead of
+  // under the UNIQUE hold the flip itself needs. A pending-UNIQUE registration taken while
+  // READ_ONLY is still held then gates every new accessor, so nothing that could invalidate the
+  // snapshot is admitted before the flip: the flip either completes right here (lock free, the
+  // common case) or on a background thread once the already-admitted readers drain, without
+  // stalling this call behind them.
+
+  std::unique_ptr<utils::UniquePendingScope> pending_unique;
+  std::filesystem::path snapshot_path;
+  uint64_t snapshot_ldt{};
+  uint64_t expected_transaction_id{};
+  IndicesInfo expected_index_definitions;
+  {
+    // The snapshot machinery (progress, abort flag) is single-flight; since readers -- and with
+    // them manual CREATE SNAPSHOT, which runs under READ_ONLY in analytical mode -- stay admitted
+    // while ours is written, take the same exclusion the CreateSnapshot member takes. Scoped to
+    // the write itself: SHOW SNAPSHOTS takes snapshot_lock_ from under a query's READ hold, so
+    // holding it while waiting for UNIQUE below would invert that order.
+    auto snapshot_expected = false;
+    if (!snapshot_running_.compare_exchange_strong(snapshot_expected, true, std::memory_order_acq_rel)) {
+      throw utils::BasicException(
+          "Cannot switch to IN_MEMORY_TRANSACTIONAL: a snapshot is currently being created. Retry once it completes.");
+    }
+    const utils::OnScopeExit clear_snapshot_running{[this] {
+      snapshot_running_.store(false, std::memory_order_release);
+      snapshot_progress_.Reset();
+    }};
+    snapshot_progress_.Start();
+    const auto snapshot_guard = std::unique_lock{snapshot_lock_};
+
+    auto read_only_accessor = ReadOnlyAccess();
+    auto *txn = read_only_accessor->GetTransaction();
+    // The txn's last_durable_ts_ was captured at construction from the pre-analytical-mode ldt;
+    // analytical-mode writes don't bump ldt, so without this the snapshot's durable_timestamp would
+    // lag its contents and consumers would skip it as "not newer".
+    txn->last_durable_ts_ = txn->start_timestamp;
+    const auto maybe_snapshot_path = durability::CreateSnapshot(this,
+                                                                txn,
+                                                                recovery_.snapshot_directory_,
+                                                                recovery_.wal_directory_,
+                                                                &vertices_,
+                                                                &edges_,
+                                                                uuid(),
+                                                                repl_storage_state_.epoch_.id(),
+                                                                repl_storage_state_.history,
+                                                                &file_retainer_,
+                                                                &abort_snapshot_,
+                                                                &snapshot_progress_,
+                                                                "storage_mode_change");
+    if (!maybe_snapshot_path) {
+      // Analytical writes never reached a WAL, so this snapshot is the only durable record the episode
+      // will ever have. Completing the switch without it would leave the data live in memory but absent
+      // from durability, and the next recovery would silently drop it. Stay analytical instead: the
+      // mode, the cached ldt and every durability file are still untouched at this point, so the user
+      // can fix the cause and retry. CreateSnapshot has already removed whatever partial file it wrote.
+      throw utils::BasicException(
+          "Failed to create the snapshot required to leave IN_MEMORY_ANALYTICAL. The database is still in "
+          "analytical mode and its data is unchanged; check the logs for the cause and retry.");
+    }
+    snapshot_path = *maybe_snapshot_path;
+    snapshot_ldt = *txn->last_durable_ts_;
+    // The index definitions the snapshot recorded: ListAllIndices reads the same transaction-pinned
+    // view (active_indices_ at start_timestamp) the snapshot writer serialized. The flip compares
+    // its own view against this to catch analytical index DDL, which runs under READ_ONLY access
+    // and can therefore commit concurrently with this snapshot without tripping the transaction-id
+    // check below.
+    expected_index_definitions = SortedIndexDefinitions(*read_only_accessor);
+
+    // Registered while READ_ONLY is still held, so no accessor of any kind is admitted between the
+    // snapshot and the flip's UNIQUE hold -- except another unique access, which a pending
+    // registration does not gate. Those are detected instead of excluded: from here on, only a
+    // transaction created under UNIQUE can obtain an id, so unless the flip's own unique transaction
+    // gets exactly the id captured below, something ran in between and the switch aborts.
+    pending_unique = std::make_unique<utils::UniquePendingScope>(main_lock_);
+    {
+      auto engine_guard = std::scoped_lock{engine_lock_};
+      expected_transaction_id = transaction_id_;
+    }
+  }
+
+  // Give in-flight readers a short grace to drain and finish synchronously, keeping the contract
+  // that an uncontended (or briefly contended) SetStorageMode returns with the mode already
+  // switched. The wait itself registers as a pending UNIQUE too, so the gate never drops. Only a
+  // long-running reader pushes the flip onto the background thread.
+  constexpr auto kSynchronousFlipGrace = std::chrono::milliseconds(100);
+  auto unique_guard = utils::ResourceLockGuard{main_lock_, utils::ResourceLockGuard::UNIQUE, std::defer_lock};
+  if (unique_guard.try_lock_for(kSynchronousFlipGrace)) {
+    pending_unique.reset();
+    auto unique_accessor = std::unique_ptr<Accessor>{new InMemoryAccessor{this, std::nullopt, std::move(unique_guard)}};
+    if (!CompleteAnalyticalToTransactionalSwitch(std::move(unique_accessor),
+                                                 std::move(snapshot_path),
+                                                 snapshot_ldt,
+                                                 expected_transaction_id,
+                                                 std::move(expected_index_definitions))) {
+      throw utils::BasicException(
+          "Another operation took exclusive storage access while the switch to IN_MEMORY_TRANSACTIONAL was being "
+          "prepared, so the prepared snapshot may not include its effects. The database is still in analytical mode "
+          "and its data is unchanged; repeat the storage mode change.");
+    }
+    return;
+  }
+
+  // Readers are still draining; hand the flip to a background thread so this call does not stall
+  // behind them. The pending registration moves with it and keeps the gate up until the flip owns
+  // UNIQUE, so everything admitted after this point waits for the flip and starts transactional.
+  {
+    auto thread_guard = std::scoped_lock{mode_switch_thread_mutex_};
+    mode_switch_thread_ = std::jthread{[this,
+                                        snapshot = std::move(snapshot_path),
+                                        snapshot_ldt,
+                                        expected_transaction_id,
+                                        expected_indices = std::move(expected_index_definitions),
+                                        pending = std::move(pending_unique)](std::stop_token stop_token) mutable {
+      utils::ThreadSetName("mg_mode_switch");
+      const utils::OnScopeExit release_permit{[this] { storage_mode_transition_permit_.release(); }};
+      try {
+        spdlog::info(
+            "Storage mode change to IN_MEMORY_TRANSACTIONAL is waiting on unique storage access; it proceeds once "
+            "running transactions finish.");
+        // Wait in slices rather than in one non-cancellable block: the readers being drained are
+        // unbounded, and the destructor joins this thread, so a blocking wait would hold shutdown
+        // hostage to them. The pending registration keeps gating admissions across the slices.
+        constexpr auto kStopCheckPeriod = std::chrono::milliseconds(100);
+        auto unique_guard = utils::ResourceLockGuard{main_lock_, utils::ResourceLockGuard::UNIQUE, std::defer_lock};
+        while (!unique_guard.try_lock_for(kStopCheckPeriod)) {
+          if (stop_token.stop_requested()) {
+            spdlog::warn(
+                "Storage mode change to IN_MEMORY_TRANSACTIONAL abandoned: the storage is shutting down. The "
+                "database stays in analytical mode and its data is unchanged; repeat the storage mode change.");
+            return;
+          }
+        }
+        spdlog::info("Storage mode change to IN_MEMORY_TRANSACTIONAL acquired unique storage access.");
+        auto unique_accessor =
+            std::unique_ptr<Accessor>{new InMemoryAccessor{this, std::nullopt, std::move(unique_guard)}};
+        // UNIQUE itself is held now; the registration has done its gating.
+        pending.reset();
+        if (!CompleteAnalyticalToTransactionalSwitch(std::move(unique_accessor),
+                                                     std::move(snapshot),
+                                                     snapshot_ldt,
+                                                     expected_transaction_id,
+                                                     std::move(expected_indices))) {
+          spdlog::error(
+              "Another operation took exclusive storage access while the switch to IN_MEMORY_TRANSACTIONAL was "
+              "being prepared, so the prepared snapshot may not include its effects. The database stays in "
+              "analytical mode and its data is unchanged; repeat the storage mode change.");
+        }
+      } catch (const std::exception &e) {
+        spdlog::error("Storage mode change to IN_MEMORY_TRANSACTIONAL failed in the background: {}", e.what());
+      } catch (...) {
+        spdlog::error("Storage mode change to IN_MEMORY_TRANSACTIONAL failed in the background.");
+      }
+    }};
+  }
+  handed_off = true;
+  spdlog::info(
+      "Storage mode change to IN_MEMORY_TRANSACTIONAL prepared; it completes in the background once running "
+      "transactions finish. New transactions wait for it and start in IN_MEMORY_TRANSACTIONAL.");
+}
+
+bool InMemoryStorage::CompleteAnalyticalToTransactionalSwitch(std::unique_ptr<Accessor> unique_accessor,
+                                                              std::filesystem::path snapshot_path,
+                                                              uint64_t snapshot_ldt, uint64_t expected_transaction_id,
+                                                              IndicesInfo expected_index_definitions) {
+  auto *txn = unique_accessor->GetTransaction();
+  if (txn->transaction_id != expected_transaction_id) {
+    // A unique-access operation (point/vector/text index DDL, DROP GRAPH, FREE MEMORY, ...) won the
+    // lock between the prepared snapshot and this hold, so that snapshot may no longer cover
+    // everything. Publishing it anyway would make it a stale durability base whose missing effects
+    // the next recovery silently drops; abort the switch instead and leave the switch state
+    // untouched -- mode and cached ldt -- so the user can simply repeat the operation. The one
+    // side effect that does remain is the prepared snapshot file itself: it is not published (no
+    // ldt advance, no archival of the files it would supersede) but it stays on disk as a valid
+    // image of the analytical state at its timestamp, so a crash while still analytical now
+    // recovers to that point instead of to the pre-analytical state. A repeated switch writes a
+    // fresh snapshot that supersedes it, and the archival step then moves it aside with the rest.
+    spdlog::error(
+        "Aborting the storage mode change to IN_MEMORY_TRANSACTIONAL: a unique-access operation ran after the "
+        "prepared snapshot (expected transaction id {}, got {}). The database stays in analytical mode; repeat the "
+        "storage mode change.",
+        expected_transaction_id,
+        txn->transaction_id);
+    return false;
+  }
+  if (!ReadOnlyMutableIndexDefinitionsEqual(SortedIndexDefinitions(*unique_accessor), expected_index_definitions)) {
+    // Analytical index DDL on most index families runs under READ_ONLY access, compatible with the
+    // hold the exit snapshot was written under, so such a commit is invisible to the transaction-id
+    // check: its transaction can predate both the snapshot and the capture. Compare the definitions
+    // themselves instead -- this hold's view against what the snapshot recorded -- and abort the
+    // same way when they diverge, since the snapshot misses (or wrongly contains) that index.
+    spdlog::error(
+        "Aborting the storage mode change to IN_MEMORY_TRANSACTIONAL: concurrent index DDL committed after the "
+        "prepared snapshot. The database stays in analytical mode; repeat the storage mode change.");
+    return false;
+  }
+
+  // Publish the snapshot's timestamp as the cached ldt. Analytical writes never reach
+  // FinalizeCommitPhase, so without this main keeps advertising the pre-analytical ldt and a replica
+  // registered afterwards is judged up to date by the heartbeat comparison -- recovery would never
+  // run and the imported data would never reach it. num_committed_txns_ is deliberately left alone:
+  // the snapshot records the same unchanged counter, so main and a recovering replica stay
+  // consistent. Advance-only, since concurrent commits are barred by the UNIQUE main_lock_ hold but
+  // the field is shared with the replication clients.
+  atomic_struct_update<CommitTsInfo>(
+      repl_storage_state_.commit_ts_info_, [ldt = snapshot_ldt](CommitTsInfo const &old_info) {
+        return CommitTsInfo{.ldt_ = std::max(old_info.ldt_, ldt), .num_committed_txns_ = old_info.num_committed_txns_};
+      });
+
+  // The switch-back snapshot is a new durability base, not an increment on the old one: an analytical
+  // episode leaves a timestamp hole no WAL can fill, so nothing written before it can be chained onto
+  // it. Archive the superseded files and restart the WAL numbering at 0 -- the two go together.
+  // Wiping alone would break recovery, since a chain whose first file has a non-zero sequence number
+  // is accepted only when some WAL predates the snapshot, and every such WAL is what was just wiped.
+  // Restarting alone would be worse: the surviving files carry this same UUID, so the new numbers
+  // would collide with theirs, and a duplicate sequence number is caught by no check anywhere.
+  DMG_ASSERT(!wal_file_, "Analytical mode must not leave an open WAL file.");
+  if (ArchiveSupersededDurabilityFiles(snapshot_path)) {
+    wal_seq_num_ = 0;
+  } else {
+    spdlog::warn(
+        "Superseded WAL files could not be archived, so WAL sequence numbering continues from {} to stay "
+        "collision-free.",
+        wal_seq_num_);
+  }
+  snapshot_runner_.Resume();
+  // Under the clients' lock for symmetry with the analytical store in SetStorageMode, so replica
+  // registration's in-lock read of storage_mode_ is serialized against every mode change, not just
+  // one direction.
+  repl_storage_state_.replication_storage_clients_.WithLock(
+      [this](auto const & /*clients*/) { storage_mode_ = StorageMode::IN_MEMORY_TRANSACTIONAL; });
+  // Hand off the same lock unique_accessor already holds; adopting main_lock_ into a second
+  // lock would give the one hold two owners and release it twice. The switch is complete at this
+  // point, so a GC throw (CollectGarbage allocates and logs) must not report it as failed -- to
+  // the client on the synchronous path or the log on the background one; periodic GC redoes the
+  // pass anyway.
+  try {
+    FreeMemory(unique_accessor->ReleaseGuard(), false);
+  } catch (const std::exception &e) {
+    spdlog::warn(
+        "The storage mode change to IN_MEMORY_TRANSACTIONAL completed, but its garbage collection pass failed: {}. "
+        "Periodic garbage collection will redo it.",
+        e.what());
+  } catch (...) {
+    spdlog::warn(
+        "The storage mode change to IN_MEMORY_TRANSACTIONAL completed, but its garbage collection pass failed. "
+        "Periodic garbage collection will redo it.");
+  }
+  return true;
 }
 
 void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool periodic) {
@@ -3766,7 +3999,7 @@ void InMemoryStorage::FinalizeWalFile() {
   }
 }
 
-bool InMemoryStorage::ArchiveSupersededDurabilityFiles(std::filesystem::path const &keep_snapshot) {
+bool InMemoryStorage::ArchiveSupersededDurabilityFiles(std::filesystem::path const &keep_snapshot) noexcept try {
   auto const use_old_dir = FLAGS_storage_backup_dir_enabled;
 
   // A leftover .old from an earlier archival describes a state even older than the one being archived
@@ -3820,9 +4053,26 @@ bool InMemoryStorage::ArchiveSupersededDurabilityFiles(std::filesystem::path con
   archive_dir(recovery_.snapshot_directory_, &keep_snapshot);
   archive_dir(recovery_.wal_directory_, nullptr);
 
-  // Deletions and renames are deferred while a file is locked (SHOW SNAPSHOTS, a replica recovery), so
-  // the directory is re-read rather than assumed empty.
-  return !utils::DirExists(recovery_.wal_directory_) || utils::GetFilesFromDir(recovery_.wal_directory_).empty();
+  // Deletions and renames are deferred while a file is locked (SHOW SNAPSHOTS, a replica recovery),
+  // so the directory is re-read rather than assumed empty. Read directly rather than through
+  // GetFilesFromDir, whose errors read as an empty directory: here a wrong "empty" restarts the
+  // sequence numbering into a collision, while a wrong "non-empty" only keeps the old numbering.
+  if (!utils::DirExists(recovery_.wal_directory_)) return true;
+  std::error_code error_code;
+  auto dir_it = std::filesystem::directory_iterator(recovery_.wal_directory_, error_code);
+  for (; !error_code && dir_it != std::filesystem::directory_iterator{}; dir_it.increment(error_code)) {
+    if (dir_it->path().filename() != kOldDurabilityDir) return false;
+  }
+  return !error_code;
+} catch (...) {
+  // Not everything above is nothrow: the file retainer's RenameFile calls throwing filesystem
+  // overloads, and the path compositions allocate. An exception here must not escape: the
+  // mode-switch caller has already published the new ldt, so a throw before its storage_mode_
+  // store would leave the switch half-applied -- invisibly so on the background path, which
+  // swallows exceptions. Degrade to the same contract as any other failure here: superseded files
+  // stay where they are, and the report of a non-empty WAL directory keeps the caller's sequence
+  // numbering collision-free.
+  return false;
 }
 
 auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -15,9 +15,12 @@
 #include <cstdint>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <ranges>
+#include <semaphore>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include "memory/db_arena_fwd.hpp"
 #include "replication_coordination_glue/role.hpp"
@@ -930,7 +933,24 @@ class InMemoryStorage final : public Storage {
   // directory, or deletes it when --storage-backup-dir-enabled=false. Leaves `keep_snapshot` as the only
   // snapshot and the WAL directory empty. Returns whether the WAL directory really did end up empty:
   // restarting the WAL sequence numbering is only safe once no pre-existing file can collide with it.
-  bool ArchiveSupersededDurabilityFiles(std::filesystem::path const &keep_snapshot);
+  // noexcept because it runs between the mode switch's ldt publication and its storage_mode_ store,
+  // where an escaping exception would leave the switch half-applied; any internal failure degrades
+  // to "superseded files stay where they are" via the return value.
+  bool ArchiveSupersededDurabilityFiles(std::filesystem::path const &keep_snapshot) noexcept;
+
+  /// The tail of an analytical -> transactional switch, run under the UNIQUE hold that
+  /// `unique_accessor` owns: publish the exit snapshot as the new durability base and store the
+  /// mode. `snapshot_path`/`snapshot_ldt` describe the snapshot prepared under READ_ONLY, and the
+  /// switch aborts (returns false, storage analytical and unchanged, for the user to repeat)
+  /// unless that snapshot still covers everything: the unique transaction's id must be exactly
+  /// `expected_transaction_id` (no unique-access operation ran in between) and the index
+  /// definitions this hold sees must match `expected_index_definitions` (no analytical index DDL,
+  /// which runs under READ_ONLY and is invisible to the id check, committed in between). The
+  /// caller owns the transition permit and releases it after this returns.
+  bool CompleteAnalyticalToTransactionalSwitch(std::unique_ptr<Accessor> unique_accessor,
+                                               std::filesystem::path snapshot_path, uint64_t snapshot_ldt,
+                                               uint64_t expected_transaction_id,
+                                               IndicesInfo expected_index_definitions);
 
   StorageInfo GetBaseInfo() override;
   StorageInfo GetInfo() override;
@@ -1029,6 +1049,18 @@ class InMemoryStorage final : public Storage {
   std::atomic_bool snapshot_running_{false};
   std::atomic_bool abort_snapshot_{false};
   SnapshotProgress snapshot_progress_;
+
+  // Serializes storage mode transitions. A semaphore rather than a mutex because the
+  // analytical -> transactional direction can finish on a background thread after SetStorageMode
+  // returns, and that thread must be the one to release the permit; a mutex cannot be unlocked
+  // from a thread other than its locker. While a transition holds the permit, storage_mode_ is
+  // pinned: the permit holder owns the only code path that writes it.
+  std::binary_semaphore storage_mode_transition_permit_{1};
+  // Completes a contended analytical -> transactional switch once running readers drain. Guarded
+  // by mode_switch_thread_mutex_: the previous flip releases the transition permit from this
+  // thread, so a new transition can reach the assignment while the old thread is still unwinding.
+  std::mutex mode_switch_thread_mutex_;
+  std::jthread mode_switch_thread_;
 
   std::shared_ptr<utils::Observer<utils::SchedulerInterval>> snapshot_periodic_observer_;
 

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <fstream>
 #include <mutex>
-#include <ranges>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -109,16 +108,31 @@ bool DeleteDir(const std::filesystem::path &dir) noexcept {
   return std::filesystem::remove_all(dir, error_code) > 0;
 }
 
-auto GetFilesFromDir(std::filesystem::path const &dir) -> std::vector<std::filesystem::path> {
+auto TryGetFilesFromDir(std::filesystem::path const &dir) noexcept
+    -> std::optional<std::vector<std::filesystem::path>> try {
   if (!utils::DirExists(dir)) {
     spdlog::error("Directory {} doesn't exist", dir);
-    return {};
+    return std::vector<std::filesystem::path>{};
   }
+  std::vector<std::filesystem::path> files;
   std::error_code error_code;
-  return std::filesystem::directory_iterator(dir, error_code) |
-         std::views::transform([](auto const &dir_entry) { return dir_entry.path(); }) |
-         std::views::filter([](std::filesystem::path const &path) { return path.filename() != ".old"; }) |
-         std::ranges::to<std::vector>();
+  auto dir_it = std::filesystem::directory_iterator(dir, error_code);
+  for (; !error_code && dir_it != std::filesystem::directory_iterator{}; dir_it.increment(error_code)) {
+    auto const &path = dir_it->path();
+    if (path.filename() != ".old") files.push_back(path);
+  }
+  if (error_code) {
+    spdlog::error("Failed to read directory {}. Err: {}", dir, error_code.message());
+    return std::nullopt;
+  }
+  return files;
+} catch (...) {
+  // Only allocation can land here (iteration reports through the error code).
+  return std::nullopt;
+}
+
+auto GetFilesFromDir(std::filesystem::path const &dir) noexcept -> std::vector<std::filesystem::path> {
+  return TryGetFilesFromDir(dir).value_or(std::vector<std::filesystem::path>{});
 }
 
 bool DeleteFile(const std::filesystem::path &file) noexcept {

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -62,7 +62,14 @@ bool DirExists(const std::filesystem::path &dir);
 /// Deletes everything from the given directory including the directory.
 bool DeleteDir(const std::filesystem::path &dir) noexcept;
 
-auto GetFilesFromDir(std::filesystem::path const &dir) -> std::vector<std::filesystem::path>;
+/// Lists a directory's entries, skipping the ".old" archive sub-directory. Never throws; a missing
+/// directory reads as an empty one, and nullopt reports a directory that exists but could not be
+/// (fully) listed -- for callers whose correctness depends on the listing being complete.
+auto TryGetFilesFromDir(std::filesystem::path const &dir) noexcept -> std::optional<std::vector<std::filesystem::path>>;
+
+/// TryGetFilesFromDir for callers that only act on what was listed: an error reads as an empty
+/// directory.
+auto GetFilesFromDir(std::filesystem::path const &dir) noexcept -> std::vector<std::filesystem::path>;
 
 /// Deletes just the specified file. Symlinks are not followed.
 bool DeleteFile(const std::filesystem::path &file) noexcept;

--- a/src/utils/file_locker.cpp
+++ b/src/utils/file_locker.cpp
@@ -30,19 +30,31 @@ void DeleteFromSystem(const std::filesystem::path &path) {
 }  // namespace
 
 ////// FileRetainer //////
-void FileRetainer::DeleteFile(const std::filesystem::path &path) {
-  if (!std::filesystem::exists(path)) {
-    spdlog::info("File {} doesn't exist.", path);
+void FileRetainer::DeleteFile(const std::filesystem::path &path) noexcept try {
+  std::error_code error_code;
+  if (!std::filesystem::exists(path, error_code)) {
+    if (error_code) {
+      spdlog::warn("Couldn't check file {} for deletion. Err: {}", path, error_code.message());
+    } else {
+      spdlog::info("File {} doesn't exist.", path);
+    }
     return;
   }
 
-  auto absolute_path = std::filesystem::absolute(path);
+  auto absolute_path = std::filesystem::absolute(path, error_code);
+  if (error_code) {
+    spdlog::warn("Couldn't resolve file {} for deletion. Err: {}", path, error_code.message());
+    return;
+  }
   if (active_accessors_.load(std::memory_order_acquire)) {
     files_for_deletion_.WithLock([&](auto &files) { files.emplace(std::move(absolute_path)); });
     return;
   }
   auto guard = std::unique_lock{main_lock_};
   DeleteOrAddToQueue(absolute_path);
+} catch (...) {
+  // Deletion is best-effort (see DeleteFromSystem); a failure leaves the file behind.
+  spdlog::warn("Couldn't delete file {}!", path);
 }
 
 void FileRetainer::RenameFile(const std::filesystem::path &orig, const std::filesystem::path &dest) {

--- a/src/utils/file_locker.hpp
+++ b/src/utils/file_locker.hpp
@@ -159,7 +159,7 @@ class FileRetainer {
    * any of the lockers, the file will be deleted after all the locks are
    * lifted.
    */
-  void DeleteFile(const std::filesystem::path &path);
+  void DeleteFile(const std::filesystem::path &path) noexcept;
 
   void RenameFile(const std::filesystem::path &orig, const std::filesystem::path &dest);
 

--- a/src/utils/scheduler.cpp
+++ b/src/utils/scheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -205,14 +205,14 @@ void Scheduler::Stop() {
 }
 
 // Sets atomic is_paused_ to true.
-void Scheduler::Pause() {
+void Scheduler::Pause() noexcept {
   // Lock needs to be held when modifying cv even if atomic
   auto lk = std::unique_lock{mutex_};
   is_paused_ = true;
 }
 
 // Sets atomic is_paused_ to false and notifies thread
-void Scheduler::Resume() {
+void Scheduler::Resume() noexcept {
   {
     // Lock needs to be held when modifying cv even if atomic
     auto lk = std::unique_lock{mutex_};

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -90,9 +90,9 @@ class Scheduler {
     SetIntervalAndWake(SchedulerInterval{period, start_time});
   }
 
-  void Resume();
+  void Resume() noexcept;
 
-  void Pause();
+  void Pause() noexcept;
 
   void Stop();
 

--- a/tests/e2e/analytical_mode/storage_mode_stress.py
+++ b/tests/e2e/analytical_mode/storage_mode_stress.py
@@ -39,7 +39,14 @@ def _flip_storage_mode(stop_event: threading.Event, errors: list) -> None:
     try:
         while not stop_event.is_set():
             execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL;")
-            execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL;")
+            try:
+                execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL;")
+            except Exception as exc:  # noqa: BLE001
+                # The switch aborts by design when another operation races the prepared exit
+                # snapshot, telling the caller to repeat it; the next iteration is that repeat.
+                # Anything else is a genuine failure.
+                if "repeat the storage mode change" not in str(exc):
+                    raise
     except Exception as exc:  # noqa: BLE001 - any exception here is itself the failure signal
         errors.append(("storage-mode-flipper", repr(exc)))
     finally:

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -26,6 +26,7 @@
 #include "storage/v2/vertex_accessor.hpp"
 #include "storage_test_utils.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "utils/exceptions.hpp"
 #include "utils/on_scope_exit.hpp"
 
 using testing::Types;
@@ -2938,7 +2939,12 @@ TEST(StorageSetStorageModeTest, ConcurrentUniqueHoldersAreNeverBothAdmitted) {
   threads.emplace_back([&] {
     while (!stop.load(std::memory_order_relaxed)) {
       store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
-      store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+      try {
+        store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+      } catch (memgraph::utils::BasicException const &) {
+        // A prober's unique access between the prepared exit snapshot and the flip aborts the
+        // switch by design, telling the caller to repeat it; the next iteration is that repeat.
+      }
     }
   });
 
@@ -3082,7 +3088,12 @@ TEST(StorageAccessRaceTest, ReadsModeAndIsolationWithoutRacingTheWriter) {
   threads.emplace_back([&] {
     while (!stop.load(std::memory_order_relaxed)) {
       store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
-      store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+      try {
+        store.SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+      } catch (memgraph::utils::BasicException const &) {
+        // A reader admitted just before the switch's pending registration can make the flip abort
+        // by design, telling the caller to repeat it; the next iteration is that repeat.
+      }
     }
   });
 

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -10,7 +10,9 @@
 // licenses/APL.txt.
 
 #include <gtest/gtest.h>
+#include <atomic>
 #include <chrono>
+#include <filesystem>
 #include <nlohmann/json.hpp>
 #include <stop_token>
 #include <string>
@@ -28,6 +30,7 @@
 #include "storage_test_utils.hpp"
 #include "tests/test_commit_args_helper.hpp"
 #include "utils/exceptions.hpp"
+#include "utils/scheduler.hpp"
 
 class StorageModeTest : public ::testing::TestWithParam<memgraph::storage::StorageMode> {
  public:
@@ -227,6 +230,154 @@ TEST_F(StorageModeMultiTxTest, AnalyticalIndexDropAccess) {
   auto acc = db->storage()->Access(memgraph::storage::READ);
   ASSERT_EQ(acc->ListAllIndices().label.size(), 0);
   acc->Abort();
+}
+
+// The analytical -> transactional direction writes its exit snapshot under READ_ONLY and finishes
+// the exclusive flip asynchronously when readers are in flight; these tests pin that contract.
+class StorageModeSwitchTest : public ::testing::Test {
+ protected:
+  std::filesystem::path data_directory = []() {
+    const auto tmp = std::filesystem::temp_directory_path() / "MG_tests_unit_storage_mode_switch";
+    std::filesystem::remove_all(tmp);
+    return tmp;
+  }();  // iile
+
+  void TearDown() override {
+    storage.reset();
+    std::filesystem::remove_all(data_directory);
+  }
+
+  std::unique_ptr<memgraph::storage::InMemoryStorage> storage =
+      std::make_unique<memgraph::storage::InMemoryStorage>(memgraph::storage::Config{
+          .durability = {
+              .storage_directory = data_directory,
+              .snapshot_wal_mode = memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+              .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)}}});
+};
+
+TEST_F(StorageModeSwitchTest, ReaderDefersSwitchBackUntilRelease) {
+  using memgraph::storage::StorageMode;
+  storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    acc->CreateVertex();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  auto reader = storage->Access(memgraph::storage::READ);
+  // Returns with the exit snapshot written but the exclusive flip still pending behind the reader.
+  storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  EXPECT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
+
+  reader.reset();
+  // Accessors requested after the switch wait for the flip, so this doubles as a barrier.
+  auto barrier = storage->Access(memgraph::storage::WRITE);
+  EXPECT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_TRANSACTIONAL);
+}
+
+TEST_F(StorageModeSwitchTest, AccessorsRequestedAfterSwitchStartTransactional) {
+  using memgraph::storage::StorageMode;
+  storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+
+  auto reader = storage->Access(memgraph::storage::READ);
+  storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  ASSERT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
+
+  std::atomic<bool> writer_admitted{false};
+  std::atomic<StorageMode> mode_at_admission{StorageMode::IN_MEMORY_ANALYTICAL};
+  std::jthread writer([&] {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    mode_at_admission.store(storage->GetStorageMode(), std::memory_order_release);
+    writer_admitted.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // The pending flip gates every new accessor: nothing is admitted into the half-switched state.
+  EXPECT_FALSE(writer_admitted.load(std::memory_order_acquire));
+
+  reader.reset();
+  writer.join();
+  EXPECT_EQ(mode_at_admission.load(std::memory_order_acquire), StorageMode::IN_MEMORY_TRANSACTIONAL);
+}
+
+TEST_F(StorageModeSwitchTest, BackToBackTransitionsSerialize) {
+  using memgraph::storage::StorageMode;
+  storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+
+  auto reader = storage->Access(memgraph::storage::READ);
+  storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  ASSERT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
+
+  // Must wait for the pending flip and only then switch, never jump ahead of it.
+  std::jthread back_to_analytical([&] { storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  reader.reset();
+  back_to_analytical.join();
+  EXPECT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
+
+  // The intermediate flip to transactional really happened: it left its exit snapshot behind.
+  size_t snapshot_count = 0;
+  for (auto const &entry : std::filesystem::directory_iterator(data_directory / "snapshots")) {
+    snapshot_count += static_cast<size_t>(entry.is_regular_file());
+  }
+  EXPECT_GE(snapshot_count, 1);
+}
+
+TEST_F(StorageModeSwitchTest, CompetingUniqueAccessAbortsSwitch) {
+  using memgraph::storage::StorageMode;
+  // A unique access can win the lock between the prepared snapshot and the flip; the flip then
+  // detects it and aborts, leaving the storage analytical for the user to repeat the switch. The
+  // race is genuine, so iterate to land on both orders and assert the invariant that holds for
+  // either: the mode is never half-switched, and repeating the switch always converges.
+  for (int i = 0; i < 20; ++i) {
+    storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+    auto reader = storage->Access(memgraph::storage::READ);
+    storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+    std::jthread interloper([&] { auto unique = storage->UniqueAccess(); });
+    reader.reset();
+    interloper.join();
+
+    // Admitted only once the flip's exclusive cycle is over, so the outcome is settled after this.
+    {
+      auto barrier = storage->Access(memgraph::storage::WRITE);
+    }
+    if (storage->GetStorageMode() == StorageMode::IN_MEMORY_ANALYTICAL) {
+      // The interloper won and the switch aborted; repeating it succeeds.
+      storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+    }
+    ASSERT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_TRANSACTIONAL);
+  }
+}
+
+TEST_F(StorageModeSwitchTest, ConcurrentReadOnlyIndexDdlAbortsSwitch) {
+  using memgraph::storage::StorageMode;
+  storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+
+  // Analytical index DDL runs under READ_ONLY access: admitted alongside the read-only exit
+  // snapshot, it can commit an index the snapshot does not record, invisibly to the
+  // transaction-id check (its transaction predates the switch).
+  auto ddl = storage->ReadOnlyAccess();
+  storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  ASSERT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
+
+  // The exit snapshot is already written; this index is missing from it.
+  ASSERT_TRUE(ddl->CreateIndex(storage->NameToLabel("ConcurrentlyIndexed")).has_value());
+  ASSERT_TRUE(ddl->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  ddl.reset();
+
+  // The flip compares index definitions against the snapshot's, detects the divergence and aborts.
+  {
+    auto barrier = storage->Access(memgraph::storage::WRITE);
+  }
+  ASSERT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
+
+  // Repeating the switch snapshots the index too and succeeds.
+  storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  ASSERT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_TRANSACTIONAL);
+  auto acc = storage->Access(memgraph::storage::READ);
+  ASSERT_EQ(acc->ListAllIndices().label.size(), 1);
 }
 
 // nlohmann ADL hooks for StorageMode (storage_mode.hpp): integer wire encoding + range-checked read.


### PR DESCRIPTION
The switch to `IN_MEMORY_TRANSACTIONAL` used to hold UNIQUE access across the whole exit snapshot, blocking every query for its duration. The snapshot is now written under READ_ONLY access -- writers stay excluded, but read queries keep running -- and only the variable flip itself takes UNIQUE access: synchronously when the lock frees within a short grace period, otherwise on a background thread once the in-flight readers drain, without stalling the switch query behind them.

Correctness across the two phases:
- A `UniquePendingScope` registered while READ_ONLY is still held gates every new accessor between the snapshot and the flip, so no write can be admitted in the gap and invalidate the snapshot. Queries issued after the switch wait for the flip and start in transactional mode -- nothing ever observes a half-switched state.
- Operations the gate cannot exclude are detected instead, and the switch aborts with everything untouched (mode, cached ldt, durability files), telling the user to repeat it:
  - unique accesses (point/vector/text index DDL, `DROP GRAPH`, `FREE MEMORY`, ...) via the transaction id the flip's unique transaction receives;
  - analytical index DDL on the remaining families, which runs under READ_ONLY access (#4633) and can therefore commit concurrently with the exit snapshot, by comparing the index definitions the flip sees against those the snapshot recorded (both transaction-pinned views).
- Transitions serialize on a semaphore, so back-to-back `STORAGE MODE` queries keep behaving as if executed one by one, and a failed exit snapshot still throws to the client with the database unchanged.

The transactional -> analytical direction is unchanged. New unit tests pin the contract: a held reader defers the flip, accessors requested after the switch block and start transactional, back-to-back transitions serialize, a competing unique access aborts the switch with a successful retry, and read-only index DDL committed concurrently with the exit snapshot aborts the switch.