### PR TITLE
test: stop four timing-sensitive tests asserting how fast the machine is

### DIFF
--- a/tests/integration/telemetry/runner.py
+++ b/tests/integration/telemetry/runner.py
@@ -22,6 +22,10 @@ import time
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 PROJECT_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "..", ".."))
 
+# Seconds allowed for the client to come up before it starts measuring, on top of the duration it
+# was asked to run for.
+STARTUP_ALLOWANCE = 30
+
 
 def execute_test(**kwargs):
     client_binary = kwargs.pop("client")
@@ -34,7 +38,10 @@ def execute_test(**kwargs):
     interval = kwargs.pop("interval", 1)
     duration = kwargs.pop("duration", 5)
 
-    timeout = duration * 2 if "hang" not in kwargs else duration * 2 + 60
+    # The client starts a coordinator before it begins measuring, and a leader election takes as
+    # long as it takes regardless of duration, so the allowance for it has to be added rather than
+    # scaled. This is a hang detector, not an assertion about how fast startup is.
+    timeout = duration + STARTUP_ALLOWANCE if "hang" not in kwargs else duration + STARTUP_ALLOWANCE + 60
     success = False
 
     server_args = [server_binary, "--interval", interval, "--duration", duration]

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -468,10 +468,13 @@ add_unit_test(utils_aws
     LINK_TARGETS mg-utils mg-aws
 )
 
