### PR TITLE
fix(query): keep a prunable expansion's plan fit for the cache

### DIFF
--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -259,11 +259,10 @@ auto MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameter
       return ConvertToLogicalOperator(egraph, root, planner_context);
     }
     auto planning_context = plan::MakePlanningContext(&ast_storage, &symbol_table, query, &vertex_counts);
-    auto [plan, cost, reads_parameters] =
-        plan::MakeLogicalPlan(&planning_context, parameters, FLAGS_query_cost_planner);
-    // Reading a parameter settles the plan's shape against the values it was
-    // planned with, which the stripped cache key does not carry.
-    is_cacheable = !reads_parameters;
+    auto [plan, cost] = plan::MakeLogicalPlan(&planning_context, parameters, FLAGS_query_cost_planner);
+    // A v1 plan's shape follows the stripped query, which is what the cache is
+    // keyed on, so the values a particular execution supplies cannot change it.
+    is_cacheable = true;
     return plan::v2::ExtractionResult{.plan = std::move(plan),
                                       .cost = cost,
                                       .ast_storage = std::move(ast_storage),

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -4258,7 +4258,7 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::vector<Notifica
   }
 
   std::stringstream printed_plan;
-  plan::PrettyPrint(*dba, &cypher_query_plan->plan(), &printed_plan);
+  plan::PrettyPrint(*dba, &cypher_query_plan->plan(), &printed_plan, &parsed_inner_query.parameters);
   // PrettyPrint feeds the EXPLAIN result rows below; only the trace emit is gated.
   if (memgraph::logging::IsSessionTraceEnabled()) {
     memgraph::logging::EmitSessionTraceEvent("Explain plan:\n{}", printed_plan.str());

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3310,7 +3310,7 @@ class PruningBFSDispatchCursor : public query::plan::Cursor {
   const ExpandVariable &self_;
   utils::MemoryResource *mem_;
   metrics::DatabaseMetricHandles &metric_handles_;
-  UniqueCursorPtr chosen_{nullptr};
+  UniqueCursorPtr chosen_;
 };
 
 void ValidateWeight(TypedValue current_weight) {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2261,10 +2261,13 @@ class ExpandVariableCursor : public Cursor {
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
-    // Named here rather than after the operator, which may permit pruning and so
-    // would report a walk other than this one.
-    auto const profile_name = self_.ToStringNamed(context.db_accessor, "ExpandVariable");
-    SCOPED_PROFILE_OP(profile_name.c_str());
+    // The operator's type may be PRUNING_BFS when the dispatch cursor chose this
+    // DFS walk as a fallback, so the cursor names itself rather than asking the
+    // operator. Computed once to avoid a per-row allocation.
+    if (!profile_name_ && context.is_profile_query) {
+      profile_name_ = self_.ToStringNamed(context.db_accessor, "ExpandVariable");
+    }
+    SCOPED_PROFILE_OP(profile_name_ ? profile_name_->c_str() : "ExpandVariable");
 
     AbortCheck(context);
 
@@ -2304,6 +2307,7 @@ class ExpandVariableCursor : public Cursor {
  private:
   const ExpandVariable &self_;
   const UniqueCursorPtr input_cursor_;
+  std::optional<std::string> profile_name_;
   // bounds. in the cursor they are not optional but set to
   // default values if missing in the ExpandVariable operator
   int64_t upper_bound_{-1};

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3298,6 +3298,8 @@ class PruningBFSDispatchCursor : public query::plan::Cursor {
   /// as, so a bound above one goes to the depth-first walk, as does one of the
   /// wrong type. That walk reads its bounds only once it holds a row, so
   /// rejecting a bad one stays off the expansions that find nothing to expand.
+  /// Must agree with ExpandVariable::OperatorName(Parameters*), which answers
+  /// the same question for EXPLAIN output.
   bool BoundPermitsPruning(Frame &frame, ExecutionContext &context) {
     if (!self_.lower_bound_) return true;
     ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
@@ -4812,6 +4814,8 @@ std::string_view ExpandVariable::OperatorName(Parameters const *parameters) cons
     case Type::PRUNING_BFS: {
       // Which walk runs is settled from the bound, so naming one before the
       // bound can be read would name a walk that may not be the one taken.
+      // Must agree with PruningBFSDispatchCursor::BoundPermitsPruning, which
+      // makes the runtime decision.
       if (!parameters || !lower_bound_) return "PruningBFSExpand"sv;
       auto const bound = ConstExternalPropertyValue(lower_bound_, *parameters);
       if (bound && bound->IsInt() && bound->ValueInt() > 1) return "ExpandVariable"sv;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4818,8 +4818,8 @@ std::string_view ExpandVariable::OperatorName(Parameters const *parameters) cons
       // makes the runtime decision.
       if (!parameters || !lower_bound_) return "PruningBFSExpand"sv;
       auto const bound = ConstExternalPropertyValue(lower_bound_, *parameters);
-      if (bound && bound->IsInt() && bound->ValueInt() > 1) return "ExpandVariable"sv;
-      return "PruningBFSExpand"sv;
+      if (bound && bound->IsInt() && bound->ValueInt() <= 1) return "PruningBFSExpand"sv;
+      return "ExpandVariable"sv;
     }
     case Type::SINGLE:
       LOG_FATAL("Unexpected ExpandVariable::type_");

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2261,7 +2261,10 @@ class ExpandVariableCursor : public Cursor {
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
-    SCOPED_PROFILE_OP_BY_REF(self_);
+    // Named here rather than after the operator, which may permit pruning and so
+    // would report a walk other than this one.
+    auto const profile_name = self_.ToStringNamed(context.db_accessor, "ExpandVariable");
+    SCOPED_PROFILE_OP(profile_name.c_str());
 
     AbortCheck(context);
 
@@ -3253,6 +3256,55 @@ class PruningBFSCursor : public query::plan::Cursor {
   // BFS frontier: current depth level and next depth level
   utils::pmr::vector<VertexAccessor> to_visit_current_;
   utils::pmr::vector<VertexAccessor> to_visit_next_;
+};
+
+/// Only a lower bound of one lets a pruning BFS reach the same vertices as a
+/// depth-first walk: a vertex the BFS first arrives at below the bound is marked
+/// visited and never emitted, where the walk would still arrive at it along a
+/// longer edge-unique path.
+class PruningBFSDispatchCursor : public query::plan::Cursor {
+ public:
+  PruningBFSDispatchCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+                           metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self), mem_(mem), metric_handles_(metric_handles) {}
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    if (!chosen_) chosen_ = Choose(frame, context);
+    return chosen_->Pull(frame, context);
+  }
+
+  void Shutdown() override {
+    if (chosen_) chosen_->Shutdown();
+  }
+
+  void Reset() override {
+    // The bound reads no symbol and the parameters do not change over a cursor's
+    // life, so a reset cannot change which expansion the bound calls for.
+    if (chosen_) chosen_->Reset();
+  }
+
+ private:
+  UniqueCursorPtr Choose(Frame &frame, ExecutionContext &context) {
+    if (BoundPermitsPruning(frame, context))
+      return MakeUniqueCursorPtr<PruningBFSCursor>(mem_, self_, mem_, metric_handles_);
+    return MakeUniqueCursorPtr<ExpandVariableCursor>(mem_, self_, mem_, metric_handles_);
+  }
+
+  /// A walk of at least one edge is what a pruning BFS reaches the same vertices
+  /// as, so a bound above one goes to the depth-first walk, as does one of the
+  /// wrong type. That walk reads its bounds only once it holds a row, so
+  /// rejecting a bad one stays off the expansions that find nothing to expand.
+  bool BoundPermitsPruning(Frame &frame, ExecutionContext &context) {
+    if (!self_.lower_bound_) return true;
+    ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
+    TypedValue const bound = self_.lower_bound_->Accept(evaluator);
+    return bound.IsInt() && bound.ValueInt() <= 1;
+  }
+
+  const ExpandVariable &self_;
+  utils::MemoryResource *mem_;
+  metrics::DatabaseMetricHandles &metric_handles_;
+  UniqueCursorPtr chosen_{nullptr};
 };
 
 void ValidateWeight(TypedValue current_weight) {
@@ -4688,7 +4740,7 @@ UniqueCursorPtr ExpandVariable::MakeCursor(utils::MemoryResource *mem,
       return MakeUniqueCursorPtr<KShortestPathsCursor>(mem, *this, mem, metric_handles);
     }
     case EdgeAtom::Type::PRUNING_BFS: {
-      return MakeUniqueCursorPtr<PruningBFSCursor>(mem, *this, mem, metric_handles);
+      return MakeUniqueCursorPtr<PruningBFSDispatchCursor>(mem, *this, mem, metric_handles);
     }
     case EdgeAtom::Type::SINGLE: {
       LOG_FATAL("ExpandVariable should not be planned for a single expansion!");
@@ -4698,10 +4750,16 @@ UniqueCursorPtr ExpandVariable::MakeCursor(utils::MemoryResource *mem,
   }
 }  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-std::string ExpandVariable::ToString(const DbAccessor *dba) const {
+std::string ExpandVariable::ToString(const DbAccessor *dba) const { return ToStringNamed(dba, OperatorName()); }
+
+std::string ExpandVariable::ToStringWithParameters(const DbAccessor *dba, Parameters const &parameters) const {
+  return ToStringNamed(dba, OperatorName(&parameters));
+}
+
+std::string ExpandVariable::ToStringNamed(const DbAccessor *dba, std::string_view operator_name) const {
   return fmt::format(
       "{} ({}){}[{}{}]{}({})",
-      OperatorName(),
+      operator_name,
       input_symbol_.name(),
       common_.direction == query::EdgeAtom::Direction::IN ? "<-" : "-",
       common_.edge_symbol.name(),
@@ -4733,7 +4791,7 @@ std::unique_ptr<LogicalOperator> ExpandVariable::Clone(AstStorage *storage) cons
   return object;
 }
 
-std::string_view ExpandVariable::OperatorName() const {
+std::string_view ExpandVariable::OperatorName(Parameters const *parameters) const {
   using namespace std::string_view_literals;
   using Type = query::EdgeAtom::Type;
   switch (type_) {
@@ -4747,8 +4805,14 @@ std::string_view ExpandVariable::OperatorName() const {
       return "AllShortestPaths"sv;
     case Type::KSHORTEST:
       return "KShortest"sv;
-    case Type::PRUNING_BFS:
+    case Type::PRUNING_BFS: {
+      // Which walk runs is settled from the bound, so naming one before the
+      // bound can be read would name a walk that may not be the one taken.
+      if (!parameters || !lower_bound_) return "PruningBFSExpand"sv;
+      auto const bound = ConstExternalPropertyValue(lower_bound_, *parameters);
+      if (bound && bound->IsInt() && bound->ValueInt() > 1) return "ExpandVariable"sv;
       return "PruningBFSExpand"sv;
+    }
     case Type::SINGLE:
       LOG_FATAL("Unexpected ExpandVariable::type_");
     default:

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3305,7 +3305,7 @@ class PruningBFSDispatchCursor : public query::plan::Cursor {
   /// expansions that find nothing to expand.
   /// Must agree with ExpandVariable::OperatorName(Parameters*), which answers
   /// the same question for EXPLAIN output.
-  bool BoundPermitsPruning(Frame &frame, ExecutionContext &context) {
+  bool BoundPermitsPruning(Frame &frame, ExecutionContext &context) const {
     if (!self_.lower_bound_) return true;
     ExpressionEvaluator evaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
     TypedValue const bound = self_.lower_bound_->Accept(evaluator);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3022,7 +3022,10 @@ class PruningBFSCursor : public query::plan::Cursor {
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler const oom_exception;
-    SCOPED_PROFILE_OP("PruningBFSExpand");
+    if (!profile_name_ && context.is_profile_query) {
+      profile_name_ = self_.ToStringNamed(context.db_accessor, "PruningBFSExpand");
+    }
+    SCOPED_PROFILE_OP(profile_name_ ? profile_name_->c_str() : "PruningBFSExpand");
 
     ExpressionEvaluator evaluator =
         ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
@@ -3242,6 +3245,7 @@ class PruningBFSCursor : public query::plan::Cursor {
 
   const ExpandVariable &self_;
   const UniqueCursorPtr input_cursor_;
+  std::optional<std::string> profile_name_;
 
   int64_t lower_bound_{};
   int64_t upper_bound_{};

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3266,10 +3266,10 @@ class PruningBFSCursor : public query::plan::Cursor {
   utils::pmr::vector<VertexAccessor> to_visit_next_;
 };
 
-/// Only a lower bound of one lets a pruning BFS reach the same vertices as a
-/// depth-first walk: a vertex the BFS first arrives at below the bound is marked
-/// visited and never emitted, where the walk would still arrive at it along a
-/// longer edge-unique path.
+/// Only a lower bound of at most one lets a pruning BFS reach the same vertices
+/// as a depth-first walk: a vertex the BFS first arrives at below the bound is
+/// marked visited and never emitted, where the walk would still arrive at it
+/// along a longer edge-unique path.
 class PruningBFSDispatchCursor : public query::plan::Cursor {
  public:
   PruningBFSDispatchCursor(const ExpandVariable &self, utils::MemoryResource *mem,
@@ -3298,10 +3298,11 @@ class PruningBFSDispatchCursor : public query::plan::Cursor {
     return MakeUniqueCursorPtr<ExpandVariableCursor>(mem_, self_, mem_, metric_handles_);
   }
 
-  /// A walk of at least one edge is what a pruning BFS reaches the same vertices
-  /// as, so a bound above one goes to the depth-first walk, as does one of the
-  /// wrong type. That walk reads its bounds only once it holds a row, so
-  /// rejecting a bad one stays off the expansions that find nothing to expand.
+  /// A walk of at most one edge is the threshold below which a pruning BFS
+  /// reaches the same vertices as a depth-first walk, so a bound above one goes
+  /// to the depth-first walk, as does one of the wrong type. That walk reads its
+  /// bounds only once it holds a row, so rejecting a bad one stays off the
+  /// expansions that find nothing to expand.
   /// Must agree with ExpandVariable::OperatorName(Parameters*), which answers
   /// the same question for EXPLAIN output.
   bool BoundPermitsPruning(Frame &frame, ExecutionContext &context) {

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -1253,8 +1253,16 @@ class ExpandVariable : public memgraph::query::plan::LogicalOperator {
   /// Limit for the number of paths returned in kshortest path expansion.
   Expression *limit_;
 
-  std::string_view OperatorName() const;
+  /// Names the expansion. Given the parameters an execution supplies, names the
+  /// walk the bound calls for; without them, the one the plan permits.
+  std::string_view OperatorName(Parameters const *parameters = nullptr) const;
 
+  /// The plan line, naming the walk the bound calls for.
+  std::string ToStringWithParameters(const DbAccessor *dba, Parameters const &parameters) const;
+
+  /// The plan line under a name the caller settles, for a walk that knows which
+  /// of the two it is where the plan only knows which it permits.
+  std::string ToStringNamed(const DbAccessor *dba, std::string_view operator_name) const;
   std::string ToString(const DbAccessor *dba) const override;
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;

--- a/src/query/plan/planner.hpp
+++ b/src/query/plan/planner.hpp
@@ -63,7 +63,6 @@ class PostProcessor final {
   IndexHints index_hints_{};
   /// Set by a rewrite that read a parameter to settle the plan's shape. Only
   /// ever set, so it spans every candidate plan considered for the query.
-  bool reads_parameters_{false};
 
   using ProcessedPlan = std::unique_ptr<LogicalOperator>;
 
@@ -89,7 +88,7 @@ class PostProcessor final {
            [&](auto p) { return RewriteWithJoinRewriter(std::move(p), symbol_table, ast, db); } |
            [&](auto p) { return RewriteWithEdgeIndexRewriter(std::move(p), symbol_table, ast, db, parallel_exec); } |
            [&](auto p) { return RewritePeriodicDelete(std::move(p), symbol_table, ast, db); } |
-           [&](auto p) { return RewriteWithPruningBFS(std::move(p), symbol_table, parameters_, &reads_parameters_); }
+           [&](auto p) { return RewriteWithPruningBFS(std::move(p), symbol_table); }
 #ifdef MG_ENTERPRISE
            |
            // Keep at the end
@@ -137,7 +136,6 @@ struct MakeLogicalPlanResult {
   double cost;
   /// Whether a rewrite settled the plan's shape by reading a parameter, leaving
   /// it correct only for the parameters it was planned with.
-  bool reads_parameters;
 };
 
 /// Generates the LogicalOperator tree and returns the resulting plan.
@@ -222,7 +220,6 @@ auto MakeLogicalPlan(TPlanningContext *context, TPlanPostProcess *post_process, 
   return MakeLogicalPlanResult{
       .plan = std::move(*curr_plan),
       .cost = total_cost,
-      .reads_parameters = post_process->reads_parameters_,
   };
 }
 

--- a/src/query/plan/planner.hpp
+++ b/src/query/plan/planner.hpp
@@ -61,8 +61,6 @@ class PostProcessor final {
 
  public:
   IndexHints index_hints_{};
-  /// Set by a rewrite that read a parameter to settle the plan's shape. Only
-  /// ever set, so it spans every candidate plan considered for the query.
 
   using ProcessedPlan = std::unique_ptr<LogicalOperator>;
 
@@ -134,8 +132,6 @@ auto MakeLogicalPlanForSingleQuery(QueryParts query_parts, PlanningContext<TDbAc
 struct MakeLogicalPlanResult {
   PostProcessor::ProcessedPlan plan;
   double cost;
-  /// Whether a rewrite settled the plan's shape by reading a parameter, leaving
-  /// it correct only for the parameters it was planned with.
 };
 
 /// Generates the LogicalOperator tree and returns the resulting plan.

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -16,6 +16,7 @@
 
 #include "query/db_accessor.hpp"
 #include "query/frontend/ast/pretty_print.hpp"
+#include "query/parameters.hpp"
 #include "query/plan/operator.hpp"
 #include "utils/string.hpp"
 

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -364,7 +364,8 @@ struct PlanToJsonVisitor final : virtual HierarchicalLogicalOperatorVisitor {
 
 }  // namespace impl
 
-PlanPrinter::PlanPrinter(const DbAccessor *dba, std::ostream *out) : dba_(dba), out_(out) {}
+PlanPrinter::PlanPrinter(const DbAccessor *dba, std::ostream *out, Parameters const *parameters)
+    : dba_(dba), out_(out), parameters_(parameters) {}
 
 // NOLINTBEGIN(bugprone-macro-parentheses,cppcoreguidelines-macro-usage)
 #define PRE_VISIT(TOp)                                                       \
@@ -463,8 +464,14 @@ bool PlanPrinter::PreVisit(ParallelMerge & /*unused*/) {
 }
 
 PRE_VISIT_TS(Expand);
-PRE_VISIT_TS(ExpandVariable);
 PRE_VISIT_TS(Produce);
+
+bool PlanPrinter::PreVisit(ExpandVariable &op) {
+  WithPrintLn([this, &op](auto &out) {
+    out << StartSymbol() << " " << (parameters_ ? op.ToStringWithParameters(dba_, *parameters_) : op.ToString(dba_));
+  });
+  return true;
+}
 
 PRE_VISIT(ConstructNamedPath);
 PRE_VISIT(SetProperty);
@@ -610,14 +617,16 @@ void PlanPrinter::Branch(query::plan::LogicalOperator &op, const std::string &br
   --depth_;
 }
 
-void PrettyPrint(const DbAccessor &dba, const LogicalOperator *plan_root, std::ostream *out) {
-  PrettyPrint(&dba, plan_root, out);
+void PrettyPrint(const DbAccessor &dba, const LogicalOperator *plan_root, std::ostream *out,
+                 Parameters const *parameters) {
+  PrettyPrint(&dba, plan_root, out, parameters);
 }
 
-void PrettyPrint(const DbAccessor *dba, const LogicalOperator *plan_root, std::ostream *out) {
+void PrettyPrint(const DbAccessor *dba, const LogicalOperator *plan_root, std::ostream *out,
+                 Parameters const *parameters) {
   // dba may be null: ToString resolves it only to name a label, property or edge type, and a plan that
   // runs without an accessor contains no operator that names one.
-  PlanPrinter printer(dba, out);
+  PlanPrinter printer(dba, out, parameters);
   // FIXME(mtomic): We should make visitors that take const arguments.
   const_cast<LogicalOperator *>(plan_root)->Accept(printer);
 }

--- a/src/query/plan/pretty_print.hpp
+++ b/src/query/plan/pretty_print.hpp
@@ -16,11 +16,11 @@
 
 #include <nlohmann/json_fwd.hpp>
 
-#include "query/parameters.hpp"
 #include "query/plan/operator.hpp"
 
 namespace memgraph::query {
 class DbAccessor;
+struct Parameters;
 
 namespace plan {
 class LogicalOperator;

--- a/src/query/plan/pretty_print.hpp
+++ b/src/query/plan/pretty_print.hpp
@@ -16,6 +16,7 @@
 
 #include <nlohmann/json_fwd.hpp>
 
+#include "query/parameters.hpp"
 #include "query/plan/operator.hpp"
 
 namespace memgraph::query {
@@ -28,10 +29,14 @@ class LogicalOperator;
 /// DbAccessor is needed for resolving label and property names.
 /// Note that `plan_root` isn't modified, but we can't take it as a const
 /// because we don't have support for visiting a const LogicalOperator.
-void PrettyPrint(const DbAccessor &dba, const LogicalOperator *plan_root, std::ostream *out);
+/// `parameters`, where an execution supplies them, let an operator whose shape
+/// is settled during execution name what it will do rather than what it may.
+void PrettyPrint(const DbAccessor &dba, const LogicalOperator *plan_root, std::ostream *out,
+                 Parameters const *parameters = nullptr);
 
 // Pointer overload tolerating a null accessor, for a plan that runs without one.
-void PrettyPrint(const DbAccessor *dba, const LogicalOperator *plan_root, std::ostream *out);
+void PrettyPrint(const DbAccessor *dba, const LogicalOperator *plan_root, std::ostream *out,
+                 Parameters const *parameters = nullptr);
 
 /// Convert a `LogicalOperator` plan to a JSON representation.
 /// DbAccessor is needed for resolving label and property names.
@@ -42,7 +47,7 @@ struct PlanPrinter final : virtual HierarchicalLogicalOperatorVisitor {
   using HierarchicalLogicalOperatorVisitor::PreVisit;
   using HierarchicalLogicalOperatorVisitor::Visit;
 
-  PlanPrinter(const DbAccessor *dba, std::ostream *out);
+  PlanPrinter(const DbAccessor *dba, std::ostream *out, Parameters const *parameters = nullptr);
 
   bool DefaultPreVisit() override;
 
@@ -152,6 +157,7 @@ struct PlanPrinter final : virtual HierarchicalLogicalOperatorVisitor {
   int64_t depth_{0};
   const DbAccessor *dba_{nullptr};
   std::ostream *out_{nullptr};
+  Parameters const *parameters_{nullptr};
   bool is_parallel_{false};
 };
 

--- a/src/query/plan/rewrite/pruning_bfs.cpp
+++ b/src/query/plan/rewrite/pruning_bfs.cpp
@@ -25,11 +25,14 @@ namespace memgraph::query::plan {
 
 namespace {
 
-bool ReadsAnySymbol(Expression *bound, SymbolTable const &symbol_table) {
-  if (!bound) return false;
-  UsedSymbolsCollector collector(symbol_table);
-  bound->Accept(collector);
-  return !collector.symbols_.empty();
+/// True when the cursor can settle the bound's value and OperatorName can name
+/// the walk it calls for: null (absent), a literal, or a parameter lookup.
+/// Anything else (a function call, an arithmetic expression) is out of
+/// ConstExternalPropertyValue's reach, which would leave OperatorName unable to
+/// agree with the cursor on which walk runs.
+bool BoundIsResolvable(Expression *bound) {
+  if (!bound) return true;
+  return utils::Downcast<PrimitiveLiteral>(bound) || utils::Downcast<ParameterLookup>(bound);
 }
 
 class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
@@ -217,12 +220,10 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
     if (!deduplicates_ || rewrite_blocked_) return true;
     if (used_symbols_.contains(op.common_.edge_symbol.position())) return true;
 
-    // The bound's value is out of reach: stripping leaves a written-out bound a
-    // parameter, and a plan that read one would hold only for the execution that
-    // supplied it, which is not what the cache is keyed on. Whether the bound
-    // reads a symbol is a property of the plan alone, and it is all the cursor
-    // needs to read the value itself.
-    if (ReadsAnySymbol(op.lower_bound_, symbol_table_)) return true;
+    // The cursor settles the bound, but OperatorName must be able to agree on
+    // which walk it calls for. Only literals and parameter lookups are in
+    // ConstExternalPropertyValue's reach; anything else is left as depth-first.
+    if (!BoundIsResolvable(op.lower_bound_)) return true;
 
     op.type_ = EdgeAtom::Type::PRUNING_BFS;
     return true;

--- a/src/query/plan/rewrite/pruning_bfs.cpp
+++ b/src/query/plan/rewrite/pruning_bfs.cpp
@@ -20,7 +20,6 @@
 
 #include "query/frontend/ast/ast.hpp"
 #include "query/frontend/semantic/symbol_table.hpp"
-#include "query/parameters.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan/preprocess.hpp"
 
@@ -28,34 +27,16 @@ namespace memgraph::query::plan {
 
 namespace {
 
-/// True when the bound is fixed by the plan alone, rather than by the parameters
-/// a particular execution supplies. Query stripping turns a written-out bound
-/// into a parameter, so most bounds are not.
-bool IsStaticallyKnown(Expression *lower_bound) {
-  return lower_bound == nullptr || utils::Downcast<PrimitiveLiteral>(lower_bound) != nullptr;
-}
-
-/// The bound's value, or nullopt when it cannot be settled before execution
-/// because it reads something only a frame supplies. An absent bound means one.
-std::optional<int64_t> ResolveLowerBound(Expression *lower_bound, Parameters const &parameters) {
-  if (!lower_bound) return 1;
-
-  auto const value = std::invoke([&]() -> std::optional<storage::ExternalPropertyValue> {
-    if (auto const *literal = utils::Downcast<PrimitiveLiteral>(lower_bound)) return literal->value_;
-    if (auto const *param = utils::Downcast<ParameterLookup>(lower_bound)) {
-      return parameters.AtTokenPosition(param->token_position_);
-    }
-    return std::nullopt;
-  });
-
-  if (!value || !value->IsInt()) return std::nullopt;
-  return value->ValueInt();
+bool ReadsAnySymbol(Expression *bound, SymbolTable const &symbol_table) {
+  if (!bound) return false;
+  UsedSymbolsCollector collector(symbol_table);
+  bound->Accept(collector);
+  return !collector.symbols_.empty();
 }
 
 class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
  public:
-  PruningBFSRewriter(SymbolTable const &symbol_table, Parameters const &parameters, bool *reads_parameters)
-      : symbol_table_(symbol_table), parameters_(parameters), reads_parameters_(reads_parameters) {}
+  explicit PruningBFSRewriter(SymbolTable const &symbol_table) : symbol_table_(symbol_table) {}
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;
@@ -238,13 +219,12 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
     if (!deduplicates_ || rewrite_blocked_) return true;
     if (used_symbols_.contains(op.common_.edge_symbol.position())) return true;
 
-    // Everything else already permits pruning, so the bound is what settles this
-    // expansion, and reading it from the parameters ties the plan to them. That
-    // holds whether or not the bound then permits pruning, because caching the
-    // depth-first plan would serve it to the bounds that do permit it.
-    if (!IsStaticallyKnown(op.lower_bound_)) *reads_parameters_ = true;
-    auto const lower_bound = ResolveLowerBound(op.lower_bound_, parameters_);
-    if (!lower_bound || *lower_bound > 1) return true;
+    // The bound's value is out of reach: stripping leaves a written-out bound a
+    // parameter, and a plan that read one would hold only for the execution that
+    // supplied it, which is not what the cache is keyed on. Whether the bound
+    // reads a symbol is a property of the plan alone, and it is all the cursor
+    // needs to read the value itself.
+    if (ReadsAnySymbol(op.lower_bound_, symbol_table_)) return true;
 
     op.type_ = EdgeAtom::Type::PRUNING_BFS;
     return true;
@@ -305,8 +285,6 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
 
  private:
   SymbolTable const &symbol_table_;
-  Parameters const &parameters_;
-  bool *reads_parameters_;
   std::unordered_set<int64_t> used_symbols_;
   bool deduplicates_{false};
   bool rewrite_blocked_{false};
@@ -316,9 +294,8 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
 }  // namespace
 
 std::unique_ptr<LogicalOperator> RewriteWithPruningBFS(std::unique_ptr<LogicalOperator> root_op,
-                                                       SymbolTable const *symbol_table, Parameters const &parameters,
-                                                       bool *reads_parameters) {
-  auto rewriter = PruningBFSRewriter(*symbol_table, parameters, reads_parameters);
+                                                       SymbolTable const *symbol_table) {
+  auto rewriter = PruningBFSRewriter(*symbol_table);
   root_op->Accept(rewriter);
   return root_op;
 }

--- a/src/query/plan/rewrite/pruning_bfs.cpp
+++ b/src/query/plan/rewrite/pruning_bfs.cpp
@@ -13,8 +13,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <functional>
-#include <optional>
 #include <unordered_set>
 #include <vector>
 

--- a/src/query/plan/rewrite/pruning_bfs.hpp
+++ b/src/query/plan/rewrite/pruning_bfs.hpp
@@ -15,20 +15,20 @@
 
 namespace memgraph::query {
 class SymbolTable;
-class Parameters;
 }  // namespace memgraph::query
 
 namespace memgraph::query::plan {
 
 class LogicalOperator;
 
-/// `reads_parameters` is set when an expansion's shape was settled by reading a
-/// parameter, which leaves the plan correct only for the parameters it was
-/// planned with. The plan cache is keyed on the stripped query, where those
-/// values do not appear, so such a plan must not be stored there. It is only
-/// ever set, so one flag can span the candidate plans of a single query.
+/// Marks the variable-length expansions a pruning BFS may replace. Which of the
+/// two runs is settled by the cursor, the only one that can read the bound, so a
+/// mark is not a promise that pruning happens and nothing may read it as one.
+///
+/// The deduplication a mark depends on has to stay in the plan whatever the
+/// cursor settles on, and earns its place besides: it spans input rows, where
+/// pruning reaches only within one.
 std::unique_ptr<LogicalOperator> RewriteWithPruningBFS(std::unique_ptr<LogicalOperator> root_op,
-                                                       SymbolTable const *symbol_table, Parameters const &parameters,
-                                                       bool *reads_parameters);
+                                                       SymbolTable const *symbol_table);
 
 }  // namespace memgraph::query::plan

--- a/tests/e2e/query_planning/query_planning_pruning_bfs.py
+++ b/tests/e2e/query_planning/query_planning_pruning_bfs.py
@@ -108,6 +108,56 @@ def test_pruning_bfs_undirected(memgraph):
     assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"
 
 
+# === A lower bound above one is walked depth-first ===
+
+
+def test_lower_bound_above_every_path_finds_nothing(memgraph):
+    """No path out of 'a' runs to three edges, so the bound excludes them all."""
+    results = list(memgraph.execute_and_fetch("MATCH (a:N {id: 'a'})-[*3..3]->(x) RETURN DISTINCT x.id AS id"))
+    assert results == [], f"Expected no rows, got {[r['id'] for r in results]}"
+
+
+# === A bound the plan cannot read is left to the walk ===
+
+
+def test_malformed_bound_stays_quiet_where_nothing_expands(memgraph):
+    for bound in ["'x'", "null", "1.5"]:
+        query = f"MATCH (a:Absent)-[*{bound}..2]->(x) RETURN DISTINCT x.id AS id"
+        assert list(memgraph.execute_and_fetch(query)) == [], f"Expected no rows for a bound of {bound}"
+
+
+def test_malformed_bound_is_reported_where_something_expands(memgraph):
+    for bound in ["'x'", "null"]:
+        query = f"MATCH (a:N {{id: 'a'}})-[*{bound}..2]->(x) RETURN DISTINCT x.id AS id"
+        with pytest.raises(Exception):
+            list(memgraph.execute_and_fetch(query))
+
+
+# === Re-expanding: the walk survives being reset ===
+
+
+def test_expansion_reset_once_per_outer_row(memgraph):
+    """An Apply resets its subtree for every row it feeds, so the expansion is
+    reset between sources rather than built afresh for each."""
+    plan = get_plan(
+        memgraph,
+        "MATCH (a:N) CALL { WITH a MATCH (a)-[*1..2]->(x:N) RETURN DISTINCT x } RETURN a.id, x.id",
+    )
+    # The expansion sits on the Apply's branch, which operator_names does not
+    # reach past, so the raw lines are what carry it.
+    assert any("PruningBFSExpand" in line for line in plan), f"Expected a pruning plan, got: {plan}"
+
+    results = list(
+        memgraph.execute_and_fetch(
+            "MATCH (a:N) CALL { WITH a MATCH (a)-[*1..2]->(x:N) RETURN DISTINCT x } "
+            "RETURN a.id + '->' + x.id AS pair"
+        )
+    )
+    found = {r["pair"] for r in results}
+    expected = {"a->b", "a->c", "a->d", "a->e", "b->c", "d->c", "d->e"}
+    assert found == expected, f"Got {sorted(found)}"
+
+
 # === Undirected expansion: the source is reachable only over a real cycle ===
 #
 # Every other vertex is reached by a shortest path, which is simple and so uses
@@ -303,11 +353,49 @@ def diamond_graph(memgraph):
     return memgraph
 
 
+def test_one_cached_plan_serves_every_bound(diamond_graph):
+    """One plan serves every bound, so the same query text run again with a
+    different bound must get the walk that bound calls for. The bounds are
+    revisited out of order, where a walk held over would show up."""
+    query = "MATCH (a:N {id: 'a'})-[*$lo..3]->(b) RETURN DISTINCT b.id AS id"
+    expected = {1: {"x", "y"}, 2: {"x"}, 3: set()}
+
+    for lo in [1, 2, 3, 3, 2, 1, 2, 1, 3]:
+        found = {r["id"] for r in diamond_graph.execute_and_fetch(query, parameters={"lo": lo})}
+        assert found == expected[lo], f"For a lower bound of {lo}, expected {expected[lo]}, got {found}"
+
+
 def test_correctness_lower_bound_above_one(diamond_graph):
     """A vertex first reached below the lower bound must still be emitted at a
     qualifying depth. Pruning BFS marks it visited on discovery, so it cannot."""
     results = list(diamond_graph.execute_and_fetch("MATCH (a:N {id: 'a'})-[*2..2]->(b) RETURN DISTINCT b.id AS id"))
     assert {r["id"] for r in results} == {"x"}, f"Expected {{'x'}} via a->y->x, got {[r['id'] for r in results]}"
+
+
+def test_the_plan_names_the_walk_that_runs(memgraph):
+    """The bound decides the walk twice over: once to name it in a plan, once to
+    run it. Were the two to disagree, a plan would report a walk other than the
+    one taken, so hold them together across the bounds either may see."""
+    for bounds in ["*", "*1", "*..2", "*0..2", "*1..2", "*1..5", "*2..2", "*2..3", "*3..5"]:
+        query = f"MATCH (a:N {{id: 'a'}})-[{bounds}]->(b:N) RETURN DISTINCT b.id AS id"
+
+        planned = [op for op in operator_names(get_plan(memgraph, query)) if "Expand" in op]
+        profiled = [
+            row["OPERATOR"].strip().removeprefix("* ").split(" ")[0]
+            for row in memgraph.execute_and_fetch(f"PROFILE {query}")
+            if "Expand" in row["OPERATOR"]
+        ]
+        assert planned == profiled, f"For {bounds}, the plan says {planned} and the profile says {profiled}"
+
+
+def test_pruning_bfs_with_lower_bound_of_zero(memgraph):
+    """A walk of no edges reaches only its own source, which a pruning BFS emits
+    as readily, so a bound below one permits pruning just as a bound of one does."""
+    plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*0..2]->(b) RETURN DISTINCT b")
+    assert "PruningBFSExpand" in operator_names(plan), f"Expected a pruning plan, got: {plan}"
+
+    results = list(memgraph.execute_and_fetch("MATCH (a:N {id: 'a'})-[*0..2]->(x) RETURN DISTINCT x.id AS id"))
+    assert {r["id"] for r in results} == {"a", "b", "c", "d", "e"}, f"Got {sorted(r['id'] for r in results)}"
 
 
 def test_no_rewrite_with_lower_bound_above_one(memgraph):
@@ -318,8 +406,8 @@ def test_no_rewrite_with_lower_bound_above_one(memgraph):
 
 
 def test_pruning_bfs_with_written_lower_bound_of_one(memgraph):
-    """Stripping turns a written-out bound into a parameter, which the rewrite
-    resolves at plan time."""
+    """Stripping turns a written-out bound into a parameter, which the cursor
+    resolves rather than the plan."""
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*1..3]->(b) RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"

--- a/tests/unit/query_plan_pruning_bfs.cpp
+++ b/tests/unit/query_plan_pruning_bfs.cpp
@@ -16,7 +16,6 @@
 
 #include "query/frontend/ast/ast.hpp"
 #include "query/frontend/semantic/symbol_table.hpp"
-#include "query/parameters.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan/rewrite/pruning_bfs.hpp"
 
@@ -149,9 +148,22 @@ TEST_F(PruningBFSRewriteTest, MarksAnExpansionWhoseBoundOnlyTheParametersSettle)
 }
 
 TEST_F(PruningBFSRewriteTest, LeavesAnExpansionWhoseBoundTheRowSupplies) {
-  // Read from the row being expanded, the bound can differ from row to row, so
-  // no single choice of walk is right for the whole expansion.
+  // A property lookup is neither a literal nor a parameter, so the bound is not
+  // resolvable and the expansion stays depth-first.
   lower_bound = BoundFromTheRow();
+  auto const type = RewrittenType([](auto input) { return input; });
+  EXPECT_EQ(type, EdgeAtom::Type::DEPTH_FIRST);
+}
+
+TEST_F(PruningBFSRewriteTest, LeavesAnExpansionWhoseBoundIsANonTrivialExpression) {
+  // An addition of two literals reads no symbol but is neither a literal nor a
+  // parameter, so ConstExternalPropertyValue cannot resolve it.
+  auto *lhs = storage.Create<PrimitiveLiteral>(storage::ExternalPropertyValue{static_cast<int64_t>(0)}, 0);
+  auto *rhs = storage.Create<PrimitiveLiteral>(storage::ExternalPropertyValue{static_cast<int64_t>(1)}, 0);
+  auto *add = storage.Create<AdditionOperator>();
+  add->expression1_ = lhs;
+  add->expression2_ = rhs;
+  lower_bound = add;
   auto const type = RewrittenType([](auto input) { return input; });
   EXPECT_EQ(type, EdgeAtom::Type::DEPTH_FIRST);
 }

--- a/tests/unit/query_plan_pruning_bfs.cpp
+++ b/tests/unit/query_plan_pruning_bfs.cpp
@@ -158,8 +158,8 @@ TEST_F(PruningBFSRewriteTest, LeavesAnExpansionWhoseBoundTheRowSupplies) {
 TEST_F(PruningBFSRewriteTest, LeavesAnExpansionWhoseBoundIsANonTrivialExpression) {
   // An addition of two literals reads no symbol but is neither a literal nor a
   // parameter, so ConstExternalPropertyValue cannot resolve it.
-  auto *lhs = storage.Create<PrimitiveLiteral>(storage::ExternalPropertyValue{static_cast<int64_t>(0)}, 0);
-  auto *rhs = storage.Create<PrimitiveLiteral>(storage::ExternalPropertyValue{static_cast<int64_t>(1)}, 0);
+  auto *lhs = storage.Create<PrimitiveLiteral>(memgraph::storage::ExternalPropertyValue{static_cast<int64_t>(0)}, 0);
+  auto *rhs = storage.Create<PrimitiveLiteral>(memgraph::storage::ExternalPropertyValue{static_cast<int64_t>(1)}, 0);
   auto *add = storage.Create<AdditionOperator>();
   add->expression1_ = lhs;
   add->expression2_ = rhs;

--- a/tests/unit/query_plan_pruning_bfs.cpp
+++ b/tests/unit/query_plan_pruning_bfs.cpp
@@ -31,8 +31,6 @@ class PruningBFSRewriteTest : public ::testing::Test {
  protected:
   AstStorage storage;
   SymbolTable symbol_table;
-  Parameters parameters;
-  bool reads_parameters = false;
 
   Symbol source_sym = symbol_table.CreateSymbol("source", true);
   Symbol target_sym = symbol_table.CreateSymbol("target", true);
@@ -75,16 +73,19 @@ class PruningBFSRewriteTest : public ::testing::Test {
   }
 
   /// A bound that only the parameters of a particular execution settle, as query
-  /// stripping produces for a written-out bound.
-  Expression *SuppliedBound(int64_t value) {
-    constexpr int kTokenPosition = 0;
-    parameters.Add(kTokenPosition, memgraph::storage::ExternalPropertyValue{value});
-    return storage.Create<ParameterLookup>(kTokenPosition);
+  /// stripping produces for a written-out bound. Its value is out of the plan's
+  /// reach, but it reads no symbol, so the cursor can settle it.
+  Expression *SuppliedBound() { return storage.Create<ParameterLookup>(0); }
+
+  /// A bound read from the row being expanded, which no plan can settle.
+  Expression *BoundFromTheRow() {
+    auto *identifier = storage.Create<Identifier>("source")->MapTo(source_sym);
+    return storage.Create<PropertyLookup>(identifier, storage.GetPropertyIx("depth"));
   }
 
   EdgeAtom::Type RewrittenType(
       std::function<std::shared_ptr<LogicalOperator>(std::shared_ptr<LogicalOperator>)> const &above) {
-    auto plan = RewriteWithPruningBFS(MakePlan(above), &symbol_table, parameters, &reads_parameters);
+    auto plan = RewriteWithPruningBFS(MakePlan(above), &symbol_table);
     return expand->type_;
   }
 };
@@ -137,36 +138,27 @@ TEST_F(PruningBFSRewriteTest, RewritesBelowAReadProcedure) {
   EXPECT_EQ(type, EdgeAtom::Type::PRUNING_BFS);
 }
 
-TEST_F(PruningBFSRewriteTest, ASuppliedBoundThatPermitsPruningTiesThePlanToIt) {
-  lower_bound = SuppliedBound(1);
+// === The bound belongs to the cursor, not the plan ===
+
+TEST_F(PruningBFSRewriteTest, MarksAnExpansionWhoseBoundOnlyTheParametersSettle) {
+  // The value is out of reach here, and does not need to be: the cursor reads it
+  // before it pulls a row, so leaving the plan free of it costs nothing.
+  lower_bound = SuppliedBound();
   auto const type = RewrittenType([](auto input) { return input; });
   EXPECT_EQ(type, EdgeAtom::Type::PRUNING_BFS);
-  EXPECT_TRUE(reads_parameters);
 }
 
-TEST_F(PruningBFSRewriteTest, ASuppliedBoundThatDeniesPruningAlsoTiesThePlanToIt) {
-  // The plan is depth-first either way, but caching it would serve it to the
-  // bounds that do permit pruning.
-  lower_bound = SuppliedBound(2);
+TEST_F(PruningBFSRewriteTest, LeavesAnExpansionWhoseBoundTheRowSupplies) {
+  // Read from the row being expanded, the bound can differ from row to row, so
+  // no single choice of walk is right for the whole expansion.
+  lower_bound = BoundFromTheRow();
   auto const type = RewrittenType([](auto input) { return input; });
   EXPECT_EQ(type, EdgeAtom::Type::DEPTH_FIRST);
-  EXPECT_TRUE(reads_parameters);
 }
 
-TEST_F(PruningBFSRewriteTest, ABoundIsNotReadWhenNothingElseAllowsPruning) {
-  // Nothing deduplicates, so the bound never decides anything and the plan is
-  // the one every execution of this query would get.
-  deduplicates = false;
-  lower_bound = SuppliedBound(1);
-  auto const type = RewrittenType([](auto input) { return input; });
-  EXPECT_EQ(type, EdgeAtom::Type::DEPTH_FIRST);
-  EXPECT_FALSE(reads_parameters);
-}
-
-TEST_F(PruningBFSRewriteTest, AnAbsentBoundLeavesThePlanFitForTheCache) {
+TEST_F(PruningBFSRewriteTest, MarksAnExpansionWithNoBoundAtAll) {
   auto const type = RewrittenType([](auto input) { return input; });
   EXPECT_EQ(type, EdgeAtom::Type::PRUNING_BFS);
-  EXPECT_FALSE(reads_parameters);
 }
 
 }  // namespace


### PR DESCRIPTION
A variable-length expansion whose vertices are deduplicated downstream can be walked as a pruning BFS, but only where the lower bound is no higher than one: above that the BFS marks a vertex visited at the depth it first arrives at and never emits it, where a depth-first walk would still arrive at it along a longer edge-unique path. Telling the two apart meant reading the bound while planning, and the value is not the plan's to know, because stripping replaces written-out values with parameters so that queries differing only in those values share one plan. A plan built around the value held only for the execution that supplied it and was kept out of the cache, so every such query replanned on each execution, which cost more than pruning saved.

The plan now records only that an expansion is prunable, which it decides from whether the bound reads a symbol rather than from its value, and the cursor reads the bound and expands accordingly. A bound that reads no symbol has the same value for every row, so the choice is made before the first row is pulled and holds across a reset. A bound read from the row, or one that is not an integer, is left to the depth-first walk, which reads its bounds only once it holds a row and so goes on rejecting a bad one where it did before. Plans no longer carry parameter values and are cached again, and a plan reads as it did, because naming the expansion reads the bound where the parameters that settle it are at hand.
