### PR TITLE
perf(mage): Skip redundant directions in path expansions

### DIFF
--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -625,6 +625,8 @@ Path::RelStep Path::PathHelper::ParseRelStep(const mgp::List &list_of_relationsh
   if (list_of_relationships.Size() == 0) {  // no relationships given, so every relationship is allowed
     step.any_outgoing = true;
     step.any_incoming = true;
+    step.needs_outgoing = true;
+    step.needs_incoming = true;
     return step;
   }
 
@@ -680,6 +682,13 @@ Path::RelStep Path::PathHelper::ParseRelStep(const mgp::List &list_of_relationsh
       direction = RelDirection::kOutgoing;
     }
     AddRelationshipDirection(step, std::move(type), direction);
+  }
+
+  step.needs_incoming = step.any_incoming;
+  step.needs_outgoing = step.any_outgoing;
+  for (auto const &[_, dir] : step.types) {
+    step.needs_incoming = step.needs_incoming || dir == RelDirection::kIncoming || dir == RelDirection::kAny;
+    step.needs_outgoing = step.needs_outgoing || dir == RelDirection::kOutgoing || dir == RelDirection::kAny;
   }
 
   return step;
@@ -938,8 +947,12 @@ void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size) {
     return;
   }
 
-  this->ExpandFromRelationships(path, node.InRelationships(), false, path_size);
-  this->ExpandFromRelationships(path, node.OutRelationships(), true, path_size);
+  if (path_data_.helper_.NeedsIncoming(path_size)) {
+    this->ExpandFromRelationships(path, node.InRelationships(), false, path_size);
+  }
+  if (path_data_.helper_.NeedsOutgoing(path_size)) {
+    this->ExpandFromRelationships(path, node.OutRelationships(), true, path_size);
+  }
 }
 
 void Path::PathExpand::StartAlgorithm(const mgp::Node &node) {
@@ -1078,8 +1091,12 @@ void Path::PathExpand::RunNodeGlobalBfs() {
       continue;
     }
 
-    ExpandTreeEntry(index, depth, node.InRelationships(), false, frontier);
-    ExpandTreeEntry(index, depth, node.OutRelationships(), true, frontier);
+    if (path_data_.helper_.NeedsIncoming(depth)) {
+      ExpandTreeEntry(index, depth, node.InRelationships(), false, frontier);
+    }
+    if (path_data_.helper_.NeedsOutgoing(depth)) {
+      ExpandTreeEntry(index, depth, node.OutRelationships(), true, frontier);
+    }
   }
 }
 
@@ -1249,8 +1266,12 @@ mgp::List Path::PathSubgraph::BFS() {
       continue;
     }
 
-    this->ExpandFromRelationships(pair, pair.first.InRelationships(), false, queue);
-    this->ExpandFromRelationships(pair, pair.first.OutRelationships(), true, queue);
+    if (path_data_.helper_.NeedsIncoming(pair.second)) {
+      this->ExpandFromRelationships(pair, pair.first.InRelationships(), false, queue);
+    }
+    if (path_data_.helper_.NeedsOutgoing(pair.second)) {
+      this->ExpandFromRelationships(pair, pair.first.OutRelationships(), true, queue);
+    }
   }
 
   return to_be_returned_nodes_;

--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -684,12 +684,13 @@ Path::RelStep Path::PathHelper::ParseRelStep(const mgp::List &list_of_relationsh
     AddRelationshipDirection(step, std::move(type), direction);
   }
 
-  auto has_dir = [&](RelDirection d) {
-    return std::ranges::any_of(step.types,
-                               [d](auto const &kv) { return kv.second == d || kv.second == RelDirection::kAny; });
+  auto has_direction = [&step](RelDirection direction) {
+    return std::ranges::any_of(step.types, [direction](const auto &type_and_direction) {
+      return type_and_direction.second == direction || type_and_direction.second == RelDirection::kAny;
+    });
   };
-  step.needs_incoming = step.any_incoming || has_dir(RelDirection::kIncoming);
-  step.needs_outgoing = step.any_outgoing || has_dir(RelDirection::kOutgoing);
+  step.needs_incoming = step.any_incoming || has_direction(RelDirection::kIncoming);
+  step.needs_outgoing = step.any_outgoing || has_direction(RelDirection::kOutgoing);
 
   return step;
 }

