### PR TITLE
Add connectivity check for custom mirrors in CI

### DIFF
--- a/.github/workflows/benchmark_on_pokec_large.yaml
+++ b/.github/workflows/benchmark_on_pokec_large.yaml
@@ -42,11 +42,7 @@ jobs:
 
         - name: Spin up mgbuild container
           run: |
-            if [[ "$OS" == "ubuntu-24.04" ]]; then
-              USE_CUSTOM_MIRROR=true
-            else
-              USE_CUSTOM_MIRROR=false
-            fi
+            USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
             ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
             --os $OS \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -65,11 +65,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -74,11 +74,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -79,11 +79,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -257,11 +253,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -350,11 +342,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -84,11 +84,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -252,11 +248,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -74,11 +74,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -74,7 +74,7 @@ jobs:
   core:
     if: ${{ inputs.run_core == 'true' }}
     name: "Core tests"
-    runs-on: [self-hosted, Linux, X64, DockerMgBuild, wasp]
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
     timeout-minutes: 60
     steps:
       - name: Set up repository

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -97,11 +97,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -277,11 +273,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -641,11 +633,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -808,11 +796,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -994,11 +978,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -74,7 +74,7 @@ jobs:
   core:
     if: ${{ inputs.run_core == 'true' }}
     name: "Core tests"
-    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild, wasp]
     timeout-minutes: 60
     steps:
       - name: Set up repository

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -192,11 +192,7 @@ jobs:
 
       - name: "Spin up mgbuild container"
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os "$OS" \
@@ -392,7 +388,7 @@ jobs:
         if: ${{ inputs.build_docker_image == 'prod' || inputs.build_docker_image == 'both' }}
         run: |
           [[ "$MALLOC" == "true" ]] && malloc=true ||malloc=false
-          [[ "$OS" == "ubuntu-24.04" ]] && USE_CUSTOM_MIRROR=true || USE_CUSTOM_MIRROR=false
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
 
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
@@ -440,7 +436,7 @@ jobs:
         if: ${{ inputs.build_docker_image == 'debug' || inputs.build_docker_image == 'both' }}
         run: |
           [[ "$MALLOC" == "true" ]] && malloc=true ||malloc=false
-          [[ "$OS" == "ubuntu-24.04" ]] && USE_CUSTOM_MIRROR=true || USE_CUSTOM_MIRROR=false
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
 
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -332,11 +332,7 @@ jobs:
 
       - name: "Spin up mgbuild container"
         run: |
-          if [[ "$OS" =~ ^ubuntu-24.04.* ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os "$OS" \
@@ -698,6 +694,9 @@ jobs:
       - name: "Build image (prod)"
         if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') }}
         run: |
+          # The image is built FROM ubuntu:24.04 whatever the build container's
+          # distro is, so the mirror check is against that, not against $OS.
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os ubuntu-24.04 --arch "$ARCH")"
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
             --os "$OS" \
@@ -709,13 +708,16 @@ jobs:
             --image-tag $PROD_IMAGE_TAG \
             --memgraph-ref $MEMGRAPH_REF \
             --cache-present $CACHE_PRESENT \
-            --custom-mirror true \
+            --custom-mirror $USE_CUSTOM_MIRROR \
             --cuda $CUDA \
             --package-flavour prod
 
       - name: "Build image (debug)"
         if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both')  }}
         run: |
+          # The image is built FROM ubuntu:24.04 whatever the build container's
+          # distro is, so the mirror check is against that, not against $OS.
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os ubuntu-24.04 --arch "$ARCH")"
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
             --os "$OS" \
@@ -727,7 +729,7 @@ jobs:
             --image-tag $DEBUG_IMAGE_TAG \
             --memgraph-ref $MEMGRAPH_REF \
             --cache-present $CACHE_PRESENT \
