### PR TITLE
test(drivers): seed the nodes the Java timeout query matches

### DIFF
--- a/tests/drivers/java/v4_1/Transactions.java
+++ b/tests/drivers/java/v4_1/Transactions.java
@@ -1,81 +1,84 @@
+import static org.neo4j.driver.Values.parameters;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.Session;
+import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.TransactionWork;
-import org.neo4j.driver.Result;
-import org.neo4j.driver.Config;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.TransientException;
-import java.util.concurrent.TimeUnit;
-
-import static org.neo4j.driver.Values.parameters;
-import java.util.*;
 
 public class Transactions {
-    public static String createPerson(Transaction tx, String name) {
-        Result result = tx.run("CREATE (a:Person {name: $name}) RETURN a.name", parameters("name", name));
-        return result.single().get(0) + "";
+  public static String createPerson(Transaction tx, String name) {
+    Result result =
+        tx.run("CREATE (a:Person {name: $name}) RETURN a.name", parameters("name", name));
+    return result.single().get(0) + "";
+  }
+
+  public static void main(String[] args) {
+    Config config = Config.builder()
+                        .withoutEncryption()
+                        .withMaxTransactionRetryTime(0, TimeUnit.SECONDS)
+                        .build();
+    Driver driver =
+        GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("neo4j", "1234"), config);
+
+    try (Session session = driver.session()) {
+      try {
+        session.writeTransaction(new TransactionWork<String>() {
+          @Override
+          public String execute(Transaction tx) {
+            createPerson(tx, "mirko");
+            Result result = tx.run("CREATE (");
+            return result.single().get(0) + "";
+          }
+        });
+      } catch (ClientException e) {
+        System.out.println(e);
+      }
+
+      session.writeTransaction(new TransactionWork<String>() {
+        @Override
+        public String execute(Transaction tx) {
+          System.out.println(createPerson(tx, "mirko"));
+          System.out.println(createPerson(tx, "slavko"));
+          return "Done";
+        }
+      });
+
+      System.out.println("All ok!");
+
+      boolean timed_out = false;
+      try {
+        session.writeTransaction(new TransactionWork<String>() {
+          @Override
+          public String execute(Transaction tx) {
+            // NOTE: The following line is tricky because maybe fast hardware can get it done ->
+            // auto generate the MATCH pattern.
+            Result result =
+                tx.run("MATCH (a), (b), (c), (d), (e), (f), (g), (h), (i) RETURN COUNT(*) AS cnt");
+            return result.single().get(0) + "";
+          }
+        });
+      } catch (TransientException e) {
+        timed_out = true;
+      }
+
+      if (timed_out) {
+        System.out.println("The query timed out as was expected.");
+      } else {
+        throw new Exception("The query should have timed out, but it didn't!");
+      }
+    } catch (Exception e) {
+      System.out.println(e);
+      System.exit(1);
     }
 
-    public static void main(String[] args) {
-        Config config = Config.builder().withoutEncryption().withMaxTransactionRetryTime(0, TimeUnit.SECONDS).build();
-        Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic( "neo4j", "1234" ), config );
-
-        try ( Session session = driver.session() ) {
-            try {
-                session.writeTransaction(new TransactionWork<String>()
-                {
-                    @Override
-                    public String execute(Transaction tx) {
-                        createPerson(tx, "mirko");
-                        Result result = tx.run("CREATE (");
-                        return result.single().get(0) + "";
-                    }
-                });
-            } catch (ClientException e) {
-                System.out.println(e);
-            }
-
-            session.writeTransaction(new TransactionWork<String>()
-            {
-                @Override
-                public String execute(Transaction tx) {
-                    System.out.println(createPerson(tx, "mirko"));
-                    System.out.println(createPerson(tx, "slavko"));
-                    return "Done";
-                }
-            });
-
-            System.out.println( "All ok!" );
-
-            boolean timed_out = false;
-            try {
-              session.writeTransaction(new TransactionWork<String>()
-              {
-                @Override
-                public String execute(Transaction tx) {
-                  // NOTE: The following line is tricky because maybe fast hardware can get it done -> auto generate the MATCH pattern.
-                  Result result = tx.run("MATCH (a), (b), (c), (d), (e), (f), (g), (h), (i) RETURN COUNT(*) AS cnt");
-                  return result.single().get(0) + "";
-                }
-              });
-            } catch (TransientException e) {
-              timed_out = true;
-            }
-
-            if (timed_out) {
-              System.out.println("The query timed out as was expected.");
-            } else {
-              throw new Exception("The query should have timed out, but it didn't!");
-            }
-        }
-        catch ( Exception e ) {
-            System.out.println( e );
-            System.exit( 1 );
-        }
-
-        driver.close();
-    }
+    driver.close();
+  }
 }

--- a/tests/drivers/java/v4_1/Transactions.java
+++ b/tests/drivers/java/v4_1/Transactions.java
@@ -53,13 +53,15 @@ public class Transactions {
 
       System.out.println("All ok!");
 
+      // The query below has to outlast the server's query timeout. Seed the nodes it matches so its
+      // cost is set here rather than by whatever an earlier test left in the database.
+      session.run("UNWIND range(1, 100000) AS i CREATE ()").consume();
+
       boolean timed_out = false;
       try {
         session.writeTransaction(new TransactionWork<String>() {
           @Override
           public String execute(Transaction tx) {
-            // NOTE: The following line is tricky because maybe fast hardware can get it done ->
-            // auto generate the MATCH pattern.
             Result result =
                 tx.run("MATCH (a), (b), (c), (d), (e), (f), (g), (h), (i) RETURN COUNT(*) AS cnt");
             return result.single().get(0) + "";

--- a/tests/drivers/java/v5_8/src/main/java/memgraph/Transactions.java
+++ b/tests/drivers/java/v5_8/src/main/java/memgraph/Transactions.java
@@ -55,13 +55,19 @@ public class Transactions {
 
       System.out.println("All ok!");
 
+      // The query below has to outlast the server's query timeout. Seed the nodes it matches so its
+      // cost is set here rather than by whatever an earlier test left in the database.
+      session.run("UNWIND range(1, 100000) AS i CREATE ()").consume();
+
       boolean timed_out = false;
       try {
         session.writeTransaction(new TransactionWork<String>() {
           @Override
           public String execute(Transaction tx) {
             Result result = tx.run("MATCH (a), (b), (c), (d), (e), (f) RETURN COUNT(*) AS cnt");
-            return result.single().get(0).asString();
+            // Not asString(): coercing the count would throw before the check below can report that
+            // the query returned instead of timing out.
+            return result.single().get(0) + "";
           }
         });
       } catch (TransientException e) {


### PR DESCRIPTION
The Java transaction tests assert that a multi-variable cartesian product outlasts the server's query timeout, but they match over whatever nodes an earlier test left behind. That makes the query's cost depend on unrelated tests and on how fast the build is, so the assertion holds only while the binary is slow enough. Seeding the nodes the query matches makes it hold on any build. The other six driver suites already seed this way.

Return the count without coercing it to a string: when the query does return, the coercion throws first and hides the check that reports the query should have timed out.
