### PR TITLE
fix(query): drop only the comprehension elements whose predicate is NULL

### DIFF
--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -915,8 +915,16 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       }
 
       auto predicate_result = list_comprehension.where_->expression_->Accept(*this);
+      // This predicate filters rather than being folded into one answer the way
+      // a quantifier's is, so an element whose predicate is NULL is left out and
+      // the rest of the list still stands. NULL is the only value besides a
+      // boolean a predicate may hold.
+      if (predicate_result.IsNull()) {
+        continue;
+      }
       if (!predicate_result.IsBool()) {
-        return TypedValue(ctx_->memory);
+        throw QueryRuntimeException("Predicate of a list comprehension must evaluate to boolean, got {}.",
+                                    predicate_result.type());
       }
       if (predicate_result.ValueBool()) {
         if (has_transformation) {

--- a/tests/gql_behave/tests/memgraph_V1/features/list_comprehension.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/list_comprehension.feature
@@ -202,3 +202,47 @@ Feature: ListComprehension
         Then the result should be:
             | result                |
             | [{a: 2, label: [0]}]  |
+
+    Scenario: Using a list comprehension whose predicate is null for one element
+        Given an empty graph
+        When executing query:
+            """
+            RETURN [x in [1, null, 3] WHERE x > 0 | x] as processed
+            """
+        Then the result should be:
+            | processed |
+            | [1, 3]    |
+
+    Scenario: Using a list comprehension whose predicate is null for every element
+        Given an empty graph
+        When executing query:
+            """
+            RETURN [x in [1, 2] WHERE null | x] as processed
+            """
+        Then the result should be:
+            | processed |
+            | []        |
+
+    Scenario: Using a list comprehension over a property missing from some elements
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:Person {name: 'Alice'})-[:KNOWS]->(:Person {name: 'Charlie', age: 35}),
+                   (a)-[:LIKES]->(:Item {name: 'Widget'})
+            """
+        When executing query:
+            """
+            MATCH (a:Person {name: 'Alice'})-[:KNOWS]->(p:Person), (a)-[:LIKES]->(i:Item)
+            RETURN [x in [p, i] WHERE x.age > 25 | x.name] as names
+            """
+        Then the result should be:
+            | names       |
+            | ['Charlie'] |
+
+    Scenario: Using a list comprehension whose predicate is not a boolean
+        Given an empty graph
+        When executing query:
+            """
+            RETURN [x in [1, 2, 3] WHERE 2 | x] as processed
+            """
+        Then an error should be raised

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1394,6 +1394,100 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionNoneWhereWrongType) {
   EXPECT_THROW(this->Eval(none), QueryRuntimeException);
 }
 
+// A list comprehension filters, so an element whose predicate is NULL is left
+// out and the rest of the list still comes back. This is what separates it from
+// the quantifiers above, which fold a NULL into their answer.
+TYPED_TEST(ExpressionEvaluatorTest, ListComprehensionKeepsElementsPastANullPredicate) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *list_comprehension =
+      LIST_COMPREHENSION(ident_x,
+                         LIST(LITERAL(1), LITERAL(memgraph::storage::ExternalPropertyValue()), LITERAL(3)),
+                         WHERE(GREATER(ident_x, LITERAL(0))),
+                         nullptr);
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  list_comprehension->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(list_comprehension);
+  ASSERT_TRUE(value.IsList());
+  ASSERT_EQ(value.ValueList().size(), 2);
+  EXPECT_EQ(value.ValueList()[0].ValueInt(), 1);
+  EXPECT_EQ(value.ValueList()[1].ValueInt(), 3);
+}
+
+TYPED_TEST(ExpressionEvaluatorTest, ListComprehensionDropsTheElementWhosePredicateIsNull) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *list_comprehension =
+      LIST_COMPREHENSION(ident_x,
+                         LIST(LITERAL(1), LITERAL(memgraph::storage::ExternalPropertyValue()), LITERAL(3)),
+                         WHERE(GREATER(ident_x, LITERAL(2))),
+                         nullptr);
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  list_comprehension->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(list_comprehension);
+  ASSERT_TRUE(value.IsList());
+  ASSERT_EQ(value.ValueList().size(), 1);
+  EXPECT_EQ(value.ValueList()[0].ValueInt(), 3);
+}
+
+// A predicate that is null for every element leaves an empty list, the same as
+// one that is false for every element.
+TYPED_TEST(ExpressionEvaluatorTest, ListComprehensionOverAlwaysNullPredicateIsEmpty) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *list_comprehension = LIST_COMPREHENSION(
+      ident_x, LIST(LITERAL(1), LITERAL(2)), WHERE(LITERAL(memgraph::storage::ExternalPropertyValue())), nullptr);
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  list_comprehension->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(list_comprehension);
+  ASSERT_TRUE(value.IsList());
+  EXPECT_TRUE(value.ValueList().empty());
+}
+
+TYPED_TEST(ExpressionEvaluatorTest, ListComprehensionAppliesItsExpressionPastANullPredicate) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *list_comprehension =
+      LIST_COMPREHENSION(ident_x,
+                         LIST(LITERAL(1), LITERAL(memgraph::storage::ExternalPropertyValue()), LITERAL(3)),
+                         WHERE(GREATER(ident_x, LITERAL(0))),
+                         ADD(ident_x, LITERAL(10)));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  list_comprehension->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(list_comprehension);
+  ASSERT_TRUE(value.IsList());
+  ASSERT_EQ(value.ValueList().size(), 2);
+  EXPECT_EQ(value.ValueList()[0].ValueInt(), 11);
+  EXPECT_EQ(value.ValueList()[1].ValueInt(), 13);
+}
+
+// NULL is the only non-boolean a predicate may hold; anything else is still a
+// mistake in the query rather than an element to skip.
+TYPED_TEST(ExpressionEvaluatorTest, ListComprehensionWhereWrongType) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *list_comprehension = LIST_COMPREHENSION(ident_x, LIST(LITERAL(1)), WHERE(LITERAL(2)), nullptr);
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  list_comprehension->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  EXPECT_THROW(this->Eval(list_comprehension), QueryRuntimeException);
+}
+
+TYPED_TEST(ExpressionEvaluatorTest, ListComprehensionOverNullList) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *list_comprehension =
+      LIST_COMPREHENSION(ident_x, LITERAL(memgraph::storage::ExternalPropertyValue()), WHERE(LITERAL(true)), nullptr);
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  list_comprehension->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  EXPECT_TRUE(this->Eval(list_comprehension).IsNull());
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, FunctionReduce) {
   AstStorage storage;
   auto *ident_sum = IDENT("sum");


### PR DESCRIPTION
A list comprehension filters, so an element whose WHERE predicate evaluates to
NULL is left out and the rest of the list still comes back. A single NULL used
to discard the whole comprehension and yield NULL, so any comprehension
filtering a list that can hold one, such as a property some elements lack,
silently lost every result it had already matched.

Filtering is what separates a comprehension from the quantifiers that share its
shape: all, any, none and single fold a NULL into their single boolean answer,
and still do. A predicate that is neither a boolean nor NULL is now refused
rather than quietly read as NULL.