--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -684,12 +684,12 @@ Path::RelStep Path::PathHelper::ParseRelStep(const mgp::List &list_of_relationsh
     AddRelationshipDirection(step, std::move(type), direction);
   }
 
-  step.needs_incoming = step.any_incoming;
-  step.needs_outgoing = step.any_outgoing;
-  for (auto const &[_, dir] : step.types) {
-    step.needs_incoming = step.needs_incoming || dir == RelDirection::kIncoming || dir == RelDirection::kAny;
-    step.needs_outgoing = step.needs_outgoing || dir == RelDirection::kOutgoing || dir == RelDirection::kAny;
-  }
+  auto has_dir = [&](RelDirection d) {
+    return std::ranges::any_of(step.types,
+                               [d](auto const &kv) { return kv.second == d || kv.second == RelDirection::kAny; });
+  };
+  step.needs_incoming = step.any_incoming || has_dir(RelDirection::kIncoming);
+  step.needs_outgoing = step.any_outgoing || has_dir(RelDirection::kOutgoing);
 
   return step;
 }

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -130,6 +130,8 @@ struct RelStep {
   std::unordered_map<std::string, RelDirection, TransparentStringHash, std::equal_to<>> types;
   bool any_incoming = false;
   bool any_outgoing = false;
+  bool needs_incoming = false;
+  bool needs_outgoing = false;
 };
 
 // What may not repeat during a walk. The `*Path` forms forbid a repeat within the current path only;
