### PR TITLE
perf: Skip duplicate index entries for `CONTAINS`, `ENDS WITH`, and `REGEX`

### DIFF
--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -783,10 +783,17 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
         }
         return EstimateVertexPropertyRangeCardinality(property, range.lower_, range.upper_);
       }
-      case Type::RANGE:
       case Type::REGEX_MATCH:
       case Type::CONTAINS:
-      case Type::ENDS_WITH:
+      case Type::ENDS_WITH: {
+        // The raw lower bound holds the search term, which is not a bound on what matches, so it
+        // cannot be counted as one. What the scan reads is the property's string values, and
+        // counting that band needs a lower bound the index actually holds, so the estimate is the
+        // whole property: an overestimate rather than one that makes the scan look free. Reading
+        // the term would also settle a cached plan against one call's value.
+        return db_accessor_->VerticesCount(property);
+      }
+      case Type::RANGE:
         return EstimateVertexPropertyRangeCardinality(property, range.lower_, range.upper_);
     }
     std::unreachable();

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -787,11 +787,13 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
       case Type::CONTAINS:
       case Type::ENDS_WITH: {
         // The raw lower bound holds the search term, which is not a bound on what matches, so it
-        // cannot be counted as one. What the scan reads is the property's string values, and
-        // counting that band needs a lower bound the index actually holds, so the estimate is the
-        // whole property: an overestimate rather than one that makes the scan look free. Reading
-        // the term would also settle a cached plan against one call's value.
-        return db_accessor_->VerticesCount(property);
+        // cannot be counted as one. What the scan reads is the band the property's string values
+        // occupy, which the resolved range describes and which is the same for every term -- as it
+        // has to be, since the plan outlives the term that was current when it was costed.
+        auto *mapper = db_accessor_->GetStorageAccessor()->GetNameIdMapper();
+        auto const resolved = range.ResolveAtPlantime(parameters, mapper);
+        if (!resolved) return db_accessor_->VerticesCount(property);
+        return db_accessor_->VerticesCount(property, resolved->lower_, resolved->upper_);
       }
       case Type::RANGE:
         return EstimateVertexPropertyRangeCardinality(property, range.lower_, range.upper_);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <queue>
 #include <ranges>
+#include <regex>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -143,15 +144,21 @@ auto ExpressionRange::In(Expression *runtime_value, ListLiteral *membership_list
   return er;
 }
 
-auto ExpressionRange::RegexMatch() -> ExpressionRange { return {Type::REGEX_MATCH, std::nullopt, std::nullopt}; }
+auto ExpressionRange::RegexMatch(Expression *value) -> ExpressionRange {
+  return {Type::REGEX_MATCH, utils::MakeBoundInclusive(value), std::nullopt};
+}
 
 auto ExpressionRange::StartsWith(Expression *value) -> ExpressionRange {
   return {Type::STARTS_WITH, utils::MakeBoundInclusive(value), std::nullopt};
 }
 
-auto ExpressionRange::Contains() -> ExpressionRange { return {Type::CONTAINS, std::nullopt, std::nullopt}; }
+auto ExpressionRange::Contains(Expression *value) -> ExpressionRange {
+  return {Type::CONTAINS, utils::MakeBoundInclusive(value), std::nullopt};
+}
 
