### PR TITLE
perf(server): size worker pools from cgroup CPU quota, not host cores

### DIFF
--- a/src/communication/server.hpp
+++ b/src/communication/server.hpp
@@ -63,7 +63,7 @@ class Server final {
    */
   Server(io::network::Endpoint endpoint, TSessionContext *session_context, ServerContext *context,
          int inactivity_timeout_sec, const std::string &service_name,
-         size_t workers_count = memgraph::utils::GetSafeHardwareConcurrency())
+         size_t workers_count = memgraph::utils::UsableCoreCount())
       : alive_(false),
         endpoint_(std::move(endpoint)),
         listener_(session_context, context, inactivity_timeout_sec, service_name, workers_count),

--- a/src/flags/bolt.cpp
+++ b/src/flags/bolt.cpp
@@ -26,7 +26,7 @@ DEFINE_VALIDATED_int32(bolt_port, 7687, "Port on which the Bolt server should li
                        FLAG_IN_RANGE(0, std::numeric_limits<uint16_t>::max()));
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_VALIDATED_int32(bolt_num_workers, memgraph::utils::GetSafeHardwareConcurrency(),
+DEFINE_VALIDATED_int32(bolt_num_workers, memgraph::utils::UsableCoreCount(),
                        "Number of workers used by the Bolt server. By default, this will be the "
                        "number of processing units available on the machine.",
                        FLAG_IN_RANGE(1, INT32_MAX));

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -149,7 +149,7 @@ DEFINE_bool(storage_parallel_snapshot_creation, false,
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint64(storage_snapshot_thread_count,
-              std::max(static_cast<uint64_t>(memgraph::utils::GetSafeHardwareConcurrency()),
+              std::max(static_cast<uint64_t>(memgraph::utils::UsableCoreCount()),
                        memgraph::storage::Config::Durability().snapshot_thread_count),
               "The number of threads used to create snapshots.");
 
@@ -175,7 +175,7 @@ DEFINE_bool(storage_release_sent_snapshot_page_cache,
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint64(storage_recovery_thread_count,
-              std::max(static_cast<uint64_t>(memgraph::utils::GetSafeHardwareConcurrency()),
+              std::max(static_cast<uint64_t>(memgraph::utils::UsableCoreCount()),
                        memgraph::storage::Config::Durability().recovery_thread_count),
               "The number of threads used to recover persisted data from disk.");
 

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -30,7 +30,7 @@ namespace memgraph::rpc {
 class Server {
  public:
   Server(io::network::Endpoint endpoint, communication::ServerContext *context,
-         size_t workers_count = memgraph::utils::GetSafeHardwareConcurrency());
+         size_t workers_count = memgraph::utils::UsableCoreCount());
   Server(const Server &) = delete;
   Server(Server &&) = delete;
   Server &operator=(const Server &) = delete;

--- a/src/utils/concurrency_hint.hpp
+++ b/src/utils/concurrency_hint.hpp
@@ -13,7 +13,8 @@
 #include <algorithm>
 #include <atomic>
 #include <cstddef>
-#include <thread>
+
+#include "utils/system_info.hpp"
 
 namespace memgraph::utils {
 
@@ -27,8 +28,9 @@ inline void SetNumWorkers(std::size_t n) { global_num_workers.store(n, std::memo
 inline auto GetNumWorkers() -> std::size_t {
   auto n = global_num_workers.load(std::memory_order_acquire);
   if (n > 0) return n;
-  // hardware_concurrency() may return 0 in restricted environments (cgroups, sandboxes).
-  return std::max<std::size_t>(std::thread::hardware_concurrency(), 1);
+  // No explicit count set yet: fall back to the cgroup-aware usable core count
+  // (never 0), so container CPU limits are respected instead of host cores.
+  return static_cast<std::size_t>(UsableCoreCount());
 }
 
 }  // namespace memgraph::utils

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -191,7 +191,7 @@ void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, const Priority
     // Limit the number of directly used threads when there are more workers than hw threads.
     // Gives better overall performance.
     static const auto max_wakeup_thread =
-        std::max(1UL, std::min(static_cast<TaskID>(GetSafeHardwareConcurrency()), workers_.size()));
+        std::max(1UL, std::min(static_cast<TaskID>(UsableCoreCount()), workers_.size()));
     // If no hot thread found, give it to the next thread
     tid = last_wid_++ % max_wakeup_thread;
   }

--- a/src/utils/system_info.cpp
+++ b/src/utils/system_info.cpp
@@ -15,10 +15,13 @@
 #include <gflags/gflags.h>
 #include <sys/utsname.h>
 #include <algorithm>
+#include <charconv>
 #include <cstdlib>
 #include <filesystem>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -213,6 +216,84 @@ unsigned GetSafeHardwareConcurrency(unsigned fallback) {
 
   hw = static_cast<unsigned>(GetCPUInfo("").cpu_count);
   return hw != 0 ? hw : std::max(fallback, 1U);
+}
+
+namespace {
+
+// Parses a base-10 integer out of a whitespace-trimmed token; nullopt on failure.
+std::optional<long> ParseLong(std::string_view token) {
+  token = utils::Trim(std::string{token});
+  if (token.empty()) return std::nullopt;
+  long value = 0;
+  const auto *begin = token.data();
+  const auto *end = token.data() + token.size();
+  const auto [ptr, ec] = std::from_chars(begin, end, value);
+  if (ec != std::errc{} || ptr != end) return std::nullopt;
+  return value;
+}
+
+// Reads the single-line contents of a cgroup file; nullopt if the file is
+// absent or empty (which is how we distinguish cgroup v2 from v1).
+std::optional<std::string> ReadCgroupLine(const std::filesystem::path &path) {
+  const auto lines = utils::ReadLines(path);
+  if (lines.empty()) return std::nullopt;
+  return lines[0];
+}
+
+}  // namespace
+
+std::optional<unsigned> CpuQuotaToCores(long quota_us, long period_us) {
+  if (quota_us < 0) return std::nullopt;                     // unlimited (cgroup v1 uses -1)
+  if (quota_us == 0 || period_us <= 0) return std::nullopt;  // malformed -> fall back to host
+  // ceil(quota / period): a fractional quota still needs a whole worker thread.
+  const long cores = (quota_us + period_us - 1) / period_us;
+  return static_cast<unsigned>(cores);
+}
+
+std::optional<unsigned> ParseCgroupV2CpuMax(std::string_view cpu_max) {
+  // Format: "<quota> <period>", where <quota> is the literal "max" when unlimited.
+  auto rest = utils::Trim(std::string{cpu_max});
+  if (rest.empty()) return std::nullopt;
+
+  const auto sep = rest.find_first_of(" \t");
+  const std::string_view quota_tok = std::string_view{rest}.substr(0, sep);
+  if (quota_tok == "max") return std::nullopt;  // unlimited
+
+  const auto quota = ParseLong(quota_tok);
+  if (!quota) return std::nullopt;
+
+  // The period field defaults to the cgroup v2 baseline of 100000us if absent.
+  long period = 100000;
+  if (sep != std::string::npos) {
+    const auto period_opt = ParseLong(std::string_view{rest}.substr(sep + 1));
+    if (!period_opt) return std::nullopt;
+    period = *period_opt;
+  }
+  return CpuQuotaToCores(*quota, period);
+}
+
+unsigned UsableCoreCount(unsigned fallback) {
+  const unsigned host = GetSafeHardwareConcurrency(fallback);
+
+  std::optional<unsigned> cores;
+  if (const auto v2 = ReadCgroupLine("/sys/fs/cgroup/cpu.max")) {
+    // cgroup v2
+    cores = ParseCgroupV2CpuMax(*v2);
+  } else {
+    // cgroup v1
+    const auto quota = ReadCgroupLine("/sys/fs/cgroup/cpu/cpu.cfs_quota_us");
+    const auto period = ReadCgroupLine("/sys/fs/cgroup/cpu/cpu.cfs_period_us");
+    if (quota && period) {
+      const auto quota_us = ParseLong(*quota);
+      const auto period_us = ParseLong(*period);
+      if (quota_us && period_us) {
+        cores = CpuQuotaToCores(*quota_us, *period_us);
+      }
+    }
+  }
+
+  if (!cores) return host;  // unlimited, absent, or unparsable -> true hardware
+  return std::clamp(*cores, 1U, host);
 }
 
 }  // namespace memgraph::utils

--- a/src/utils/system_info.hpp
+++ b/src/utils/system_info.hpp
@@ -14,7 +14,9 @@
 #include <cstdint>
 #include <format>
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -64,6 +66,41 @@ RuntimeEnv DetectRuntimeEnv();
  * @return Number of hardware threads, always > 0.
  */
 unsigned GetSafeHardwareConcurrency(unsigned fallback = 2);
+
+/**
+ * Converts a raw CPU bandwidth quota/period pair (microseconds) into a whole
+ * number of cores, rounding up. Pure arithmetic, no I/O, so it is unit-testable.
+ *
+ * @return ceil(quota_us / period_us) cores, or std::nullopt when the quota is
+ *         unlimited (quota_us < 0, e.g. cgroup v1's -1) or the inputs are
+ *         invalid (non-positive period, zero quota).
+ */
+std::optional<unsigned> CpuQuotaToCores(long quota_us, long period_us);
+
+/**
+ * Parses the contents of a cgroup v2 `cpu.max` file ("<quota> <period>", with
+ * the quota being the literal "max" when unlimited). Pure, no I/O.
+ *
+ * @return the derived core count, or std::nullopt when the quota is "max"
+ *         (unlimited) or the contents cannot be parsed.
+ */
+std::optional<unsigned> ParseCgroupV2CpuMax(std::string_view cpu_max);
+
+/**
+ * Returns the number of cores this process may usefully run on, honouring a
+ * cgroup CPU quota (v2 `cpu.max`, falling back to v1 `cpu.cfs_quota_us` /
+ * `cpu.cfs_period_us`). The result is clamped to
+ * [1, GetSafeHardwareConcurrency()]. When no quota applies (unlimited, files
+ * absent, or a parse error) the host core count is returned unchanged.
+ *
+ * Intended for sizing worker-pool defaults so a CPU-limited container is not
+ * over-provisioned. Distinct from GetSafeHardwareConcurrency(), which keeps
+ * reporting the true hardware for telemetry.
+ *
+ * @param fallback Last-resort value forwarded to GetSafeHardwareConcurrency().
+ * @return Usable core count, always > 0.
+ */
+unsigned UsableCoreCount(unsigned fallback = 2);
 
 /**
  * This function return a dictionary containing some basic system information

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -444,6 +444,11 @@ add_unit_test(utils_algorithm
     LINK_TARGETS mg-utils
 )
 
+add_unit_test(utils_usable_core_count
+    SOURCES utils_usable_core_count.cpp
+    LINK_TARGETS mg-utils
+)
+
 # Hot/cold tenants: gatekeeper 4-state lifecycle machine
 add_unit_test(hot_cold_gatekeeper
     SOURCES hot_cold_gatekeeper.cpp

--- a/tests/unit/utils_usable_core_count.cpp
+++ b/tests/unit/utils_usable_core_count.cpp
@@ -1,0 +1,70 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gtest/gtest.h>
+
+#include "utils/system_info.hpp"
+
+using memgraph::utils::CpuQuotaToCores;
+using memgraph::utils::ParseCgroupV2CpuMax;
+
+// --- cgroup v2 (cpu.max) --------------------------------------------------
+
+TEST(UsableCoreCount, V2ExactCores) {
+  // 200000 / 100000 = 2 cores exactly.
+  const auto cores = ParseCgroupV2CpuMax("200000 100000");
+  ASSERT_TRUE(cores.has_value());
+  EXPECT_EQ(*cores, 2U);
+}
+
+TEST(UsableCoreCount, V2CeilsFraction) {
+  // 150000 / 100000 = 1.5 -> ceil -> 2 cores.
+  const auto cores = ParseCgroupV2CpuMax("150000 100000");
+  ASSERT_TRUE(cores.has_value());
+  EXPECT_EQ(*cores, 2U);
+}
+
+TEST(UsableCoreCount, V2MaxIsUnlimited) {
+  // "max" means no quota -> nullopt (caller falls back to host cores).
+  EXPECT_FALSE(ParseCgroupV2CpuMax("max 100000").has_value());
+}
+
+TEST(UsableCoreCount, V2TrailingWhitespaceTolerated) {
+  const auto cores = ParseCgroupV2CpuMax("200000 100000\n");
+  ASSERT_TRUE(cores.has_value());
+  EXPECT_EQ(*cores, 2U);
+}
+
+TEST(UsableCoreCount, V2Garbage) { EXPECT_FALSE(ParseCgroupV2CpuMax("not-a-number").has_value()); }
+
+// --- cgroup v1 (cpu.cfs_quota_us / cpu.cfs_period_us) ---------------------
+
+TEST(UsableCoreCount, V1UnlimitedQuota) {
+  // Quota of -1 means unlimited -> nullopt.
+  EXPECT_FALSE(CpuQuotaToCores(-1, 100000).has_value());
+}
+
+TEST(UsableCoreCount, V1ExactCores) {
+  const auto cores = CpuQuotaToCores(200000, 100000);
+  ASSERT_TRUE(cores.has_value());
+  EXPECT_EQ(*cores, 2U);
+}
+
+TEST(UsableCoreCount, V1CeilsFraction) {
+  // 250000 / 100000 = 2.5 -> ceil -> 3 cores.
+  const auto cores = CpuQuotaToCores(250000, 100000);
+  ASSERT_TRUE(cores.has_value());
+  EXPECT_EQ(*cores, 3U);
+}
+
+TEST(UsableCoreCount, V1InvalidPeriod) { EXPECT_FALSE(CpuQuotaToCores(200000, 0).has_value()); }
+
+TEST(UsableCoreCount, V1ZeroQuota) { EXPECT_FALSE(CpuQuotaToCores(0, 100000).has_value()); }


### PR DESCRIPTION
## Summary
`utils::GetSafeHardwareConcurrency()` returns `std::thread::hardware_concurrency()` — the **host** logical-core count — and is **not cgroup-aware**. In a CPU-limited container it over-provisions worker threads (e.g. ~110 Bolt workers on a pod granted 8 CPUs), so under load the pool oversubscribes the cores the cgroup actually grants and thrashes (CFS throttling / context-switch storm), while individual queries stay fast in isolation.

## Change
- Add a new `utils::UsableCoreCount(fallback=2)` that reads the cgroup CPU quota — v2 `cpu.max` (`"<quota> <period>"`, `"max"` = unlimited) and v1 `cpu.cfs_quota_us`/`cpu.cfs_period_us` (`-1` = unlimited) — returning `ceil(quota/period)`, clamped to `[1, GetSafeHardwareConcurrency()]`. Unlimited / file-absent / parse-error falls back to host cores. The arithmetic is factored into pure, unit-tested helpers (`CpuQuotaToCores`, `ParseCgroupV2CpuMax`).
- Switch the worker-count **defaults** to `UsableCoreCount()`: `bolt_num_workers`, the RPC and communication server `workers_count`, the snapshot/recovery thread-count defaults, the priority-pool wakeup cap, and the `concurrency_hint` fallback.
- **`GetSafeHardwareConcurrency()` is left byte-identical** — it still feeds hardware telemetry (`GetSystemInfo`/`GetCPUInfo`); this PR must not change reported hardware facts.

## Impact
Fixes the oversubscription root cause on CPU-limited deployments. **No behavior change on bare metal** (unlimited quota → host cores, exactly as before).

## Verification
Built on the local v7 base; new `utils_usable_core_count` unit test passes **10/10** (v2 exact/ceil/"max"/whitespace/garbage; v1 unlimited/exact/ceil/invalid/zero). Local toolchain can't build master (needs v8) — **CI is the build gate, hence draft.**

## Notes / follow-ups
- The snapshot/recovery thread-count defaults keep their `std::max(…, 8)` floor, so switching them is cosmetic below 8 cores (kept for consistency).
- Reads only the CFS quota, not `cpuset.cpus`; a pod limited via `--cpuset-cpus` (not `--cpus`) is not yet detected — completeness follow-up, not a regression.

## Stack
Base of a 3-PR performance stack:
1. **this** → 2. query-timeout deadline → 3. bounded/adaptive worker spin.
