### PR TITLE
fix(query): load parquet and JSONL from signed URLs of any length

### DIFF
--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -233,7 +233,7 @@ jobs:
     if: ${{ inputs.run_clang_tidy == 'true' }}
     name: "Clang tidy"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,10 @@ add_compile_options(
         -Werror=deprecated
         -Wno-error=deprecated-declarations
         $<$<CXX_COMPILER_ID:Clang>:-Werror=reorder-init-list>
+        # A member whose constructor starts a thread reading other members is initialized in
+        # declaration order, not the order the initializer list is written in.
+        $<$<CXX_COMPILER_ID:Clang>:-Werror=reorder-ctor>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=reorder>
 )
 
 # Use lld linker to speedup build and use less memory.

--- a/src/query/arrow_parquet/reader.cpp
+++ b/src/query/arrow_parquet/reader.cpp
@@ -16,13 +16,15 @@ module;
 #include "query/typed_value.hpp"
 #include "requests/requests.hpp"
 #include "utils/data_queue.hpp"
+#include "utils/download_temp_file.hpp"
 #include "utils/exceptions.hpp"
-#include "utils/file.hpp"
 #include "utils/pmr/string.hpp"
+#include "utils/prefetched.hpp"
 #include "utils/temporal.hpp"
 
 #include <chrono>
 #include <exception>
+#include <memory>
 #include <stdexcept>
 #include <string_view>
 #include <thread>
@@ -140,17 +142,9 @@ auto LoadFileFromS3(memgraph::utils::pmr::string const &file, memgraph::utils::S
   return std::move(*maybe_parquet_reader);
 }
 
-// nullptr for error
-auto LoadFileFromDisk(std::string file_path)
+auto BuildFileReader(std::shared_ptr<arrow::io::ReadableFile> file)
     -> std::expected<std::unique_ptr<parquet::arrow::FileReader>, arrow::Status> {
   arrow::MemoryPool *pool = arrow::default_memory_pool();
-
-  auto maybe_file = arrow::io::ReadableFile::Open(file_path, pool);
-  if (!maybe_file.ok()) {
-    return std::unexpected{maybe_file.status()};
-  }
-
-  auto const &file = *maybe_file;
 
   auto reader_properties = parquet::ReaderProperties(pool);
   reader_properties.enable_buffered_stream();
@@ -161,7 +155,7 @@ auto LoadFileFromDisk(std::string file_path)
 
   parquet::arrow::FileReaderBuilder reader_builder;
 
-  if (auto const status = reader_builder.Open(file, reader_properties); !status.ok()) {
+  if (auto const status = reader_builder.Open(std::move(file), reader_properties); !status.ok()) {
     return std::unexpected{status};
   }
 
@@ -174,6 +168,29 @@ auto LoadFileFromDisk(std::string file_path)
   }
 
   return file_reader;
+}
+
+auto LoadFileFromDisk(std::string file_path)
+    -> std::expected<std::unique_ptr<parquet::arrow::FileReader>, arrow::Status> {
+  auto maybe_file = arrow::io::ReadableFile::Open(file_path, arrow::default_memory_pool());
+  if (!maybe_file.ok()) {
+    return std::unexpected{maybe_file.status()};
+  }
+
+  return BuildFileReader(*maybe_file);
+}
+
+auto LoadFileFromDescriptor(memgraph::utils::OwnedFd fd)
+    -> std::expected<std::unique_ptr<parquet::arrow::FileReader>, arrow::Status> {
+  // Arrow closes what it is given, but only once it has accepted it: on failure the descriptor is
+  // still ours, which is what holding it in an owner until that point takes care of.
+  auto maybe_file = arrow::io::ReadableFile::Open(fd.Get(), arrow::default_memory_pool());
+  if (!maybe_file.ok()) {
+    return std::unexpected{maybe_file.status()};
+  }
+  static_cast<void>(fd.Release());
+
+  return BuildFileReader(*maybe_file);
 }
 
 // Multiply a tick count by us_per_unit to convert it to microseconds, throwing instead of silently overflowing
