### PR TITLE
perf(bolt): bounded-try + reschedule the autocommit PREPARE engine_lock

### DIFF
--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -123,10 +123,8 @@ class Session {
     }
 
     if (state_ == State::PendingPrepare) {
-      // HandlePrepare stashed a would-block PREPARE (parse kept in SessionHL::parsed_res_). Stop here WITHOUT
-      // entering the dechunk loop so it can't read the next chunk -- a message pipelined behind the PREPARE must
-      // not run before it finishes; DoWork hands the completion to the pool. Unlike PendingBegin, PREPARE is driven
-      // at the top of Execute_ (never from the loop's switch), so this is the one and only spot it can surface.
+      // Stop before the dechunk loop so a message pipelined behind the PREPARE can't run before it finishes; DoWork
+      // hands the completion to the pool. PREPARE surfaces only here (driven at the top of Execute_, not the switch).
       return true;  // more data to process
     }
 
@@ -249,9 +247,8 @@ class Session {
     pending_prepare_retries_ = 0;
   }
 
-  // Build and send the RUN header (output field names + optional qid) as the PREPARE's single SUCCESS. Shared by
-  // HandlePrepare's inline path and FinishPendingPrepare_'s pool path so the exactly-one header is byte-identical.
-  // Returns false if the send failed (caller moves to Close).
+  // Emits the RUN header (field names + optional qid) as the PREPARE's single SUCCESS. Shared by HandlePrepare's
+  // inline path and FinishPendingPrepare_'s pool path so that one header is byte-identical whichever path runs.
   bool SendPrepareHeader(const std::vector<std::string> &header, std::optional<int> qid) {
     std::vector<Value> vec;
     map_t data;
@@ -350,9 +347,8 @@ class Session {
   // After this many reschedules, FinishPendingBegin_ does one blocking acquire (fairness: a BEGIN cannot starve).
   static constexpr uint32_t kBeginRescheduleCap = 32;
 
-  // Set on a PREPARE WouldBlock bail; the parse itself lives in SessionHL::parsed_res_. Cleared once the PREPARE
-  // completes (header sent) or fails. Mutually exclusive with pending_begin_extra_ (a BEGIN and a PREPARE step
-  // cannot both be mid-flight on the same session).
+  // Cleared once the PREPARE completes (header sent) or fails. Mutually exclusive with pending_begin_extra_
+  // (state_ is single-valued, so a BEGIN and a PREPARE step cannot both be mid-flight on the same session).
   bool pending_prepare_{false};
 
   // Times FinishPendingPrepare_ lost the bounded-try engine-lock race for the current PREPARE; reset on a fresh stash.

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -122,6 +122,14 @@ class Session {
       // We are here, so the query will have the correct priority; just fall down to execute any other requests
     }
 
+    if (state_ == State::PendingPrepare) {
+      // HandlePrepare stashed a would-block PREPARE (parse kept in SessionHL::parsed_res_). Stop here WITHOUT
+      // entering the dechunk loop so it can't read the next chunk -- a message pipelined behind the PREPARE must
+      // not run before it finishes; DoWork hands the completion to the pool. Unlike PendingBegin, PREPARE is driven
+      // at the top of Execute_ (never from the loop's switch), so this is the one and only spot it can surface.
+      return true;  // more data to process
+    }
+
     ChunkState chunk_state;
     while ((chunk_state = decoder_buffer_.GetChunk()) != ChunkState::Partial) {
       if (chunk_state == ChunkState::Whole) {
@@ -231,6 +239,66 @@ class Session {
     }
   }
 
+  // Used by DoWork to hand a stashed would-block PREPARE off to the pool instead of continuing the dechunk loop.
+  bool HasPendingPrepare() const { return pending_prepare_; }
+
+  // Flag a PREPARE whose bounded-try acquire bailed with WouldBlock. The parse stays in SessionHL::parsed_res_
+  // (re-runnable), so the bolt layer only records that a completion is owed plus a fresh retry count.
+  void StashPendingPrepare() {
+    pending_prepare_ = true;
+    pending_prepare_retries_ = 0;
+  }
+
+  // Build and send the RUN header (output field names + optional qid) as the PREPARE's single SUCCESS. Shared by
+  // HandlePrepare's inline path and FinishPendingPrepare_'s pool path so the exactly-one header is byte-identical.
+  // Returns false if the send failed (caller moves to Close).
+  bool SendPrepareHeader(const std::vector<std::string> &header, std::optional<int> qid) {
+    std::vector<Value> vec;
+    map_t data;
+    vec.reserve(header.size());
+    for (const auto &field : header) vec.emplace_back(field);
+    data.emplace("fields", std::move(vec));
+    if (version_.major > 1 && qid) {
+      data.emplace("qid", Value{*qid});
+    }
+    return encoder_.MessageSuccess(data);
+  }
+
+  // Pool-side completion of a PREPARE that HandlePrepare bailed on with WouldBlock. Retries InterpretPrepare with a
+  // bounded-try acquire (Blocking after kPrepareRescheduleCap, so it can't starve); on loss returns Reschedule with
+  // parsed_res_ intact. Emits the PREPARE's one and only header SUCCESS -- never on HandlePrepare's bail path.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  PendingPrepareOutcome FinishPendingPrepare_(TImpl &impl) {
+    MG_ASSERT(pending_prepare_, "FinishPendingPrepare_ without a pending PREPARE");
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+    const bool cap_reached = pending_prepare_retries_ >= kPrepareRescheduleCap;
+    const auto mode =
+        cap_reached ? memgraph::storage::EngineLockMode::Blocking : memgraph::storage::EngineLockMode::TryBounded;
+    try {
+      auto [header, qid] = impl.InterpretPrepare(mode);  // consumes parsed_res_ on success
+      if (!SendPrepareHeader(header, qid)) {
+        state_ = State::Close;
+        pending_prepare_ = false;
+        return PendingPrepareOutcome::ClientError;
+      }
+      state_ = State::Result;
+      pending_prepare_ = false;
+      return PendingPrepareOutcome::Done;
+    } catch (const memgraph::query::WouldBlockInlineException &) {
+      // Only TryBounded throws this; Blocking (at the cap) never does, so the cap terminates the reschedule loop.
+      // parsed_res_ stays intact in SessionHL and pending_prepare_ stays true for the re-post.
+      ++pending_prepare_retries_;
+      return PendingPrepareOutcome::Reschedule;
+    } catch (const std::exception &e) {
+      state_ = HandleFailure(impl, e);
+      pending_prepare_ = false;
+      return PendingPrepareOutcome::ClientError;
+    }
+  }
+
   // TODO: Rethink if there is a way to hide some members. At the momement all of them are public.
   TInputStream &input_stream_;
   TOutputStream &output_stream_;
@@ -281,6 +349,16 @@ class Session {
   uint32_t pending_begin_retries_{0};
   // After this many reschedules, FinishPendingBegin_ does one blocking acquire (fairness: a BEGIN cannot starve).
   static constexpr uint32_t kBeginRescheduleCap = 32;
+
+  // Set on a PREPARE WouldBlock bail; the parse itself lives in SessionHL::parsed_res_. Cleared once the PREPARE
+  // completes (header sent) or fails. Mutually exclusive with pending_begin_extra_ (a BEGIN and a PREPARE step
+  // cannot both be mid-flight on the same session).
+  bool pending_prepare_{false};
+
+  // Times FinishPendingPrepare_ lost the bounded-try engine-lock race for the current PREPARE; reset on a fresh stash.
+  uint32_t pending_prepare_retries_{0};
+  // After this many reschedules, FinishPendingPrepare_ does one blocking acquire (fairness: a PREPARE cannot starve).
+  static constexpr uint32_t kPrepareRescheduleCap = 32;
 
   const std::string kTimestampFormat = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}";
   const std::string session_uuid_;  //!< unique identifier of the session (auto generated)

--- a/src/communication/bolt/v1/state.hpp
+++ b/src/communication/bolt/v1/state.hpp
@@ -56,6 +56,14 @@ enum class State : uint8_t {
   PendingBegin,
 
   /**
+   * A PREPARE (the Parsed->Result step) whose engine-lock acquire would block has been decoded and parsed; its
+   * completion is being run out-of-band on a pool worker. Execute_ returns without touching any message buffered
+   * behind the PREPARE, so ordering is preserved until the PREPARE finishes. The parse itself is held in
+   * SessionHL::parsed_res_ (re-runnable); the bolt layer only tracks the pending flag + retry count.
+   */
+  PendingPrepare,
+
+  /**
    * This state handles errors, if client handles error response correctly next
    * state is Idle.
    */
@@ -74,4 +82,10 @@ enum class State : uint8_t {
 // ClientError - send failed or the begin threw; state moved to Close/Error.
 // Reschedule  - the bounded-try engine-lock acquire lost the race; extras stay stashed, re-post to the pool.
 enum class PendingBeginOutcome : uint8_t { Done, ClientError, Reschedule };
+
+// Outcome of the pool-side completion of a would-block PREPARE (FinishPendingPrepare_).
+// Done        - the PREPARE completed and the header SUCCESS was sent.
+// ClientError - send failed or the prepare threw; state moved to Close/Error.
+// Reschedule  - the bounded-try engine-lock acquire lost the race; parsed_res_ stays intact, re-post to the pool.
+enum class PendingPrepareOutcome : uint8_t { Done, ClientError, Reschedule };
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/state.hpp
+++ b/src/communication/bolt/v1/state.hpp
@@ -56,10 +56,9 @@ enum class State : uint8_t {
   PendingBegin,
 
   /**
-   * A PREPARE (the Parsed->Result step) whose engine-lock acquire would block has been decoded and parsed; its
-   * completion is being run out-of-band on a pool worker. Execute_ returns without touching any message buffered
-   * behind the PREPARE, so ordering is preserved until the PREPARE finishes. The parse itself is held in
-   * SessionHL::parsed_res_ (re-runnable); the bolt layer only tracks the pending flag + retry count.
+   * A PREPARE (Parsed->Result) whose engine-lock acquire would block has been decoded and parsed; its
+   * completion runs out-of-band on a pool worker (never the strand). Execute_ returns without touching any message
+   * buffered behind the PREPARE, so ordering is preserved; the parse is held in SessionHL::parsed_res_ (re-runnable).
    */
   PendingPrepare,
 

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -214,9 +214,8 @@ inline State HandleFailure(TSession &session, const std::exception &e) {
 template <typename TSession>
 State HandlePrepare(TSession &session) {
   try {
-    // Interpret can throw. Bounded-try engine-lock acquire (mirrors HandleBegin): rather than busy-spin this pool
-    // worker behind a long write commit's durability hold, InterpretPrepare throws WouldBlockInlineException on
-    // contention while keeping parsed_res_ intact, so the completion reschedules on the pool.
+    // Interpret can throw. Bounded-try acquire (mirrors HandleBegin) so this pool worker reschedules instead of
+    // busy-spinning behind a write commit: on contention InterpretPrepare throws WouldBlock, parsed_res_ left intact.
     const auto [header, qid] = session.InterpretPrepare(storage::EngineLockMode::TryBounded);
     // Send the header (exactly one SUCCESS). The PendingPrepare bail below must NOT send it.
     if (!session.SendPrepareHeader(header, qid)) {

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -214,26 +214,20 @@ inline State HandleFailure(TSession &session, const std::exception &e) {
 template <typename TSession>
 State HandlePrepare(TSession &session) {
   try {
-    // Interpret can throw.
-    const auto [header, qid] = session.InterpretPrepare();
-    // Convert std::string to Value
-    std::vector<Value> vec;
-    map_t data;
-    vec.reserve(header.size());
-    for (auto &i : header) vec.emplace_back(std::move(i));
-    data.emplace("fields", std::move(vec));
-    if (session.version_.major > 1) {
-      if (qid) {
-        data.emplace("qid", Value{*qid});
-      }
-    }
-
-    // Send the header.
-    if (!session.encoder_.MessageSuccess(data)) {
+    // Interpret can throw. Bounded-try engine-lock acquire (mirrors HandleBegin): rather than busy-spin this pool
+    // worker behind a long write commit's durability hold, InterpretPrepare throws WouldBlockInlineException on
+    // contention while keeping parsed_res_ intact, so the completion reschedules on the pool.
+    const auto [header, qid] = session.InterpretPrepare(storage::EngineLockMode::TryBounded);
+    // Send the header (exactly one SUCCESS). The PendingPrepare bail below must NOT send it.
+    if (!session.SendPrepareHeader(header, qid)) {
       spdlog::trace("Couldn't send query header!");
       return State::Close;
     }
     return State::Result;
+  } catch (const memgraph::query::WouldBlockInlineException &) {
+    // parsed_res_ is intact (re-runnable); the pool retries via FinishPendingPrepare_, which emits the one SUCCESS.
+    session.StashPendingPrepare();
+    return State::PendingPrepare;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -410,8 +410,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                   return;
                 }
                 if (shared_this->session_.HasPendingPrepare()) {
-                  // PREPARE's engine-lock acquire would block: finish it off the worker via the pool
-                  // (PostFinishPendingPrepare). Return now so no message pipelined behind the PREPARE runs first.
+                  // As the BEGIN bail above, for PREPARE: return so nothing pipelined behind it runs first.
                   shared_this->PostFinishPendingPrepare();
                   return;
                 }
@@ -462,8 +461,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
         session_.ApproximateQueryPriority());
   }
 
-  // Completes a would-block PREPARE on the POOL (AddTask, never the strand): Reschedule re-posts so the worker never
-  // blocks behind a slow commit; a terminal outcome resumes DoWork/DoRead. FinishPendingPrepare emits the header once.
+  // PREPARE mirror of PostFinishPendingBegin above; FinishPendingPrepare emits the run header (not SUCCESS) once.
   void PostFinishPendingPrepare() {
     session_context_->AddTask(
         [shared_this = shared_from_this()](const auto /*thread_priority*/) {

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -386,6 +386,9 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
         while (session_.HasPendingBegin()) {
           session_.FinishPendingBegin();
         }
+        while (session_.HasPendingPrepare()) {
+          session_.FinishPendingPrepare();
+        }
       }
       // Handled all data,  async wait for new incoming data
       DoReadAsio();
@@ -404,6 +407,12 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                   // BEGIN's engine-lock acquire would block: finish it off the worker via the pool
                   // (PostFinishPendingBegin). Return now so no message pipelined behind the BEGIN runs first.
                   shared_this->PostFinishPendingBegin();
+                  return;
+                }
+                if (shared_this->session_.HasPendingPrepare()) {
+                  // PREPARE's engine-lock acquire would block: finish it off the worker via the pool
+                  // (PostFinishPendingPrepare). Return now so no message pipelined behind the PREPARE runs first.
+                  shared_this->PostFinishPendingPrepare();
                   return;
                 }
                 // Check if we can just steal this task (loop through)
@@ -438,6 +447,33 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                 return;
               case memgraph::communication::bolt::PendingBeginOutcome::Done:
               case memgraph::communication::bolt::PendingBeginOutcome::ClientError:
+                if (shared_this->session_.HasBufferedData()) {
+                  shared_this->DoWork();
+                } else {
+                  shared_this->DoRead();
+                }
+                return;
+            }
+          } catch (const std::exception & /* unused */) {
+            boost::asio::post(shared_this->strand_,
+                              [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
+          }
+        },
+        session_.ApproximateQueryPriority());
+  }
+
+  // Completes a would-block PREPARE on the POOL (AddTask, never the strand): Reschedule re-posts so the worker never
+  // blocks behind a slow commit; a terminal outcome resumes DoWork/DoRead. FinishPendingPrepare emits the header once.
+  void PostFinishPendingPrepare() {
+    session_context_->AddTask(
+        [shared_this = shared_from_this()](const auto /*thread_priority*/) {
+          try {
+            switch (shared_this->session_.FinishPendingPrepare()) {
+              case memgraph::communication::bolt::PendingPrepareOutcome::Reschedule:
+                shared_this->PostFinishPendingPrepare();  // re-post to the POOL, never post(strand_)
+                return;
+              case memgraph::communication::bolt::PendingPrepareOutcome::Done:
+              case memgraph::communication::bolt::PendingPrepareOutcome::ClientError:
                 if (shared_this->session_.HasBufferedData()) {
                   shared_this->DoWork();
                 } else {

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -561,25 +561,38 @@ void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, cons
   }
 }
 
-std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrepare() {
+std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrepare(storage::EngineLockMode try_mode) {
   if (!parsed_res_) {
     throw memgraph::communication::bolt::ClientError("Trying to prepare a query that was not parsed.");
   }
 
   try {
-    auto parsed_res = *std::move(parsed_res_);
-    parsed_res_.reset();
+    // Pass the parsed input by reference. Under TryBounded, Prepare throws WouldBlockInlineException
+    // before it moves from parsed_res_, so on a would-block parsed_res_ stays intact and this Prepare
+    // can be retried with the same parsed input. Only clear parsed_res_ once Prepare (and the
+    // authorization check) have succeeded and consumed it.
     auto result =
-        interpreter_.Prepare(std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
+        interpreter_.Prepare(parsed_res_->parsed_query, parsed_res_->get_params_pv, parsed_res_->extra, try_mode);
     interpreter_.CheckAuthorized(result.privileges, result.db);
-
+    parsed_res_.reset();
     return {std::move(result.headers), result.qid};
+  } catch (const memgraph::query::WouldBlockInlineException &) {
+    // The inline accessor acquire would block; parsed_res_ is untouched. Rethrow unchanged so the
+    // bolt layer can reschedule and retry this Prepare with the same parsed input.
+    throw;
   } catch (const memgraph::query::QueryException &e) {
+    parsed_res_.reset();
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {
+    parsed_res_.reset();
     // Count the number of specific exceptions thrown
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
+  } catch (...) {
+    // Any other failure consumes this parse (matching the pre-retry behaviour of resetting up front);
+    // only a would-block, handled above, retains parsed_res_.
+    parsed_res_.reset();
+    throw;
   }
 }
 

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -17,6 +17,7 @@
 #include "communication/v2/session.hpp"
 #include "glue/SessionContext.hpp"
 #include "query/interpreter.hpp"
+#include "storage/v2/access_type.hpp"
 
 namespace memgraph::glue {
 using bolt_value_t = memgraph::communication::bolt::Value;
@@ -77,7 +78,8 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   void InterpretParse(const std::string &query, bolt_map_t params, const bolt_map_t &extra);
 
-  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare();
+  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare(
+      storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   std::pair<std::vector<std::string>, std::optional<int>> Interpret(const std::string &query, const bolt_map_t &params,
                                                                     const bolt_map_t &extra) {
@@ -142,6 +144,10 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   inline bool Execute() { return Execute_(*this); }
 
   inline memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return FinishPendingBegin_(*this); }
+
+  inline memgraph::communication::bolt::PendingPrepareOutcome FinishPendingPrepare() {
+    return FinishPendingPrepare_(*this);
+  }
 
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10598,16 +10598,14 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     AdvanceCommand();
   } else {
     ResetInterpreter();
-    transaction_queries_->push_back(parsed_query.query_string);
     if (current_db_.db_transactional_accessor_ /* && !in_explicit_transaction_*/) {
       // If we're not in an explicit transaction block and we have an open
       // transaction, abort it since we're about to prepare a new query.
       AbortCommand(nullptr);
     }
-
-    SetupInterpreterTransaction(extras);
-    memgraph::logging::EmitSessionTraceEvent(
-        "Query [{}] associated with transaction [{}]", parsed_query.query_string, current_transaction_.value_or(0));
+    // The transaction_queries_ record and SetupInterpreterTransaction (consumes a tx id and marks
+    // the transaction ACTIVE) are deferred until after the storage accessor is acquired, below in
+    // the try block, so the acquire runs before any non-idempotent transaction setup.
   }
 
   auto *const cypher_query = utils::Downcast<CypherQuery>(parsed_query.query);
@@ -10809,6 +10807,13 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
           throw StorageModeChangedDuringSetupException();
         }
       }
+
+      // Deferred from the autocommit branch above: the storage accessor is now held, so record the
+      // query and open the interpreter transaction (consumes the tx id, marks the status ACTIVE).
+      transaction_queries_->push_back(parsed_query.query_string);
+      SetupInterpreterTransaction(extras);
+      memgraph::logging::EmitSessionTraceEvent(
+          "Query [{}] associated with transaction [{}]", parsed_query.query_string, current_transaction_.value_or(0));
     }
 
     if (current_db_.db_acc_) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10561,8 +10561,8 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
   std::optional<storage::StorageAccessType> accessor_type_;
 };
 
-Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParameters_fn params_getter,
-                                                QueryExtras const &extras) {
+Interpreter::PrepareResult Interpreter::Prepare(ParseRes &parse_res, UserParameters_fn &params_getter,
+                                                QueryExtras const &extras, storage::EngineLockMode try_mode) {
   std::optional<memory::DbArenaScope> db_arena_scope;
   if (current_db_.db_acc_) {
     db_arena_scope.emplace(current_db_.db_acc_->get());
@@ -10795,7 +10795,8 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
         if (transaction_requirements.isolation_level_override_) {
           SetNextTransactionIsolationLevel(*transaction_requirements.isolation_level_override_);
         }
-        SetupDatabaseTransaction(transaction_requirements.could_commit_, *transaction_requirements.accessor_type_);
+        SetupDatabaseTransaction(
+            transaction_requirements.could_commit_, *transaction_requirements.accessor_type_, try_mode);
 
         // SET STORAGE MODE can land between the unlocked read of `storage_mode` and the accessor
         // taking its hold, leaving the access type chosen for a mode no longer in force: an index

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -392,7 +392,12 @@ class Interpreter final {
 
   Interpreter::ParseRes Parse(const std::string &query, UserParameters_fn params_getter, QueryExtras const &extras);
 
-  Interpreter::PrepareResult Prepare(ParseRes parse_res, UserParameters_fn params_getter, QueryExtras const &extras);
+  // parse_res and params_getter are taken by non-const reference: they are only moved-from on the
+  // success path, after the storage accessor is acquired. If the acquire bails with
+  // WouldBlockInlineException (TryBounded mode) they are left untouched, so the caller can retry
+  // Prepare with the same parsed input.
+  Interpreter::PrepareResult Prepare(ParseRes &parse_res, UserParameters_fn &params_getter, QueryExtras const &extras,
+                                     storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   /**
    * Prepare a query for execution.
@@ -407,7 +412,9 @@ class Interpreter final {
     // Split Prepare in two (Parse and Prepare)
     // This allows us to parse, deduce priority and schedule accordingly
     // Leaving this one-shot version for back-compatiblity
-    return Prepare(Parse(query, params_getter, extras), params_getter, extras);
+    // parse_res must be an lvalue: the ParseRes overload binds it by reference.
+    auto parse_res = Parse(query, params_getter, extras);
+    return Prepare(parse_res, params_getter, extras);
   }
 
   /**

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -70,7 +70,16 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
     throw ClientError("client sent invalid query");
   }
 
-  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare() {
+  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare(
+      memgraph::storage::EngineLockMode try_mode = memgraph::storage::EngineLockMode::Blocking) {
+    // Pool bounded-try (mirrors BeginTransaction): lose the engine-lock race for the first N TryBounded
+    // attempts, then succeed. The first loss bails HandlePrepare into State::PendingPrepare; the rest make
+    // FinishPendingPrepare_ return Reschedule. Blocking (the fairness-cap fallback) is never gated, so the
+    // reschedule loop is guaranteed to terminate.
+    if (try_mode == memgraph::storage::EngineLockMode::TryBounded && try_bounded_fail_count_ > 0) {
+      --try_bounded_fail_count_;
+      throw memgraph::query::WouldBlockInlineException{};
+    }
     if (query_ == kQueryReturn42 || query_ == kQueryEmpty || query_ == kQueryReturnMultiple) {
       return {{"result_name"}, {}};
     }
@@ -180,8 +189,8 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   void TestHook_ShouldAbort() { should_abort_ = true; }
 
-  // Make the next `n` TryBounded engine-lock acquires lose the race, then succeed. Drives the
-  // HandleBegin bail + FinishPendingBegin_ reschedule path deterministically.
+  // Make the next `n` TryBounded engine-lock acquires lose the race, then succeed. Drives the HandleBegin /
+  // HandlePrepare bail + FinishPendingBegin_ / FinishPendingPrepare_ reschedule paths deterministically.
   void TestHook_FailBoundedTries(int n) { try_bounded_fail_count_ = n; }
 
   void Execute() {
@@ -197,6 +206,8 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
   bool ExecuteStep() { return Execute_(*this); }
 
   memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return FinishPendingBegin_(*this); }
+
+  memgraph::communication::bolt::PendingPrepareOutcome FinishPendingPrepare() { return FinishPendingPrepare_(*this); }
 
  private:
   std::string query_;
@@ -1485,4 +1496,155 @@ TEST(BoltSession, PendingBeginHoldsBackPipelinedMessageUntilItCompletes) {
   session.Execute();
   EXPECT_EQ(session.state_, State::Result);  // RUN parsed+prepared, awaiting PULL
   CheckSuccessMessage(output, /*clear=*/false);
+}
+
+// ---------------------------------------------------------------------------
+// Pending-PREPARE reschedule (pool-native, no strand inline). A RUN is first parsed (State::Parsed); the
+// follow-up PREPARE, whose bounded-try engine-lock acquire loses the race, bails out of HandlePrepare into
+// State::PendingPrepare (parse retained in SessionHL::parsed_res_). The completion is retried out-of-band via
+// FinishPendingPrepare(), which reschedules on each further loss and, past the fairness cap, does one blocking
+// acquire so the PREPARE cannot starve. Its single header SUCCESS is emitted only on the terminal Done.
+// ---------------------------------------------------------------------------
+
+using memgraph::communication::bolt::PendingPrepareOutcome;
+
+// Count whole bolt frames in `output`, consuming it. A frame is a 2-byte length header, `len` payload bytes,
+// then the 2-byte end marker; used to prove "exactly one header" without pinning exact payload bytes.
+static int DrainFrameCount(std::vector<uint8_t> &output) {
+  int frames = 0;
+  while (output.size() > 0) {
+    const int len = (output[0] << 8) + output[1];
+    output.erase(output.begin(), output.begin() + len + 4);
+    ++frames;
+  }
+  return frames;
+}
+
+TEST(BoltSession, PendingPrepareReschedulesThenCompletesWithOneHeader) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // 4 bounded-try losses: the 1st is consumed by HandlePrepare (PREPARE -> PendingPrepare), leaving 3 for
+  // FinishPendingPrepare -> exactly 3 Reschedule outcomes before the 4th attempt wins.
+  constexpr int kExpectedReschedules = 3;
+  session.TestHook_FailBoundedTries(kExpectedReschedules + 1);
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  output.clear();
+
+  // First dechunk pass parses the RUN (State::Parsed); the second drives HandlePrepare, whose bounded-try
+  // acquire loses and parks the PREPARE in State::PendingPrepare (parse retained in parsed_res_).
+  ASSERT_TRUE(session.ExecuteStep());
+  ASSERT_EQ(session.state_, State::Parsed);
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingPrepare);
+  EXPECT_TRUE(session.HasPendingPrepare());
+  EXPECT_TRUE(output.empty());  // no header emitted on the bail path
+
+  // Each lost bounded-try returns Reschedule and MUST keep the PREPARE pending (parse retained); a premature
+  // reset would trip FinishPendingPrepare_'s MG_ASSERT on the next attempt.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;  // fail loudly instead of looping forever if the retry logic regresses
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingPrepare();
+    if (outcome == PendingPrepareOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingPrepareOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingPrepare());  // pending state survives across reschedules
+    EXPECT_TRUE(output.empty());               // no header while rescheduling
+    EXPECT_EQ(session.state_, State::PendingPrepare);
+    ++reschedules;
+  }
+
+  // Making HandlePrepare/FinishPendingPrepare block instead of bail (never reaching PendingPrepare) breaks this
+  // exact count -> the test is mutation-checkable.
+  EXPECT_EQ(reschedules, kExpectedReschedules);
+  EXPECT_FALSE(session.HasPendingPrepare());  // pending flag cleared on the terminal Done
+  EXPECT_EQ(session.state_, State::Result);
+  // Exactly ONE header SUCCESS, emitted only by FinishPendingPrepare on Done.
+  CheckSuccessMessage(output, /*clear=*/false);
+  EXPECT_EQ(DrainFrameCount(output), 1);
+}
+
+TEST(BoltSession, PendingPrepareFairnessCapForcesBlockingTerminal) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // EVERY bounded-try loses the race: only the fairness cap can end the loop.
+  session.TestHook_FailBoundedTries(1000);
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  output.clear();
+
+  ASSERT_TRUE(session.ExecuteStep());
+  ASSERT_EQ(session.state_, State::Parsed);
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingPrepare);
+  EXPECT_TRUE(session.HasPendingPrepare());
+  EXPECT_TRUE(output.empty());
+
+  // Under unbounded contention the pool-side completion must still terminate: after kPrepareRescheduleCap
+  // reschedules FinishPendingPrepare_ does one Blocking acquire (never gated by the fail hook, never throws
+  // WouldBlock), completing the PREPARE. Count the reschedules to prove it is the cap -- not a lucky
+  // bounded-try -- that breaks the loop. kPrepareRescheduleCap is private, so the expected count is a literal
+  // kept in sync with it.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingPrepare();
+    if (outcome == PendingPrepareOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingPrepareOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingPrepare());
+    EXPECT_TRUE(output.empty());
+    EXPECT_EQ(session.state_, State::PendingPrepare);
+    ++reschedules;
+  }
+  EXPECT_EQ(reschedules, 32);  // == kPrepareRescheduleCap; the terminal Blocking acquire fires on the next call
+  EXPECT_FALSE(session.HasPendingPrepare());
+  EXPECT_EQ(session.state_, State::Result);
+  CheckSuccessMessage(output, /*clear=*/false);  // exactly one header, from the Blocking fallback
+  EXPECT_EQ(DrainFrameCount(output), 1);
+}
+
+TEST(BoltSession, PendingPrepareHoldsBackPipelinedMessageUntilItCompletes) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // One loss (consumed by HandlePrepare) forces the PREPARE onto the pending path; the first
+  // FinishPendingPrepare then wins. Keeps this test focused on ordering, not on the reschedule count.
+  session.TestHook_FailBoundedTries(1);
+  // A RUN immediately followed by its PULL, in one buffer, with the engine lock "contended".
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  WriteChunkHeader(input_stream, sizeof(v4::pullall_req));
+  input_stream.Write(v4::pullall_req, sizeof(v4::pullall_req));
+  WriteChunkTail(input_stream);
+  output.clear();
+
+  // First pass parses the RUN; the second bails the PREPARE into PendingPrepare. Neither reads the pipelined
+  // PULL: Execute_ stops at PendingPrepare BEFORE the dechunk loop, so the PULL stays queued and unanswered.
+  ASSERT_TRUE(session.ExecuteStep());
+  ASSERT_EQ(session.state_, State::Parsed);
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingPrepare);
+  EXPECT_TRUE(session.HasPendingPrepare());
+  EXPECT_TRUE(output.empty());             // no header for the PREPARE yet, and the PULL was not processed
+  EXPECT_TRUE(session.HasBufferedData());  // the PULL is still queued behind the parked PREPARE
+
+  // Complete the PREPARE: exactly one header SUCCESS. The PULL is STILL unread.
+  ASSERT_EQ(session.FinishPendingPrepare(), PendingPrepareOutcome::Done);
+  EXPECT_EQ(session.state_, State::Result);
+  EXPECT_FALSE(session.HasPendingPrepare());
+  CheckSuccessMessage(output, /*clear=*/false);  // only the PREPARE's header -- the PULL produced nothing
+  EXPECT_EQ(DrainFrameCount(output), 1);
+
+  // Only now, after the PREPARE finished, does the resume process the pipelined PULL -- proving ordering.
+  session.Execute();
+  EXPECT_EQ(session.state_, State::Idle);  // PULL drained the RUN's result
+  EXPECT_EQ(DrainFrameCount(output), 2);   // RECORD(42) + SUCCESS from the pipelined PULL
 }


### PR DESCRIPTION
## What

Extends #4669's bounded-try + reschedule from the explicit `BEGIN` message to the **autocommit** path — a bare `RUN <cypher>` with no open transaction, which is the majority of traffic. An autocommit query acquires its transaction under `engine_lock_` at **PREPARE** time; when a concurrent write commit holds that lock across its SYNC/STRICT_SYNC durability wait, the PREPARE previously **busy-spun a pool worker** behind the slow commit. Now it bounded-tries and, on a would-block, **reschedules its completion to a pool worker** instead of spinning — the worker stays free to drain other work during the commit's durability hold.

Stacked on #4669 (base branch `perf/begin-engine-lock-tryresched`).

## Where the seam is

Autocommit is three bolt steps, and the accessor is acquired in the isolated middle one:

| Step | Bolt | Accessor |
| --- | --- | --- |
| RUN | `HandleRunV4/V5` → `InterpretParse` → `State::Parsed` (parse only) | no |
| **PREPARE** | `HandlePrepare` → `InterpretPrepare` → `Interpreter::Prepare` | **yes** (interpreter.cpp) |
| PULL | `State::Result` handler | reuses |

`HandlePrepare` is a clean "acquire + send header" step that streams no rows — structurally identical to `HandleBegin`. So the reschedule seam mirrors #4669 exactly (`State::PendingPrepare`, `FinishPendingPrepare_`, `PostFinishPendingPrepare`, `kPrepareRescheduleCap = 32` blocking fallback), with the one difference that completion emits the query **header** (not a bare SUCCESS) — via a shared `SendPrepareHeader` helper so it's emitted exactly once across the inline and rescheduled paths.

## Reuses #4669 unchanged

All storage machinery is reused as-is: `EngineLockMode::TryBounded`, `BoundedTryLock`, `TransactionEngineWouldBlock`, `Database::TryAccess`, `WouldBlockInlineException`. **Zero storage-layer change.**

## Two hazards solved

- **Parse ownership on retry.** `InterpretPrepare` used to move + reset `parsed_res_` before calling `Prepare`, and `Prepare` took its args by value — so a would-block destroyed the only parsed copy (re-parsing would double-fire the audit log). Fixed: `Prepare`'s `ParseRes` overload now takes `parse_res`/`params_getter` by reference and moves from them only on the success path (after the acquire); `InterpretPrepare` keeps `parsed_res_` on a would-block and resets it on success.
- **Per-retry side effects.** The autocommit branch of `Prepare` was reordered so the accessor acquire runs **before** `transaction_queries_->push_back` and `SetupInterpreterTransaction` (which consumes a tx id + flips status to ACTIVE). A would-block bail is now pristine — no duplicate query-list entry, no tx-id churn. This reorder is behavior-identical on the blocking path (see verification).

## Scope

Autocommit **READ/WRITE** only. Unchanged (still blocking): a RUN inside an open explicit transaction (accessor already open), `BEGIN`/`COMMIT`/`ROLLBACK` strings, UNIQUE/READ_ONLY acquires, and on-disk storage (no non-blocking probe — reschedules to the cap then blocks, same documented residual as #4669).

One minor observability nuance from the reorder: an autocommit query that *blocks inside* a UNIQUE/READ_ONLY acquire is now `IDLE` (not listed by `SHOW TRANSACTIONS`) during that wait. Inert for `TERMINATE` (the acquire wait was never status-interruptible), tiny window, only on a blocking acquire.

## Tests

`tests/unit/bolt_session.cpp` — three `PendingPrepare` cases mirroring #4669's `PendingBegin` trio: reschedules-then-one-header, fairness-cap→blocking-terminal, pipelined-message-held-until-complete. All mutation-checkable against the production state machine (header bytes, not counters).

## Verification

- Reorder: logic-verifier **EQUIVALENT** on all paths; interpreter unit suite **183/184** (1 pre-existing skip).
- Bolt seam: concurrency-debugger — **all 6** ordering/liveness invariants CONFIRMED (exactly-one-header, no-pipelined-before-complete, pool-not-strand re-post, cap→blocking termination, flag/parse-state consistency, bounded websocket drain).
- Build clean; `bolt_session` **41/41** (3 new).

Benchmarks (autocommit slow-commit scenarios) to be confirmed on a perf-stable box.
