### PR TITLE
perf(storage): bounded-try + reschedule BEGIN engine_lock (WS4)

### DIFF
--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -26,6 +26,8 @@
 #include "communication/bolt/v1/states/handshake.hpp"
 #include "communication/bolt/v1/states/init.hpp"
 #include "communication/metrics.hpp"
+#include "query/exceptions.hpp"        // WouldBlockInlineException (pending-BEGIN reschedule signal)
+#include "storage/v2/access_type.hpp"  // storage::EngineLockMode (BeginTransaction engine-mode arg)
 #include "utils/exceptions.hpp"
 #include "utils/session_context.hpp"
 #include "utils/timestamp.hpp"
@@ -157,6 +159,14 @@ class Session {
         return true;  // more data to process
       }
 
+      if (state_ == State::PendingBegin) {
+        // HandleBegin decoded a BEGIN whose engine-lock acquire would block and stashed it. Stop the dechunk
+        // loop WITHOUT reading the next chunk so no message pipelined behind the BEGIN runs before it finishes;
+        // decoder_buffer_ is left exactly after the fully-consumed BEGIN chunk. DoWork sees HasPendingBegin()
+        // and hands the completion to the pool (PostFinishPendingBegin).
+        return true;  // more data to process (the pending BEGIN, off-loop)
+      }
+
       if (state_ == State::Close) [[unlikely]] {
         // State::Close is handled here because we always want to check for
         // it after the above select. If any of the states above return a
@@ -170,6 +180,62 @@ class Session {
   void HandleError() {
     if (!at_least_one_run_) {
       spdlog::info("Sudden connection loss. Make sure the client supports Memgraph.");
+    }
+  }
+
+  // True once HandleBegin has stashed a would-block BEGIN (state_ == PendingBegin). DoWork uses this to hand
+  // the completion to the pool instead of continuing the dechunk loop.
+  bool HasPendingBegin() const { return pending_begin_extra_.has_value(); }
+
+  // Whether the underlying input stream still holds bytes the dechunk loop hasn't consumed. Used to decide
+  // whether the post-BEGIN resume re-enters the worker (DoWork) or waits for the next async read (DoRead).
+  bool HasBufferedData() const { return input_stream_.size() > 0; }
+
+  // Stash the BEGIN's decoded extras (and reset the reschedule count) after HandleBegin's bounded-try acquire
+  // bailed with WouldBlock, so FinishPendingBegin_ can retry the Access on the pool without re-decoding.
+  void StashPendingBegin(Value extra) {
+    pending_begin_extra_ = std::move(extra);
+    pending_begin_retries_ = 0;  // fresh BEGIN: start the reschedule fairness count over
+  }
+
+  // Pool-side completion of a BEGIN that bailed in HandleBegin with WouldBlock. Re-runs the FULL begin
+  // (Configure + BeginTransaction) on the worker; Configure re-running is idempotent (it early-outs), so it is
+  // safe to run here and across reschedules. Rather than block the worker on engine_lock_ behind a long write
+  // commit, it uses a bounded-spin acquire (TryBounded) and, on loss, returns Reschedule so the caller re-posts
+  // to the pool. After kBeginRescheduleCap reschedules it falls back to one Blocking acquire so the BEGIN cannot
+  // starve. The stash is consumed (reset) ONLY on a terminal outcome (Done/ClientError); on Reschedule it MUST
+  // stay stashed so the next attempt retries the Access without re-decoding. SUCCESS is emitted here and here
+  // only -- never on HandleBegin's bail path -- so the BEGIN yields exactly one SUCCESS.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  PendingBeginOutcome FinishPendingBegin_(TImpl &impl) {
+    MG_ASSERT(pending_begin_extra_.has_value(), "FinishPendingBegin_ without a pending BEGIN");
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+    const bool cap_reached = pending_begin_retries_ >= kBeginRescheduleCap;
+    const auto mode =
+        cap_reached ? memgraph::storage::EngineLockMode::Blocking : memgraph::storage::EngineLockMode::TryBounded;
+    const Value &extra = *pending_begin_extra_;  // reference, NOT move -- may need it again on reschedule
+    try {
+      impl.Configure(extra.ValueMap());               // real reconfigure runs here, on the worker (blocking OK)
+      impl.BeginTransaction(extra.ValueMap(), mode);  // bounded-try (or blocking at the cap) Access on the worker
+      if (!encoder_.MessageSuccess({})) {
+        state_ = State::Close;
+        pending_begin_extra_.reset();
+        return PendingBeginOutcome::ClientError;
+      }
+      state_ = State::Idle;
+      pending_begin_extra_.reset();  // consume on success
+      return PendingBeginOutcome::Done;
+    } catch (const memgraph::query::WouldBlockInlineException &) {
+      // Reachable only when mode == TryBounded (Blocking never throws it). Keep extras stashed and reschedule.
+      ++pending_begin_retries_;
+      return PendingBeginOutcome::Reschedule;  // pending_begin_extra_ intentionally NOT reset
+    } catch (const std::exception &e) {
+      state_ = HandleFailure(impl, e);
+      pending_begin_extra_.reset();  // consume on error
+      return PendingBeginOutcome::ClientError;
     }
   }
 
@@ -216,6 +282,16 @@ class Session {
   }
 
  private:
+  // Extras decoded by a BEGIN that bailed in HandleBegin with WouldBlock, carried across the worker->pool
+  // reschedule so FinishPendingBegin_ can retry the Access without re-decoding the chunk.
+  std::optional<Value> pending_begin_extra_{};
+
+  // Number of times FinishPendingBegin_ has lost the bounded-try engine-lock race for the current pending BEGIN.
+  // Reset to 0 when a fresh BEGIN is stashed (StashPendingBegin).
+  uint32_t pending_begin_retries_{0};
+  // After this many reschedules, FinishPendingBegin_ does one blocking acquire (fairness: a BEGIN cannot starve).
+  static constexpr uint32_t kBeginRescheduleCap = 32;
+
   const std::string kTimestampFormat = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}";
   const std::string session_uuid_;  //!< unique identifier of the session (auto generated)
   const std::string login_timestamp_;

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -160,11 +160,9 @@ class Session {
       }
 
       if (state_ == State::PendingBegin) {
-        // HandleBegin decoded a BEGIN whose engine-lock acquire would block and stashed it. Stop the dechunk
-        // loop WITHOUT reading the next chunk so no message pipelined behind the BEGIN runs before it finishes;
-        // decoder_buffer_ is left exactly after the fully-consumed BEGIN chunk. DoWork sees HasPendingBegin()
-        // and hands the completion to the pool (PostFinishPendingBegin).
-        return true;  // more data to process (the pending BEGIN, off-loop)
+        // HandleBegin stashed a would-block BEGIN. Stop the dechunk loop WITHOUT reading the next chunk so a
+        // message pipelined behind the BEGIN can't run before it finishes; DoWork hands the completion to the pool.
+        return true;  // more data to process
       }
 
       if (state_ == State::Close) [[unlikely]] {
@@ -183,29 +181,22 @@ class Session {
     }
   }
 
-  // True once HandleBegin has stashed a would-block BEGIN (state_ == PendingBegin). DoWork uses this to hand
-  // the completion to the pool instead of continuing the dechunk loop.
+  // Used by DoWork to hand a stashed would-block BEGIN off to the pool instead of continuing the dechunk loop.
   bool HasPendingBegin() const { return pending_begin_extra_.has_value(); }
 
-  // Whether the underlying input stream still holds bytes the dechunk loop hasn't consumed. Used to decide
-  // whether the post-BEGIN resume re-enters the worker (DoWork) or waits for the next async read (DoRead).
+  // Decides whether the post-BEGIN resume re-enters the worker (DoWork) or waits for the next async read (DoRead).
   bool HasBufferedData() const { return input_stream_.size() > 0; }
 
-  // Stash the BEGIN's decoded extras (and reset the reschedule count) after HandleBegin's bounded-try acquire
-  // bailed with WouldBlock, so FinishPendingBegin_ can retry the Access on the pool without re-decoding.
+  // Stash the BEGIN's decoded extras after HandleBegin's bounded-try acquire bailed with WouldBlock, so
+  // FinishPendingBegin_ can retry the Access on the pool without re-decoding.
   void StashPendingBegin(Value extra) {
     pending_begin_extra_ = std::move(extra);
-    pending_begin_retries_ = 0;  // fresh BEGIN: start the reschedule fairness count over
+    pending_begin_retries_ = 0;
   }
 