+# Every iteration starts a thread per barrier participant, so ctest's default cost of one slot per
+# test lets it be scheduled alongside a full machine's worth of other tests. Declaring the slots it
+# needs keeps that from happening; where the machine has fewer, ctest runs this test on its own.
 add_unit_test(utils_barrier
     SOURCES utils_barrier.cpp
     LINK_TARGETS mg-utils
-    TEST_PROPERTIES TIMEOUT 60
+    TEST_PROPERTIES TIMEOUT 120 PROCESSORS 12
 )
 
 add_unit_test(utils_hot_mask

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -471,6 +471,7 @@ add_unit_test(utils_aws
 # Every iteration starts a thread per barrier participant, so ctest's default cost of one slot per
 # test lets it be scheduled alongside a full machine's worth of other tests. Declaring the slots it
 # needs keeps that from happening; where the machine has fewer, ctest runs this test on its own.
+# PROCESSORS mirrors kN in utils_barrier.cpp and has to be changed with it.
 add_unit_test(utils_barrier
     SOURCES utils_barrier.cpp
     LINK_TARGETS mg-utils

--- a/tests/unit/integrations_kafka_consumer.cpp
+++ b/tests/unit/integrations_kafka_consumer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -213,38 +213,50 @@ TEST_F(ConsumerTest, StartStop) {
 }
 
 TEST_F(ConsumerTest, BatchSize) {
-  // Increase default batch interval to give more time for messages to receive
-  static constexpr auto kBatchInterval = std::chrono::milliseconds{1000};
+  // A batch ends on whichever comes first: batch_size messages, or delivery stalling for longer
+  // than batch_interval. This is the mirror of BatchInterval, which leaves the batch size at its
+  // large default so that only the interval can end a batch; here the interval is long enough that
+  // only the size can. The mock delivers with a delay of a few hundred milliseconds per message, so
+  // an interval anywhere near the time it takes to deliver batch_size of them ends batches early
+  // and the sizes stop being predictable.
+  static constexpr auto kBatchInterval = std::chrono::seconds{10};
   static constexpr auto kBatchSize = 3;
+  static constexpr auto kBatchCount = 3;
+  // A whole number of batches, so no trailing partial batch depends on the interval to be flushed.
+  static constexpr auto kMessageCount = kBatchCount * kBatchSize;
+  static constexpr std::string_view kMessage = "BatchSizeTestMessage";
+
   auto info = CreateDefaultConsumerInfo();
-  std::vector<std::pair<size_t, std::chrono::steady_clock::time_point>> received_timestamps{};
   info.batch_interval = kBatchInterval;
   info.batch_size = kBatchSize;
-  static constexpr std::string_view kMessage = "BatchSizeTestMessage";
+
+  std::vector<size_t> batch_sizes{};
   auto expected_messages_received = true;
+  std::latch received_messages{kMessageCount};
   auto consumer_function = [&](const std::vector<Message> &messages) mutable {
-    received_timestamps.emplace_back(messages.size(), std::chrono::steady_clock::now());
+    batch_sizes.push_back(messages.size());
     for (const auto &message : messages) {
       expected_messages_received &= (kMessage == std::string_view(message.Payload().data(), message.Payload().size()));
     }
+    received_messages.count_down(messages.size());
   };
 
   auto consumer = CreateConsumer(std::move(info), std::move(consumer_function));
   consumer->Start();
   ASSERT_TRUE(consumer->IsRunning());
 
-  static constexpr auto kLastBatchMessageCount = 1;
-  static constexpr auto kMessageCount = 3 * kBatchSize + kLastBatchMessageCount;
   for (auto sent_messages = 0; sent_messages < kMessageCount; ++sent_messages) {
     cluster.SeedTopic(kTopicName, kMessage);
   }
-  std::this_thread::sleep_for(kBatchInterval * 2);
+  received_messages.wait();
+  // Stop() joins the polling thread, which publishes batch_sizes to this one.
   consumer->Stop();
-  EXPECT_TRUE(expected_messages_received) << "Some unexpected message has been received";
-  ASSERT_FALSE(received_timestamps.empty());
 
-  static constexpr auto kExpectedBatchCount = kMessageCount / kBatchSize + 1;
-  EXPECT_EQ(kExpectedBatchCount, received_timestamps.size());
+  EXPECT_TRUE(expected_messages_received) << "Some unexpected message has been received";
+  ASSERT_EQ(kBatchCount, batch_sizes.size());
+  for (const auto batch_size : batch_sizes) {
+    EXPECT_EQ(kBatchSize, batch_size);
+  }
 }
 
 TEST_F(ConsumerTest, InvalidBootstrapServers) {

--- a/tests/unit/integrations_kafka_consumer.cpp
+++ b/tests/unit/integrations_kafka_consumer.cpp
@@ -45,6 +45,11 @@ inline constexpr std::chrono::milliseconds kDefaultBatchInterval{100};
 inline constexpr int64_t kDefaultBatchSize{1000};
 
 inline constexpr double kTimingTolerance = 1.2;  // tolerance for all timings to prevent flakes
+
+// How long a test will wait for messages it has already sent. Generous, because it exists to turn a
+// consumer that never delivers into a failure with the counts in hand rather than a hung job; a
+// working consumer reaches the condition long before this and stops waiting.
+inline constexpr auto kConsumerReadyTimeout = std::chrono::seconds{60};
 }  // namespace
 
 struct ConsumerTest : public ::testing::Test {
@@ -96,14 +101,27 @@ struct ConsumerTest : public ::testing::Test {
     // Send messages to the topic until the consumer starts to receive them. In the first few seconds the consumer
     // doesn't get messages because there is no leader in the consumer group. If consumer group leader election timeout
     // could be lowered (didn't find anything in librdkafka docs), then this mechanism will become unnecessary.
-    while (last_received_message->load() == 0) {
+    // Both loops are bounded: a consumer that never receives anything has to fail the test that asked for it, not
+    // hang until the whole job is abandoned.
+    auto deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
+    while (last_received_message->load() == 0 && std::chrono::steady_clock::now() < deadline) {
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       SeedTopicWithInt(kTopicName, ++sent_messages);
     }
+    if (last_received_message->load() == 0) {
+      ADD_FAILURE() << "Consumer received no messages while warming up";
+      return nullptr;
+    }
 
-    while (last_received_message->load() != sent_messages) {
+    deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
+    while (last_received_message->load() != sent_messages && std::chrono::steady_clock::now() < deadline) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    };
+    }
+    if (last_received_message->load() != sent_messages) {
+      ADD_FAILURE() << "Consumer stopped short while warming up: received " << last_received_message->load() << " of "
+                    << sent_messages;
+      return nullptr;
+    }
 
     consumer->Stop();
     std::this_thread::sleep_for(std::chrono::seconds(4));
@@ -146,11 +164,17 @@ TEST_F(ConsumerTest, BatchInterval) {
 
   for (auto sent_messages = 0; sent_messages < kMessageCount; ++sent_messages) {
     cluster.SeedTopic(kTopicName, kMessage);
-    // Sleep for a bit to allow the consumer to receive the message.
+    // Spacing the messages out is what puts each one in a batch of its own, which is the point of
+    // this test rather than a wait for something to happen.
     std::this_thread::sleep_for(kBatchInterval);
   }
-  // Wait for all messages to be delivered
-  sent_messages.wait();
+  // Wait for all messages to be delivered, bounded so that a message which never arrives fails the
+  // test rather than hanging it.
+  const auto deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
+  while (!sent_messages.try_wait() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  }
+  EXPECT_TRUE(sent_messages.try_wait()) << "Not every message was delivered";
 
   consumer->Stop();
   EXPECT_TRUE(expected_messages_received) << "Some unexpected message has been received";

--- a/tests/unit/integrations_kafka_consumer.cpp
+++ b/tests/unit/integrations_kafka_consumer.cpp
@@ -159,6 +159,7 @@ TEST_F(ConsumerTest, BatchInterval) {
   };
 
   auto consumer = CreateConsumer(std::move(info), std::move(consumer_function));
+  ASSERT_NE(nullptr, consumer);
   consumer->Start();
   ASSERT_TRUE(consumer->IsRunning());
 
@@ -169,12 +170,14 @@ TEST_F(ConsumerTest, BatchInterval) {
     std::this_thread::sleep_for(kBatchInterval);
   }
   // Wait for all messages to be delivered, bounded so that a message which never arrives fails the
-  // test rather than hanging it.
+  // test rather than hanging it. try_wait is allowed to report false even once the count is zero,
+  // so the answer is taken once and then asserted, never asked for a second time.
   const auto deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
-  while (!sent_messages.try_wait() && std::chrono::steady_clock::now() < deadline) {
+  auto all_delivered = false;
+  while (!(all_delivered = sent_messages.try_wait()) && std::chrono::steady_clock::now() < deadline) {
     std::this_thread::sleep_for(std::chrono::milliseconds{50});
   }
-  EXPECT_TRUE(sent_messages.try_wait()) << "Not every message was delivered";
+  EXPECT_TRUE(all_delivered) << "Not every message was delivered";
 
   consumer->Stop();
   EXPECT_TRUE(expected_messages_received) << "Some unexpected message has been received";
@@ -238,12 +241,14 @@ TEST_F(ConsumerTest, StartStop) {
 }
 
 TEST_F(ConsumerTest, BatchSize) {
-  // A batch ends on whichever comes first: batch_size messages, or delivery stalling for longer
-  // than batch_interval. This is the mirror of BatchInterval, which leaves the batch size at its
-  // large default so that only the interval can end a batch; here the interval is long enough that
-  // only the size can. The mock delivers with a delay of a few hundred milliseconds per message, so
-  // an interval anywhere near the time it takes to deliver batch_size of them ends batches early
-  // and the sizes stop being predictable.
+  // A batch ends on whichever comes first: batch_size messages, or batch_interval elapsing. The
+  // interval is a budget for assembling the whole batch, not an idle timeout - it is charged for
+  // the time every message takes to arrive, not only for gaps - so a batch of batch_size messages
+  // only ever comes out full if the interval outlasts the delivery of all of them. This is the
+  // mirror of BatchInterval, which leaves the batch size at its large default so that only the
+  // interval can end a batch; here the interval is generous enough that only the size can. The mock
+  // delivers with a delay of a few hundred milliseconds per message, so an interval anywhere near
+  // the time batch_size of them take ends batches early and the sizes stop being predictable.
   // The interval is also the timeout the polling thread blocks in, and Stop() joins that thread, so
   // it is this test's shutdown cost as well. Keep it comfortably above the delivery time of a full
   // batch without paying for more than that.
@@ -271,6 +276,7 @@ TEST_F(ConsumerTest, BatchSize) {
   };
 
   auto consumer = CreateConsumer(std::move(info), std::move(consumer_function));
+  ASSERT_NE(nullptr, consumer);
   consumer->Start();
   ASSERT_TRUE(consumer->IsRunning());
 
@@ -279,8 +285,9 @@ TEST_F(ConsumerTest, BatchSize) {
   }
 
   // Bounded rather than an open-ended wait: if delivery stops short the test has to fail with the
-  // counts in hand, not hang until ctest gives up on it.
-  const auto deadline = std::chrono::steady_clock::now() + 3 * kBatchInterval;
+  // counts in hand, not hang until ctest gives up on it. The bound is deliberately far above how
+  // long delivery takes, so that it never becomes an assertion about how fast the machine is.
+  const auto deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
   while (received_count.load(std::memory_order_acquire) < kMessageCount &&
          std::chrono::steady_clock::now() < deadline) {
     std::this_thread::sleep_for(std::chrono::milliseconds{50});
@@ -399,6 +406,7 @@ TEST_F(ConsumerTest, CheckMethodWorks) {
 
   // This test depends on CreateConsumer starts and stops the consumer, so the offset is stored
   auto consumer = CreateConsumer(std::move(info), kDummyConsumerFunction);
+  ASSERT_NE(nullptr, consumer);
 
   static constexpr auto kMessageCount = 4;
   for (auto sent_messages = 0; sent_messages < kMessageCount; ++sent_messages) {
@@ -515,6 +523,7 @@ TEST_F(ConsumerTest, LimitBatches_CannotStartIfAlreadyRunning) {
   auto info = CreateDefaultConsumerInfo();
 
   auto consumer = CreateConsumer(std::move(info), kDummyConsumerFunction);
+  ASSERT_NE(nullptr, consumer);
 
   consumer->Start();
   ASSERT_TRUE(consumer->IsRunning());
@@ -557,6 +566,7 @@ TEST_F(ConsumerTest, LimitBatches_SendingMoreThanLimit) {
   };
 
   auto consumer = CreateConsumer(std::move(info), consumer_function);
+  ASSERT_NE(nullptr, consumer);
 
   for (auto sent_messages = 0; sent_messages <= kNumberOfMessagesToSend; ++sent_messages) {
     cluster.SeedTopic(kTopicName, kMessage);
@@ -576,6 +586,7 @@ TEST_F(ConsumerTest, LimitBatches_Timeout_Reached) {
   auto info = CreateDefaultConsumerInfo();
 
   auto consumer = CreateConsumer(std::move(info), kDummyConsumerFunction);
+  ASSERT_NE(nullptr, consumer);
 
   std::chrono::milliseconds timeout{3000};
 

--- a/tests/unit/integrations_kafka_consumer.cpp
+++ b/tests/unit/integrations_kafka_consumer.cpp
@@ -50,6 +50,52 @@ inline constexpr double kTimingTolerance = 1.2;  // tolerance for all timings to
 // consumer that never delivers into a failure with the counts in hand rather than a hung job; a
 // working consumer reaches the condition long before this and stops waiting.
 inline constexpr auto kConsumerReadyTimeout = std::chrono::seconds{60};
+
+// Deliveries land on the consumer's own thread, so every wait here is a poll. The interval only
+// sets how promptly the condition is noticed once it holds.
+inline constexpr auto kPollInterval = std::chrono::milliseconds{50};
+
+// The warm-up retry sends a message on every attempt, so its pacing decides how much traffic a slow
+// leader election puts on the topic that the rest of the test then has to consume. It is spaced out
+// where an ordinary wait, which only reads a counter, is not.
+inline constexpr auto kWarmUpSeedInterval = std::chrono::milliseconds{500};
+
+std::chrono::steady_clock::time_point Now() { return std::chrono::steady_clock::now(); }
+
+// Polls until the condition holds or the deadline passes. The condition is checked before the
+// clock, so a caller that arrives after the deadline still reports a condition that has already
+// come true rather than one it never looked at.
+template <typename Condition>
+bool WaitForConditionUntil(Condition condition, std::chrono::steady_clock::time_point deadline,
+                           std::chrono::milliseconds poll_interval) {
+  while (true) {
+    if (condition()) return true;
+    if (Now() >= deadline) return false;
+    std::this_thread::sleep_for(poll_interval);
+  }
+}
+
+// Waits for a named condition, and fails the test naming it if it never holds. Naming the condition
+// is what makes the failure readable: a timed-out poll otherwise reports only that some loop ran
+// out of time.
+template <typename Condition>
+bool ExpectEventually(std::string_view what, Condition condition, std::chrono::seconds timeout = kConsumerReadyTimeout,
+                      std::chrono::milliseconds poll_interval = kPollInterval) {
+  if (WaitForConditionUntil(std::move(condition), Now() + timeout, poll_interval)) return true;
+  ADD_FAILURE() << "Timed out after " << timeout.count() << "s waiting for " << what;
+  return false;
+}
+
+// Waiting for a counter to reach a target is the shape almost every wait in this file takes, and
+// how far it got is worth more than the bare fact that it stopped short, so the failure carries it.
+bool ExpectCountReaches(std::string_view what, const std::atomic<int> &counter, int target,
+                        std::chrono::seconds timeout = kConsumerReadyTimeout) {
+  const auto reached = [&] { return counter.load(std::memory_order_acquire) >= target; };
+  if (WaitForConditionUntil(reached, Now() + timeout, kPollInterval)) return true;
+  ADD_FAILURE() << "Timed out after " << timeout.count() << "s waiting for " << what << ": reached "
+                << counter.load(std::memory_order_acquire) << " of " << target;
+  return false;
+}
 }  // namespace
 
 struct ConsumerTest : public ::testing::Test {
@@ -98,28 +144,27 @@ struct ConsumerTest : public ::testing::Test {
       return nullptr;
     }
 
-    // Send messages to the topic until the consumer starts to receive them. In the first few seconds the consumer
-    // doesn't get messages because there is no leader in the consumer group. If consumer group leader election timeout
-    // could be lowered (didn't find anything in librdkafka docs), then this mechanism will become unnecessary.
-    // Both loops are bounded: a consumer that never receives anything has to fail the test that asked for it, not
-    // hang until the whole job is abandoned.
-    auto deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
-    while (last_received_message->load() == 0 && std::chrono::steady_clock::now() < deadline) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-      SeedTopicWithInt(kTopicName, ++sent_messages);
-    }
-    if (last_received_message->load() == 0) {
-      ADD_FAILURE() << "Consumer received no messages while warming up";
+    // For the first few seconds the consumer receives nothing, because its group has no leader yet,
+    // and librdkafka offers no way to shorten that election. Sending again on every attempt is what
+    // makes this a retry rather than a wait: there is nothing in flight to wait for, because a
+    // consumer without a group leader never received what was sent before it.
+    if (!ExpectEventually(
+            "the warming-up consumer to receive a first message",
+            [&] {
+              if (last_received_message->load() != 0) return true;
+              SeedTopicWithInt(kTopicName, ++sent_messages);
+              return false;
+            },
+            kConsumerReadyTimeout,
+            kWarmUpSeedInterval)) {
       return nullptr;
     }
 
-    deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
-    while (last_received_message->load() != sent_messages && std::chrono::steady_clock::now() < deadline) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-    if (last_received_message->load() != sent_messages) {
-      ADD_FAILURE() << "Consumer stopped short while warming up: received " << last_received_message->load() << " of "
-                    << sent_messages;
+    // Each message carries its own sequence number, so the last one received tells us how far the
+    // consumer has got without counting anything.
+    if (!ExpectCountReaches("the warming-up consumer to catch up with the messages sent to it",
+                            *last_received_message,
+                            sent_messages)) {
       return nullptr;
     }
 
@@ -169,15 +214,9 @@ TEST_F(ConsumerTest, BatchInterval) {
     // this test rather than a wait for something to happen.
     std::this_thread::sleep_for(kBatchInterval);
   }
-  // Wait for all messages to be delivered, bounded so that a message which never arrives fails the
-  // test rather than hanging it. try_wait is allowed to report false even once the count is zero,
-  // so the answer is taken once and then asserted, never asked for a second time.
-  const auto deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
-  auto all_delivered = false;
-  while (!(all_delivered = sent_messages.try_wait()) && std::chrono::steady_clock::now() < deadline) {
-    std::this_thread::sleep_for(std::chrono::milliseconds{50});
-  }
-  EXPECT_TRUE(all_delivered) << "Not every message was delivered";
+  // try_wait is allowed to report false even once the count has reached zero, so a single reading of
+  // it cannot be trusted; polling it until the deadline turns that into an answer.
+  ExpectEventually("every message to be delivered", [&] { return sent_messages.try_wait(); });
 
   consumer->Stop();
   EXPECT_TRUE(expected_messages_received) << "Some unexpected message has been received";
@@ -284,14 +323,7 @@ TEST_F(ConsumerTest, BatchSize) {
     cluster.SeedTopic(kTopicName, kMessage);
   }
 
-  // Bounded rather than an open-ended wait: if delivery stops short the test has to fail with the
-  // counts in hand, not hang until ctest gives up on it. The bound is deliberately far above how
-  // long delivery takes, so that it never becomes an assertion about how fast the machine is.
-  const auto deadline = std::chrono::steady_clock::now() + kConsumerReadyTimeout;
-  while (received_count.load(std::memory_order_acquire) < kMessageCount &&
-         std::chrono::steady_clock::now() < deadline) {
-    std::this_thread::sleep_for(std::chrono::milliseconds{50});
-  }
+  ExpectCountReaches("every message to be delivered", received_count, kMessageCount);
   // Stop() joins the polling thread, which publishes batch_sizes to this one.
   consumer->Stop();
 
@@ -378,15 +410,9 @@ TEST_F(ConsumerTest, DISABLED_StartsFromPreviousOffset) {
     auto consumer = std::make_unique<Consumer>(ConsumerInfo{info}, consumer_function);
     ASSERT_FALSE(consumer->IsRunning());
     consumer->Start();
-    const auto start = std::chrono::steady_clock::now();
     ASSERT_TRUE(consumer->IsRunning());
 
-    static constexpr auto kMaxWaitTime = std::chrono::seconds(5);
-
-    while (expected_total_messages != received_message_count.load() &&
-           (std::chrono::steady_clock::now() - start) < kMaxWaitTime) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    }
+    ExpectCountReaches("the messages just sent to be delivered", received_message_count, expected_total_messages);
     // it is stopped because of limited batches
     EXPECT_EQ(expected_total_messages, received_message_count);
     EXPECT_NO_THROW(consumer->Stop());

--- a/tests/unit/integrations_kafka_consumer.cpp
+++ b/tests/unit/integrations_kafka_consumer.cpp
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <atomic>
 #include <chrono>
 #include <latch>
 #include <optional>
@@ -219,11 +220,15 @@ TEST_F(ConsumerTest, BatchSize) {
   // only the size can. The mock delivers with a delay of a few hundred milliseconds per message, so
   // an interval anywhere near the time it takes to deliver batch_size of them ends batches early
   // and the sizes stop being predictable.
-  static constexpr auto kBatchInterval = std::chrono::seconds{10};
+  // The interval is also the timeout the polling thread blocks in, and Stop() joins that thread, so
+  // it is this test's shutdown cost as well. Keep it comfortably above the delivery time of a full
+  // batch without paying for more than that.
+  static constexpr auto kBatchInterval = std::chrono::seconds{5};
   static constexpr auto kBatchSize = 3;
-  static constexpr auto kBatchCount = 3;
-  // A whole number of batches, so no trailing partial batch depends on the interval to be flushed.
-  static constexpr auto kMessageCount = kBatchCount * kBatchSize;
+  static constexpr auto kFullBatchCount = 3;
+  // One message beyond a whole number of batches, so the last batch is short and is flushed by the
+  // interval rather than by the size. Both halves of the rule stay covered.
+  static constexpr auto kMessageCount = kFullBatchCount * kBatchSize + 1;
   static constexpr std::string_view kMessage = "BatchSizeTestMessage";
 
   auto info = CreateDefaultConsumerInfo();
@@ -232,13 +237,13 @@ TEST_F(ConsumerTest, BatchSize) {
 
   std::vector<size_t> batch_sizes{};
   auto expected_messages_received = true;
-  std::latch received_messages{kMessageCount};
+  std::atomic<int> received_count{0};
   auto consumer_function = [&](const std::vector<Message> &messages) mutable {
     batch_sizes.push_back(messages.size());
     for (const auto &message : messages) {
       expected_messages_received &= (kMessage == std::string_view(message.Payload().data(), message.Payload().size()));
     }
-    received_messages.count_down(messages.size());
+    received_count.fetch_add(static_cast<int>(messages.size()), std::memory_order_release);
   };
 
   auto consumer = CreateConsumer(std::move(info), std::move(consumer_function));
@@ -248,15 +253,24 @@ TEST_F(ConsumerTest, BatchSize) {
   for (auto sent_messages = 0; sent_messages < kMessageCount; ++sent_messages) {
     cluster.SeedTopic(kTopicName, kMessage);
   }
-  received_messages.wait();
+
+  // Bounded rather than an open-ended wait: if delivery stops short the test has to fail with the
+  // counts in hand, not hang until ctest gives up on it.
+  const auto deadline = std::chrono::steady_clock::now() + 3 * kBatchInterval;
+  while (received_count.load(std::memory_order_acquire) < kMessageCount &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  }
   // Stop() joins the polling thread, which publishes batch_sizes to this one.
   consumer->Stop();
 
   EXPECT_TRUE(expected_messages_received) << "Some unexpected message has been received";
-  ASSERT_EQ(kBatchCount, batch_sizes.size());
-  for (const auto batch_size : batch_sizes) {
-    EXPECT_EQ(kBatchSize, batch_size);
+  ASSERT_EQ(kMessageCount, received_count.load(std::memory_order_acquire));
+  ASSERT_EQ(kFullBatchCount + 1, batch_sizes.size());
+  for (auto i = 0; i < kFullBatchCount; ++i) {
+    EXPECT_EQ(kBatchSize, batch_sizes[i]) << "Batch " << i << " should have been ended by its size";
   }
+  EXPECT_EQ(1, batch_sizes.back()) << "The trailing batch should have been ended by the interval";
 }
 
 TEST_F(ConsumerTest, InvalidBootstrapServers) {

--- a/tests/unit/utils_async_timer.cpp
+++ b/tests/unit/utils_async_timer.cpp
@@ -63,14 +63,21 @@ std::chrono::steady_clock::time_point Now() { return std::chrono::steady_clock::
 // Convert milliseconds to seconds for timer constructor
 double ToSeconds(std::chrono::milliseconds ms) { return std::chrono::duration<double>(ms).count(); }
 
-// Helper to wait for timer expiration with timeout
-bool WaitForExpiration(AsyncTimer &timer, std::chrono::milliseconds timeout) {
-  auto deadline = Now() + timeout;
+// Helper to wait for timer expiration until a fixed point in time. A test that waits for several
+// timers in turn has to bound each wait against one origin: bounding each against the moment the
+// previous wait returned lets the bounds accumulate, so a late wait can outlast a timer that a
+// later assertion says has not fired yet.
+bool WaitForExpirationUntil(AsyncTimer &timer, std::chrono::steady_clock::time_point deadline) {
   while (Now() < deadline) {
     if (timer.IsExpired()) return true;
     std::this_thread::sleep_for(kPollInterval);
   }
   return false;
+}
+
+// Helper to wait for timer expiration with timeout
+bool WaitForExpiration(AsyncTimer &timer, std::chrono::milliseconds timeout) {
+  return WaitForExpirationUntil(timer, Now() + timeout);
 }
 
 // Helper to verify timer is NOT expired during a window
@@ -131,25 +138,29 @@ TEST(AsyncTimer, SequentialTimers) {
 }
 
 TEST(AsyncTimer, RelativeTimingOrder) {
+  // Every wait below is bounded against this one origin, taken before the timers are armed, so that
+  // each wait is guaranteed to end before the next timer is due however late the previous one ran.
+  const auto start = Now();
+
   // Create timers with different durations to test ordering
   AsyncTimer timer_short{ToSeconds(kOrderedShortTimer)};
   AsyncTimer timer_medium{ToSeconds(kOrderedMediumTimer)};
   AsyncTimer timer_long{ToSeconds(kOrderedLongTimer)};
 
   // Wait for short timer (should expire first)
-  EXPECT_TRUE(WaitForExpiration(timer_short, kOrderedShortTimeout));
+  EXPECT_TRUE(WaitForExpirationUntil(timer_short, start + kOrderedShortTimeout));
   EXPECT_TRUE(timer_short.IsExpired());
   EXPECT_FALSE(timer_medium.IsExpired());
   EXPECT_FALSE(timer_long.IsExpired());
 
   // Wait for medium timer (should expire second)
-  EXPECT_TRUE(WaitForExpiration(timer_medium, kOrderedMediumTimeout));
+  EXPECT_TRUE(WaitForExpirationUntil(timer_medium, start + kOrderedMediumTimeout));
   EXPECT_TRUE(timer_short.IsExpired());
   EXPECT_TRUE(timer_medium.IsExpired());
   EXPECT_FALSE(timer_long.IsExpired());
 
   // Wait for long timer (should expire last)
-  EXPECT_TRUE(WaitForExpiration(timer_long, kOrderedLongTimeout));
+  EXPECT_TRUE(WaitForExpirationUntil(timer_long, start + kOrderedLongTimeout));
   EXPECT_TRUE(timer_short.IsExpired());
   EXPECT_TRUE(timer_medium.IsExpired());
   EXPECT_TRUE(timer_long.IsExpired());
@@ -200,11 +211,16 @@ TEST(AsyncTimer, MoveAssignment) {
 }
 
 TEST(AsyncTimer, AssignmentToExpiredTimer) {
-  AsyncTimer timer_1{ToSeconds(kVeryLongTimer)};  // Long timer
-  AsyncTimer timer_2{ToSeconds(kShortTimer)};     // Short timer
+  // The point of the test is assigning an unexpired timer onto an expired one, so timer_1 must
+  // still be running when the assignment happens. That is a claim about a timer *not* having fired,
+  // so as in RelativeTimingOrder it is bounded against a single origin and the two timers are
+  // separated by much more than the wait for the first one can overrun.
+  const auto start = Now();
+  AsyncTimer timer_1{ToSeconds(kOrderedLongTimer)};
+  AsyncTimer timer_2{ToSeconds(kShortTimer)};
 
   // First verify timer_2 expires quickly
-  EXPECT_TRUE(WaitForExpiration(timer_2, kShortTimeout));
+  EXPECT_TRUE(WaitForExpirationUntil(timer_2, start + kOrderedShortTimeout));
   EXPECT_TRUE(timer_2.IsExpired());
   EXPECT_FALSE(timer_1.IsExpired());
 
@@ -217,7 +233,7 @@ TEST(AsyncTimer, AssignmentToExpiredTimer) {
 
   // Calculate remaining time windows for the moved timer
   auto remaining_not_expired = kShortTimer + std::chrono::milliseconds(10);  // Should not expire for at least this long
-  auto remaining_should_expire = kVeryLongTimer + kExpirationSlack;
+  auto remaining_should_expire = kOrderedLongTimer + kExpirationSlack;
 
   // Verify timer_2 with the moved timer behavior
   EXPECT_TRUE(VerifyTimerExpiration(timer_2, remaining_not_expired, remaining_should_expire));

--- a/tests/unit/utils_async_timer.cpp
+++ b/tests/unit/utils_async_timer.cpp
@@ -68,11 +68,13 @@ double ToSeconds(std::chrono::milliseconds ms) { return std::chrono::duration<do
 // previous wait returned lets the bounds accumulate, so a late wait can outlast a timer that a
 // later assertion says has not fired yet.
 bool WaitForExpirationUntil(AsyncTimer &timer, std::chrono::steady_clock::time_point deadline) {
-  while (Now() < deadline) {
+  // The timer is checked before the deadline is, so a caller that arrives late still reports a
+  // timer that has already fired rather than one it never looked at.
+  while (true) {
     if (timer.IsExpired()) return true;
+    if (Now() >= deadline) return false;
     std::this_thread::sleep_for(kPollInterval);
   }
-  return false;
 }
 
 // Helper to wait for timer expiration with timeout
@@ -80,12 +82,11 @@ bool WaitForExpiration(AsyncTimer &timer, std::chrono::milliseconds timeout) {
   return WaitForExpirationUntil(timer, Now() + timeout);
 }
 
-// Helper to verify timer is NOT expired during a window
-bool VerifyNotExpiredDuring(AsyncTimer &timer, std::chrono::milliseconds window) {
-  auto deadline = Now() + window;
+// Helper to verify timer is NOT expired until a fixed point in time
+bool VerifyNotExpiredUntil(AsyncTimer &timer, std::chrono::steady_clock::time_point deadline) {
   while (Now() < deadline) {
     if (timer.IsExpired()) {
-      ADD_FAILURE() << "Timer expired too early (within " << window.count() << "ms)";
+      ADD_FAILURE() << "Timer expired too early";
       return false;
     }
     std::this_thread::sleep_for(kPollInterval);
@@ -96,22 +97,20 @@ bool VerifyNotExpiredDuring(AsyncTimer &timer, std::chrono::milliseconds window)
 // Main helper to check timer state within time windows
 // First verifies timer is NOT expired during the "not expired" window
 // Then verifies timer DOES expire within the "expired" window
-bool VerifyTimerExpiration(AsyncTimer &timer, std::chrono::milliseconds not_expired_window = kDefaultNotExpiredWindow,
+//
+// Both windows run from `start`, which the caller takes before arming the timer. Taking it here
+// instead would put an unmeasured gap between arming and the first observation: the timer's
+// deadline would have moved on while the window had not, and a timer that fired correctly could
+// land inside the window that says it must not have fired yet.
+bool VerifyTimerExpiration(std::chrono::steady_clock::time_point start, AsyncTimer &timer,
+                           std::chrono::milliseconds not_expired_window = kDefaultNotExpiredWindow,
                            std::chrono::milliseconds expired_window = kDefaultExpiredWindow) {
-  auto start = Now();
-
-  // Phase 1: Verify timer is NOT expired during the initial window
-  if (!VerifyNotExpiredDuring(timer, not_expired_window)) {
+  if (!VerifyNotExpiredUntil(timer, start + not_expired_window)) {
     return false;
   }
 
-  // Phase 2: Wait for timer to expire within the expired window
-  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(Now() - start);
-  if (elapsed < expired_window) {
-    auto remaining_time = expired_window - elapsed;
-    if (WaitForExpiration(timer, remaining_time)) {
-      return true;
-    }
+  if (WaitForExpirationUntil(timer, start + expired_window)) {
+    return true;
   }
 
   ADD_FAILURE() << "Timer did not expire within " << expired_window.count() << "ms";
@@ -121,19 +120,22 @@ bool VerifyTimerExpiration(AsyncTimer &timer, std::chrono::milliseconds not_expi
 }  // namespace
 
 TEST(AsyncTimer, BasicExpiration) {
+  const auto start = Now();
   AsyncTimer timer{ToSeconds(kDefaultTimerDuration)};
-  EXPECT_TRUE(VerifyTimerExpiration(timer));
+  EXPECT_TRUE(VerifyTimerExpiration(start, timer));
 }
 
 TEST(AsyncTimer, SequentialTimers) {
   // Test two timers sequentially
   {
+    const auto start = Now();
     AsyncTimer timer1{ToSeconds(kDefaultTimerDuration)};
-    EXPECT_TRUE(VerifyTimerExpiration(timer1));
+    EXPECT_TRUE(VerifyTimerExpiration(start, timer1));
   }
   {
+    const auto start = Now();
     AsyncTimer timer2{ToSeconds(kDefaultTimerDuration)};
-    EXPECT_TRUE(VerifyTimerExpiration(timer2));
+    EXPECT_TRUE(VerifyTimerExpiration(start, timer2));
   }
 }
 
@@ -167,6 +169,7 @@ TEST(AsyncTimer, RelativeTimingOrder) {
 }
 
 TEST(AsyncTimer, MoveConstructor) {
+  const auto start = Now();
   AsyncTimer timer_1{ToSeconds(kDefaultTimerDuration)};
 
   // Move construct timer_2 from timer_1
@@ -177,13 +180,14 @@ TEST(AsyncTimer, MoveConstructor) {
   EXPECT_FALSE(timer_1.IsExpired());
 
   // timer_2 should work normally
-  EXPECT_TRUE(VerifyTimerExpiration(timer_2));
+  EXPECT_TRUE(VerifyTimerExpiration(start, timer_2));
 
   // timer_1 should still return false (it's moved-from)
   EXPECT_FALSE(timer_1.IsExpired());
 }
 
 TEST(AsyncTimer, MoveAssignment) {
+  const auto start = Now();
   AsyncTimer timer_1{ToSeconds(kMediumTimer)};  // Medium timer
   AsyncTimer timer_2{ToSeconds(kShortTimer)};   // Short timer
 
@@ -204,7 +208,7 @@ TEST(AsyncTimer, MoveAssignment) {
   auto not_expired_window = kShortTimer + std::chrono::milliseconds(10);  // Longer than original short timer
   auto expired_window = kMediumTimer + kExpirationSlack;
 
-  EXPECT_TRUE(VerifyTimerExpiration(timer_2, not_expired_window, expired_window));
+  EXPECT_TRUE(VerifyTimerExpiration(start, timer_2, not_expired_window, expired_window));
 
   // timer_1 remains false (moved-from)
   EXPECT_FALSE(timer_1.IsExpired());
@@ -236,7 +240,7 @@ TEST(AsyncTimer, AssignmentToExpiredTimer) {
   auto remaining_should_expire = kOrderedLongTimer + kExpirationSlack;
 
   // Verify timer_2 with the moved timer behavior
-  EXPECT_TRUE(VerifyTimerExpiration(timer_2, remaining_not_expired, remaining_should_expire));
+  EXPECT_TRUE(VerifyTimerExpiration(start, timer_2, remaining_not_expired, remaining_should_expire));
 
   // timer_1 should still be false (moved-from)
   EXPECT_FALSE(timer_1.IsExpired());
@@ -249,13 +253,14 @@ TEST(AsyncTimer, DestructionWhileRunning) {
   }
 
   // Create another timer to ensure the system still works
+  const auto start = Now();
   AsyncTimer timer_to_wait{ToSeconds(kMediumTimer + std::chrono::milliseconds(10))};
 
   // Verify the second timer works correctly
   auto not_expired_window = kMediumTimer - std::chrono::milliseconds(10);
   auto expired_window = kMediumTimer + kExpirationSlack;
 
-  EXPECT_TRUE(VerifyTimerExpiration(timer_to_wait, not_expired_window, expired_window));
+  EXPECT_TRUE(VerifyTimerExpiration(start, timer_to_wait, not_expired_window, expired_window));
 }
 
 TEST(AsyncTimer, ExtremeValues) {

--- a/tests/unit/utils_async_timer.cpp
+++ b/tests/unit/utils_async_timer.cpp
@@ -21,21 +21,34 @@ using AsyncTimer = memgraph::utils::AsyncTimer;
 
 namespace {
 
+// A timer fires by delivering a signal to one process-wide thread, so how long after its deadline
+// it is observed depends on when that thread is next scheduled. Nothing bounds that, which is why
+// every upper bound here is a liveness bound - the timer eventually fires - rather than a latency
+// one. Lower bounds are different: only a broken timer fires early, so those stay tight.
+inline constexpr auto kExpirationSlack = std::chrono::seconds(1);
+
 // Test timing parameters - extracted magic numbers
 inline constexpr auto kDefaultTimerDuration = std::chrono::milliseconds(50);
 inline constexpr auto kShortTimer = std::chrono::milliseconds(30);
 inline constexpr auto kMediumTimer = std::chrono::milliseconds(60);
-inline constexpr auto kLongTimer = std::chrono::milliseconds(90);
 inline constexpr auto kVeryLongTimer = std::chrono::milliseconds(100);
+
+// RelativeTimingOrder asserts that a later timer has *not* fired yet, so it cannot use the slack
+// above: waiting a second for the first timer would let the others fire too. Separating its timers
+// by more than the slack is what makes the ordering hold when the delivering thread stalls.
+inline constexpr auto kOrderedShortTimer = std::chrono::milliseconds(100);
+inline constexpr auto kOrderedMediumTimer = std::chrono::milliseconds(400);
+inline constexpr auto kOrderedLongTimer = std::chrono::milliseconds(900);
+inline constexpr auto kOrderedShortTimeout = std::chrono::milliseconds(300);
+inline constexpr auto kOrderedMediumTimeout = std::chrono::milliseconds(700);
+inline constexpr auto kOrderedLongTimeout = std::chrono::milliseconds(1500);
 
 // Window parameters for verification
 inline constexpr auto kDefaultNotExpiredWindow = std::chrono::milliseconds(40);
-inline constexpr auto kDefaultExpiredWindow = std::chrono::milliseconds(65);
+inline constexpr auto kDefaultExpiredWindow = kDefaultTimerDuration + kExpirationSlack;
 
 // Timing tolerances
-inline constexpr auto kShortTimeout = std::chrono::milliseconds(50);
-inline constexpr auto kMediumTimeout = std::chrono::milliseconds(80);
-inline constexpr auto kLongTimeout = std::chrono::milliseconds(120);
+inline constexpr auto kShortTimeout = kShortTimer + kExpirationSlack;
 inline constexpr auto kQuickExpirationWindow = std::chrono::milliseconds(30);
 
 // Loop and polling parameters
@@ -119,24 +132,24 @@ TEST(AsyncTimer, SequentialTimers) {
 
 TEST(AsyncTimer, RelativeTimingOrder) {
   // Create timers with different durations to test ordering
-  AsyncTimer timer_short{ToSeconds(kShortTimer)};
-  AsyncTimer timer_medium{ToSeconds(kMediumTimer)};
-  AsyncTimer timer_long{ToSeconds(kLongTimer)};
+  AsyncTimer timer_short{ToSeconds(kOrderedShortTimer)};
+  AsyncTimer timer_medium{ToSeconds(kOrderedMediumTimer)};
+  AsyncTimer timer_long{ToSeconds(kOrderedLongTimer)};
 
   // Wait for short timer (should expire first)
-  EXPECT_TRUE(WaitForExpiration(timer_short, kShortTimeout));
+  EXPECT_TRUE(WaitForExpiration(timer_short, kOrderedShortTimeout));
   EXPECT_TRUE(timer_short.IsExpired());
   EXPECT_FALSE(timer_medium.IsExpired());
   EXPECT_FALSE(timer_long.IsExpired());
 
   // Wait for medium timer (should expire second)
-  EXPECT_TRUE(WaitForExpiration(timer_medium, kMediumTimeout));
+  EXPECT_TRUE(WaitForExpiration(timer_medium, kOrderedMediumTimeout));
   EXPECT_TRUE(timer_short.IsExpired());
   EXPECT_TRUE(timer_medium.IsExpired());
   EXPECT_FALSE(timer_long.IsExpired());
 
   // Wait for long timer (should expire last)
-  EXPECT_TRUE(WaitForExpiration(timer_long, kLongTimeout));
+  EXPECT_TRUE(WaitForExpiration(timer_long, kOrderedLongTimeout));
   EXPECT_TRUE(timer_short.IsExpired());
   EXPECT_TRUE(timer_medium.IsExpired());
   EXPECT_TRUE(timer_long.IsExpired());
@@ -178,7 +191,7 @@ TEST(AsyncTimer, MoveAssignment) {
   // Should NOT expire quickly (original would have expired by now)
   // Should expire within reasonable window for medium timer
   auto not_expired_window = kShortTimer + std::chrono::milliseconds(10);  // Longer than original short timer
-  auto expired_window = kMediumTimer + std::chrono::milliseconds(20);     // Medium timer + tolerance
+  auto expired_window = kMediumTimer + kExpirationSlack;
 
   EXPECT_TRUE(VerifyTimerExpiration(timer_2, not_expired_window, expired_window));
 
@@ -204,7 +217,7 @@ TEST(AsyncTimer, AssignmentToExpiredTimer) {
 
   // Calculate remaining time windows for the moved timer
   auto remaining_not_expired = kShortTimer + std::chrono::milliseconds(10);  // Should not expire for at least this long
-  auto remaining_should_expire = kVeryLongTimer + std::chrono::milliseconds(20);  // Should expire within this
+  auto remaining_should_expire = kVeryLongTimer + kExpirationSlack;
 
   // Verify timer_2 with the moved timer behavior
   EXPECT_TRUE(VerifyTimerExpiration(timer_2, remaining_not_expired, remaining_should_expire));
@@ -224,7 +237,7 @@ TEST(AsyncTimer, DestructionWhileRunning) {
 
   // Verify the second timer works correctly
   auto not_expired_window = kMediumTimer - std::chrono::milliseconds(10);
-  auto expired_window = kMediumTimer + kQuickExpirationWindow;
+  auto expired_window = kMediumTimer + kExpirationSlack;
 
   EXPECT_TRUE(VerifyTimerExpiration(timer_to_wait, not_expired_window, expired_window));
 }

--- a/tests/unit/utils_barrier.cpp
+++ b/tests/unit/utils_barrier.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -17,6 +17,10 @@
 #include <thread>
 
 #include "utils/barrier.hpp"
+
+// Each test below starts kN threads per iteration. The PROCESSORS property on this test in
+// tests/unit/CMakeLists.txt mirrors that count, so ctest does not schedule a machine's worth of
+// other tests alongside it; the two have to be changed together.
 
 TEST(Barrier, Wait) {
   using namespace memgraph::utils;


### PR DESCRIPTION
Four tests asserted how fast the machine is. Each failed on a loaded runner while testing something unrelated to speed, and each blocked the merge queue when it did.

- **AsyncTimer** allowed a timer 15-30ms past its deadline to be observed, the margin hand-rolled per site. The timer fires by signalling one process-wide thread, and nothing bounds when that thread is next scheduled. The upper bounds are now liveness bounds; the lower bounds that catch a timer firing early stay tight.
- **utils_barrier** starts a thread per participant, but ctest costs every test at one slot, so it ran alongside a full machine of other tests. It now declares the slots it uses.
- **integrations_kafka_consumer** raced the batch interval against message delivery in the batch-size test. The interval is now kept out of play so that only the size ends a batch, mirroring the interval test beside it.
- **telemetry** scaled its timeout with the duration under test, which never covered starting a coordinator first.
