### PR TITLE
perf(query): route write-free COMMIT to HIGH priority

### DIFF
--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -234,12 +234,11 @@ utils::Priority SessionHL::ApproximateQueryPriority() const {
   if (parsed_res_ && state_ == memgraph::communication::bolt::State::Parsed) {
     return std::visit(utils::Overloaded{
                           [this](const query::Interpreter::TransactionQuery &tx_query) {
-                            // BEGIN; COMMIT; ROLLBACK -> LOW, EXCEPT a read-only COMMIT: it is near-noop (no
-                            // engine_lock/WAL/replication), so route it HIGH to drain in-flight read transactions
-                            // fast instead of queueing them behind heavy LOW work (which keeps them open and pins
-                            // the GC horizon).
+                            // A write-free COMMIT is a near-noop (empty deltas -> no engine_lock/WAL/replication);
+                            // route it HIGH so read txns drain fast instead of queueing behind heavy LOW work
+                            // (which keeps them open and pins the GC horizon). BEGIN/ROLLBACK/write-COMMIT stay LOW.
                             if (tx_query == query::Interpreter::TransactionQuery::COMMIT &&
-                                interpreter_.IsCurrentTransactionRead()) {
+                                interpreter_.IsCurrentTransactionEmpty()) {
                               return utils::Priority::HIGH;
                             }
                             return utils::Priority::LOW;

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -233,8 +233,15 @@ utils::Priority SessionHL::ApproximateQueryPriority() const {
   // Query has been parsed and a priority can be determined
   if (parsed_res_ && state_ == memgraph::communication::bolt::State::Parsed) {
     return std::visit(utils::Overloaded{
-                          [](const query::Interpreter::TransactionQuery &) {
-                            // BEGIN; COMMIT; ROLLBACK
+                          [this](const query::Interpreter::TransactionQuery &tx_query) {
+                            // BEGIN; COMMIT; ROLLBACK -> LOW, EXCEPT a read-only COMMIT: it is near-noop (no
+                            // engine_lock/WAL/replication), so route it HIGH to drain in-flight read transactions
+                            // fast instead of queueing them behind heavy LOW work (which keeps them open and pins
+                            // the GC horizon).
+                            if (tx_query == query::Interpreter::TransactionQuery::COMMIT &&
+                                interpreter_.IsCurrentTransactionRead()) {
+                              return utils::Priority::HIGH;
+                            }
                             return utils::Priority::LOW;
                           },
                           [](const query::Interpreter::ParseInfo &parse_info) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10193,9 +10193,10 @@ PreparedQuery PrepareUserProfileQuery(ParsedQuery parsed_query, InterpreterConte
 
 std::optional<uint64_t> Interpreter::GetTransactionId() const { return current_transaction_; }
 
-bool Interpreter::IsCurrentTransactionRead() const {
-  return current_db_.db_transactional_accessor_ &&
-         current_db_.db_transactional_accessor_->original_access_type() == storage::StorageAccessType::READ;
+bool Interpreter::IsCurrentTransactionEmpty() const {
+  if (!current_db_.db_transactional_accessor_) return false;
+  const auto *txn = current_db_.db_transactional_accessor_->GetTransaction();
+  return txn->deltas.empty() && txn->md_deltas.empty();
 }
 
 void Interpreter::BeginTransaction(QueryExtras const &extras) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10193,6 +10193,11 @@ PreparedQuery PrepareUserProfileQuery(ParsedQuery parsed_query, InterpreterConte
 
 std::optional<uint64_t> Interpreter::GetTransactionId() const { return current_transaction_; }
 
+bool Interpreter::IsCurrentTransactionRead() const {
+  return current_db_.db_transactional_accessor_ &&
+         current_db_.db_transactional_accessor_->original_access_type() == storage::StorageAccessType::READ;
+}
+
 void Interpreter::BeginTransaction(QueryExtras const &extras) {
   ResetInterpreter();
   auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras);

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -466,6 +466,11 @@ class Interpreter final {
 
   std::optional<uint64_t> GetTransactionId() const;
 
+  // True iff an active transaction is open as READ (declared read-only at BEGIN). A read-only COMMIT
+  // is near-noop (no engine_lock/WAL/replication), so the scheduler routes it HIGH to drain fast and
+  // keep in-flight read transactions from piling up (which would pin the GC horizon).
+  bool IsCurrentTransactionRead() const;
+
   // Returns the notification produced by the commit, if any. A SYNC replication failure does not abort the
   // transaction, so it is reported as a notification instead of an exception.
   std::optional<Notification> CommitTransaction();

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -466,10 +466,8 @@ class Interpreter final {
 
   std::optional<uint64_t> GetTransactionId() const;
 
-  // True iff an active transaction is open as READ (declared read-only at BEGIN). A read-only COMMIT
-  // is near-noop (no engine_lock/WAL/replication), so the scheduler routes it HIGH to drain fast and
-  // keep in-flight read transactions from piling up (which would pin the GC horizon).
-  bool IsCurrentTransactionRead() const;
+  // True iff an active transaction has no pending writes; its COMMIT is a near-noop the scheduler routes HIGH.
+  bool IsCurrentTransactionEmpty() const;
 
   // Returns the notification produced by the commit, if any. A SYNC replication failure does not abort the
   // transaction, so it is reported as a notification instead of an exception.

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -2700,27 +2700,32 @@ TYPED_TEST(InterpreterTest, CommitIsLow) {
 }
 
 // SessionHL::ApproximateQueryPriority routes an explicit COMMIT to HIGH only when the active transaction
-// was opened READ (client declared mode="r" at BEGIN); a write COMMIT stays LOW. The routing's sole
-// discriminator is Interpreter::IsCurrentTransactionRead() -- the SessionHL glue itself is a Bolt session
-// (covered by e2e), so assert the predicate that drives it. (CommitIsLow above exercises the unrelated
-// GetQueryPriority path, which stores LOW on the prepared COMMIT regardless of transaction mode.)
-TYPED_TEST(InterpreterTest, ReadOnlyTransactionRoutesCommitHigh) {
+// has no pending writes (empty deltas), because only then is the COMMIT a near-noop (no
+// engine_lock/WAL/replication). The routing's sole discriminator is Interpreter::IsCurrentTransactionEmpty()
+// -- the SessionHL glue itself is a Bolt session (covered by e2e), so assert the predicate that drives it.
+// (CommitIsLow above exercises the unrelated GetQueryPriority path, which stores LOW on the prepared COMMIT.)
+TYPED_TEST(InterpreterTest, EmptyTransactionRoutesCommitHigh) {
   auto &interpreter = this->default_interpreter.interpreter;
   // No active transaction -> nothing to promote.
-  EXPECT_FALSE(interpreter.IsCurrentTransactionRead());
+  EXPECT_FALSE(interpreter.IsCurrentTransactionEmpty());
 
   interpreter.BeginTransaction(memgraph::query::QueryExtras{.is_read = true});
-  EXPECT_TRUE(interpreter.IsCurrentTransactionRead());  // read-only COMMIT would be routed HIGH
+  EXPECT_TRUE(interpreter.IsCurrentTransactionEmpty());  // no writes -> COMMIT routed HIGH
   interpreter.RollbackTransaction();
 
   // Cleared once the transaction ends.
-  EXPECT_FALSE(interpreter.IsCurrentTransactionRead());
+  EXPECT_FALSE(interpreter.IsCurrentTransactionEmpty());
 }
 
-TYPED_TEST(InterpreterTest, WriteTransactionKeepsCommitLow) {
+// The signal is deltas, not the declared read/write mode: a write-capable transaction that actually
+// wrote has deltas, so its COMMIT is not a noop and stays LOW. (A write-capable transaction that only
+// read would have empty deltas and route HIGH -- the case the plain read/write mode flag would miss.)
+TYPED_TEST(InterpreterTest, TransactionWithWritesKeepsCommitLow) {
   auto &interpreter = this->default_interpreter.interpreter;
   interpreter.BeginTransaction(memgraph::query::QueryExtras{.is_read = false});
-  EXPECT_FALSE(interpreter.IsCurrentTransactionRead());  // write COMMIT stays LOW
+  auto [stream, qid] = this->Prepare("CREATE (:Node)");
+  this->Pull(&stream);
+  EXPECT_FALSE(interpreter.IsCurrentTransactionEmpty());  // wrote deltas -> COMMIT stays LOW
   interpreter.RollbackTransaction();
 }
 

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -2699,6 +2699,31 @@ TYPED_TEST(InterpreterTest, CommitIsLow) {
   EXPECT_EQ(this->default_interpreter.interpreter.GetQueryPriority(qid), memgraph::utils::Priority::LOW);
 }
 
+// SessionHL::ApproximateQueryPriority routes an explicit COMMIT to HIGH only when the active transaction
+// was opened READ (client declared mode="r" at BEGIN); a write COMMIT stays LOW. The routing's sole
+// discriminator is Interpreter::IsCurrentTransactionRead() -- the SessionHL glue itself is a Bolt session
+// (covered by e2e), so assert the predicate that drives it. (CommitIsLow above exercises the unrelated
+// GetQueryPriority path, which stores LOW on the prepared COMMIT regardless of transaction mode.)
+TYPED_TEST(InterpreterTest, ReadOnlyTransactionRoutesCommitHigh) {
+  auto &interpreter = this->default_interpreter.interpreter;
+  // No active transaction -> nothing to promote.
+  EXPECT_FALSE(interpreter.IsCurrentTransactionRead());
+
+  interpreter.BeginTransaction(memgraph::query::QueryExtras{.is_read = true});
+  EXPECT_TRUE(interpreter.IsCurrentTransactionRead());  // read-only COMMIT would be routed HIGH
+  interpreter.RollbackTransaction();
+
+  // Cleared once the transaction ends.
+  EXPECT_FALSE(interpreter.IsCurrentTransactionRead());
+}
+
+TYPED_TEST(InterpreterTest, WriteTransactionKeepsCommitLow) {
+  auto &interpreter = this->default_interpreter.interpreter;
+  interpreter.BeginTransaction(memgraph::query::QueryExtras{.is_read = false});
+  EXPECT_FALSE(interpreter.IsCurrentTransactionRead());  // write COMMIT stays LOW
+  interpreter.RollbackTransaction();
+}
+
 TYPED_TEST(InterpreterTest, CreateIndexQueryPriorityIsLow) {
   auto [stream, qid] = this->Prepare("CREATE INDEX ON :Person(id)");
   EXPECT_EQ(this->default_interpreter.interpreter.GetQueryPriority(qid), memgraph::utils::Priority::LOW);


### PR DESCRIPTION
Routes a **write-free** transaction's `COMMIT` to the HIGH-priority worker so read transactions drain fast (avoids open-transaction pileup / a pinned GC horizon under load).

- `SessionHL::ApproximateQueryPriority()` promotes the COMMIT to HIGH when `Interpreter::IsCurrentTransactionEmpty()` (active accessor has empty `deltas` **and** `md_deltas`).
- This is the exact precondition for the commit's noop fast-path: `PrepareForCommitPhase` short-circuits an empty transaction to `commit_log_->MarkFinished` — no `engine_lock_`, no WAL, no replication — in both the in-memory and disk engines. So a HIGH-routed COMMIT is provably cheap and cannot carry a durability-wait or starve admin/health work.
- Keying on emptiness rather than the declared `mode="r"` flag also drains the common case a mode check misses: a default write-capable session running a read-only transaction (client never set `mode="r"`). A transaction that actually wrote has deltas, so its COMMIT stays LOW. BEGIN and ROLLBACK stay LOW.