### PR TITLE
fix(storage): accept a list held by a vector index in a type constraint

### DIFF
--- a/src/storage/v2/constraints/type_constraints.cpp
+++ b/src/storage/v2/constraints/type_constraints.cpp
@@ -275,6 +275,9 @@ TypeConstraintKind PropertyValueToTypeConstraintKind(const PropertyValue &proper
     case PropertyValueType::IntList:
     case PropertyValueType::DoubleList:
     case PropertyValueType::NumericList:
+    // A vector index holds its list out of line and leaves this in the record's place. It is the
+    // same list to the user, so it answers the same constraint kind.
+    case PropertyValueType::VectorIndexId:
       return TypeConstraintKind::LIST;
     case PropertyValueType::Map:
       return TypeConstraintKind::MAP;
@@ -298,8 +301,6 @@ TypeConstraintKind PropertyValueToTypeConstraintKind(const PropertyValue &proper
     case PropertyValueType::Point2d:
     case PropertyValueType::Point3d:
       return TypeConstraintKind::POINT;
-    case PropertyValueType::VectorIndexId:
-      MG_ASSERT(false, "VectorIndexId is not supported for type constraints");
     case PropertyValueType::Null:
       MG_ASSERT(false, "Unexpected conversion from PropertyValueType::Null to TypeConstraint::Type");
   }

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -1595,6 +1595,32 @@ TYPED_TEST(ConstraintsTest, TypeConstraintsListHeldByVectorIndex) {
   }
 }
 
+// The same list encoding reached through the other validation path: the label is already on the
+// vertex, so the value being written is checked directly rather than the record it lands in.
+TYPED_TEST(ConstraintsTest, TypeConstraintsListHeldByVectorIndexAddLabelFirst) {
+  if (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    GTEST_SKIP() << "Type constraints not implemented for on-disk";
+  }
+
+  {
+    auto constraint_acc = this->CreateConstraintAccessor();
+    auto res = constraint_acc->CreateTypeConstraint(this->label1, this->prop1, TypeConstraintKind::LIST);
+    ASSERT_NO_ERROR(res);
+    ASSERT_NO_ERROR(constraint_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  {
+    auto acc1 = this->storage->Access(memgraph::storage::WRITE);
+    auto vertex1 = acc1->CreateVertex();
+    auto const held_by_index = PropertyValue(PropertyValue::VectorIndexIdData{
+        .ids = memgraph::utils::small_vector<uint64_t>{acc1->GetNameIdMapper()->NameToId("a_vector_index")},
+        .vector = memgraph::utils::small_vector<float>{1.0F, 2.0F}});
+
+    ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
+    ASSERT_NO_ERROR(vertex1.SetProperty(this->prop1, held_by_index));
+  }
+}
+
 TYPED_TEST(ConstraintsTest, TypeConstraintsSubtypeCheckForTemporalDataAddLabelLast) {
   if (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
     GTEST_SKIP() << "Type constraints not implemented for on-disk";


### PR DESCRIPTION
Checking a value against a type constraint now reads a list that a vector index
holds as the list it is. Such a list is stored out of line, leaving a reference
in the record where the value would sit, and the check had no case for that
reference. Writing one to a vertex that already carried the constrained label
reached an assertion that no value should be able to reach, which ends the
process rather than rejecting the write, and does so in release builds as well.

Validating a record that is already stored was already able to read the
encoding, so the gap was confined to the check made on a value as it is
written, which is the one taken when the label is put on before the property.
A list is accepted there now on the same terms as everywhere else, and nothing
about how the value is stored changes.