-  // Pool-side completion of a BEGIN that bailed in HandleBegin with WouldBlock. Re-runs the FULL begin
-  // (Configure + BeginTransaction) on the worker; Configure re-running is idempotent (it early-outs), so it is
-  // safe to run here and across reschedules. Rather than block the worker on engine_lock_ behind a long write
-  // commit, it uses a bounded-spin acquire (TryBounded) and, on loss, returns Reschedule so the caller re-posts
-  // to the pool. After kBeginRescheduleCap reschedules it falls back to one Blocking acquire so the BEGIN cannot
-  // starve. The stash is consumed (reset) ONLY on a terminal outcome (Done/ClientError); on Reschedule it MUST
-  // stay stashed so the next attempt retries the Access without re-decoding. SUCCESS is emitted here and here
-  // only -- never on HandleBegin's bail path -- so the BEGIN yields exactly one SUCCESS.
+  // Pool-side completion of a BEGIN that HandleBegin bailed on with WouldBlock. Retries the Access with a
+  // bounded-try acquire (Blocking after kBeginRescheduleCap, so it can't starve); on loss returns Reschedule
+  // with the stash intact. Emits the BEGIN's one and only SUCCESS -- never on HandleBegin's bail path.
   template <typename TImpl>
     requires requires(TImpl &impl) {
       { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
@@ -218,23 +209,24 @@ class Session {
         cap_reached ? memgraph::storage::EngineLockMode::Blocking : memgraph::storage::EngineLockMode::TryBounded;
     const Value &extra = *pending_begin_extra_;  // reference, NOT move -- may need it again on reschedule
     try {
-      impl.Configure(extra.ValueMap());               // real reconfigure runs here, on the worker (blocking OK)
-      impl.BeginTransaction(extra.ValueMap(), mode);  // bounded-try (or blocking at the cap) Access on the worker
+      impl.Configure(
+          extra.ValueMap());  // idempotent on identical extras (early-outs), so safe to re-run across reschedules
+      impl.BeginTransaction(extra.ValueMap(), mode);
       if (!encoder_.MessageSuccess({})) {
         state_ = State::Close;
         pending_begin_extra_.reset();
         return PendingBeginOutcome::ClientError;
       }
       state_ = State::Idle;
-      pending_begin_extra_.reset();  // consume on success
+      pending_begin_extra_.reset();
       return PendingBeginOutcome::Done;
     } catch (const memgraph::query::WouldBlockInlineException &) {
-      // Reachable only when mode == TryBounded (Blocking never throws it). Keep extras stashed and reschedule.
+      // Only TryBounded throws this; Blocking (at the cap) never does, so the cap terminates the reschedule loop.
       ++pending_begin_retries_;
       return PendingBeginOutcome::Reschedule;  // pending_begin_extra_ intentionally NOT reset
     } catch (const std::exception &e) {
       state_ = HandleFailure(impl, e);
-      pending_begin_extra_.reset();  // consume on error
+      pending_begin_extra_.reset();
       return PendingBeginOutcome::ClientError;
     }
   }
@@ -282,12 +274,10 @@ class Session {
   }
 
  private:
-  // Extras decoded by a BEGIN that bailed in HandleBegin with WouldBlock, carried across the worker->pool
-  // reschedule so FinishPendingBegin_ can retry the Access without re-decoding the chunk.
+  // BEGIN extras stashed on a WouldBlock bail, carried across the worker->pool reschedule (retry without re-decoding).
   std::optional<Value> pending_begin_extra_{};
 
-  // Number of times FinishPendingBegin_ has lost the bounded-try engine-lock race for the current pending BEGIN.
-  // Reset to 0 when a fresh BEGIN is stashed (StashPendingBegin).
+  // Times FinishPendingBegin_ lost the bounded-try engine-lock race for the current BEGIN; reset on a fresh stash.
   uint32_t pending_begin_retries_{0};
   // After this many reschedules, FinishPendingBegin_ does one blocking acquire (fairness: a BEGIN cannot starve).
   static constexpr uint32_t kBeginRescheduleCap = 32;

--- a/src/communication/bolt/v1/state.hpp
+++ b/src/communication/bolt/v1/state.hpp
@@ -49,6 +49,13 @@ enum class State : uint8_t {
   Result,
 
   /**
+   * A BEGIN whose engine-lock acquire would block has been decoded and stashed; its completion is
+   * being run out-of-band on a pool worker. Execute_ returns to the dechunk loop's caller without
+   * touching any message buffered behind the BEGIN, so ordering is preserved until the BEGIN finishes.
+   */
+  PendingBegin,
+
+  /**
    * This state handles errors, if client handles error response correctly next
    * state is Idle.
    */
@@ -61,4 +68,10 @@ enum class State : uint8_t {
    */
   Close,
 };
+
+// Outcome of the pool-side completion of a would-block BEGIN (FinishPendingBegin_).
+// Done        - the BEGIN completed and SUCCESS was sent.
+// ClientError - send failed or the begin threw; state moved to Close/Error.
+// Reschedule  - the bounded-try engine-lock acquire lost the race; extras stay stashed, re-post to the pool.
+enum class PendingBeginOutcome : uint8_t { Done, ClientError, Reschedule };
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -27,6 +27,8 @@
 #include "communication/exceptions.hpp"
 #include "license/license_sender.hpp"
 #include "metrics/prometheus_metrics.hpp"
+#include "query/exceptions.hpp"        // WouldBlockInlineException (pending-BEGIN reschedule signal)
+#include "storage/v2/access_type.hpp"  // storage::EngineLockMode
 #include "storage/v2/property_value.hpp"
 #include "utils/logging.hpp"
 #include "utils/memory_tracker.hpp"
@@ -436,12 +438,20 @@ State HandleBegin(TSession &session, const State state, const Marker marker) {
 
   try {
     session.Configure(extra.ValueMap());
-    session.BeginTransaction(extra.ValueMap());
+    // Bounded-try engine-lock acquire: rather than busy-spin this pool worker behind a long write commit's
+    // durability hold, bail with WouldBlockInlineException on contention and let the completion reschedule.
+    session.BeginTransaction(extra.ValueMap(), storage::EngineLockMode::TryBounded);
     if (!session.encoder_.MessageSuccess({})) {
       spdlog::trace("Couldn't send success message!");
       return State::Close;
     }
     return State::Idle;
+  } catch (const memgraph::query::WouldBlockInlineException &) {
+    // The engine lock was contended. Stash the decoded extras and hand off to the pool; the accessor-first
+    // reorder left interpreter txn state pristine (no id consumed). Do NOT MessageSuccess here -- the SUCCESS
+    // is emitted only by FinishPendingBegin_ once the BEGIN actually completes.
+    session.StashPendingBegin(std::move(extra));
+    return State::PendingBegin;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -27,8 +27,8 @@
 #include "communication/exceptions.hpp"
 #include "license/license_sender.hpp"
 #include "metrics/prometheus_metrics.hpp"
-#include "query/exceptions.hpp"        // WouldBlockInlineException (pending-BEGIN reschedule signal)
-#include "storage/v2/access_type.hpp"  // storage::EngineLockMode
+#include "query/exceptions.hpp"
+#include "storage/v2/access_type.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/logging.hpp"
 #include "utils/memory_tracker.hpp"
@@ -447,9 +447,8 @@ State HandleBegin(TSession &session, const State state, const Marker marker) {
     }
     return State::Idle;
   } catch (const memgraph::query::WouldBlockInlineException &) {
-    // The engine lock was contended. Stash the decoded extras and hand off to the pool; the accessor-first
-    // reorder left interpreter txn state pristine (no id consumed). Do NOT MessageSuccess here -- the SUCCESS
-    // is emitted only by FinishPendingBegin_ once the BEGIN actually completes.
+    // Accessor-first reorder left interpreter txn state pristine (no id consumed), so the pool can retry.
+    // Do NOT MessageSuccess here -- the one SUCCESS is emitted by FinishPendingBegin_ when the BEGIN completes.
     session.StashPendingBegin(std::move(extra));
     return State::PendingBegin;
   } catch (const std::exception &e) {

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -43,6 +43,7 @@
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/system/detail/error_code.hpp>
 
+#include "communication/bolt/v1/state.hpp"
 #include "communication/buffer.hpp"
 #include "communication/context.hpp"
 #include "communication/exceptions.hpp"
@@ -379,6 +380,15 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     try {
       // Execute until all data has been read
       while (session_.Execute()) {
+        // The websocket path runs the bolt state machine synchronously on the strand (no pool hand-off). A BEGIN
+        // whose bounded-try engine-lock acquire lost the race parks in State::PendingBegin, which makes Execute()
+        // keep returning true. Drive it to a terminal outcome inline here: the pool resume path (DoWork/DoRead)
+        // would switch this connection off the websocket read loop, so it can't be reused. This preserves master's
+        // pre-existing behavior of completing a websocket BEGIN inline on the strand (FinishPendingBegin converges
+        // via the fairness cap: after kBeginRescheduleCap tries it does one blocking acquire).
+        while (session_.HasPendingBegin()) {
+          session_.FinishPendingBegin();
+        }
       }
       // Handled all data,  async wait for new incoming data
       DoReadAsio();
@@ -393,6 +403,13 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           try {
             while (true) {
               if (shared_this->session_.Execute()) {
+                if (shared_this->session_.HasPendingBegin()) {
+                  // Execute_ bailed with a BEGIN whose engine-lock acquire would block. Finish it off this
+                  // worker (never spin here behind a long write commit); PostFinishPendingBegin re-posts to the
+                  // pool on contention. Return now so no message pipelined behind the BEGIN runs before it does.
+                  shared_this->PostFinishPendingBegin();
+                  return;
+                }
                 // Check if we can just steal this task (loop through)
                 if (thread_priority > shared_this->session_.ApproximateQueryPriority()) {
                   // Task priority lower; reschedule
@@ -404,6 +421,37 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                 shared_this->DoRead();
                 return;
               }
+            }
+          } catch (const std::exception & /* unused */) {
+            boost::asio::post(shared_this->strand_,
+                              [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
+          }
+        },
+        session_.ApproximateQueryPriority());
+  }
+
+  // Post the pool-side completion of a would-block BEGIN. On engine-lock contention FinishPendingBegin() returns
+  // Reschedule and we re-post to the POOL (AddTask) -- never to the strand -- so the worker never blocks behind a
+  // long write commit. After the fairness cap FinishPendingBegin() does one blocking acquire and returns terminally.
+  // On a terminal outcome the normal read path resumes: DoWork if input bytes remain (a message pipelined behind the
+  // BEGIN), else DoRead to await the next chunk. SUCCESS for the BEGIN is emitted exactly once, inside
+  // FinishPendingBegin().
+  void PostFinishPendingBegin() {
+    session_context_->AddTask(
+        [shared_this = shared_from_this()](const auto /*thread_priority*/) {
+          try {
+            switch (shared_this->session_.FinishPendingBegin()) {
+              case memgraph::communication::bolt::PendingBeginOutcome::Reschedule:
+                shared_this->PostFinishPendingBegin();  // re-post to the POOL, never post(strand_)
+                return;
+              case memgraph::communication::bolt::PendingBeginOutcome::Done:
+              case memgraph::communication::bolt::PendingBeginOutcome::ClientError:
+                if (shared_this->session_.HasBufferedData()) {
+                  shared_this->DoWork();
+                } else {
+                  shared_this->DoRead();
+                }
+                return;
             }
           } catch (const std::exception & /* unused */) {
             boost::asio::post(shared_this->strand_,

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -380,12 +380,9 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     try {
       // Execute until all data has been read
       while (session_.Execute()) {
-        // The websocket path runs the bolt state machine synchronously on the strand (no pool hand-off). A BEGIN
-        // whose bounded-try engine-lock acquire lost the race parks in State::PendingBegin, which makes Execute()
-        // keep returning true. Drive it to a terminal outcome inline here: the pool resume path (DoWork/DoRead)
-        // would switch this connection off the websocket read loop, so it can't be reused. This preserves master's
-        // pre-existing behavior of completing a websocket BEGIN inline on the strand (FinishPendingBegin converges
-        // via the fairness cap: after kBeginRescheduleCap tries it does one blocking acquire).
+        // Websocket runs the bolt state machine inline on the strand; a parked BEGIN keeps Execute() returning true.
+        // Drive it terminal here -- the pool resume (DoWork/DoRead) would take this connection off the websocket read
+        // loop.
         while (session_.HasPendingBegin()) {
           session_.FinishPendingBegin();
         }
@@ -404,9 +401,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
             while (true) {
               if (shared_this->session_.Execute()) {
                 if (shared_this->session_.HasPendingBegin()) {
-                  // Execute_ bailed with a BEGIN whose engine-lock acquire would block. Finish it off this
-                  // worker (never spin here behind a long write commit); PostFinishPendingBegin re-posts to the
-                  // pool on contention. Return now so no message pipelined behind the BEGIN runs before it does.
+                  // BEGIN's engine-lock acquire would block: finish it off the worker via the pool
+                  // (PostFinishPendingBegin). Return now so no message pipelined behind the BEGIN runs first.
                   shared_this->PostFinishPendingBegin();
                   return;
                 }
@@ -430,12 +426,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
         session_.ApproximateQueryPriority());
   }
 
-  // Post the pool-side completion of a would-block BEGIN. On engine-lock contention FinishPendingBegin() returns
-  // Reschedule and we re-post to the POOL (AddTask) -- never to the strand -- so the worker never blocks behind a
-  // long write commit. After the fairness cap FinishPendingBegin() does one blocking acquire and returns terminally.
-  // On a terminal outcome the normal read path resumes: DoWork if input bytes remain (a message pipelined behind the
-  // BEGIN), else DoRead to await the next chunk. SUCCESS for the BEGIN is emitted exactly once, inside
-  // FinishPendingBegin().
+  // Completes a would-block BEGIN on the POOL (AddTask, never the strand): Reschedule re-posts so the worker never
+  // blocks behind a slow commit; a terminal outcome resumes DoWork/DoRead. FinishPendingBegin emits SUCCESS once.
   void PostFinishPendingBegin() {
     session_context_->AddTask(
         [shared_this = shared_from_this()](const auto /*thread_priority*/) {

--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -22,6 +22,7 @@
 #include "query/stream/streams.hpp"
 #include "query/trigger.hpp"
 #include "storage/v2/disk/storage.hpp"
+#include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 #include "storage/v2/storage_mode.hpp"
 #include "storage/v2/ttl.hpp"
@@ -67,6 +68,16 @@ std::unique_ptr<storage::Accessor> Database::Access(storage::StorageAccessType r
                                                     std::optional<storage::IsolationLevel> override_isolation_level,
                                                     std::optional<std::chrono::milliseconds> timeout) {
   return storage_->Access(rw_type, override_isolation_level, timeout);
+}
+
+std::unique_ptr<storage::Accessor> Database::TryAccess(storage::StorageAccessType rw_type,
+                                                       std::optional<storage::IsolationLevel> override_isolation_level,
+                                                       storage::EngineLockMode engine_mode) {
+  auto *in_memory = dynamic_cast<storage::InMemoryStorage *>(storage_.get());
+  if (in_memory == nullptr) {
+    return nullptr;
+  }
+  return in_memory->TryAccess(rw_type, override_isolation_level, engine_mode);
 }
 
 std::unique_ptr<storage::Accessor> Database::UniqueAccess(

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -91,6 +91,14 @@ class Database {
                                             std::optional<storage::IsolationLevel> override_isolation_level = {},
                                             std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
+  // Non-blocking accessor for the bounded-try BEGIN fast path: returns a READ/WRITE accessor if the
+  // storage lock can be taken without blocking, or nullptr if it would block (a DDL/UNIQUE holder)
+  // OR the storage is not in-memory (only InMemoryStorage offers the probe). Callers must fall back
+  // to the blocking Access() path on nullptr; this is a one-shot try, never a poll loop.
+  std::unique_ptr<storage::Accessor> TryAccess(
+      storage::StorageAccessType rw_type, std::optional<storage::IsolationLevel> override_isolation_level = {},
+      storage::EngineLockMode engine_mode = storage::EngineLockMode::TryBounded);
+
   std::unique_ptr<storage::Accessor> UniqueAccess(std::optional<storage::IsolationLevel> override_isolation_level = {},
                                                   std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -669,9 +669,9 @@ bolt_map_t SessionHL::CommitTransaction() {
   }
 }
 
-void SessionHL::BeginTransaction(const bolt_map_t &extra) {
+void SessionHL::BeginTransaction(const bolt_map_t &extra, storage::EngineLockMode try_mode) {
   try {
-    interpreter_.BeginTransaction(ToQueryExtras(extra));
+    interpreter_.BeginTransaction(ToQueryExtras(extra), try_mode);
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -69,7 +69,7 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   void Configure(const bolt_map_t &run_time_info);
 
-  void BeginTransaction(const bolt_map_t &extra);
+  void BeginTransaction(const bolt_map_t &extra, storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   bolt_map_t CommitTransaction();
 
@@ -140,6 +140,8 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   utils::Priority ApproximateQueryPriority() const;
 
   inline bool Execute() { return Execute_(*this); }
+
+  inline memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return FinishPendingBegin_(*this); }
 
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }
 

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -67,6 +67,16 @@ class PeriodicCommitException : public QueryException {
   SPECIALIZE_GET_EXCEPTION_NAME(PeriodicCommitException)
 };
 
+// Internal control-flow signal for the bounded-try BEGIN fast path: thrown when a non-blocking
+// (try) storage-access attempt would block on a UNIQUE (DDL) holder, so the caller must fall back
+// to the blocking path. Deliberately NOT a QueryException -- it is caught only at the BEGIN call
+// site and never surfaces to the client.
+class WouldBlockInlineException : public utils::BasicException {
+ public:
+  WouldBlockInlineException() : utils::BasicException("inline transaction start would block") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(WouldBlockInlineException)
+};
+
 /**
  * @brief Base class of all query language related exceptions which can be retried.
  * All exceptions derived from this one will be interpreted as TransientError-s,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -195,7 +195,7 @@ TypedValue EvaluateConfigMapToTypedValue(std::unordered_map<Expression *, Expres
 // access
 void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-    storage::StorageAccessType acc_type) {
+    storage::StorageAccessType acc_type, storage::EngineLockMode try_mode) {
   if (!db_acc_) {
     throw DatabaseContextRequiredException("Database required for the transaction setup.");
   }
@@ -206,9 +206,14 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     case storage::StorageAccessType::READ:
       [[fallthrough]];
     case storage::StorageAccessType::WRITE:
-      db_transactional_accessor_ = db_acc->Access(acc_type,
-                                                  override_isolation_level,
-                                                  /*allow timeout*/ timeout);
+      if (try_mode == storage::EngineLockMode::Blocking) {
+        db_transactional_accessor_ = db_acc->Access(acc_type,
+                                                    override_isolation_level,
+                                                    /*allow timeout*/ timeout);
+      } else {
+        db_transactional_accessor_ = db_acc->TryAccess(acc_type, override_isolation_level, try_mode);
+        if (!db_transactional_accessor_) throw WouldBlockInlineException{};
+      }
       break;
     case storage::StorageAccessType::UNIQUE:
       db_transactional_accessor_ = db_acc->UniqueAccess(override_isolation_level, /*allow timeout*/ timeout);
@@ -3909,22 +3914,17 @@ auto CreateTimeoutTimer(QueryExtras const &extras, InterpreterConfig const &conf
 }
 
 PreparedQuery Interpreter::PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum,
-                                                   QueryExtras const &extras) {
+                                                   QueryExtras const &extras, storage::EngineLockMode try_mode) {
   std::function<void()> handler;
 
   switch (tx_query_enum) {
     case TransactionQuery::BEGIN: {
       // TODO: Evaluate doing move(extras). Currently the extras is very small, but this will be important if it ever
       // becomes large.
-      handler = [this, extras = extras] {
+      handler = [this, extras = extras, try_mode] {
         if (in_explicit_transaction_) {
           throw ExplicitTransactionUsageException("Nested transactions are not supported.");
         }
-        SetupInterpreterTransaction(extras);
-        // Multiple paths can lead to transaction BEGIN, so we need to reset the timer in the handler
-        current_timeout_timer_ = CreateTimeoutTimer(extras, interpreter_context_->config);
-        in_explicit_transaction_ = true;
-        expect_rollback_ = false;
         if (!current_db_.db_acc_)
           throw DatabaseContextRequiredException("No current database for transaction defined.");
         // Fail-closed on a broken database: an explicit transaction opens a data accessor and its queries
@@ -3933,8 +3933,15 @@ PreparedQuery Interpreter::PrepareTransactionQuery(Interpreter::TransactionQuery
         if ((*current_db_.db_acc_)->storage()->IsBroken()) {
           throw QueryException(kBrokenDatabaseError);
         }
-        SetupDatabaseTransaction(true,
-                                 extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE);
+        // Accessor first: on the try (bounded) path a would-block bail must leave interpreter txn state untouched
+        // (no id consumed, status still IDLE) so the caller can fall back to the blocking path.
+        SetupDatabaseTransaction(
+            true, extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE, try_mode);
+        SetupInterpreterTransaction(extras);
+        // Multiple paths can lead to transaction BEGIN, so we need to reset the timer in the handler
+        current_timeout_timer_ = CreateTimeoutTimer(extras, interpreter_context_->config);
+        in_explicit_transaction_ = true;
+        expect_rollback_ = false;
       };
     } break;
     case TransactionQuery::COMMIT: {
@@ -10193,9 +10200,9 @@ PreparedQuery PrepareUserProfileQuery(ParsedQuery parsed_query, InterpreterConte
 
 std::optional<uint64_t> Interpreter::GetTransactionId() const { return current_transaction_; }
 
-void Interpreter::BeginTransaction(QueryExtras const &extras) {
+void Interpreter::BeginTransaction(QueryExtras const &extras, storage::EngineLockMode try_mode) {
   ResetInterpreter();
-  auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras);
+  auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras, try_mode);
   prepared_query.query_handler(nullptr, {});
 }
 
@@ -11222,8 +11229,9 @@ void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privi
   }
 }
 
-void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type) {
-  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type);
+void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type,
+                                           storage::EngineLockMode try_mode) {
+  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type, try_mode);
 }
 
 void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -263,7 +263,8 @@ struct CurrentDB {
   CurrentDB &operator=(CurrentDB const &) = delete;
 
   void SetupDatabaseTransaction(std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE);
+                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE,
+                                storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {
@@ -462,7 +463,8 @@ class Interpreter final {
   std::map<std::string, TypedValue> Pull(TStream *result_stream, std::optional<int> n = {},
                                          std::optional<int> qid = {});
 
-  void BeginTransaction(QueryExtras const &extras = {});
+  void BeginTransaction(QueryExtras const &extras = {},
+                        storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   std::optional<uint64_t> GetTransactionId() const;
 
@@ -687,7 +689,8 @@ class Interpreter final {
 
   static void AppendNotificationToSummary(const Notification &notification, std::map<std::string, TypedValue> &summary);
 
-  PreparedQuery PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum, QueryExtras const &extras = {});
+  PreparedQuery PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum, QueryExtras const &extras = {},
+                                        storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
   void Commit();
   // Resets tx-tracking left ACTIVE by SetupInterpreterTransaction when NOTHING skips Commit()/Abort()'s cleanup.
   void FinishAutocommitNothing();
@@ -703,7 +706,8 @@ class Interpreter final {
   std::optional<std::function<void(std::string_view)>> on_change_{};
   void SetupInterpreterTransaction(const QueryExtras &extras);
   void SetupDatabaseTransaction(bool couldCommit,
-                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE);
+                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE,
+                                storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 };
 
 template <typename TStream>

--- a/src/storage/v2/access_type.hpp
+++ b/src/storage/v2/access_type.hpp
@@ -23,4 +23,12 @@ enum StorageAccessType : uint8_t {
   READ_ONLY = 4,  // Ensures writers have gone
 };
 
+// How CreateTransaction acquires engine_lock_ to mint a transaction:
+//   Blocking   - wait indefinitely (default; write-commit / GC / recovery paths).
+//   TryBounded - bounded spin-try (a few us) then throw; the pool BEGIN fallback, which reschedules
+//                on throw instead of spinning behind a long write-commit hold.
+// Lives in this leaf header (not storage.hpp) so the protocol/dbms layers that only name the enum
+// don't have to pull the full storage.hpp translation unit.
+enum class EngineLockMode : uint8_t { Blocking, TryBounded };
+
 }  // namespace memgraph::storage

--- a/src/storage/v2/access_type.hpp
+++ b/src/storage/v2/access_type.hpp
@@ -23,12 +23,9 @@ enum StorageAccessType : uint8_t {
   READ_ONLY = 4,  // Ensures writers have gone
 };
 
-// How CreateTransaction acquires engine_lock_ to mint a transaction:
-//   Blocking   - wait indefinitely (default; write-commit / GC / recovery paths).
-//   TryBounded - bounded spin-try (a few us) then throw; the pool BEGIN fallback, which reschedules
-//                on throw instead of spinning behind a long write-commit hold.
-// Lives in this leaf header (not storage.hpp) so the protocol/dbms layers that only name the enum
-// don't have to pull the full storage.hpp translation unit.
+// engine_lock_ acquisition for CreateTransaction: Blocking waits indefinitely (default);
+// TryBounded spin-tries ~2us then throws (pool BEGIN fallback that reschedules on throw).
+// Kept in this leaf header so protocol/dbms callers that only name the enum need not pull storage.hpp.
 enum class EngineLockMode : uint8_t { Blocking, TryBounded };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2492,7 +2492,9 @@ auto DiskStorage::DiskAccessor::PointVertices(LabelId /*label*/, PropertyId /*pr
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PointIndexStorage DiskStorage::empty_point_index_ = PointIndexStorage{};
 
-Transaction DiskStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) {
+Transaction DiskStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                           EngineLockMode engine_mode) {
+  MG_ASSERT(engine_mode == EngineLockMode::Blocking, "DiskStorage has no non-blocking transaction mint");
   /// We acquire the transaction engine lock here because we access (and
   /// modify) the transaction engine variables (`transaction_id` and
   /// `timestamp`) below.

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -628,7 +628,8 @@ class DiskStorage final : public Storage {
 
   RocksDBStorage *GetRocksDBStorage() const { return kvstore_.get(); }
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                EngineLockMode engine_mode = EngineLockMode::Blocking) override;
 
   void SetEdgeImportMode(EdgeImportMode edge_import_status);
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -4854,8 +4854,12 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
 std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccess(StorageAccessType rw_type,
                                                               std::optional<IsolationLevel> override_isolation_level,
                                                               EngineLockMode engine_mode) {
-  utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::try_to_lock};
-  if (!guard.owns_lock()) return nullptr;
+  // Bounded-try main_lock_ too (not just engine_lock_): a brief exclusive hold -- a transient UNIQUE
+  // that gates shared acquirers under writer-preference -- should ride out within a tiny budget rather
+  // than fail instantly (std::try_to_lock) and force an admission reschedule. Mirrors engine_lock_'s ~2us try.
+  constexpr auto kMainLockTryBudget = std::chrono::microseconds{2};
+  utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::defer_lock};
+  if (!guard.try_lock_for(kMainLockTryBudget)) return nullptr;
   try {
     return std::unique_ptr<InMemoryAccessor>(
         new InMemoryAccessor{this, override_isolation_level, std::move(guard), engine_mode});

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -69,6 +69,7 @@
 #include "utils/on_scope_exit.hpp"
 #include "utils/resource_lock.hpp"
 #include "utils/scheduler.hpp"
+#include "utils/spin_lock.hpp"
 #include "utils/stat.hpp"
 #include "utils/temporal.hpp"
 #include "utils/variant_helpers.hpp"
@@ -612,8 +613,9 @@ void InMemoryStorage::UpdateLabelCount(LabelId const label, int64_t const change
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryStorage *storage,
                                                     std::optional<IsolationLevel> override_isolation_level,
-                                                    utils::ResourceLockGuard guard)
-    : Accessor(storage, override_isolation_level, std::move(guard)), config_(storage->config_.salient.items) {}
+                                                    utils::ResourceLockGuard guard, EngineLockMode engine_mode)
+    : Accessor(storage, override_isolation_level, std::move(guard), engine_mode),
+      config_(storage->config_.salient.items) {}
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryAccessor &&other) noexcept
     : Accessor(std::move(other)), config_(other.config_) {}
@@ -2867,7 +2869,8 @@ std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::FindEdge(Gid edge
   return EdgeAccessor::Create(edge_ref, edge_type, from, to, storage_, &transaction_, view);
 }
 
-Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) {
+Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                               EngineLockMode engine_mode) {
   // We acquire the transaction engine lock here because we access (and
   // modify) the transaction engine variables (`transaction_id` and
   // `timestamp`) below.
@@ -2878,7 +2881,24 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
   ActiveIndicesPtr active_indices;
   ActiveConstraintsPtr active_constraints;
   {
-    auto guard = std::lock_guard{engine_lock_};
+    // The acquire must precede every mutation below, so a contended non-blocking probe bails
+    // (throws) having changed nothing (no transaction_id_/timestamp_ bump, no index/constraint read).
+    // Bounded-try budget: keep tiny -- we would rather bail-and-reschedule than spin behind a long
+    // write-commit that holds engine_lock_ across durability/replication.
+    constexpr auto kBeginEngineTryBudget = std::chrono::microseconds{2};
+    std::unique_lock<utils::SpinLock> guard;
+    switch (engine_mode) {
+      case EngineLockMode::Blocking:
+        guard = std::unique_lock{engine_lock_};  // blocking acquire
+        break;
+      case EngineLockMode::TryBounded:
+        // BoundedTryLock spins with an arch-guarded relax (portable to aarch64) and returns false
+        // WITHOUT holding the lock on timeout, so throwing here leaks nothing. On success it owns the
+        // lock; adopt that ownership so the existing RAII unlock at scope exit stays correct.
+        if (!utils::BoundedTryLock(engine_lock_, kBeginEngineTryBudget)) throw TransactionEngineWouldBlock{};
+        guard = std::unique_lock{engine_lock_, std::adopt_lock};
+        break;
+    }
     transaction_id = transaction_id_++;
     start_timestamp = timestamp_++;
     // IMPORTANT: this is retrieved while under the lock so that the index is consistant with the timestamp
@@ -4835,10 +4855,16 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
 }
 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccess(StorageAccessType rw_type,
-                                                              std::optional<IsolationLevel> override_isolation_level) {
+                                                              std::optional<IsolationLevel> override_isolation_level,
+                                                              EngineLockMode engine_mode) {
   utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::try_to_lock};
   if (!guard.owns_lock()) return nullptr;
-  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{this, override_isolation_level, std::move(guard)});
+  try {
+    return std::unique_ptr<InMemoryAccessor>(
+        new InMemoryAccessor{this, override_isolation_level, std::move(guard), engine_mode});
+  } catch (const TransactionEngineWouldBlock &) {
+    return nullptr;  // engine lock contended (e.g. a write-commit's durability phase); caller falls back to pool
+  }
 }
 
 void InMemoryStorage::CreateSnapshotHandler(

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2881,20 +2881,17 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
   ActiveIndicesPtr active_indices;
   ActiveConstraintsPtr active_constraints;
   {
-    // The acquire must precede every mutation below, so a contended non-blocking probe bails
-    // (throws) having changed nothing (no transaction_id_/timestamp_ bump, no index/constraint read).
-    // Bounded-try budget: keep tiny -- we would rather bail-and-reschedule than spin behind a long
-    // write-commit that holds engine_lock_ across durability/replication.
+    // Acquire must precede every mutation below: a contended TryBounded probe throws having
+    // changed nothing -- no transaction_id_/timestamp_ bump, no index/constraint read.
     constexpr auto kBeginEngineTryBudget = std::chrono::microseconds{2};
     std::unique_lock<utils::SpinLock> guard;
     switch (engine_mode) {
       case EngineLockMode::Blocking:
-        guard = std::unique_lock{engine_lock_};  // blocking acquire
+        guard = std::unique_lock{engine_lock_};
         break;
       case EngineLockMode::TryBounded:
-        // BoundedTryLock spins with an arch-guarded relax (portable to aarch64) and returns false
-        // WITHOUT holding the lock on timeout, so throwing here leaks nothing. On success it owns the
-        // lock; adopt that ownership so the existing RAII unlock at scope exit stays correct.
+        // BoundedTryLock returns false WITHOUT holding the lock on timeout, so throwing leaks nothing;
+        // on success it owns the lock -- adopt it so the scope-exit RAII unlock stays correct.
         if (!utils::BoundedTryLock(engine_lock_, kBeginEngineTryBudget)) throw TransactionEngineWouldBlock{};
         guard = std::unique_lock{engine_lock_, std::adopt_lock};
         break;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -167,7 +167,7 @@ class InMemoryStorage final : public Storage {
 
     /// Takes ownership of a hold the caller acquired; see Accessor's constructor.
     explicit InMemoryAccessor(InMemoryStorage *storage, std::optional<IsolationLevel> override_isolation_level,
-                              utils::ResourceLockGuard guard);
+                              utils::ResourceLockGuard guard, EngineLockMode engine_mode = EngineLockMode::Blocking);
 
     std::expected<void, ConstraintViolation> ExistenceConstraintsViolation() const;
 
@@ -811,7 +811,8 @@ class InMemoryStorage final : public Storage {
   /// InMemoryStorage's alone: DiskStorage has no probe rather than one that always fails, so a
   /// caller polling it would spin instead of learning that it should just block.
   std::unique_ptr<Accessor> TryAccess(StorageAccessType rw_type,
-                                      std::optional<IsolationLevel> override_isolation_level = {});
+                                      std::optional<IsolationLevel> override_isolation_level = {},
+                                      EngineLockMode engine_mode = EngineLockMode::TryBounded);
 
   void FreeMemory(utils::ResourceLockGuard main_guard, bool periodic) override;
 
@@ -852,7 +853,8 @@ class InMemoryStorage final : public Storage {
   void CreateSnapshotHandler(
       std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb);
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                EngineLockMode engine_mode = EngineLockMode::Blocking) override;
 
   void SetStorageMode(StorageMode storage_mode);
 

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -121,14 +121,14 @@ std::unique_ptr<Accessor> Storage::ReadOnlyAccess(std::optional<IsolationLevel> 
 std::unique_ptr<Accessor> Storage::ReadOnlyAccess() { return ReadOnlyAccess({}, std::nullopt); }
 
 Storage::Accessor::Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level,
-                            utils::ResourceLockGuard guard)
+                            utils::ResourceLockGuard guard, EngineLockMode engine_mode)
     : storage_(storage),
       // The hold is taken before the transaction is created, so a freshly created transaction can
       // never dangle in an active state during an exclusive operation.
       guard_(std::move(guard)),
       // Both reads are under guard_, already constructed above, so the hold pins them.
       transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
-                                              storage->storage_mode_)),
+                                              storage->storage_mode_, engine_mode)),
       is_transaction_active_(true),
       original_access_type_(ToAccessType(guard_.type())) {
   DMG_ASSERT(guard_.owns_lock() && guard_.mutex() == std::addressof(storage_->main_lock_),

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -47,6 +47,10 @@
 #include "utils/resource_lock.hpp"
 #include "utils/synchronized_metadata_store.hpp"
 
+// Test-only: fixture in tests/unit/storage_v2.cpp (global namespace); forward-declared so the
+// qualified friend in Storage below names an existing entity.
+class StorageEngineLockContentionTest;
+
 namespace memgraph::metrics {
 struct DatabaseMetricHandles;
 }  // namespace memgraph::metrics
@@ -282,6 +286,9 @@ class Storage {
   friend class ReplicationServer;
   friend class ReplicationStorageClient;
   friend class VectorIndex;
+  // Test-only: lets StorageEngineLockContentionTest hold engine_lock_ to verify the non-blocking
+  // TryAccess bail (see tests/unit/storage_v2.cpp).
+  friend class ::StorageEngineLockContentionTest;
 
  public:
   Storage(Config config, StorageMode storage_mode, PlanInvalidatorPtr invalidator,

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -47,8 +47,7 @@
 #include "utils/resource_lock.hpp"
 #include "utils/synchronized_metadata_store.hpp"
 
-// Test-only: fixture in tests/unit/storage_v2.cpp (global namespace); forward-declared so the
-// qualified friend in Storage below names an existing entity.
+// Test fixture (global ns, tests/unit/storage_v2.cpp); forward-declared for the friend below.
 class StorageEngineLockContentionTest;
 
 namespace memgraph::metrics {
@@ -286,8 +285,7 @@ class Storage {
   friend class ReplicationServer;
   friend class ReplicationStorageClient;
   friend class VectorIndex;
-  // Test-only: lets StorageEngineLockContentionTest hold engine_lock_ to verify the non-blocking
-  // TryAccess bail (see tests/unit/storage_v2.cpp).
+  // Test-only: fixture holds engine_lock_ to exercise the non-blocking TryAccess bail.
   friend class ::StorageEngineLockContentionTest;
 
  public:
@@ -548,12 +546,8 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
 utils::ResourceLockGuard AcquireGuardOrThrow(Storage *storage, StorageAccessType rw_type,
                                              std::optional<std::chrono::milliseconds> timeout);
 
-// EngineLockMode (Blocking / TryBounded) lives in storage/v2/access_type.hpp (a leaf header
-// included above), so protocol/dbms layers that only name the enum need not pull this header.
-
-// Thrown by CreateTransaction on a non-blocking mode (TryBounded) when the transaction-engine lock
-// is held by a concurrent commit/GC, so a non-blocking probe (TryAccess) can bail instead of
-// blocking. Caught in TryAccess and turned into a nullptr; never surfaces to callers.
+// Thrown by CreateTransaction under TryBounded when engine_lock_ is held by a concurrent commit/GC;
+// caught in TryAccess (returns nullptr) and never surfaces to callers.
 struct TransactionEngineWouldBlock final : std::exception {
   const char *what() const noexcept override { return "transaction engine lock busy"; }
 };

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -12,6 +12,8 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
+#include <exception>
 #include <optional>
 #include <set>
 #include <string>
@@ -387,7 +389,8 @@ class Storage {
 
   virtual void UpdateLabelCount(LabelId label, int64_t change) = 0;
 
-  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) = 0;
+  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                        EngineLockMode engine_mode = EngineLockMode::Blocking) = 0;
 
   virtual void PrepareForNewEpoch() = 0;
 
@@ -538,11 +541,23 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
 utils::ResourceLockGuard AcquireGuardOrThrow(Storage *storage, StorageAccessType rw_type,
                                              std::optional<std::chrono::milliseconds> timeout);
 
+// EngineLockMode (Blocking / TryBounded) lives in storage/v2/access_type.hpp (a leaf header
+// included above), so protocol/dbms layers that only name the enum need not pull this header.
+
+// Thrown by CreateTransaction on a non-blocking mode (TryBounded) when the transaction-engine lock
+// is held by a concurrent commit/GC, so a non-blocking probe (TryAccess) can bail instead of
+// blocking. Caught in TryAccess and turned into a nullptr; never surfaces to callers.
+struct TransactionEngineWouldBlock final : std::exception {
+  const char *what() const noexcept override { return "transaction engine lock busy"; }
+};
+
 class Accessor {
  public:
   /// Takes ownership of a hold on `storage`'s main_lock_. The caller acquires it: blocking with a
   /// timeout via AcquireGuardOrThrow, or non-blocking via a try_to_lock guard. Construction itself
-  /// never blocks and never fails, so a probe can decide whether to build an accessor at all.
+  /// never blocks and never fails, EXCEPT on a non-blocking `engine_mode`: TryBounded bounded-tries
+  /// the transaction-engine lock and throws TransactionEngineWouldBlock if it is contended, so a
+  /// probe can decide whether to build an accessor at all without blocking.
   ///
   /// The access type comes from the guard, not alongside it. It is recorded as
   /// original_access_type_, which the WAL carries to replicas to pick the mode they replay under,
@@ -552,7 +567,8 @@ class Accessor {
   /// The isolation level and storage mode are read from `storage` under the guard rather than
   /// passed in: SetIsolationLevel and SetStorageMode write them under UNIQUE, so a caller reading
   /// them before acquiring could build a transaction against a mode that has since changed.
-  Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level, utils::ResourceLockGuard guard);
+  Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level, utils::ResourceLockGuard guard,
+           EngineLockMode engine_mode = EngineLockMode::Blocking);
 
   Accessor(const Accessor &) = delete;
   Accessor &operator=(const Accessor &) = delete;

--- a/src/utils/spin_lock.hpp
+++ b/src/utils/spin_lock.hpp
@@ -69,18 +69,14 @@ class SpinLock {
   pthread_spinlock_t lock_;
 };
 
-// Spin-try to acquire `lock` for up to `budget`, returning true iff acquired. Unlike lock(), this
-// caps the busy-wait: used where a caller would rather bail-and-reschedule than spin behind a
-// long holder (e.g. a write commit holding engine_lock_ across durability/replication). Keep the
-// budget SMALL (a few microseconds) -- a large budget wastes CPU spinning behind a long holder.
+// Spin-try to acquire `lock` for up to `budget`; returns true iff acquired. Lets a caller
+// bail-and-reschedule instead of spinning behind a long holder; keep budget SMALL -- a large one wastes CPU.
 inline bool BoundedTryLock(SpinLock &lock, std::chrono::nanoseconds budget) {
   if (lock.try_lock()) return true;
   const auto deadline = std::chrono::steady_clock::now() + budget;
   do {
-    // Arch-guarded CPU relax (mirrors utils/yielder.hpp): a real pause/yield hint on x86/aarch64,
-    // and a compiler barrier elsewhere so this header stays free of <thread> while still preventing
-    // the spin body from being hoisted/optimized away. Inlined rather than pulling yielder.hpp,
-    // which #undef's its PAUSE macro and carries a stateful sleep/backoff loop we don't want here.
+    // Arch CPU-relax hint (mirrors yielder.hpp PAUSE), compiler barrier elsewhere. Not reused because
+    // yielder.hpp #undef's PAUSE and pulls in <thread> + a stateful backoff loop we don't want here.
 #if defined(__x86_64__) || defined(__i386__)
     __builtin_ia32_pause();
 #elif defined(__aarch64__)

--- a/src/utils/spin_lock.hpp
+++ b/src/utils/spin_lock.hpp
@@ -13,6 +13,8 @@
 
 #include <pthread.h>
 
+#include <chrono>
+
 #include "utils/logging.hpp"
 
 namespace memgraph::utils {
@@ -66,4 +68,28 @@ class SpinLock {
  private:
   pthread_spinlock_t lock_;
 };
+
+// Spin-try to acquire `lock` for up to `budget`, returning true iff acquired. Unlike lock(), this
+// caps the busy-wait: used where a caller would rather bail-and-reschedule than spin behind a
+// long holder (e.g. a write commit holding engine_lock_ across durability/replication). Keep the
+// budget SMALL (a few microseconds) -- a large budget wastes CPU spinning behind a long holder.
+inline bool BoundedTryLock(SpinLock &lock, std::chrono::nanoseconds budget) {
+  if (lock.try_lock()) return true;
+  const auto deadline = std::chrono::steady_clock::now() + budget;
+  do {
+    // Arch-guarded CPU relax (mirrors utils/yielder.hpp): a real pause/yield hint on x86/aarch64,
+    // and a compiler barrier elsewhere so this header stays free of <thread> while still preventing
+    // the spin body from being hoisted/optimized away. Inlined rather than pulling yielder.hpp,
+    // which #undef's its PAUSE macro and carries a stateful sleep/backoff loop we don't want here.
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__)
+    asm volatile("yield" ::: "memory");
+#else
+    asm volatile("" ::: "memory");
+#endif
+    if (lock.try_lock()) return true;
+  } while (std::chrono::steady_clock::now() < deadline);
+  return false;
+}
 }  // namespace memgraph::utils

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -18,6 +18,7 @@
 #include "communication/bolt/v1/session.hpp"
 #include "communication/exceptions.hpp"
 #include "query/exceptions.hpp"
+#include "storage/v2/access_type.hpp"  // storage::EngineLockMode (BeginTransaction engine-mode arg)
 #include "utils/logging.hpp"
 
 using memgraph::communication::bolt::ChunkedEncoderBuffer;
@@ -114,7 +115,16 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   bolt_map_t Discard(std::optional<int> /*unused*/, std::optional<int> /*unused*/) { return {}; }
 
-  void BeginTransaction(const bolt_map_t &extra) {
+  void BeginTransaction(const bolt_map_t &extra,
+                        memgraph::storage::EngineLockMode mode = memgraph::storage::EngineLockMode::Blocking) {
+    // Pool bounded-try: simulate losing the engine-lock race for the first N attempts, then succeed. The
+    // first loss happens inside HandleBegin (the BEGIN goes State::PendingBegin); the rest happen inside
+    // FinishPendingBegin_ (each returns Reschedule). Blocking (the fairness-cap fallback) never throws
+    // WouldBlock, so it is intentionally NOT gated here -- that is what guarantees the loop terminates.
+    if (mode == memgraph::storage::EngineLockMode::TryBounded && try_bounded_fail_count_ > 0) {
+      --try_bounded_fail_count_;
+      throw memgraph::query::WouldBlockInlineException{};
+    }
     if (extra.contains("tx_metadata")) {
       auto const &metadata = extra.at("tx_metadata").ValueMap();
       if (!metadata.empty()) md_ = metadata;
@@ -170,6 +180,10 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   void TestHook_ShouldAbort() { should_abort_ = true; }
 
+  // Make the next `n` TryBounded engine-lock acquires lose the race, then succeed. Drives the
+  // HandleBegin bail + FinishPendingBegin_ reschedule path deterministically.
+  void TestHook_FailBoundedTries(int n) { try_bounded_fail_count_ = n; }
+
   void Execute() {
     while (Execute_(*this)) {
       // Execute now exists on result, so it can be schduled again.
@@ -177,10 +191,18 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
     }
   }
 
+  // Run the dechunk loop exactly once (one Execute_ pass), mirroring communication/v2 DoWork's single
+  // Execute() call so a test can observe the mid-batch bail into State::PendingBegin. The naive Execute()
+  // above would keep re-entering while the BEGIN is parked, so the pending-BEGIN path must be stepped.
+  bool ExecuteStep() { return Execute_(*this); }
+
+  memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return FinishPendingBegin_(*this); }
+
  private:
   std::string query_;
   bolt_map_t md_;
   bool should_abort_ = false;
+  int try_bounded_fail_count_{0};
 };
 
 // TODO: This could be done in fixture.
@@ -1325,4 +1347,142 @@ TEST(BoltSession, PartialStream) {
     auto const find_msg = std::search(cbegin(output), cend(output), cbegin(error_msg), cend(error_msg));
     EXPECT_NE(find_msg, cend(output));
   }
+}
+
+// ---------------------------------------------------------------------------
+// Pending-BEGIN reschedule (pool-native, no strand inline). A BEGIN whose bounded-try engine-lock
+// acquire loses the race bails out of HandleBegin into State::PendingBegin (stashing its decoded
+// extras); the completion is retried out-of-band via FinishPendingBegin(), which reschedules on each
+// further loss and, past the fairness cap, does one blocking acquire so the BEGIN cannot starve.
+// ---------------------------------------------------------------------------
+
+// A minimal single-chunk BEGIN with an empty extras map, pre-framed (chunk header + end marker) so it
+// can be written straight into the input stream:
+//   0x00 0x03           chunk size 3
+//   0xB1                TinyStruct1
+//   0x11                Begin signature
+//   0xA0                empty TinyMap (extras)
+//   0x00 0x00           end-of-message terminator
+static constexpr std::array<uint8_t, 7> begin_bytes{0x00, 0x03, 0xB1, 0x11, 0xA0, 0x00, 0x00};
+
+using memgraph::communication::bolt::PendingBeginOutcome;
+
+TEST(BoltSession, PendingBeginReschedulesThenCompletesWithOneSuccess) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // 4 bounded-try losses: the 1st is consumed by HandleBegin (BEGIN -> PendingBegin), leaving 3 losses
+  // for FinishPendingBegin -> exactly 3 Reschedule outcomes before the 4th attempt wins.
+  constexpr int kExpectedReschedules = 3;
+  session.TestHook_FailBoundedTries(kExpectedReschedules + 1);
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  output.clear();
+
+  // One dechunk pass: HandleBegin bails with WouldBlock, stashes the extras, parks in PendingBegin.
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingBegin);
+  EXPECT_TRUE(session.HasPendingBegin());
+  EXPECT_TRUE(output.empty());  // no SUCCESS emitted on the bail path
+
+  // Each lost bounded-try returns Reschedule and MUST keep the extras stashed (HasPendingBegin stays
+  // true); a premature reset would trip FinishPendingBegin_'s MG_ASSERT on the next attempt.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;  // fail loudly instead of looping forever if the retry logic regresses
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingBegin();
+    if (outcome == PendingBeginOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingBeginOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingBegin());  // stash survives across reschedules
+    EXPECT_TRUE(output.empty());             // no reply while rescheduling
+    EXPECT_EQ(session.state_, State::PendingBegin);
+    ++reschedules;
+  }
+
+  // Reverting the reschedule (e.g. HandleBegin/FinishPendingBegin blocking instead of bailing) breaks
+  // this exact count -> the test is mutation-checkable.
+  EXPECT_EQ(reschedules, kExpectedReschedules);
+  EXPECT_FALSE(session.HasPendingBegin());  // stash consumed on the terminal Done
+  EXPECT_EQ(session.state_, State::Idle);
+  // Exactly ONE SUCCESS, emitted only by FinishPendingBegin on Done (empty extras -> canonical frame).
+  ASSERT_EQ(output.size(), sizeof(success_resp));
+  CheckSuccessMessage(output, /*clear=*/false);
+}
+
+TEST(BoltSession, PendingBeginFairnessCapForcesBlockingTerminal) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // EVERY bounded-try loses the race: only the fairness cap can end the loop.
+  session.TestHook_FailBoundedTries(1000);
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  output.clear();
+
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingBegin);
+  EXPECT_TRUE(session.HasPendingBegin());
+  EXPECT_TRUE(output.empty());
+
+  // Under unbounded contention the pool-side completion must still terminate: after kBeginRescheduleCap
+  // reschedules FinishPendingBegin_ does one Blocking acquire (which is never gated by the fail hook and
+  // never throws WouldBlock), completing the BEGIN. Count the reschedules to prove it is the cap -- not a
+  // lucky bounded-try -- that breaks the loop. kBeginRescheduleCap is private, so the expected count is a
+  // literal kept in sync with it.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingBegin();
+    if (outcome == PendingBeginOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingBeginOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingBegin());
+    EXPECT_TRUE(output.empty());
+    EXPECT_EQ(session.state_, State::PendingBegin);
+    ++reschedules;
+  }
+  EXPECT_EQ(reschedules, 32);  // == kBeginRescheduleCap; the terminal Blocking acquire fires on the next call
+  EXPECT_FALSE(session.HasPendingBegin());
+  EXPECT_EQ(session.state_, State::Idle);
+  ASSERT_EQ(output.size(), sizeof(success_resp));  // exactly one SUCCESS, from the Blocking fallback
+  CheckSuccessMessage(output, /*clear=*/false);
+}
+
+TEST(BoltSession, PendingBeginHoldsBackPipelinedMessageUntilItCompletes) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // One loss (consumed by HandleBegin) is enough to force the BEGIN onto the pending path; the first
+  // FinishPendingBegin then wins. Keeps this test focused on ordering, not on the reschedule count.
+  session.TestHook_FailBoundedTries(1);
+  // A BEGIN immediately followed by a RUN, in one buffer, with the engine lock "contended".
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  output.clear();
+
+  // One dechunk pass stops at the BEGIN: Execute_ returns at State::PendingBegin WITHOUT reading the RUN
+  // chunk, so the RUN is neither decoded nor answered while the BEGIN is outstanding.
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingBegin);
+  EXPECT_TRUE(session.HasPendingBegin());
+  EXPECT_TRUE(output.empty());             // no SUCCESS for the BEGIN yet, and the RUN was not processed
+  EXPECT_TRUE(session.HasBufferedData());  // the RUN is still queued behind the parked BEGIN
+
+  // Complete the BEGIN: exactly one SUCCESS (empty extras -> canonical frame). The RUN is STILL unread.
+  ASSERT_EQ(session.FinishPendingBegin(), PendingBeginOutcome::Done);
+  EXPECT_EQ(session.state_, State::Idle);
+  EXPECT_FALSE(session.HasPendingBegin());
+  ASSERT_EQ(output.size(), sizeof(success_resp));  // only the BEGIN's SUCCESS -- the RUN produced nothing
+  CheckSuccessMessage(output, /*clear=*/true);
+
+  // Only now, after the BEGIN finished, does the resume process the pipelined RUN -- proving ordering.
+  session.Execute();
+  EXPECT_EQ(session.state_, State::Result);  // RUN parsed+prepared, awaiting PULL
+  CheckSuccessMessage(output, /*clear=*/false);
 }

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3198,3 +3198,45 @@ TEST_F(StorageTryAccessTest, ReadOnlyHeldBlocksNewWrite) {
   ASSERT_NE(write_acc, nullptr);
   EXPECT_NO_THROW(write_acc->Abort());
 }
+
+// TryAccess is non-blocking on the transaction-engine lock: it defaults to EngineLockMode::TryBounded,
+// so CreateTransaction bounded-spins engine_lock_ (2us) and, on failure, throws
+// TransactionEngineWouldBlock, which TryAccess turns into nullptr so the BEGIN caller reschedules onto
+// the pool instead of busy-spinning a worker. The StorageTryAccessTest cases above cover the free
+// (acquire succeeds) side; this covers the contended side deterministically: utils::SpinLock is
+// non-recursive, so a single test thread that already holds engine_lock_ forces the bounded acquire to
+// time out. A blocking Access must still succeed once the lock is released.
+class StorageEngineLockContentionTest : public ::testing::Test {
+ protected:
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+
+  // TEST_F's body runs in a class derived from this fixture, and friendship is not inherited, so the
+  // private engine_lock_ access must live in a member of the befriended fixture itself.
+  void LockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.lock(); }
+
+  void UnlockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.unlock(); }
+};
+
+TEST_F(StorageEngineLockContentionTest, EngineLockHeldMakesTryAccessBailWhileBlockingAccessWaits) {
+  using namespace memgraph::storage;
+
+  // Hold the transaction-engine lock, as a concurrent write-commit's durability phase would.
+  LockEngine();
+  // A TryBounded probe must bail (return nullptr) rather than busy-spin the pool worker.
+  EXPECT_EQ(store.TryAccess(READ), nullptr);
+  EXPECT_EQ(store.TryAccess(WRITE), nullptr);
+  UnlockEngine();
+
+  // Once released, the bounded-try probe succeeds and yields a usable accessor.
+  auto try_acc = store.TryAccess(READ);
+  ASSERT_NE(try_acc, nullptr);
+  EXPECT_NO_THROW(try_acc->Abort());
+  try_acc.reset();
+
+  // A blocking Access (EngineLockMode::Blocking, the default) also succeeds against the free lock; it is
+  // the path the BEGIN falls back to at the fairness cap and never throws TransactionEngineWouldBlock.
+  auto blocking_acc = store.Access(READ);
+  ASSERT_NE(blocking_acc, nullptr);
+  EXPECT_NO_THROW(blocking_acc->Abort());
+}

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3218,7 +3218,9 @@ class StorageEngineLockContentionTest : public ::testing::Test {
   void UnlockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.unlock(); }
 };
 
-TEST_F(StorageEngineLockContentionTest, EngineLockHeldMakesTryAccessBailWhileBlockingAccessWaits) {
+// A TryBounded TryAccess bails with nullptr while engine_lock_ is held; once released the lock is
+// reusable (no leak/poison) via both a fresh TryAccess and a blocking Access.
+TEST_F(StorageEngineLockContentionTest, EngineLockHeldMakesTryBoundedAccessBailAndLeavesLockReusable) {
   using namespace memgraph::storage;
 
   // Hold the transaction-engine lock, as a concurrent write-commit's durability phase would.


### PR DESCRIPTION
## What

An explicit `BEGIN` mints its transaction under `engine_lock_` (a `SpinLock`). A concurrent write commit holds that same lock across its durability/replication wait (SYNC / STRICT_SYNC 2PC), so every `BEGIN` **busy-spins a Bolt/pool worker** behind the slow commit — the customer symptom where fast reads collapse once client count exceeds worker count and commits are slow.

This makes `BEGIN`'s engine-lock acquisition **bounded-try + reschedule** instead of blocking: the worker attempts a tiny (~2 µs) bounded spin; on contention it bails and the BEGIN's completion is **re-posted to the priority pool** rather than spinning. Workers stay free to drain other work during a commit's durability hold. This is coroutines' worker-admission idea, scoped to the explicit-BEGIN lock path.

## Change from the original #4669

This branch is the **disentangled** version. The original stacked on the now-closed **#4666** (inline-BEGIN-on-the-strand), which carried a ~6% no-stall regression. That coupling is **removed**: this is **pool-native only** — no strand inlining. It rebases directly on `master`.

## Mechanism

- `storage::EngineLockMode { Blocking, TryBounded }` (leaf header `access_type.hpp`). Default `Blocking` — every existing caller is unchanged.
- `utils::BoundedTryLock(SpinLock&, ns)` — bounded spin-try (budget 2 µs), arch-guarded relax.
- `CreateTransaction(TryBounded)` throws `TransactionEngineWouldBlock` **before** any `transaction_id_`/`timestamp_` mutation → a bail changes nothing. Caught inside `InMemoryStorage::TryAccess` → returns `nullptr`.
- Interpreter **accessor-first reorder**: `SetupDatabaseTransaction` runs before `SetupInterpreterTransaction`/timer/flags, so a would-block bail leaves interpreter txn state pristine (no id consumed). `nullptr` → `query::WouldBlockInlineException`.
- Bolt: `HandleBegin` catches it → `StashPendingBegin` + `State::PendingBegin`. `Execute_` bails without touching any message pipelined behind the BEGIN (ordering preserved). `PostFinishPendingBegin` re-posts to the **pool** (never the strand); `PendingBeginOutcome::{Done,ClientError,Reschedule}`. Fairness: after `kBeginRescheduleCap = 32` reschedules it does one blocking acquire, so a BEGIN can't starve. `SUCCESS` is emitted exactly once (in `FinishPendingBegin_`).
- Websocket path drives the pending BEGIN to terminal inline on the strand (bounded by the cap), preserving master's inline-completion there.

## Scope

Explicit `BEGIN` message only. Autocommit / implicit-`Prepare` admission (a bare `RUN` with no `BEGIN`) still acquires blocking — that's the follow-up that reuses this machinery (`State::PendingRun`).

## Known residual

On-disk storage has no non-blocking probe, so `TryAccess` returns `nullptr` and an on-disk `BEGIN` reschedules up to the cap (32×) then blocks — correct, but suboptimal. A one-hop on-disk fix is a tracked follow-up.

## Tests

- `bolt_session`: `PendingBeginReschedulesThenCompletesWithOneSuccess`, `PendingBeginFairnessCapForcesBlockingTerminal`, `PendingBeginHoldsBackPipelinedMessageUntilItCompletes`.
- `storage_v2`: `EngineLockHeldMakesTryBoundedAccessBailAndLeavesLockReusable`.
- All green (bolt_session 38/38, storage_v2 64/64). Each is mutation-checkable against the production state machine.

## Benchmarks

Explicit-BEGIN + slow-commit scenarios improve; autocommit is flat (out of scope, as expected). STRICT_SYNC (2 PC, longest lock hold) shows the largest gains. Exact deltas to be confirmed on a perf-stable box — the netlab dev VM is not perf-stable.