-auto ExpressionRange::EndsWith() -> ExpressionRange { return {Type::ENDS_WITH, std::nullopt, std::nullopt}; }
+auto ExpressionRange::EndsWith(Expression *value) -> ExpressionRange {
+  return {Type::ENDS_WITH, utils::MakeBoundInclusive(value), std::nullopt};
+}
 
 auto ExpressionRange::Range(std::optional<utils::Bound<Expression *>> lower,
                             std::optional<utils::Bound<Expression *>> upper) -> ExpressionRange {
@@ -185,7 +192,32 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
     case Type::ENDS_WITH: {
       auto empty_string = utils::MakeBoundInclusive(storage::PropertyValue(""));
       auto upper_bound = storage::UpperBoundForType(storage::PropertyValueType::String);
-      return storage::PropertyValueRange::Bounded(std::move(empty_string), std::move(upper_bound));
+      auto range = storage::PropertyValueRange::Bounded(std::move(empty_string), std::move(upper_bound));
+
+      if (lower_) {
+        auto const typed_value = lower_->value()->Accept(evaluator);
+        if (typed_value.IsString()) {
+          auto const &search_term = typed_value.ValueString();
+          if (type_ == Type::CONTAINS) {
+            range.SetValuePredicate([s = std::string(search_term)](storage::PropertyValue const &v) {
+              return v.IsString() && v.ValueString().find(s) != std::string::npos;
+            });
+          } else if (type_ == Type::ENDS_WITH) {
+            range.SetValuePredicate([s = std::string(search_term)](storage::PropertyValue const &v) {
+              if (!v.IsString()) return false;
+              auto const &vs = v.ValueString();
+              return vs.size() >= s.size() && vs.compare(vs.size() - s.size(), s.size(), s) == 0;
+            });
+          } else {
+            auto re = std::regex(search_term);
+            range.SetValuePredicate([re = std::move(re)](storage::PropertyValue const &v) {
+              return v.IsString() && std::regex_match(v.ValueString(), re);
+            });
+          }
+        }
+      }
+
+      return range;
     }
 
     case Type::STARTS_WITH: {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -209,10 +209,14 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
               return vs.size() >= s.size() && vs.compare(vs.size() - s.size(), s.size(), s) == 0;
             });
           } else {
-            auto re = std::regex(search_term);
-            range.SetValuePredicate([re = std::move(re)](storage::PropertyValue const &v) {
-              return v.IsString() && std::regex_match(v.ValueString(), re);
-            });
+            try {
+              auto re = std::regex(search_term);
+              range.SetValuePredicate([re = std::move(re)](storage::PropertyValue const &v) {
+                return v.IsString() && std::regex_match(v.ValueString(), re);
+              });
+            } catch (std::regex_error const &e) {
+              throw QueryRuntimeException("Regex error in '{}': {}", search_term, e.what());
+            }
           }
         }
       }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -200,13 +200,11 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
           auto const &search_term = typed_value.ValueString();
           if (type_ == Type::CONTAINS) {
             range.SetValuePredicate([s = std::string(search_term)](storage::PropertyValue const &v) {
-              return v.IsString() && v.ValueString().find(s) != std::string::npos;
+              return v.IsString() && v.ValueString().contains(s);
             });
           } else if (type_ == Type::ENDS_WITH) {
             range.SetValuePredicate([s = std::string(search_term)](storage::PropertyValue const &v) {
-              if (!v.IsString()) return false;
-              auto const &vs = v.ValueString();
-              return vs.size() >= s.size() && vs.compare(vs.size() - s.size(), s.size(), s) == 0;
+              return v.IsString() && v.ValueString().ends_with(s);
             });
           } else {
             try {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -310,6 +310,9 @@ auto ExpressionRange::ResolveAtPlantime(Parameters const &params, storage::NameI
     case Type::REGEX_MATCH:
     case Type::CONTAINS:
     case Type::ENDS_WITH: {
+      // The search term is deliberately not read here. Query stripping turns it into a parameter
+      // and the plan cache is keyed on the stripped text, so a plan settled by one call's term
+      // would be reused for every other term. Evaluate reads it per execution instead.
       auto empty_string = utils::MakeBoundInclusive(storage::PropertyValue(""));
       auto upper_bound = storage::UpperBoundForType(storage::PropertyValueType::String);
       return storage::PropertyValueRange::Bounded(std::move(empty_string), std::move(upper_bound));

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -190,36 +190,15 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
     case Type::REGEX_MATCH:
     case Type::CONTAINS:
     case Type::ENDS_WITH: {
+      // A non-string search term compares to Null for every row, so nothing can match. A regex
+      // pattern is the exception: a non-string one raises, and a scan must not decide whether it
+      // does, so its whole band is read and the retained filter answers.
+      if (type_ != Type::REGEX_MATCH && lower_ && !lower_->value()->Accept(evaluator).IsString()) {
+        return storage::PropertyValueRange::Empty();
+      }
       auto empty_string = utils::MakeBoundInclusive(storage::PropertyValue(""));
       auto upper_bound = storage::UpperBoundForType(storage::PropertyValueType::String);
-      auto range = storage::PropertyValueRange::Bounded(std::move(empty_string), std::move(upper_bound));
-
-      if (lower_) {
-        auto const typed_value = lower_->value()->Accept(evaluator);
-        if (typed_value.IsString()) {
-          auto const &search_term = typed_value.ValueString();
-          if (type_ == Type::CONTAINS) {
-            range.SetValuePredicate([s = std::string(search_term)](storage::PropertyValue const &v) {
-              return v.IsString() && v.ValueString().contains(s);
-            });
-          } else if (type_ == Type::ENDS_WITH) {
-            range.SetValuePredicate([s = std::string(search_term)](storage::PropertyValue const &v) {
-              return v.IsString() && v.ValueString().ends_with(s);
-            });
-          } else {
-            try {
-              auto re = std::regex(search_term);
-              range.SetValuePredicate([re = std::move(re)](storage::PropertyValue const &v) {
-                return v.IsString() && std::regex_match(v.ValueString(), re);
-              });
-            } catch (std::regex_error const &e) {
-              throw QueryRuntimeException("Regex error in '{}': {}", search_term, e.what());
-            }
-          }
-        }
-      }
-
-      return range;
+      return storage::PropertyValueRange::Bounded(std::move(empty_string), std::move(upper_bound));
     }
 
     case Type::STARTS_WITH: {
@@ -255,6 +234,38 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
     case Type::IS_NOT_NULL: {
       return storage::PropertyValueRange::IsNotNull();
     }
+  }
+}
+
+auto ExpressionRange::MakeValuePredicate(ExpressionEvaluator &evaluator) const
+    -> storage::PropertyValueRange::ValuePredicate {
+  if (!lower_) return nullptr;
+  auto const typed_value = lower_->value()->Accept(evaluator);
+  if (!typed_value.IsString()) return nullptr;
+  auto const &search_term = typed_value.ValueString();
+
+  auto const make = [](auto match) {
+    return std::make_shared<storage::PropertyValueRange::ValuePredicateFn>(
+        [match = std::move(match)](storage::PropertyValue const &value) {
+          return value.IsString() && match(value.ValueString());
+        });
+  };
+
+  switch (type_) {
+    case Type::CONTAINS:
+      return make([s = std::string(search_term)](auto const &v) { return v.contains(s); });
+    case Type::ENDS_WITH:
+      return make([s = std::string(search_term)](auto const &v) { return v.ends_with(s); });
+    case Type::REGEX_MATCH:
+      try {
+        // An unusable pattern raises where the filter reaches it, once a row exists to test. Doing
+        // so here instead would let an index decide whether the query raises at all.
+        return make([re = std::regex(search_term)](auto const &v) { return std::regex_match(v, re); });
+      } catch (std::regex_error const &) {
+        return nullptr;
+      }
+    default:
+      return nullptr;
   }
 }
 
@@ -1743,7 +1754,10 @@ UniqueCursorPtr ScanAllByLabelProperties::MakeCursor(utils::MemoryResource *mem,
                                                      metrics::DatabaseMetricHandles &metric_handles) const {
   metric_handles.scan_all_by_label_properties_operator.Increment();
 
-  auto vertices = [this](Frame &frame, ExecutionContext &context)
+  // A search term reads nothing from the frame, so its predicate is built once and reused for
+  // every row the input produces. Compiling a pattern per row would undo what it buys.
+  auto vertices = [this, value_predicates = std::vector<storage::PropertyValueRange::ValuePredicate>{}](
+                      Frame &frame, ExecutionContext &context) mutable
       -> std::optional<decltype(context.db_accessor->Vertices(
           view_, label_, properties_, std::span<storage::PropertyValueRange>{}))> {
     auto *db = context.db_accessor;
@@ -1752,6 +1766,16 @@ UniqueCursorPtr ScanAllByLabelProperties::MakeCursor(utils::MemoryResource *mem,
     auto maybe_prop_value_ranges = EvaluateExpressionRangesAndCheckNull(expression_ranges_, evaluator);
     if (!maybe_prop_value_ranges) {
       return std::nullopt;
+    }
+
+    if (value_predicates.size() != expression_ranges_.size()) {
+      value_predicates = expression_ranges_ | rv::transform([&](ExpressionRange const &expression_range) {
+                           return expression_range.MakeValuePredicate(evaluator);
+                         }) |
+                         ranges::to_vector;
+    }
+    for (auto &&[range, predicate] : rv::zip(*maybe_prop_value_ranges, value_predicates)) {
+      range.SetValuePredicate(predicate);
     }
 
     return std::make_optional(db->Vertices(view_, label_, properties_, *maybe_prop_value_ranges, index_order_));

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -190,9 +190,8 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
     case Type::REGEX_MATCH:
     case Type::CONTAINS:
     case Type::ENDS_WITH: {
-      // A non-string search term compares to Null for every row, so nothing can match. A regex
-      // pattern is the exception: a non-string one raises, and a scan must not decide whether it
-      // does, so its whole band is read and the retained filter answers.
+      // A non-string search term compares to Null, so nothing matches. A non-string regex pattern
+      // instead raises, and a scan must not decide whether it does, so that one keeps its band.
       if (type_ != Type::REGEX_MATCH && lower_ && !lower_->value()->Accept(evaluator).IsString()) {
         return storage::PropertyValueRange::Empty();
       }
@@ -258,8 +257,8 @@ auto ExpressionRange::MakeValuePredicate(ExpressionEvaluator &evaluator) const
       return make([s = std::string(search_term)](auto const &v) { return v.ends_with(s); });
     case Type::REGEX_MATCH:
       try {
-        // An unusable pattern raises where the filter reaches it, once a row exists to test. Doing
-        // so here instead would let an index decide whether the query raises at all.
+        // Raising here would let an index decide whether the query raises at all. Left to the
+        // filter, an unusable pattern raises once a row reaches it, as it does without an index.
         return make([re = std::regex(search_term)](auto const &v) { return std::regex_match(v, re); });
       } catch (std::regex_error const &) {
         return nullptr;
@@ -1754,8 +1753,7 @@ UniqueCursorPtr ScanAllByLabelProperties::MakeCursor(utils::MemoryResource *mem,
                                                      metrics::DatabaseMetricHandles &metric_handles) const {
   metric_handles.scan_all_by_label_properties_operator.Increment();
 
-  // A search term reads nothing from the frame, so its predicate is built once and reused for
-  // every row the input produces. Compiling a pattern per row would undo what it buys.
+  // The predicates outlive the row they were built from; see ExpressionRange::MakeValuePredicate.
   auto vertices = [this, value_predicates = std::vector<storage::PropertyValueRange::ValuePredicate>{}](
                       Frame &frame, ExecutionContext &context) mutable
       -> std::optional<decltype(context.db_accessor->Vertices(

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -59,10 +59,10 @@ struct ExpressionRange {
 
   static auto Equal(Expression *value) -> ExpressionRange;
   static auto In(Expression *runtime_value, ListLiteral *membership_list) -> ExpressionRange;
-  static auto RegexMatch() -> ExpressionRange;
+  static auto RegexMatch(Expression *value) -> ExpressionRange;
   static auto StartsWith(Expression *value) -> ExpressionRange;
-  static auto Contains() -> ExpressionRange;
-  static auto EndsWith() -> ExpressionRange;
+  static auto Contains(Expression *value) -> ExpressionRange;
+  static auto EndsWith(Expression *value) -> ExpressionRange;
   static auto Range(std::optional<utils::Bound<Expression *>> lower, std::optional<utils::Bound<Expression *>> upper)
       -> ExpressionRange;
   static auto IsNotNull() -> ExpressionRange;

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -69,13 +69,12 @@ struct ExpressionRange {
 
   auto Evaluate(ExpressionEvaluator &evaluator) const -> storage::PropertyValueRange;
 
-  /// The predicate that decides which of the values inside the evaluated bounds actually satisfy
-  /// this range, or an empty one where the bounds already say everything. Null for every type but
-  /// CONTAINS, ENDS_WITH and REGEX_MATCH, whose bounds only narrow the scan to the string type.
+  /// Which of the values inside the evaluated bounds satisfy the range, where the bounds alone
+  /// cannot say. Null unless the bounds merely narrow the scan to the string type.
   ///
-  /// Separate from Evaluate because the two have different lifetimes: the bounds may read a symbol
-  /// and so are evaluated per row, while a search term that reads any symbol makes the filter no
-  /// index candidate at all, leaving the predicate the same for the whole execution.
+  /// Kept apart from Evaluate because the two have different lifetimes: bounds may read a symbol
+  /// and so are evaluated per row, while a search term never can (PropertyFilter::IsStringPredicate
+  /// says why), leaving the predicate the same for the whole execution.
   auto MakeValuePredicate(ExpressionEvaluator &evaluator) const -> storage::PropertyValueRange::ValuePredicate;
 
   auto ResolveAtPlantime(Parameters const &params, storage::NameIdMapper *name_id_mapper) const

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -68,6 +68,16 @@ struct ExpressionRange {
   static auto IsNotNull() -> ExpressionRange;
 
   auto Evaluate(ExpressionEvaluator &evaluator) const -> storage::PropertyValueRange;
+
+  /// The predicate that decides which of the values inside the evaluated bounds actually satisfy
+  /// this range, or an empty one where the bounds already say everything. Null for every type but
+  /// CONTAINS, ENDS_WITH and REGEX_MATCH, whose bounds only narrow the scan to the string type.
+  ///
+  /// Separate from Evaluate because the two have different lifetimes: the bounds may read a symbol
+  /// and so are evaluated per row, while a search term that reads any symbol makes the filter no
+  /// index candidate at all, leaving the predicate the same for the whole execution.
+  auto MakeValuePredicate(ExpressionEvaluator &evaluator) const -> storage::PropertyValueRange::ValuePredicate;
+
   auto ResolveAtPlantime(Parameters const &params, storage::NameIdMapper *name_id_mapper) const
       -> std::optional<storage::PropertyValueRange>;
 

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -295,12 +295,11 @@ class PropertyFilter {
   }
 
   /// The predicates that read a search term to narrow a scan over the property's string values,
-  /// either as the seek key or as the value predicate that skips whole groups of equal values. A
-  /// correlated one -- whose search term reads a symbol other than the one being scanned -- is
-  /// deliberately not indexed: the term then describes a single row of the other branch, while a
-  /// Cartesian evaluates it once for the whole pass, and indexing it anyway would need an
-  /// IndexedJoin that re-seeks the index per outer row. On an edge it is not plannable at all.
-  /// Before the feature they were plain filters over a scan, and a correlated one stays that way.
+  /// as the seek key or as the predicate that skips whole groups of equal values. One whose search
+  /// term reads a symbol other than the scanned one is refused as an index candidate: the term
+  /// then describes a single row of the other branch, while a Cartesian evaluates it once for the
+  /// whole pass. It stays a filter over a scan, which is also why an indexed search term is the
+  /// same for the whole execution.
   static constexpr bool IsStringPredicate(Type t) {
     return t == Type::STARTS_WITH || t == Type::CONTAINS || t == Type::ENDS_WITH || t == Type::REGEX_MATCH;
   }

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -294,20 +294,22 @@ class PropertyFilter {
     return t == Type::REGEX_MATCH || t == Type::STARTS_WITH || t == Type::CONTAINS || t == Type::ENDS_WITH;
   }
 
+  /// The predicates that read a search term to narrow a scan over the property's string values,
+  /// either as the seek key or as the value predicate that skips whole groups of equal values. A
+  /// correlated one -- whose search term reads a symbol other than the one being scanned -- is
+  /// deliberately not indexed: the term then describes a single row of the other branch, while a
+  /// Cartesian evaluates it once for the whole pass, and indexing it anyway would need an
+  /// IndexedJoin that re-seeks the index per outer row. On an edge it is not plannable at all.
+  /// Before the feature they were plain filters over a scan, and a correlated one stays that way.
+  static constexpr bool IsStringPredicate(Type t) {
+    return t == Type::STARTS_WITH || t == Type::CONTAINS || t == Type::ENDS_WITH || t == Type::REGEX_MATCH;
+  }
+
   /// True when the index seek key is built from this filter's value expression, rather than being a
   /// constant span of the property's type. Such a scan can only run where that expression's symbols
   /// are bound, so a Cartesian above it has to be converted into an IndexedJoin. Types that both
   /// require a post-filter and seek on their value (STARTS_WITH) create that dependency without
   /// their expression ever being removed, so removal alone cannot be used to detect it.
-  /// The three predicates this feature made index candidates. A correlated one -- whose value reads a
-  /// symbol other than the one being scanned -- is deliberately not indexed: on a node it turns a
-  /// Cartesian into an IndexedJoin that re-seeks the index once per outer row, and on an edge it is
-  /// not plannable at all. Before the feature they were plain filters over a scan, and a correlated
-  /// one stays that way.
-  static constexpr bool IsStringPredicate(Type t) {
-    return t == Type::STARTS_WITH || t == Type::CONTAINS || t == Type::ENDS_WITH;
-  }
-
   static constexpr bool SeeksOnValue(Type t) {
     return t == Type::EQUAL || t == Type::RANGE || t == Type::IN || t == Type::STARTS_WITH;
   }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1186,36 +1186,36 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     return std::ranges::any_of(filter.used_symbols, [&scanned_symbol](Symbol const &s) { return s != scanned_symbol; });
   }
 
+  // Whether a scan of `scanned_symbol` may read this filter's value expression. Every path that
+  // hands a filter to a scan has to ask, so that none of them can admit a value the scan cannot
+  // evaluate where it runs.
+  static bool CanKeyIndexScan(const Symbol &scanned_symbol, const std::unordered_set<Symbol> &bound_symbols,
+                              FilterInfo const &filter) {
+    // Skip filter expressions which use the symbol whose property we are
+    // looking up or aren't bound. We cannot scan by such expressions. For
+    // example, in `n.a = 2 + n.b` both sides of `=` refer to `n`, so we
+    // cannot scan `n` by property index.
+
+    // TODO: technically we could filter for existance of n.a or n.b, BUT ATM when we replace
+    //       scan+filter with index based scanby we remove the associated filter
+    //       `n.a = 2 + n.b` would an example of a filter that could be enhanced by an index but does not
+    //       remove the need for the filter
+    if (filter.property_filter->is_symbol_in_value_) return false;
+    if (!std::ranges::all_of(filter.used_symbols, [&](Symbol const &s) { return bound_symbols.contains(s); })) {
+      return false;
+    }
+    return !IsCorrelatedStringPredicate(scanned_symbol, filter);
+  }
+
   auto GetCandidateLabelPropertiesIndices(const Symbol &symbol, const std::unordered_set<Symbol> &bound_symbols)
       -> CandidateLabelPropertiesIndices {
-    auto are_bound = [&bound_symbols](const auto &used_symbols) {
-      for (const auto &used_symbol : used_symbols) {
-        if (!bound_symbols.contains(used_symbol)) {
-          return false;
-        }
-      }
-      return true;
-    };
-
     auto candidate_label_properties_indices = CandidateLabelPropertiesIndices{};
 
     namespace r = ranges;
     namespace rv = r::views;
 
     auto as_storage_label = [&](auto const &label) { return GetLabel(label); };
-    auto valid_filter = [&](auto const &filter) {
-      // Skip filter expressions which use the symbol whose property we are
-      // looking up or aren't bound. We cannot scan by such expressions. For
-      // example, in `n.a = 2 + n.b` both sides of `=` refer to `n`, so we
-      // cannot scan `n` by property index.
-
-      // TODO: technically we could filter for existance of n.a or n.b, BUT ATM when we replace
-      //       scan+filter with index based scanby we remove the associated filter
-      //       `n.a = 2 + n.b` would an example of a filter that could be enhanced by an index but does not
-      //       remove the need for the filter
-      return !filter.property_filter->is_symbol_in_value_ && are_bound(filter.used_symbols) &&
-             !IsCorrelatedStringPredicate(symbol, filter);
-    };
+    auto valid_filter = [&](auto const &filter) { return CanKeyIndexScan(symbol, bound_symbols, filter); };
     auto as_propertyIX = [&](auto const &filter) -> auto const & { return filter.property_filter->property_ids_; };
     auto as_property_path = [&](auto const &filter) -> storage::PropertyPath {
       std::vector<storage::PropertyId> storage_property_ids;
@@ -1741,10 +1741,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     std::optional<Candidate> best;
 
     for (auto const &filter : property_filters) {
-      if (filter.property_filter->is_symbol_in_value_ ||
-          !std::ranges::all_of(filter.used_symbols, [&](auto const &s) { return bound_symbols.contains(s); }) ||
-          IsCorrelatedStringPredicate(node_symbol, filter))
-        continue;
+      if (!CanKeyIndexScan(node_symbol, bound_symbols, filter)) continue;
       if (filter.property_filter->property_ids_.path.size() != 1) continue;
       auto const &prop_ix = filter.property_filter->property_ids_.path[0];
       auto property = GetProperty(prop_ix);
@@ -2008,7 +2005,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         (!max_vertex_count || *max_vertex_count >= found_index->vertex_count) && or_labels.empty()) {
       // When a selected filter is IS_NOT_NULL but a string predicate (CONTAINS/ENDS_WITH/REGEX)
       // exists for the same property, upgrade to the string predicate. Both scan the same index
-      // range, but the string predicate attaches a ValuePredicate enabling index skip scan.
+      // range, but the string predicate attaches a ValuePredicate enabling index skip scan. The
+      // candidate has to pass the same test the selected filters did: it is about to key a scan.
       std::vector<FilterInfo> superseded_filters;
       for (auto &filter_info : found_index->filters) {
         if (filter_info.property_filter->type_ != PropertyFilter::Type::IS_NOT_NULL) continue;
@@ -2018,7 +2016,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           if (ct != PropertyFilter::Type::CONTAINS && ct != PropertyFilter::Type::ENDS_WITH &&
               ct != PropertyFilter::Type::REGEX_MATCH)
             continue;
-          if (candidate.property_filter->is_symbol_in_value_) continue;
+          if (!CanKeyIndexScan(node_symbol, bound_symbols, candidate)) continue;
           superseded_filters.push_back(filter_info);
           filter_info = candidate;
           break;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -2026,6 +2026,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       }
       for (auto const &f : superseded_filters) {
         metadata.filters_to_erase.push_back(f);
+        metadata.expressions_to_mark_for_removal.push_back(f.expression);
       }
 
       // Collect metadata for filter cleanup

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1187,8 +1187,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   }
 
   // Whether a scan of `scanned_symbol` may read this filter's value expression. Every path that
-  // hands a filter to a scan has to ask, so that none of them can admit a value the scan cannot
-  // evaluate where it runs.
+  // hands a filter to a scan asks here, so none of them can admit a value the scan cannot evaluate
+  // where it runs.
   static bool CanKeyIndexScan(const Symbol &scanned_symbol, const std::unordered_set<Symbol> &bound_symbols,
                               FilterInfo const &filter) {
     // Skip filter expressions which use the symbol whose property we are
@@ -2005,8 +2005,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         (!max_vertex_count || *max_vertex_count >= found_index->vertex_count) && or_labels.empty()) {
       // When a selected filter is IS_NOT_NULL but a string predicate (CONTAINS/ENDS_WITH/REGEX)
       // exists for the same property, upgrade to the string predicate. Both scan the same index
-      // range, but the string predicate attaches a ValuePredicate enabling index skip scan. The
-      // candidate has to pass the same test the selected filters did: it is about to key a scan.
+      // range, but the string predicate attaches a ValuePredicate enabling index skip scan.
       std::vector<FilterInfo> superseded_filters;
       for (auto &filter_info : found_index->filters) {
         if (filter_info.property_filter->type_ != PropertyFilter::Type::IS_NOT_NULL) continue;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -2009,15 +2009,23 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       // When a selected filter is IS_NOT_NULL but a string predicate (CONTAINS/ENDS_WITH/REGEX)
       // exists for the same property, upgrade to the string predicate. Both scan the same index
       // range, but the string predicate attaches a ValuePredicate enabling index skip scan.
+      std::vector<FilterInfo> superseded_filters;
       for (auto &filter_info : found_index->filters) {
         if (filter_info.property_filter->type_ != PropertyFilter::Type::IS_NOT_NULL) continue;
         for (auto const &candidate : filters_.PropertyFilters(node_symbol)) {
           if (candidate.property_filter->property_ids_ != filter_info.property_filter->property_ids_) continue;
-          if (!PropertyFilter::IsStringPredicate(candidate.property_filter->type_)) continue;
+          auto const ct = candidate.property_filter->type_;
+          if (ct != PropertyFilter::Type::CONTAINS && ct != PropertyFilter::Type::ENDS_WITH &&
+              ct != PropertyFilter::Type::REGEX_MATCH)
+            continue;
           if (candidate.property_filter->is_symbol_in_value_) continue;
+          superseded_filters.push_back(filter_info);
           filter_info = candidate;
           break;
         }
+      }
+      for (auto const &f : superseded_filters) {
+        metadata.filters_to_erase.push_back(f);
       }
 
       // Collect metadata for filter cleanup

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1786,13 +1786,13 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     auto const make_string_range = [&]() -> std::optional<ExpressionRange> {
       switch (prop_filter.type_) {
         case PropertyFilter::Type::REGEX_MATCH:
-          return ExpressionRange::RegexMatch();
+          return ExpressionRange::RegexMatch(prop_filter.value_);
         case PropertyFilter::Type::STARTS_WITH:
           return ExpressionRange::StartsWith(prop_filter.value_);
         case PropertyFilter::Type::CONTAINS:
-          return ExpressionRange::Contains();
+          return ExpressionRange::Contains(prop_filter.value_);
         case PropertyFilter::Type::ENDS_WITH:
-          return ExpressionRange::EndsWith();
+          return ExpressionRange::EndsWith(prop_filter.value_);
         default:
           return std::nullopt;
       }
@@ -1866,16 +1866,16 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           return ExpressionRange::In(filter.property_filter->value_, membership_list);
         }
         case PropertyFilter::Type::REGEX_MATCH: {
-          return ExpressionRange::RegexMatch();
+          return ExpressionRange::RegexMatch(filter.property_filter->value_);
         }
         case PropertyFilter::Type::STARTS_WITH: {
           return ExpressionRange::StartsWith(filter.property_filter->value_);
         }
         case PropertyFilter::Type::CONTAINS: {
-          return ExpressionRange::Contains();
+          return ExpressionRange::Contains(filter.property_filter->value_);
         }
         case PropertyFilter::Type::ENDS_WITH: {
-          return ExpressionRange::EndsWith();
+          return ExpressionRange::EndsWith(filter.property_filter->value_);
         }
         case PropertyFilter::Type::RANGE: {
           return ExpressionRange::Range(filter.property_filter->lower_bound_, filter.property_filter->upper_bound_);
@@ -2006,6 +2006,20 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
     if (found_index &&
         // Use label+property index if we satisfy max_vertex_count.
         (!max_vertex_count || *max_vertex_count >= found_index->vertex_count) && or_labels.empty()) {
+      // When a selected filter is IS_NOT_NULL but a string predicate (CONTAINS/ENDS_WITH/REGEX)
+      // exists for the same property, upgrade to the string predicate. Both scan the same index
+      // range, but the string predicate attaches a ValuePredicate enabling index skip scan.
+      for (auto &filter_info : found_index->filters) {
+        if (filter_info.property_filter->type_ != PropertyFilter::Type::IS_NOT_NULL) continue;
+        for (auto const &candidate : filters_.PropertyFilters(node_symbol)) {
+          if (candidate.property_filter->property_ids_ != filter_info.property_filter->property_ids_) continue;
+          if (!PropertyFilter::IsStringPredicate(candidate.property_filter->type_)) continue;
+          if (candidate.property_filter->is_symbol_in_value_) continue;
+          filter_info = candidate;
+          break;
+        }
+      }
+
       // Collect metadata for filter cleanup
       for (auto const &filter_info : found_index->filters) {
         const PropertyFilter prop_filter = *filter_info.property_filter;

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -24,6 +24,7 @@
 #include <concepts>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 #include <ranges>
@@ -65,7 +66,10 @@ struct PropertyValueRange {
 
   static auto IsNotNull() -> PropertyValueRange { return {Type::IS_NOT_NULL, std::nullopt, std::nullopt}; }
 
-  using ValuePredicate = std::function<bool(PropertyValue const &)>;
+  using ValuePredicateFn = std::function<bool(PropertyValue const &)>;
+  /// Held by pointer: a scan hands the same predicate to every iterator it makes, and one carrying
+  /// a compiled pattern is expensive to copy.
+  using ValuePredicate = std::shared_ptr<ValuePredicateFn const>;
 
   void SetValuePredicate(ValuePredicate predicate) { value_predicate_ = std::move(predicate); }
 

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -23,6 +23,7 @@
 #include <array>
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 #include <ranges>
@@ -64,6 +65,12 @@ struct PropertyValueRange {
 
   static auto IsNotNull() -> PropertyValueRange { return {Type::IS_NOT_NULL, std::nullopt, std::nullopt}; }
 
+  using ValuePredicate = std::function<bool(PropertyValue const &)>;
+
+  void SetValuePredicate(ValuePredicate predicate) { value_predicate_ = std::move(predicate); }
+
+  ValuePredicate const &GetValuePredicate() const { return value_predicate_; }
+
   bool IsValueInRange(PropertyValue const &value) const {
     // A range nothing can match admits nothing, whatever its bounds happen to be: an empty one
     // carries none at all, and reading those as unbounded would admit every value.
@@ -99,6 +106,8 @@ struct PropertyValueRange {
   PropertyValueRange(Type type, std::optional<utils::Bound<PropertyValue>> lower,
                      std::optional<utils::Bound<PropertyValue>> upper)
       : type_{type}, lower_{std::move(lower)}, upper_{std::move(upper)} {}
+
+  ValuePredicate value_predicate_;
 };
 
 /** A non-owning view over property values known to be in *index* order (the

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1201,9 +1201,8 @@ void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid()
     auto const &leading_value = index_iterator_->values[0];
     if ((*leading_predicate)(leading_value)) break;
 
-    // Advance one entry. If the next entry has the same value, the group
-    // is large enough to warrant an O(log n) seek; otherwise the iterator
-    // is already past the group.
+    // Only seek when the group turns out to hold more than the one entry: a seek costs more than
+    // the step that has already left a single-entry group behind.
     ++index_iterator_;
     if (index_iterator_ != self_->index_accessor_.end() && index_iterator_->values[0] == leading_value) {
       index_iterator_ = self_->index_accessor_.find_greater(std::span<PropertyValue const>{&leading_value, 1});

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -372,10 +372,10 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
 
 }  // namespace
 
-template <IndexOrder Order, std::size_t N>
-bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<(std::vector<PropertyValue> const &rhs) const {
-  auto const prefix = values | std::views::take(std::min(rhs.size(), values.size()));
-  // In DESC, "less than" in skip-list terms means "greater than" in value terms.
+namespace {
+template <IndexOrder Order, typename Range, typename Values>
+bool EntryLessThan(Values const &values, Range const &rhs) {
+  auto const prefix = values | std::views::take(std::min(std::ranges::size(rhs), values.size()));
   if constexpr (Order == IndexOrder::DESC) {
     return std::ranges::lexicographical_compare(rhs, prefix);
   } else {
@@ -383,13 +383,39 @@ bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<(std::vector<Pro
   }
 }
 
+template <typename Range, typename Values>
+bool EntryEqual(Values const &values, Range const &rhs) {
+  return std::ranges::equal(values | std::views::take(std::min(std::ranges::size(rhs), values.size())), rhs);
+}
+}  // namespace
+
+template <IndexOrder Order, std::size_t N>
+bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<(std::vector<PropertyValue> const &rhs) const {
+  return EntryLessThan<Order>(values, rhs);
+}
+
+template <IndexOrder Order, std::size_t N>
+bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<(std::span<PropertyValue const> rhs) const {
+  return EntryLessThan<Order>(values, rhs);
+}
+
 template <IndexOrder Order, std::size_t N>
 bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator==(std::vector<PropertyValue> const &rhs) const {
-  return std::ranges::equal(values | std::views::take(std::min(rhs.size(), values.size())), rhs);
+  return EntryEqual(values, rhs);
+}
+
+template <IndexOrder Order, std::size_t N>
+bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator==(std::span<PropertyValue const> rhs) const {
+  return EntryEqual(values, rhs);
 }
 
 template <IndexOrder Order, std::size_t N>
 bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<=(std::vector<PropertyValue> const &rhs) const {
+  return *this < rhs || *this == rhs;
+}
+
+template <IndexOrder Order, std::size_t N>
+bool InMemoryLabelPropertyIndex::BasicEntry<Order, N>::operator<=(std::span<PropertyValue const> rhs) const {
   return *this < rhs || *this == rhs;
 }
 
@@ -1190,8 +1216,8 @@ void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid()
     // is already past the group.
     ++index_iterator_;
     if (index_iterator_ != self_->index_accessor_.end() && index_iterator_->values[0] == leading_value) {
-      std::vector<PropertyValue> seek_key{leading_value};
-      index_iterator_ = self_->index_accessor_.find_greater(seek_key);
+      std::array<PropertyValue, 1> seek_key{leading_value};
+      index_iterator_ = self_->index_accessor_.find_greater(std::span<PropertyValue const>{seek_key});
     }
     current_vertex_ = nullptr;
   }

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1177,8 +1177,7 @@ InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::operator++() {
 template <typename EntryT>
 void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid() {
   constexpr bool is_desc = EntryT::kOrder == IndexOrder::DESC;
-  auto const &predicates = self_->value_predicates_;
-  auto const has_predicates = std::ranges::any_of(predicates, [](auto const &p) { return !!p; });
+  auto const &leading_predicate = !self_->value_predicates_.empty() ? self_->value_predicates_[0] : nullptr;
 
   while (true) {
     AdvanceUntilValid_(index_iterator_,
@@ -1197,19 +1196,10 @@ void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid()
                        /*use_cache=*/true,
                        /*reverse_iteration=*/is_desc);
 
-    if (!has_predicates || index_iterator_ == self_->index_accessor_.end()) break;
+    if (!leading_predicate || index_iterator_ == self_->index_accessor_.end()) break;
 
-    // Test value predicates on the found entry's leading value.
-    // If rejected, seek past the entire value group and retry.
     auto const &leading_value = index_iterator_->values[0];
-    bool accepted = true;
-    for (auto const &predicate : predicates) {
-      if (predicate && !predicate(leading_value)) {
-        accepted = false;
-        break;
-      }
-    }
-    if (accepted) break;
+    if (leading_predicate(leading_value)) break;
 
     // Advance one entry. If the next entry has the same value, the group
     // is large enough to warrant an O(log n) seek; otherwise the iterator

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1206,8 +1206,7 @@ void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid()
     // is already past the group.
     ++index_iterator_;
     if (index_iterator_ != self_->index_accessor_.end() && index_iterator_->values[0] == leading_value) {
-      std::array<PropertyValue, 1> seek_key{leading_value};
-      index_iterator_ = self_->index_accessor_.find_greater(std::span<PropertyValue const>{seek_key});
+      index_iterator_ = self_->index_accessor_.find_greater(std::span<PropertyValue const>{&leading_value, 1});
     }
     current_vertex_ = nullptr;
   }

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1177,7 +1177,7 @@ InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::operator++() {
 template <typename EntryT>
 void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid() {
   constexpr bool is_desc = EntryT::kOrder == IndexOrder::DESC;
-  auto const &leading_predicate = !self_->value_predicates_.empty() ? self_->value_predicates_[0] : nullptr;
+  auto const *leading_predicate = self_->leading_predicate_.get();
 
   while (true) {
     AdvanceUntilValid_(index_iterator_,
@@ -1199,7 +1199,7 @@ void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid()
     if (!leading_predicate || index_iterator_ == self_->index_accessor_.end()) break;
 
     auto const &leading_value = index_iterator_->values[0];
-    if (leading_predicate(leading_value)) break;
+    if ((*leading_predicate)(leading_value)) break;
 
     // Advance one entry. If the next entry has the same value, the group
     // is large enough to warrant an O(log n) seek; otherwise the iterator
@@ -1229,9 +1229,8 @@ InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterable(typename utils::SkipListD
       transaction_(transaction),
       max_gid_(max_gid) {
   bounds_valid_ = ValidateBounds(ranges, lower_bound_, upper_bound_);  // NOLINT
-  value_predicates_.reserve(ranges.size());
-  for (auto const &range : ranges) {
-    value_predicates_.push_back(range.GetValuePredicate());
+  if (!ranges.empty()) {
+    leading_predicate_ = ranges[0].GetValuePredicate();
   }
 }
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1151,21 +1151,50 @@ InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::operator++() {
 template <typename EntryT>
 void InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterator::AdvanceUntilValid() {
   constexpr bool is_desc = EntryT::kOrder == IndexOrder::DESC;
-  AdvanceUntilValid_(index_iterator_,
-                     self_->index_accessor_.end(),
-                     current_vertex_,
-                     current_vertex_accessor_,
-                     self_->storage_,
-                     self_->transaction_,
-                     self_->view_,
-                     self_->label_,
-                     self_->lower_bound_,
-                     self_->upper_bound_,
-                     self_->permutation_helper_,
-                     self_->max_gid_,
-                     match_scratch_,
-                     /*use_cache=*/true,
-                     /*reverse_iteration=*/is_desc);
+  auto const &predicates = self_->value_predicates_;
+  auto const has_predicates = std::ranges::any_of(predicates, [](auto const &p) { return !!p; });
+
+  while (true) {
+    AdvanceUntilValid_(index_iterator_,
+                       self_->index_accessor_.end(),
+                       current_vertex_,
+                       current_vertex_accessor_,
+                       self_->storage_,
+                       self_->transaction_,
+                       self_->view_,
+                       self_->label_,
+                       self_->lower_bound_,
+                       self_->upper_bound_,
+                       self_->permutation_helper_,
+                       self_->max_gid_,
+                       match_scratch_,
+                       /*use_cache=*/true,
+                       /*reverse_iteration=*/is_desc);
+
+    if (!has_predicates || index_iterator_ == self_->index_accessor_.end()) break;
+
+    // Test value predicates on the found entry's leading value.
+    // If rejected, seek past the entire value group and retry.
+    auto const &leading_value = index_iterator_->values[0];
+    bool accepted = true;
+    for (auto const &predicate : predicates) {
+      if (predicate && !predicate(leading_value)) {
+        accepted = false;
+        break;
+      }
+    }
+    if (accepted) break;
+
+    // Advance one entry. If the next entry has the same value, the group
+    // is large enough to warrant an O(log n) seek; otherwise the iterator
+    // is already past the group.
+    ++index_iterator_;
+    if (index_iterator_ != self_->index_accessor_.end() && index_iterator_->values[0] == leading_value) {
+      std::vector<PropertyValue> seek_key{leading_value};
+      index_iterator_ = self_->index_accessor_.find_greater(seek_key);
+    }
+    current_vertex_ = nullptr;
+  }
 }
 
 template <typename EntryT>
@@ -1185,6 +1214,10 @@ InMemoryLabelPropertyIndex::Iterable<EntryT>::Iterable(typename utils::SkipListD
       transaction_(transaction),
       max_gid_(max_gid) {
   bounds_valid_ = ValidateBounds(ranges, lower_bound_, upper_bound_);  // NOLINT
+  value_predicates_.reserve(ranges.size());
+  for (auto const &range : ranges) {
+    value_predicates_.push_back(range.GetValuePredicate());
+  }
 }
 
 template <typename EntryT>

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -75,8 +75,11 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     friend bool operator==(BasicEntry const &, BasicEntry const &) = default;
 
     bool operator<(std::vector<PropertyValue> const &rhs) const;
+    bool operator<(std::span<PropertyValue const> rhs) const;
     bool operator==(std::vector<PropertyValue> const &rhs) const;
+    bool operator==(std::span<PropertyValue const> rhs) const;
     bool operator<=(std::vector<PropertyValue> const &rhs) const;
+    bool operator<=(std::span<PropertyValue const> rhs) const;
   };
 
   template <std::size_t N = std::dynamic_extent>

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -329,7 +329,9 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
     std::vector<std::optional<utils::Bound<PropertyValue>>> lower_bound_;
     std::vector<std::optional<utils::Bound<PropertyValue>>> upper_bound_;
-    std::vector<PropertyValueRange::ValuePredicate> value_predicates_;
+    /// Only the leading property's predicate is held: it is the one a group of equal values can be
+    /// skipped by, because the index orders on it first. The rest are answered by the post-filter.
+    PropertyValueRange::ValuePredicate leading_predicate_;
     bool bounds_valid_{true};
     View view_;
     Storage *storage_;

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -326,6 +326,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
     std::vector<std::optional<utils::Bound<PropertyValue>>> lower_bound_;
     std::vector<std::optional<utils::Bound<PropertyValue>>> upper_bound_;
+    std::vector<PropertyValueRange::ValuePredicate> value_predicates_;
     bool bounds_valid_{true};
     View view_;
     Storage *storage_;

--- a/src/utils/skip_list.hpp
+++ b/src/utils/skip_list.hpp
@@ -1021,6 +1021,18 @@ class SkipList final : detail::SkipListNode_base {
       return skiplist_->find_equal_or_greater(key);
     }
 
+    /// Finds the first key strictly greater than the given key.
+    template <typename TKey>
+    Iterator find_greater(const TKey &key) {
+      return skiplist_->find_greater(key);
+    }
+
+    /// Finds the first key strictly greater than the given key.
+    template <typename TKey>
+    ConstIterator find_greater(const TKey &key) const {
+      return skiplist_->find_greater(key);
+    }
+
     /// Estimates the number of items that are contained in the list that are
     /// identical to the key determined using the equality operator. The default
     /// layer is chosen to optimize duration vs. precision. The lower the layer
@@ -1168,6 +1180,11 @@ class SkipList final : detail::SkipListNode_base {
     template <typename TKey>
     ConstIterator find_equal_or_greater(const TKey &key) const {
       return skiplist_->find_equal_or_greater(key);
+    }
+
+    template <typename TKey>
+    ConstIterator find_greater(const TKey &key) const {
+      return skiplist_->find_greater(key);
     }
 
     template <typename TKey>
@@ -1450,6 +1467,36 @@ class SkipList final : detail::SkipListNode_base {
   }
 
   template <typename TKey>
+  void find_node_strict_greater(const TKey &key, std::array<TNode *, kSkipListMaxHeight> &preds,
+                                std::array<TNode *, kSkipListMaxHeight> &succs) const {
+    TNode *pred = head_;
+    for (int layer = kSkipListMaxHeight - 1; layer >= 0; --layer) {
+      TNode *curr = pred->nexts[layer].load(std::memory_order_acquire);
+      while (curr != nullptr && curr->obj <= key) {
+        pred = curr;
+        curr = pred->nexts[layer].load(std::memory_order_acquire);
+      }
+      preds[layer] = pred;
+      succs[layer] = curr;
+    }
+  }
+
+  template <typename TKey>
+  Iterator find_greater_(const TKey &key) const {
+    std::array<TNode *, kSkipListMaxHeight> preds{};
+    std::array<TNode *, kSkipListMaxHeight> succs{};
+    find_node_strict_greater(key, preds, succs);
+    while (true) {
+      if (!succs[0]) return Iterator{nullptr};
+      auto valid =
+          succs[0]->fully_linked.load(std::memory_order_acquire) && !succs[0]->marked.load(std::memory_order_acquire);
+      if (valid) return Iterator{succs[0]};
+      // Entry was marked/not fully linked; advance linearly to the next valid node
+      succs[0] = succs[0]->nexts[0].load(std::memory_order_acquire);
+    }
+  }
+
+  template <typename TKey>
   Iterator find_equal_or_greater_(const TKey &key, std::array<TNode *, kSkipListMaxHeight> &preds,
                                   std::array<TNode *, kSkipListMaxHeight> &succs) const {
     while (true) {
@@ -1482,6 +1529,16 @@ class SkipList final : detail::SkipListNode_base {
   template <typename TKey>
   ConstIterator find_equal_or_greater(const TKey &key) const {
     return ConstIterator{find_equal_or_greater_(key)};
+  }
+
+  template <typename TKey>
+  Iterator find_greater(const TKey &key) {
+    return Iterator{find_greater_(key)};
+  }
+
+  template <typename TKey>
+  ConstIterator find_greater(const TKey &key) const {
+    return ConstIterator{find_greater_(key)};
   }
 
   template <typename TKey>

--- a/src/utils/skip_list.hpp
+++ b/src/utils/skip_list.hpp
@@ -1585,15 +1585,19 @@ class SkipList final : detail::SkipListNode_base {
     std::array<TNode *, kSkipListMaxHeight> succs{};
     int layer_found = -1;
     if (lower) {
+      // find_node reports the layer holding the key, or -1 when the list has no such key. It fills
+      // the predecessors either way, and those -- the last node before the bound at each layer --
+      // are all the walk below needs. A range is described by where its bounds fall between the
+      // keys, so a bound matching no element still has elements above it to count.
       layer_found = find_node(lower->value(), preds, succs);
+      if (layer_found == -1) {
+        layer_found = kSkipListMaxHeight - 1;
+      }
     } else {
       for (auto &pred : preds) {
         pred = head_;
       }
       layer_found = kSkipListMaxHeight - 1;
-    }
-    if (layer_found == -1) {
-      return 0;
     }
 
     uint64_t count = 0;

--- a/tests/concurrent/CMakeLists.txt
+++ b/tests/concurrent/CMakeLists.txt
@@ -38,6 +38,9 @@ target_link_libraries(${test_prefix}skip_list_insert mg-utils mg-memory)
 add_concurrent_test(skip_list_insert_competitive.cpp)
 target_link_libraries(${test_prefix}skip_list_insert_competitive mg-utils mg-memory)
 
+add_concurrent_test(skip_list_estimate.cpp)
+target_link_libraries(${test_prefix}skip_list_estimate mg-utils mg-memory)
+
 add_concurrent_test(skip_list_mixed.cpp)
 target_link_libraries(${test_prefix}skip_list_mixed mg-utils mg-memory)
 

--- a/tests/concurrent/skip_list_estimate.cpp
+++ b/tests/concurrent/skip_list_estimate.cpp
@@ -1,0 +1,112 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Reads the range estimators while the list is being inserted into and removed from. An estimate
+// has no exact answer to check against under concurrent modification, so what is asserted is that
+// the walk stays inside the list: it terminates, and it never reports more items than the list has
+// ever held. Bounds that match no element are the point of the exercise, since those walk from a
+// predecessor the seek found rather than from a node that is known to be present.
+
+#include <atomic>
+#include <cstdint>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "utils/bound.hpp"
+#include "utils/logging.hpp"
+#include "utils/skip_list.hpp"
+
+const int kNumThreadsInsert = 4;
+const int kNumThreadsRemove = 2;
+const int kNumThreadsEstimate = 4;
+
+// Only even keys are ever inserted, so every odd bound falls between two keys and matches nothing.
+const uint64_t kMaxNum = 200000;
+
+int main() {
+  memgraph::utils::SkipList<uint64_t> list;
+  std::atomic<bool> run{true};
+
+  std::vector<std::thread> threads_modify;
+  std::vector<std::thread> threads_estimate;
+
+  for (int i = 0; i < kNumThreadsInsert; ++i) {
+    threads_modify.emplace_back([&list, i] {
+      for (uint64_t num = i * kMaxNum; num < (i + 1) * kMaxNum; ++num) {
+        auto acc = list.access();
+        acc.insert(num * 2);
+      }
+    });
+  }
+  for (int i = 0; i < kNumThreadsRemove; ++i) {
+    threads_modify.emplace_back([&list, i] {
+      for (uint64_t num = i * kMaxNum; num < (i + 1) * kMaxNum; ++num) {
+        auto acc = list.access();
+        acc.remove(num * 2);
+      }
+    });
+  }
+
+  constexpr uint64_t ceiling = kNumThreadsInsert * kMaxNum * 2;
+
+  for (int i = 0; i < kNumThreadsEstimate; ++i) {
+    threads_estimate.emplace_back([&list, &run, i] {
+      std::mt19937 gen(7919 + i);
+      std::uniform_int_distribution<uint64_t> dist(0, ceiling);
+      while (run.load(std::memory_order_relaxed)) {
+        auto acc = list.access();
+        // Odd, so present in no list state this run can reach.
+        auto const absent_lower = dist(gen) | 1U;
+        auto const absent_upper = dist(gen) | 1U;
+
+        auto const open_above =
+            acc.estimate_range_count<uint64_t>({{absent_lower, memgraph::utils::BoundType::INCLUSIVE}}, std::nullopt);
+        MG_ASSERT(open_above <= ceiling, "Range count {} exceeds every key the list can hold", open_above);
+
+        auto const exclusive =
+            acc.estimate_range_count<uint64_t>({{absent_lower, memgraph::utils::BoundType::EXCLUSIVE}}, std::nullopt);
+        MG_ASSERT(exclusive <= ceiling, "Range count {} exceeds every key the list can hold", exclusive);
+
+        if (absent_lower <= absent_upper) {
+          auto const bounded =
+              acc.estimate_range_count<uint64_t>({{absent_lower, memgraph::utils::BoundType::INCLUSIVE}},
+                                                 {{absent_upper, memgraph::utils::BoundType::INCLUSIVE}});
+          MG_ASSERT(bounded <= ceiling, "Range count {} exceeds every key the list can hold", bounded);
+        }
+
+        auto const whole = acc.estimate_range_count<uint64_t>(std::nullopt, std::nullopt);
+        MG_ASSERT(whole <= ceiling, "Range count {} exceeds every key the list can hold", whole);
+      }
+    });
+  }
+
+  for (auto &thread : threads_modify) {
+    thread.join();
+  }
+  run.store(false, std::memory_order_relaxed);
+  for (auto &thread : threads_estimate) {
+    thread.join();
+  }
+
+  // With the writers done the count at the exact layer is not an estimate any more. Key 1 is odd,
+  // so it is in no list state this run can reach, and every key except 0 sits above it.
+  auto acc = list.access();
+  auto const expected = acc.size() - (acc.contains(uint64_t{0}) ? 1 : 0);
+  auto const from_absent_bound =
+      acc.estimate_range_count<uint64_t>({{uint64_t{1}, memgraph::utils::BoundType::INCLUSIVE}}, std::nullopt, 1);
+  MG_ASSERT(from_absent_bound == expected,
+            "Counting from a bound that matches no key gave {}, {} keys sit above it",
+            from_absent_bound,
+            expected);
+
+  return 0;
+}

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -541,5 +541,81 @@ def test_skip_scan_with_duplicate_leading_values(memgraph, duplicate_leading_gra
     assert list(memgraph.execute_and_fetch(q_count))[0]["c"] == 100
 
 
+# --- a correlated search term must not key a skip scan ---
+
+
+@pytest.mark.parametrize("predicate_prefix", ["", "b.t IS NOT NULL AND "], ids=["bare", "is-not-null"])
+@pytest.mark.parametrize(
+    "operator,left_values,right_values,expected",
+    [
+        pytest.param("CONTAINS", ["al", "be"], ["alpha", "beta"], [("al", "alpha"), ("be", "beta")], id="contains"),
+        pytest.param("ENDS WITH", ["ha", "ta"], ["alpha", "beta"], [("ha", "alpha"), ("ta", "beta")], id="ends-with"),
+        pytest.param("=~", ["al.*", "be.*"], ["alpha", "beta"], [("al.*", "alpha"), ("be.*", "beta")], id="regex"),
+    ],
+)
+def test_correlated_search_term_agrees_with_an_unindexed_scan(
+    memgraph, operator, left_values, right_values, expected, predicate_prefix
+):
+    # A Cartesian pulls its right branch once per pass, against whichever left row was last on the
+    # frame, so a search term read from the other branch describes that one row alone. A skip scan
+    # keyed on it walks past the entries every other left row needed, and the post-filter that
+    # remains cannot bring back rows the scan never produced.
+    memgraph.execute("UNWIND $vs AS v CREATE (:CORRL {t: v});", {"vs": left_values})
+    for label in ("CORRIDX", "CORRPLAIN"):
+        memgraph.execute(f"UNWIND $vs AS v CREATE (:{label} {{t: v}});", {"vs": right_values})
+    memgraph.execute("CREATE INDEX ON :CORRIDX(t);")
+
+    def rows(label):
+        q = (
+            f"MATCH (a:CORRL), (b:{label}) WHERE {predicate_prefix}b.t {operator} a.t "
+            f"RETURN a.t AS a, b.t AS b ORDER BY a, b"
+        )
+        return [(r["a"], r["b"]) for r in memgraph.execute_and_fetch(q)]
+
+    indexed = rows("CORRIDX")
+    plain = rows("CORRPLAIN")
+    memgraph.execute("DROP INDEX ON :CORRIDX(t);")
+    assert plain == expected
+    assert indexed == expected
+
+
+# --- an index must not decide whether a regex query raises ---
+
+
+def test_invalid_regex_does_not_raise_before_a_row_is_read(memgraph):
+    # Compiling the pattern to seed a skip scan happens before the first row is read, so a pattern
+    # that only the filter ever rejected now decides the query's fate. With no row to test, the
+    # query returned nothing rather than raising, and an index must not change that.
+    memgraph.execute("CREATE INDEX ON :RXEMPTY(p);")
+    assert list(memgraph.execute_and_fetch("MATCH (n:RXEMPTY) WHERE n.p =~ '[' RETURN n.p AS v")) == []
+    memgraph.execute("DROP INDEX ON :RXEMPTY(p);")
+
+
+def test_invalid_regex_still_raises_when_a_row_reaches_the_filter(memgraph):
+    memgraph.execute("CREATE INDEX ON :RXROW(p);")
+    memgraph.execute("CREATE (:RXROW {p: 'aa'});")
+    with pytest.raises(Exception):
+        list(memgraph.execute_and_fetch("MATCH (n:RXROW) WHERE n.p =~ '[' RETURN n.p AS v"))
+    memgraph.execute("DROP INDEX ON :RXROW(p);")
+
+
+def test_non_string_regex_pattern_raises_with_and_without_an_index(memgraph):
+    # A non-string pattern is the one string-predicate argument that raises rather than comparing to
+    # Null, so narrowing the range must not quietly swallow it.
+    memgraph.execute("CREATE (:RXNOIDX {p: 'aa'}), (:RXIDX {p: 'aa'});")
+    memgraph.execute("CREATE INDEX ON :RXIDX(p);")
+    for label in ("RXNOIDX", "RXIDX"):
+        with pytest.raises(Exception):
+            list(memgraph.execute_and_fetch(f"MATCH (n:{label}) WHERE n.p =~ 5 RETURN n.p AS v"))
+    memgraph.execute("DROP INDEX ON :RXIDX(p);")
+
+
+def test_null_regex_pattern_matches_nothing(memgraph):
+    memgraph.execute("CREATE (:RXNULL {p: 'aa'});")
+    memgraph.execute("CREATE INDEX ON :RXNULL(p);")
+    assert list(memgraph.execute_and_fetch("MATCH (n:RXNULL) WHERE n.p =~ null RETURN n.p AS v")) == []
+    memgraph.execute("DROP INDEX ON :RXNULL(p);")
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA", "-v"]))

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -488,5 +488,56 @@ def test_is_not_null_upgraded_to_string_predicate(memgraph, predicate, expected)
     assert [r["t"] for r in result] == expected
 
 
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        "n.a = 'k000' AND n.b CONTAINS '5'",
+        "n.a = 'k000' AND n.b ENDS WITH '0'",
+        "n.a = 'k000' AND n.b =~ '.*5'",
+    ],
+)
+def test_composite_index_non_leading_string_predicate(memgraph, predicate):
+    for label in ("CIDX", "CPLAIN"):
+        memgraph.execute(
+            f"FOREACH (i IN range(0,99) | FOREACH (j IN range(0,99) | "
+            f"CREATE (:{label} {{a:'k'+right('00'+toString(i),3), b:'v'+right('00'+toString(j),3)}})));"
+        )
+    memgraph.execute("CREATE INDEX ON :CIDX(a, b);")
+    q = "MATCH (n:{L}) WHERE {p} RETURN n.a AS a, n.b AS b ORDER BY a, b"
+    indexed = [(r["a"], r["b"]) for r in memgraph.execute_and_fetch(q.format(L="CIDX", p=predicate))]
+    plain = [(r["a"], r["b"]) for r in memgraph.execute_and_fetch(q.format(L="CPLAIN", p=predicate))]
+    memgraph.execute("DROP INDEX ON :CIDX(a, b);")
+    assert indexed == plain
+    assert indexed
+
+
+@pytest.fixture
+def duplicate_leading_graph(memgraph):
+    memgraph.execute("CREATE INDEX ON :DUP(type);")
+    memgraph.execute(
+        "FOREACH (i IN range(1, 100) | "
+        "FOREACH (t IN ['alpha', 'beta', 'gamma'] | "
+        "CREATE (:DUP {type: t, seq: i})));"
+    )
+    yield memgraph
+    memgraph.execute("DROP INDEX ON :DUP(type);")
+
+
+@pytest.mark.parametrize(
+    "predicate,expected_type",
+    [
+        ("n.type CONTAINS 'lph'", "alpha"),
+        ("n.type ENDS WITH 'ta'", "beta"),
+        ("n.type =~ 'gam.*'", "gamma"),
+    ],
+)
+def test_skip_scan_with_duplicate_leading_values(memgraph, duplicate_leading_graph, predicate, expected_type):
+    q = f"MATCH (n:DUP) WHERE {predicate} RETURN DISTINCT n.type AS t"
+    result = [r["t"] for r in memgraph.execute_and_fetch(q)]
+    assert result == [expected_type]
+    q_count = f"MATCH (n:DUP) WHERE {predicate} RETURN count(n) AS c"
+    assert list(memgraph.execute_and_fetch(q_count))[0]["c"] == 100
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA", "-v"]))

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -196,7 +196,7 @@ def test_edge_starts_with_null_returns_empty(memgraph, edge_graph):
     assert result == []
 
 
-# --- regression tests for defects found in review ---
+# --- an index may change the plan but never the rows ---
 
 
 @pytest.fixture
@@ -556,10 +556,9 @@ def test_skip_scan_with_duplicate_leading_values(memgraph, duplicate_leading_gra
 def test_correlated_search_term_agrees_with_an_unindexed_scan(
     memgraph, operator, left_values, right_values, expected, predicate_prefix
 ):
-    # A Cartesian pulls its right branch once per pass, against whichever left row was last on the
-    # frame, so a search term read from the other branch describes that one row alone. A skip scan
-    # keyed on it walks past the entries every other left row needed, and the post-filter that
-    # remains cannot bring back rows the scan never produced.
+    # A Cartesian pulls its right branch once per pass, so a search term read from the other branch
+    # describes one left row alone. A skip scan keyed on it walks past the entries the other left
+    # rows needed, and the post-filter cannot bring back rows the scan never produced.
     memgraph.execute("UNWIND $vs AS v CREATE (:CORRL {t: v});", {"vs": left_values})
     for label in ("CORRIDX", "CORRPLAIN"):
         memgraph.execute(f"UNWIND $vs AS v CREATE (:{label} {{t: v}});", {"vs": right_values})
@@ -583,9 +582,8 @@ def test_correlated_search_term_agrees_with_an_unindexed_scan(
 
 
 def test_invalid_regex_does_not_raise_before_a_row_is_read(memgraph):
-    # Compiling the pattern to seed a skip scan happens before the first row is read, so a pattern
-    # that only the filter ever rejected now decides the query's fate. With no row to test, the
-    # query returned nothing rather than raising, and an index must not change that.
+    # An unusable pattern is rejected by the filter, which no row ever reaches here. Seeding a skip
+    # scan reads the pattern earlier, and must not turn a query that answers into one that raises.
     memgraph.execute("CREATE INDEX ON :RXEMPTY(p);")
     assert list(memgraph.execute_and_fetch("MATCH (n:RXEMPTY) WHERE n.p =~ '[' RETURN n.p AS v")) == []
     memgraph.execute("DROP INDEX ON :RXEMPTY(p);")

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -469,25 +469,23 @@ def test_non_string_subject_compares_to_null(memgraph, op):
 
 
 @pytest.mark.parametrize(
-    "predicate,needle",
+    "predicate,expected",
     [
-        ("n.type CONTAINS 'lph'", "CONTAINS"),
-        ("n.type ENDS WITH 'ha'", "ENDS WITH"),
-        ("n.type =~ 'al.*'", "=~"),
+        ("n.type CONTAINS 'lph'", ["alpha"]),
+        ("n.type ENDS WITH 'ha'", ["alpha"]),
+        ("n.type =~ 'al.*'", ["alpha"]),
     ],
 )
-def test_is_not_null_upgraded_to_string_predicate(memgraph, predicate, needle):
+def test_is_not_null_upgraded_to_string_predicate(memgraph, predicate, expected):
     """When IS NOT NULL and a string predicate target the same indexed property,
     the planner upgrades to the string predicate so the skip-scan ValuePredicate
-    reaches the storage layer. The string predicate should not survive as a
-    separate Filter operator."""
-    query = f"MATCH (n:N) WHERE n.type IS NOT NULL AND {predicate} RETURN n"
+    reaches the storage layer."""
+    query = f"MATCH (n:N) WHERE n.type IS NOT NULL AND {predicate} RETURN n.type AS t ORDER BY t"
     plan = get_plan(memgraph, query)
     ops = operator_names(plan)
     assert "ScanAllByLabelProperties" in ops, f"Expected index scan, got: {plan}"
-    # The string predicate should be absorbed into the scan, not left as a post-filter.
-    filter_lines = [line for line in plan if "Filter" in line and needle in line]
-    assert not filter_lines, f"String predicate should not remain as a post-filter: {plan}"
+    result = list(memgraph.execute_and_fetch(query))
+    assert [r["t"] for r in result] == expected
 
 
 if __name__ == "__main__":

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -468,5 +468,27 @@ def test_non_string_subject_compares_to_null(memgraph, op):
     assert list(memgraph.execute_and_fetch(q))[0]["c"] == 0
 
 
+@pytest.mark.parametrize(
+    "predicate,needle",
+    [
+        ("n.type CONTAINS 'lph'", "CONTAINS"),
+        ("n.type ENDS WITH 'ha'", "ENDS WITH"),
+        ("n.type =~ 'al.*'", "=~"),
+    ],
+)
+def test_is_not_null_upgraded_to_string_predicate(memgraph, predicate, needle):
+    """When IS NOT NULL and a string predicate target the same indexed property,
+    the planner upgrades to the string predicate so the skip-scan ValuePredicate
+    reaches the storage layer. The string predicate should not survive as a
+    separate Filter operator."""
+    query = f"MATCH (n:N) WHERE n.type IS NOT NULL AND {predicate} RETURN n"
+    plan = get_plan(memgraph, query)
+    ops = operator_names(plan)
+    assert "ScanAllByLabelProperties" in ops, f"Expected index scan, got: {plan}"
+    # The string predicate should be absorbed into the scan, not left as a post-filter.
+    filter_lines = [line for line in plan if "Filter" in line and needle in line]
+    assert not filter_lines, f"String predicate should not remain as a post-filter: {plan}"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA", "-v"]))

--- a/tests/e2e/query_planning/query_planning_string_operators.py
+++ b/tests/e2e/query_planning/query_planning_string_operators.py
@@ -511,9 +511,11 @@ def test_composite_index_non_leading_string_predicate(memgraph, predicate):
     assert indexed
 
 
-@pytest.fixture
-def duplicate_leading_graph(memgraph):
-    memgraph.execute("CREATE INDEX ON :DUP(type);")
+@pytest.fixture(params=["ASC", "DESC"])
+def duplicate_leading_graph(request, memgraph):
+    order = request.param
+    config = "" if order == "ASC" else ' WITH CONFIG {"order": "DESC"}'
+    memgraph.execute(f"CREATE INDEX ON :DUP(type){config};")
     memgraph.execute(
         "FOREACH (i IN range(1, 100) | "
         "FOREACH (t IN ['alpha', 'beta', 'gamma'] | "

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -600,5 +600,90 @@ TEST_F(QueryCostEstimator, ExtractListFromInUnwindMatching) {
   EXPECT_EQ(extracted->elements_.size(), 2);
 }
 
+/** A fixture for the string predicates, whose scan is narrowed to the string type rather than to a
+ * span around the search term. Holds a global property index over values spread across the
+ * alphabet, so an estimate that mistook the search term for a bound would move as the term moves. */
+class QueryCostEstimatorStringPredicates : public ::testing::Test {
+ protected:
+  std::unique_ptr<ms::Storage> db = std::make_unique<ms::InMemoryStorage>();
+  std::optional<std::unique_ptr<ms::Storage::Accessor>> storage_dba;
+  std::optional<memgraph::query::DbAccessor> dba;
+  ms::PropertyId prop = db->NameToProperty("s");
+
+  std::shared_ptr<LogicalOperator> last_op_ = std::make_shared<Once>();
+  AstStorage storage_;
+  SymbolTable symbol_table_;
+  Parameters parameters_;
+  int symbol_count = 0;
+
+  static constexpr int kStringCount = 1000;
+
+  void SetUp() override {
+    {
+      auto unique_acc = db->UniqueAccess();
+      ASSERT_TRUE(unique_acc->CreateGlobalVertexIndex(prop).has_value());
+      ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    storage_dba.emplace(db->Access(memgraph::storage::WRITE));
+    dba.emplace(storage_dba->get());
+    // Spread across the alphabet, so a term mistaken for a bound would cut the count differently
+    // depending on the letter it starts with.
+    for (int i = 0; i < kStringCount; ++i) {
+      auto vertex = dba->InsertVertex();
+      auto value = std::string(1, static_cast<char>('a' + i % 26)) + std::to_string(i);
+      ASSERT_TRUE(vertex.SetProperty(prop, ms::PropertyValue(std::move(value))).has_value());
+    }
+    dba->AdvanceCommand();
+  }
+
+  Symbol NextSymbol() { return symbol_table_.CreateSymbol("Symbol" + std::to_string(symbol_count++), true); }
+
+  template <typename TValue>
+  Expression *Literal(TValue value) {
+    return storage_.Create<PrimitiveLiteral>(value);
+  }
+
+  template <typename TValue>
+  Expression *Parameter(TValue value) {
+    int token_position = parameters_.size();
+    parameters_.Add(token_position, ms::ExternalPropertyValue(value));
+    return storage_.Create<ParameterLookup>(token_position);
+  }
+
+  double CostOf(ExpressionRange range) {
+    last_op_ = std::make_shared<ScanAllByVertexProperty>(nullptr, NextSymbol(), prop, range);
+    CostEstimator<memgraph::query::DbAccessor> cost_estimator(
+        &*dba, symbol_table_, parameters_, memgraph::query::plan::IndexHints());
+    last_op_->Accept(cost_estimator);
+    return cost_estimator.cost();
+  }
+};
+
+TEST_F(QueryCostEstimatorStringPredicates, EstimateDoesNotMoveWithTheSearchTerm) {
+  // Query stripping turns the term into a parameter and the plan cache is keyed on the stripped
+  // text, so a plan costed against one call's term would be handed to every other term. The
+  // estimate therefore has to be the same for all of them, non-strings included.
+  auto const reference = CostOf(ExpressionRange::Contains(Literal("a")));
+  for (auto *term : {Literal("a"), Literal("m"), Literal("z"), Literal("zzzz"), Parameter("z"), Literal(5)}) {
+    EXPECT_FLOAT_EQ(CostOf(ExpressionRange::Contains(term)), reference);
+    EXPECT_FLOAT_EQ(CostOf(ExpressionRange::EndsWith(term)), reference);
+    EXPECT_FLOAT_EQ(CostOf(ExpressionRange::RegexMatch(term)), reference);
+  }
+}
+
+TEST_F(QueryCostEstimatorStringPredicates, EstimateCoversTheStringsTheScanReads) {
+  // Every value here is a string, so the band these predicates read is the whole property. An
+  // estimate far below it would make the scan look free and win comparisons it should lose.
+  auto const whole_property = CostOf(ExpressionRange::IsNotNull());
+  ASSERT_GT(whole_property, 0.0);
+  EXPECT_GT(CostOf(ExpressionRange::Contains(Literal("a"))), whole_property / 2);
+}
+
+TEST_F(QueryCostEstimatorStringPredicates, StartsWithStillNarrowsToItsPrefix) {
+  // The prefix is a real bound on what matches, and STARTS_WITH already accepts that its plan is
+  // settled by the term. This pins the line between the two: only the prefix seek reads it.
+  EXPECT_LT(CostOf(ExpressionRange::StartsWith(Literal("a"))), CostOf(ExpressionRange::IsNotNull()));
+}
+
 // TODO test cost when ScanAll, Expand, Accumulate, Limit
 // vs cost for SA, Expand, Limit

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -609,6 +609,7 @@ class QueryCostEstimatorStringPredicates : public ::testing::Test {
   std::optional<std::unique_ptr<ms::Storage::Accessor>> storage_dba;
   std::optional<memgraph::query::DbAccessor> dba;
   ms::PropertyId prop = db->NameToProperty("s");
+  ms::PropertyId mixed = db->NameToProperty("mixed");
 
   std::shared_ptr<LogicalOperator> last_op_ = std::make_shared<Once>();
   AstStorage storage_;
@@ -622,6 +623,7 @@ class QueryCostEstimatorStringPredicates : public ::testing::Test {
     {
       auto unique_acc = db->UniqueAccess();
       ASSERT_TRUE(unique_acc->CreateGlobalVertexIndex(prop).has_value());
+      ASSERT_TRUE(unique_acc->CreateGlobalVertexIndex(mixed).has_value());
       ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
     storage_dba.emplace(db->Access(memgraph::storage::WRITE));
@@ -632,6 +634,12 @@ class QueryCostEstimatorStringPredicates : public ::testing::Test {
       auto vertex = dba->InsertVertex();
       auto value = std::string(1, static_cast<char>('a' + i % 26)) + std::to_string(i);
       ASSERT_TRUE(vertex.SetProperty(prop, ms::PropertyValue(std::move(value))).has_value());
+    }
+    // A property whose values are mostly numbers: a string predicate reads only the tail of it.
+    for (int i = 0; i < kStringCount; ++i) {
+      auto vertex = dba->InsertVertex();
+      auto value = i % 10 == 0 ? ms::PropertyValue(std::to_string(i)) : ms::PropertyValue(i);
+      ASSERT_TRUE(vertex.SetProperty(mixed, std::move(value)).has_value());
     }
     dba->AdvanceCommand();
   }
@@ -650,8 +658,10 @@ class QueryCostEstimatorStringPredicates : public ::testing::Test {
     return storage_.Create<ParameterLookup>(token_position);
   }
 
-  double CostOf(ExpressionRange range) {
-    last_op_ = std::make_shared<ScanAllByVertexProperty>(nullptr, NextSymbol(), prop, range);
+  double CostOf(ExpressionRange range) { return CostOfProperty(prop, range); }
+
+  double CostOfProperty(ms::PropertyId property, ExpressionRange range) {
+    last_op_ = std::make_shared<ScanAllByVertexProperty>(nullptr, NextSymbol(), property, range);
     CostEstimator<memgraph::query::DbAccessor> cost_estimator(
         &*dba, symbol_table_, parameters_, memgraph::query::plan::IndexHints());
     last_op_->Accept(cost_estimator);
@@ -677,6 +687,15 @@ TEST_F(QueryCostEstimatorStringPredicates, EstimateCoversTheStringsTheScanReads)
   auto const whole_property = CostOf(ExpressionRange::IsNotNull());
   ASSERT_GT(whole_property, 0.0);
   EXPECT_GT(CostOf(ExpressionRange::Contains(Literal("a"))), whole_property / 2);
+}
+
+TEST_F(QueryCostEstimatorStringPredicates, EstimateNarrowsToTheStringsWhenMostValuesAreNot) {
+  // A string predicate reads the property's string values, not the numbers sorted below them, and
+  // the band those occupy is the same whatever the search term is.
+  auto const whole_property = CostOfProperty(mixed, ExpressionRange::IsNotNull());
+  auto const string_band = CostOfProperty(mixed, ExpressionRange::Contains(Literal("a")));
+  EXPECT_LT(string_band, whole_property / 2);
+  EXPECT_GT(string_band, CostParam::kMinimumCost);
 }
 
 TEST_F(QueryCostEstimatorStringPredicates, StartsWithStillNarrowsToItsPrefix) {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2273,7 +2273,7 @@ TYPED_TEST(TestPlanner, FilterRegexMatchIndex) {
   CheckPlan(planner.plan(),
             symbol_table,
             ExpectScanAllByLabelProperties(
-                label, std::vector{ms::PropertyPath{prop}}, std::vector{ExpressionRange::RegexMatch()}),
+                label, std::vector{ms::PropertyPath{prop}}, std::vector{ExpressionRange::RegexMatch(LITERAL("regex"))}),
             ExpectFilter(),
             ExpectProduce());
 }

--- a/tests/unit/skip_list.cpp
+++ b/tests/unit/skip_list.cpp
@@ -760,6 +760,36 @@ TEST(SkipList, EstimateRangeCount) {
   }
 }
 
+TEST(SkipList, EstimateRangeCountLowerBoundNeedNotBeInTheList) {
+  // A range is described by where its bounds fall between the keys, not by the keys themselves, so
+  // a bound that no element matches has to count the same elements as the next key above it.
+  memgraph::utils::SkipList<Counter> list;
+  const int64_t kKeys = 100;
+  const int64_t kMembers = 10;
+  {
+    auto acc = list.access();
+    for (int64_t key = 0; key < kKeys; ++key) {
+      for (int64_t member = 0; member < kMembers; ++member) {
+        ASSERT_TRUE(acc.insert({key * 2, member}).second);
+      }
+    }
+  }
+
+  auto acc = list.access();
+  using memgraph::utils::BoundType;
+  for (int64_t absent : {1, 51, 197}) {
+    auto const from_absent = acc.estimate_range_count<int64_t>({{absent, BoundType::INCLUSIVE}}, std::nullopt, 1);
+    auto const from_next_key = acc.estimate_range_count<int64_t>({{absent + 1, BoundType::INCLUSIVE}}, std::nullopt, 1);
+    EXPECT_GT(from_next_key, 0);
+    EXPECT_EQ(from_absent, from_next_key);
+  }
+
+  // An absent bound inside a bounded range behaves the same way.
+  auto const bounded_from_absent =
+      acc.estimate_range_count<int64_t>({{51, BoundType::INCLUSIVE}}, {{59, BoundType::INCLUSIVE}}, 1);
+  EXPECT_EQ(bounded_from_absent, 4 * kMembers);  // keys 52, 54, 56, 58
+}
+
 template <typename TElem, typename TCmp>
 void BenchmarkEstimateAverageNumberOfEquals(memgraph::utils::SkipList<TElem> *list, const TCmp &cmp) {
   std::cout << "List size: " << list->size() << std::endl;


### PR DESCRIPTION
For loosely bounded ranges (`CONTAINS`, `ENDS WITH`, `REGEX` on strings), when the number of distinct property values is much lower than the total index entry count, scanning can skip past groups of entries sharing the same value. If two consecutive index entries have the same property value, the group likely contains many more; a logarithmic seek to the next distinct value replaces linear iteration through the group.