### PR TITLE
fix: Drop post-filter for indexed `STARTS WITH` queries

### DIFF
--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -288,10 +288,19 @@ class PropertyFilter {
     ENDS_WITH = 7
   };
 
-  /// True when the index scan is a superset and the original expression
-  /// must be retained as a post-filter.
-  static constexpr bool RequiresPostFilter(Type t) {
+  /// True when an edge index scan admits rows the filter rejects, so the original expression must
+  /// be retained as a post-filter. An edge scan ranges upwards from a single bound with no ceiling,
+  /// so even a prefix match reads past the prefix and on into the types that sort after strings.
+  static constexpr bool RequiresPostFilterOnEdgeScan(Type t) {
     return t == Type::REGEX_MATCH || t == Type::STARTS_WITH || t == Type::CONTAINS || t == Type::ENDS_WITH;
+  }
+
+  /// True when a node index scan admits rows the filter rejects, so the original expression must be
+  /// retained as a post-filter. A node scan bounds a prefix match above as well as below, and those
+  /// two bounds span exactly the strings carrying the prefix, so STARTS_WITH has nothing left to
+  /// check. The rest have no bound narrower than the whole string type.
+  static constexpr bool RequiresPostFilterOnNodeScan(Type t) {
+    return t == Type::REGEX_MATCH || t == Type::CONTAINS || t == Type::ENDS_WITH;
   }
 
   /// The predicates that read a search term to narrow a scan over the property's string values,
@@ -306,9 +315,9 @@ class PropertyFilter {
 
   /// True when the index seek key is built from this filter's value expression, rather than being a
   /// constant span of the property's type. Such a scan can only run where that expression's symbols
-  /// are bound, so a Cartesian above it has to be converted into an IndexedJoin. Types that both
-  /// require a post-filter and seek on their value (STARTS_WITH) create that dependency without
-  /// their expression ever being removed, so removal alone cannot be used to detect it.
+  /// are bound, so a Cartesian above it has to be converted into an IndexedJoin. On an edge scan
+  /// STARTS_WITH both keeps its post-filter and seeks on its value, creating that dependency without
+  /// its expression ever being removed, so removal alone cannot be used to detect it.
   static constexpr bool SeeksOnValue(Type t) {
     return t == Type::EQUAL || t == Type::RANGE || t == Type::IN || t == Type::STARTS_WITH;
   }

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -1089,7 +1089,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     if (found_index) {
       // Copy the property filter and then erase it from filters.
       const auto prop_filter = *found_index->filter.property_filter;
-      if (!PropertyFilter::RequiresPostFilter(prop_filter.type_)) {
+      if (!PropertyFilter::RequiresPostFilterOnEdgeScan(prop_filter.type_)) {
         filter_exprs_for_removal_.insert(found_index->filter.expression);
       } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
         filter_exprs_keying_a_seek_.insert(found_index->filter.expression);
@@ -1214,7 +1214,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     auto const build_scan_edgeproperty = [&]() -> std::shared_ptr<LogicalOperator> {
       // Copy the property filter and then erase it from filters.
       const auto prop_filter = *found_property_index->filter.property_filter;
-      if (!PropertyFilter::RequiresPostFilter(prop_filter.type_)) {
+      if (!PropertyFilter::RequiresPostFilterOnEdgeScan(prop_filter.type_)) {
         filter_exprs_for_removal_.insert(found_property_index->filter.expression);
       } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
         filter_exprs_keying_a_seek_.insert(found_property_index->filter.expression);

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -248,8 +248,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
     // A Cartesian pulls its right branch once per pass, not once per left row, so it cannot feed a
     // seek keyed on the other branch. Convert only when a consumed filter created such a dependency.
-    // A retained post-filter is not removed, but may still have keyed the seek below (STARTS WITH),
-    // so `did_remove` alone would miss the dependency it created.
+    // A retained post-filter is not removed, but may still have keyed the seek below (CONTAINS,
+    // ENDS WITH), so `did_remove` alone would miss the dependency it created.
     if (removal.did_remove || !removed_filters.empty()) {
       LogicalOperator *input = op.input().get();
       LogicalOperator *parent = &op;
@@ -1760,7 +1760,11 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     if (max_vertex_count && best->estimated_count > *max_vertex_count) return std::nullopt;
 
     auto const &prop_filter = *best->filter.property_filter;
-    if (!PropertyFilter::RequiresPostFilter(prop_filter.type_)) {
+    // The node-path scan computes exact [prefix, PrefixSuccessor) bounds via ExpressionRange, so
+    // STARTS_WITH needs no post-filter here. (The edge-path scan still uses a lower-bound-only range
+    // and keeps RequiresPostFilter true.)
+    if (!PropertyFilter::RequiresPostFilter(prop_filter.type_) ||
+        prop_filter.type_ == PropertyFilter::Type::STARTS_WITH) {
       metadata.expressions_to_mark_for_removal.push_back(best->filter.expression);
     } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
       metadata.expressions_keying_a_seek.push_back(best->filter.expression);
@@ -2030,7 +2034,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       for (auto const &filter_info : found_index->filters) {
         const PropertyFilter prop_filter = *filter_info.property_filter;
 
-        if (!PropertyFilter::RequiresPostFilter(prop_filter.type_)) {
+        if (!PropertyFilter::RequiresPostFilter(prop_filter.type_) ||
+            prop_filter.type_ == PropertyFilter::Type::STARTS_WITH) {
           metadata.expressions_to_mark_for_removal.push_back(filter_info.expression);
         } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
           metadata.expressions_keying_a_seek.push_back(filter_info.expression);
@@ -2115,7 +2120,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
             // Filter cleanup, track which expressions to remove
             for (auto const &filter_info : label_property_index.filters) {
               const PropertyFilter prop_filter = *filter_info.property_filter;
-              if (!PropertyFilter::RequiresPostFilter(prop_filter.type_)) {
+              if (!PropertyFilter::RequiresPostFilter(prop_filter.type_) ||
+                  prop_filter.type_ == PropertyFilter::Type::STARTS_WITH) {
                 metadata.expressions_to_mark_for_removal.push_back(filter_info.expression);
               } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
                 metadata.expressions_keying_a_seek.push_back(filter_info.expression);

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -231,8 +231,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       Filters own_filters;
       own_filters.CollectFilterExpression(op.expression_, *symbol_table_);
       for (auto const &filter : own_filters) {
-        if (filter_exprs_for_removal_.contains(filter.expression) ||
-            filter_exprs_keying_a_seek_.contains(filter.expression)) {
+        if (filter_exprs_for_removal_.contains(filter.expression)) {
           removed_filters.push_back(filter);
         }
       }
@@ -248,9 +247,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
     // A Cartesian pulls its right branch once per pass, not once per left row, so it cannot feed a
     // seek keyed on the other branch. Convert only when a consumed filter created such a dependency.
-    // A retained post-filter is not removed, but may still have keyed the seek below (CONTAINS,
-    // ENDS WITH), so `did_remove` alone would miss the dependency it created.
-    if (removal.did_remove || !removed_filters.empty()) {
+    // Every node predicate that keys a seek is consumed by the scan, so removal detects them all.
+    if (removal.did_remove) {
       LogicalOperator *input = op.input().get();
       LogicalOperator *parent = &op;
 
@@ -973,8 +971,6 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   // additional symbols that are present from other non-main branches but have influence on indexing
   std::unordered_set<Symbol> additional_bound_symbols_;
-  // Expressions kept in a Filter that still supplied a seek key to a scan below it.
-  std::unordered_set<Expression *> filter_exprs_keying_a_seek_;
   // Enclosing scope's symbols: live on the frame, but not produced by this branch, so they must stay
   // out of the plan - ModifiedSymbols has consumers that read it as "produced by this subtree".
   std::unordered_set<Symbol> const inherited_bound_symbols_;
@@ -1710,8 +1706,6 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   struct ScanByIndexMetadata {
     std::vector<FilterInfo> filters_to_erase;
     std::vector<Expression *> expressions_to_mark_for_removal;
-    // Retained post-filters that nonetheless supplied the scan's seek key.
-    std::vector<Expression *> expressions_keying_a_seek;
     std::vector<LabelIx> labels_to_erase;   // For EraseLabelFilter or EraseOrLabelFilter
     bool is_or_label_filter = false;        // If true, use EraseOrLabelFilter instead of EraseLabelFilter
     bool all_property_filters_same = true;  // For OR labels: whether all filters are the same
@@ -1760,14 +1754,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     if (max_vertex_count && best->estimated_count > *max_vertex_count) return std::nullopt;
 
     auto const &prop_filter = *best->filter.property_filter;
-    // The node-path scan computes exact [prefix, PrefixSuccessor) bounds via ExpressionRange, so
-    // STARTS_WITH needs no post-filter here. (The edge-path scan still uses a lower-bound-only range
-    // and keeps RequiresPostFilter true.)
-    if (!PropertyFilter::RequiresPostFilter(prop_filter.type_) ||
-        prop_filter.type_ == PropertyFilter::Type::STARTS_WITH) {
+    if (!PropertyFilter::RequiresPostFilterOnNodeScan(prop_filter.type_)) {
       metadata.expressions_to_mark_for_removal.push_back(best->filter.expression);
-    } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
-      metadata.expressions_keying_a_seek.push_back(best->filter.expression);
     }
     metadata.filters_to_erase.push_back(best->filter);
 
@@ -2034,11 +2022,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       for (auto const &filter_info : found_index->filters) {
         const PropertyFilter prop_filter = *filter_info.property_filter;
 
-        if (!PropertyFilter::RequiresPostFilter(prop_filter.type_) ||
-            prop_filter.type_ == PropertyFilter::Type::STARTS_WITH) {
+        if (!PropertyFilter::RequiresPostFilterOnNodeScan(prop_filter.type_)) {
           metadata.expressions_to_mark_for_removal.push_back(filter_info.expression);
-        } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
-          metadata.expressions_keying_a_seek.push_back(filter_info.expression);
         }
 
         metadata.filters_to_erase.push_back(filter_info);
@@ -2120,11 +2105,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
             // Filter cleanup, track which expressions to remove
             for (auto const &filter_info : label_property_index.filters) {
               const PropertyFilter prop_filter = *filter_info.property_filter;
-              if (!PropertyFilter::RequiresPostFilter(prop_filter.type_) ||
-                  prop_filter.type_ == PropertyFilter::Type::STARTS_WITH) {
+              if (!PropertyFilter::RequiresPostFilterOnNodeScan(prop_filter.type_)) {
                 metadata.expressions_to_mark_for_removal.push_back(filter_info.expression);
-              } else if (PropertyFilter::SeeksOnValue(prop_filter.type_)) {
-                metadata.expressions_keying_a_seek.push_back(filter_info.expression);
               }
             }
             auto or_membership_lists =
@@ -2180,8 +2162,6 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                        metadata.expressions_to_mark_for_removal.end());
     }
     filter_exprs_for_removal_.insert(removed_expressions.begin(), removed_expressions.end());
-    filter_exprs_keying_a_seek_.insert(metadata.expressions_keying_a_seek.begin(),
-                                       metadata.expressions_keying_a_seek.end());
   }
 
   // Creates a ScanAll by the best possible index for the `node_symbol`. If the node

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -52,11 +52,10 @@ def test_starts_with_uses_label_property_scan(memgraph):
     assert "ScanAll" not in ops, f"ScanAll should not appear, got: {plan}"
 
 
-def test_starts_with_filter_is_consumed_by_index(memgraph):
-    """The [prefix, PrefixSuccessor) range is exact, so no post-filter should remain."""
+def test_starts_with_filter_is_consumed_by_label_property_index(memgraph):
+    # The scan's two bounds span exactly the strings carrying the prefix, so nothing is left to check.
     plan = get_plan(memgraph, "MATCH (n:N) WHERE n.type STARTS WITH 'al' RETURN n")
-    filters = [line for line in plan if "Filter" in line]
-    assert filters == [], f"STARTS WITH should not leave a post-filter, got: {plan}"
+    assert "Filter" not in operator_names(plan), f"STARTS WITH should not leave a post-filter, got: {plan}"
 
 
 def test_ends_with_uses_label_property_scan(memgraph):
@@ -198,6 +197,13 @@ def test_edge_ends_with_uses_edge_type_property_range(memgraph, edge_graph):
     assert [r["k"] for r in result] == ["gamma"]
 
 
+def test_edge_starts_with_keeps_its_post_filter(memgraph, edge_graph):
+    # An edge scan ranges upwards from the prefix with no ceiling, so it reads past the prefix and
+    # the predicate has to be checked again afterwards.
+    plan = get_plan(memgraph, "MATCH (a)-[r:REL]->(b) WHERE r.kind STARTS WITH 'be' RETURN r.kind AS k")
+    assert "Filter" in operator_names(plan), f"An edge prefix scan must keep its post-filter, got: {plan}"
+
+
 def test_edge_starts_with_null_returns_empty(memgraph, edge_graph):
     result = list(memgraph.execute_and_fetch("MATCH (a)-[r:REL]->(b) WHERE r.kind STARTS WITH null RETURN r.kind AS k"))
     assert result == []
@@ -219,8 +225,7 @@ def cartesian_graph(memgraph):
 
 def test_starts_with_across_cartesian_keeps_all_rows(memgraph, cartesian_graph):
     # A Cartesian pulls its right branch once per pass, so a seek keyed on the left branch is only
-    # sound once the Cartesian has become an IndexedJoin. STARTS WITH keeps a post-filter, so the
-    # conversion cannot be driven by expression removal alone.
+    # sound once the Cartesian has become an IndexedJoin.
     result = list(
         memgraph.execute_and_fetch("MATCH (a:CA), (b:CB) WHERE b.t STARTS WITH a.t RETURN b.t AS t ORDER BY t")
     )
@@ -259,6 +264,25 @@ def test_global_property_index_string_predicates(memgraph, global_index_graph, p
     assert "ScanAllByVertexProperty" in operator_names(plan), f"Expected the global index, got: {plan}"
     result = list(memgraph.execute_and_fetch(f"MATCH (n:GI) WHERE {predicate} RETURN n.gp AS p ORDER BY p"))
     assert [r["p"] for r in result] == expected
+
+
+def test_starts_with_filter_is_consumed_by_global_property_index(memgraph, global_index_graph):
+    # Matching without a label keeps a surviving label check out of the plan, so the only Filter that
+    # could appear is the predicate itself.
+    plan = get_plan(memgraph, "MATCH (n) WHERE n.gp STARTS WITH 'hel' RETURN n.gp AS p")
+    ops = operator_names(plan)
+    assert "ScanAllByVertexProperty" in ops, f"Expected the global index, got: {plan}"
+    assert "Filter" not in ops, f"STARTS WITH should not leave a post-filter, got: {plan}"
+
+
+@pytest.mark.parametrize("predicate", ["n.gp CONTAINS 'ell'", "n.gp ENDS WITH 'lo'", "n.gp =~ 'hel.*'"])
+def test_unbounded_string_predicates_keep_their_post_filter(memgraph, global_index_graph, predicate):
+    # These three have no bound narrower than the whole string type, so the scan hands back rows the
+    # predicate rejects and it must still run.
+    plan = get_plan(memgraph, f"MATCH (n) WHERE {predicate} RETURN n.gp AS p")
+    ops = operator_names(plan)
+    assert "ScanAllByVertexProperty" in ops, f"Expected the global index, got: {plan}"
+    assert "Filter" in ops, f"{predicate} must keep its post-filter, got: {plan}"
 
 
 def test_far_smaller_band_index_still_wins(memgraph):

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -52,6 +52,13 @@ def test_starts_with_uses_label_property_scan(memgraph):
     assert "ScanAll" not in ops, f"ScanAll should not appear, got: {plan}"
 
 
+def test_starts_with_filter_is_consumed_by_index(memgraph):
+    """The [prefix, PrefixSuccessor) range is exact, so no post-filter should remain."""
+    plan = get_plan(memgraph, "MATCH (n:N) WHERE n.type STARTS WITH 'al' RETURN n")
+    filters = [line for line in plan if "Filter" in line]
+    assert filters == [], f"STARTS WITH should not leave a post-filter, got: {plan}"
+
+
 def test_ends_with_uses_label_property_scan(memgraph):
     plan = get_plan(memgraph, "MATCH (n:N) WHERE n.type ENDS WITH 'ha' RETURN n")
     ops = operator_names(plan)


### PR DESCRIPTION
Remove the post-filter for indexed `STARTS WITH` queries. These are no longer required because we compute an exact `ExpressionRange` which covers all and only strings with the required prefix.

Note that edge-path scans still uses a lower-bound filter and requires a post-filter.