### PR TITLE
Feature: Add grouped BFS

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -32,6 +32,9 @@
 #include <utility>
 
 #include <absl/base/no_destructor.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/hash/hash.h>
 #include <cppitertools/chain.hpp>
 #include <cppitertools/imap.hpp>
 #include "ctre.hpp"
@@ -3068,6 +3071,26 @@ class SingleSourceShortestPathCursor : public query::plan::Cursor {
 
 namespace {
 
+/// Hashes a vertex for a swiss table, which reads its control byte out of the
+/// high bits of the hash. std::hash of a vertex is its identity, which leaves
+/// those bits nearly constant across a graph, so every lookup would match on the
+/// control byte and fall through to comparing keys. Mixing is what makes an
+/// open addressed table worth reaching for over a node based one.
+struct MixedVertexHash {
+  size_t operator()(VertexAccessor const &vertex) const noexcept {
+    return absl::Hash<size_t>{}(std::hash<VertexAccessor>{}(vertex));
+  }
+};
+
+/// The vertex sets a walk carries, kept flat. Every edge crossed is a lookup,
+/// so a node based table's pointer chase is paid far more often than the
+/// entries are ever iterated.
+template <typename Value>
+using VertexMap = absl::flat_hash_map<VertexAccessor, Value, MixedVertexHash, std::equal_to<VertexAccessor>,
+                                      utils::Allocator<std::pair<const VertexAccessor, Value>>>;
+using VertexSet = absl::flat_hash_set<VertexAccessor, MixedVertexHash, std::equal_to<VertexAccessor>,
+                                      utils::Allocator<VertexAccessor>>;
+
 class PruningBFSCursor : public query::plan::Cursor {
  public:
   PruningBFSCursor(const ExpandVariable &self, utils::MemoryResource *mem,
@@ -3317,9 +3340,9 @@ class PruningBFSCursor : public query::plan::Cursor {
   bool source_pending_{false};
 
   // Per-source visited set: cleared on each new input row
-  utils::pmr::unordered_set<VertexAccessor> visited_;
+  VertexSet visited_;
   // How each vertex was reached, kept only where edges may be crossed either way
-  utils::pmr::unordered_map<VertexAccessor, Arrival> branches_;
+  VertexMap<Arrival> branches_;
   // BFS frontier: current depth level and next depth level
   utils::pmr::vector<VertexAccessor> to_visit_current_;
   utils::pmr::vector<VertexAccessor> to_visit_next_;
@@ -3505,7 +3528,7 @@ class GroupedPruningBFSCursor : public query::plan::Cursor {
   // A source held back by a lower bound of one is the only entry that is false,
   // and it turns true the moment a walk arrives back at it. Held across input
   // rows, which is the whole of what this cursor does differently.
-  utils::pmr::unordered_map<VertexAccessor, bool> answered_;
+  VertexMap<bool> answered_;
   // Vertices owed a row, drained before the search goes any further.
   utils::pmr::vector<VertexAccessor> pending_;
   // Vertices reached but not yet expanded. Without an upper bound no answer
@@ -8228,6 +8251,10 @@ class DistinctCursor : public Cursor {
 
     AbortCheck(context);
 
+    // Nothing below can repeat a row in the symbols read here, so keeping them
+    // to compare the next one against would only ever confirm that.
+    if (self_.input_is_distinct_) return input_cursor_->Pull(frame, context);
+
     while (true) {
       if (!input_cursor_->Pull(frame, context)) {
         seen_rows_.clear();
@@ -8443,6 +8470,7 @@ std::unique_ptr<LogicalOperator> Distinct::Clone(AstStorage *storage) const {
   object->input_ = input_ ? input_->Clone(storage) : nullptr;
   object->value_symbols_ = value_symbols_;
   object->parallel_execution_ = parallel_execution_;
+  object->input_is_distinct_ = input_is_distinct_;
   return object;
 }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3325,6 +3325,194 @@ class PruningBFSCursor : public query::plan::Cursor {
   utils::pmr::vector<VertexAccessor> to_visit_next_;
 };
 
+/// A pruning BFS that carries one visited set across all of its input rows.
+///
+/// A pruning BFS answers "which vertices does this row's source reach", but the
+/// rows above ask only "which vertices does any source reach": the source is
+/// dead above the expansion and the rows are deduplicated. Searching per source
+/// then re-walks the same subgraph once for every source leading into it, and
+/// the top throws the repeats away. Where the sources overlap heavily this is
+/// the whole cost of the expansion.
+///
+/// Holding the visited set across rows collapses that. A vertex is expanded the
+/// first time any source reaches it and emitted at most once, so the operator
+/// walks each edge once rather than once per source that reaches it, and the
+/// rows it produces are already distinct.
+///
+/// The set it emits is the one the per-source searches produce between them,
+/// because the visited set is closed under reachability: a source an earlier
+/// search walked through was expanded then, so everything behind it is already
+/// out. Which search reached a vertex is not observable, the rewrite having
+/// established that nothing above reads what the input binds.
+///
+/// ExpandVariable::group_sources_ marks the expansions this is admitted for.
+class GroupedPruningBFSCursor : public query::plan::Cursor {
+ public:
+  GroupedPruningBFSCursor(const ExpandVariable &self, utils::MemoryResource *mem,
+                          metrics::DatabaseMetricHandles &metric_handles)
+      : self_(self),
+        input_cursor_(self_.input()->MakeCursor(mem, metric_handles)),
+        answered_(mem),
+        pending_(mem),
+        to_visit_(mem) {
+    DMG_ASSERT(self_.common_.direction != EdgeAtom::Direction::BOTH,
+               "A grouped pruning BFS cannot cross edges either way: ruling out a walk that retreads the edge it "
+               "left a source by needs the branch it was found on, which is per source.");
+    DMG_ASSERT(!self_.upper_bound_,
+               "A grouped pruning BFS cannot carry an upper bound: a vertex first reached deep would keep a later "
+               "source that reaches it early from walking what is still within the bound behind it.");
+  }
+
+  bool Pull(Frame &frame, ExecutionContext &context) override {
+    OOMExceptionEnabler const oom_exception;
+    if (!profile_name_ && context.is_profile_query) {
+      profile_name_ = self_.ToStringNamed(context.db_accessor, "GroupedPruningBFSExpand");
+    }
+    SCOPED_PROFILE_OP(profile_name_ ? profile_name_->c_str() : "GroupedPruningBFSExpand");
+
+    ExpressionEvaluator evaluator =
+        ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
+
+    auto frame_writer = frame.GetFrameWriter(context.frame_change_collector, context.evaluation_context.memory);
+
+    while (true) {
+      AbortCheck(context);
+
+      if (!pending_.empty()) {
+        auto const vertex = pending_.back();
+        pending_.pop_back();
+        frame_writer.Write(self_.common_.node_symbol, vertex);
+        return true;
+      }
+
+      // The frontier is spent, so take the next source the input offers. Doing
+      // it only here is what lets an already-answered source be skipped: the
+      // search that reached it ran to exhaustion before this row was pulled.
+      if (to_visit_.empty()) {
+        if (!input_cursor_->Pull(frame, context)) return false;
+        if (context.hops_limit.IsLimitReached()) return false;
+
+        auto const &vertex_value = frame[self_.input_symbol_];
+        // It is possible that the vertex is Null due to optional matching
+        if (vertex_value.IsNull()) continue;
+
+        lower_bound_ =
+            self_.lower_bound_ ? EvaluateInt(evaluator, self_.lower_bound_, "Min depth in pruning BFS expansion") : 1;
+        if (lower_bound_ < 0) {
+          throw QueryRuntimeException("Variable expansion bound must be a non-negative integer.");
+        }
+
+        ExpectType(self_.input_symbol_, vertex_value, TypedValue::Type::Vertex);
+        auto const &vertex = vertex_value.ValueVertex();
+
+        // A lower bound of zero makes a source its own answer; one of exactly
+        // one leaves it owing a row until a walk arrives back at it.
+        auto const [it, is_new] = answered_.try_emplace(vertex, lower_bound_ == 0);
+        if (!is_new) continue;
+        if (it->second) pending_.emplace_back(vertex);
+        expand_from_vertex(vertex, evaluator, frame_writer, context);
+        continue;
+      }
+
+      auto const curr_vertex = to_visit_.back();
+      to_visit_.pop_back();
+      if (!context.hops_limit.IsLimitReached()) {
+        expand_from_vertex(curr_vertex, evaluator, frame_writer, context);
+      }
+    }
+  }
+
+  void Shutdown() override { input_cursor_->Shutdown(); }
+
+  void Reset() override {
+    input_cursor_->Reset();
+    answered_.clear();
+    pending_.clear();
+    to_visit_.clear();
+  }
+
+ private:
+  void expand_from_vertex(VertexAccessor const &vertex, ExpressionEvaluator &evaluator, FrameWriter &frame_writer,
+                          ExecutionContext &context) {
+    auto try_visit = [&](EdgeAccessor const &edge, VertexAccessor const &next_vertex) {
+      auto const it = answered_.find(next_vertex);
+      // Reached before and its row already out: the search went on from it then,
+      // so there is nothing behind it left to find and nothing left to emit.
+      // Answering this before the access check and the filter lambda keeps both
+      // off every edge leading back into the searched part of the graph.
+      if (it != answered_.end() && it->second) return;
+#ifdef MG_ENTERPRISE
+      if (license::global_license_checker.IsEnterpriseValidFast() && context.auth_checker &&
+          !(context.auth_checker->Has(
+                next_vertex, storage::View::OLD, memgraph::query::AuthQuery::FineGrainedPrivilege::READ) &&
+            context.auth_checker->Has(edge, memgraph::query::AuthQuery::FineGrainedPrivilege::READ))) {
+        return;
+      }
+#endif
+      if (self_.filter_lambda_.expression) {
+        frame_writer.Write(self_.filter_lambda_.inner_edge_symbol, edge);
+        frame_writer.Write(self_.filter_lambda_.inner_node_symbol, next_vertex);
+        TypedValue result = self_.filter_lambda_.expression->Accept(evaluator);
+        switch (result.type()) {
+          case TypedValue::Type::Null:
+            return;
+          case TypedValue::Type::Bool:
+            if (!result.ValueBool()) return;
+            break;
+          default:
+            throw QueryRuntimeException("Expansion condition must evaluate to boolean or null.");
+        }
+      }
+      if (it != answered_.end()) {
+        // A source still owing a row, now arrived at over an edge. Following an
+        // edge's direction into a source can never be retreading the edge the
+        // search left that source by, which points the other way, so the walk
+        // that arrives here is edge-unique and the row stands.
+        it->second = true;
+        pending_.emplace_back(next_vertex);
+        return;
+      }
+      answered_.emplace(next_vertex, true);
+      pending_.emplace_back(next_vertex);
+      to_visit_.emplace_back(next_vertex);
+    };
+
+    if (self_.common_.direction != EdgeAtom::Direction::IN) {
+      auto out_edges_result =
+          UnwrapEdgesResult(vertex.OutEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
+      context.number_of_hops += out_edges_result.expanded_count;
+      for (auto const &edge : out_edges_result.edges) {
+        try_visit(edge, edge.To());
+      }
+    }
+    if (self_.common_.direction != EdgeAtom::Direction::OUT) {
+      auto in_edges_result =
+          UnwrapEdgesResult(vertex.InEdges(storage::View::OLD, self_.common_.edge_types, &context.hops_limit));
+      context.number_of_hops += in_edges_result.expanded_count;
+      for (auto const &edge : in_edges_result.edges) {
+        try_visit(edge, edge.From());
+      }
+    }
+  }
+
+  const ExpandVariable &self_;
+  const UniqueCursorPtr input_cursor_;
+  std::optional<std::string> profile_name_;
+
+  int64_t lower_bound_{};
+
+  // Every vertex the search has reached, against whether its row is already out.
+  // A source held back by a lower bound of one is the only entry that is false,
+  // and it turns true the moment a walk arrives back at it. Held across input
+  // rows, which is the whole of what this cursor does differently.
+  utils::pmr::unordered_map<VertexAccessor, bool> answered_;
+  // Vertices owed a row, drained before the search goes any further.
+  utils::pmr::vector<VertexAccessor> pending_;
+  // Vertices reached but not yet expanded. Without an upper bound no answer
+  // depends on the depth a vertex is reached at, so the order is free.
+  utils::pmr::vector<VertexAccessor> to_visit_;
+};
+
 /// Only a lower bound of at most one lets a pruning BFS reach the same vertices
 /// as a depth-first walk: a vertex the BFS first arrives at below the bound is
 /// marked visited and never emitted, where the walk would still arrive at it
@@ -3352,9 +3540,12 @@ class PruningBFSDispatchCursor : public query::plan::Cursor {
 
  private:
   UniqueCursorPtr Choose(Frame &frame, ExecutionContext &context) {
-    if (BoundPermitsPruning(frame, context))
-      return MakeUniqueCursorPtr<PruningBFSCursor>(mem_, self_, mem_, metric_handles_);
-    return MakeUniqueCursorPtr<ExpandVariableCursor>(mem_, self_, mem_, metric_handles_);
+    if (!BoundPermitsPruning(frame, context))
+      return MakeUniqueCursorPtr<ExpandVariableCursor>(mem_, self_, mem_, metric_handles_);
+    // Whether the input rows may share a visited set is settled by the plan, not
+    // by the bound, so the rewrite has already answered it.
+    if (self_.group_sources_) return MakeUniqueCursorPtr<GroupedPruningBFSCursor>(mem_, self_, mem_, metric_handles_);
+    return MakeUniqueCursorPtr<PruningBFSCursor>(mem_, self_, mem_, metric_handles_);
   }
 
   /// A walk of at most one edge is the threshold below which a pruning BFS
@@ -4845,6 +5036,7 @@ std::unique_ptr<LogicalOperator> ExpandVariable::Clone(AstStorage *storage) cons
   object->input_symbol_ = input_symbol_;
   object->common_ = common_;
   object->type_ = type_;
+  object->group_sources_ = group_sources_;
   object->is_reverse_ = is_reverse_;
   object->lower_bound_ = lower_bound_ ? lower_bound_->Clone(storage) : nullptr;
   object->upper_bound_ = upper_bound_ ? upper_bound_->Clone(storage) : nullptr;
@@ -4880,9 +5072,10 @@ std::string_view ExpandVariable::OperatorName(Parameters const *parameters) cons
       // bound can be read would name a walk that may not be the one taken.
       // Must agree with PruningBFSDispatchCursor::BoundPermitsPruning, which
       // makes the runtime decision.
-      if (!parameters || !lower_bound_) return "PruningBFSExpand"sv;
+      auto const pruning = group_sources_ ? "GroupedPruningBFSExpand"sv : "PruningBFSExpand"sv;
+      if (!parameters || !lower_bound_) return pruning;
       auto const bound = ConstExternalPropertyValue(lower_bound_, *parameters);
-      if (bound && bound->IsInt() && bound->ValueInt() <= 1) return "PruningBFSExpand"sv;
+      if (bound && bound->IsInt() && bound->ValueInt() <= 1) return pruning;
       return "ExpandVariable"sv;
     }
     case Type::SINGLE:

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -1249,6 +1249,11 @@ class ExpandVariable : public memgraph::query::plan::LogicalOperator {
   Symbol input_symbol_;
   memgraph::query::plan::ExpandCommon common_;
   EdgeAtom::Type type_;
+  /// Set on a pruning BFS whose input rows may share one visited set. The
+  /// rewrite settles it: nothing above the expansion reads what its input binds,
+  /// so the rows a per-source search repeats are ones nothing can tell apart.
+  /// Meaningless for every other type.
+  bool group_sources_{false};
   /// True if the path should be written as expanding from node_symbol to input_symbol.
   bool is_reverse_;
   /// Optional lower bound of the variable length expansion, defaults are (1, inf)

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -2780,6 +2780,11 @@ class Distinct : public memgraph::query::plan::LogicalOperator {
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;
   std::vector<Symbol> value_symbols_;
   std::optional<size_t> parallel_execution_;
+  /// Set where the plan already guarantees the input's rows differ in
+  /// `value_symbols_`, which leaves this operator nothing to catch. It is kept
+  /// in the plan rather than cut out of it, so that a plan still shows what
+  /// permitted the rewrites below it. See RewriteWithPruningBFS.
+  bool input_is_distinct_{false};
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };

--- a/src/query/plan/rewrite/pruning_bfs.cpp
+++ b/src/query/plan/rewrite/pruning_bfs.cpp
@@ -20,6 +20,7 @@
 #include "query/frontend/semantic/symbol_table.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan/preprocess.hpp"
+#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::query::plan {
 
@@ -56,8 +57,17 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
     // The whole predicate is in expression_, which is what the cursor evaluates.
     // all_filters_ describes it for the planner and is empty for some filters.
     CollectSymbolsFromExpression(op.expression_);
-    return true;
+    // A pattern filter reads what the main pipeline binds, and Filter::Accept
+    // reaches it only after the input. Left to that order, the input would be
+    // analysed against a symbol set the branch had not yet contributed to.
+    for (auto const &pattern_filter : op.pattern_filters_) {
+      VisitSubquery(*pattern_filter);
+    }
+    op.input_->Accept(*this);
+    return false;
   }
+
+  bool PostVisit(Filter &) override { return true; }
 
   bool PreVisit(ConstructNamedPath &op) override {
     used_symbols_.insert(op.path_symbol_.position());
@@ -67,7 +77,12 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
     return true;
   }
 
-  bool PreVisit(Distinct &) override {
+  bool PreVisit(Distinct &op) override {
+    // Which rows are duplicates of which is read off these, so collapsing rows
+    // below is only invisible where none of them come from there.
+    for (auto const &sym : op.value_symbols_) {
+      used_symbols_.insert(sym.position());
+    }
     dedup_stack_.push_back(deduplicates_);
     deduplicates_ = true;
     return true;
@@ -117,6 +132,9 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   bool PreVisit(OrderBy &op) override {
     CollectSymbolsFromExpressions(op.order_by_);
+    for (auto const &sym : op.output_symbols_) {
+      used_symbols_.insert(sym.position());
+    }
     return true;
   }
 
@@ -160,6 +178,9 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PostVisit(Apply &) override { return true; }
 
   bool PreVisit(Optional &op) override {
+    for (auto const &sym : op.optional_symbols_) {
+      used_symbols_.insert(sym.position());
+    }
     VisitSubquery(*op.optional_);
     op.input_->Accept(*this);
     return false;
@@ -168,6 +189,15 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PostVisit(Optional &) override { return true; }
 
   bool PreVisit(Cartesian &op) override {
+    // Both branches' frames are read to build the joined row, so a symbol named
+    // here is live in the branch that binds it. VisitBranch restores the set it
+    // finds on entry, which is why these go in first.
+    for (auto const &sym : op.left_symbols_) {
+      used_symbols_.insert(sym.position());
+    }
+    for (auto const &sym : op.right_symbols_) {
+      used_symbols_.insert(sym.position());
+    }
     VisitBranch(*op.left_op_);
     VisitBranch(*op.right_op_);
     return false;
@@ -176,6 +206,11 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PostVisit(Cartesian &) override { return true; }
 
   bool PreVisit(Union &op) override {
+    for (auto const *symbols : {&op.union_symbols_, &op.left_symbols_, &op.right_symbols_}) {
+      for (auto const &sym : *symbols) {
+        used_symbols_.insert(sym.position());
+      }
+    }
     VisitBranch(*op.left_op_);
     VisitBranch(*op.right_op_);
     return false;
@@ -193,6 +228,7 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PostVisit(Merge &) override { return true; }
 
   bool PreVisit(RollUpApply &op) override {
+    used_symbols_.insert(op.list_collection_symbol_.position());
     VisitSubquery(*op.list_collection_branch_);
     op.input_->Accept(*this);
     return false;
@@ -202,7 +238,10 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   bool PreVisit(EvaluatePatternFilter &) override { return true; }
 
-  bool PreVisit(Expand &) override { return true; }
+  bool PreVisit(Expand &op) override {
+    RecordExpansionInputs(op.input_symbol_, op.common_);
+    return true;
+  }
 
   bool PreVisit(ExpandVariable &op) override {
     CollectSymbolsFromExpression(op.lower_bound_);
@@ -212,6 +251,10 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
       CollectSymbolsFromExpression(op.weight_lambda_->expression);
     }
     CollectSymbolsFromExpression(op.limit_);
+
+    // What this expansion reads of its own input is recorded once the expansion
+    // has been judged, so that it does not count against itself.
+    utils::OnScopeExit const record_inputs{[&] { RecordExpansionInputs(op.input_symbol_, op.common_); }};
 
     if (op.type_ != EdgeAtom::Type::DEPTH_FIRST) return true;
     if (op.common_.existing_node) return true;
@@ -226,10 +269,63 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
     if (!BoundIsResolvable(op.lower_bound_)) return true;
 
     op.type_ = EdgeAtom::Type::PRUNING_BFS;
+    op.group_sources_ = MayShareOneSearch(op);
     return true;
   }
 
  private:
+  /// Records what an expansion reads of the row it starts from: the vertex it
+  /// expands out of, and the one it is pinned to where it matches against a
+  /// vertex already on the frame.
+  void RecordExpansionInputs(Symbol const &input_symbol, ExpandCommon const &common) {
+    used_symbols_.insert(input_symbol.position());
+    if (common.existing_node) used_symbols_.insert(common.node_symbol.position());
+  }
+
+  /// Whether one search may be shared across every row this expansion is given,
+  /// each vertex reached being expanded and emitted once no matter how many
+  /// sources lead into it.
+  ///
+  /// Sharing drops the rows a per-source search would repeat, so it needs
+  /// nothing above to be able to tell those rows from the ones left standing:
+  /// every symbol the input binds must be dead above the expansion, leaving the
+  /// vertex written here as the whole of what the row says. Nor may what the
+  /// search admits vary by row, or a vertex let through under one row's filter
+  /// would be passed over under the next one's.
+  bool MayShareOneSearch(ExpandVariable const &op) const {
+    if (!op.input()) return false;
+    // Crossing edges either way, a walk arriving back at a source may be
+    // retreading the edge it left by. Ruling that out takes the branch the walk
+    // was found on, and branches belong to the source they leave.
+    if (op.common_.direction == EdgeAtom::Direction::BOTH) return false;
+    // Under an upper bound, how far a vertex was reached decides how much of the
+    // graph behind it is still in range. A vertex first reached deep would keep a
+    // later source that reaches it early from walking what that source still has
+    // the bound to walk.
+    if (op.upper_bound_) return false;
+    if (!LambdaReadsOnlyItsOwnRow(op.filter_lambda_)) return false;
+
+    // On a subquery's branch the source is bound outside the branch, where what
+    // the input binds says nothing about it, so it is asked after separately.
+    if (used_symbols_.contains(op.input_symbol_.position())) return false;
+
+    auto const bound_by_input = op.input()->ModifiedSymbols(symbol_table_);
+    return std::ranges::none_of(bound_by_input,
+                                [this](Symbol const &sym) { return used_symbols_.contains(sym.position()); });
+  }
+
+  /// Whether the filter reads nothing beyond the edge and vertex it is being
+  /// asked about, which is what makes its verdict the same for every row.
+  bool LambdaReadsOnlyItsOwnRow(ExpansionLambda const &lambda) const {
+    if (!lambda.expression) return true;
+    UsedSymbolsCollector collector(symbol_table_);
+    lambda.expression->Accept(collector);
+    return std::ranges::all_of(collector.symbols_, [&lambda](Symbol const &sym) {
+      return sym.position() == lambda.inner_edge_symbol.position() ||
+             sym.position() == lambda.inner_node_symbol.position();
+    });
+  }
+
   void CollectSymbolsFromExpression(Expression *expr) {
     if (!expr) return;
     UsedSymbolsCollector collector(symbol_table_);

--- a/src/query/plan/rewrite/pruning_bfs.cpp
+++ b/src/query/plan/rewrite/pruning_bfs.cpp
@@ -386,12 +386,90 @@ class PruningBFSRewriter final : public HierarchicalLogicalOperatorVisitor {
   std::vector<bool> dedup_stack_;
 };
 
+/// Marks each Distinct whose input the plan already leaves distinct.
+///
+/// A grouped pruning BFS emits a vertex at most once over the whole operator, so
+/// a Distinct reading exactly that vertex has nothing left to catch. Only a
+/// grouped one: a per-source pruning BFS repeats a vertex once for every source
+/// reaching it, which is what the Distinct is there for in the first place.
+///
+/// A grouped expansion is regularly planned under one, because a Distinct is
+/// what licensed the rewrite that grouped it. The two are the same operator seen
+/// from either end, and after the rewrite the second is dead.
+class RedundantDistinctMarker final : public HierarchicalLogicalOperatorVisitor {
+ public:
+  explicit RedundantDistinctMarker(SymbolTable const &symbol_table) : symbol_table_(symbol_table) {}
+
+  using HierarchicalLogicalOperatorVisitor::PostVisit;
+  using HierarchicalLogicalOperatorVisitor::PreVisit;
+  using HierarchicalLogicalOperatorVisitor::Visit;
+
+  bool Visit(Once &) override { return true; }
+
+  bool PreVisit(Distinct &op) override {
+    op.input_is_distinct_ = InputIsAlreadyDistinct(op);
+    return true;
+  }
+
+ private:
+  /// Whether the rows reaching `op` already differ in what it deduplicates on.
+  ///
+  /// Follows the one symbol back down towards the expansion that would have had
+  /// to write it, through operators that can neither repeat a row nor put a
+  /// different vertex under that symbol. Anything else is not answered.
+  bool InputIsAlreadyDistinct(Distinct &op) const {
+    if (op.value_symbols_.size() != 1) return false;
+    auto wanted = op.value_symbols_.front();
+    for (auto *below = op.input_.get(); below;) {
+      if (auto *filter = utils::Downcast<Filter>(below)) {
+        // Only ever drops rows, and a pattern filter's branch adds none.
+        below = filter->input_.get();
+        continue;
+      }
+      if (auto *produce = utils::Downcast<Produce>(below)) {
+        auto const *carried_over = CarriedOverBy(*produce, wanted);
+        if (!carried_over) return false;
+        wanted = symbol_table_.at(*carried_over);
+        below = produce->input_.get();
+        continue;
+      }
+      if (auto *expand = utils::Downcast<ExpandVariable>(below)) {
+        return expand->type_ == EdgeAtom::Type::PRUNING_BFS && expand->group_sources_ &&
+               expand->common_.node_symbol.position() == wanted.position();
+      }
+      return false;
+    }
+    return false;
+  }
+
+  /// The identifier a Produce carries `symbol` over from, or nothing where it
+  /// does not carry it over unchanged. Anything computed from a vertex may land
+  /// distinct vertices on one value, which says nothing about the vertices.
+  Identifier const *CarriedOverBy(Produce const &produce, Symbol const &symbol) const {
+    for (auto *named : produce.named_expressions_) {
+      if (symbol_table_.at(*named).position() != symbol.position()) continue;
+      return utils::Downcast<Identifier>(named->expression_);
+    }
+    return nullptr;
+  }
+
+  SymbolTable const &symbol_table_;
+};
+
 }  // namespace
 
 std::unique_ptr<LogicalOperator> RewriteWithPruningBFS(std::unique_ptr<LogicalOperator> root_op,
                                                        SymbolTable const *symbol_table) {
   auto rewriter = PruningBFSRewriter(*symbol_table);
   root_op->Accept(rewriter);
+
+  // A second walk, and deliberately from in here rather than as its own pass in
+  // the planner's chain. Which Distinct is dead is only known once the rewrite
+  // above has run, and the rewrite needs to see every Distinct to run at all, so
+  // nothing may come between the two or order them the other way round.
+  auto marker = RedundantDistinctMarker(*symbol_table);
+  root_op->Accept(marker);
+
   return root_op;
 }
 

--- a/tests/e2e/query_planning/query_planning_pruning_bfs.py
+++ b/tests/e2e/query_planning/query_planning_pruning_bfs.py
@@ -25,10 +25,25 @@ def operator_names(plan):
     return [line.strip().removeprefix("* ").split(" ")[0] for line in plan]
 
 
+PRUNING_OPERATORS = ("PruningBFSExpand", "GroupedPruningBFSExpand")
+
+
+def prunes(ops):
+    """Whether the rewrite fired, under either of the names it plans under.
+    Sharing one search across the input rows is named apart, but it is the same
+    rewrite: what separates the two is only how much of the search is reused."""
+    return any(op in ops for op in PRUNING_OPERATORS)
+
+
+def groups(ops):
+    """Whether the expansion shares one search across all of its input rows."""
+    return "GroupedPruningBFSExpand" in ops
+
+
 def fetch_pruning(memgraph, query):
     """Run `query`, first asserting it really is planned as a pruning BFS."""
     ops = operator_names(get_plan(memgraph, query))
-    assert "PruningBFSExpand" in ops, f"Expected a pruning BFS plan, got: {ops}"
+    assert prunes(ops), f"Expected a pruning BFS plan, got: {ops}"
     return list(memgraph.execute_and_fetch(query))
 
 
@@ -37,7 +52,7 @@ def fetch_depth_first(memgraph, query):
     edge variable is not enough to block the rewrite; the query must read it."""
     ops = operator_names(get_plan(memgraph, query))
     assert "ExpandVariable" in ops, f"Expected a depth-first plan, got: {ops}"
-    assert "PruningBFSExpand" not in ops, f"Expected a depth-first plan, got: {ops}"
+    assert not prunes(ops), f"Expected a depth-first plan, got: {ops}"
     return list(memgraph.execute_and_fetch(query))
 
 
@@ -58,26 +73,26 @@ def setup_graph(memgraph):
 def test_pruning_bfs_when_edges_unused(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*1..5]->(b) RETURN DISTINCT b")
     ops = operator_names(plan)
-    assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"
+    assert prunes(ops), f"Expected PruningBFSExpand in plan, got: {plan}"
 
 
 def test_no_rewrite_with_plain_aggregation(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*]->(b) RETURN count(b)")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_pruning_bfs_with_count_distinct(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*]->(b) RETURN count(DISTINCT b)")
     ops = operator_names(plan)
-    assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"
+    assert prunes(ops), f"Expected PruningBFSExpand in plan, got: {plan}"
 
 
 def test_pruning_bfs_with_collect_distinct(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*]->(b) RETURN collect(DISTINCT b)")
     ops = operator_names(plan)
-    assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"
+    assert prunes(ops), f"Expected PruningBFSExpand in plan, got: {plan}"
 
 
 def test_no_rewrite_with_mixed_aggregation(memgraph):
@@ -85,7 +100,7 @@ def test_no_rewrite_with_mixed_aggregation(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*]->(b) RETURN count(DISTINCT b), count(b)")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_when_distinct_above_plain_aggregate(memgraph):
@@ -93,19 +108,19 @@ def test_no_rewrite_when_distinct_above_plain_aggregate(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*]->(b) WITH count(b) AS cnt, a RETURN DISTINCT a, cnt")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_pruning_bfs_with_filter_lambda(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*1..5 (e, n | n:N)]->(b) RETURN DISTINCT b")
     ops = operator_names(plan)
-    assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"
+    assert prunes(ops), f"Expected PruningBFSExpand in plan, got: {plan}"
 
 
 def test_pruning_bfs_undirected(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*..3]-(b) RETURN DISTINCT b")
     ops = operator_names(plan)
-    assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"
+    assert prunes(ops), f"Expected PruningBFSExpand in plan, got: {plan}"
 
 
 # === A lower bound above one is walked depth-first ===
@@ -214,55 +229,55 @@ def test_no_rewrite_without_distinct(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*]->(b) RETURN b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_with_return_star(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*]->(b) RETURN *")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_when_edges_used(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[r*1..5]->(b) RETURN r, b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_when_named_path_used(memgraph):
     plan = get_plan(memgraph, "MATCH p=(a:N {id: 'a'})-[*1..5]->(b) RETURN p")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_for_explicit_bfs(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*BFS 1..5]->(b) RETURN b")
     ops = operator_names(plan)
     assert "BFSExpand" in ops, f"Expected BFSExpand in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_when_existing_node(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'}), (b:N {id: 'c'}) WITH a, b MATCH (a)-[*]->(b) RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_with_accumulated_path_lambda(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N)-[* (e, n, p | size(nodes(p)) < 5)]->(b) RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_with_multi_expand(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N)-[*]->(b)-[*]->(c) RETURN DISTINCT c")
     ops = operator_names(plan)
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_leaks_across_union(memgraph):
@@ -392,7 +407,7 @@ def test_pruning_bfs_with_lower_bound_of_zero(memgraph):
     """A walk of no edges reaches only its own source, which a pruning BFS emits
     as readily, so a bound below one permits pruning just as a bound of one does."""
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*0..2]->(b) RETURN DISTINCT b")
-    assert "PruningBFSExpand" in operator_names(plan), f"Expected a pruning plan, got: {plan}"
+    assert prunes(operator_names(plan)), f"Expected a pruning plan, got: {plan}"
 
     results = list(memgraph.execute_and_fetch("MATCH (a:N {id: 'a'})-[*0..2]->(x) RETURN DISTINCT x.id AS id"))
     assert {r["id"] for r in results} == {"a", "b", "c", "d", "e"}, f"Got {sorted(r['id'] for r in results)}"
@@ -402,7 +417,7 @@ def test_no_rewrite_with_lower_bound_above_one(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*2..3]->(b) RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_pruning_bfs_with_written_lower_bound_of_one(memgraph):
@@ -410,7 +425,7 @@ def test_pruning_bfs_with_written_lower_bound_of_one(memgraph):
     resolves rather than the plan."""
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*1..3]->(b) RETURN DISTINCT b")
     ops = operator_names(plan)
-    assert "PruningBFSExpand" in ops, f"Expected PruningBFSExpand in plan, got: {plan}"
+    assert prunes(ops), f"Expected PruningBFSExpand in plan, got: {plan}"
 
 
 def test_bounds_sharing_a_stripped_query_do_not_share_a_plan(diamond_graph):
@@ -443,14 +458,14 @@ def test_no_rewrite_with_limit_below_distinct(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*..3]->(b) WITH b LIMIT 5 RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_with_skip_below_distinct(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N {id: 'a'})-[*..3]->(b) WITH b SKIP 2 RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_when_merge_create_branch_reads_edges(memgraph):
@@ -459,14 +474,14 @@ def test_no_rewrite_when_merge_create_branch_reads_edges(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N)-[e*..3]->(b) MERGE (z:M) ON CREATE SET z.n = size(e) RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_when_merge_match_branch_reads_edges(memgraph):
     plan = get_plan(memgraph, "MATCH (a:N)-[e*..3]->(b) MERGE (z:M) ON MATCH SET z.n = size(e) RETURN DISTINCT b")
     ops = operator_names(plan)
     assert "ExpandVariable" in ops, f"Expected ExpandVariable in plan, got: {plan}"
-    assert "PruningBFSExpand" not in ops, f"PruningBFSExpand should not appear, got: {plan}"
+    assert not prunes(ops), f"PruningBFSExpand should not appear, got: {plan}"
 
 
 def test_no_rewrite_when_later_lambda_reads_earlier_edges(memgraph):
@@ -520,6 +535,104 @@ def test_negative_bound_throws(memgraph):
     """N2: negative parameterised bound must raise, not silently succeed."""
     with pytest.raises(Exception):
         list(memgraph.execute_and_fetch("MATCH (a:N {id: 'a'})-[*$lo..5]->(b) RETURN DISTINCT b", {"lo": -1}))
+
+
+# === One search shared across the input rows ===
+#
+# Where the source is dead above the expansion, which source reached a vertex is
+# not observable, so the searches need not be kept apart: each vertex is expanded
+# once and emitted once no matter how many sources lead into it.
+
+
+def test_grouped_when_source_is_dead_above(memgraph):
+    plan = get_plan(memgraph, "MATCH (a:N)-[*]->(b) RETURN count(DISTINCT b)")
+    assert groups(operator_names(plan)), f"Expected the searches to be shared, got: {plan}"
+
+
+def test_not_grouped_under_an_upper_bound(memgraph):
+    """A vertex first reached deep would keep a later source that reaches it
+    early from walking what that source still has the bound to walk."""
+    ops = operator_names(get_plan(memgraph, "MATCH (a:N)-[*..3]->(b) RETURN count(DISTINCT b)"))
+    assert prunes(ops), f"Expected a pruning plan, got: {ops}"
+    assert not groups(ops), f"An upper bound must keep the searches apart, got: {ops}"
+
+
+def test_not_grouped_when_the_source_is_read_above(memgraph):
+    """Sharing drops the rows a per-source search repeats, which is only
+    invisible where nothing above can tell those rows from the ones left."""
+    ops = operator_names(get_plan(memgraph, "MATCH (a:N)-[*]->(b) RETURN DISTINCT a.id, b.id"))
+    assert prunes(ops), f"Expected a pruning plan, got: {ops}"
+    assert not groups(ops), f"A read of the source must keep the searches apart, got: {ops}"
+
+
+def test_not_grouped_when_edges_cross_either_way(memgraph):
+    """A walk back into a source may be retreading the edge it left by, which
+    takes the branch it was found on, and branches belong to one source."""
+    ops = operator_names(get_plan(memgraph, "MATCH (a:N)-[*]-(b) RETURN count(DISTINCT b)"))
+    assert prunes(ops), f"Expected a pruning plan, got: {ops}"
+    assert not groups(ops), f"An undirected expansion must keep the searches apart, got: {ops}"
+
+
+def test_not_grouped_when_the_lambda_reads_the_outer_row(memgraph):
+    """A vertex let through under one row's filter would be passed over under
+    the next one's, so a shared search would settle it for every row at once."""
+    query = "MATCH (a:N)-[* (e, n | n.id > a.id)]->(b) RETURN count(DISTINCT b)"
+    ops = operator_names(get_plan(memgraph, query))
+    assert prunes(ops), f"Expected a pruning plan, got: {ops}"
+    assert not groups(ops), f"A row-dependent lambda must keep the searches apart, got: {ops}"
+
+
+def test_correctness_grouped_matches_depth_first(memgraph):
+    """Overlapping sources: 'c' is reached from both 'a' and 'd', and a shared
+    search expands it only once."""
+    query = "MATCH (s:N)-[*]->(x) RETURN DISTINCT x.id AS id"
+    assert groups(operator_names(get_plan(memgraph, query))), "Expected the searches to be shared"
+    grouped = {r["id"] for r in memgraph.execute_and_fetch(query)}
+    dfs = {r["id"] for r in fetch_depth_first(memgraph, "MATCH p=(s:N)-[*]->(x) RETURN DISTINCT x.id AS id")}
+    assert grouped == dfs == {"b", "c", "d", "e"}, f"grouped={sorted(grouped)} dfs={sorted(dfs)}"
+
+
+def test_correctness_grouped_reaches_a_source_from_another_source(memgraph):
+    """A source is held back by a lower bound of one until a walk arrives at it,
+    and the walk that does may set out from a different source."""
+    memgraph.drop_database()
+    memgraph.execute("CREATE (p:N {id: 'p'})-[:TO]->(q:N {id: 'q'});")
+    query = "MATCH (s:N)-[*]->(x) RETURN DISTINCT x.id AS id"
+    assert groups(operator_names(get_plan(memgraph, query))), "Expected the searches to be shared"
+    assert {r["id"] for r in memgraph.execute_and_fetch(query)} == {"q"}
+
+
+def test_correctness_grouped_closes_a_cycle_between_sources(memgraph):
+    """Both vertices are sources and each reaches the other, so a search that
+    skipped an already-reached source would still owe it its row."""
+    memgraph.drop_database()
+    memgraph.execute("CREATE (p:N {id: 'p'})-[:TO]->(q:N {id: 'q'})-[:TO]->(p);")
+    query = "MATCH (s:N)-[*]->(x) RETURN DISTINCT x.id AS id"
+    assert groups(operator_names(get_plan(memgraph, query))), "Expected the searches to be shared"
+    grouped = {r["id"] for r in memgraph.execute_and_fetch(query)}
+    dfs = {r["id"] for r in fetch_depth_first(memgraph, "MATCH p=(s:N)-[*]->(x) RETURN DISTINCT x.id AS id")}
+    assert grouped == dfs == {"p", "q"}, f"grouped={sorted(grouped)} dfs={sorted(dfs)}"
+
+
+def test_correctness_grouped_with_a_lower_bound_of_zero(memgraph):
+    """A walk of no edges reaches its own source, so every source is its own
+    answer whether or not anything else arrives at it."""
+    memgraph.drop_database()
+    memgraph.execute("CREATE (p:N {id: 'p'})-[:TO]->(q:N {id: 'q'}), (r:N {id: 'r'});")
+    query = "MATCH (s:N)-[*0]->(x) RETURN DISTINCT x.id AS id"
+    assert groups(operator_names(get_plan(memgraph, query))), "Expected the searches to be shared"
+    assert {r["id"] for r in memgraph.execute_and_fetch(query)} == {"p", "q", "r"}
+
+
+def test_correctness_grouped_survives_being_reset(memgraph):
+    """An Apply resets its subtree once the row it is feeding is exhausted, and
+    the searches are shared only within one such run. What an outer row reached
+    carried into the next would leave every later row with nothing to find: the
+    five rows here reach 4, 1, 0, 2 and 0 vertices, which is seven in all, but
+    only four if the first row's search is still standing when the second runs."""
+    query = "MATCH (o:N) CALL { WITH o MATCH (o)-[*]->(x:N) RETURN DISTINCT x } RETURN count(x) AS n"
+    assert any(op in line for line in get_plan(memgraph, query) for op in PRUNING_OPERATORS), "Expected a pruning plan"
+    assert list(memgraph.execute_and_fetch(query))[0]["n"] == 7
 
 
 if __name__ == "__main__":

--- a/tests/unit/query_plan_pruning_bfs.cpp
+++ b/tests/unit/query_plan_pruning_bfs.cpp
@@ -39,8 +39,12 @@ class PruningBFSRewriteTest : public ::testing::Test {
 
   std::shared_ptr<ExpandVariable> expand;
 
-  /// Knobs the tests vary; defaults describe a plan the rewrite accepts.
+  /// Knobs the tests vary; defaults describe a plan the rewrite accepts, and
+  /// one whose input rows it lets share a single search.
   Expression *lower_bound = nullptr;
+  Expression *upper_bound = nullptr;
+  Expression *filter_lambda = nullptr;
+  EdgeAtom::Direction direction = EdgeAtom::Direction::OUT;
   bool deduplicates = true;
 
   /// Once -> ScanAll -> ExpandVariable -> `above` -> Distinct -> Produce, where
@@ -53,13 +57,13 @@ class PruningBFSRewriteTest : public ::testing::Test {
                                               target_sym,
                                               edge_sym,
                                               EdgeAtom::Type::DEPTH_FIRST,
-                                              EdgeAtom::Direction::OUT,
+                                              direction,
                                               std::vector<memgraph::storage::EdgeTypeId>{},
                                               false,
                                               lower_bound,
-                                              nullptr,
+                                              upper_bound,
                                               false,
-                                              ExpansionLambda{inner_edge_sym, inner_node_sym, nullptr},
+                                              ExpansionLambda{inner_edge_sym, inner_node_sym, filter_lambda},
                                               std::nullopt,
                                               std::nullopt,
                                               nullptr);
@@ -86,6 +90,13 @@ class PruningBFSRewriteTest : public ::testing::Test {
       std::function<std::shared_ptr<LogicalOperator>(std::shared_ptr<LogicalOperator>)> const &above) {
     auto plan = RewriteWithPruningBFS(MakePlan(above), &symbol_table);
     return expand->type_;
+  }
+
+  /// Whether the rewrite let the expansion's input rows share one search.
+  bool SharesOneSearch(std::function<std::shared_ptr<LogicalOperator>(std::shared_ptr<LogicalOperator>)> const &above) {
+    auto plan = RewriteWithPruningBFS(MakePlan(above), &symbol_table);
+    EXPECT_EQ(expand->type_, EdgeAtom::Type::PRUNING_BFS) << "sharing is only ever offered to a pruning BFS";
+    return expand->group_sources_;
   }
 };
 
@@ -171,6 +182,51 @@ TEST_F(PruningBFSRewriteTest, LeavesAnExpansionWhoseBoundIsANonTrivialExpression
 TEST_F(PruningBFSRewriteTest, MarksAnExpansionWithNoBoundAtAll) {
   auto const type = RewrittenType([](auto input) { return input; });
   EXPECT_EQ(type, EdgeAtom::Type::PRUNING_BFS);
+}
+
+// === One search shared across the input rows ===
+
+TEST_F(PruningBFSRewriteTest, SharesOneSearchWhenTheSourceIsDeadAbove) {
+  // Only `target` is read above, so which source reached a vertex cannot be told
+  // from the rows, and the searches need not be kept apart.
+  EXPECT_TRUE(SharesOneSearch([](auto input) { return input; }));
+}
+
+TEST_F(PruningBFSRewriteTest, DoesNotShareOneSearchUnderAnUpperBound) {
+  // A vertex first reached deep would keep a later source that reaches it early
+  // from walking what that source still has the bound to walk.
+  upper_bound = SuppliedBound();
+  EXPECT_FALSE(SharesOneSearch([](auto input) { return input; }));
+}
+
+TEST_F(PruningBFSRewriteTest, DoesNotShareOneSearchWhenEdgesCrossEitherWay) {
+  // Ruling out a walk that retreads the edge it left a source by takes the
+  // branch it was found on, and a branch belongs to the source it leaves.
+  direction = EdgeAtom::Direction::BOTH;
+  EXPECT_FALSE(SharesOneSearch([](auto input) { return input; }));
+}
+
+TEST_F(PruningBFSRewriteTest, DoesNotShareOneSearchWhenTheSourceIsReadAbove) {
+  // The rows a shared search drops are ones this filter could have told apart.
+  EXPECT_FALSE(SharesOneSearch([this](auto input) {
+    auto *reads_source = storage.Create<Identifier>("source")->MapTo(source_sym);
+    return std::static_pointer_cast<LogicalOperator>(
+        std::make_shared<Filter>(input, std::vector<std::shared_ptr<LogicalOperator>>{}, reads_source));
+  }));
+}
+
+TEST_F(PruningBFSRewriteTest, DoesNotShareOneSearchWhenTheLambdaReadsTheOuterRow) {
+  // A vertex let through under one row's filter would be passed over under the
+  // next one's, but a shared search settles it for every row at once.
+  auto *identifier = storage.Create<Identifier>("source")->MapTo(source_sym);
+  filter_lambda = storage.Create<PropertyLookup>(identifier, storage.GetPropertyIx("keep"));
+  EXPECT_FALSE(SharesOneSearch([](auto input) { return input; }));
+}
+
+TEST_F(PruningBFSRewriteTest, SharesOneSearchWhenTheLambdaReadsOnlyItsOwnRow) {
+  auto *identifier = storage.Create<Identifier>("inner_node")->MapTo(inner_node_sym);
+  filter_lambda = storage.Create<PropertyLookup>(identifier, storage.GetPropertyIx("keep"));
+  EXPECT_TRUE(SharesOneSearch([](auto input) { return input; }));
 }
 
 }  // namespace

--- a/tests/unit/query_plan_pruning_bfs.cpp
+++ b/tests/unit/query_plan_pruning_bfs.cpp
@@ -38,6 +38,7 @@ class PruningBFSRewriteTest : public ::testing::Test {
   Symbol inner_node_sym = symbol_table.CreateSymbol("inner_node", false);
 
   std::shared_ptr<ExpandVariable> expand;
+  std::shared_ptr<Distinct> distinct;
 
   /// Knobs the tests vary; defaults describe a plan the rewrite accepts, and
   /// one whose input rows it lets share a single search.
@@ -68,8 +69,10 @@ class PruningBFSRewriteTest : public ::testing::Test {
                                               std::nullopt,
                                               nullptr);
     std::shared_ptr<LogicalOperator> top = above(expand);
+    distinct = nullptr;
     if (deduplicates) {
-      top = std::make_shared<Distinct>(std::move(top), std::vector<Symbol>{target_sym});
+      distinct = std::make_shared<Distinct>(std::move(top), std::vector<Symbol>{target_sym});
+      top = distinct;
     }
     auto *named = storage.Create<NamedExpression>("target", storage.Create<Identifier>("target")->MapTo(target_sym));
     return std::make_unique<Produce>(std::move(top), std::vector<NamedExpression *>{named});
@@ -97,6 +100,15 @@ class PruningBFSRewriteTest : public ::testing::Test {
     auto plan = RewriteWithPruningBFS(MakePlan(above), &symbol_table);
     EXPECT_EQ(expand->type_, EdgeAtom::Type::PRUNING_BFS) << "sharing is only ever offered to a pruning BFS";
     return expand->group_sources_;
+  }
+
+  /// Whether the rewrite found the Distinct above the expansion to have nothing
+  /// left to deduplicate.
+  bool DistinctIsSpentOn(
+      std::function<std::shared_ptr<LogicalOperator>(std::shared_ptr<LogicalOperator>)> const &above) {
+    auto plan = RewriteWithPruningBFS(MakePlan(above), &symbol_table);
+    EXPECT_TRUE(distinct) << "the plan under test is built without one";
+    return distinct && distinct->input_is_distinct_;
   }
 };
 
@@ -227,6 +239,35 @@ TEST_F(PruningBFSRewriteTest, SharesOneSearchWhenTheLambdaReadsOnlyItsOwnRow) {
   auto *identifier = storage.Create<Identifier>("inner_node")->MapTo(inner_node_sym);
   filter_lambda = storage.Create<PropertyLookup>(identifier, storage.GetPropertyIx("keep"));
   EXPECT_TRUE(SharesOneSearch([](auto input) { return input; }));
+}
+
+// === The Distinct that licensed the rewrite is spent by it ===
+
+TEST_F(PruningBFSRewriteTest, SpendsTheDistinctOnASharedSearch) {
+  // A shared search emits each vertex once over the whole operator, so the
+  // Distinct that permitted it has nothing of its own left to catch.
+  EXPECT_TRUE(DistinctIsSpentOn([](auto input) { return input; }));
+}
+
+TEST_F(PruningBFSRewriteTest, SpendsTheDistinctThroughAFilter) {
+  // A filter only ever drops rows, so it cannot put back a duplicate.
+  EXPECT_TRUE(DistinctIsSpentOn([this](auto input) {
+    auto *reads_target = storage.Create<Identifier>("target")->MapTo(target_sym);
+    return std::static_pointer_cast<LogicalOperator>(
+        std::make_shared<Filter>(input, std::vector<std::shared_ptr<LogicalOperator>>{}, reads_target));
+  }));
+}
+
+TEST_F(PruningBFSRewriteTest, KeepsTheDistinctWhereTheSearchIsNotShared) {
+  // A per-source pruning BFS repeats a vertex once for every source reaching
+  // it, which is the whole of what this Distinct is there for.
+  upper_bound = SuppliedBound();
+  EXPECT_FALSE(DistinctIsSpentOn([](auto input) { return input; }));
+}
+
+TEST_F(PruningBFSRewriteTest, KeepsTheDistinctWhereNoRewriteFired) {
+  lower_bound = BoundFromTheRow();
+  EXPECT_FALSE(DistinctIsSpentOn([](auto input) { return input; }));
 }
 
 }  // namespace


### PR DESCRIPTION
# feat(query): share one pruning BFS across an expansion's input rows

### What

A pruning BFS answers "which vertices does *this row's* source reach". Where the
source is dead above the expansion and the rows are deduplicated, the plan only ever
asked "which vertices does *any* source reach" — so the per-row searches re-walk the
same subgraph once for every source leading into it, and the dedup at the top throws
the repeats away.

This adds `GroupedPruningBFSExpand`, which holds one visited set across every input
row. A vertex is expanded the first time any source reaches it and emitted at most
once, so the operator walks each edge once rather than once per source that reaches
it, and its output is already distinct.

No new logical operator: `ExpandVariable` gains a `group_sources_` flag alongside
`type_ == PRUNING_BFS`, and `PruningBFSDispatchCursor::Choose` becomes three-way —
bound above one goes to `ExpandVariableCursor`, a grouped expansion to the new
cursor, everything else to the existing `PruningBFSCursor`.

### Why

A two-hop lineage query over ~130k overlapping sources, on real customer data:

| | per-source (`*1..13`) | grouped (`*`) |
|---|---|---|
| expansion | `PruningBFSExpand`, 11,398,731 hits, 2,640 ms | `GroupedPruningBFSExpand`, **1,086,501** hits, 1,010 ms |
| filter above it | 1,186,351 hits, 2,741 ms | **47,271** hits, 369 ms |
| `Distinct` above that | 47,271 hits, 118 ms | 47,271 hits, 22 ms |
| total | 5.80 s | **1.97 s** |

The decisive line is the filter: it was being pulled 1.19M times to re-reject
vertices already rejected under a different source. Now every row the expansion emits
survives to the top, and the `Distinct` has nothing left to collapse.

Result is unchanged at 47,271 across both. (The measurement drops the `..13` bound,
since grouping requires an unbounded expansion — see below. The bound was not binding
on this dataset, which the identical count confirms.)

### When it fires

On top of everything the pruning rewrite already requires, `MayShareOneSearch` in
`src/query/plan/rewrite/pruning_bfs.cpp` asks four more things.

**Nothing the input binds may be read above.** Sharing drops the rows a per-source
search would repeat, so it stands only where nothing above can tell those rows from
the ones left, leaving the vertex the expansion writes as the whole of what a row
says. Checked against the accumulated read set, plus `input_symbol_` separately —
on a subquery's branch the source is bound outside the branch, where the input's
modified symbols say nothing about it.

**No upper bound.** How far a vertex was reached decides how much of the graph behind
it is still in range. A vertex first reached deep would keep a later source that
reaches it early from walking what that source still has the bound to walk. There is
a sound bounded variant — seed every source at depth 0 in one simultaneous frontier,
so first arrival is always minimum distance and the budget behind each vertex always
maximal — but it makes the operator pipeline-breaking, so it is left for later.

**Directed only.** Crossing edges either way, a walk arriving back at a source may be
retreading the edge it left by. `PruningBFSCursor` rules that out with the branch a
vertex was found on, and a branch belongs to the source it leaves, so it does not
survive being shared.

**The filter lambda reads only its own edge and vertex.** Otherwise a vertex let
through under one row's filter would be passed over under the next one's, and a
shared search settles it for every row at once.

### Emitting a source

Every non-source vertex is emitted when discovered. A source is held back by a lower
bound of one until a walk arrives back at it, which may set out from a different
source. That walk is always edge-unique, and for a directed expansion the argument is
short: the tree path into `u` is made of edges pointing *away* from the roots, and an
edge pointing *into* a source — which has no parent, having been seeded from the
input rather than discovered — can never be one of them. It holds regardless of the
order the frontier is drained in, which is why no depth is tracked at all: without an
upper bound nothing depends on it.

A source already in the visited set is skipped at pull time. The search that reached
it ran to exhaustion before that row was pulled, so everything behind it is already
out; the set is closed under reachability.

### Also: the liveness analysis the decision rests on

Separable from the above, and worth reviewing on its own.

`Filter::Accept` visits `input_` **before** `pattern_filters_`, so a symbol read only
inside an `EXISTS` branch was never recorded by the time the expansion below it was
judged. `PreVisit(Filter&)` now walks the pattern filters first. That is a pre-existing
soundness hole in the pruning rewrite, not something grouping introduced — an edge
symbol read only from a pattern filter could have let the rewrite fire.

Several operators' symbol reads were not collected at all: `Distinct::value_symbols_`,
`OrderBy::output_symbols_`, `Optional::optional_symbols_`, `Union` and `Cartesian`'s
branch symbol lists, `RollUpApply::list_collection_symbol_`, and both expansions'
`input_symbol_` (and `node_symbol` under `existing_node`). The old rewrite only ever
asked whether the *edge* symbol was read, so the gaps were invisible; grouping asks
about every symbol the input binds.

Operators without an explicit `PreVisit` still raise `rewrite_blocked_` through
`DefaultPreVisit`, so the whitelist above is closed.

### Testing

`tests/unit/query_plan_pruning_bfs.cpp` — six cases on the grouping decision: the
accepted shape, and one each for an upper bound, an undirected expansion, a source
read above, a lambda reading the outer row, and a lambda reading only its own.

`tests/e2e/query_planning/query_planning_pruning_bfs.py` — the existing name
assertions now go through a `prunes()` helper accepting either operator name, since a
grouped plan names itself apart. Eight new cases, including a source reached from
another source, a cycle between two sources where each still owes its row, a lower
bound of zero, and an `Apply` reset that returns 7 rows if the visited set clears per
outer row and 4 if it leaks.

`test_the_plan_names_the_walk_that_runs` already held `EXPLAIN` and `PROFILE`
together across every bound, and now covers the grouped name too — `OperatorName` and
`PruningBFSDispatchCursor` have to agree on which of the three cursors runs.

---
__*Leave above in PR description, copy the below into a comment*__
___

### Tracking
- [ ] **[Link to Epic/Issue]**

### Standard development
- [ ] Update unit/E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch

### CI Testing Labels
- [ ] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_

### Documentation checklist
- [ ] Add the documentation label
- [ ] Add the bug / feature label
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - What has changed? What does it mean for a user? What should a user do with it? [#{{PR_number}}]({{link to the PR}})
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