@@ -530,14 +547,12 @@ struct ParquetReader::impl {
   BatchIterator row_it_;
   utils::MemoryResource *resource_;
   utils::pmr::vector<Row> rows_;
-  utils::DataQueue<utils::pmr::vector<Row>> work_queue_;
   Header header_;
-  // Set by the prefetcher thread if a batch fails to be read/converted, read by the consumer once the queue drains.
-  // Declared before prefetcher_thread_ so it outlives the thread (destroyed after the thread is joined).
-  std::exception_ptr prefetch_error_;
-  std::jthread prefetcher_thread_;  // should get destroyed before all other variables that it uses as a reference
   uint64_t row_in_batch_{0};
   uint64_t current_batch_size_{0};
+  // Declared last so everything the reading thread touches is constructed before that thread starts,
+  // and destroyed only after it has been joined.
+  memgraph::utils::Prefetched<utils::pmr::vector<Row>> batches_;
 };
 
 ParquetReader::impl::impl(std::unique_ptr<parquet::arrow::FileReader> file_reader,
@@ -548,54 +563,48 @@ ParquetReader::impl::impl(std::unique_ptr<parquet::arrow::FileReader> file_reade
       row_it_(BatchIterator(std::move(rbr), num_columns_)),
       resource_(resource),
       rows_(resource),
-      work_queue_(2),
       header_(std::move(header)),
-      prefetcher_thread_{[this](std::stop_token stop_token) {
-        // Any exception thrown while reading a batch or converting a value (e.g. an out-of-range temporal value that
-        // fails LocalTime/LocalDateTime/Duration validation) must not escape this thread's top-level function - that
-        // would call std::terminate and crash the whole process. Capture it and hand it to the consumer instead, which
-        // rethrows it from GetNextRow so it surfaces as a regular query error.
-        try {
-          while (!stop_token.stop_requested()) {
-            auto const batch_ref = row_it_.Next();
-            // No more data
-            if (batch_ref.empty()) {
-              work_queue_.finish();
-              break;
-            }
+      batches_{2,
+               [this](auto const &push_batch) {
+                 // A batch read or a value conversion can throw. Prefetched carries that to the consumer
+                 // rather than letting it reach the top of this thread.
+                 try {
+                   while (true) {
+                     auto const batch_ref = row_it_.Next();
+                     // No more data
+                     if (batch_ref.empty()) {
+                       return;
+                     }
 
-            auto const num_rows = batch_ref[0]->length();
-            utils::pmr::vector<Row> queued_batch(resource_);
-            queued_batch.reserve(num_rows);
-            for (auto i = 0; i < num_rows; ++i) {
-              // temporary needs to be created
-              // NOLINTNEXTLINE
-              queued_batch.emplace_back(Row{resource_});
-            }
+                     auto const num_rows = batch_ref[0]->length();
+                     utils::pmr::vector<Row> queued_batch(resource_);
+                     queued_batch.reserve(num_rows);
+                     for (auto i = 0; i < num_rows; ++i) {
+                       // temporary needs to be created
+                       // NOLINTNEXTLINE
+                       queued_batch.emplace_back(Row{resource_});
+                     }
 
-            std::vector<std::function<TypedValue(int64_t)>> converters;
-            converters.reserve(num_columns_);
-            for (int j = 0U; j < num_columns_; j++) {
-              converters.push_back(CreateColumnConverter(batch_ref[j], resource_));
-            }
+                     std::vector<std::function<TypedValue(int64_t)>> converters;
+                     converters.reserve(num_columns_);
+                     for (int j = 0U; j < num_columns_; j++) {
+                       converters.push_back(CreateColumnConverter(batch_ref[j], resource_));
+                     }
 
-            for (int j = 0U; j < num_columns_; j++) {
-              auto const &converter = converters[j];
-              for (int64_t i = 0; i < num_rows; i++) {
-                queued_batch[i].emplace(header_[j], converter(i));  // RVO should kick in here
-              }
-            }
-            work_queue_.push(std::move(queued_batch));
-          }
-        } catch (const std::exception &e) {
-          prefetch_error_ =
-              std::make_exception_ptr(QueryRuntimeException("Error while loading PARQUET file: {}", e.what()));
-          work_queue_.finish();
-        } catch (...) {
-          prefetch_error_ = std::current_exception();
-          work_queue_.finish();
-        }
-      }}
+                     for (int j = 0U; j < num_columns_; j++) {
+                       auto const &converter = converters[j];
+                       for (int64_t i = 0; i < num_rows; i++) {
+                         queued_batch[i].emplace(header_[j], converter(i));  // RVO should kick in here
+                       }
+                     }
+                     if (!push_batch(std::move(queued_batch))) {
+                       return;
+                     }
+                   }
+                 } catch (const std::exception &e) {
+                   throw QueryRuntimeException("Error while loading PARQUET file: {}", e.what());
+                 }
+               }}
 
 {
   rows_.reserve(batch_rows);
@@ -606,20 +615,13 @@ ParquetReader::impl::impl(std::unique_ptr<parquet::arrow::FileReader> file_reade
   }
 }
 
-ParquetReader::impl::~impl() {
-  prefetcher_thread_.request_stop();
-  work_queue_.finish();
-}
+ParquetReader::impl::~impl() = default;
 
 auto ParquetReader::impl::GetNextRow(Row &out) -> bool {
   if (row_in_batch_ >= current_batch_size_) {
-    if (!work_queue_.pop(rows_)) {
-      // The queue is drained. If the prefetcher aborted with an error, surface it on the consumer thread so it becomes
-      // a query error rather than a process crash. (finish() happens-before this pop() returning false, so the write to
-      // prefetch_error_ that precedes finish() is visible here without extra synchronization.)
-      if (prefetch_error_) {
-        std::rethrow_exception(prefetch_error_);
-      }
+    // Rethrows on this thread whatever reading a batch threw, so it becomes a query error rather
+    // than reaching the top of the thread that read it.
+    if (!batches_.Next(rows_)) {
       return false;
     }
     row_in_batch_ = 0;
@@ -637,21 +639,43 @@ ParquetReader::ParquetReader(utils::pmr::string const &uri, utils::S3Config s3_c
 
     // When using a file that should be downloaded using https or ftp, we first download it and then load it
     if (url_matcher(uri)) {
-      auto const base_path = std::filesystem::path{"/tmp"} / std::filesystem::path{uri}.filename();
-      auto [local_file_path, file] = utils::CreateUniqueDownloadFile(base_path);
-      if (requests::CreateAndDownloadFile(std::string{uri},
-                                          std::move(file),
-                                          memgraph::flags::run_time::GetFileDownloadConnTimeoutSec(),
-                                          std::move(abort_check))) {
-        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-        utils::OnScopeExit const on_exit{[&local_file_path]() { utils::DeleteFile(local_file_path); }};
-
-        return LoadFileFromDisk(local_file_path);
+      auto temp_file = utils::DownloadTempFile::Create();
+      if (!temp_file) {
+        return std::unexpected{arrow::Status{
+            arrow::StatusCode::IOError,
+            fmt::format("Couldn't create a file to download {} into: {}", uri, temp_file.error().message())}};
       }
-      utils::DeleteFile(local_file_path);
 
-      return std::unexpected{
-          arrow::Status{arrow::StatusCode::UnknownError, fmt::format("Couldn't download file: {}", uri)}};
+      auto stream = temp_file->OpenStream();
+      if (!stream) {
+        return std::unexpected{arrow::Status{
+            arrow::StatusCode::IOError,
+            fmt::format("Couldn't open the download of {} for writing: {}", uri, stream.error().message())}};
+      }
+
+      if (auto const downloaded =
+              requests::CreateAndDownloadFile(std::string{uri},
+                                              std::move(*stream),
+                                              memgraph::flags::run_time::GetFileDownloadConnTimeoutSec(),
+                                              std::move(abort_check));
+          !downloaded) {
+        // Thrown rather than returned: an arrow::Status has nowhere to carry whether trying again
+        // could help.
+        memgraph::query::ThrowDownloadFailed(
+            downloaded.error().Retryable(),
+            fmt::format("Couldn't download file {}: {}", uri, downloaded.error().message));
+      }
+
+      // The reader takes a descriptor of its own, so the download outlives `temp_file` going out of
+      // scope here and needs no cleanup: it was unlinked when it was created.
+      auto fd = temp_file->DupFd();
+      if (!fd) {
+        return std::unexpected{
+            arrow::Status{arrow::StatusCode::IOError,
+                          fmt::format("Couldn't read back the download of {}: {}", uri, fd.error().message())}};
+      }
+
+      return LoadFileFromDescriptor(std::move(*fd));
     }
 
     if (s3_matcher(uri)) {

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -105,13 +105,6 @@ struct StoppingContext {
     }
     return AbortReason::NO_ABORT;
   }
-
-  auto MakeMaybeAborter(std::size_t n = 20) const noexcept {
-    return [maybe_check_abort = utils::ResettableCounter{n}, ctx = *this]() -> AbortReason {
-      // Not thread safe
-      return maybe_check_abort() ? ctx.MustAbort() : AbortReason::NO_ABORT;
-    };
-  }
 };
 
 struct ExecutionContext {

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -220,6 +220,24 @@ class QueryRuntimeException : public QueryException {
   SPECIALIZE_GET_EXCEPTION_NAME(QueryRuntimeException)
 };
 
+/// A download that could deliver the file if the query were run again, such as one the server failed
+/// to serve or that never reached it. Reported to the client as retryable, and counted separately
+/// from other retryable errors so a run of them is visible.
+class TransientDownloadException : public RetryBasicException {
+ public:
+  using RetryBasicException::RetryBasicException;
+  SPECIALIZE_GET_EXCEPTION_NAME(TransientDownloadException)
+};
+
+/// Reports a failed download. Whether trying again could help is what decides which of the two the
+/// client sees, and that question belongs to whoever attempted the transfer.
+[[noreturn]] inline void ThrowDownloadFailed(bool const retryable, std::string message) {
+  if (retryable) {
+    throw TransientDownloadException(std::move(message));
+  }
+  throw QueryRuntimeException(std::move(message));
+}
+
 enum class AbortReason : uint8_t {
   NO_ABORT = 0,
 

--- a/src/query/jsonl/reader.cpp
+++ b/src/query/jsonl/reader.cpp
@@ -11,9 +11,18 @@
 
 module;
 
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <exception>
+#include <fstream>
 #include <functional>
+#include <memory>
+#include <streambuf>
 #include <string>
+#include <thread>
 #include <utility>
+#include <vector>
 
 #include "ctre.hpp"
 #include "flags/run_time_configurable.hpp"
@@ -21,10 +30,11 @@ module;
 #include "simdjson.h"
 #include "spdlog/spdlog.h"
 
+#include "query/exceptions.hpp"
 #include "query/typed_value.hpp"
+#include "utils/byte_source.hpp"
 #include "utils/exceptions.hpp"
-#include "utils/file.hpp"
-#include "utils/likely.hpp"
+#include "utils/queued_byte_source.hpp"
 
 module memgraph.query.jsonl.reader;
 
@@ -105,7 +115,9 @@ void IterateObject(simdjson::ondemand::object &obj, auto &out, memgraph::utils::
   for (auto &&field : obj) {
     std::string_view key_view;
     // Check for error
-    if (UNLIKELY(field.unescaped_key().get(key_view))) continue;
+    if (field.unescaped_key().get(key_view)) [[unlikely]] {
+      continue;
+    }
     // NOLINTNEXTLINE
     TypedValue::TString key{key_view, resource};
 
@@ -115,6 +127,10 @@ void IterateObject(simdjson::ondemand::object &obj, auto &out, memgraph::utils::
   }
 }
 
+// With blocks of a known size this is a read-ahead in bytes: enough to keep a transfer working while
+// a chunk is parsed, and small beside the source itself.
+constexpr std::size_t kQueuedBlocks = 4;
+
 }  // namespace
 
 namespace memgraph::query {
@@ -122,15 +138,12 @@ namespace memgraph::query {
 struct JsonlReader::impl {
  public:
   impl(std::string uri, std::optional<utils::S3Config> s3_cfg, std::pmr::memory_resource *resource,
-       std::function<void()> abort_check)
-      : uri_{std::move(uri)}, resource_{resource} {
-    InitSimdjsonContent(std::move(s3_cfg), std::move(abort_check));
-
-    if (UNLIKELY(parser_.iterate_many(content_).get(docs_))) {
-      throw utils::BasicException("Failed to create iterator over documents for file {}", uri_);
-    }
-
-    it_ = docs_.begin();
+       std::function<void()> abort_check, std::size_t chunk_size)
+      : uri_{std::move(uri)},
+        resource_{resource},
+        chunk_size_{std::max<std::size_t>(chunk_size, 1)},
+        buffer_{chunk_size_} {
+    source_ = OpenSource(std::move(s3_cfg), std::move(abort_check));
   }
 
   impl(impl const &) = delete;
@@ -140,70 +153,135 @@ struct JsonlReader::impl {
 
   ~impl() = default;
 
-  // Performs file download if necessary before loading the file from disk
-  void InitSimdjsonContent(std::optional<utils::S3Config> s3_cfg, std::function<void()> abort_check) {
+  auto GetNextRow(Row &out) -> bool {
+    while (true) {
+      if (parsed_ && it_ != docs_.end()) [[likely]] {
+        out.clear();
+        auto obj = (*it_)->get_object().value();
+        IterateObject(obj, out, resource_);
+        ++it_;
+        return true;
+      }
+      if (!Refill()) return false;
+    }
+  }
+
+ private:
+  auto OpenSource(std::optional<utils::S3Config> s3_cfg, std::function<void()> abort_check)
+      -> std::unique_ptr<memgraph::utils::ByteSource> {
     constexpr auto url_matcher = ctre::starts_with<"(https?|ftp)://">;
     constexpr auto s3_matcher = ctre::starts_with<"s3://">;
 
-    auto const build_base_path = [&]() -> std::filesystem::path {
-      return std::filesystem::path{"/tmp"} / std::filesystem::path{uri_}.filename();
-    };
-
     if (url_matcher(uri_)) {
-      auto [new_path, file] = utils::CreateUniqueDownloadFile(build_base_path());
+      return std::make_unique<memgraph::utils::QueuedByteSource>(
+          kQueuedBlocks,
+          [uri = uri_,
+           abort_check = std::move(abort_check)](memgraph::utils::QueuedByteSource::Push const &push) mutable {
+            auto const sink = [&push](char const *data, std::size_t size) -> std::size_t {
+              return push(data, size) ? size : 0;
+            };
+            if (auto const downloaded = requests::DownloadToSink(
+                    uri, sink, memgraph::flags::run_time::GetFileDownloadConnTimeoutSec(), std::move(abort_check));
+                !downloaded) {
+              ThrowDownloadFailed(downloaded.error().Retryable(),
+                                  fmt::format("Failed to download file {}: {}", uri, downloaded.error().message));
+            }
+          });
+    }
 
-      if (!requests::CreateAndDownloadFile(uri_,
-                                           std::move(file),
-                                           memgraph::flags::run_time::GetFileDownloadConnTimeoutSec(),
-                                           std::move(abort_check))) {
-        utils::DeleteFile(new_path);
-        throw utils::BasicException("Failed to download file {}", uri_);
-      }
-      // .value() can throw ac exception hence and we don't want to leak new_path
-      auto const on_exit = utils::OnScopeExit([&new_path]() { utils::DeleteFile(new_path); });
-      content_ = simdjson::padded_string::load(new_path.string()).value();
-    } else if (s3_matcher(uri_)) {
+    if (s3_matcher(uri_)) {
       DMG_ASSERT(s3_cfg.has_value(), "S3Config doesn't have a value");
       if (auto const res = s3_cfg->Validate(); res.has_value()) {
         throw utils::BasicException(utils::AwsValidationErrorToStr(*res));
       }
-      auto const new_path = utils::CreateUniqueDownloadFile(build_base_path()).first;
-      // .value() can throw ac exception hence and we don't want to leak new_path
-      auto const on_exit = utils::OnScopeExit([&new_path]() { utils::DeleteFile(new_path); });
-      if (auto const res = utils::GetS3Object(uri_, *s3_cfg, new_path.string()); !res.has_value()) {
-        throw utils::BasicException(res.error().message);
-      }
-      content_ = simdjson::padded_string::load(new_path.string()).value();
-    } else {
-      content_ = simdjson::padded_string::load(uri_).value();
+      return std::make_unique<memgraph::utils::QueuedByteSource>(
+          kQueuedBlocks,
+          [uri = uri_, config = *s3_cfg, abort_check = std::move(abort_check)](
+              memgraph::utils::QueuedByteSource::Push const &push) {
+            memgraph::utils::PushStreambuf sink{push, abort_check};
+            auto const res = utils::GetS3ObjectStreaming(uri, config, sink);
+            sink.RethrowIfStopped();
+            if (!res.has_value()) {
+              throw utils::BasicException(res.error().message);
+            }
+          });
     }
+
+    return std::make_unique<memgraph::utils::FileByteSource>(uri_);
   }
 
-  auto GetNextRow(Row &out) -> bool {
-    if (UNLIKELY(it_ == docs_.end())) return false;
+  void Resize(std::size_t size, std::size_t keep) {
+    simdjson::padded_string resized{size};
+    std::memcpy(resized.data(), buffer_.data(), keep);
+    buffer_ = std::move(resized);
+  }
 
-    out.clear();
-    auto obj = (*it_)->get_object().value();
-    IterateObject(obj, out, resource_);
-    ++it_;
+  // Carries the trailing partial document to the front of the buffer, tops the buffer up from the
+  // source and parses again. Returns false once nothing parseable is left.
+  auto Refill() -> bool {
+    auto const carry = parsed_ ? std::min(docs_.truncated_bytes(), filled_) : std::size_t{0};
 
+    // Release the stream's reference to the buffer before that buffer is moved or reallocated.
+    docs_ = simdjson::ondemand::document_stream{};
+    parsed_ = false;
+
+    if (carry > 0 && carry < filled_) {
+      std::memmove(buffer_.data(), buffer_.data() + (filled_ - carry), carry);
+    }
+    filled_ = carry;
+
+    // A document larger than the buffer fills it without completing, leaving nowhere to read the
+    // rest of it into. Growing is what lets the parser make progress again.
+    if (filled_ == buffer_.size()) {
+      Resize(std::max<std::size_t>(buffer_.size() * 2, 64), carry);
+    } else if (buffer_.size() > chunk_size_ && carry * 2 <= chunk_size_) {
+      // One oversized document would otherwise leave the buffer grown for the rest of the source.
+      // Only give the space back once what is being carried fits well inside the configured size, so
+      // a run of large documents does not thrash between the two.
+      Resize(chunk_size_, carry);
+    }
+
+    // One read, then parse whatever turned up. Waiting for a full buffer would hold back every row
+    // in it until the slowest byte arrived.
+    auto const read = source_->Read(buffer_.data() + filled_, buffer_.size() - filled_);
+    filled_ += read;
+    auto const read_any = read > 0;
+
+    // Either the source is spent, or what remains is a fragment it will never complete. A trailing
+    // fragment is dropped rather than reported.
+    if (filled_ == 0 || (!read_any && carry == filled_)) {
+      return false;
+    }
+
+    // The batch size is the buffer rather than what is in it: the parser reallocates its working
+    // buffers whenever this differs from the previous call, and what a read returns varies. It is at
+    // least what is in the buffer either way, which is what keeps the whole of it parsed as final.
+    if (parser_.iterate_many(buffer_.data(), filled_, buffer_.size()).get(docs_)) [[unlikely]] {
+      throw utils::BasicException("Failed to create iterator over documents for file {}", uri_);
+    }
+    it_ = docs_.begin();
+    parsed_ = true;
     return true;
   }
 
- private:
   std::string uri_;
   std::pmr::memory_resource *resource_;
+  std::size_t chunk_size_;
   simdjson::ondemand::parser parser_;
-  simdjson::padded_string content_;
+  simdjson::padded_string buffer_;
+  std::size_t filled_{0};
+  bool parsed_{false};
   simdjson::ondemand::document_stream docs_;
   simdjson::ondemand::document_stream::iterator it_;
+  // Declared last so a source that runs a thread is shut down before the parse state it feeds.
+  std::unique_ptr<memgraph::utils::ByteSource> source_;
 };
 
 JsonlReader::JsonlReader(std::string file, std::optional<utils::S3Config> s3_cfg, std::pmr::memory_resource *resource,
-                         std::function<void()> abort_check)
-    : pimpl_{
-          // NOLINTNEXTLINE
-          std::make_unique<JsonlReader::impl>(std::move(file), std::move(s3_cfg), resource, std::move(abort_check))} {}
+                         std::function<void()> abort_check, std::size_t chunk_size)
+    : pimpl_{// NOLINTNEXTLINE
+             std::make_unique<JsonlReader::impl>(std::move(file), std::move(s3_cfg), resource, std::move(abort_check),
+                                                 chunk_size)} {}
 
 JsonlReader::~JsonlReader() {}
 

--- a/src/query/jsonl/reader.cppm
+++ b/src/query/jsonl/reader.cppm
@@ -11,7 +11,9 @@
 
 module;
 
+#include <cstddef>
 #include <functional>
+#include <optional>
 #include <string>
 
 #include "query/typed_value.hpp"
@@ -23,10 +25,14 @@ export module memgraph.query.jsonl.reader;
 export namespace memgraph::query {
 using Row = TypedValue::TMap;
 
+/// How much of the source is held in memory while parsing. A document larger than this grows the
+/// buffer for as long as that document is being read.
+inline constexpr std::size_t kDefaultJsonlChunkSize = 1U << 20U;
+
 class JsonlReader {
  public:
   explicit JsonlReader(std::string file, std::optional<utils::S3Config> s3_cfg, std::pmr::memory_resource *resource,
-                       std::function<void()> abort_check);
+                       std::function<void()> abort_check, std::size_t chunk_size = kDefaultJsonlChunkSize);
   ~JsonlReader();
 
   JsonlReader(JsonlReader const &other) = delete;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -9472,7 +9472,7 @@ class LoadJsonlCursor : public Cursor {
         s3_config.emplace(utils::S3Config::Build(std::move(*maybe_config_map), BuildRunTimeS3Config()));
       }
 
-      auto abort_check_erased = context.stopping_context.MakeMaybeAborter(1);
+      auto abort_check_erased = MakeThrowingAborter(context);
 
       reader_.emplace(std::string{maybe_file}, std::move(s3_config), mem, std::move(abort_check_erased));
     }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -428,11 +428,26 @@ uint64_t ComputeProfilingKey(const T *obj) {
 // impact on performance for the expected (non-abort) case.
 thread_local auto maybe_check_abort = utils::ResettableCounter{20};
 
+// Ending a query that must stop always takes this form, so the two places that check share it
+// rather than each deciding what an abort means.
+inline void ThrowIfAborting(StoppingContext const &stopping_context) {
+  if (auto const reason = stopping_context.MustAbort(); reason != AbortReason::NO_ABORT) [[unlikely]] {
+    throw HintedAbortError(reason);
+  }
+}
+
 inline void AbortCheck(ExecutionContext const &context) {
   if (!maybe_check_abort()) return;
 
-  if (auto const reason = context.stopping_context.MustAbort(); reason != AbortReason::NO_ABORT)
-    throw HintedAbortError(reason);
+  ThrowIfAborting(context.stopping_context);
+}
+
+// A download runs to completion inside a single Pull, so the check above gets no chance to run while
+// it does. The transfer takes this one instead, which must signal by throwing: that is the only form
+// a transfer can act on. A transfer offers this far less often than a scan offers rows, and how
+// promptly a download stops is what the caller waits on, so it looks every time.
+auto MakeThrowingAborter(ExecutionContext const &context) -> std::function<void()> {
+  return [stopping_context = context.stopping_context]() { ThrowIfAborting(stopping_context); };
 }
 
 std::vector<storage::LabelId> EvaluateLabels(const std::vector<StorageLabelType> &labels,
@@ -9333,7 +9348,7 @@ class LoadParquetCursor : public Cursor {
                                     utils::kAwsEndpointUrlQuerySetting);
       }
 
-      auto abort_check_erased = context.stopping_context.MakeMaybeAborter(1);
+      auto abort_check_erased = MakeThrowingAborter(context);
 
       // No need to check if maybe_file is std::nullopt, as the parser makes sure
       // we can't get a nullptr for the 'file_' member in the LoadParquet clause

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -43,8 +43,8 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
       : symbol_table_(symbol_table),
         ast_storage_(ast_storage),
         db_(db),
-        inherited_bound_symbols_(std::move(inherited_bound_symbols)),
-        order_by_eliminator_(db, prev_ops_, parallel_execution) {}
+        order_by_eliminator_(db, prev_ops_, parallel_execution),
+        inherited_bound_symbols_(std::move(inherited_bound_symbols)) {}
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -204,8 +204,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         db_(db),
         index_hints_(std::move(index_hints)),
         parameters_(parameters),
-        inherited_bound_symbols_(std::move(inherited_bound_symbols)),
-        order_by_eliminator_(db, prev_ops_, parallel_execution) {}
+        order_by_eliminator_(db, prev_ops_, parallel_execution),
+        inherited_bound_symbols_(std::move(inherited_bound_symbols)) {}
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;

--- a/src/requests/requests.cpp
+++ b/src/requests/requests.cpp
@@ -16,14 +16,12 @@
 #include <fmt/format.h>
 #include <gflags/gflags.h>
 #include <array>
-#include <chrono>
 #include <compare>
 #include <cstdio>
 #include <ctre.hpp>
 #include <exception>
 #include <filesystem>
 #include <nlohmann/json.hpp>
-#include <optional>
 #include <sstream>
 #include <utility>
 
@@ -31,7 +29,7 @@
 #include "spdlog/spdlog.h"
 #include "utils/counter.hpp"
 #include "utils/exceptions.hpp"
-#include "utils/likely.hpp"
+#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::requests {
 
@@ -39,51 +37,41 @@ namespace {
 
 struct ProgressData {
   std::function<void()> abort_check_;
-  std::optional<std::chrono::steady_clock::time_point> last_tp_;
+  // Why the caller wanted to stop. Kept so it can be rethrown once the transfer has unwound, since
+  // an exception must not cross libcurl's frames.
+  std::exception_ptr abort_error_;
 };
 
 // Callback function for reporting progress during a file download
 auto DownloadProgressCb(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t /*ultotal*/,
                         curl_off_t /*ulnow*/) -> int {
-  // No need to update the progress
-  if (dltotal == 0) return 0;
-
   constexpr auto kAbortTransferReturnCode = 1;
   constexpr auto kContinueTransferReturnCode = 0;
 
   auto *data = static_cast<ProgressData *>(clientp);
 
-  // Catch HintedAbortError and abort the transfer if got the request to terminate the transactions
+  // Ahead of anything that needs a total: a transfer whose length the server never announces still
+  // has to be stoppable, and a chunked response never reports one.
   // abort_check_ could be a nullptr.
   if (data->abort_check_) {
     try {
       data->abort_check_();
-    } catch (std::exception const &e) {
+    } catch (...) {
+      data->abort_error_ = std::current_exception();
       return kAbortTransferReturnCode;
     }
   }
 
-  static thread_local auto counter = utils::ResettableCounter(500);
+  // Only the progress figure needs a total to mean anything.
+  if (dltotal != 0) {
+    static thread_local auto counter = utils::ResettableCounter(500);
 
-  // Don't log too often but log when the file download is complete
-  if (counter() || dlnow == dltotal) {
-    auto const progress = (100.0F * static_cast<float>(dlnow)) / static_cast<float>(dltotal);
-    spdlog::trace("Downloaded {:.2f}% of the file", progress);
-  }
-
-  auto const now = std::chrono::steady_clock::now();
-
-  // If not the first call, check whether it passed more than 10s between callbacks
-  if (LIKELY(data->last_tp_.has_value())) {
-    constexpr auto download_timeout = 10;
-    // Steady clock guarantees this won't underflow
-    if (now - *(data->last_tp_) > std::chrono::seconds{download_timeout}) {
-      // Signal to the libcurl that it should abort the transfer
-      return kAbortTransferReturnCode;
+    // Don't log too often but log when the file download is complete
+    if (counter() || dlnow == dltotal) {
+      auto const progress = (100.0F * static_cast<float>(dlnow)) / static_cast<float>(dltotal);
+      spdlog::trace("Downloaded {:.2f}% of the file", progress);
     }
   }
-
-  data->last_tp_.emplace(now);
 
   return kContinueTransferReturnCode;
 }
@@ -189,29 +177,45 @@ bool RequestPostJson(const std::string &url, const nlohmann::json &data, int tim
   return true;
 }
 
-// File will be destroyed when it goes out of scope by calling std::fclose.
-// Clients are responsible for deleting the file if the downnload fails
-bool CreateAndDownloadFile(const std::string &url, utils::FileUniquePtr file, uint64_t const connection_timeout,
-                           std::function<void()> abort_check) {
-  CURL *curl = nullptr;
-  CURLcode res = CURLE_UNSUPPORTED_PROTOCOL;
+std::expected<void, DownloadError> CreateAndDownloadFile(const std::string &url, utils::FileUniquePtr file,
+                                                         uint64_t const connection_timeout,
+                                                         std::function<void()> abort_check) {
+  // A short write ends the transfer, which is what a full disk should do.
+  auto const sink = [&file](char const *data, size_t const size) -> size_t {
+    return std::fwrite(data, 1, size, file.get());
+  };
 
+  return DownloadToSink(url, sink, connection_timeout, std::move(abort_check));
+}
+
+std::expected<void, DownloadError> DownloadToSink(const std::string &url, WriteSink const &write,
+                                                  uint64_t const connection_timeout, std::function<void()> abort_check,
+                                                  uint64_t const stall_window_sec) {
   auto const user_agent = fmt::format("memgraph/{}", gflags::VersionString());
 
-  curl = curl_easy_init();
+  auto *curl = curl_easy_init();
   if (!curl) {
     spdlog::error("requests: Couldn't init curl");
-    return false;
+    return std::unexpected{DownloadError{.message = "could not start a request"}};
   }
+  utils::OnScopeExit const cleanup{[curl]() { curl_easy_cleanup(curl); }};
 
   ProgressData progress_data{.abort_check_ = std::move(abort_check)};
 
+  constexpr auto write_callback = [](char *ptr, size_t size, size_t nmemb, void *userdata) -> size_t {
+    auto const *sink = static_cast<WriteSink const *>(userdata);
+    return (*sink)(ptr, size * nmemb);
+  };
+
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, file.get());
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, +write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &write);
   // Timeout for establishing a connection
-  // Includes DNS, all protocol handshakes and negotiations until there is an established connection with the remote
-  // side
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, connection_timeout);
+  // Give up on a body that stops arriving. libcurl decides this from the bytes the server actually
+  // delivers, so a sink that blocks while its reader catches up does not look like a stall.
+  curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+  curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, static_cast<long>(stall_window_sec));  // NOLINT(google-runtime-int)
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "GET");
   curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent.c_str());
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
@@ -220,20 +224,47 @@ bool CreateAndDownloadFile(const std::string &url, utils::FileUniquePtr file, ui
   curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0);
   curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &progress_data);
   curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, DownloadProgressCb);
-  // Fail fast on HTTP errors (don't write error pages to file)
+  // Fail fast on HTTP errors, so an error page is never handed to the sink
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+  // TLS below 1.2 is deprecated. Stating the floor here keeps it independent of what the TLS backend
+  // this is built against happens to permit.
+  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
   SetCaInfo(curl);
 
-  res = curl_easy_perform(curl);
-
-  if (res != CURLE_OK) {
-    spdlog::error("Error happened while downloading file {}: {}", url, curl_easy_strerror(res));
-    return false;
+  auto const res = curl_easy_perform(curl);
+  if (res == CURLE_OK) {
+    return {};
   }
 
-  curl_easy_cleanup(curl);
+  // The caller stopped this deliberately, so report what it asked for rather than a download failure.
+  if (progress_data.abort_error_) {
+    std::rethrow_exception(progress_data.abort_error_);
+  }
 
-  return true;
+  long status = 0;  // NOLINT(google-runtime-int) - curl_easy_getinfo requires long*
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+
+  auto error = DownloadError{.http_status = static_cast<int>(status), .message = curl_easy_strerror(res)};
+  switch (res) {
+    case CURLE_HTTP_RETURNED_ERROR:
+      error.kind = ClassifyHttpStatus(static_cast<int>(status));
+      error.message = fmt::format("the server replied {}", status);
+      break;
+    case CURLE_WRITE_ERROR:
+      error.kind = DownloadFailure::LocalWrite;
+      error.message = "the download could not be written";
+      break;
+    case CURLE_OPERATION_TIMEDOUT:
+      error.kind = DownloadFailure::Stalled;
+      error.message = "the transfer stopped making progress";
+      break;
+    default:
+      error.kind = DownloadFailure::Network;
+      break;
+  }
+
+  spdlog::error("Error happened while downloading {}: {}", url, error.message);
+  return std::unexpected{std::move(error)};
 }
 
 auto DownloadToStream(std::string_view url, std::ostream &os) -> bool {

--- a/src/requests/requests.hpp
+++ b/src/requests/requests.hpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <expected>
 #include <functional>
 #include <nlohmann/json_fwd.hpp>
 #include <ostream>
@@ -45,18 +46,86 @@ void Init();
 bool RequestPostJson(const std::string &url, const nlohmann::json &data, int timeout_in_seconds = 10,
                      std::atomic<bool> const *abort_flag = nullptr);
 
+/// Why a download did not deliver the whole body.
+enum class DownloadFailure : uint8_t {
+  /// Could not reach the server, or lost it part way through.
+  Network,
+  /// The server refused the request as written, and will keep refusing it.
+  HttpClientError,
+  /// The server turned this attempt away but invited another, such as while it is rate limiting.
+  HttpTryAgain,
+  /// The server failed to serve a request it accepted.
+  HttpServerError,
+  /// The destination would not take what was delivered, such as a full disk.
+  LocalWrite,
+  /// Nothing arrived for long enough that the transfer was given up on.
+  Stalled,
+};
+
+/// What a status the server replied with says about repeating the request. A 5xx is the server
+/// failing something it accepted, and 408 and 429 are the two 4xx that ask for the same request
+/// again rather than a different one.
+[[nodiscard]] constexpr auto ClassifyHttpStatus(int status) -> DownloadFailure {
+  constexpr auto kRequestTimeout = 408;
+  constexpr auto kTooManyRequests = 429;
+  constexpr auto kServerError = 500;
+
+  if (status >= kServerError) {
+    return DownloadFailure::HttpServerError;
+  }
+  if (status == kRequestTimeout || status == kTooManyRequests) {
+    return DownloadFailure::HttpTryAgain;
+  }
+  return DownloadFailure::HttpClientError;
+}
+
+struct DownloadError {
+  DownloadFailure kind{DownloadFailure::Network};
+  /// The status the server replied with, or 0 if it never replied.
+  int http_status{0};
+  std::string message;
+
+  /// Whether making the same request again could produce a different outcome. Deciding this is HTTP's
+  /// business, so it is settled here rather than by each caller.
+  [[nodiscard]] auto Retryable() const -> bool {
+    return kind == DownloadFailure::Network || kind == DownloadFailure::HttpServerError ||
+           kind == DownloadFailure::HttpTryAgain || kind == DownloadFailure::Stalled;
+  }
+};
+
+/// Sends a GET request to `url` and writes the response body into `file`, which is closed when the
+/// call returns. Reports why the body was not delivered in full.
+std::expected<void, DownloadError> CreateAndDownloadFile(const std::string &url, utils::FileUniquePtr file,
+                                                         uint64_t connection_timeout,
+                                                         std::function<void()> abort_check = nullptr);
+
+/// Receives a block of the response body and returns how many of those bytes it took. Taking fewer
+/// than offered ends the transfer.
+using WriteSink = std::function<size_t(char const *, size_t)>;
+
+/// How long a body may go on arriving at under a byte a second before the transfer is treated as
+/// stalled. Long enough that a slow but living server is left alone.
+inline constexpr uint64_t kDefaultStallWindowSec = 30;
+
 /**
- * This functions sends a GET request to the given `url` and writes the response
- * to the given `path`.
+ * Sends a GET request to `url` and hands the response body to `write` as it arrives, without ever
+ * holding the whole body.
  *
  * @param url url to which to send the request
- * @param file utils::FileUniquePtr= unique_ptr<FILE> with custom fclose deleter
- * @param connection_timeout the timeout that should be used when making the request. The default timeout of 0 would use
- * built-in connection timeout of 300s.
- * @return bool true if the request was successful, false otherwise.
+ * @param write receives each block of the body. Returning less than it was given aborts the
+ *        transfer, which is how a reader that has stopped consuming brings the download to an end.
+ * @param connection_timeout the timeout that should be used when making the request. The default
+ *        timeout of 0 would use built-in connection timeout of 300s.
+ * @param abort_check called periodically while the transfer is in progress, and signals by throwing
+ * @param stall_window_sec how long the body may go on arriving at under a byte a second before the
+ *        transfer is given up on as stalled. Measured against what the server delivers, so a `write`
+ *        that takes its time does not count towards it.
+ * @return nothing if the whole body was delivered, otherwise why it was not
  */
-bool CreateAndDownloadFile(const std::string &url, utils::FileUniquePtr file, uint64_t connection_timeout,
-                           std::function<void()> abort_check = nullptr);
+std::expected<void, DownloadError> DownloadToSink(const std::string &url, WriteSink const &write,
+                                                  uint64_t connection_timeout,
+                                                  std::function<void()> abort_check = nullptr,
+                                                  uint64_t stall_window_sec = kDefaultStallWindowSec);
 
 /**
  * Downloads content into a stream

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(mg-utils
     async_timer.cpp
     base64.cpp
     crc_accumulator.cpp
+    download_temp_file.cpp
     file.cpp
     file_locker.cpp
     file_owner.cpp

--- a/src/utils/aws.cppm
+++ b/src/utils/aws.cppm
@@ -15,10 +15,12 @@ module;
 #include <map>
 #include <optional>
 #include <ostream>
+#include <streambuf>
 #include <string>
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/transfer/TransferManager.h>
@@ -162,6 +164,12 @@ auto BuildClientConfiguration(std::string const &aws_region, std::optional<std::
   if (aws_endpoint_url.has_value()) {
     client_config.endpointOverride = *aws_endpoint_url;
   }
+  // How long the transfer may stay below lowSpeedLimit before it is given up on, which the default
+  // of zero disables entirely. A body that stops arriving part way through would otherwise leave the
+  // thread reading it blocked with nothing to time it out, and a reader waiting on that thread has
+  // no way to stop it. The limit is one byte a second, so a slow transfer that is still making
+  // progress is not affected however long it takes.
+  client_config.requestTimeoutMs = 30'000;
   return client_config;
 }
 
@@ -202,41 +210,68 @@ auto ExtractBucketAndObjectKey(std::string_view uri)
   return std::make_pair(uri.substr(0, slash_pos), uri.substr(slash_pos + 1));
 }
 
-auto GetS3ObjectOutcome(std::string_view uri, S3Config const &s3_config)
-    -> std::expected<Aws::S3::Model::GetObjectOutcome, S3Error> {
-  Aws::Auth::AWSCredentials const credentials(*s3_config.aws_access_key, *s3_config.aws_secret_key);
-  // Use path-style for S3-compatible services (4th param = false)
-  Aws::S3::S3Client const s3_client(credentials,
-                                    BuildClientConfiguration(*s3_config.aws_region, s3_config.aws_endpoint_url),
-                                    Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-                                    false);
+constexpr auto kStreamingGetTag = "MemgraphS3StreamingGet";
 
-  return ExtractBucketAndObjectKey(uri).transform(
-      [&s3_client](
-          std::pair<std::string_view, std::string_view> const &bucket_info) -> Aws::S3::Model::GetObjectOutcome {
-        return s3_client.GetObject(BuildGetObjectRequest(bucket_info.first, bucket_info.second));
-      });
+// Writes the object at `uri` into `sink` as the body arrives, so neither this function nor the SDK
+// ever holds the whole object. The SDK's default response stream would collect it in full first.
+auto GetS3ObjectStreaming(std::string_view uri, S3Config const &s3_config, std::streambuf &sink)
+    -> std::expected<void, S3Error> {
+  GlobalS3APIManager::GetInstance();
+
+  auto bucket_info = ExtractBucketAndObjectKey(uri);
+  if (!bucket_info.has_value()) {
+    return std::unexpected{bucket_info.error()};
+  }
+
+  auto client_config = BuildClientConfiguration(*s3_config.aws_region, s3_config.aws_endpoint_url);
+  // Every attempt writes the body it receives from the start into this same sink, which has no
+  // position to rewind. A retry after a partial response would therefore hand the caller that
+  // partial body followed by a whole one and still report success, so a failure has to surface
+  // instead of being retried under the sink.
+  client_config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>(kStreamingGetTag, 0);
+
+  Aws::Auth::AWSCredentials const credentials(*s3_config.aws_access_key, *s3_config.aws_secret_key);
+  Aws::S3::S3Client const s3_client(
+      credentials, client_config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+
+  auto request = BuildGetObjectRequest(bucket_info->first, bucket_info->second);
+  request.SetResponseStreamFactory([&sink]() { return Aws::New<Aws::IOStream>(kStreamingGetTag, &sink); });
+
+  auto const outcome = s3_client.GetObject(request);
+  if (!outcome.IsSuccess()) {
+    // The SDK names a failure by reading back the body it just wrote, which a sink that only accepts
+    // writes cannot supply. The status always survives, because it comes from the headers.
+    auto const &error = outcome.GetError();
+    auto const status = static_cast<int>(error.GetResponseCode());
+    auto const &name = error.GetExceptionName();
+
+    auto message = std::string{};
+    if (status == 0) {
+      message = fmt::format("Failed to get object from S3 {}. {}", uri, error.GetMessage());
+    } else if (name.empty()) {
+      message = fmt::format("Failed to get object from S3 {}. The server replied {}", uri, status);
+    } else {
+      message = fmt::format("Failed to get object from S3 {}. The server replied {}: {}", uri, status, name);
+    }
+
+    return std::unexpected{S3Error{.status_code = S3ErrorCode::S3_API_ERROR, .message = std::move(message)}};
+  }
+
+  return {};
 }
 
 // Writes the content of the S3 object from the uri into ostream
 // returns nullopt is all good, value of the error if something wrong
+// On failure the stream may already hold part of the object, so a caller must discard it rather than
+// use what is there.
 auto GetS3Object(std::string uri, S3Config const &s3_config, std::ostream &ostream) -> std::expected<void, S3Error> {
-  GlobalS3APIManager::GetInstance();
-  auto const outcome = GetS3ObjectOutcome(uri, s3_config);
-
-  if (!outcome.has_value()) {
-    return std::unexpected{outcome.error()};
+  auto *sink = ostream.rdbuf();
+  if (sink == nullptr) {
+    return std::unexpected{
+        S3Error{.status_code = S3ErrorCode::S3_API_ERROR, .message = "Output stream has no buffer to write into"}};
   }
 
-  if (!outcome.value().IsSuccess()) {
-    return std::unexpected{S3Error{
-        .status_code = S3ErrorCode::S3_API_ERROR,
-        .message =
-            fmt::format("Failed to get object from S3 {}. Error: {}", uri, outcome.value().GetError().GetMessage())}};
-  }
-
-  ostream << outcome.value().GetResult().GetBody().rdbuf();
-  return {};
+  return GetS3ObjectStreaming(uri, s3_config, *sink);
 }
 
 // Writes the content of the S3 object from the uri into a file on the local disk

--- a/src/utils/byte_source.hpp
+++ b/src/utils/byte_source.hpp
@@ -1,0 +1,72 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstddef>
+#include <fstream>
+#include <ios>
+#include <string>
+#include <utility>
+
+#include "utils/exceptions.hpp"
+
+namespace memgraph::utils {
+
+/// A stream of bytes read once, front to back.
+///
+/// Deliberately narrower than an input stream: there is no seeking and no going back, so a source
+/// can be something arriving over a network as easily as a file on disk. Code that must revisit
+/// bytes it has already read needs its own buffer, or a different interface.
+///
+/// A source is read by one consumer at a time.
+class ByteSource {
+ public:
+  ByteSource() = default;
+  ByteSource(ByteSource const &) = delete;
+  auto operator=(ByteSource const &) -> ByteSource & = delete;
+  ByteSource(ByteSource &&) = delete;
+  auto operator=(ByteSource &&) -> ByteSource & = delete;
+  virtual ~ByteSource() = default;
+
+  /// Reads into `out` and returns how many bytes were read, which may be fewer than `size` even
+  /// though more is still to come. Blocks only while there is nothing at all to return. Zero means
+  /// the source is exhausted. Throws if the source failed, which is what separates a failure from
+  /// an orderly end.
+  virtual auto Read(char *out, std::size_t size) -> std::size_t = 0;
+};
+
+/// A file on local disk, read through in one pass.
+class FileByteSource final : public ByteSource {
+ public:
+  explicit FileByteSource(std::string path) : path_{std::move(path)}, stream_{path_, std::ios::binary} {
+    if (!stream_.is_open()) {
+      throw BasicException("Couldn't open file {}", path_);
+    }
+  }
+
+  auto Read(char *out, std::size_t size) -> std::size_t override {
+    stream_.read(out, static_cast<std::streamsize>(size));
+    // A failed read reports nothing read, which is indistinguishable from the end of the file. Left
+    // alone it would end the load early and call the result complete.
+    if (stream_.bad()) [[unlikely]] {
+      throw BasicException("Failed to read file {}", path_);
+    }
+    return static_cast<std::size_t>(stream_.gcount());
+  }
+
+ private:
+  // Declared before the stream, which is opened from it.
+  std::string path_;
+  std::ifstream stream_;
+};
+
+}  // namespace memgraph::utils

--- a/src/utils/data_queue.hpp
+++ b/src/utils/data_queue.hpp
@@ -103,6 +103,28 @@ class DataQueue {
   }
 
   /**
+   * Pops an item only if one is already waiting.  Never blocks, so a consumer
+   * that already has something to return can drain what has arrived without
+   * committing to wait for more.
+   *
+   * @param[out] item  If `try_pop` returns `true`, it contains the popped item.
+   *                    If it returns `false`, it is unmodified.
+   * @returns          True if an item was popped.
+   */
+  bool try_pop(T &item) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (queue_.empty()) {
+        return false;
+      }
+      std::swap(item, queue_.front());
+      queue_.pop();
+    }
+    writerCv_.notify_one();
+    return true;
+  }
+
+  /**
    * Sets the maximum queue size.  If `maxSize == 0` then it is unbounded.
    *
    * @param maxSize The new maximum queue size.

--- a/src/utils/download_temp_file.cpp
+++ b/src/utils/download_temp_file.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "utils/download_temp_file.hpp"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace memgraph::utils {
+
+namespace {
+auto LastError() -> std::error_code { return std::error_code{errno, std::generic_category()}; }
+
+// Only the last six X are replaced, whatever the template contains, so a longer run of them buys no
+// additional randomness. Uniqueness is the kernel's guarantee here, not this string's.
+constexpr auto kDownloadTemplate = "memgraph_download_XXXXXX";
+}  // namespace
+
+auto DownloadTempFile::Create(std::filesystem::path const &dir) -> std::expected<DownloadTempFile, std::error_code> {
+  auto path = (dir / kDownloadTemplate).string();
+
+  auto const fd = ::mkstemp(path.data());
+  if (fd == -1) {
+    return std::unexpected{LastError()};
+  }
+
+  if (::unlink(path.c_str()) == -1) {
+    auto const error = LastError();
+    ::close(fd);
+    return std::unexpected{error};
+  }
+
+  return DownloadTempFile{fd};
+}
+
+auto DownloadTempFile::Create() -> std::expected<DownloadTempFile, std::error_code> {
+  std::error_code error;
+  auto const dir = std::filesystem::temp_directory_path(error);
+  if (error) {
+    return std::unexpected{error};
+  }
+  return Create(dir);
+}
+
+DownloadTempFile::DownloadTempFile(DownloadTempFile &&other) noexcept : fd_{std::exchange(other.fd_, -1)} {}
+
+auto DownloadTempFile::operator=(DownloadTempFile &&other) noexcept -> DownloadTempFile & {
+  if (this != &other) {
+    if (fd_ != -1) {
+      ::close(fd_);
+    }
+    fd_ = std::exchange(other.fd_, -1);
+  }
+  return *this;
+}
+
+DownloadTempFile::~DownloadTempFile() {
+  if (fd_ != -1) {
+    ::close(fd_);
+  }
+}
+
+auto DownloadTempFile::OpenStream() -> std::expected<FileUniquePtr, std::error_code> {
+  // The stream gets a descriptor of its own so that a writer which closes what it is handed cannot
+  // take the file out from under a reader that has not run yet.
+  auto duplicated = DupFd();
+  if (!duplicated) {
+    return std::unexpected{duplicated.error()};
+  }
+
+  auto *stream = ::fdopen(duplicated->Get(), "wb");
+  if (stream == nullptr) {
+    return std::unexpected{LastError()};
+  }
+  // fdopen took it over: closing the stream closes the descriptor.
+  static_cast<void>(duplicated->Release());
+
+  return FileUniquePtr{stream, &std::fclose};
+}
+
+// Seeking moves the offset of the open file description, which every descriptor taken from this one
+// shares, so this is not a const operation however little of the object itself it touches.
+// NOLINTNEXTLINE(readability-make-member-function-const)
+auto DownloadTempFile::DupFd() -> std::expected<OwnedFd, std::error_code> {
+  auto duplicated = OwnedFd{::dup(fd_)};
+  if (duplicated.Get() == -1) {
+    return std::unexpected{LastError()};
+  }
+
+  // A duplicate shares its file offset with the original, which a completed write leaves at the end.
+  if (::lseek(duplicated.Get(), 0, SEEK_SET) == -1) {
+    return std::unexpected{LastError()};
+  }
+
+  return duplicated;
+}
+
+}  // namespace memgraph::utils

--- a/src/utils/download_temp_file.hpp
+++ b/src/utils/download_temp_file.hpp
@@ -1,0 +1,98 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <unistd.h>
+
+#include <expected>
+#include <filesystem>
+#include <system_error>
+#include <utility>
+
+#include "utils/file.hpp"
+
+namespace memgraph::utils {
+
+/// An open file descriptor with an owner. Closing it is this type's job, so a function that returns
+/// one has said who closes it without a caller having to read for the answer.
+class OwnedFd {
+ public:
+  explicit OwnedFd(int fd) noexcept : fd_{fd} {}
+
+  OwnedFd(OwnedFd const &) = delete;
+  auto operator=(OwnedFd const &) -> OwnedFd & = delete;
+
+  OwnedFd(OwnedFd &&other) noexcept : fd_{std::exchange(other.fd_, -1)} {}
+
+  auto operator=(OwnedFd &&other) noexcept -> OwnedFd & {
+    if (this != &other) {
+      Close();
+      fd_ = std::exchange(other.fd_, -1);
+    }
+    return *this;
+  }
+
+  ~OwnedFd() { Close(); }
+
+  [[nodiscard]] auto Get() const noexcept -> int { return fd_; }
+
+  /// Hands the descriptor to a caller that takes it over, such as a library that closes what it is
+  /// given. This object holds nothing afterwards.
+  [[nodiscard]] auto Release() noexcept -> int { return std::exchange(fd_, -1); }
+
+ private:
+  void Close() noexcept {
+    if (auto const fd = std::exchange(fd_, -1); fd != -1) {
+      ::close(fd);
+    }
+  }
+
+  int fd_{-1};
+};
+
+/// A file that exists only as an open descriptor, for downloading content that is read once and
+/// discarded.
+///
+/// The name is a fixed-length template rather than anything derived from a caller-supplied URI, so
+/// no input can push it past the filesystem's limit on a path component. It is unlinked as soon as
+/// it is created, which means the download cannot be left behind by a signal or a crash, and that
+/// no consumer can come to depend on what it was called.
+class DownloadTempFile {
+ public:
+  /// Creates the file in `dir`.
+  static auto Create(std::filesystem::path const &dir) -> std::expected<DownloadTempFile, std::error_code>;
+
+  /// Creates the file in the directory `TMPDIR` names, falling back to the system default.
+  static auto Create() -> std::expected<DownloadTempFile, std::error_code>;
+
+  DownloadTempFile(DownloadTempFile const &) = delete;
+  auto operator=(DownloadTempFile const &) -> DownloadTempFile & = delete;
+
+  DownloadTempFile(DownloadTempFile &&other) noexcept;
+  auto operator=(DownloadTempFile &&other) noexcept -> DownloadTempFile &;
+
+  ~DownloadTempFile();
+
+  /// A stream positioned at the start of the file, for a writer that closes what it is handed.
+  /// Closing it leaves this object's own descriptor open.
+  [[nodiscard]] auto OpenStream() -> std::expected<FileUniquePtr, std::error_code>;
+
+  /// A descriptor of its own, positioned at the start of the file.
+  [[nodiscard]] auto DupFd() -> std::expected<OwnedFd, std::error_code>;
+
+ private:
+  explicit DownloadTempFile(int fd) noexcept : fd_{fd} {}
+
+  int fd_{-1};
+};
+
+}  // namespace memgraph::utils

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -19,6 +19,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <mutex>

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -34,42 +34,6 @@
 
 namespace memgraph::utils {
 
-auto CreateUniqueDownloadFile(std::filesystem::path const &base_path)
-    -> std::pair<std::filesystem::path, FileUniquePtr> {
-  // w for writing
-  // b for binary
-  // x for exclusive access
-  constexpr auto file_mode = "wbx";
-
-  // Try without suffix
-  FileUniquePtr file(std::fopen(base_path.string().data(), file_mode), &std::fclose);
-
-  if (file) {
-    return std::make_pair(base_path, std::move(file));
-  }
-
-  auto const stem = base_path.stem();
-  auto const ext = base_path.extension();
-  auto const parent = base_path.parent_path();
-
-  auto suffix = 1;
-  // We don't want more than 10k files with the same name
-  constexpr auto max_suffix = 10'000;
-
-  std::filesystem::path new_path;
-
-  do {
-    new_path = parent / std::format("{}_{}{}", stem.string(), suffix, ext.string());
-    FileUniquePtr file(std::fopen(new_path.string().data(), file_mode), &std::fclose);
-    if (file) {
-      return std::make_pair(new_path, std::move(file));
-    }
-  } while (suffix++ < max_suffix);
-
-  throw utils::BasicException("More than 10k files with the same name. File {} won't be downloaded.",
-                              base_path.string());
-}
-
 std::filesystem::path GetExecutablePath() { return std::filesystem::read_symlink("/proc/self/exe"); }
 
 std::vector<std::string> ReadLines(const std::filesystem::path &path) noexcept {

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -38,9 +38,6 @@ namespace memgraph::utils {
 
 using FileUniquePtr = std::unique_ptr<FILE, decltype(&std::fclose)>;
 
-auto CreateUniqueDownloadFile(std::filesystem::path const &base_path)
-    -> std::pair<std::filesystem::path, FileUniquePtr>;
-
 /// Get the path of the current executable.
 ///
 /// @throw std::filesystem::filesystem_error

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -17,10 +17,14 @@
  */
 #pragma once
 
+#include <unistd.h>
+
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/src/utils/prefetched.hpp
+++ b/src/utils/prefetched.hpp
@@ -1,0 +1,101 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <thread>
+#include <utility>
+
+#include "utils/data_queue.hpp"
+
+namespace memgraph::utils {
+
+/// Runs a producer on its own thread and hands what it makes to a consumer, one item at a time.
+///
+/// For a source that pushes its work at whoever will take it while the code consuming it wants to
+/// pull one item at a time. The queue is bounded, so a producer faster than its consumer waits
+/// rather than running away with memory.
+///
+/// A consumer that stops early is the ordinary case, not an error: destroying this tells the
+/// producer to stop, and the destructor does not return until it has. What the producer threw is
+/// carried across and rethrown from `Next`, so a failure on the other thread reaches the caller
+/// rather than being lost.
+///
+/// One producer, one consumer. `Next` is not safe to call from two threads.
+///
+/// As a member, declare this after everything the producer reads. Members are constructed in
+/// declaration order and the thread starts here, so anything declared later is still uninitialized
+/// when the producer first runs, whatever order the initializer list is written in.
+template <typename T>
+class Prefetched {
+ public:
+  /// Offers one item to the consumer. Returns false once the consumer has stopped, which is the
+  /// producer's signal to return; it must not keep pushing after that.
+  using Push = std::function<bool(T)>;
+
+  /// Runs on the producer thread. Returning ends the source; throwing reports a failure to the
+  /// consumer.
+  using Produce = std::function<void(Push const &)>;
+
+  /// `depth` is how many items may wait for the consumer, and so how far the producer may run ahead.
+  Prefetched(std::size_t depth, Produce produce)
+      : queue_{depth}, thread_{[this, produce = std::move(produce)]() { Run(produce); }} {}
+
+  Prefetched(Prefetched const &) = delete;
+  auto operator=(Prefetched const &) -> Prefetched & = delete;
+  Prefetched(Prefetched &&) = delete;
+  auto operator=(Prefetched &&) -> Prefetched & = delete;
+
+  ~Prefetched() {
+    // Refusing further items is what a blocked producer sees, so shutting the queue before the
+    // thread is joined is what keeps that join from waiting on a consumer that has gone.
+    queue_.finish();
+  }
+
+  /// Hands over an item only if one is already waiting. Never blocks, so a consumer that already has
+  /// something to return can take what has arrived without committing to wait for more.
+  auto TryNext(T &out) -> bool { return queue_.try_pop(out); }
+
+  /// Hands over the next item. Returns false once the source is spent, and rethrows what the
+  /// producer threw if it failed.
+  auto Next(T &out) -> bool {
+    if (queue_.pop(out)) {
+      return true;
+    }
+
+    // finish() happens-before pop() reporting the queue drained, so a failure recorded before it is
+    // visible here without further synchronization.
+    if (failure_) {
+      std::rethrow_exception(std::exchange(failure_, nullptr));
+    }
+    return false;
+  }
+
+ private:
+  void Run(Produce const &produce) {
+    try {
+      produce([this](T item) { return queue_.push(std::move(item)); });
+    } catch (...) {
+      failure_ = std::current_exception();
+    }
+    queue_.finish();
+  }
+
+  DataQueue<T> queue_;
+  std::exception_ptr failure_;
+  // Declared last so the thread is joined before anything it touches is destroyed.
+  std::jthread thread_;
+};
+
+}  // namespace memgraph::utils

--- a/src/utils/queued_byte_source.hpp
+++ b/src/utils/queued_byte_source.hpp
@@ -1,0 +1,157 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <streambuf>
+#include <utility>
+#include <vector>
+
+#include "utils/byte_source.hpp"
+#include "utils/prefetched.hpp"
+
+namespace memgraph::utils {
+
+/// Turns a transfer that pushes bytes into a source that can be pulled from, gathering what it is
+/// handed into blocks of a known size.
+///
+/// For a source that decides when to hand over data, such as a download, being read by code that
+/// wants to ask for the next so many bytes. The thread, the queue and the failure channel belong to
+/// Prefetched; what is here is the byte bookkeeping.
+///
+/// A block reaches the reader once it is full, or when the transfer ends, whichever comes first. A
+/// transfer that trickles therefore keeps the first read waiting until it has handed over a whole
+/// block. That is a wait on the reading side only: a caller that wants to stop the transfer does so
+/// through the check it gave the sink, which runs on every write.
+class QueuedByteSource final : public ByteSource {
+ public:
+  /// Runs on the transfer's own thread. `push` returns false once the reader has stopped, which is
+  /// the signal to abandon the transfer.
+  using Push = std::function<bool(char const *, std::size_t)>;
+  using Transfer = std::function<void(Push const &)>;
+
+  static constexpr std::size_t kBlockBytes = 256U * 1024U;
+
+  QueuedByteSource(std::size_t queued_blocks, Transfer transfer)
+      : blocks_{queued_blocks,
+                [transfer = std::move(transfer)](auto const &push_block) { GatherIntoBlocks(transfer, push_block); }} {}
+
+  auto Read(char *out, std::size_t size) -> std::size_t override {
+    std::size_t taken = 0;
+    while (taken < size) {
+      if (offset_ == block_.size()) {
+        offset_ = 0;
+        block_.clear();
+        // Wait only for the first block. Handing back the blocks that have arrived keeps rows
+        // flowing instead of stalling until the buffer is full, which on a slow transfer is a wait
+        // a cancel would sit behind.
+        auto const got = taken == 0 ? blocks_.Next(block_) : blocks_.TryNext(block_);
+        if (!got) break;
+      }
+      auto const take = std::min(size - taken, block_.size() - offset_);
+      std::memcpy(out + taken, block_.data() + offset_, take);
+      offset_ += take;
+      taken += take;
+    }
+    return taken;
+  }
+
+ private:
+  // A source chooses how much it hands over at a time, and a transfer's is a good deal smaller than
+  // a parse chunk. Gathering writes into blocks of a known size makes the queue's depth mean a
+  // predictable number of bytes, and saves an allocation for every small write a source makes.
+  static void GatherIntoBlocks(Transfer const &transfer, Prefetched<std::vector<char>>::Push const &push_block) {
+    std::vector<char> gathered;
+    gathered.reserve(kBlockBytes);
+
+    auto const hand_over = [&gathered, &push_block]() {
+      if (gathered.empty()) return true;
+      auto const accepted = push_block(std::move(gathered));
+      gathered.clear();
+      gathered.reserve(kBlockBytes);
+      return accepted;
+    };
+
+    transfer([&gathered, &hand_over](char const *data, std::size_t size) {
+      while (size > 0) {
+        auto const take = std::min(size, kBlockBytes - gathered.size());
+        gathered.insert(gathered.end(), data, data + take);
+        data += take;
+        size -= take;
+        if (gathered.size() == kBlockBytes && !hand_over()) return false;
+      }
+      return true;
+    });
+    hand_over();
+  }
+
+  std::vector<char> block_;
+  std::size_t offset_{0};
+  // Declared last so everything the reading thread touches is constructed before that thread starts,
+  // and destroyed only after it has been joined.
+  Prefetched<std::vector<char>> blocks_;
+};
+
+/// Lets a library that writes into a stream feed a QueuedByteSource. Only the write side is used, so
+/// there is nothing to put back and nowhere to seek.
+class PushStreambuf final : public std::streambuf {
+ public:
+  PushStreambuf(QueuedByteSource::Push push, std::function<void()> abort_check)
+      : push_{std::move(push)}, abort_check_{std::move(abort_check)} {}
+
+  /// Reports why the transfer ended, if the caller's check ended it. A refused write is how that
+  /// check reaches a library writing into this, so the transfer's own failure will say only that a
+  /// write was refused; this is the reason behind it and takes precedence. Call it before reporting
+  /// anything the transfer returned. Reports once.
+  void RethrowIfStopped() {
+    if (stopped_) {
+      std::rethrow_exception(std::exchange(stopped_, nullptr));
+    }
+  }
+
+ protected:
+  auto xsputn(char const *s, std::streamsize n) -> std::streamsize override {
+    if (n <= 0 || !KeepGoing()) return 0;
+    return push_(s, static_cast<std::size_t>(n)) ? n : 0;
+  }
+
+  auto overflow(int_type ch) -> int_type override {
+    if (traits_type::eq_int_type(ch, traits_type::eof())) return traits_type::not_eof(ch);
+    if (!KeepGoing()) return traits_type::eof();
+    auto const byte = traits_type::to_char_type(ch);
+    return push_(&byte, 1) ? ch : traits_type::eof();
+  }
+
+ private:
+  // Refusing the write is the only way to stop a transfer that is driving this, so the reason is
+  // kept rather than thrown through the library doing the writing.
+  auto KeepGoing() -> bool {
+    if (!abort_check_) return true;
+    try {
+      abort_check_();
+    } catch (...) {
+      stopped_ = std::current_exception();
+      return false;
+    }
+    return true;
+  }
+
+  QueuedByteSource::Push push_;
+  std::function<void()> abort_check_;
+  std::exception_ptr stopped_;
+};
+
+}  // namespace memgraph::utils

--- a/src/utils/tmp_dir.hpp
+++ b/src/utils/tmp_dir.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,19 +11,32 @@
 
 #pragma once
 
+#include <cerrno>
+#include <cstdlib>
 #include <filesystem>
+#include <string>
+#include <system_error>
 
 namespace memgraph::utils {
 /**
- * @brief Creates a temporary directory with a unique name under /tmp/
+ * @brief Creates a temporary directory whose name the kernel makes unique, under the directory
+ * TMPDIR names.
+ *
+ * The name is chosen and the directory created in one step, so no other process can take the name in
+ * between.
  *
  * @return std::filesystem::path
- * @throws std::filesystem::filesystem_error as defined by create_directories
+ * @throws std::filesystem::filesystem_error if the directory cannot be created
  */
 inline std::filesystem::path TempDir() {
-  const std::filesystem::path tmp_dir_path{std::filesystem::temp_directory_path() /= std::tmpnam(nullptr)};
-  std::filesystem::create_directories(tmp_dir_path);
-  return tmp_dir_path;
+  auto path = (std::filesystem::temp_directory_path() / "memgraph_XXXXXX").string();
+
+  if (::mkdtemp(path.data()) == nullptr) {
+    throw std::filesystem::filesystem_error("Couldn't create a temporary directory",
+                                            std::error_code{errno, std::generic_category()});
+  }
+
+  return path;
 }
 
 }  // namespace memgraph::utils

--- a/tests/e2e/load_jsonl/load_jsonl_s3.py
+++ b/tests/e2e/load_jsonl/load_jsonl_s3.py
@@ -26,6 +26,40 @@ AWS_SECRET_ACCESS_KEY = "test"
 AWS_REGION = "us-east-1"
 BUCKET_NAME = "deps.memgraph.io"
 
+# A filesystem allows 255 bytes in one path component. The object's own name passes that, so the URL
+# is too long to name a file however little the signing library adds to it, which is a few
+# parameters under one signature version and several hundred bytes under another.
+NAME_MAX = 255
+LONG_OBJECT_KEY = "test_types_" + "a" * NAME_MAX + ".jsonl"
+
+
+def make_s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=AWS_ENDPOINT_URL,
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+
+
+def test_presigned_url_longer_than_a_path_component():
+    s3_client = make_s3_client()
+    s3_client.upload_file(get_file_path("test_types.jsonl"), BUCKET_NAME, LONG_OBJECT_KEY)
+    presigned_url = s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": BUCKET_NAME, "Key": LONG_OBJECT_KEY},
+        ExpiresIn=3600,
+    )
+
+    assert len(presigned_url.split("/")[-1]) > NAME_MAX
+
+    cursor = connect(host="localhost", port=7687).cursor()
+    load_query = f"LOAD JSONL FROM '{presigned_url}' AS row CREATE (n:N {{id: row.id, name: row.name}})"
+    execute_and_fetch_all(cursor, load_query)
+    assert execute_and_fetch_all(cursor, "match (n) return count(n)")[0][0] == 120
+    execute_and_fetch_all(cursor, "match (n) detach delete n")
+
 
 def test_aws_region_not_provided_err_msg():
     cursor = connect(host="localhost", port=7687).cursor()
@@ -99,14 +133,7 @@ def test_http_file():
 
 
 def main():
-    # Configure S3 client for LocalStack
-    s3_client = boto3.client(
-        "s3",
-        endpoint_url=AWS_ENDPOINT_URL,
-        aws_access_key_id=AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-        region_name=AWS_REGION,
-    )
+    s3_client = make_s3_client()
 
     # Create bucket if it doesn't exist
     try:

--- a/tests/e2e/load_parquet/load_parquet.py
+++ b/tests/e2e/load_parquet/load_parquet.py
@@ -9,10 +9,106 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
+import multiprocessing
 import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 from common import connect, execute_and_fetch_all, get_file_path
+
+# Long enough that a slow machine still gets the transfer under way before the abort is due, since
+# an abort landing first would prove nothing about a download.
+QUERY_TIMEOUT_SECONDS = 5
+TRICKLE_STEP_BYTES = 8
+TRICKLE_STEP_SECONDS = 0.25
+
+
+def _serve_until_released(body: bytes, ports, sent, release):
+    """Announces the length of `body`, hands over a fraction of it, then stops sending."""
+    # Far short of the announced length, so no amount of waiting completes the transfer.
+    limit = len(body) // 2
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            try:
+                while sent.value < limit and not release.is_set():
+                    chunk = body[sent.value : sent.value + TRICKLE_STEP_BYTES]
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+                    sent.value += len(chunk)
+                    time.sleep(TRICKLE_STEP_SECONDS)
+                release.wait()
+            except (BrokenPipeError, ConnectionResetError):
+                pass  # the client gave up, which is what this test is about
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    ports.put(server.server_port)
+    server.serve_forever()
+
+
+def serve_a_transfer_that_never_finishes(body: bytes):
+    """Starts the server of `_serve_until_released` in a process of its own.
+
+    Returns the process, its port, an event that releases the held connection, and a count of the
+    bytes handed over.
+    """
+    ports = multiprocessing.Queue()
+    sent = multiprocessing.Value("i", 0)
+    release = multiprocessing.Event()
+    server = multiprocessing.Process(target=_serve_until_released, args=(body, ports, sent, release), daemon=True)
+    server.start()
+    return server, ports.get(timeout=30), release, sent
+
+
+def _load_and_report(url: str, outcome):
+    try:
+        cursor = connect(host="localhost", port=7687).cursor()
+        execute_and_fetch_all(cursor, f"LOAD PARQUET FROM '{url}' AS row CREATE (n:N {{id: row.id}})")
+        outcome.put(("completed", ""))
+    except Exception as e:
+        outcome.put(("error", str(e)))
+
+
+def test_a_download_that_cannot_finish_is_stopped_by_an_abort():
+    with open(get_file_path("nodes_100.parquet"), "rb") as fixture:
+        body = fixture.read()
+    server, port, release, sent = serve_a_transfer_that_never_finishes(body)
+    url = f"http://127.0.0.1:{port}/nodes_100.parquet"
+
+    cursor = connect(host="localhost", port=7687).cursor()
+    previous_timeout = dict(execute_and_fetch_all(cursor, "SHOW DATABASE SETTINGS"))["query.timeout"]
+    execute_and_fetch_all(cursor, f"SET DATABASE SETTING 'query.timeout' TO '{QUERY_TIMEOUT_SECONDS}'")
+
+    # The client blocks in a driver call that holds the interpreter lock for as long as the load
+    # runs, so this waits on a process rather than a thread. A thread would leave nothing here able
+    # to run, including the wait meant to bound it.
+    outcome = multiprocessing.Queue()
+    loader = multiprocessing.Process(target=_load_and_report, args=(url, outcome), daemon=True)
+    loader.start()
+    try:
+        # The transfer is checked for an abort as it runs, so the load ends on the query timeout
+        # rather than on the bytes it is waiting for, which never arrive.
+        loader.join(timeout=60.0)
+        assert not loader.is_alive(), "the load kept waiting on a transfer that can never finish"
+        assert sent.value > 0, "the download never reached the server"
+        result, message = outcome.get(timeout=10.0)
+        assert result == "error", f"expected the load to fail, got {result}"
+        assert "abort" in message.lower(), message
+    finally:
+        release.set()
+        loader.terminate()
+        loader.join(timeout=10.0)
+        server.terminate()
+        server.join(timeout=10.0)
+        execute_and_fetch_all(cursor, f"SET DATABASE SETTING 'query.timeout' TO '{previous_timeout}'")
+        execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n")
 
 
 def test_non_existing_file_err_ms():

--- a/tests/e2e/load_parquet/load_s3_parquet.py
+++ b/tests/e2e/load_parquet/load_s3_parquet.py
@@ -26,6 +26,22 @@ AWS_SECRET_ACCESS_KEY = "test"
 AWS_REGION = "us-east-1"
 BUCKET_NAME = "deps.memgraph.io"
 
+# A filesystem allows 255 bytes in one path component. The object's own name passes that, so the URL
+# is too long to name a file however little the signing library adds to it, which is a few
+# parameters under one signature version and several hundred bytes under another.
+NAME_MAX = 255
+LONG_OBJECT_KEY = "nodes_100_" + "a" * NAME_MAX + ".parquet"
+
+
+def make_s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=AWS_ENDPOINT_URL,
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+
 
 def test_aws_region_not_provided_err_msg():
     cursor = connect(host="localhost", port=7687).cursor()
@@ -59,6 +75,27 @@ def test_http_file():
     load_query = (
         f"LOAD PARQUET FROM '{AWS_ENDPOINT_URL}/{BUCKET_NAME}/nodes_100.parquet' WITH CONFIG {{'aws_region': '{AWS_REGION}', "
         f"'aws_access_key': '{AWS_ACCESS_KEY_ID}', 'aws_secret_key': '{AWS_SECRET_ACCESS_KEY}', 'aws_endpoint_url': '{AWS_ENDPOINT_URL}' }} AS row CREATE (n:N {{id: row.id, name: row.name, age: row.age, city: row.city}})"
+    )
+    execute_and_fetch_all(cursor, load_query)
+    assert execute_and_fetch_all(cursor, "match (n) return count(n)")[0][0] == 100
+    execute_and_fetch_all(cursor, "match (n) detach delete n")
+
+
+def test_presigned_url_longer_than_a_path_component():
+    s3_client = make_s3_client()
+    s3_client.upload_file(str(Path(__file__).parent / "nodes_100.parquet"), BUCKET_NAME, LONG_OBJECT_KEY)
+    presigned_url = s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": BUCKET_NAME, "Key": LONG_OBJECT_KEY},
+        ExpiresIn=3600,
+    )
+
+    assert len(presigned_url.split("/")[-1]) > NAME_MAX
+
+    cursor = connect(host="localhost", port=7687).cursor()
+    load_query = (
+        f"LOAD PARQUET FROM '{presigned_url}' AS row "
+        f"CREATE (n:N {{id: row.id, name: row.name, age: row.age, city: row.city}})"
     )
     execute_and_fetch_all(cursor, load_query)
     assert execute_and_fetch_all(cursor, "match (n) return count(n)")[0][0] == 100
@@ -101,14 +138,7 @@ def test_small_file_nodes_runtime_setting():
 
 
 def main():
-    # Configure S3 client for LocalStack
-    s3_client = boto3.client(
-        "s3",
-        endpoint_url=AWS_ENDPOINT_URL,
-        aws_access_key_id=AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-        region_name=AWS_REGION,
-    )
+    s3_client = make_s3_client()
 
     # Create bucket if it doesn't exist
     try:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -633,6 +633,11 @@ add_unit_test(csv_csv_parsing
     LINK_TARGETS mg::csv
 )
 
+add_unit_test(query_jsonl_reader
+    SOURCES query_jsonl_reader.cpp
+    LINK_TARGETS mg-query
+)
+
 add_unit_test(utils_prefetched
     SOURCES utils_prefetched.cpp
     LINK_TARGETS mg-utils

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -648,6 +648,16 @@ add_unit_test(utils_download_temp_file
     LINK_TARGETS mg-utils
 )
 
+add_unit_test(query_download_failure_reporting
+    SOURCES query_download_failure_reporting.cpp
+    LINK_TARGETS mg-query mg-requests
+)
+
+add_unit_test(requests_transfer_stall
+    SOURCES requests_transfer_stall.cpp
+    LINK_TARGETS mg-requests mg-utils
+)
+
 add_unit_test(utils_async_timer
     SOURCES utils_async_timer.cpp
     LINK_TARGETS mg-utils

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -633,6 +633,21 @@ add_unit_test(csv_csv_parsing
     LINK_TARGETS mg::csv
 )
 
+add_unit_test(utils_prefetched
+    SOURCES utils_prefetched.cpp
+    LINK_TARGETS mg-utils
+)
+
+add_unit_test(utils_byte_source
+    SOURCES utils_byte_source.cpp
+    LINK_TARGETS mg-utils
+)
+
+add_unit_test(utils_download_temp_file
+    SOURCES utils_download_temp_file.cpp
+    LINK_TARGETS mg-utils
+)
+
 add_unit_test(utils_async_timer
     SOURCES utils_async_timer.cpp
     LINK_TARGETS mg-utils
@@ -1346,4 +1361,9 @@ add_unit_test(safe_hardware_concurrency
 add_unit_test(logging
     SOURCES logging.cpp
     LINK_TARGETS gflags mg-flags
+)
+
+add_unit_test(utils_queued_byte_source
+    SOURCES utils_queued_byte_source.cpp
+    LINK_TARGETS mg-utils
 )

--- a/tests/unit/query_download_failure_reporting.cpp
+++ b/tests/unit/query_download_failure_reporting.cpp
@@ -1,0 +1,94 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "query/exceptions.hpp"
+#include "requests/requests.hpp"
+#include "utils/exceptions.hpp"
+
+using memgraph::query::QueryException;
+using memgraph::query::QueryRuntimeException;
+using memgraph::query::ThrowDownloadFailed;
+using memgraph::query::TransientDownloadException;
+using memgraph::requests::ClassifyHttpStatus;
+using memgraph::requests::DownloadError;
+using memgraph::requests::DownloadFailure;
+
+namespace {
+auto Retryable(DownloadFailure kind) -> bool { return DownloadError{.kind = kind}.Retryable(); }
+}  // namespace
+
+TEST(DownloadFailureReporting, RepeatingTheRequestCouldHelpWhenNothingRefusedIt) {
+  EXPECT_TRUE(Retryable(DownloadFailure::Network)) << "the server may be reachable on another attempt";
+  EXPECT_TRUE(Retryable(DownloadFailure::HttpServerError)) << "the server accepted the request and may serve it later";
+  EXPECT_TRUE(Retryable(DownloadFailure::HttpTryAgain)) << "the server turned this attempt away, not the request";
+  EXPECT_TRUE(Retryable(DownloadFailure::Stalled)) << "a transfer that stopped arriving may arrive next time";
+}
+
+TEST(DownloadFailureReporting, RepeatingTheRequestCannotHelpWhenItWasRefusedOrCouldNotBeStored) {
+  EXPECT_FALSE(Retryable(DownloadFailure::HttpClientError)) << "the server will refuse the same request again";
+  EXPECT_FALSE(Retryable(DownloadFailure::LocalWrite)) << "the destination, not the request, is what failed";
+}
+
+TEST(DownloadFailureReporting, AStatusAskingForAnotherAttemptIsWorthRetrying) {
+  EXPECT_TRUE(Retryable(ClassifyHttpStatus(429))) << "a rate limit lifts, and the request that hit it then succeeds";
+  EXPECT_TRUE(Retryable(ClassifyHttpStatus(408))) << "the server gave up waiting for the request, not on its content";
+  EXPECT_TRUE(Retryable(ClassifyHttpStatus(500))) << "the server failed something it had accepted";
+  EXPECT_TRUE(Retryable(ClassifyHttpStatus(503)))
+      << "a server that is unavailable now may serve the same request later";
+}
+
+TEST(DownloadFailureReporting, AStatusRefusingTheRequestItselfIsNotWorthRetrying) {
+  EXPECT_FALSE(Retryable(ClassifyHttpStatus(400))) << "the request is malformed however many times it is sent";
+  EXPECT_FALSE(Retryable(ClassifyHttpStatus(403))) << "the credentials do not grant access on a second attempt either";
+  EXPECT_FALSE(Retryable(ClassifyHttpStatus(404)))
+      << "the object is missing, and repeating the request will not find it";
+}
+
+TEST(DownloadFailureReporting, ARetryableFailureIsReportedAsWorthRetrying) {
+  EXPECT_THROW(ThrowDownloadFailed(true, "server is having a moment"), TransientDownloadException);
+}
+
+TEST(DownloadFailureReporting, AFailureThatCannotSucceedIsReportedAsTheCallersFault) {
+  EXPECT_THROW(ThrowDownloadFailed(false, "no such object"), QueryRuntimeException);
+}
+
+// A session reports QueryException to the client as a permanent error and every other
+// BasicException as one worth retrying, catching QueryException first. A retryable download that
+// inherited from QueryException would therefore reach the client as permanent, and the driver would
+// give up on a failure that another attempt could get past.
+TEST(DownloadFailureReporting, WhatIsWorthRetryingIsNotReportedAsPermanent) {
+  static_assert(!std::is_base_of_v<QueryException, TransientDownloadException>,
+                "a retryable download must not be caught as a permanent query error");
+  static_assert(std::is_base_of_v<memgraph::utils::BasicException, TransientDownloadException>,
+                "a retryable download must still be reported to the client at all");
+
+  try {
+    ThrowDownloadFailed(true, "server is having a moment");
+    FAIL() << "the call must not return";
+  } catch (QueryException const &) {
+    FAIL() << "a retryable download would reach the client as a permanent error";
+  } catch (memgraph::utils::BasicException const &e) {
+    EXPECT_STREQ(e.what(), "server is having a moment");
+  }
+}
+
+TEST(DownloadFailureReporting, WhatCannotSucceedIsReportedAsPermanent) {
+  try {
+    ThrowDownloadFailed(false, "no such object");
+    FAIL() << "the call must not return";
+  } catch (QueryException const &e) {
+    EXPECT_STREQ(e.what(), "no such object");
+  }
+}

--- a/tests/unit/query_jsonl_reader.cpp
+++ b/tests/unit/query_jsonl_reader.cpp
@@ -1,0 +1,169 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <cstdint>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <memory_resource>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "query/typed_value.hpp"
+
+import memgraph.query.jsonl.reader;
+
+namespace fs = std::filesystem;
+
+// Small enough that documents straddle chunk boundaries, and not a power of two so the boundaries do
+// not line up with anything in the content.
+constexpr std::size_t kTinyChunk = 7;
+
+class JsonlReaderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    dir_ = fs::temp_directory_path() / "jsonl_reader_test";
+    fs::create_directories(dir_);
+  }
+
+  void TearDown() override {
+    if (fs::exists(dir_)) {
+      fs::remove_all(dir_);
+    }
+  }
+
+  auto WriteFile(std::string_view name, std::string_view content) -> std::string {
+    auto const path = dir_ / name;
+    std::ofstream out{path, std::ios::binary};
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    out.close();
+    return path.string();
+  }
+
+  static auto ReadIds(std::string const &path, std::size_t chunk_size) -> std::vector<int64_t> {
+    auto *resource = std::pmr::new_delete_resource();
+    memgraph::query::JsonlReader reader{path, std::nullopt, resource, {}, chunk_size};
+
+    std::vector<int64_t> ids;
+    memgraph::query::Row row{resource};
+    while (reader.GetNextRow(row)) {
+      auto const field = row.find("id");
+      ids.push_back(field == row.end() ? -1 : field->second.ValueInt());
+    }
+    return ids;
+  }
+
+  static auto Documents(int count) -> std::string {
+    std::string content;
+    for (auto i = 1; i <= count; ++i) {
+      content += std::format(R"({{"id": {}}})", i);
+      content += '\n';
+    }
+    return content;
+  }
+
+  fs::path dir_;
+};
+
+TEST_F(JsonlReaderTest, NumbersKeepTheirTypeAndValue) {
+  // A big integer does not fit int64, so it is carried through as the raw token rather than being
+  // narrowed to something that is no longer the number in the file.
+  auto const path = WriteFile("numbers.jsonl",
+                              R"({"i": 42, "neg": -7, "d": 1.5, "big": 123456789012345678901234567890})"
+                              "\n");
+
+  auto *resource = std::pmr::new_delete_resource();
+  memgraph::query::JsonlReader reader{path, std::nullopt, resource, {}, kTinyChunk};
+  memgraph::query::Row row{resource};
+  ASSERT_TRUE(reader.GetNextRow(row));
+
+  ASSERT_TRUE(row.find("i")->second.IsInt());
+  EXPECT_EQ(row.find("i")->second.ValueInt(), 42);
+  ASSERT_TRUE(row.find("neg")->second.IsInt());
+  EXPECT_EQ(row.find("neg")->second.ValueInt(), -7);
+  ASSERT_TRUE(row.find("d")->second.IsDouble());
+  EXPECT_DOUBLE_EQ(row.find("d")->second.ValueDouble(), 1.5);
+  ASSERT_TRUE(row.find("big")->second.IsString());
+  EXPECT_EQ(row.find("big")->second.ValueString(), "123456789012345678901234567890");
+
+  EXPECT_FALSE(reader.GetNextRow(row));
+}
+
+TEST_F(JsonlReaderTest, EveryDocumentIsParsedWhenTheChunkIsSmallerThanTheFile) {
+  auto const path = WriteFile("many.jsonl", Documents(10));
+
+  EXPECT_EQ(ReadIds(path, kTinyChunk), (std::vector<int64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+}
+
+TEST_F(JsonlReaderTest, ADocumentLargerThanTheChunkIsStillParsed) {
+  auto const filler = std::string(500, 'x');
+  auto const path = WriteFile("big.jsonl", std::format("{{\"id\": 1, \"pad\": \"{}\"}}\n{{\"id\": 2}}\n", filler));
+
+  EXPECT_EQ(ReadIds(path, kTinyChunk), (std::vector<int64_t>{1, 2}));
+}
+
+TEST_F(JsonlReaderTest, DocumentsAlternatingAroundTheChunkSizeAreAllParsed) {
+  auto const filler = std::string(400, 'x');
+  std::string content;
+  std::vector<int64_t> expected;
+  for (auto i = 1; i <= 12; ++i) {
+    // Every third document forces the buffer to grow; the rest let it give the space back.
+    content +=
+        (i % 3 == 0) ? std::format(R"({{"id": {}, "pad": "{}"}})", i, filler) : std::format(R"({{"id": {}}})", i);
+    content += '\n';
+    expected.push_back(i);
+  }
+  auto const path = WriteFile("alternating.jsonl", content);
+
+  EXPECT_EQ(ReadIds(path, kTinyChunk), expected);
+}
+
+TEST_F(JsonlReaderTest, ALastDocumentWithoutATrailingNewlineIsKept) {
+  auto const path = WriteFile("no_newline.jsonl",
+                              R"({"id": 1})"
+                              "\n"
+                              R"({"id": 2})");
+
+  EXPECT_EQ(ReadIds(path, kTinyChunk), (std::vector<int64_t>{1, 2}));
+}
+
+TEST_F(JsonlReaderTest, BlankLinesBetweenDocumentsAreSkipped) {
+  auto const path = WriteFile("blanks.jsonl", "{\"id\": 1}\n\n\n{\"id\": 2}\n");
+
+  EXPECT_EQ(ReadIds(path, kTinyChunk), (std::vector<int64_t>{1, 2}));
+}
+
+TEST_F(JsonlReaderTest, ATruncatedTrailingDocumentIsDropped) {
+  auto const path = WriteFile("truncated.jsonl", "{\"id\": 1}\n{\"id\": 2}\n{\"id\": 3");
+
+  EXPECT_EQ(ReadIds(path, kTinyChunk), (std::vector<int64_t>{1, 2}));
+}
+
+TEST_F(JsonlReaderTest, AnEmptyFileYieldsNoRows) {
+  auto const path = WriteFile("empty.jsonl", "");
+
+  EXPECT_TRUE(ReadIds(path, kTinyChunk).empty());
+}
+
+TEST_F(JsonlReaderTest, TheChunkSizeDoesNotChangeTheResult) {
+  auto const path = WriteFile("sizes.jsonl", Documents(40));
+  auto const expected = ReadIds(path, 1U << 20U);
+
+  ASSERT_EQ(expected.size(), 40U);
+  EXPECT_EQ(ReadIds(path, kTinyChunk), expected);
+  EXPECT_EQ(ReadIds(path, 13), expected);
+  EXPECT_EQ(ReadIds(path, 64), expected);
+  EXPECT_EQ(ReadIds(path, 4096), expected);
+}

--- a/tests/unit/requests_transfer_stall.cpp
+++ b/tests/unit/requests_transfer_stall.cpp
@@ -1,0 +1,163 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "requests/requests.hpp"
+#include "utils/logging.hpp"
+
+using memgraph::requests::DownloadFailure;
+using memgraph::requests::DownloadToSink;
+
+namespace {
+
+constexpr std::size_t kBodyBytes = 64U * 1024U;
+constexpr uint64_t kConnectionTimeoutSec = 5;
+
+// Serves one request on a loopback port the kernel picks, so tests can run alongside each other.
+// Whether the body follows the headers is what each test varies.
+class OneShotServer {
+ public:
+  enum class Behaviour : std::uint8_t {
+    /// Sends the whole body and closes, as a healthy server does.
+    SendWholeBody,
+    /// Announces a body and then sends none of it, as a server that has died mid-response does.
+    AnnounceBodyThenGoSilent,
+  };
+
+  explicit OneShotServer(Behaviour behaviour) : behaviour_{behaviour} {
+    listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    MG_ASSERT(listen_fd_ != -1, "could not open a listening socket");
+    int const reuse = 1;
+    ::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    MG_ASSERT(::bind(listen_fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0, "could not bind");
+    MG_ASSERT(::listen(listen_fd_, 1) == 0, "could not listen");
+
+    socklen_t len = sizeof(addr);
+    MG_ASSERT(::getsockname(listen_fd_, reinterpret_cast<sockaddr *>(&addr), &len) == 0, "could not read the port");
+    port_ = ::ntohs(addr.sin_port);
+
+    thread_ = std::thread{[this] { Serve(); }};
+  }
+
+  ~OneShotServer() {
+    stop_ = true;
+    ::shutdown(listen_fd_, SHUT_RDWR);
+    ::close(listen_fd_);
+    thread_.join();
+  }
+
+  OneShotServer(OneShotServer const &) = delete;
+  OneShotServer &operator=(OneShotServer const &) = delete;
+  OneShotServer(OneShotServer &&) = delete;
+  OneShotServer &operator=(OneShotServer &&) = delete;
+
+  [[nodiscard]] auto Url() const -> std::string { return fmt::format("http://127.0.0.1:{}/body", port_); }
+
+ private:
+  void Serve() {
+    auto const conn = ::accept(listen_fd_, nullptr, nullptr);
+    if (conn == -1) return;
+
+    // Enough of the request to know it has all arrived; the tests only ever send a plain GET.
+    std::string request;
+    std::array<char, 1024> buf{};
+    while (request.find("\r\n\r\n") == std::string::npos) {
+      auto const got = ::recv(conn, buf.data(), buf.size(), 0);
+      if (got <= 0) {
+        ::close(conn);
+        return;
+      }
+      request.append(buf.data(), static_cast<std::size_t>(got));
+    }
+
+    auto const headers = fmt::format("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", kBodyBytes);
+    ::send(conn, headers.data(), headers.size(), MSG_NOSIGNAL);
+
+    if (behaviour_ == Behaviour::SendWholeBody) {
+      std::string const body(kBodyBytes, 'x');
+      ::send(conn, body.data(), body.size(), MSG_NOSIGNAL);
+    } else {
+      while (!stop_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds{50});
+      }
+    }
+    ::close(conn);
+  }
+
+  Behaviour behaviour_;
+  int listen_fd_{-1};
+  uint16_t port_{0};
+  std::atomic<bool> stop_{false};
+  std::thread thread_;
+};
+
+}  // namespace
+
+// Whether a transfer is making progress is a question about the server. A consumer holding the sink
+// is not a stalled transfer, and ending the download because of one turns a load that would have
+// finished into a failure that reports itself as worth retrying.
+TEST(TransferStall, AConsumerThatPausesForLongerThanTheStallWindowDoesNotEndTheTransfer) {
+  OneShotServer server{OneShotServer::Behaviour::SendWholeBody};
+
+  auto paused = false;
+  std::size_t received = 0;
+  auto const sink = [&paused, &received](char const * /*data*/, std::size_t const size) -> std::size_t {
+    if (!std::exchange(paused, true)) {
+      std::this_thread::sleep_for(std::chrono::seconds{11});
+    }
+    received += size;
+    return size;
+  };
+
+  auto const result = DownloadToSink(server.Url(), sink, kConnectionTimeoutSec);
+
+  ASSERT_TRUE(result.has_value()) << "a paused consumer ended the transfer: " << result.error().message;
+  EXPECT_EQ(received, kBodyBytes) << "the whole body should still have been delivered";
+}
+
+// The case the stall window exists for: a server that accepted the request and then stopped sending
+// leaves nothing to wait for, and the caller has to be told rather than left blocked.
+TEST(TransferStall, AServerThatStopsSendingEndsTheTransfer) {
+  OneShotServer server{OneShotServer::Behaviour::AnnounceBodyThenGoSilent};
+
+  auto const sink = [](char const * /*data*/, std::size_t const size) -> std::size_t { return size; };
+
+  constexpr uint64_t kStallWindowSec = 2;
+  auto const started = std::chrono::steady_clock::now();
+  auto const result = DownloadToSink(server.Url(), sink, kConnectionTimeoutSec, nullptr, kStallWindowSec);
+  auto const elapsed = std::chrono::steady_clock::now() - started;
+
+  ASSERT_FALSE(result.has_value()) << "a body that never arrives is not a completed download";
+  EXPECT_EQ(result.error().kind, DownloadFailure::Stalled);
+  EXPECT_TRUE(result.error().Retryable()) << "the same request may well be served next time";
+  EXPECT_LT(elapsed, std::chrono::seconds{30}) << "the transfer should end on the stall window it was given";
+}

--- a/tests/unit/utils_byte_source.cpp
+++ b/tests/unit/utils_byte_source.cpp
@@ -1,0 +1,101 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "utils/byte_source.hpp"
+#include "utils/exceptions.hpp"
+
+using memgraph::utils::FileByteSource;
+
+namespace {
+auto WriteTempFile(std::string_view contents) -> std::filesystem::path {
+  auto path = std::filesystem::temp_directory_path() /
+              ("byte_source_" + std::to_string(::getpid()) + "_" + std::to_string(std::rand()) + ".bin");
+  std::ofstream out{path, std::ios::binary};
+  out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+  return path;
+}
+
+auto DrainToString(memgraph::utils::ByteSource &source) -> std::string {
+  std::string seen;
+  std::array<char, 7> buffer{};
+  while (auto const read = source.Read(buffer.data(), buffer.size())) {
+    seen.append(buffer.data(), read);
+  }
+  return seen;
+}
+}  // namespace
+
+TEST(FileByteSourceTest, HandsOverEveryByteOfTheFile) {
+  auto const path = WriteTempFile("the quick brown fox jumps over the lazy dog");
+  FileByteSource source{path.string()};
+
+  EXPECT_EQ(DrainToString(source), "the quick brown fox jumps over the lazy dog");
+
+  std::filesystem::remove(path);
+}
+
+TEST(FileByteSourceTest, AnEmptyFileIsExhaustedStraightAway) {
+  auto const path = WriteTempFile("");
+  FileByteSource source{path.string()};
+
+  std::array<char, 4> buffer{};
+  EXPECT_EQ(source.Read(buffer.data(), buffer.size()), 0U);
+
+  std::filesystem::remove(path);
+}
+
+TEST(FileByteSourceTest, ReadingPastTheEndKeepsReportingExhausted) {
+  auto const path = WriteTempFile("ab");
+  FileByteSource source{path.string()};
+
+  std::array<char, 8> buffer{};
+  EXPECT_EQ(source.Read(buffer.data(), buffer.size()), 2U);
+  EXPECT_EQ(source.Read(buffer.data(), buffer.size()), 0U);
+  EXPECT_EQ(source.Read(buffer.data(), buffer.size()), 0U);
+
+  std::filesystem::remove(path);
+}
+
+TEST(FileByteSourceTest, AskingForNothingReadsNothingAndLeavesTheRestToCome) {
+  auto const path = WriteTempFile("abc");
+  FileByteSource source{path.string()};
+
+  EXPECT_EQ(source.Read(nullptr, 0), 0U);
+  EXPECT_EQ(DrainToString(source), "abc");
+
+  std::filesystem::remove(path);
+}
+
+TEST(FileByteSourceTest, AFileThatCannotBeOpenedIsReportedAtConstruction) {
+  EXPECT_THROW(FileByteSource{"/nonexistent/directory/nothing-here.bin"}, memgraph::utils::BasicException);
+}
+
+// A read that fails reports no bytes, which on its own is indistinguishable from reaching the end.
+// Taken for the end it would stop a load early and call the result complete, so it must be raised.
+// A directory is the case that reaches this: it opens, then refuses to be read from.
+TEST(FileByteSourceTest, AReadThatFailsIsNotMistakenForTheEndOfTheSource) {
+  auto const directory = std::filesystem::temp_directory_path();
+  FileByteSource source{directory.string()};
+
+  std::array<char, 8> buffer{};
+  EXPECT_THROW(source.Read(buffer.data(), buffer.size()), memgraph::utils::BasicException);
+}

--- a/tests/unit/utils_download_temp_file.cpp
+++ b/tests/unit/utils_download_temp_file.cpp
@@ -1,0 +1,169 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <fcntl.h>
+#include <limits.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+#include <gtest/gtest.h>
+
+#include "utils/download_temp_file.hpp"
+#include "utils/on_scope_exit.hpp"
+
+namespace fs = std::filesystem;
+
+using memgraph::utils::DownloadTempFile;
+
+class DownloadTempFileTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    test_dir_ = fs::temp_directory_path() / "download_temp_file_test";
+    fs::create_directories(test_dir_);
+  }
+
+  void TearDown() override {
+    if (fs::exists(test_dir_)) {
+      fs::remove_all(test_dir_);
+    }
+  }
+
+  static auto ReadAll(int fd) -> std::string {
+    std::string content;
+    std::array<char, 64> buffer{};
+    while (auto const bytes = ::read(fd, buffer.data(), buffer.size())) {
+      if (bytes < 0) break;
+      content.append(buffer.data(), static_cast<std::size_t>(bytes));
+    }
+    return content;
+  }
+
+  static void Write(DownloadTempFile &file, std::string_view content) {
+    auto stream = file.OpenStream();
+    ASSERT_TRUE(stream.has_value()) << stream.error().message();
+    ASSERT_EQ(std::fwrite(content.data(), 1, content.size(), stream->get()), content.size());
+  }
+
+  fs::path test_dir_;
+};
+
+TEST_F(DownloadTempFileTest, ContentWrittenThroughTheStreamIsReadableThroughTheDescriptor) {
+  auto file = DownloadTempFile::Create(test_dir_);
+  ASSERT_TRUE(file.has_value()) << file.error().message();
+
+  Write(*file, "parquet bytes");
+
+  auto fd = file->DupFd();
+  ASSERT_TRUE(fd.has_value()) << fd.error().message();
+
+  EXPECT_EQ(ReadAll(fd->Get()), "parquet bytes");
+}
+
+TEST_F(DownloadTempFileTest, NoDirectoryEntryIsLeftBehind) {
+  auto file = DownloadTempFile::Create(test_dir_);
+  ASSERT_TRUE(file.has_value()) << file.error().message();
+
+  EXPECT_TRUE(fs::is_empty(test_dir_));
+}
+
+TEST_F(DownloadTempFileTest, TheFileIsAlreadyUnlinked) {
+  auto file = DownloadTempFile::Create(test_dir_);
+  ASSERT_TRUE(file.has_value()) << file.error().message();
+
+  auto fd = file->DupFd();
+  ASSERT_TRUE(fd.has_value()) << fd.error().message();
+
+  struct stat info{};
+  ASSERT_EQ(::fstat(fd->Get(), &info), 0);
+  EXPECT_EQ(info.st_nlink, 0);
+}
+
+#ifdef __linux__
+// The only way to recover the path of an unlinked file, and procfs is not mounted everywhere.
+TEST_F(DownloadTempFileTest, FileIsCreatedInTheRequestedDirectoryUnderNameMax) {
+  auto file = DownloadTempFile::Create(test_dir_);
+  ASSERT_TRUE(file.has_value()) << file.error().message();
+
+  auto fd = file->DupFd();
+  ASSERT_TRUE(fd.has_value()) << fd.error().message();
+
+  auto const target = fs::read_symlink(fs::path{"/proc/self/fd"} / std::to_string(fd->Get()));
+  EXPECT_EQ(target.parent_path(), test_dir_);
+  EXPECT_TRUE(target.filename().string().starts_with("memgraph_download_"));
+  EXPECT_LT(target.filename().string().size(), NAME_MAX);
+}
+#endif
+
+TEST_F(DownloadTempFileTest, DuplicatedDescriptorOutlivesTheOwner) {
+  std::optional<memgraph::utils::OwnedFd> fd;
+  {
+    auto file = DownloadTempFile::Create(test_dir_);
+    ASSERT_TRUE(file.has_value()) << file.error().message();
+    Write(*file, "outlives the owner");
+
+    auto duplicated = file->DupFd();
+    ASSERT_TRUE(duplicated.has_value()) << duplicated.error().message();
+    fd = std::move(*duplicated);
+  }
+
+  EXPECT_EQ(ReadAll(fd->Get()), "outlives the owner");
+}
+
+TEST_F(DownloadTempFileTest, AnOwnedDescriptorClosesWhenItGoesOutOfScope) {
+  auto file = DownloadTempFile::Create(test_dir_);
+  ASSERT_TRUE(file.has_value()) << file.error().message();
+
+  int raw = -1;
+  {
+    auto fd = file->DupFd();
+    ASSERT_TRUE(fd.has_value()) << fd.error().message();
+    raw = fd->Get();
+    ASSERT_NE(::fcntl(raw, F_GETFD), -1) << "descriptor should be open while owned";
+  }
+
+  EXPECT_EQ(::fcntl(raw, F_GETFD), -1) << "descriptor should be closed once the owner is gone";
+}
+
+TEST_F(DownloadTempFileTest, ReleasingAnOwnedDescriptorLeavesItOpen) {
+  auto file = DownloadTempFile::Create(test_dir_);
+  ASSERT_TRUE(file.has_value()) << file.error().message();
+
+  int raw = -1;
+  {
+    auto fd = file->DupFd();
+    ASSERT_TRUE(fd.has_value()) << fd.error().message();
+    raw = fd->Release();
+  }
+  auto const close_raw = memgraph::utils::OnScopeExit{[&] { ::close(raw); }};
+
+  EXPECT_NE(::fcntl(raw, F_GETFD), -1) << "a released descriptor belongs to the caller";
+}
+
+TEST_F(DownloadTempFileTest, AnUnwritableDirectoryIsReportedAsAnErrorCode) {
+  if (::geteuid() == 0) {
+    GTEST_SKIP() << "root bypasses the directory permissions this test relies on";
+  }
+
+  auto const unwritable = test_dir_ / "unwritable";
+  fs::create_directories(unwritable);
+  fs::permissions(unwritable, fs::perms::owner_read | fs::perms::owner_exec);
+  auto const restore = memgraph::utils::OnScopeExit{[&] { fs::permissions(unwritable, fs::perms::owner_all); }};
+
+  auto file = DownloadTempFile::Create(unwritable);
+
+  ASSERT_FALSE(file.has_value());
+  EXPECT_EQ(file.error(), std::errc::permission_denied);
+}

--- a/tests/unit/utils_file.cpp
+++ b/tests/unit/utils_file.cpp
@@ -15,17 +15,22 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
+#include <climits>
+#include <cstdio>
 #include <fstream>
 #include <map>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
-#include <unordered_set>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "page_cache_probe.hpp"
+#include "utils/download_temp_file.hpp"
 #include "utils/file.hpp"
 #include "utils/on_scope_exit.hpp"
 #include "utils/spin_lock.hpp"
@@ -645,127 +650,6 @@ void CreateFiles(const fs::path &path) {
   CreateFile(path / "existing_file_000");
   fs::create_symlink(path / "existing_file_000", path / "symlink_file_000");
   fs::permissions(path / "existing_file_000", fs::perms::none);
-}
-
-class GetUniqueDownloadPathTest : public testing::Test {
- protected:
-  void SetUp() override {
-    test_dir_ = std::filesystem::temp_directory_path() / "get_unique_path_test";
-    std::filesystem::create_directories(test_dir_);
-  }
-
-  void TearDown() override {
-    if (std::filesystem::exists(test_dir_)) {
-      std::filesystem::remove_all(test_dir_);
-    }
-  }
-
-  // Creates empty file
-  static void CreateFile(std::filesystem::path const &path) {
-    std::ofstream file(path);
-    file.close();
-  }
-
-  std::filesystem::path test_dir_;
-};
-
-using memgraph::utils::CreateUniqueDownloadFile;
-
-TEST_F(GetUniqueDownloadPathTest, ThreadSafeFiles) {
-  auto const path = test_dir_ / "thread.csv";
-  // hardware_concurrency can return 0, should be considered only a hint
-  auto const num_threads = std::max(std::thread::hardware_concurrency(), 8U);
-
-  std::vector<std::filesystem::path> storage(num_threads);
-  for (auto i = 0U; i < num_threads; i++) {
-    std::jthread exec{
-        [&path, thread_id = i, &storage]() { storage[thread_id] = CreateUniqueDownloadFile(path).first; }};
-  }
-
-  std::unordered_set<std::filesystem::path> checker;
-  for (auto const &path : storage) {
-    ASSERT_TRUE(checker.insert(path).second);
-  }
-}
-
-TEST_F(GetUniqueDownloadPathTest, CreateFirstAttempt) {
-  auto const path = test_dir_ / "nonexistent.csv";
-  ASSERT_EQ(path, CreateUniqueDownloadFile(path).first);
-}
-
-TEST_F(GetUniqueDownloadPathTest, CreateSecondAttempt) {
-  auto const path = test_dir_ / "file.csv";
-  CreateFile(path);
-  auto const new_path = test_dir_ / "file_1.csv";
-  ASSERT_EQ(new_path, CreateUniqueDownloadFile(path).first);
-}
-
-TEST_F(GetUniqueDownloadPathTest, MultipleFilesExist) {
-  auto base = test_dir_ / "file.txt";
-  CreateFile(base);
-  CreateFile(test_dir_ / "file_1.txt");
-  CreateFile(test_dir_ / "file_2.txt");
-
-  auto result = CreateUniqueDownloadFile(base).first;
-
-  EXPECT_EQ(result, test_dir_ / "file_3.txt");
-}
-
-TEST_F(GetUniqueDownloadPathTest, GapInSequence) {
-  auto base = test_dir_ / "file.txt";
-  CreateFile(base);
-  CreateFile(test_dir_ / "file_1.txt");
-  // Skip file_2.txt
-  CreateFile(test_dir_ / "file_3.txt");
-
-  auto result = CreateUniqueDownloadFile(base).first;
-
-  // Should return _2 since _1 exists but _2 doesn't
-  EXPECT_EQ(result, test_dir_ / "file_2.txt");
-}
-
-TEST_F(GetUniqueDownloadPathTest, NoExtension) {
-  auto base = test_dir_ / "file";
-  CreateFile(base);
-
-  auto result = CreateUniqueDownloadFile(base).first;
-
-  EXPECT_EQ(result, test_dir_ / "file_1");
-}
-
-TEST_F(GetUniqueDownloadPathTest, MultipleExtensions) {
-  auto base = test_dir_ / "archive.tar.gz";
-  CreateFile(base);
-
-  auto result = CreateUniqueDownloadFile(base).first;
-
-  EXPECT_EQ(result, test_dir_ / "archive.tar_1.gz");
-}
-
-TEST_F(GetUniqueDownloadPathTest, LargeSequenceNumber) {
-  auto base = test_dir_ / "file.txt";
-  CreateFile(base);
-
-  // Create files up to _99
-  for (int i = 1; i <= 99; ++i) {
-    CreateFile(test_dir_ / std::format("file_{}.txt", i));
-  }
-
-  auto result = CreateUniqueDownloadFile(base).first;
-
-  EXPECT_EQ(result, test_dir_ / "file_100.txt");
-}
-
-TEST_F(GetUniqueDownloadPathTest, MaxSuffixReached) {
-  auto base = test_dir_ / "file.txt";
-  CreateFile(base);
-
-  // Create files up to and including _10000
-  for (int i = 1; i <= 10'000; ++i) {
-    CreateFile(test_dir_ / std::format("file_{}.txt", i));
-  }
-
-  EXPECT_THROW(CreateUniqueDownloadFile(base), memgraph::utils::BasicException);
 }
 
 class UtilsFileTest : public ::testing::Test {

--- a/tests/unit/utils_prefetched.cpp
+++ b/tests/unit/utils_prefetched.cpp
@@ -1,0 +1,161 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "utils/prefetched.hpp"
+
+using memgraph::utils::Prefetched;
+
+namespace {
+auto Drain(Prefetched<int> &source) -> std::vector<int> {
+  std::vector<int> seen;
+  int item = 0;
+  while (source.Next(item)) {
+    seen.push_back(item);
+  }
+  return seen;
+}
+}  // namespace
+
+TEST(PrefetchedTest, DeliversEveryItemInOrder) {
+  Prefetched<int> source{4, [](auto const &push) {
+                           for (auto i = 1; i <= 200; ++i) {
+                             if (!push(i)) return;
+                           }
+                         }};
+
+  auto const seen = Drain(source);
+
+  ASSERT_EQ(seen.size(), 200U);
+  for (auto i = 0U; i < seen.size(); ++i) {
+    ASSERT_EQ(seen[i], static_cast<int>(i) + 1);
+  }
+}
+
+TEST(PrefetchedTest, AProducerThatDeliversNothingIsSpentImmediately) {
+  Prefetched<int> source{4, [](auto const & /*push*/) {}};
+
+  EXPECT_TRUE(Drain(source).empty());
+}
+
+TEST(PrefetchedTest, WhatTheProducerThrowsReachesTheConsumer) {
+  Prefetched<int> source{4, [](auto const &push) {
+                           push(1);
+                           throw std::runtime_error{"produced badly"};
+                         }};
+
+  int item = 0;
+  // Whatever was produced before the failure is still handed over first.
+  ASSERT_TRUE(source.Next(item));
+  EXPECT_EQ(item, 1);
+
+  EXPECT_THROW(
+      {
+        while (source.Next(item)) {
+        }
+      },
+      std::runtime_error);
+}
+
+TEST(PrefetchedTest, TheProducerIsToldToStopWhenTheConsumerGivesUp) {
+  std::atomic<bool> told_to_stop{false};
+  std::atomic<int> produced{0};
+
+  {
+    Prefetched<int> source{2, [&](auto const &push) {
+                             for (auto i = 0; i < 1'000'000; ++i) {
+                               produced.fetch_add(1, std::memory_order_relaxed);
+                               if (!push(i)) {
+                                 told_to_stop.store(true, std::memory_order_release);
+                                 return;
+                               }
+                             }
+                           }};
+
+    int item = 0;
+    ASSERT_TRUE(source.Next(item));
+    // Destroyed here, having consumed one item out of a million.
+  }
+
+  EXPECT_TRUE(told_to_stop.load(std::memory_order_acquire))
+      << "the producer should learn to stop through the value push returns";
+  EXPECT_LT(produced.load(std::memory_order_relaxed), 1'000'000) << "destruction should not wait for the whole source";
+}
+
+TEST(PrefetchedTest, TheQueueDepthBoundsWhatIsProducedAhead) {
+  constexpr auto kDepth = 2;
+  std::atomic<int> produced{0};
+
+  Prefetched<int> source{kDepth, [&](auto const &push) {
+                           for (auto i = 0; i < 100; ++i) {
+                             produced.fetch_add(1, std::memory_order_relaxed);
+                             if (!push(i)) return;
+                           }
+                         }};
+
+  // Give the producer every chance to run ahead before anything is consumed.
+  for (auto attempt = 0; attempt < 50 && produced.load(std::memory_order_relaxed) <= kDepth; ++attempt) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{2});
+  }
+
+  // It may sit one item beyond the queue, in the push that is blocking.
+  EXPECT_LE(produced.load(std::memory_order_relaxed), kDepth + 1)
+      << "a bounded queue is what keeps a fast producer from running away";
+
+  int item = 0;
+  while (source.Next(item)) {
+  }
+}
+
+TEST(PrefetchedTest, TryNextTakesOnlyWhatHasAlreadyArrived) {
+  std::atomic<bool> release{false};
+  Prefetched<int> source{4, [&](auto const &push) {
+                           push(1);
+                           while (!release.load(std::memory_order_acquire)) {
+                             std::this_thread::sleep_for(std::chrono::milliseconds{1});
+                           }
+                           push(2);
+                         }};
+
+  int item = 0;
+  // The first item is worth waiting for; after that the consumer keeps going rather than blocking on
+  // a producer that has nothing ready.
+  ASSERT_TRUE(source.Next(item));
+  EXPECT_EQ(item, 1);
+  EXPECT_FALSE(source.TryNext(item)) << "nothing has arrived yet, so this must not wait";
+
+  release.store(true, std::memory_order_release);
+  ASSERT_TRUE(source.Next(item));
+  EXPECT_EQ(item, 2);
+}
+
+TEST(PrefetchedTest, AMoveOnlyItemSurvivesTheQueue) {
+  Prefetched<std::string> source{2, [](auto const &push) {
+                                   push(std::string(1000, 'x'));
+                                   push(std::string(1000, 'y'));
+                                 }};
+
+  std::string item;
+  ASSERT_TRUE(source.Next(item));
+  EXPECT_EQ(item, std::string(1000, 'x'));
+  ASSERT_TRUE(source.Next(item));
+  EXPECT_EQ(item, std::string(1000, 'y'));
+  EXPECT_FALSE(source.Next(item));
+}

--- a/tests/unit/utils_queued_byte_source.cpp
+++ b/tests/unit/utils_queued_byte_source.cpp
@@ -1,0 +1,264 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "utils/exceptions.hpp"
+#include "utils/queued_byte_source.hpp"
+
+using memgraph::utils::PushStreambuf;
+using memgraph::utils::QueuedByteSource;
+
+namespace {
+
+constexpr std::size_t kBlocks = 4;
+
+/// Reads the whole source with a buffer of `read_size`, which is deliberately not a divisor of the
+/// block size in most tests so reads land inside blocks as well as on their edges.
+auto DrainToString(QueuedByteSource &source, std::size_t read_size) -> std::string {
+  std::string seen;
+  std::vector<char> buffer(read_size);
+  while (auto const read = source.Read(buffer.data(), buffer.size())) {
+    seen.append(buffer.data(), read);
+  }
+  return seen;
+}
+
+auto Repeated(char c, std::size_t n) -> std::string { return std::string(n, c); }
+
+}  // namespace
+
+TEST(QueuedByteSourceTest, EveryByteAnUnevenTransferPushesIsReadBack) {
+  auto const body = Repeated('a', 1000) + Repeated('b', 3) + Repeated('c', 50'000);
+
+  QueuedByteSource source{kBlocks, [&body](auto const &push) {
+                            // Pushed in uneven pieces, as a transfer hands over whatever arrived.
+                            std::size_t offset = 0;
+                            for (auto piece : {1U, 7U, 999U, 4096U, 65'536U}) {
+                              if (offset >= body.size()) break;
+                              auto const take = std::min<std::size_t>(piece, body.size() - offset);
+                              if (!push(body.data() + offset, take)) return;
+                              offset += take;
+                            }
+                            if (offset < body.size()) push(body.data() + offset, body.size() - offset);
+                          }};
+
+  EXPECT_EQ(DrainToString(source, 333), body);
+}
+
+TEST(QueuedByteSourceTest, ABodyLargerThanOneBlockCrossesTheBlockBoundaryIntact) {
+  auto const body = Repeated('x', QueuedByteSource::kBlockBytes * 2 + 17);
+
+  QueuedByteSource source{kBlocks, [&body](auto const &push) { push(body.data(), body.size()); }};
+
+  auto const seen = DrainToString(source, 4096);
+  ASSERT_EQ(seen.size(), body.size());
+  EXPECT_EQ(seen, body);
+}
+
+TEST(QueuedByteSourceTest, ATransferThatPushesNothingIsExhaustedStraightAway) {
+  QueuedByteSource source{kBlocks, [](auto const & /*push*/) {}};
+
+  char byte = 0;
+  EXPECT_EQ(source.Read(&byte, 1), 0U);
+}
+
+TEST(QueuedByteSourceTest, WhatTheTransferThrowsReachesTheReader) {
+  QueuedByteSource source{kBlocks, [](auto const &push) {
+                            std::string const head(QueuedByteSource::kBlockBytes, 'h');
+                            push(head.data(), head.size());
+                            throw std::runtime_error{"the transfer gave up"};
+                          }};
+
+  EXPECT_THROW(DrainToString(source, 1024), std::runtime_error);
+}
+
+TEST(QueuedByteSourceTest, TheTransferIsToldToStopWhenTheReaderGivesUp) {
+  std::atomic<bool> told_to_stop{false};
+
+  {
+    QueuedByteSource source{1, [&told_to_stop](auto const &push) {
+                              std::string const block(QueuedByteSource::kBlockBytes, 'z');
+                              for (auto i = 0; i < 10'000; ++i) {
+                                if (!push(block.data(), block.size())) {
+                                  told_to_stop.store(true, std::memory_order_release);
+                                  return;
+                                }
+                              }
+                            }};
+
+    char byte = 0;
+    ASSERT_EQ(source.Read(&byte, 1), 1U);
+    // Destroyed having read one byte of a body far larger than the queue can hold.
+  }
+
+  EXPECT_TRUE(told_to_stop.load(std::memory_order_acquire))
+      << "the transfer should learn to stop through the value push returns";
+}
+
+TEST(QueuedByteSourceTest, ReadHandsBackTheBlocksThatArrivedRatherThanWaitingToFillTheBuffer) {
+  std::atomic<bool> handed_over{false};
+  std::atomic<bool> release{false};
+
+  QueuedByteSource source{kBlocks, [&handed_over, &release](auto const &push) {
+                            std::string const two_blocks(QueuedByteSource::kBlockBytes * 2, 'f');
+                            push(two_blocks.data(), two_blocks.size());
+                            // Both blocks are on the queue once push has returned.
+                            handed_over.store(true, std::memory_order_release);
+                            while (!release.load(std::memory_order_acquire)) {
+                              std::this_thread::sleep_for(std::chrono::milliseconds{1});
+                            }
+                            std::string const tail(QueuedByteSource::kBlockBytes, 's');
+                            push(tail.data(), tail.size());
+                          }};
+
+  while (!handed_over.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+  }
+
+  // Asking for more than has arrived must not wait for the rest. Only the first block is worth
+  // waiting for; after that a stalled transfer is one a cancellation would otherwise sit behind.
+  std::vector<char> buffer(QueuedByteSource::kBlockBytes * 4);
+  auto const read = source.Read(buffer.data(), buffer.size());
+  EXPECT_EQ(read, QueuedByteSource::kBlockBytes * 2)
+      << "the reader waited for the buffer to fill instead of taking the blocks that had arrived";
+  EXPECT_EQ(std::count(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(read), 'f'), read);
+
+  release.store(true, std::memory_order_release);
+  auto const rest = DrainToString(source, QueuedByteSource::kBlockBytes);
+  EXPECT_EQ(rest.size(), QueuedByteSource::kBlockBytes);
+  EXPECT_EQ(std::count(rest.begin(), rest.end(), 's'), rest.size());
+}
+
+// A block is handed over once it is full, so a transfer that stops part way through one leaves those
+// bytes waiting. Ending the transfer is what releases them, which is why a reader is never left
+// holding a source that has more to give but will not give it.
+TEST(QueuedByteSourceTest, BytesShortOfAWholeBlockAreHandedOverWhenTheTransferEnds) {
+  QueuedByteSource source{kBlocks, [](auto const &push) {
+                            std::string const partial(10, 'p');
+                            push(partial.data(), partial.size());
+                          }};
+
+  EXPECT_EQ(DrainToString(source, 1024), Repeated('p', 10));
+}
+
+TEST(PushStreambufTest, WhatIsWrittenToTheStreamReachesThePush) {
+  std::string received;
+  PushStreambuf sink{[&received](char const *data, std::size_t size) {
+                       received.append(data, size);
+                       return true;
+                     },
+                     nullptr};
+
+  std::ostream out{&sink};
+  // A long write goes through xsputn; single characters go through overflow.
+  out << Repeated('q', 5000);
+  out.put('!');
+  out.flush();
+
+  EXPECT_EQ(received, Repeated('q', 5000) + "!");
+}
+
+TEST(PushStreambufTest, NothingIsReportedWhenTheTransferWasNotStopped) {
+  PushStreambuf sink{[](char const *, std::size_t) { return true; }, nullptr};
+
+  std::ostream out{&sink};
+  out << "fine";
+  out.flush();
+
+  EXPECT_NO_THROW(sink.RethrowIfStopped());
+}
+
+TEST(PushStreambufTest, AWriteIsRefusedOnceTheCallersCheckStopsTheTransfer) {
+  std::size_t written = 0;
+  PushStreambuf sink{[&written](char const *, std::size_t size) {
+                       written += size;
+                       return true;
+                     },
+                     []() { throw std::runtime_error{"asked to stop"}; }};
+
+  std::ostream out{&sink};
+  out << Repeated('w', 100);
+  out.flush();
+
+  EXPECT_EQ(written, 0U) << "the write must be refused, which is how a transfer is told to stop";
+  EXPECT_TRUE(out.fail()) << "refusing the write must be visible to whatever is writing";
+}
+
+// The reason the transfer ended lives here because it cannot be thrown through the library doing the
+// writing. That library will report only that a write was refused, so this takes precedence.
+TEST(PushStreambufTest, TheReasonTheCallersCheckGaveIsWhatIsReported) {
+  PushStreambuf sink{[](char const *, std::size_t) { return true; },
+                     []() { throw std::runtime_error{"asked to stop"}; }};
+
+  std::ostream out{&sink};
+  out << "anything";
+  out.flush();
+
+  try {
+    sink.RethrowIfStopped();
+    FAIL() << "the reason the transfer ended was lost";
+  } catch (std::runtime_error const &e) {
+    EXPECT_STREQ(e.what(), "asked to stop");
+  }
+}
+
+TEST(PushStreambufTest, TheReasonIsReportedOnceRatherThanOnEveryAsk) {
+  PushStreambuf sink{[](char const *, std::size_t) { return true; },
+                     []() { throw std::runtime_error{"asked to stop"}; }};
+
+  std::ostream out{&sink};
+  out << "anything";
+  out.flush();
+
+  EXPECT_THROW(sink.RethrowIfStopped(), std::runtime_error);
+  EXPECT_NO_THROW(sink.RethrowIfStopped());
+}
+
+TEST(PushStreambufTest, ATransferThatIsRefusedByTheSinkStopsWriting) {
+  std::size_t offered = 0;
+  PushStreambuf sink{[&offered](char const *, std::size_t size) {
+                       offered += size;
+                       return false;
+                     },
+                     nullptr};
+
+  std::ostream out{&sink};
+  out << Repeated('r', 100);
+  out.flush();
+
+  EXPECT_EQ(offered, 100U) << "the sink should have been offered the write once";
+  EXPECT_TRUE(out.fail()) << "a refused write must be visible to whatever is writing";
+}
+
+// A source that pushes into a stream and a reader that pulls bytes are the two halves of a
+// download, so they are checked together as well as apart.
+TEST(QueuedByteSourceTest, AStreamWrittenThroughTheSinkIsReadBackByTheSource) {
+  auto const body = Repeated('m', QueuedByteSource::kBlockBytes + 1234);
+
+  QueuedByteSource source{kBlocks, [&body](auto const &push) {
+                            PushStreambuf sink{push, nullptr};
+                            std::ostream out{&sink};
+                            out << body;
+                            out.flush();
+                          }};
+
+  EXPECT_EQ(DrainToString(source, 777), body);
+}


### PR DESCRIPTION
A download for LOAD PARQUET or LOAD JSONL goes into a file whose name nothing derives from the URI. A URL's last path component can be longer than a filesystem allows for one, carrying an object name and the parameters a signed URL adds to it, so a name taken from the URI cannot always be created at all. The directory holding it comes from TMPDIR.

JSONL never reaches disk: a transfer feeds a bounded queue that the parser drains a chunk at a time, on its own thread because a transfer pushes bytes while a reader pulls rows. A load holds a chunk rather than the whole source, so what it buffers follows the chunk size and the depth of the queue rather than the size of the file. A transfer in flight can be cancelled, because the check handed to it signals by throwing, which is the one form a transfer can act on. A failure reports the HTTP status alongside whether trying again could help, so a client retries only what could succeed.
