### PR TITLE
feat: Make OpenMetrics the default monitoring endpoint format

### DIFF
--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -49,22 +49,14 @@ DEFINE_VALIDATED_int32(monitoring_port, 7444,
 DEFINE_VALIDATED_int32(metrics_port, 9091, "Port on which the Memgraph server for exposing metrics should listen.",
                        FLAG_IN_RANGE(0, std::numeric_limits<uint16_t>::max()));
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_VALIDATED_string(metrics_format, "JSON",
+DEFINE_VALIDATED_string(metrics_format, "OpenMetrics",
                         "Format for the metrics endpoint. Supported values: OpenMetrics, JSON. JSON is deprecated.", {
                           (void)flagname;
                           if (value == "OpenMetrics") return true;
                           if (value == "JSON") {
-                            // As JSON is currently the default, if `--metrics-format=JSON` is
-                            // specified then this validator fires once at startup and again when
-                            // the flag is parsed, producing two deprecation warnings. This
-                            // suppresses the second one.
-                            static bool already_warned{false};
-                            if (!already_warned) {
-                              already_warned = true;
-                              spdlog::warn(
-                                  "--metrics-format=JSON is deprecated and will be removed in a future release. Please "
-                                  "use OpenMetrics instead.");
-                            }
+                            spdlog::warn(
+                                "--metrics-format=JSON is deprecated and will be removed in a future release. Please "
+                                "use OpenMetrics instead.");
                             return true;
                           }
                           return false;

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -143,8 +143,8 @@ startup_config_dict = {
         "IP address on which the Memgraph server for exposing metrics should listen.",
     ),
     "metrics_format": (
-        "JSON",
-        "JSON",
+        "OpenMetrics",
+        "OpenMetrics",
         "Format for the metrics endpoint. Supported values: OpenMetrics, JSON. JSON is deprecated.",
     ),
     "metrics_port": ("9091", "9091", "Port on which the Memgraph server for exposing metrics should listen."),

--- a/tests/e2e/configuration/workloads.yaml
+++ b/tests/e2e/configuration/workloads.yaml
@@ -5,9 +5,8 @@ args: &args
   - "300"
   - "--storage-wal-enabled=True"
   # configuration_check.py asserts SHOW CONFIG matches the compiled defaults, so pin
-  # metrics-format to the default (JSON) — otherwise the e2e harness injects
-  # --metrics-format=OpenMetrics and the current-value check fails.
-  - "--metrics-format=JSON"
+  # metrics-format to the default (OpenMetrics).
+  - "--metrics-format=OpenMetrics"
 
 snap_args: &snap_args
   - "--log-level=TRACE"

--- a/tests/e2e/high_availability/instance_metrics.py
+++ b/tests/e2e/high_availability/instance_metrics.py
@@ -91,7 +91,6 @@ def get_memgraph_instances_description(test_name: str):
                 "--management-port",
                 "10121",
                 "--metrics-port=9095",
-                "--metrics-format=OpenMetrics",
             ],
             "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
             "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -255,11 +255,6 @@ class MemgraphInstanceRunner:
             "--storage-properties-on-edges",
             f"--storage-snapshot-on-exit={storage_snapshot_on_exit}",
         ]
-        # Default the metrics endpoint to OpenMetrics unless the workload opts out
-        # (e.g. tests that exercise the deprecated JSON format set --metrics-format
-        # explicitly, in which case their value wins).
-        if not any(arg.startswith("--metrics-format") for arg in self.args):
-            default_args.append("--metrics-format=OpenMetrics")
         args_mg = default_args + self.args
 
         if bolt_port:

--- a/tests/e2e/show_metrics/workloads.yaml
+++ b/tests/e2e/show_metrics/workloads.yaml
@@ -25,7 +25,7 @@ show_metrics_snapshot_cluster: &show_metrics_snapshot_cluster
 show_metrics_openmetrics_cluster: &show_metrics_openmetrics_cluster
   cluster:
     main:
-      args: ["--bolt-port", "7687", "--log-level=TRACE", "--metrics-port=9091", "--metrics-format=OpenMetrics"]
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--metrics-port=9091"]
       log_file: "show_metrics_openmetrics.log"
       setup_queries: []
       validation_queries: []

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -676,7 +676,6 @@ class Memgraph(BaseRunner):
         kwargs["data_directory"] = data_directory
         kwargs["storage_properties_on_edges"] = True
         kwargs["bolt_num_workers"] = self._bolt_num_workers
-        kwargs["metrics_format"] = "OpenMetrics"
         for key, value in self._vendor_args.items():
             kwargs[key] = value
         return _convert_args_to_flags(self._memgraph_binary, **kwargs)

--- a/tests/smoke/features/monitoring.bash
+++ b/tests/smoke/features/monitoring.bash
@@ -4,8 +4,8 @@ source "$SCRIPT_DIR/../utils.bash"
 
 test_monitoring() {
   echo "FEATURE: Monitoring"
-  response=$(curl -X GET "http://localhost:$MEMGRAPH_MONITORING_PORT/metrics")
-  if ! echo "$response" | jq -e '.General | has("vertex_count")'; then
+  response=$(curl -s -X GET "http://localhost:$MEMGRAPH_MONITORING_PORT/metrics")
+  if ! grep -qE '^memgraph_vertex_count(\{[^}]*\})? ' <<< "$response"; then
     echo "Monitoring data is missing vertex count."
     exit 1
   fi

--- a/tests/unit/prometheus_metrics.cpp
+++ b/tests/unit/prometheus_metrics.cpp
@@ -21,7 +21,6 @@
 #include "dbms/constants.hpp"
 #include "dbms/database.hpp"
 #include "disk_test_utils.hpp"
-#include "flags/general.hpp"
 #include "metrics/scoped_gauge.hpp"
 #include "metrics/scoped_histogram_timer.hpp"
 #include "storage/v2/config.hpp"
@@ -47,7 +46,6 @@ std::optional<double> FindSample(std::vector<prometheus::MetricFamily> const &fa
 }  // namespace
 
 TEST(PrometheusMetrics, GetOrAddDatabaseRegistersMetrics) {
-  FLAGS_metrics_format = "OpenMetrics";
   memgraph::metrics::PrometheusMetrics pm;
   auto reg = pm.AddDatabase(memgraph::utils::UUID{}, "db1");
 
@@ -60,7 +58,6 @@ TEST(PrometheusMetrics, GetOrAddDatabaseRegistersMetrics) {
 }
 
 TEST(PrometheusMetrics, MultipleDatabasesAreIsolated) {
-  FLAGS_metrics_format = "OpenMetrics";
   memgraph::metrics::PrometheusMetrics pm;
   auto db1 = pm.AddDatabase(memgraph::utils::UUID{}, "db1");
   auto db2 = pm.AddDatabase(memgraph::utils::UUID{}, "db2");
@@ -74,7 +71,6 @@ TEST(PrometheusMetrics, MultipleDatabasesAreIsolated) {
 }
 
 TEST(PrometheusMetrics, UpdateGaugesSetsStorageValues) {
-  FLAGS_metrics_format = "OpenMetrics";
   memgraph::metrics::PrometheusMetrics pm;
   memgraph::metrics::StorageSnapshot snapshot{.vertex_count = 7,
                                               .edge_count = 3,
@@ -176,7 +172,6 @@ TEST(DatabaseMetrics, SwitchToOnDiskUpdatesSnapshotCallback) {
 }
 
 TEST(PrometheusMetrics, UpdateGaugesReturnsZeroAfterDefaultDbUuidChange) {
-  FLAGS_metrics_format = "OpenMetrics";
   memgraph::metrics::PrometheusMetrics pm;
 
   memgraph::utils::UUID const uuid_a{};

--- a/tests/unit/storage_v2_gc_metrics_fixture.hpp
+++ b/tests/unit/storage_v2_gc_metrics_fixture.hpp
@@ -18,7 +18,6 @@
 #include <optional>
 #include <string>
 
-#include "flags/general.hpp"
 #include "metrics/prometheus_metrics.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/resource_lock.hpp"
@@ -35,7 +34,6 @@ inline auto UniqueGuard(memgraph::utils::ResourceLock &lock) {
 class StorageV2GcMetricsTest : public testing::Test {
  protected:
   void SetUp() override {
-    FLAGS_metrics_format = "OpenMetrics";
     db_name_ = testing::UnitTest::GetInstance()->current_test_info()->name();
     InitStorage(std::chrono::seconds(3600));
   }


### PR DESCRIPTION
Change the default value of `--metrics-format` from `JSON` to `OpenMetrics`, advancing the deprecation path for the `JSON` endpoint. The deprecated `JSON` metrics endpoint will remain available for several versions.

**BREAKING**: Any users relying on the JSON endpoint without an explicit `--metrics-format=JSON` flag will get `OpenMetrics` metrics after upgrading. They need to either upgrade their monitoring dashboard, or explicitly state `--metrics-format=JSON`.