-            --custom-mirror true \
+            --custom-mirror $USE_CUSTOM_MIRROR \
             --cuda $CUDA \
             --package-flavour debug
 

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -80,11 +80,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -189,11 +185,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -317,11 +309,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -474,11 +462,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -586,11 +570,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -729,11 +709,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -880,11 +856,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -1016,11 +988,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -1156,11 +1124,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -1505,11 +1469,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -1633,11 +1593,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/reusable_stress_tests.yaml
+++ b/.github/workflows/reusable_stress_tests.yaml
@@ -78,11 +78,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -209,11 +205,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          if [[ "$OS" == "ubuntu-24.04" ]]; then
-            USE_CUSTOM_MIRROR=true
-          else
-            USE_CUSTOM_MIRROR=false
-          fi
+          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/tools/ci/ubuntu-mirrors/use_custom_mirror.sh
+++ b/tools/ci/ubuntu-mirrors/use_custom_mirror.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decide whether a build should use the custom APT mirror kept in this
+# directory, and print "true" or "false".
+#
+# The ci.sources files here point at the Hetzner mirror, which only answers
+# from inside the Hetzner network. On runners hosted anywhere else every
+# apt-get in the build container stalls until it times out, so those machines
+# have to fall back to the distro's default sources.
+#
+# "true" is printed only when the build targets the release those files pin
+# (noble, i.e. ubuntu-24.04) and every mirror URI in them answers a HEAD for
+# its Release file within a couple of seconds.
+#
+# An unreachable mirror is an answer, not an error: the script still exits 0
+# and prints "false", so callers can use it inline. Only a usage error (bad
+# flag, missing sources file) exits non-zero.
+#
+#   USE_CUSTOM_MIRROR="$(tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
+#
+# Set MG_USE_CUSTOM_MIRROR=true|false to skip the probe and force the answer.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The only distro the ci.sources files describe; keep in step with their Suites.
+SUPPORTED_OS="ubuntu-24.04"
+CONNECT_TIMEOUT=1
+MAX_TIME=2
+# One retry: the timeouts are tight enough that a single hiccup shouldn't cost
+# an in-network runner its mirror.
+ATTEMPTS=2
+
+print_help() {
+  cat <<'EOF'
+Usage: use_custom_mirror.sh --os OS --arch ARCH
+
+Prints "true" if the custom APT mirror in tools/ci/ubuntu-mirrors is usable for
+this build, "false" otherwise.
+
+  --os OS     Target distro, as CI names it (e.g. ubuntu-24.04,
+              ubuntu-24.04-arm, centos-10). Anything but ubuntu-24.04 answers
+              "false".
+  --arch ARCH amd|arm -- picks which ci.sources file to probe.
+EOF
+}
+
+os=""
+arch=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --os) os="${2:-}"; shift 2 ;;
+    --arch) arch="${2:-}"; shift 2 ;;
+    -h|--help) print_help; exit 0 ;;
+    *)
+      echo "Error: unknown argument '$1'" >&2
+      print_help >&2
+      exit 2
+    ;;
+  esac
+done
+
+if [[ -z "$os" || -z "$arch" ]]; then
+  echo "Error: --os and --arch are required" >&2
+  print_help >&2
+  exit 2
+fi
+
+answer() {
+  echo "$1"
+  exit 0
+}
+
+if [[ -n "${MG_USE_CUSTOM_MIRROR:-}" ]]; then
+  echo "use_custom_mirror: MG_USE_CUSTOM_MIRROR=$MG_USE_CUSTOM_MIRROR, skipping probe" >&2
+  if [[ "$MG_USE_CUSTOM_MIRROR" == "true" ]]; then
+    answer true
+  fi
+  answer false
+fi
+
+# CI appends -arm to the distro name for arm build containers.
+if [[ "${os%-arm}" != "$SUPPORTED_OS" ]]; then
+  echo "use_custom_mirror: os '$os' is not $SUPPORTED_OS" >&2
+  answer false
+fi
+
+sources="$SCRIPT_DIR/$arch/ci.sources"
+if [[ ! -f "$sources" ]]; then
+  echo "Error: no sources file at $sources" >&2
+  exit 2
+fi
+
+# Each stanza carries a single URI followed by its suites. Probe the Release
+# file of the stanza's first suite -- that is the first thing apt fetches from
+# that URI, so a mirror serving it serves the rest.
+mapfile -t urls < <(awk '
+  /^URIs:/               { uri = $2 }
+  /^Suites:/ && uri != "" { print uri "/dists/" $2 "/Release"; uri = "" }
+' "$sources")
+
+if [[ ${#urls[@]} -eq 0 ]]; then
+  echo "Error: no URIs/Suites pairs in $sources" >&2
+  exit 2
+fi
+
+probe() {
+  local url="$1" attempt
+  for (( attempt = 1; attempt <= ATTEMPTS; attempt++ )); do
+    if curl --head --location --fail --silent \
+            --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+            --output /dev/null "$url"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+for url in "${urls[@]}"; do
+  if ! probe "$url"; then
+    echo "use_custom_mirror: $url unreachable, falling back to the default sources" >&2
+    answer false
+  fi
+done
+
+echo "use_custom_mirror: mirror reachable, using $sources" >&2
+answer true

--- a/tools/ci/ubuntu-mirrors/use_custom_mirror.sh
+++ b/tools/ci/ubuntu-mirrors/use_custom_mirror.sh
@@ -45,13 +45,19 @@ this build, "false" otherwise.
 EOF
 }
 
+need_value() {
+  echo "Error: $1 requires a value" >&2
+  print_help >&2
+  exit 2
+}
+
 os=""
 arch=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --os) os="${2:-}"; shift 2 ;;
-    --arch) arch="${2:-}"; shift 2 ;;
+    --os) [[ $# -ge 2 ]] || need_value "$1"; os="$2"; shift 2 ;;
+    --arch) [[ $# -ge 2 ]] || need_value "$1"; arch="$2"; shift 2 ;;
     -h|--help) print_help; exit 0 ;;
     *)
       echo "Error: unknown argument '$1'" >&2


### PR DESCRIPTION
The custom mirror used in CI only works for machines with Hetzner's infrastructure. If we try to add machines from other providers, the mirror fails to connect when launching the mgbuild container and the jobs that use it will fail. This PR adds a script to check the connectivity before deciding whether to use it or not.

