### PR TITLE
perf(bolt): inline explicit-transaction BEGIN (non-blocking on the strand)

### DIFF
--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -225,8 +225,15 @@ class Session {
       return InlineBeginResult::ClientError;
     }
 
+    // Off-strand for any BEGIN that needs a real reconfigure (first BEGIN, db-switch, impersonation):
+    // Configure would take the dbms/auth locks, which can block. Hand the whole BEGIN to the pool.
+    if (!impl.ConfigureWouldBeNoOp(extra.ValueMap())) {
+      pending_begin_extra_ = std::move(extra);
+      return InlineBeginResult::WouldBlock;  // fallback runs the FULL begin (Configure + BeginTransaction) on a worker
+    }
+
     try {
-      impl.Configure(extra.ValueMap());
+      // Configure is verified a no-op above, so it is skipped here; the full begin runs on the pool otherwise.
       impl.BeginTransaction(extra.ValueMap(), /*try_only=*/true);  // may throw WouldBlockInlineException
       if (!encoder_.MessageSuccess({})) {
         state_ = State::Close;
@@ -244,9 +251,11 @@ class Session {
     }
   }
 
-  // Pool-side completion of a BEGIN that bailed inline with WouldBlock. Configure already ran on the strand,
-  // so it is NOT re-run here; only the blocking Access + SUCCESS remain. bolt_messages was already counted by
-  // TryInlineBegin_, so it is NOT incremented again.
+  // Pool-side completion of a BEGIN that bailed inline with WouldBlock. Runs the FULL begin (Configure +
+  // BeginTransaction) on the worker so it covers BOTH bail causes: the gate bail (a real, lock-taking
+  // reconfigure was needed) and the engine-lock contention bail. Configure re-running when it was actually a
+  // no-op is harmless -- it early-outs again. bolt_messages/at_least_one_run_ were already counted by
+  // TryInlineBegin_, so they are NOT touched here.
   template <typename TImpl>
     requires requires(TImpl &impl) {
       { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
@@ -257,6 +266,7 @@ class Session {
     Value extra = std::move(*pending_begin_extra_);
     pending_begin_extra_.reset();
     try {
+      impl.Configure(extra.ValueMap());                            // real reconfigure runs here, on the worker (blocking OK)
       impl.BeginTransaction(extra.ValueMap(), /*try_only=*/false);  // blocking Access on the worker
       if (!encoder_.MessageSuccess({})) {
         state_ = State::Close;

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -26,6 +26,7 @@
 #include "communication/bolt/v1/states/handshake.hpp"
 #include "communication/bolt/v1/states/init.hpp"
 #include "communication/metrics.hpp"
+#include "query/exceptions.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/session_context.hpp"
 #include "utils/timestamp.hpp"
@@ -42,6 +43,13 @@ class SessionException : public utils::BasicException {
   using utils::BasicException::BasicException;
   SPECIALIZE_GET_EXCEPTION_NAME(SessionException)
 };
+
+// Outcome of the strand-side inline-BEGIN fast path (TryInlineBegin_).
+// NotBegin  - the buffered message is not an inline-eligible BEGIN; leave it for the normal pool path.
+// Handled   - BEGIN ran inline and SUCCESS was sent; nothing left to do.
+// ClientError - the message was malformed / send failed; state moved to Close.
+// WouldBlock - the storage lock was contended; extras are stashed for FinishPendingBeginBlocking_ on the pool.
+enum class InlineBeginResult : uint8_t { NotBegin, Handled, ClientError, WouldBlock };
 
 /**
  * Bolt Session
@@ -167,6 +175,99 @@ class Session {
     return false;  // no more data
   }
 
+  bool HasBufferedData() const { return input_stream_.size() > 0; }
+
+  // Strand-side fast path: run an explicit BEGIN inline (on the ASIO strand) when the whole message has
+  // arrived and the storage lock is uncontended, saving the thread-pool hop. See InlineBeginResult for the
+  // per-outcome contract.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  InlineBeginResult TryInlineBegin_(TImpl &impl) {
+    // Inline only for bolt v4+ and only from an idle (not-in-txn) state.
+    if (version_.major < 4) return InlineBeginResult::NotBegin;
+    if (state_ != State::Idle) return InlineBeginResult::NotBegin;
+
+    // Non-destructive raw-buffer peek: GetChunk() is destructive, so it must not run until we are certain
+    // this is a fully-arrived single-chunk BEGIN -- a non-BEGIN or partial message must stay intact for the pool path.
+    const size_t avail = input_stream_.size();
+    if (avail < 4) return InlineBeginResult::NotBegin;
+    const uint8_t *raw = input_stream_.data();
+    const size_t chunk_size = (static_cast<size_t>(raw[0]) << 8) | raw[1];
+    // Require the whole single chunk + its 0x00 0x00 terminator to be present.
+    if (avail < 2 + chunk_size + 2) return InlineBeginResult::NotBegin;
+    if (raw[2 + chunk_size] != 0 || raw[2 + chunk_size + 1] != 0)
+      return InlineBeginResult::NotBegin;  // multi-chunk -> normal path
+    if (raw[2] != static_cast<uint8_t>(Marker::TinyStruct1)) return InlineBeginResult::NotBegin;
+    if (raw[3] != static_cast<uint8_t>(Signature::Begin)) return InlineBeginResult::NotBegin;
+
+    // Committed to inline handling of this BEGIN. Replicate the side effects the normal
+    // Execute_/StateExecutingRun path performs, exactly once.
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+    memgraph::metrics::Metrics().global.bolt_messages->Increment();
+    at_least_one_run_ = true;
+
+    ChunkState cs;
+    while ((cs = decoder_buffer_.GetChunk()) == ChunkState::Whole) { /* drain chunks */ }
+    if (cs != ChunkState::Done) return InlineBeginResult::NotBegin;  // defensive; completeness was checked above
+
+    Marker marker;
+    Signature signature;
+    if (!decoder_.ReadMessageHeader(&signature, &marker)) {
+      state_ = State::Close;
+      return InlineBeginResult::ClientError;
+    }
+
+    Value extra;
+    if (!decoder_.ReadValue(&extra, Value::Type::Map)) {
+      state_ = State::Close;
+      return InlineBeginResult::ClientError;
+    }
+
+    try {
+      impl.Configure(extra.ValueMap());
+      impl.BeginTransaction(extra.ValueMap(), /*try_only=*/true);  // may throw WouldBlockInlineException
+      if (!encoder_.MessageSuccess({})) {
+        state_ = State::Close;
+        return InlineBeginResult::ClientError;
+      }
+      state_ = State::Idle;
+      return InlineBeginResult::Handled;
+    } catch (const memgraph::query::WouldBlockInlineException &) {
+      // Clean bail: accessor acquired first, so interpreter txn state is untouched. Stash extras for the pool fallback.
+      pending_begin_extra_ = std::move(extra);
+      return InlineBeginResult::WouldBlock;
+    } catch (const std::exception &e) {
+      state_ = HandleFailure(impl, e);  // same failure handling as the normal HandleBegin path
+      return InlineBeginResult::ClientError;
+    }
+  }
+
+  // Pool-side completion of a BEGIN that bailed inline with WouldBlock. Configure already ran on the strand,
+  // so it is NOT re-run here; only the blocking Access + SUCCESS remain. bolt_messages was already counted by
+  // TryInlineBegin_, so it is NOT incremented again.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  void FinishPendingBeginBlocking_(TImpl &impl) {
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+    MG_ASSERT(pending_begin_extra_.has_value(), "FinishPendingBeginBlocking_ without a pending BEGIN");
+    Value extra = std::move(*pending_begin_extra_);
+    pending_begin_extra_.reset();
+    try {
+      impl.BeginTransaction(extra.ValueMap(), /*try_only=*/false);  // blocking Access on the worker
+      if (!encoder_.MessageSuccess({})) {
+        state_ = State::Close;
+        return;
+      }
+      state_ = State::Idle;
+    } catch (const std::exception &e) {
+      state_ = HandleFailure(impl, e);
+    }
+  }
+
   void HandleError() {
     if (!at_least_one_run_) {
       spdlog::info("Sudden connection loss. Make sure the client supports Memgraph.");
@@ -216,6 +317,10 @@ class Session {
   }
 
  private:
+  // Extras decoded by an inline BEGIN that bailed with WouldBlock, carried across the strand->pool handoff so
+  // FinishPendingBeginBlocking_ can retry the Access without re-decoding.
+  std::optional<Value> pending_begin_extra_{};
+
   const std::string kTimestampFormat = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}";
   const std::string session_uuid_;  //!< unique identifier of the session (auto generated)
   const std::string login_timestamp_;

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -43,6 +43,7 @@
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/system/detail/error_code.hpp>
 
+#include "communication/bolt/v1/session.hpp"
 #include "communication/buffer.hpp"
 #include "communication/context.hpp"
 #include "communication/exceptions.hpp"
@@ -364,7 +365,42 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     }
 
     input_buffer_.write_end()->Written(bytes_transferred);
-    DoWork();
+
+    // Fast path: an eligible explicit-transaction BEGIN runs inline on this strand thread, skipping the
+    // thread-pool hop. See InlineBeginResult for the per-outcome contract.
+    using memgraph::communication::bolt::InlineBeginResult;
+    switch (session_.TryInlineBegin()) {
+      case InlineBeginResult::NotBegin:
+        DoWork();
+        break;
+      case InlineBeginResult::Handled:
+      case InlineBeginResult::ClientError:
+        if (session_.HasBufferedData()) {
+          DoWork();
+        } else {
+          DoRead();
+        }
+        break;
+      case InlineBeginResult::WouldBlock:
+        // A DDL (UNIQUE) holds the storage lock: finish the BEGIN with a blocking accessor on a worker.
+        session_context_->AddTask(
+            [shared_this = shared_from_this()](const auto /*thread_priority*/) {
+              try {
+                shared_this->session_.FinishPendingBeginBlocking();
+                if (shared_this->session_.HasBufferedData()) {
+                  shared_this->DoWork();
+                } else {
+                  shared_this->DoRead();
+                }
+              } catch (const std::exception & /* unused */) {
+                boost::asio::post(shared_this->strand_, [shared_this, eptr = std::current_exception()]() {
+                  shared_this->HandleException(eptr);
+                });
+              }
+            },
+            session_.ApproximateQueryPriority());
+        break;
+    }
   }
 
   void OnReadAsio(const boost::system::error_code &ec, const size_t bytes_transferred) {

--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -22,6 +22,7 @@
 #include "query/stream/streams.hpp"
 #include "query/trigger.hpp"
 #include "storage/v2/disk/storage.hpp"
+#include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 #include "storage/v2/storage_mode.hpp"
 #include "storage/v2/ttl.hpp"
@@ -67,6 +68,15 @@ std::unique_ptr<storage::Accessor> Database::Access(storage::StorageAccessType r
                                                     std::optional<storage::IsolationLevel> override_isolation_level,
                                                     std::optional<std::chrono::milliseconds> timeout) {
   return storage_->Access(rw_type, override_isolation_level, timeout);
+}
+
+std::unique_ptr<storage::Accessor> Database::TryAccess(
+    storage::StorageAccessType rw_type, std::optional<storage::IsolationLevel> override_isolation_level) {
+  auto *in_memory = dynamic_cast<storage::InMemoryStorage *>(storage_.get());
+  if (in_memory == nullptr) {
+    return nullptr;
+  }
+  return in_memory->TryAccess(rw_type, override_isolation_level);
 }
 
 std::unique_ptr<storage::Accessor> Database::UniqueAccess(

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -91,6 +91,13 @@ class Database {
                                             std::optional<storage::IsolationLevel> override_isolation_level = {},
                                             std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
+  // Non-blocking accessor for the inline-BEGIN fast path: returns a READ/WRITE accessor if the
+  // storage lock can be taken without blocking, or nullptr if it would block (a DDL/UNIQUE holder)
+  // OR the storage is not in-memory (only InMemoryStorage offers the probe). Callers must fall back
+  // to the blocking Access() path on nullptr; this is a one-shot try, never a poll loop.
+  std::unique_ptr<storage::Accessor> TryAccess(storage::StorageAccessType rw_type,
+                                               std::optional<storage::IsolationLevel> override_isolation_level = {});
+
   std::unique_ptr<storage::Accessor> UniqueAccess(std::optional<storage::IsolationLevel> override_isolation_level = {},
                                                   std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -691,6 +691,7 @@ void SessionHL::Configure(const bolt_map_t &run_time_info) {
 #endif
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static): uses runtime_config_ under MG_ENTERPRISE.
 bool SessionHL::ConfigureWouldBeNoOp(const bolt_map_t &run_time_info) const {
 #ifdef MG_ENTERPRISE
   if (flags::CoordinationSetupInstance().IsCoordinator()) return true;  // Configure returns early anyway

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -691,6 +691,16 @@ void SessionHL::Configure(const bolt_map_t &run_time_info) {
 #endif
 }
 
+bool SessionHL::ConfigureWouldBeNoOp(const bolt_map_t &run_time_info) const {
+#ifdef MG_ENTERPRISE
+  if (flags::CoordinationSetupInstance().IsCoordinator()) return true;  // Configure returns early anyway
+  return runtime_config_.ConfigureIsNoOp(run_time_info);
+#else
+  (void)run_time_info;
+  return true;  // community Configure is a no-op
+#endif
+}
+
 SessionHL::SessionHL(Context context, memgraph::communication::v2::InputStream *input_stream,
                      memgraph::communication::v2::OutputStream *output_stream)
     : Session<memgraph::communication::v2::InputStream, memgraph::communication::v2::OutputStream>(input_stream,
@@ -749,6 +759,10 @@ bolt_map_t SessionHL::DecodeSummary(const std::map<std::string, memgraph::query:
 }
 
 #ifdef MG_ENTERPRISE
+bool RuntimeConfig::ConfigureIsNoOp(const bolt_map_t &run_time_info) const {
+  return previous_run_time_info_ && run_time_info == *previous_run_time_info_;
+}
+
 void RuntimeConfig::Configure(const bolt_map_t &run_time_info, bool in_explicit_tx) {
   // NOTE: Once in a transaction, the drivers stop explicitly sending the config and count on using it until commit
   // Runtime config is sent at the beginning of the transaction, but is missing during the transaction

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -669,9 +669,9 @@ bolt_map_t SessionHL::CommitTransaction() {
   }
 }
 
-void SessionHL::BeginTransaction(const bolt_map_t &extra) {
+void SessionHL::BeginTransaction(const bolt_map_t &extra, bool try_only) {
   try {
-    interpreter_.BeginTransaction(ToQueryExtras(extra));
+    interpreter_.BeginTransaction(ToQueryExtras(extra), try_only);
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -69,7 +69,7 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   void Configure(const bolt_map_t &run_time_info);
 
-  void BeginTransaction(const bolt_map_t &extra);
+  void BeginTransaction(const bolt_map_t &extra, bool try_only = false);
 
   bolt_map_t CommitTransaction();
 
@@ -140,6 +140,9 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   utils::Priority ApproximateQueryPriority() const;
 
   inline bool Execute() { return Execute_(*this); }
+
+  inline memgraph::communication::bolt::InlineBeginResult TryInlineBegin() { return TryInlineBegin_(*this); }
+  inline void FinishPendingBeginBlocking() { FinishPendingBeginBlocking_(*this); }
 
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }
 

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -38,6 +38,12 @@ class RuntimeConfig {
 
   void Configure(const bolt_map_t &run_time_info, bool in_explicit_tx);
 
+  // True iff Configure(run_time_info) would early-out (unchanged config) -- i.e. it would take no
+  // locks and do no DB/auth work. Used by the inline-BEGIN fast path to stay off the strand when a
+  // real (lock-taking) reconfigure is needed. Defined in the .cpp so the bolt_map_t comparison sees
+  // the same operator== visibility as RuntimeConfig::Configure's own early-out.
+  bool ConfigureIsNoOp(const bolt_map_t &run_time_info) const;
+
   bool db_explicit_ = false;
   bool user_explicit_ = false;
 
@@ -68,6 +74,10 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   /// BOLT level API ///
 
   void Configure(const bolt_map_t &run_time_info);
+
+  // True iff Configure(run_time_info) would take no locks and do no work. The inline-BEGIN fast path
+  // uses this to keep the (potentially blocking) dbms/auth reconfigure off the Bolt strand.
+  bool ConfigureWouldBeNoOp(const bolt_map_t &run_time_info) const;
 
   void BeginTransaction(const bolt_map_t &extra, bool try_only = false);
 

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -68,6 +68,16 @@ class PeriodicCommitException : public QueryException {
   SPECIALIZE_GET_EXCEPTION_NAME(PeriodicCommitException)
 };
 
+// Internal control-flow signal for the inline-BEGIN fast path: thrown when a non-blocking
+// (try_only) storage-access attempt would block on a UNIQUE (DDL) holder, so the caller must
+// fall back to the blocking pool path. Deliberately NOT a QueryException — it is caught only at
+// the inline Bolt call site and never surfaces to the client.
+class WouldBlockInlineException : public utils::BasicException {
+ public:
+  WouldBlockInlineException() : utils::BasicException("inline transaction start would block") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(WouldBlockInlineException)
+};
+
 /**
  * @brief Base class of all query language related exceptions which can be retried.
  * All exceptions derived from this one will be interpreted as TransientError-s,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -195,7 +195,7 @@ TypedValue EvaluateConfigMapToTypedValue(std::unordered_map<Expression *, Expres
 // access
 void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-    storage::StorageAccessType acc_type) {
+    storage::StorageAccessType acc_type, bool try_only) {
   if (!db_acc_) {
     throw DatabaseContextRequiredException("Database required for the transaction setup.");
   }
@@ -206,9 +206,14 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     case storage::StorageAccessType::READ:
       [[fallthrough]];
     case storage::StorageAccessType::WRITE:
-      db_transactional_accessor_ = db_acc->Access(acc_type,
-                                                  override_isolation_level,
-                                                  /*allow timeout*/ timeout);
+      if (try_only) {
+        db_transactional_accessor_ = db_acc->TryAccess(acc_type, override_isolation_level);
+        if (!db_transactional_accessor_) throw WouldBlockInlineException{};
+      } else {
+        db_transactional_accessor_ = db_acc->Access(acc_type,
+                                                    override_isolation_level,
+                                                    /*allow timeout*/ timeout);
+      }
       break;
     case storage::StorageAccessType::UNIQUE:
       db_transactional_accessor_ = db_acc->UniqueAccess(override_isolation_level, /*allow timeout*/ timeout);
@@ -3911,22 +3916,17 @@ auto CreateTimeoutDeadline(QueryExtras const &extras, InterpreterConfig const &c
 }  // namespace
 
 PreparedQuery Interpreter::PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum,
-                                                   QueryExtras const &extras) {
+                                                   QueryExtras const &extras, bool try_only) {
   std::function<void()> handler;
 
   switch (tx_query_enum) {
     case TransactionQuery::BEGIN: {
       // TODO: Evaluate doing move(extras). Currently the extras is very small, but this will be important if it ever
       // becomes large.
-      handler = [this, extras = extras] {
+      handler = [this, extras = extras, try_only] {
         if (in_explicit_transaction_) {
           throw ExplicitTransactionUsageException("Nested transactions are not supported.");
         }
-        SetupInterpreterTransaction(extras);
-        // Multiple paths can lead to transaction BEGIN, so we need to reset the timer in the handler
-        current_timeout_deadline_ = CreateTimeoutDeadline(extras, interpreter_context_->config);
-        in_explicit_transaction_ = true;
-        expect_rollback_ = false;
         if (!current_db_.db_acc_)
           throw DatabaseContextRequiredException("No current database for transaction defined.");
         // Fail-closed on a broken database: an explicit transaction opens a data accessor and its queries
@@ -3935,8 +3935,16 @@ PreparedQuery Interpreter::PrepareTransactionQuery(Interpreter::TransactionQuery
         if ((*current_db_.db_acc_)->storage()->IsBroken()) {
           throw QueryException(kBrokenDatabaseError);
         }
+        // Accessor first: on the try_only path a would-block bail must leave interpreter txn state untouched
+        // (no id consumed, status still IDLE) so the caller can fall back to the blocking path.
         SetupDatabaseTransaction(true,
-                                 extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE);
+                                 extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE,
+                                 try_only);
+        SetupInterpreterTransaction(extras);
+        // Multiple paths can lead to transaction BEGIN, so we need to reset the timer in the handler
+        current_timeout_deadline_ = CreateTimeoutDeadline(extras, interpreter_context_->config);
+        in_explicit_transaction_ = true;
+        expect_rollback_ = false;
       };
     } break;
     case TransactionQuery::COMMIT: {
@@ -10195,9 +10203,9 @@ PreparedQuery PrepareUserProfileQuery(ParsedQuery parsed_query, InterpreterConte
 
 std::optional<uint64_t> Interpreter::GetTransactionId() const { return current_transaction_; }
 
-void Interpreter::BeginTransaction(QueryExtras const &extras) {
+void Interpreter::BeginTransaction(QueryExtras const &extras, bool try_only) {
   ResetInterpreter();
-  auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras);
+  auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras, try_only);
   prepared_query.query_handler(nullptr, {});
 }
 
@@ -11224,8 +11232,8 @@ void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privi
   }
 }
 
-void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type) {
-  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type);
+void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type, bool try_only) {
+  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type, try_only);
 }
 
 void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -263,7 +263,8 @@ struct CurrentDB {
   CurrentDB &operator=(CurrentDB const &) = delete;
 
   void SetupDatabaseTransaction(std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE);
+                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE,
+                                bool try_only = false);
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {
@@ -462,7 +463,7 @@ class Interpreter final {
   std::map<std::string, TypedValue> Pull(TStream *result_stream, std::optional<int> n = {},
                                          std::optional<int> qid = {});
 
-  void BeginTransaction(QueryExtras const &extras = {});
+  void BeginTransaction(QueryExtras const &extras = {}, bool try_only = false);
 
   std::optional<uint64_t> GetTransactionId() const;
 
@@ -687,7 +688,8 @@ class Interpreter final {
 
   static void AppendNotificationToSummary(const Notification &notification, std::map<std::string, TypedValue> &summary);
 
-  PreparedQuery PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum, QueryExtras const &extras = {});
+  PreparedQuery PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum, QueryExtras const &extras = {},
+                                        bool try_only = false);
   void Commit();
   // Resets tx-tracking left ACTIVE by SetupInterpreterTransaction when NOTHING skips Commit()/Abort()'s cleanup.
   void FinishAutocommitNothing();
@@ -703,7 +705,8 @@ class Interpreter final {
   std::optional<std::function<void(std::string_view)>> on_change_{};
   void SetupInterpreterTransaction(const QueryExtras &extras);
   void SetupDatabaseTransaction(bool couldCommit,
-                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE);
+                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE,
+                                bool try_only = false);
 };
 
 template <typename TStream>

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2492,7 +2492,9 @@ auto DiskStorage::DiskAccessor::PointVertices(LabelId /*label*/, PropertyId /*pr
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PointIndexStorage DiskStorage::empty_point_index_ = PointIndexStorage{};
 
-Transaction DiskStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) {
+Transaction DiskStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                           bool try_engine) {
+  MG_ASSERT(!try_engine, "DiskStorage has no non-blocking transaction mint");
   /// We acquire the transaction engine lock here because we access (and
   /// modify) the transaction engine variables (`transaction_id` and
   /// `timestamp`) below.

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -628,7 +628,8 @@ class DiskStorage final : public Storage {
 
   RocksDBStorage *GetRocksDBStorage() const { return kvstore_.get(); }
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                bool try_engine = false) override;
 
   void SetEdgeImportMode(EdgeImportMode edge_import_status);
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -607,8 +607,9 @@ void InMemoryStorage::UpdateLabelCount(LabelId const label, int64_t const change
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryStorage *storage,
                                                     std::optional<IsolationLevel> override_isolation_level,
-                                                    utils::ResourceLockGuard guard)
-    : Accessor(storage, override_isolation_level, std::move(guard)), config_(storage->config_.salient.items) {}
+                                                    utils::ResourceLockGuard guard, bool try_engine)
+    : Accessor(storage, override_isolation_level, std::move(guard), try_engine),
+      config_(storage->config_.salient.items) {}
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryAccessor &&other) noexcept
     : Accessor(std::move(other)), config_(other.config_) {}
@@ -2862,7 +2863,8 @@ std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::FindEdge(Gid edge
   return EdgeAccessor::Create(edge_ref, edge_type, from, to, storage_, &transaction_, view);
 }
 
-Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) {
+Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                               bool try_engine) {
   // We acquire the transaction engine lock here because we access (and
   // modify) the transaction engine variables (`transaction_id` and
   // `timestamp`) below.
@@ -2873,7 +2875,14 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
   ActiveIndicesPtr active_indices;
   ActiveConstraintsPtr active_constraints;
   {
-    auto guard = std::lock_guard{engine_lock_};
+    // The try_lock must precede every mutation below, so a contended non-blocking probe bails
+    // (throws) having changed nothing (no transaction_id_/timestamp_ bump, no index/constraint read).
+    auto guard = std::unique_lock{engine_lock_, std::defer_lock};
+    if (try_engine) {
+      if (!guard.try_lock()) throw TransactionEngineWouldBlock{};
+    } else {
+      guard.lock();
+    }
     transaction_id = transaction_id_++;
     start_timestamp = timestamp_++;
     // IMPORTANT: this is retrieved while under the lock so that the index is consistant with the timestamp
@@ -4833,7 +4842,12 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccess(StorageAccessType 
                                                               std::optional<IsolationLevel> override_isolation_level) {
   utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::try_to_lock};
   if (!guard.owns_lock()) return nullptr;
-  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{this, override_isolation_level, std::move(guard)});
+  try {
+    return std::unique_ptr<InMemoryAccessor>(
+        new InMemoryAccessor{this, override_isolation_level, std::move(guard), /*try_engine=*/true});
+  } catch (const TransactionEngineWouldBlock &) {
+    return nullptr;  // engine lock contended (e.g. a write-commit's durability phase); caller falls back to pool
+  }
 }
 
 void InMemoryStorage::CreateSnapshotHandler(

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -167,7 +167,7 @@ class InMemoryStorage final : public Storage {
 
     /// Takes ownership of a hold the caller acquired; see Accessor's constructor.
     explicit InMemoryAccessor(InMemoryStorage *storage, std::optional<IsolationLevel> override_isolation_level,
-                              utils::ResourceLockGuard guard);
+                              utils::ResourceLockGuard guard, bool try_engine = false);
 
     std::expected<void, ConstraintViolation> ExistenceConstraintsViolation() const;
 
@@ -852,7 +852,8 @@ class InMemoryStorage final : public Storage {
   void CreateSnapshotHandler(
       std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb);
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                bool try_engine = false) override;
 
   void SetStorageMode(StorageMode storage_mode);
 

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -121,14 +121,14 @@ std::unique_ptr<Accessor> Storage::ReadOnlyAccess(std::optional<IsolationLevel> 
 std::unique_ptr<Accessor> Storage::ReadOnlyAccess() { return ReadOnlyAccess({}, std::nullopt); }
 
 Storage::Accessor::Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level,
-                            utils::ResourceLockGuard guard)
+                            utils::ResourceLockGuard guard, bool try_engine)
     : storage_(storage),
       // The hold is taken before the transaction is created, so a freshly created transaction can
       // never dangle in an active state during an exclusive operation.
       guard_(std::move(guard)),
       // Both reads are under guard_, already constructed above, so the hold pins them.
       transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
-                                              storage->storage_mode_)),
+                                              storage->storage_mode_, try_engine)),
       is_transaction_active_(true),
       original_access_type_(ToAccessType(guard_.type())) {
   DMG_ASSERT(guard_.owns_lock() && guard_.mutex() == std::addressof(storage_->main_lock_),

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <atomic>
+#include <exception>
 #include <optional>
 #include <set>
 #include <string>
@@ -44,6 +45,10 @@
 #include "storage/v2/vertices_iterable.hpp"
 #include "utils/resource_lock.hpp"
 #include "utils/synchronized_metadata_store.hpp"
+
+// Test-only: fixture in tests/unit/storage_v2.cpp (global namespace); forward-declared so the
+// qualified friend in Storage below names an existing entity.
+class StorageEngineLockContentionTest;
 
 namespace memgraph::metrics {
 struct DatabaseMetricHandles;
@@ -280,6 +285,9 @@ class Storage {
   friend class ReplicationServer;
   friend class ReplicationStorageClient;
   friend class VectorIndex;
+  // Test-only: lets StorageEngineLockContentionTest hold engine_lock_ to verify the non-blocking
+  // TryAccess bail (see tests/unit/storage_v2.cpp).
+  friend class ::StorageEngineLockContentionTest;
 
  public:
   Storage(Config config, StorageMode storage_mode, PlanInvalidatorPtr invalidator,
@@ -387,7 +395,8 @@ class Storage {
 
   virtual void UpdateLabelCount(LabelId label, int64_t change) = 0;
 
-  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) = 0;
+  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                        bool try_engine = false) = 0;
 
   virtual void PrepareForNewEpoch() = 0;
 
@@ -538,11 +547,20 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
 utils::ResourceLockGuard AcquireGuardOrThrow(Storage *storage, StorageAccessType rw_type,
                                              std::optional<std::chrono::milliseconds> timeout);
 
+// Thrown by CreateTransaction(..., try_engine=true) when the transaction-engine lock is held by a
+// concurrent commit/GC, so a non-blocking probe (TryAccess) can bail instead of blocking. Caught in
+// TryAccess and turned into a nullptr; never surfaces to callers.
+struct TransactionEngineWouldBlock final : std::exception {
+  const char *what() const noexcept override { return "transaction engine lock busy"; }
+};
+
 class Accessor {
  public:
   /// Takes ownership of a hold on `storage`'s main_lock_. The caller acquires it: blocking with a
   /// timeout via AcquireGuardOrThrow, or non-blocking via a try_to_lock guard. Construction itself
-  /// never blocks and never fails, so a probe can decide whether to build an accessor at all.
+  /// never blocks and never fails, EXCEPT on the `try_engine` probe path: with try_engine=true the
+  /// mint try-locks the transaction-engine lock and throws TransactionEngineWouldBlock if it is
+  /// contended, so a probe can decide whether to build an accessor at all without blocking.
   ///
   /// The access type comes from the guard, not alongside it. It is recorded as
   /// original_access_type_, which the WAL carries to replicas to pick the mode they replay under,
@@ -552,7 +570,8 @@ class Accessor {
   /// The isolation level and storage mode are read from `storage` under the guard rather than
   /// passed in: SetIsolationLevel and SetStorageMode write them under UNIQUE, so a caller reading
   /// them before acquiring could build a transaction against a mode that has since changed.
-  Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level, utils::ResourceLockGuard guard);
+  Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level, utils::ResourceLockGuard guard,
+           bool try_engine = false);
 
   Accessor(const Accessor &) = delete;
   Accessor &operator=(const Accessor &) = delete;

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -168,6 +168,8 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   void Configure(const bolt_map_t &) {}
 
+  bool ConfigureWouldBeNoOp(const bolt_map_t &) const { return true; }
+
   std::string GetCurrentDB() const { return ""; }
 
   void TestHook_ShouldAbort() { should_abort_ = true; }

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -114,7 +114,9 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   bolt_map_t Discard(std::optional<int> /*unused*/, std::optional<int> /*unused*/) { return {}; }
 
-  void BeginTransaction(const bolt_map_t &extra) {
+  void BeginTransaction(const bolt_map_t &extra, bool try_only = false) {
+    // Simulate a contended storage lock (e.g. held UNIQUE) on the non-blocking inline path only.
+    if (try_only && fail_try_) throw memgraph::query::WouldBlockInlineException{};
     if (extra.contains("tx_metadata")) {
       auto const &metadata = extra.at("tx_metadata").ValueMap();
       if (!metadata.empty()) md_ = metadata;
@@ -170,6 +172,8 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   void TestHook_ShouldAbort() { should_abort_ = true; }
 
+  void TestHook_FailTry() { fail_try_ = true; }
+
   void Execute() {
     while (Execute_(*this)) {
       // Execute now exists on result, so it can be schduled again.
@@ -177,10 +181,15 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
     }
   }
 
+  memgraph::communication::bolt::InlineBeginResult TryInlineBegin() { return TryInlineBegin_(*this); }
+
+  void FinishPendingBeginBlocking() { FinishPendingBeginBlocking_(*this); }
+
  private:
   std::string query_;
   bolt_map_t md_;
   bool should_abort_ = false;
+  bool fail_try_{false};
 };
 
 // TODO: This could be done in fixture.
@@ -1325,4 +1334,65 @@ TEST(BoltSession, PartialStream) {
     auto const find_msg = std::search(cbegin(output), cend(output), cbegin(error_msg), cend(error_msg));
     EXPECT_NE(find_msg, cend(output));
   }
+}
+
+// A minimal single-chunk BEGIN with an empty extras map:
+//   0x00 0x03           chunk size 3
+//   0xB1                TinyStruct1
+//   0x11                Begin signature
+//   0xA0                empty TinyMap (extras)
+//   0x00 0x00           end-of-message terminator
+static constexpr std::array<uint8_t, 7> begin_bytes{0x00, 0x03, 0xB1, 0x11, 0xA0, 0x00, 0x00};
+
+using memgraph::communication::bolt::InlineBeginResult;
+
+TEST(BoltSession, InlineBeginHandledWhenLockFree) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  output.clear();  // scope the assertion below to the inline reply
+
+  EXPECT_EQ(session.TryInlineBegin(), InlineBeginResult::Handled);
+  EXPECT_EQ(session.state_, State::Idle);
+  EXPECT_FALSE(output.empty());          // a SUCCESS was written inline
+  EXPECT_EQ(input_stream.size(), 0ul);   // the BEGIN was consumed
+}
+
+TEST(BoltSession, InlineBeginNotBeginLeavesBufferIntact) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // A RUN message (signature 0x10) is not a BEGIN; the non-destructive peek must leave it for the pool path.
+  WriteRunRequest(input_stream, kQueryReturn42, true);
+  const auto size_before = input_stream.size();
+
+  EXPECT_EQ(session.TryInlineBegin(), InlineBeginResult::NotBegin);
+  EXPECT_EQ(input_stream.size(), size_before);  // nothing consumed
+}
+
+TEST(BoltSession, InlineBeginWouldBlockThenPoolFallback) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  session.TestHook_FailTry();  // simulate a contended storage lock on the non-blocking try
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  output.clear();
+
+  EXPECT_EQ(session.TryInlineBegin(), InlineBeginResult::WouldBlock);
+  EXPECT_TRUE(output.empty());  // a would-block does not reply inline
+
+  // The blocking path (try_only=false) is not gated by fail_try_, so it completes the BEGIN.
+  session.FinishPendingBeginBlocking();
+  EXPECT_FALSE(output.empty());  // SUCCESS now written
+  EXPECT_EQ(session.state_, State::Idle);
 }

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3198,3 +3198,35 @@ TEST_F(StorageTryAccessTest, ReadOnlyHeldBlocksNewWrite) {
   ASSERT_NE(write_acc, nullptr);
   EXPECT_NO_THROW(write_acc->Abort());
 }
+
+// TryAccess is non-blocking on the transaction-engine lock: CreateTransaction(..., try_engine=true)
+// does engine_lock_.try_lock() and, on failure, throws TransactionEngineWouldBlock, which TryAccess
+// turns into nullptr so the inline-BEGIN caller falls back to the pool instead of busy-spinning the
+// strand. StorageTryAccessTest covers the free (try_lock succeeds) side; this covers the contended
+// side deterministically: utils::SpinLock is non-recursive, so a single test thread that already
+// holds engine_lock_ forces the internal try_lock() to fail.
+class StorageEngineLockContentionTest : public ::testing::Test {
+ protected:
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+
+  // TEST_F's body runs in a class derived from this fixture, and friendship is not inherited, so the
+  // private engine_lock_ access must live in a member of the befriended fixture itself.
+  void LockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.lock(); }
+  void UnlockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.unlock(); }
+};
+
+TEST_F(StorageEngineLockContentionTest, EngineLockHeldMakesTryAccessBailWithoutBlocking) {
+  using namespace memgraph::storage;
+
+  // Hold the transaction-engine lock, as a concurrent write-commit's durability phase would.
+  LockEngine();
+  // A non-blocking probe must bail (return nullptr) rather than busy-spin the (would-be strand) thread.
+  EXPECT_EQ(store.TryAccess(READ), nullptr);
+  EXPECT_EQ(store.TryAccess(WRITE), nullptr);
+  UnlockEngine();
+
+  // Once released, the same probe succeeds and yields a usable accessor.
+  auto acc = store.TryAccess(READ);
+  EXPECT_NE(acc, nullptr);
+}


### PR DESCRIPTION
### Problem

Explicit / managed transactions (BEGIN … RUN … COMMIT) pay a priority-thread-pool dispatch plus a worker wake **per BEGIN**. BEGIN is bounded and cheap in everything but the storage-accessor acquisition; under chatty explicit-transaction workloads that per-BEGIN hop is measurable overhead.

### What this does

Runs an eligible BEGIN **inline on the Bolt strand/IO thread**, skipping the pool dispatch, and falls back to the pool only when it genuinely must. The accessor is acquired **non-blockingly**; transaction/snapshot semantics are unchanged (`start_timestamp` still pinned at BEGIN, `MessageSuccess` sent exactly once).

### Stacked on #4662

This is stacked on **#4662 (per-query AsyncTimer → steady_clock deadline)** — not a convenience: an inline BEGIN under the default 600 s execution timeout would otherwise construct a per-query `AsyncTimer`, inserting into the **process-global `expiration_flags` skiplist under a SpinLock** on the strand — the exact contention measured at ~66 % CPU in the incident. #4662 removes that structure, so the inline path never touches it. **Review/merge #4662 first.**

### Provably non-blocking on the strand (concurrency-audited)

A concurrency audit enumerated every lock/blocking op reachable on the inline path and classified each as non-blocking / bounded-leaf / **strand-hazard**. All unconditional strand hazards are closed:

| Hazard | Resolution |
|---|---|
| `main_lock_` (storage access) | `TryAccess` acquires it `try_to_lock`; contention → pool fallback |
| `engine_lock_` (transaction mint) | `try_engine` threaded through `CreateTransaction`/`Accessor` ctors → `engine_lock_.try_lock()`; contention throws the internal `TransactionEngineWouldBlock` → `nullptr` → `WouldBlockInlineException` → pool. try_lock precedes any id/timestamp mutation; RAII releases the held `main_lock_` on the throw. Disk asserts it is never asked for the non-blocking mint. |
| AsyncTimer global skiplist | eliminated by the #4662 deadline change (no per-BEGIN global insert) |
| `dbms_handler` / `auth` locks (DB-switch / impersonation in `Configure`) | inline path gated on `ConfigureWouldBeNoOp`; a BEGIN needing a real reconfigure bails to the pool, where `Configure` runs. Also fixes a latent bug: the prior inline path called `Configure` on the strand unconditionally. |

**Documented residual (accepted):** the `active_indices_`/`active_constraints_` snapshot read nested under `engine_lock_` can briefly (sub-µs — one `shared_ptr` move) block a READ inline-BEGIN against a concurrent READ_ONLY index publish. Closing it safely would risk the timestamp↔index-consistency invariant (those reads follow the id/timestamp bump), so it is left as-is.

### How it's built (bottom-up)

- **storage**: `dbms::Database::TryAccess` non-blocking probe (in-memory only; `nullptr` on-disk → pool). `try_engine` non-blocking transaction mint (this PR's hardening).
- **interpreter**: `try_only` threaded `BeginTransaction`→`SetupDatabaseTransaction`; BEGIN handler reordered so guards + accessor precede `SetupInterpreterTransaction` (a would-block bail leaves state pristine — no txn id consumed, status still IDLE); `WouldBlockInlineException` (not a `QueryException`).
- **bolt session**: `TryInlineBegin_` / `FinishPendingBeginBlocking_` + `InlineBeginResult`; non-destructive raw peek detects a fully-arrived single-chunk BEGIN (v4+, idle) before any dechunk; the `Configure` gate; `Configure` moved into the pool fallback.
- **communication/v2**: `OnRead` runs an eligible BEGIN inline; `WouldBlock` → pool fallback completing the BEGIN with a blocking accessor.

### Tests

- `storage_v2.cpp`: deterministic **engine_lock-held → `TryAccess` returns `nullptr`** (mints no transaction), then succeeds once released — via a single test friend on `Storage`, single-threaded (non-recursive SpinLock).
- `bolt_session.cpp`: inline BEGIN when free → `Handled` (no pool dispatch); non-BEGIN → `NotBegin` with the input buffer byte-for-byte intact (proves the non-destructive peek); simulated would-block → pool fallback commits.

### Validation

All changed TUs compile clean under toolchain-v7 with production RelWithDebInfo flags (per-TU `-fsyntax-only`; full link + test execution is blocked on this box by the toolchain-v8/libuuid requirement). **CI is the authoritative link + test validator.**
