### PR TITLE
refactor(query): give the value relations the names openCypher uses

### DIFF
--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -25,6 +25,7 @@
 #include "query/frontend/ast/ordering.hpp"
 #include "query/frontend/semantic/symbol.hpp"
 #include "query/typed_value.hpp"
+#include "query/value_relations.hpp"
 #include "query/virtual_edge.hpp"
 #include "query/virtual_node.hpp"
 #include "storage/v2/id_types.hpp"
@@ -35,203 +36,11 @@
 
 namespace memgraph::query {
 
-namespace {
-/// Reads an ordering from a type that leaves no pair unordered as the total one
-/// it already is. Only sound for such a type; the two that are not, a double
-/// and a point, are placed by CompareDoublesNaNLast instead.
-inline std::weak_ordering AlreadyTotal(std::partial_ordering order) {
-  if (std::is_lt(order)) return std::weak_ordering::less;
-  if (std::is_gt(order)) return std::weak_ordering::greater;
-  DMG_ASSERT(order == std::partial_ordering::equivalent, "A type that orders every pair reported one unordered");
-  return std::weak_ordering::equivalent;
-}
-
-inline std::weak_ordering TypedValueCompare(TypedValue const &a, TypedValue const &b);
-
-/// Orders two paths as the alternating list of nodes and relationships each
-/// runs through, from its start.
-inline std::weak_ordering ComparePathsAsAlternating(Path const &lhs, Path const &rhs) {
-  auto const length = [](Path const &p) { return p.vertices().size() + p.edges().size(); };
-  auto const common = std::min(length(lhs), length(rhs));
-  for (size_t i = 0; i != common; ++i) {
-    // Even positions hold a node, odd positions the relationship after it.
-    auto const order = (i % 2 == 0) ? (lhs.vertices()[i / 2].Gid().AsUint() <=> rhs.vertices()[i / 2].Gid().AsUint())
-                                    : (lhs.edges()[i / 2].Gid().AsUint() <=> rhs.edges()[i / 2].Gid().AsUint());
-    if (order != 0) return order;
-  }
-  return length(lhs) <=> length(rhs);
-}
-
-/// Where a type sits in the global sort order, which is what lets values of
-/// unlike types be ordered against one another at all.
-///
-/// Cypher fixes this order down to NUMBER and then VOID, and requires only that
-/// the types it does not name are not placed after a NaN. The ones it does not
-/// name are put where Neo4j puts them, so that a query ordering a mixed column
-/// answers alike on both.
-///
-/// @throw QueryRuntimeException for a type no order is defined over.
-inline int SortRank(TypedValue::Type type) {
-  switch (type) {
-    using enum TypedValue::Type;
-    case Map:
-      return 0;
-    case Vertex:
-      return 1;
-    case VirtualNode:
-      return 2;
-    case Edge:
-      return 3;
-    case VirtualEdge:
-      return 4;
-    case List:
-      return 5;
-    case Path:
-      return 6;
-    case Point2d:
-      return 7;
-    case Point3d:
-      return 8;
-    case ZonedDateTime:
-      return 9;
-    case LocalDateTime:
-      return 10;
-    case Date:
-      return 11;
-    case LocalTime:
-      return 12;
-    case Duration:
-      return 13;
-    case Enum:
-      return 14;
-    case String:
-      return 15;
-    case Bool:
-      return 16;
-    // The one rank two types share, since an integer and a double are ordered
-    // against each other as numbers rather than by their types.
-    case Int:
-    case Double:
-      return 17;
-    case Null:
-      return 18;
-
-    case Graph:
-    case VirtualGraph:
-    case Function:
-      throw QueryRuntimeException("Comparison is not defined for values of type {}.", type);
-  }
-}
-
-/// Orders two values under orderability, the total order behind ORDER BY.
-///
-/// Unlike comparability, which the `<` family reads, this one places every pair
-/// somewhere: a Null sorts after everything and alongside another Null, and a
-/// list is ordered against another list element by element. What a type's own
-/// values order like is not decided here; that is shared with comparability.
-///
-/// @throw QueryRuntimeException for a type no order is defined over.
-std::weak_ordering TypedValueCompare(TypedValue const &a, TypedValue const &b) {
-  // First assume typical same type comparisons
-  if (a.type() == b.type()) {
-    switch (a.type()) {
-      using enum TypedValue::Type;
-      // Null sorts alongside Null here, where comparability would refuse to say.
-      case Null:
-        return std::weak_ordering::equivalent;
-      case List:
-        return std::lexicographical_compare_three_way(a.UnsafeValueList().begin(),
-                                                      a.UnsafeValueList().end(),
-                                                      b.UnsafeValueList().begin(),
-                                                      b.UnsafeValueList().end(),
-                                                      TypedValueCompare);
-      case Map: {
-        // By key and then by value, in the order the keys are held, with a map
-        // that runs out first coming before one that continues.
-        auto const &lhs = a.UnsafeValueMap();
-        auto const &rhs = b.UnsafeValueMap();
-        auto lhs_it = lhs.begin();
-        auto rhs_it = rhs.begin();
-        for (; lhs_it != lhs.end() && rhs_it != rhs.end(); ++lhs_it, ++rhs_it) {
-          if (auto const order = lhs_it->first <=> rhs_it->first; order != 0) return order;
-          if (auto const order = TypedValueCompare(lhs_it->second, rhs_it->second); order != 0) return order;
-        }
-        return lhs.size() <=> rhs.size();
-      }
-      case Vertex:
-        return a.UnsafeValueVertex().Gid().AsUint() <=> b.UnsafeValueVertex().Gid().AsUint();
-      case Edge:
-        return a.UnsafeValueEdge().Gid().AsUint() <=> b.UnsafeValueEdge().Gid().AsUint();
-      case VirtualNode:
-        return a.UnsafeValueVirtualNode().Gid().AsUint() <=> b.UnsafeValueVirtualNode().Gid().AsUint();
-      case VirtualEdge:
-        return a.UnsafeValueVirtualEdge().Gid().AsUint() <=> b.UnsafeValueVirtualEdge().Gid().AsUint();
-      case Path:
-        // As the list of nodes and relationships the path alternates between,
-        // read from its start.
-        return ComparePathsAsAlternating(a.UnsafeValuePath(), b.UnsafeValuePath());
-
-      case Graph:
-      case VirtualGraph:
-      case Function:
-        throw QueryRuntimeException("Comparison is not defined for values of type {}.", a.type());
-
-      // The two types that can hold a NaN, which has to be given a place here
-      // rather than left beside nothing as comparability leaves it.
-      case Double:
-        return TypedValue::CompareDoublesNaNLast(a.UnsafeValueDouble(), b.UnsafeValueDouble());
-      case Point2d: {
-        auto const &lhs = a.UnsafeValuePoint2d();
-        auto const &rhs = b.UnsafeValuePoint2d();
-        if (auto const order = lhs.crs() <=> rhs.crs(); order != 0) return order;
-        if (auto const order = TypedValue::CompareDoublesNaNLast(lhs.x(), rhs.x()); order != 0) return order;
-        return TypedValue::CompareDoublesNaNLast(lhs.y(), rhs.y());
-      }
-      case Point3d: {
-        auto const &lhs = a.UnsafeValuePoint3d();
-        auto const &rhs = b.UnsafeValuePoint3d();
-        if (auto const order = lhs.crs() <=> rhs.crs(); order != 0) return order;
-        if (auto const order = TypedValue::CompareDoublesNaNLast(lhs.x(), rhs.x()); order != 0) return order;
-        if (auto const order = TypedValue::CompareDoublesNaNLast(lhs.y(), rhs.y()); order != 0) return order;
-        return TypedValue::CompareDoublesNaNLast(lhs.z(), rhs.z());
-      }
-
-      case Bool:
-      case Int:
-      case String:
-      case Date:
-      case LocalTime:
-      case LocalDateTime:
-      case ZonedDateTime:
-      case Duration:
-      case Enum:
-        // Ordered by what they hold, which comparability orders them by too.
-        // Between them the two cover every type this case admits, and none of
-        // them holds a value that sits outside its own order.
-        if (auto const order = TypedValue::ComparePayload(a, b)) return AlreadyTotal(*order);
-        return AlreadyTotal(*TypedValue::ComparePayloadOrderOnly(a, b));
-    }
-  }
-
-  // Unlike types are separated by where their types sit, which puts a null
-  // after everything and a map before it.
-  if (auto const order = SortRank(a.type()) <=> SortRank(b.type()); order != 0) return order;
-
-  // The one rank two types share: an integer against a double, where the double
-  // may again be a NaN.
-  if (a.IsInt()) {
-    return TypedValue::CompareDoublesNaNLast(static_cast<double>(a.UnsafeValueInt()), b.UnsafeValueDouble());
-  }
-  return TypedValue::CompareDoublesNaNLast(a.UnsafeValueDouble(), static_cast<double>(b.UnsafeValueInt()));
-}
-
-}  // namespace
-
 struct OrderedTypedValueCompare {
   OrderedTypedValueCompare(Ordering ordering) : ordering_{ordering}, ascending{ordering == Ordering::ASC} {}
 
   auto operator()(const TypedValue &lhs, const TypedValue &rhs) const -> std::weak_ordering {
-    return ascending ? TypedValueCompare(lhs, rhs) : TypedValueCompare(rhs, lhs);
+    return ascending ? relations::orderability::Compare(lhs, rhs) : relations::orderability::Compare(rhs, lhs);
   }
 
   auto ordering() const { return ordering_; }
@@ -243,8 +52,8 @@ struct OrderedTypedValueCompare {
 
 /// Custom Comparator type for comparing vectors of TypedValues.
 ///
-/// Does lexicographical ordering of elements based on the above
-/// defined TypedValueCompare, and also accepts a vector of Orderings
+/// Does lexicographical ordering of elements based on orderability, the
+/// relation ORDER BY reads, and also accepts a vector of Orderings
 /// the define how respective elements compare.
 class TypedValueVectorCompare final {
  public:

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7303,7 +7303,7 @@ class AggregateCursor : public Cursor {
             // over, rather than under comparability. The two differ over a NaN,
             // which orderability places after every other number and
             // comparability places beside none of them.
-            if (std::is_lt(TypedValueCompare(input_value, agg_value->values_[pos]))) {
+            if (std::is_lt(relations::orderability::Compare(input_value, agg_value->values_[pos]))) {
               agg_value->values_[pos] = std::move(input_value);
             }
           } catch (const QueryRuntimeException &) {
@@ -7316,7 +7316,7 @@ class AggregateCursor : public Cursor {
           //  all comments as for Op::Min
           EnsureOkForMinMax(input_value);
           try {
-            if (std::is_gt(TypedValueCompare(input_value, agg_value->values_[pos]))) {
+            if (std::is_gt(relations::orderability::Compare(input_value, agg_value->values_[pos]))) {
               agg_value->values_[pos] = std::move(input_value);
             }
           } catch (const QueryRuntimeException &) {
@@ -11672,13 +11672,13 @@ void UnifyAggregation(auto &main_aggregation, auto &other_aggregation, const aut
         case Aggregation::Op::MIN: {
           // Orderability, for the reason given where the values are first
           // accumulated; merging two partial results has to order them alike.
-          if (std::is_lt(TypedValueCompare(other_value, main_value))) {
+          if (std::is_lt(relations::orderability::Compare(other_value, main_value))) {
             main_value = std::move(other_value);
           }
           break;
         }
         case Aggregation::Op::MAX: {
-          if (std::is_gt(TypedValueCompare(other_value, main_value))) {
+          if (std::is_gt(relations::orderability::Compare(other_value, main_value))) {
             main_value = std::move(other_value);
           }
           break;

--- a/src/query/value_relations.hpp
+++ b/src/query/value_relations.hpp
@@ -1,0 +1,244 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/// @file
+/// The relations openCypher defines over values, under the names it gives them.
+///
+/// There are four, and they differ only over the values that sit outside them:
+/// a Null, a NaN, and a pair of unlike types. Everywhere else they agree, which
+/// is why they are only comprehensible as a set and why they are written
+/// together here. A relation answering a question that belongs to one of the
+/// others is the defect this arrangement exists to make visible.
+///
+/// * comparability, which `< <= > >=` each read.
+/// * equality, which `= <> IN` read.
+/// * equivalence, which DISTINCT and grouping read.
+/// * orderability, which ORDER BY, min and max read.
+#pragma once
+
+#include <algorithm>
+#include <compare>
+
+#include "query/exceptions.hpp"
+#include "query/fmt.hpp"
+#include "query/typed_value.hpp"
+// typed_value.hpp only forward-declares these two, and the ordering reads the
+// identity out of each.
+#include "query/virtual_edge.hpp"
+#include "query/virtual_node.hpp"
+
+namespace memgraph::query::relations {
+
+/// The total order behind ORDER BY, min and max.
+///
+/// Alone among the four it places every pair of values, which is what makes a
+/// sort possible: `std::sort` has a strict weak ordering as its precondition
+/// and is undefined behaviour without one. A Null sorts after everything and
+/// alongside another Null, a NaN sorts after the numbers, and values of unlike
+/// types are separated by where their types sit.
+namespace orderability {
+
+namespace detail {
+
+/// Reads an ordering from a type that leaves no pair unordered as the total one
+/// it already is. Only sound for such a type; the two that are not, a double
+/// and a point, are placed by TypedValue::CompareDoublesNaNLast instead.
+inline std::weak_ordering AlreadyTotal(std::partial_ordering order) {
+  if (std::is_lt(order)) return std::weak_ordering::less;
+  if (std::is_gt(order)) return std::weak_ordering::greater;
+  DMG_ASSERT(order == std::partial_ordering::equivalent, "A type that orders every pair reported one unordered");
+  return std::weak_ordering::equivalent;
+}
+
+/// Orders two paths as the alternating list of nodes and relationships each
+/// runs through, from its start.
+inline std::weak_ordering ComparePathsAsAlternating(Path const &lhs, Path const &rhs) {
+  auto const length = [](Path const &p) { return p.vertices().size() + p.edges().size(); };
+  auto const common = std::min(length(lhs), length(rhs));
+  for (size_t i = 0; i != common; ++i) {
+    // Even positions hold a node, odd positions the relationship after it.
+    auto const order = (i % 2 == 0) ? (lhs.vertices()[i / 2].Gid().AsUint() <=> rhs.vertices()[i / 2].Gid().AsUint())
+                                    : (lhs.edges()[i / 2].Gid().AsUint() <=> rhs.edges()[i / 2].Gid().AsUint());
+    if (order != 0) return order;
+  }
+  return length(lhs) <=> length(rhs);
+}
+
+}  // namespace detail
+
+/// Where a type sits in the global sort order, which is what lets values of
+/// unlike types be ordered against one another at all.
+///
+/// Cypher fixes this order down to NUMBER and then VOID, and requires only that
+/// the types it does not name are not placed after a NaN. The ones it does not
+/// name are put where Neo4j puts them, so that a query ordering a mixed column
+/// answers alike on both.
+///
+/// @throw QueryRuntimeException for a type no order is defined over.
+inline int SortRank(TypedValue::Type type) {
+  switch (type) {
+    using enum TypedValue::Type;
+    case Map:
+      return 0;
+    case Vertex:
+      return 1;
+    case VirtualNode:
+      return 2;
+    case Edge:
+      return 3;
+    case VirtualEdge:
+      return 4;
+    case List:
+      return 5;
+    case Path:
+      return 6;
+    case Point2d:
+      return 7;
+    case Point3d:
+      return 8;
+    case ZonedDateTime:
+      return 9;
+    case LocalDateTime:
+      return 10;
+    case Date:
+      return 11;
+    case LocalTime:
+      return 12;
+    case Duration:
+      return 13;
+    case Enum:
+      return 14;
+    case String:
+      return 15;
+    case Bool:
+      return 16;
+    // The one rank two types share, since an integer and a double are ordered
+    // against each other as numbers rather than by their types.
+    case Int:
+    case Double:
+      return 17;
+    case Null:
+      return 18;
+
+    case Graph:
+    case VirtualGraph:
+    case Function:
+      throw QueryRuntimeException("Comparison is not defined for values of type {}.", type);
+  }
+}
+
+/// Orders two values.
+///
+/// Unlike comparability, which the `<` family reads, this one places every pair
+/// somewhere: a Null sorts after everything and alongside another Null, and a
+/// list is ordered against another list element by element. What a type's own
+/// values order like is not decided here; that is shared with comparability.
+///
+/// Defined in the header because a sort calls it once per comparison.
+///
+/// @throw QueryRuntimeException for a type no order is defined over.
+inline std::weak_ordering Compare(TypedValue const &a, TypedValue const &b) {
+  // First assume typical same type comparisons
+  if (a.type() == b.type()) {
+    switch (a.type()) {
+      using enum TypedValue::Type;
+      // Null sorts alongside Null here, where comparability would refuse to say.
+      case Null:
+        return std::weak_ordering::equivalent;
+      case List:
+        return std::lexicographical_compare_three_way(a.UnsafeValueList().begin(),
+                                                      a.UnsafeValueList().end(),
+                                                      b.UnsafeValueList().begin(),
+                                                      b.UnsafeValueList().end(),
+                                                      Compare);
+      case Map: {
+        // By key and then by value, in the order the keys are held, with a map
+        // that runs out first coming before one that continues.
+        auto const &lhs = a.UnsafeValueMap();
+        auto const &rhs = b.UnsafeValueMap();
+        auto lhs_it = lhs.begin();
+        auto rhs_it = rhs.begin();
+        for (; lhs_it != lhs.end() && rhs_it != rhs.end(); ++lhs_it, ++rhs_it) {
+          if (auto const order = lhs_it->first <=> rhs_it->first; order != 0) return order;
+          if (auto const order = Compare(lhs_it->second, rhs_it->second); order != 0) return order;
+        }
+        return lhs.size() <=> rhs.size();
+      }
+      case Vertex:
+        return a.UnsafeValueVertex().Gid().AsUint() <=> b.UnsafeValueVertex().Gid().AsUint();
+      case Edge:
+        return a.UnsafeValueEdge().Gid().AsUint() <=> b.UnsafeValueEdge().Gid().AsUint();
+      case VirtualNode:
+        return a.UnsafeValueVirtualNode().Gid().AsUint() <=> b.UnsafeValueVirtualNode().Gid().AsUint();
+      case VirtualEdge:
+        return a.UnsafeValueVirtualEdge().Gid().AsUint() <=> b.UnsafeValueVirtualEdge().Gid().AsUint();
+      case Path:
+        // As the list of nodes and relationships the path alternates between,
+        // read from its start.
+        return detail::ComparePathsAsAlternating(a.UnsafeValuePath(), b.UnsafeValuePath());
+
+      case Graph:
+      case VirtualGraph:
+      case Function:
+        throw QueryRuntimeException("Comparison is not defined for values of type {}.", a.type());
+
+      // The two types that can hold a NaN, which has to be given a place here
+      // rather than left beside nothing as comparability leaves it.
+      case Double:
+        return TypedValue::CompareDoublesNaNLast(a.UnsafeValueDouble(), b.UnsafeValueDouble());
+      case Point2d: {
+        auto const &lhs = a.UnsafeValuePoint2d();
+        auto const &rhs = b.UnsafeValuePoint2d();
+        if (auto const order = lhs.crs() <=> rhs.crs(); order != 0) return order;
+        if (auto const order = TypedValue::CompareDoublesNaNLast(lhs.x(), rhs.x()); order != 0) return order;
+        return TypedValue::CompareDoublesNaNLast(lhs.y(), rhs.y());
+      }
+      case Point3d: {
+        auto const &lhs = a.UnsafeValuePoint3d();
+        auto const &rhs = b.UnsafeValuePoint3d();
+        if (auto const order = lhs.crs() <=> rhs.crs(); order != 0) return order;
+        if (auto const order = TypedValue::CompareDoublesNaNLast(lhs.x(), rhs.x()); order != 0) return order;
+        if (auto const order = TypedValue::CompareDoublesNaNLast(lhs.y(), rhs.y()); order != 0) return order;
+        return TypedValue::CompareDoublesNaNLast(lhs.z(), rhs.z());
+      }
+
+      case Bool:
+      case Int:
+      case String:
+      case Date:
+      case LocalTime:
+      case LocalDateTime:
+      case ZonedDateTime:
+      case Duration:
+      case Enum:
+        // Ordered by what they hold, which comparability orders them by too.
+        // Between them the two cover every type this case admits, and none of
+        // them holds a value that sits outside its own order.
+        if (auto const order = TypedValue::ComparePayload(a, b)) return detail::AlreadyTotal(*order);
+        return detail::AlreadyTotal(*TypedValue::ComparePayloadOrderOnly(a, b));
+    }
+  }
+
+  // Unlike types are separated by where their types sit, which puts a null
+  // after everything and a map before it.
+  if (auto const order = SortRank(a.type()) <=> SortRank(b.type()); order != 0) return order;
+
+  // The one rank two types share: an integer against a double, where the double
+  // may again be a NaN.
+  if (a.IsInt()) {
+    return TypedValue::CompareDoublesNaNLast(static_cast<double>(a.UnsafeValueInt()), b.UnsafeValueDouble());
+  }
+  return TypedValue::CompareDoublesNaNLast(a.UnsafeValueDouble(), static_cast<double>(b.UnsafeValueInt()));
+}
+
+}  // namespace orderability
+
+}  // namespace memgraph::query::relations

--- a/tests/benchmark/query/typed_value_ops.cpp
+++ b/tests/benchmark/query/typed_value_ops.cpp
@@ -22,16 +22,20 @@
 
 #include <benchmark/benchmark.h>
 
+#include <algorithm>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
 
 #include "query/typed_value.hpp"
+#include "query/value_relations.hpp"
 #include "utils/memory.hpp"
 
 namespace {
 
 using memgraph::query::TypedValue;
+namespace relations = memgraph::query::relations;
 
 memgraph::utils::MemoryResource *Mem() { return memgraph::utils::NewDeleteResource(); }
 
@@ -216,6 +220,58 @@ void EqualityOfListsWithNull(benchmark::State &state) {
   state.SetItemsProcessed(state.iterations());
 }
 
+// Orderability, the relation ORDER BY, min and max read. A sort calls it once per comparison, which
+// is the granularity that decides where it may be defined.
+void Orderability(benchmark::State &state, std::string_view what) {
+  auto const lhs = Make(what);
+  auto const rhs = Make(what);
+  for (auto _ : state) benchmark::DoNotOptimize(relations::orderability::Compare(lhs, rhs));
+  state.SetItemsProcessed(state.iterations());
+}
+
+// The pair only this relation admits, where the answer comes from where the two types sit rather
+// than from either value.
+void OrderabilityOfUnlikeTypes(benchmark::State &state) {
+  auto const lhs = Make("String");
+  auto const rhs = Make("Int");
+  for (auto _ : state) benchmark::DoNotOptimize(relations::orderability::Compare(lhs, rhs));
+  state.SetItemsProcessed(state.iterations());
+}
+
+// The placement comparability leaves undone, and the one path where the ordering does more work
+// than a plain three-way comparison.
+void OrderabilityOfNaN(benchmark::State &state) {
+  auto const lhs = TypedValue{std::numeric_limits<double>::quiet_NaN(), Mem()};
+  auto const rhs = TypedValue{1.0, Mem()};
+  for (auto _ : state) benchmark::DoNotOptimize(relations::orderability::Compare(lhs, rhs));
+  state.SetItemsProcessed(state.iterations());
+}
+
+// What the relation exists for. Sorting is where its cost is actually paid, and a per-comparison
+// figure alone hides how often a sort calls it.
+void SortMixedColumn(benchmark::State &state) {
+  auto const source = std::vector<TypedValue>{Make("Int"),
+                                              Make("String"),
+                                              Make("Bool"),
+                                              Make("List"),
+                                              Make("Double"),
+                                              TypedValue{Mem()},
+                                              Make("Date"),
+                                              Make("Int"),
+                                              Make("String"),
+                                              Make("Double"),
+                                              Make("Bool"),
+                                              Make("List")};
+  for (auto _ : state) {
+    auto values = source;
+    std::ranges::sort(values, [](TypedValue const &a, TypedValue const &b) {
+      return std::is_lt(relations::orderability::Compare(a, b));
+    });
+    benchmark::DoNotOptimize(values);
+  }
+  state.SetItemsProcessed(state.iterations() * source.size());
+}
+
 #define FOR_EACH_TYPE(op)                                                \
   BENCHMARK_CAPTURE(op, Int, "Int")->Unit(benchmark::kNanosecond);       \
   BENCHMARK_CAPTURE(op, Double, "Double")->Unit(benchmark::kNanosecond); \
@@ -248,6 +304,10 @@ BENCHMARK(EquivalenceOfNestedLists)->Unit(benchmark::kNanosecond);
 BENCHMARK_CAPTURE(EqualityOfMaps, Plain, false)->Unit(benchmark::kNanosecond);
 BENCHMARK_CAPTURE(EqualityOfMaps, WithNull, true)->Unit(benchmark::kNanosecond);
 BENCHMARK(EqualityOfListsWithNull)->Unit(benchmark::kNanosecond);
+FOR_EACH_TYPE(Orderability)
+BENCHMARK(OrderabilityOfUnlikeTypes)->Unit(benchmark::kNanosecond);
+BENCHMARK(OrderabilityOfNaN)->Unit(benchmark::kNanosecond);
+BENCHMARK(SortMixedColumn)->Unit(benchmark::kNanosecond);
 
 #undef FOR_EACH_TYPE
 #undef FOR_EACH_ORDERED_TYPE

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -367,6 +367,11 @@ add_unit_test(typed_value
     LINK_TARGETS mg-query disk_test_utils
 )
 
+add_unit_test(query_value_relations
+    SOURCES query_value_relations.cpp
+    LINK_TARGETS mg-query
+)
+
 # Test mg-communication
 add_unit_test(bolt_chunked_decoder_buffer
     SOURCES bolt_chunked_decoder_buffer.cpp

--- a/tests/unit/query_value_relations.cpp
+++ b/tests/unit/query_value_relations.cpp
@@ -1,0 +1,129 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "query/value_relations.hpp"
+
+namespace memgraph::query::tests {
+namespace {
+
+using memgraph::query::TypedValue;
+namespace orderability = memgraph::query::relations::orderability;
+
+/// The types orderability places, one value of each, written in the order the
+/// relation is meant to put them. Graph, VirtualGraph and Function are absent
+/// because no order is defined over them.
+std::vector<TypedValue> OrderedSample() {
+  return {
+      TypedValue(std::vector<TypedValue>{TypedValue(1)}),  // List
+      TypedValue("string"),
+      TypedValue(true),
+      TypedValue(int64_t{42}),
+      TypedValue(),  // Null
+  };
+}
+
+TEST(Orderability, PlacesEveryPairOfUnlikeTypes) {
+  auto const sample = OrderedSample();
+  for (auto const &a : sample) {
+    for (auto const &b : sample) {
+      // Nothing is left unplaced; a weak ordering has no such state to return.
+      auto const order = orderability::Compare(a, b);
+      EXPECT_TRUE(std::is_lt(order) || std::is_gt(order) || order == std::weak_ordering::equivalent);
+    }
+  }
+}
+
+TEST(Orderability, SampleIsInAscendingOrder) {
+  auto const sample = OrderedSample();
+  for (size_t i = 1; i < sample.size(); ++i) {
+    EXPECT_TRUE(std::is_lt(orderability::Compare(sample[i - 1], sample[i])))
+        << "index " << i - 1 << " should sort before " << i;
+  }
+}
+
+TEST(Orderability, IsAntisymmetric) {
+  auto const sample = OrderedSample();
+  for (auto const &a : sample) {
+    for (auto const &b : sample) {
+      auto const forward = orderability::Compare(a, b);
+      auto const backward = orderability::Compare(b, a);
+      EXPECT_EQ(std::is_lt(forward), std::is_gt(backward));
+      EXPECT_EQ(std::is_gt(forward), std::is_lt(backward));
+    }
+  }
+}
+
+TEST(Orderability, IsTransitive) {
+  auto const sample = OrderedSample();
+  for (auto const &a : sample) {
+    for (auto const &b : sample) {
+      for (auto const &c : sample) {
+        if (std::is_lt(orderability::Compare(a, b)) && std::is_lt(orderability::Compare(b, c))) {
+          EXPECT_TRUE(std::is_lt(orderability::Compare(a, c)));
+        }
+      }
+    }
+  }
+}
+
+TEST(Orderability, PlacesNaNAfterEveryNumber) {
+  auto const nan = TypedValue(std::numeric_limits<double>::quiet_NaN());
+  for (auto const &number :
+       {TypedValue(int64_t{0}), TypedValue(-1.5), TypedValue(std::numeric_limits<double>::infinity())}) {
+    EXPECT_TRUE(std::is_gt(orderability::Compare(nan, number)));
+    EXPECT_TRUE(std::is_lt(orderability::Compare(number, nan)));
+  }
+}
+
+TEST(Orderability, PlacesTwoNaNsAlongsideOneAnother) {
+  auto const nan = TypedValue(std::numeric_limits<double>::quiet_NaN());
+  EXPECT_EQ(orderability::Compare(nan, nan), std::weak_ordering::equivalent);
+}
+
+TEST(Orderability, PlacesNullAfterEverything) {
+  auto const null = TypedValue();
+  for (auto const &value : OrderedSample()) {
+    if (value.IsNull()) continue;
+    EXPECT_TRUE(std::is_gt(orderability::Compare(null, value)));
+  }
+  EXPECT_EQ(orderability::Compare(null, null), std::weak_ordering::equivalent);
+}
+
+TEST(Orderability, OrdersIntegersAgainstDoublesAsNumbers) {
+  // Both share one rank, so the ordering reads their values rather than their
+  // types.
+  EXPECT_TRUE(std::is_lt(orderability::Compare(TypedValue(int64_t{1}), TypedValue(1.5))));
+  EXPECT_TRUE(std::is_gt(orderability::Compare(TypedValue(int64_t{2}), TypedValue(1.5))));
+  EXPECT_EQ(orderability::Compare(TypedValue(int64_t{2}), TypedValue(2.0)), std::weak_ordering::equivalent);
+}
+
+TEST(Orderability, SortsAMixedColumnWithoutRaising) {
+  auto values = OrderedSample();
+  std::ranges::reverse(values);
+  // Sorting is the property the relation exists for, and it is undefined
+  // behaviour unless the relation is a strict weak ordering.
+  std::ranges::sort(values,
+                    [](TypedValue const &a, TypedValue const &b) { return std::is_lt(orderability::Compare(a, b)); });
+  auto const expected = OrderedSample();
+  for (size_t i = 0; i != values.size(); ++i) {
+    EXPECT_EQ(orderability::Compare(values[i], expected[i]), std::weak_ordering::equivalent) << "at index " << i;
+  }
+}
+
+}  // namespace
+}  // namespace memgraph::query::tests


### PR DESCRIPTION
Orderability, the relation ORDER BY and the aggregations read, sat in an
anonymous namespace inside a header shared by nine translation units. Internal
linkage meant nothing outside those translation units could name it, so the
relation could only be reached through a plan: the one test covering it stood up
a storage accessor, a symbol table and three operators in order to call a
comparison function, and no benchmark or profile could address it at all. The
three relations it is only comprehensible beside were named after their callers
rather than after what the language calls them.

It moves to a header of its own under the name openCypher gives it, carrying a
note of what the other three relations are and why the four differ only over a
Null, a NaN and a pair of unlike types. The definitions stay in the header
because a sort calls them once per comparison, which is the constraint that put
them there originally and the one a later tidy-up is most likely to undo without
noticing. Behaviour is unchanged and the generated code is unchanged; what
changes is that the relation can now be stated, measured and reasoned about on
its own, and its callers say which relation they are reading.
