### PR TITLE
perf(query): cut the per-row work an aggregation does not need

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -6768,6 +6768,17 @@ void DefaultAggregation(ExecutionContext &context, const std::vector<Aggregate::
 }
 
 inline size_t align_forward(size_t ptr, size_t alignment) { return (ptr + (alignment - 1)) & ~(alignment - 1); }
+
+/// Whether a container leaves each element where it is for as long as that element is in it.
+///
+/// True of the associative containers that hold each element in its own node, which the standard
+/// requires to keep references and pointers good through any rehash. False by default, so a
+/// container that has not said it keeps addresses is treated as one that does not.
+template <typename>
+inline constexpr bool kKeepsElementAddresses = false;
+
+template <typename Key, typename T, typename Hash, typename Pred, typename Alloc>
+inline constexpr bool kKeepsElementAddresses<std::unordered_map<Key, T, Hash, Pred, Alloc>> = true;
 }  // namespace
 
 #ifdef MG_ENTERPRISE
@@ -6785,8 +6796,8 @@ class AggregateCursor : public Cursor {
         aggregation_(mem),
         reused_group_by_(self.group_by_.size(), mem) {
     // Which aggregations are a COUNT over a plain identifier, and so can be answered from the
-    // frame slot the identifier names. Worked out once here rather than per row, which is what
-    // takes the virtual dispatch out of the row loop as well as the value it would have built.
+    // frame slot that identifier names. Settling it once for the cursor keeps both the question
+    // and the dispatch that answering it per row would take out of the row loop.
     count_from_frame_slot_.reserve(self.aggregations_.size());
     for (auto const &aggregation : self.aggregations_) {
       auto const *identifier = (aggregation.op == Aggregation::Op::COUNT && aggregation.arg1 != nullptr)
@@ -6829,8 +6840,7 @@ class AggregateCursor : public Cursor {
 
   void Reset() override {
     input_cursor_->Reset();
-    aggregation_.clear();
-    single_group_ = nullptr;
+    ResetAggregation();
     aggregation_it_ = aggregation_.begin();
     pulled_all_input_ = false;
   }
@@ -6971,22 +6981,44 @@ class AggregateCursor : public Cursor {
     }
   };
 
+  // Accumulated groups: keyed by the vector of group-by values, holding an AggregationValue.
+  using AggregationMap =
+      utils::pmr::unordered_map<utils::pmr::vector<TypedValue>, CompactAggregationValue,
+                                // use FNV collection hashing specialized for a
+                                // vector of TypedValues
+                                utils::FnvCollection<utils::pmr::vector<TypedValue>, TypedValue, TypedValue::Hash>,
+                                // custom equality
+                                TypedValueVectorEqual>;
+
+  // `single_group_` keeps the address of a mapped value for as long as rows keep arriving, so the
+  // container has to be one that leaves its elements where they are as it grows. A map that stores
+  // its elements in nodes does; one that stores them in an open-addressed array moves them on
+  // rehash, which would leave that address naming a slot the map no longer owns.
+  static_assert(kKeepsElementAddresses<AggregationMap>,
+                "AggregateCursor holds a pointer to a mapped value, which this container would move");
+
+  /// Gives `aggregation_` the contents of `replacement`, or no contents when given none.
+  ///
+  /// `single_group_` names an element of that map and is dropped here, because an alias cannot
+  /// outlive what it names. This is the only place the map's contents change, so the two cannot
+  /// come apart.
+  void ResetAggregation(AggregationMap *replacement = nullptr) {
+    if (replacement == nullptr) {
+      aggregation_.clear();
+    } else {
+      aggregation_ = std::move(*replacement);
+    }
+    single_group_ = nullptr;
+  }
+
   const Aggregate &self_;
   const UniqueCursorPtr input_cursor_;
-  // storage for aggregated data
-  // map key is the vector of group-by values
-  // map value is an AggregationValue struct
-  utils::pmr::unordered_map<utils::pmr::vector<TypedValue>, CompactAggregationValue,
-                            // use FNV collection hashing specialized for a
-                            // vector of TypedValues
-                            utils::FnvCollection<utils::pmr::vector<TypedValue>, TypedValue, TypedValue::Hash>,
-                            // custom equality
-                            TypedValueVectorEqual>
-      aggregation_;
+  AggregationMap aggregation_;
   // this is a for object reuse, to avoid re-allocating this buffer
   utils::pmr::vector<TypedValue> reused_group_by_;
-  // The single group of an aggregation with no grouping key, once it exists. Null whenever
-  // `aggregation_` is empty or has been replaced.
+  // The one group of an aggregation with no grouping key, once it exists, and null until then.
+  // It names an element of `aggregation_`, so `ResetAggregation` is what may change that map's
+  // contents: an alias must not outlive the element it names.
   CompactAggregationValue *single_group_{nullptr};
   // Per aggregation: the frame slot a COUNT over a plain identifier reads, or -1 when the
   // aggregation is anything else. Parallel to `self_.aggregations_`.
@@ -7066,10 +7098,10 @@ class AggregateCursor : public Cursor {
     reused_group_by_.clear();
     evaluator->ResetPropertyLookupCache();
 
-    // An aggregation with no grouping key has exactly one group, so every row after the first
-    // hashes an empty key to find the entry it found last time. Holding that entry instead is
-    // what keeps a bare `count(*)` from paying a hash table probe per row. The pointer stays
-    // valid because nothing is inserted or erased once the single group exists.
+    // An aggregation with no grouping key has exactly one group, so holding it spares every row
+    // after the first a hash and a probe that can have only one answer. The held group keeps its
+    // address because the map is one that leaves elements where they are, nothing erases it, and
+    // the map's contents only change through `ResetAggregation`, which lets go of it.
     if (self_.group_by_.empty()) {
       if (single_group_ == nullptr) {
         auto *mem = aggregation_.get_allocator().resource();
@@ -7131,8 +7163,8 @@ class AggregateCursor : public Cursor {
         continue;
       }
 
-      // COUNT only asks whether there is a value, which the frame slot answers on its own when
-      // the argument is a plain identifier. Building the value to ask is what this skips.
+      // COUNT asks only whether there is a value, and for a plain identifier the frame slot
+      // answers that without the value having to be built to be asked.
       if (auto const slot = count_from_frame_slot_[pos]; slot >= 0) {
         DMG_ASSERT(static_cast<size_t>(slot) < frame.elems().size(), "Identifier names no frame slot");
         auto const &slot_value = frame.elems()[slot];
@@ -7451,11 +7483,14 @@ class AggregateCursor : public Cursor {
 
   /** Checks if the given TypedValue is legal in AVG and SUM. If not
    * an appropriate exception is thrown. */
-  /// Adds `addend` into the running total `total`, in place where the two agree on a numeric
-  /// type. Both have been through `EnsureOkForAvgSum`, so both are an integer or a double, and
-  /// `operator+` on that pair is an addition and the type rules around it: integers stay integers
-  /// until a double joins them, and the total is a double from then on. Doing it here keeps the
-  /// per-row addition from building a result to move-assign over the total and throwing it away.
+  /// Adds `addend` into the running total `total`, in place where the two are the same kind of
+  /// number.
+  ///
+  /// `EnsureOkForAvgSum` admits only an integer or a double as an addend, and the total starts as
+  /// an integer and only ever takes one of those, so both are integers or doubles here. Where they
+  /// agree, the sum is the one `operator+` gives and can be written straight into the total,
+  /// sparing a result value per row. Addition owns the rule for the pair that disagrees, where an
+  /// integer total meets a double and stops being an integer, so that pair is handed to it.
   static void AddInto(TypedValue &total, const TypedValue &addend) {
     if (total.IsDouble()) {
       total.ValueDouble() +=
@@ -7466,7 +7501,6 @@ class AggregateCursor : public Cursor {
       total.ValueInt() += addend.UnsafeValueInt();
       return;
     }
-    // An integer total meeting a double: the total changes type, which is the general addition.
     total = total + addend;
   }
 
@@ -11686,9 +11720,7 @@ class AggregateParallelCursor : public ParallelBranchCursor {
         }
         // Reuse already completed section if available
         if (complete_aggregation != nullptr) {
-          static_cast<AggregateCursor *>(cursor)->aggregation_ = std::move(*complete_aggregation);
-          // The single-group shortcut points into the map that was just replaced.
-          static_cast<AggregateCursor *>(cursor)->single_group_ = nullptr;
+          static_cast<AggregateCursor *>(cursor)->ResetAggregation(complete_aggregation);
         }
       };
       auto post_pull_func = [&branch_aggregations_mutex, &aggregations, &branch_aggregations](Cursor *cursor,

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -6783,7 +6783,19 @@ class AggregateCursor : public Cursor {
       : self_(self),
         input_cursor_(self_.input_->MakeCursor(mem, metric_handles)),
         aggregation_(mem),
-        reused_group_by_(self.group_by_.size(), mem) {}
+        reused_group_by_(self.group_by_.size(), mem) {
+    // Which aggregations are a COUNT over a plain identifier, and so can be answered from the
+    // frame slot the identifier names. Worked out once here rather than per row, which is what
+    // takes the virtual dispatch out of the row loop as well as the value it would have built.
+    count_from_frame_slot_.reserve(self.aggregations_.size());
+    for (auto const &aggregation : self.aggregations_) {
+      auto const *identifier = (aggregation.op == Aggregation::Op::COUNT && aggregation.arg1 != nullptr)
+                                   ? utils::Downcast<Identifier>(aggregation.arg1)
+                                   : nullptr;
+      auto const unmapped = identifier == nullptr || identifier->symbol_pos_ < 0;
+      count_from_frame_slot_.push_back(unmapped ? -1 : identifier->symbol_pos_);
+    }
+  }
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
@@ -6976,6 +6988,9 @@ class AggregateCursor : public Cursor {
   // The single group of an aggregation with no grouping key, once it exists. Null whenever
   // `aggregation_` is empty or has been replaced.
   CompactAggregationValue *single_group_{nullptr};
+  // Per aggregation: the frame slot a COUNT over a plain identifier reads, or -1 when the
+  // aggregation is anything else. Parallel to `self_.aggregations_`.
+  std::vector<int32_t> count_from_frame_slot_;
   // iterator over the accumulated cache
   decltype(aggregation_.begin()) aggregation_it_ = aggregation_.begin();
   // this LogicalOp pulls all from the input on it's first pull
@@ -7062,7 +7077,7 @@ class AggregateCursor : public Cursor {
         single_group_ = &res.first->second;
         if (res.second /*was newly inserted*/) EnsureInitialized(frame, single_group_);
       }
-      Update(evaluator, single_group_);
+      Update(frame, evaluator, single_group_);
       return;
     }
 
@@ -7073,7 +7088,7 @@ class AggregateCursor : public Cursor {
     auto res = aggregation_.try_emplace(reused_group_by_, mem, self_.aggregations_.size(), self_.remember_.size());
     auto &agg_value = res.first->second;
     if (res.second /*was newly inserted*/) EnsureInitialized(frame, &agg_value);
-    Update(evaluator, &agg_value);
+    Update(frame, evaluator, &agg_value);
   }
 
   /** Ensures the new AggregationValue has been initialized. This means
@@ -7100,7 +7115,7 @@ class AggregateCursor : public Cursor {
 
   /** Updates the given AggregationValue with new data. Assumes that
    * the AggregationValue has been initialized */
-  void Update(ExpressionEvaluator *evaluator, AggregateCursor::CompactAggregationValue *agg_value) {
+  void Update(const Frame &frame, ExpressionEvaluator *evaluator, AggregateCursor::CompactAggregationValue *agg_value) {
     DMG_ASSERT(self_.aggregations_.size() == agg_value->num_aggs_,
                "Expected as much AggregationValue.values_ as there are "
                "aggregations.");
@@ -7113,6 +7128,18 @@ class AggregateCursor : public Cursor {
       if (!input_expr_ptr) {
         agg_value->counts_[pos] += 1;
         // value is deferred to post-processing
+        continue;
+      }
+
+      // COUNT only asks whether there is a value, which the frame slot answers on its own when
+      // the argument is a plain identifier. Building the value to ask is what this skips.
+      if (auto const slot = count_from_frame_slot_[pos]; slot >= 0) {
+        DMG_ASSERT(static_cast<size_t>(slot) < frame.elems().size(), "Identifier names no frame slot");
+        auto const &slot_value = frame.elems()[slot];
+        if (slot_value.IsNull()) continue;
+        if (agg_elem.distinct && !agg_value->unique_values_[pos].insert(slot_value).second) continue;
+        agg_value->counts_[pos] += 1;
+        // COUNT's result is read from `counts_` in post processing, so there is no value to set.
         continue;
       }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7235,7 +7235,7 @@ class AggregateCursor : public Cursor {
         // the input has been processed
         case Aggregation::Op::SUM:
           EnsureOkForAvgSum(input_value);
-          agg_value->values_[pos] = agg_value->values_[pos] + input_value;
+          AddInto(agg_value->values_[pos], input_value);
           break;
         case Aggregation::Op::COLLECT_LIST:
           agg_value->values_[pos].ValueList().push_back(std::move(input_value));
@@ -7451,6 +7451,25 @@ class AggregateCursor : public Cursor {
 
   /** Checks if the given TypedValue is legal in AVG and SUM. If not
    * an appropriate exception is thrown. */
+  /// Adds `addend` into the running total `total`, in place where the two agree on a numeric
+  /// type. Both have been through `EnsureOkForAvgSum`, so both are an integer or a double, and
+  /// `operator+` on that pair is an addition and the type rules around it: integers stay integers
+  /// until a double joins them, and the total is a double from then on. Doing it here keeps the
+  /// per-row addition from building a result to move-assign over the total and throwing it away.
+  static void AddInto(TypedValue &total, const TypedValue &addend) {
+    if (total.IsDouble()) {
+      total.ValueDouble() +=
+          addend.IsDouble() ? addend.UnsafeValueDouble() : static_cast<double>(addend.UnsafeValueInt());
+      return;
+    }
+    if (total.IsInt() && addend.IsInt()) {
+      total.ValueInt() += addend.UnsafeValueInt();
+      return;
+    }
+    // An integer total meeting a double: the total changes type, which is the general addition.
+    total = total + addend;
+  }
+
   void EnsureOkForAvgSum(const TypedValue &value) const {
     switch (value.type()) {
       case TypedValue::Type::Int:

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7482,8 +7482,6 @@ class AggregateCursor : public Cursor {
     }
   }
 
-  /** Checks if the given TypedValue is legal in AVG and SUM. If not
-   * an appropriate exception is thrown. */
   /// Adds `addend` into the running total `total`, in place where the two are the same kind of
   /// number.
   ///
@@ -7505,6 +7503,8 @@ class AggregateCursor : public Cursor {
     total = total + addend;
   }
 
+  /** Checks if the given TypedValue is legal in AVG and SUM. If not
+   * an appropriate exception is thrown. */
   void EnsureOkForAvgSum(const TypedValue &value) const {
     switch (value.type()) {
       case TypedValue::Type::Int:

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -6818,6 +6818,7 @@ class AggregateCursor : public Cursor {
   void Reset() override {
     input_cursor_->Reset();
     aggregation_.clear();
+    single_group_ = nullptr;
     aggregation_it_ = aggregation_.begin();
     pulled_all_input_ = false;
   }
@@ -6972,6 +6973,9 @@ class AggregateCursor : public Cursor {
       aggregation_;
   // this is a for object reuse, to avoid re-allocating this buffer
   utils::pmr::vector<TypedValue> reused_group_by_;
+  // The single group of an aggregation with no grouping key, once it exists. Null whenever
+  // `aggregation_` is empty or has been replaced.
+  CompactAggregationValue *single_group_{nullptr};
   // iterator over the accumulated cache
   decltype(aggregation_.begin()) aggregation_it_ = aggregation_.begin();
   // this LogicalOp pulls all from the input on it's first pull
@@ -7047,8 +7051,21 @@ class AggregateCursor : public Cursor {
     reused_group_by_.clear();
     evaluator->ResetPropertyLookupCache();
 
-    // TODO: if self_.group_by_.size() == 0, aggregation_ -> there is only one (becasue we are doing *)
-    //       can this be optimised so we don't need to do aggregation_.try_emplace which has a hash cost
+    // An aggregation with no grouping key has exactly one group, so every row after the first
+    // hashes an empty key to find the entry it found last time. Holding that entry instead is
+    // what keeps a bare `count(*)` from paying a hash table probe per row. The pointer stays
+    // valid because nothing is inserted or erased once the single group exists.
+    if (self_.group_by_.empty()) {
+      if (single_group_ == nullptr) {
+        auto *mem = aggregation_.get_allocator().resource();
+        auto res = aggregation_.try_emplace(reused_group_by_, mem, self_.aggregations_.size(), self_.remember_.size());
+        single_group_ = &res.first->second;
+        if (res.second /*was newly inserted*/) EnsureInitialized(frame, single_group_);
+      }
+      Update(evaluator, single_group_);
+      return;
+    }
+
     for (Expression *expression : self_.group_by_) {
       reused_group_by_.emplace_back(expression->Accept(*evaluator));
     }
@@ -11624,6 +11641,8 @@ class AggregateParallelCursor : public ParallelBranchCursor {
         // Reuse already completed section if available
         if (complete_aggregation != nullptr) {
           static_cast<AggregateCursor *>(cursor)->aggregation_ = std::move(*complete_aggregation);
+          // The single-group shortcut points into the map that was just replaced.
+          static_cast<AggregateCursor *>(cursor)->single_group_ = nullptr;
         }
       };
       auto post_pull_func = [&branch_aggregations_mutex, &aggregations, &branch_aggregations](Cursor *cursor,

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7482,14 +7482,11 @@ class AggregateCursor : public Cursor {
     }
   }
 
-  /// Adds `addend` into the running total `total`, in place where the two are the same kind of
-  /// number.
+  /// Adds `addend` into the running total `total`. Each must be an integer or a double.
   ///
-  /// `EnsureOkForAvgSum` admits only an integer or a double as an addend, and the total starts as
-  /// an integer and only ever takes one of those, so both are integers or doubles here. Where they
-  /// agree, the sum is the one `operator+` gives and can be written straight into the total,
-  /// sparing a result value per row. Addition owns the rule for the pair that disagrees, where an
-  /// integer total meets a double and stops being an integer, so that pair is handed to it.
+  /// Where the two are the same kind of number the addition happens in place, sparing a result
+  /// value per row. An integer total meeting a double stops being an integer, and addition owns
+  /// that rule, so that pair is handed to it.
   static void AddInto(TypedValue &total, const TypedValue &addend) {
     if (total.IsDouble()) {
       total.ValueDouble() +=

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7145,12 +7145,25 @@ class AggregateCursor : public Cursor {
     }
   }
 
+  /// Takes `value` into the aggregation at `pos`: a Null is not aggregated, DISTINCT drops a
+  /// repeat, and anything that survives both is counted.
+  ///
+  /// Answers whether the value still has to reach the aggregation itself. A COUNT never needs it
+  /// to, its result being read from the counts, so a COUNT may ignore the answer.
+  static bool TakeRowIn(CompactAggregationValue *agg_value, size_t pos, bool distinct, TypedValue const &value) {
+    if (value.IsNull()) return false;
+    if (distinct && !agg_value->unique_values_[pos].insert(value).second) return false;
+    agg_value->counts_[pos] += 1;
+    return true;
+  }
+
   /** Updates the given AggregationValue with new data. Assumes that
    * the AggregationValue has been initialized */
   void Update(const Frame &frame, ExpressionEvaluator *evaluator, AggregateCursor::CompactAggregationValue *agg_value) {
     DMG_ASSERT(self_.aggregations_.size() == agg_value->num_aggs_,
                "Expected as much AggregationValue.values_ as there are "
                "aggregations.");
+    DMG_ASSERT(count_from_frame_slot_.size() == agg_value->num_aggs_, "Classification is indexed by aggregation");
 
     for (size_t pos = 0; pos < agg_value->num_aggs_; ++pos) {
       const auto &agg_elem = self_.aggregations_[pos];
@@ -7167,26 +7180,14 @@ class AggregateCursor : public Cursor {
       // answers that without the value having to be built to be asked.
       if (auto const slot = count_from_frame_slot_[pos]; slot >= 0) {
         DMG_ASSERT(static_cast<size_t>(slot) < frame.elems().size(), "Identifier names no frame slot");
-        auto const &slot_value = frame.elems()[slot];
-        if (slot_value.IsNull()) continue;
-        if (agg_elem.distinct && !agg_value->unique_values_[pos].insert(slot_value).second) continue;
-        agg_value->counts_[pos] += 1;
-        // COUNT's result is read from `counts_` in post processing, so there is no value to set.
+        TakeRowIn(agg_value, pos, agg_elem.distinct, frame.elems()[slot]);
         continue;
       }
 
       TypedValue input_value = input_expr_ptr->Accept(*evaluator);
+      if (!TakeRowIn(agg_value, pos, agg_elem.distinct, input_value)) continue;
 
-      // Aggregations skip Null input values.
-      if (input_value.IsNull()) continue;
       const auto &agg_op = agg_elem.op;
-      if (agg_elem.distinct) {
-        auto insert_result = agg_value->unique_values_[pos].insert(input_value);
-        if (!insert_result.second) {
-          continue;
-        }
-      }
-      agg_value->counts_[pos] += 1;
       if (agg_value->counts_[pos] == 1) {
         // first value, nothing to aggregate. check type, set and continue.
         switch (agg_op) {

--- a/tests/e2e/parallel/test_parallel_correctness.py
+++ b/tests/e2e/parallel/test_parallel_correctness.py
@@ -157,6 +157,18 @@ class TestParallelCorrectness:
             populated_db, "MATCH (n) RETURN count(*), sum(n.p), avg(n.p), min(n.p), max(n.p)"
         )
 
+    def test_aggregations_over_bound_variable(self, populated_db):
+        """Count a bound variable, which is answered from the frame rather than from a built value."""
+        verify_parallel_matches_serial(populated_db, "MATCH (n) RETURN count(n)")
+        verify_parallel_matches_serial(populated_db, "MATCH (n) RETURN count(DISTINCT n)")
+        verify_parallel_matches_serial(populated_db, "MATCH (n) RETURN count(n), count(DISTINCT n), count(*)")
+
+    def test_aggregations_over_null_bound_variable(self, populated_db):
+        """A variable that is Null for some rows: it is neither counted nor reaches the DISTINCT set."""
+        verify_parallel_matches_serial(
+            populated_db, "MATCH (n) OPTIONAL MATCH (n)-[]->(m) RETURN count(m), count(DISTINCT m)"
+        )
+
     def test_aggregations_grouped(self, populated_db):
         """Test grouped aggregations."""
         # Group by label (though we mostly have :A and :B and :Person)

--- a/tests/unit/query_plan_accumulate_aggregate.cpp
+++ b/tests/unit/query_plan_accumulate_aggregate.cpp
@@ -517,6 +517,63 @@ TYPED_TEST(QueryPlanTest, AggregateCountIdentifierSkipsNull) {
   EXPECT_EQ(2, count(true)) << "Nulls skipped before dedup, and the repeated 2 counted once";
 }
 
+// SUM and AVG accumulate into the value they already hold, so the type of the running total has
+// to follow the same rules addition does: integers stay integers until a double joins them, and
+// from then on the total is a double whatever arrives after it.
+TYPED_TEST(QueryPlanTest, AggregateSumKeepsAdditionsTypeRules) {
+  auto storage_dba = this->db->Access(memgraph::storage::WRITE);
+  memgraph::query::DbAccessor dba(storage_dba.get());
+  SymbolTable symbol_table;
+
+  auto sum_of = [&](std::vector<memgraph::storage::ExternalPropertyValue> values, Aggregation::Op op) {
+    auto input_expr = this->storage.template Create<PrimitiveLiteral>(std::move(values));
+    auto x = symbol_table.CreateSymbol("x", true);
+    auto unwind = std::make_shared<plan::Unwind>(nullptr, input_expr, x);
+    auto produce = this->MakeAggregationProduce(unwind, symbol_table, {IDENT("x")->MapTo(x)}, {op}, {}, {}, false);
+    auto context = MakeContext(this->storage, symbol_table, &dba);
+    auto results = CollectProduce(*produce, &context);
+    EXPECT_EQ(1, results.size());
+    return results[0][0];
+  };
+  using PV = memgraph::storage::ExternalPropertyValue;
+
+  auto all_ints = sum_of({PV(1), PV(2), PV(3)}, Aggregation::Op::SUM);
+  EXPECT_EQ(all_ints.type(), TypedValue::Type::Int) << "integers alone keep an integer total";
+  EXPECT_EQ(all_ints.ValueInt(), 6);
+
+  auto int_then_double = sum_of({PV(1), PV(2), PV(0.5)}, Aggregation::Op::SUM);
+  ASSERT_EQ(int_then_double.type(), TypedValue::Type::Double) << "a double arriving promotes the total";
+  EXPECT_DOUBLE_EQ(int_then_double.ValueDouble(), 3.5);
+
+  auto double_then_int = sum_of({PV(0.5), PV(1), PV(2)}, Aggregation::Op::SUM);
+  ASSERT_EQ(double_then_int.type(), TypedValue::Type::Double) << "the total stays a double after that";
+  EXPECT_DOUBLE_EQ(double_then_int.ValueDouble(), 3.5);
+
+  auto with_nulls = sum_of({PV(1), PV(), PV(2)}, Aggregation::Op::SUM);
+  ASSERT_EQ(with_nulls.type(), TypedValue::Type::Int);
+  EXPECT_EQ(with_nulls.ValueInt(), 3) << "Null is skipped rather than making the total Null";
+
+  auto mean = sum_of({PV(1), PV(2)}, Aggregation::Op::AVG);
+  ASSERT_EQ(mean.type(), TypedValue::Type::Double) << "an average is a double even over integers";
+  EXPECT_DOUBLE_EQ(mean.ValueDouble(), 1.5);
+}
+
+TYPED_TEST(QueryPlanTest, AggregateSumRejectsNonNumeric) {
+  auto storage_dba = this->db->Access(memgraph::storage::WRITE);
+  memgraph::query::DbAccessor dba(storage_dba.get());
+  SymbolTable symbol_table;
+
+  auto input_expr =
+      this->storage.template Create<PrimitiveLiteral>(std::vector<memgraph::storage::ExternalPropertyValue>{
+          memgraph::storage::ExternalPropertyValue(1), memgraph::storage::ExternalPropertyValue("not a number")});
+  auto x = symbol_table.CreateSymbol("x", true);
+  auto unwind = std::make_shared<plan::Unwind>(nullptr, input_expr, x);
+  auto produce =
+      this->MakeAggregationProduce(unwind, symbol_table, {IDENT("x")->MapTo(x)}, {Aggregation::Op::SUM}, {}, {}, false);
+  auto context = MakeContext(this->storage, symbol_table, &dba);
+  EXPECT_THROW(CollectProduce(*produce, &context), QueryRuntimeException);
+}
+
 TYPED_TEST(QueryPlanTest, AggregateFirstValueTypes) {
   // testing exceptions that get emitted by the first-value
   // type check

--- a/tests/unit/query_plan_accumulate_aggregate.cpp
+++ b/tests/unit/query_plan_accumulate_aggregate.cpp
@@ -517,6 +517,43 @@ TYPED_TEST(QueryPlanTest, AggregateCountIdentifierSkipsNull) {
   EXPECT_EQ(2, count(true)) << "Nulls skipped before dedup, and the repeated 2 counted once";
 }
 
+// An aggregation with no grouping key holds on to its single accumulator rather than looking it
+// up per row. A reset clears the map that accumulator lives in, so the next pull has to build a
+// fresh one: accumulating through the old one would count the second pass on top of the first.
+TYPED_TEST(QueryPlanTest, AggregateNoGroupKeyStartsOverAfterReset) {
+  auto storage_dba = this->db->Access(memgraph::storage::WRITE);
+  memgraph::query::DbAccessor dba(storage_dba.get());
+  SymbolTable symbol_table;
+
+  // UNWIND [1, 2, 3] AS x RETURN count(x)
+  auto input_expr = this->storage.template Create<PrimitiveLiteral>(
+      std::vector<memgraph::storage::ExternalPropertyValue>{memgraph::storage::ExternalPropertyValue(1),
+                                                            memgraph::storage::ExternalPropertyValue(2),
+                                                            memgraph::storage::ExternalPropertyValue(3)});
+
+  auto x = symbol_table.CreateSymbol("x", true);
+  auto unwind = std::make_shared<plan::Unwind>(nullptr, input_expr, x);
+  auto produce = this->MakeAggregationProduce(
+      unwind, symbol_table, {IDENT("x")->MapTo(x)}, {Aggregation::Op::COUNT}, {}, {}, false);
+
+  auto context = MakeContext(this->storage, symbol_table, &dba);
+  auto const result_symbol = context.symbol_table.at(*produce->named_expressions_[0]);
+
+  Frame frame(context.symbol_table.max_position());
+  auto cursor = produce->MakeCursor(memgraph::utils::NewDeleteResource(), TestMetricHandles());
+
+  auto count_once = [&]() -> int64_t {
+    EXPECT_TRUE(cursor->Pull(frame, context));
+    auto const value = frame[result_symbol];
+    EXPECT_FALSE(cursor->Pull(frame, context)) << "no grouping key means exactly one group";
+    return value.ValueInt();
+  };
+
+  EXPECT_EQ(3, count_once());
+  cursor->Reset();
+  EXPECT_EQ(3, count_once()) << "the accumulator from before the reset must not be added to";
+}
+
 // SUM and AVG accumulate into the value they already hold, so the type of the running total has
 // to follow the same rules addition does: integers stay integers until a double joins them, and
 // from then on the total is a double whatever arrives after it.

--- a/tests/unit/query_plan_accumulate_aggregate.cpp
+++ b/tests/unit/query_plan_accumulate_aggregate.cpp
@@ -484,6 +484,39 @@ TYPED_TEST(QueryPlanTest, AggregateCountEdgeCases) {
   EXPECT_EQ(2, count());
 }
 
+// COUNT over a bare identifier, where the identifier is bound to Null for some rows. Null is
+// skipped by every aggregation, so a row whose identifier holds Null is not counted, and two
+// rows holding the same value are two counts unless DISTINCT says otherwise.
+TYPED_TEST(QueryPlanTest, AggregateCountIdentifierSkipsNull) {
+  auto storage_dba = this->db->Access(memgraph::storage::WRITE);
+  memgraph::query::DbAccessor dba(storage_dba.get());
+  SymbolTable symbol_table;
+
+  // UNWIND [1, Null, 2, Null, 2] AS x RETURN count(x), count(DISTINCT x)
+  auto input_expr = this->storage.template Create<PrimitiveLiteral>(
+      std::vector<memgraph::storage::ExternalPropertyValue>{memgraph::storage::ExternalPropertyValue(1),
+                                                            memgraph::storage::ExternalPropertyValue(),
+                                                            memgraph::storage::ExternalPropertyValue(2),
+                                                            memgraph::storage::ExternalPropertyValue(),
+                                                            memgraph::storage::ExternalPropertyValue(2)});
+
+  auto x = symbol_table.CreateSymbol("x", true);
+  auto unwind = std::make_shared<plan::Unwind>(nullptr, input_expr, x);
+
+  auto count = [&](bool distinct) {
+    auto produce = this->MakeAggregationProduce(
+        unwind, symbol_table, {IDENT("x")->MapTo(x)}, {Aggregation::Op::COUNT}, {}, {}, distinct);
+    auto context = MakeContext(this->storage, symbol_table, &dba);
+    auto results = CollectProduce(*produce, &context);
+    EXPECT_EQ(1, results.size());
+    EXPECT_EQ(TypedValue::Type::Int, results[0][0].type());
+    return results[0][0].ValueInt();
+  };
+
+  EXPECT_EQ(3, count(false)) << "the two Nulls must not be counted";
+  EXPECT_EQ(2, count(true)) << "Nulls skipped before dedup, and the repeated 2 counted once";
+}
+
 TYPED_TEST(QueryPlanTest, AggregateFirstValueTypes) {
   // testing exceptions that get emitted by the first-value
   // type check


### PR DESCRIPTION
An aggregation repeated three things per row that the row does not decide. One
with no grouping key hashed an empty key and probed the group map for the entry
it had found the row before, and now holds that entry once it exists. COUNT over
a plain identifier built the value only to ask whether there was one, and now
reads the frame slot the identifier names, with the question of which
aggregations qualify settled when the cursor is made rather than per row. SUM and
AVG added the running total to the row's value and assigned the result back over
the total, and now add into the total where the two agree on a numeric type.

Results are unchanged. Null is still skipped before anything else, so it is
neither counted nor reaches the set behind DISTINCT. The group map still holds
the result, so the parallel aggregation goes on merging what it always did, and
the held entry is released whenever that map is cleared or replaced. The type
rules are addition's own: an integer total stays an integer until a double joins
it, and the pair that changes the total's type goes on through the general
addition.