@@ -197,6 +199,11 @@ class PathHelper {
 
   // Whether a relationship of this type, traversed this way out of a node at `depth`, may be followed.
   [[nodiscard]] bool RelationshipAdmitted(std::string_view rel_type, bool outgoing, int64_t depth) const;
+
+  // Whether the step at `depth` can admit any incoming or outgoing relationship at all.
+  [[nodiscard]] bool NeedsIncoming(int64_t depth) const { return RelStepAt(depth).needs_incoming; }
+
+  [[nodiscard]] bool NeedsOutgoing(int64_t depth) const { return RelStepAt(depth).needs_outgoing; }
 
   [[nodiscard]] static LabelBools GetLabelBools(const mgp::Node &node, const LabelStep &step);
 

--- a/tests/mgbench/workloads/path_module.py
+++ b/tests/mgbench/workloads/path_module.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import random
+
+from benchmark_context import BenchmarkContext
+from constants import GraphVendors
+from workloads.base import Workload
+
+
+# Measures `path.expand` and `path.subgraph_nodes` on a hub-and-spoke graph whose edges all point
+# towards the hub, where a directed filter admits only the outgoing side.
+#
+# The `near_hub` pair is the one that guards the optimisation: it starts a hop out, so the walk
+# reaches the hub at depth 1 and skips its whole incoming list while still traversing. The queries
+# starting *at* the hub skip that list at depth 0 and then find an empty outgoing list, so they
+# report the saving but touch no edges afterwards; they cannot detect a later regression on their
+# own. The undirected variants are the controls: both directions are needed, so they run the
+# unchanged code path.
+class PathModule(Workload):
+    NAME = "path_module"
+    VARIANTS = ["small", "medium", "large"]
+    DEFAULT_VARIANT = "medium"
+
+    SIZES = {
+        "small": {"vertices": 1001, "edges": 3000},
+        "medium": {"vertices": 10001, "edges": 30000},
+        "large": {"vertices": 100001, "edges": 300000},
+    }
+
+    def __init__(self, variant: str = None, benchmark_context: BenchmarkContext = None):
+        super().__init__(variant, benchmark_context=benchmark_context)
+        self._spokes = self._size["vertices"] - 1
+
+    def indexes_generator(self):
+        return [
+            ("CREATE INDEX ON :Hub(id);", {}),
+            ("CREATE INDEX ON :Spoke(id);", {}),
+        ]
+
+    def dataset_generator(self):
+        queries = [("CREATE (:Hub {id: 0});", {})]
+        for i in range(0, self._spokes):
+            queries.append(("CREATE (:Spoke {id: $id});", {"id": i}))
+
+        # All spokes point at the hub, so the hub's incoming list holds every edge and its outgoing
+        # list is empty. An `INNER>` filter out of the hub must therefore reject the whole incoming
+        # list, which is the case this benchmark exists to measure.
+        queries.append(("MATCH (h:Hub), (s:Spoke) CREATE (s)-[:INNER]->(h);", {}))
+
+        # A second layer of directed edges between spokes gives the traversal somewhere to go after
+        # the first hop, so the deeper levels are not all dead ends.
+        for _ in range(0, self._size["edges"]):
+            queries.append(
+                (
+                    "MATCH (a:Spoke {id: $a}), (b:Spoke {id: $b}) CREATE (a)-[:OUTER]->(b);",
+                    {"a": self._get_random_spoke(), "b": self._get_random_spoke()},
+                )
+            )
+        return queries
+
+    def _get_random_spoke(self):
+        return random.randint(0, self._spokes - 1)
+
+    def benchmark__directional__subgraph_nodes_directed(self):
+        match self._vendor:
+            case GraphVendors.MEMGRAPH:
+                return (
+                    "MATCH (h:Hub {id: 0}) CALL path.subgraph_nodes(h, "
+                    '{relationshipFilter: ["INNER>", "OUTER>"], maxLevel: 3}) '
+                    "YIELD nodes RETURN count(nodes);",
+                    {},
+                )
+            case _:
+                raise Exception(f"Unknown vendor {self._vendor}")
+
+    def benchmark__directional__subgraph_nodes_undirected(self):
+        match self._vendor:
+            case GraphVendors.MEMGRAPH:
+                return (
+                    "MATCH (h:Hub {id: 0}) CALL path.subgraph_nodes(h, "
+                    '{relationshipFilter: ["INNER", "OUTER"], maxLevel: 3}) '
+                    "YIELD nodes RETURN count(nodes);",
+                    {},
+                )
+            case _:
+                raise Exception(f"Unknown vendor {self._vendor}")
+
+    def benchmark__directional__expand_directed(self):
+        match self._vendor:
+            case GraphVendors.MEMGRAPH:
+                return (
+                    "MATCH (h:Hub {id: 0}) CALL path.expand(h, "
+                    '["INNER>", "OUTER>"], [], 1, 3) '
+                    "YIELD result RETURN count(result);",
+                    {},
+                )
+            case _:
+                raise Exception(f"Unknown vendor {self._vendor}")
+
+    def benchmark__directional__expand_undirected(self):
+        match self._vendor:
+            case GraphVendors.MEMGRAPH:
+                return (
+                    "MATCH (h:Hub {id: 0}) CALL path.expand(h, "
+                    '["INNER", "OUTER"], [], 1, 3) '
+                    "YIELD result RETURN count(result);",
+                    {},
+                )
+            case _:
+                raise Exception(f"Unknown vendor {self._vendor}")
+
+    # Starting one hop away from the hub: the first step crosses INNER to the hub, so the walk still
+    # meets the supernode, just at depth 1 rather than depth 0. Unlike the queries that start at the
+    # hub, this one keeps traversing afterwards, so it is the pair that a regression would move.
+    def benchmark__directional__subgraph_nodes_near_hub(self):
+        match self._vendor:
+            case GraphVendors.MEMGRAPH:
+                return (
+                    "MATCH (s:Spoke {id: $id}) CALL path.subgraph_nodes(s, "
+                    '{relationshipFilter: ["INNER>", "OUTER>"], maxLevel: 3}) '
+                    "YIELD nodes RETURN count(nodes);",
+                    {"id": self._get_random_spoke()},
+                )
+            case _:
+                raise Exception(f"Unknown vendor {self._vendor}")
+
+    def benchmark__directional__subgraph_nodes_near_hub_undirected(self):
+        match self._vendor:
+            case GraphVendors.MEMGRAPH:
+                return (
+                    "MATCH (s:Spoke {id: $id}) CALL path.subgraph_nodes(s, "
+                    '{relationshipFilter: ["INNER", "OUTER"], maxLevel: 3}) '
+                    "YIELD nodes RETURN count(nodes);",
+                    {"id": self._get_random_spoke()},
+                )
+            case _:
+                raise Exception(f"Unknown vendor {self._vendor}")


### PR DESCRIPTION
When `path.subgraph_nodes` or `path.expand` is called with a directional filter (e.g. ["SHARES_HELD_BY>", "HAS_MAJORITY_OWNER>"]), the BFS previously iterated both incoming and outgoing edges at every node, rejecting the unwanted direction one relationship at a time inside `RelationshipAdmitted`. On high-degree nodes this is expensive: the entire incoming edge list is copied and walked for nothing, because all these edges will trivially be rejected by their direction.

This change puts the direction check to before the iterator is created, avoiding the storage access entirely.