### PR TITLE
perf(storage): experimental lock-free read snapshot (commit-lock narrowing) [DO NOT MERGE — CI flag-on]

### DIFF
--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -935,6 +935,16 @@ jobs:
           --cpuset-mems="0" \
           "mgbuild_${TOOLCHAIN}_${OS}"
 
+      - name: Run lockfree-read-snapshot A/B smoke
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
+          --organization-name $MEMGRAPH_ORGANIZATION_NAME \
+          test-memgraph lockfree-read-snapshot-ab
+
       - name: Run micro benchmarks
         run: |
           ./release/package/mgbuild.sh \

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -63,7 +63,7 @@ SUPPORTED_ARCHS=(
 SUPPORTED_TESTS=(
     clang-tidy cppcheck-and-clang-format code-analysis
     code-coverage drivers drivers-high-availability durability e2e gql-behave
-    integration leftover-CTest macro-benchmark
+    integration leftover-CTest lockfree-read-snapshot-ab macro-benchmark
     mgbench stress-plain stress-ssl
     query_modules_e2e query_modules_unit
     unit unit-coverage upload-to-bench-graph
@@ -1992,6 +1992,15 @@ test_memgraph() {
       docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $MGBUILD_ROOT_DIR/tests/gql_behave && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && ./continuous_integration --parallel-execution"
       docker cp $build_container:$test_output_dir/gql_behave_status.csv $test_output_host_dest/gql_behave_status_parallel.csv
       docker cp $build_container:$test_output_dir/gql_behave_status.html $test_output_host_dest/gql_behave_status_parallel.html
+    ;;
+    lockfree-read-snapshot-ab)
+      # A/B smoke for the experimental lockfree-read-snapshot flag: launches the
+      # freshly built binary OFF vs ON across GOOD/BAD/NEUTRAL and asserts the run
+      # is operationally clean (--fail-on-error gates on crashes/worker-errors, not
+      # on perf direction). Toolchain is activated so the spawned memgraph finds its
+      # runtime libs; ve3 (with the neo4j driver from tests/requirements.txt) is
+      # created on demand if a prior test target has not already built it.
+      docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && $ACTIVATE_TOOLCHAIN && cd $MGBUILD_ROOT_DIR/tests && ([[ -d ve3 ]] || (python3 -m venv ve3 && source ve3/bin/activate && pip install --upgrade pip && pip install -r requirements.txt)) && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR "'&& python3 tests/benchmark_lockfree_read_snapshot/ab_bench.py --memgraph-binary build/memgraph --scenario all --duration 4 --warmup 1 --vertices 2000 --readers 4 --writers 2 --write-batch 500 --reps 1 --fail-on-error'
     ;;
     macro-benchmark)
       docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export USER=mg && export LANG=$(echo $LANG) && cd $MGBUILD_ROOT_DIR/tests/macro_benchmark "'&& ./harness QuerySuite MemgraphRunner --groups aggregation 1000_create unwind_create dense_expand match --no-strict'

--- a/specs/lockfree-read-snapshot.md
+++ b/specs/lockfree-read-snapshot.md
@@ -1,0 +1,143 @@
+# Lock-free read snapshot (`--experimental-enabled=lockfree-read-snapshot`)
+
+**Status:** Experimental (opt-in, off by default)
+**Area:** storage/v2 (MVCC, durability, garbage collection), replication
+
+One-line summary: an experimental storage mode that stops new transactions from
+stalling behind a slow commit's durability/replication wait, so read throughput no
+longer collapses when writes are slow — without changing what any transaction sees.
+
+## Problem Statement
+
+Under normal load Memgraph serves reads quickly. But when commits become slow — most
+commonly with **SYNC or STRICT_SYNC replication** (a commit waits for a replica round
+trip) or slow disk durability — read throughput can fall off a cliff even though the
+reads themselves are cheap.
+
+The reason is observable only as a symptom: while a write commit is waiting for its
+durability/replication to finish, **every new transaction that tries to start is blocked**,
+regardless of whether it is a read or a write. A single in-flight slow commit serializes
+all incoming `BEGIN`s behind it. So a workload that mixes fast reads with occasional slow
+commits sees its reads periodically freeze for the duration of each commit's wait, and
+aggregate read throughput drops far below what the hardware can do.
+
+## Solution
+
+An opt-in, startup-only flag, `--experimental-enabled=lockfree-read-snapshot`
+(default off). When enabled, a new transaction no longer has to wait for an in-flight
+commit's durability/replication round trip in order to start. New `BEGIN`s proceed
+immediately; a reader is given a consistent view of the database **as of the last commit
+that has fully completed** at the moment it starts.
+
+Concretely, with the flag on:
+
+- Reads and read-heavy workloads keep running at full speed while a slow write commit is
+  in flight, instead of stalling for the length of that commit's replication/durability
+  wait. This is the whole point of the feature and applies to transactions at **every
+  isolation level**.
+- A transaction that starts while a commit is mid-flight is ordered **before** that
+  commit: it does not see that commit's changes, exactly as if it had started an instant
+  earlier. It never sees a half-finished commit (no dirty reads of not-yet-durable data).
+- Write throughput is unchanged. Commits still complete one at a time; this feature makes
+  readers stop waiting on them, it does not make commits faster.
+
+## Guarantees
+
+- **Snapshot Isolation is preserved.** A transaction sees a single consistent snapshot and
+  is protected against lost updates, exactly as without the flag. The only observable
+  semantic difference is timing (see "First-updater-wins" below).
+- **Off is identical to today.** With the flag off (the default), behavior is byte-for-byte
+  the same as the current release on every path — reads, writes, GC, durability, and
+  replication. Turning the flag on is the only thing that changes behavior.
+- **Durable data does not depend on the flag.** Snapshots and WAL written with the flag on
+  are identical to those written with it off, and vice versa. You can start with the flag
+  on, restart with it off (or the reverse), and recover the exact same data. The flag
+  affects only in-memory scheduling, never what is persisted.
+- **Opt-in and immutable for the process lifetime.** The flag is a startup argument. It
+  cannot be changed at runtime, so a running instance has one consistent behavior.
+
+## Configuration
+
+| | |
+|---|---|
+| Flag | `--experimental-enabled=lockfree-read-snapshot` |
+| Default | off |
+| Scope | per instance, set at startup, immutable while running |
+| Combine with other experiments | yes — `--experimental-enabled` takes a comma-separated list |
+
+## Applicability
+
+- **Isolation levels.** The *unblocking* (readers no longer wait behind commits) applies to
+  all isolation levels. The change to *what a transaction sees* applies only to
+  **`SNAPSHOT`** isolation, because that is the only level that reads from a fixed snapshot;
+  `READ COMMITTED` and `READ UNCOMMITTED` observe no behavioral change beyond no longer
+  being blocked.
+- **Storage mode.** In-memory transactional storage only. **On-disk** storage
+  (`--storage-mode=ON_DISK_TRANSACTIONAL`) is unaffected — the flag is inert there.
+  **Analytical** in-memory mode is likewise unaffected (it keeps no version history to
+  snapshot).
+
+## Costs and trade-offs
+
+Enabling the flag is a deliberate trade, honest about the following:
+
+- **More write aborts under write contention (first-updater-wins).** Two transactions that
+  race to write the same object are more likely to result in one of them getting a
+  serialization error and having to retry, rather than one silently layering on top. This
+  is standard Postgres-style first-updater-wins behavior. It never produces a wrong result
+  — it converts some would-be conflicts into explicit, retryable serialization errors.
+- **Slightly more version history retained.** While a long-running, old reader is active,
+  garbage collection is a little more conservative, so a bit more version history is kept
+  for the duration of that reader. It does not leak: retention returns to normal once the
+  old reader finishes.
+- **Edge-heavy workloads under slow commits pay more.** Concurrently modifying the same
+  vertex's edges while a commit on it is mid-flight can push those writes onto a slower
+  path (more aborts, and version history retained as a group until all contributors
+  finish). This lands in exactly the edge-heavy + slow-commit combination the feature is
+  meant to help, so the benefit and this cost should be weighed together for such
+  workloads.
+
+## Limitations and status
+
+- **Experimental.** The flag is off by default and intended for evaluation, not yet for
+  production reliance.
+- **Replicated clusters are not yet cleared for flag-on.** The single-instance and
+  main-side behavior is implemented and tested; enabling the flag on a **replicated
+  cluster** (particularly STRICT_SYNC 2PC) still needs end-to-end validation before it
+  should be turned on there.
+- **Performance benefit is not yet quantified end-to-end.** The mechanism removes the
+  read-blocking; the actual throughput improvement under slow-SYNC-commit workloads still
+  needs a multi-machine A/B measurement to put numbers on it.
+
+## Out of scope
+
+- Making commits themselves faster (this feature only stops readers from waiting on them).
+- Any change to on-disk or analytical storage.
+- Any new user-facing query surface — there is no new Cypher syntax; the only surface is
+  the startup flag.
+
+## Product decisions and rationale
+
+1. **Opt-in, off by default.** The change is behavior-preserving for correctness but alters
+   commit/GC scheduling; keeping it off by default means upgrading never silently changes
+   how an instance behaves. Operators choose it deliberately for read-latency-sensitive,
+   slow-commit workloads.
+2. **Startup-only / immutable.** A running instance has one consistent regime, which keeps
+   the semantics and the internal bookkeeping simple and predictable, and avoids mixed
+   behavior within a single process.
+3. **Snapshot-semantics change limited to `SNAPSHOT` isolation.** That is the only level
+   whose reads are anchored to a snapshot; applying the change elsewhere would be a no-op,
+   so it is scoped to where it is meaningful while every level still gets the unblocking
+   benefit.
+4. **First-updater-wins accepted.** Turning some silent write races into explicit
+   serialization errors is the correct, safe behavior under a snapshot boundary; clients
+   already retry serialization errors.
+
+## References
+
+- Implementation and its correctness argument live on the PR that introduces the flag
+  (branch `experiment/commit-lock-narrowing`); a design-level walk-through of the mechanism
+  (the three-phase commit, the read snapshot, and the garbage-collection horizon split) and
+  the deterministic interleaving tests accompany it there.
+- Motivating problem: reads collapsing under slow SYNC/STRICT_SYNC commits because every
+  `BEGIN` serializes behind the commit's durability/replication wait.

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -740,9 +740,15 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
                                            .num_committed_txns_ = snapshot_info.num_committed_txns};
       storage->repl_storage_state_.commit_ts_info_.store(new_info, std::memory_order_release);
       if (storage->config_.experimental_lockfree_read_snapshot) {
-        // Rewound by the Clear() above; reseed the read-snapshot watermark to the recovered durable ts
-        // so post-sync readers on this replica freeze a correct SI boundary (not the reset initial id).
-        storage->last_committed_mvcc_ts_.store(snapshot_info.durable_timestamp, std::memory_order_release);
+        // Rewound by the Clear() above; reseed the read-snapshot watermark from the local MVCC counter
+        // (storage->timestamp_ - 1 = highest committed ts in this replica's own timestamp space).
+        // Using the local counter is space-correct: readers compare against local MVCC delta timestamps,
+        // which live in the same space.  Guard against underflow at the initial counter value.
+        storage->last_committed_mvcc_ts_.store(
+            std::max(storage->last_committed_mvcc_ts_.load(std::memory_order_relaxed),
+                     storage->timestamp_ > storage::kTimestampInitialId ? storage->timestamp_ - 1
+                                                                        : storage::kTimestampInitialId),
+            std::memory_order_release);
       }
       spdlog::trace("Set num committed txns to {} after loading snapshot.", snapshot_info.num_committed_txns);
       // We are the only active transaction, so mark everything up to the next timestamp

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -739,6 +739,11 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
       storage::CommitTsInfo const new_info{.ldt_ = snapshot_info.durable_timestamp,
                                            .num_committed_txns_ = snapshot_info.num_committed_txns};
       storage->repl_storage_state_.commit_ts_info_.store(new_info, std::memory_order_release);
+      if (storage->config_.experimental_lockfree_read_snapshot) {
+        // Rewound by the Clear() above; reseed the read-snapshot watermark to the recovered durable ts
+        // so post-sync readers on this replica freeze a correct SI boundary (not the reset initial id).
+        storage->last_committed_mvcc_ts_.store(snapshot_info.durable_timestamp, std::memory_order_release);
+      }
       spdlog::trace("Set num committed txns to {} after loading snapshot.", snapshot_info.num_committed_txns);
       // We are the only active transaction, so mark everything up to the next timestamp
       if (storage->timestamp_ > 0) storage->commit_log_->MarkFinishedInRange(0, storage->timestamp_ - 1);

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -739,17 +739,8 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
       storage::CommitTsInfo const new_info{.ldt_ = snapshot_info.durable_timestamp,
                                            .num_committed_txns_ = snapshot_info.num_committed_txns};
       storage->repl_storage_state_.commit_ts_info_.store(new_info, std::memory_order_release);
-      if (storage->config_.experimental_lockfree_read_snapshot) {
-        // Rewound by the Clear() above; reseed the read-snapshot watermark from the local MVCC counter
-        // (storage->timestamp_ - 1 = highest committed ts in this replica's own timestamp space).
-        // Using the local counter is space-correct: readers compare against local MVCC delta timestamps,
-        // which live in the same space.  Guard against underflow at the initial counter value.
-        storage->last_committed_mvcc_ts_.store(
-            std::max(storage->last_committed_mvcc_ts_.load(std::memory_order_relaxed),
-                     storage->timestamp_ > storage::kTimestampInitialId ? storage->timestamp_ - 1
-                                                                        : storage::kTimestampInitialId),
-            std::memory_order_release);
-      }
+      // Rewound by the Clear() above; reseed the local-counter watermark (no-op with the flag off).
+      storage->SeedReadSnapshotWatermarkFromLocalCounter();
       spdlog::trace("Set num committed txns to {} after loading snapshot.", snapshot_info.num_committed_txns);
       // We are the only active transaction, so mark everything up to the next timestamp
       if (storage->timestamp_ > 0) storage->commit_log_->MarkFinishedInRange(0, storage->timestamp_ - 1);

--- a/src/flags/experimental.cpp
+++ b/src/flags/experimental.cpp
@@ -49,9 +49,11 @@ namespace memgraph::flags {
 
 auto const mapping = std::map{
     std::pair{"planner-v2"sv, Experiments::PLANNER_V2},
+    std::pair{"lockfree-read-snapshot"sv, Experiments::LOCKFREE_READ_SNAPSHOT},
 };
 auto const reverse_mapping = std::map{
     std::pair{Experiments::PLANNER_V2, "planner-v2"sv},
+    std::pair{Experiments::LOCKFREE_READ_SNAPSHOT, "lockfree-read-snapshot"sv},
 };
 auto const config_mapping = std::map<std::string_view, Experiments>{};
 

--- a/src/flags/experimental.hpp
+++ b/src/flags/experimental.hpp
@@ -32,6 +32,7 @@ namespace memgraph::flags {
 enum class Experiments : uint8_t {
   NONE = 0,
   PLANNER_V2 = 1 << 0,
+  LOCKFREE_READ_SNAPSHOT = 1 << 1,
 };
 
 bool AreExperimentsEnabled(Experiments experiments);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -555,7 +555,10 @@ int main(int argc, char **argv) {
       // EXPERIMENTAL (lock-free-read-snapshot): CLI-only, immutable during execution. Runtime-only, never
       // persisted, so durable data is identical regardless of this flag (flip across restart is safe).
       .experimental_lockfree_read_snapshot =
-          memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::LOCKFREE_READ_SNAPSHOT),
+          // TEMP(CI): force ON so server/e2e CI runs with the flag on regardless of --experimental-enabled.
+          // REVERT to `memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::LOCKFREE_READ_SNAPSHOT)`
+          // before merge.
+      true,
       .transaction = {.isolation_level = memgraph::flags::ParseIsolationLevel()},
       .disk = {.main_storage_directory = FLAGS_data_directory + "/rocksdb_main_storage",
                .label_index_directory = FLAGS_data_directory + "/rocksdb_label_index",

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -552,6 +552,10 @@ int main(int argc, char **argv) {
                      .release_sent_snapshot_page_cache = FLAGS_storage_release_sent_snapshot_page_cache,
                      .allow_parallel_snapshot_creation = FLAGS_storage_parallel_snapshot_creation,
                      .allow_parallel_schema_creation = FLAGS_storage_parallel_schema_recovery},
+      // EXPERIMENTAL (lock-free-read-snapshot): CLI-only, immutable during execution. Runtime-only, never
+      // persisted, so durable data is identical regardless of this flag (flip across restart is safe).
+      .experimental_lockfree_read_snapshot =
+          memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::LOCKFREE_READ_SNAPSHOT),
       .transaction = {.isolation_level = memgraph::flags::ParseIsolationLevel()},
       .disk = {.main_storage_directory = FLAGS_data_directory + "/rocksdb_main_storage",
                .label_index_directory = FLAGS_data_directory + "/rocksdb_label_index",

--- a/src/storage/v2/commit_probe.hpp
+++ b/src/storage/v2/commit_probe.hpp
@@ -1,0 +1,35 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <functional>
+
+namespace memgraph::storage {
+
+// Test-only instrumentation for the commit path (lock-free-read-snapshot experiment).
+// A test installs a CommitProbe on the storage; the commit path invokes each hook at the
+// corresponding phase boundary so the test can block it on a latch and run another
+// transaction at a precise instant. In production the storage's probe pointer is null and
+// every call site is a single predictable null-check (near-zero cost). Hooks are optional.
+struct CommitProbe {
+  std::function<void()> after_mint;         // T minted, engine_lock released, before durability
+  std::function<void()> during_durability;  // inside the (unlocked) WAL+replication window
+  std::function<void()> before_publish;     // about to reacquire engine_lock to publish
+  std::function<void()> after_publish;      // visibility store + watermark advanced
+};
+
+// Safe invoker: no-op if the hook is unset. Call sites use InvokeProbe(probe, &CommitProbe::after_mint).
+inline void InvokeProbe(CommitProbe *probe, std::function<void()> CommitProbe::*hook) {
+  if (probe != nullptr && (probe->*hook)) (probe->*hook)();
+}
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -123,6 +123,11 @@ struct Config {
     friend bool operator==(const Durability &lrh, const Durability &rhs) = default;
   } durability;
 
+  // EXPERIMENTAL, per-instance, RUNTIME-ONLY. Enables the lock-free read-snapshot
+  // (commit-lock-narrowing) MVCC path. MUST NOT be persisted or placed in SalientConfig:
+  // durable data must be identical regardless of this flag (flip across restart is safe).
+  bool experimental_lockfree_read_snapshot{false};
+
   struct Transaction {
     IsolationLevel isolation_level{IsolationLevel::SNAPSHOT_ISOLATION};
     friend bool operator==(const Transaction &lrh, const Transaction &rhs) = default;

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -126,7 +126,8 @@ struct Config {
   // EXPERIMENTAL, per-instance, RUNTIME-ONLY. Enables the lock-free read-snapshot
   // (commit-lock-narrowing) MVCC path. MUST NOT be persisted or placed in SalientConfig:
   // durable data must be identical regardless of this flag (flip across restart is safe).
-  bool experimental_lockfree_read_snapshot{false};
+  bool experimental_lockfree_read_snapshot{
+      true};  // TEMP(CI): default ON to run the suite with the flag on. REVERT before merge.
 
   struct Transaction {
     IsolationLevel isolation_level{IsolationLevel::SNAPSHOT_ISOLATION};

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -14607,7 +14607,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     // Write label indices.
     {
       spdlog::trace("snapshot writing label indices");
-      auto label = transaction->active_indices_->label_->ListIndices(transaction->start_timestamp);
+      auto label = transaction->active_indices_->label_->ListIndices(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(label.size());
       for (const auto &item : label) {
         write_mapping(item);
@@ -14620,7 +14620,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     // Write label indices statistics.
     {
       // NOTE: On-disk does not support snapshots
-      auto labels = transaction->active_indices_->label_->ListIndices(transaction->start_timestamp);
+      auto labels = transaction->active_indices_->label_->ListIndices(transaction->SchemaVisibilityBound());
       const auto size_pos = snapshot.GetPosition();
       snapshot.WriteUint(0);  // Just a place holder
       unsigned i = 0;
@@ -14705,8 +14705,8 @@ std::optional<std::filesystem::path> CreateSnapshot(
       }
     };
 
-    auto asc_indices = inmem_active_indices->ListIndices(transaction->start_timestamp, IndexOrder::ASC);
-    auto desc_indices = inmem_active_indices->ListIndices(transaction->start_timestamp, IndexOrder::DESC);
+    auto asc_indices = inmem_active_indices->ListIndices(transaction->SchemaVisibilityBound(), IndexOrder::ASC);
+    auto desc_indices = inmem_active_indices->ListIndices(transaction->SchemaVisibilityBound(), IndexOrder::DESC);
 
     spdlog::trace("snapshot writing label-property indices");
     // Write ASC label+properties indices.
@@ -14732,7 +14732,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     snapshot.WriteMarker(Marker::SECTION_EDGE_INDICES);
     {
       spdlog::trace("snapshot writing edge-type indices");
-      auto edge_type = transaction->active_indices_->edge_type_->ListIndices(transaction->start_timestamp);
+      auto edge_type = transaction->active_indices_->edge_type_->ListIndices(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
         write_mapping(item);
@@ -14745,7 +14745,8 @@ std::optional<std::filesystem::path> CreateSnapshot(
     // Write edge-type + property indices.
     {
       spdlog::trace("snapshot writing edge-type-property indices");
-      auto edge_type = transaction->active_indices_->edge_type_properties_->ListIndices(transaction->start_timestamp);
+      auto edge_type =
+          transaction->active_indices_->edge_type_properties_->ListIndices(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
         write_mapping(item.first);
@@ -14759,7 +14760,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     // Write global edge property indices.
     {
       spdlog::trace("snapshot writing edge-property indices");
-      auto indices = transaction->active_indices_->edge_property_->ListIndices(transaction->start_timestamp);
+      auto indices = transaction->active_indices_->edge_property_->ListIndices(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(indices.size());
       for (const auto &property : indices) {
         write_mapping(property);
@@ -14769,7 +14770,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     // Write global vertex property indices.
     {
       spdlog::trace("snapshot writing vertex-property indices");
-      auto indices = transaction->active_indices_->vertex_property_->ListIndices(transaction->start_timestamp);
+      auto indices = transaction->active_indices_->vertex_property_->ListIndices(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(indices.size());
       for (const auto &property : indices) {
         write_mapping(property);
@@ -14856,7 +14857,8 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write existence constraints.
     {
-      auto existence = transaction->active_constraints_->existence_->ListConstraints(transaction->start_timestamp);
+      auto existence =
+          transaction->active_constraints_->existence_->ListConstraints(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(existence.size());
       for (const auto &item : existence) {
         write_mapping(item.first);
@@ -14869,7 +14871,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write unique constraints.
     {
-      auto unique = transaction->active_constraints_->unique_->ListConstraints(transaction->start_timestamp);
+      auto unique = transaction->active_constraints_->unique_->ListConstraints(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(unique.size());
       for (const auto &item : unique) {
         write_mapping(item.first);
@@ -14884,7 +14886,8 @@ std::optional<std::filesystem::path> CreateSnapshot(
     }
     // Write type constraints
     {
-      auto type_constraints = transaction->active_constraints_->type_->ListConstraints(transaction->start_timestamp);
+      auto type_constraints =
+          transaction->active_constraints_->type_->ListConstraints(transaction->SchemaVisibilityBound());
       snapshot.WriteUint(type_constraints.size());
       for (const auto &[label, property, type] : type_constraints) {
         write_mapping(label);

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -86,6 +86,13 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   std::optional<uint64_t> current_wal_from_timestamp;
   uint64_t last_durable_timestamp{kTimestampInitialId};
 
+  // EXPERIMENTAL (lock-free-read-snapshot): under the flag the committer holds commit_mutex_ (not engine_lock_)
+  // across its WAL-append window, so take commit_mutex_ here — in the committer's lock order, before engine_lock_ —
+  // to keep the current WAL stable while its seq/timestamps are read. Released together with transaction_guard.
+  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  if (main_storage->config_.experimental_lockfree_read_snapshot) {
+    commit_serializer.emplace(main_storage->commit_mutex_);
+  }
   std::unique_lock transaction_guard(
       main_storage->engine_lock_);  // Hold the main_storage lock so the current wal file cannot be changed
 
@@ -101,6 +108,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
     current_wal_seq_num.emplace(main_storage->wal_file_->SequenceNumber());
     // No need to hold the lock since the current WAL is present
     transaction_guard.unlock();
+    commit_serializer.reset();
   }
 
   // Get WAL files, ordered by timestamp, from oldest to newest
@@ -110,6 +118,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   if (transaction_guard.owns_lock()) {
     transaction_guard.unlock();  // In case we didn't have a current wal file, we can unlock only now since there is no
                                  // guarantee what we'll see after we add the wal file
+    commit_serializer.reset();
   }
 
   // Read in snapshot files

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -35,6 +35,7 @@
 #include "replication_coordination_glue/role.hpp"
 #include "requests/requests.hpp"
 #include "spdlog/spdlog.h"
+#include "storage/v2/commit_probe.hpp"
 #include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/durability/durability.hpp"
 #include "storage/v2/durability/paths.hpp"
@@ -1054,6 +1055,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   MG_ASSERT(!transaction_.has_serialization_error, "Unable to commit due to serialization error.");
 
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  const bool lockfree = config_.experimental_lockfree_read_snapshot;
 
   PublishIndexArming();
 
@@ -1083,6 +1085,11 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
     return std::unexpected{validation_result.error()};
   }
 
+  // Serialize committers across mint->durability->publish so mint-order == publish-order
+  // (keeps the watermark contiguous). Acquired BEFORE the mint. Held for the whole function.
+  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  if (lockfree) commit_serializer.emplace(mem_storage->commit_mutex_);
+
   auto engine_guard = std::unique_lock{storage_->engine_lock_};
   commit_timestamp_.emplace(mem_storage->GetCommitTimestamp());
 
@@ -1109,9 +1116,16 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   // so the wal files are consistent
   auto const durability_commit_timestamp = commit_args.durable_timestamp(*commit_timestamp_);
 
+  // Release engine_lock so WAL + replication run lock-free (commit_mutex_ still held);
+  // BEGIN can now mint a start_timestamp without waiting on the durability RTT.
+  if (lockfree) {
+    engine_guard.unlock();
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_mint);
+  }
+
   // Specific case in which durability mode is != PERIODIC_SNAPSHOT_WITH_WAL
   if (!mem_storage->InitializeWalFile(mem_storage->repl_storage_state_.epoch_.id())) {
-    FinalizeCommitPhase(durability_commit_timestamp);
+    FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/lockfree);
     // No WAL file, hence no need to finalize it
     return {};
   }
@@ -1123,6 +1137,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
   // If main executes this: Block until we receive votes from all replicas.
   // If replica executes this:,
+  InvokeProbe(mem_storage->commit_probe_, &CommitProbe::during_durability);
   auto const repl_prepare_phase_ok =
       HandleDurabilityAndReplicate(durability_commit_timestamp, replicating_txn, commit_args);
 
@@ -1132,7 +1147,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
         // If SYNC and ASYNC replica executes this, commit immediately while holding the engine lock
         if (!two_phase_commit) {
           // WAL file is already finalized
-          FinalizeCommitPhase(durability_commit_timestamp);
+          FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/lockfree);
         }
       });
   if (replica_write_was_applied) {
@@ -1147,7 +1162,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
         // If there are no STRICT_SYNC replicas for the current txn
         if (!replicating_txn.ShouldRunTwoPC()) {
           // WAL file is already finalized
-          FinalizeCommitPhase(durability_commit_timestamp);
+          FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/lockfree);
 
           auto failures = replicating_txn.CollectAllFailures();
           // update replicas' cached commit info to this txn's absolute committed-txn count
@@ -1164,7 +1179,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
         if (repl_prepare_phase_ok) {
           // All replicas voted yes, hence they want to commit the current transaction
-          FinalizeCommitPhase(durability_commit_timestamp);
+          FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/lockfree);
         }
         // We need to finalize WAL file after running FinalizeCommitPhase because we update there commit value in WAL
 
@@ -1183,7 +1198,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
         if (!failures.empty()) {
           // Release engine lock because we don't have to hold it anymore for abort
-          engine_guard.unlock();
+          if (engine_guard.owns_lock()) engine_guard.unlock();
           AbortAndResetCommitTs();
           return std::unexpected{ReplicationError{.failures = std::move(failures), .transaction_committed = false}};
         }
@@ -1194,8 +1209,15 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   return *std::move(res);
 }
 
-void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durability_commit_timestamp) {
+void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durability_commit_timestamp,
+                                                            bool const acquire_engine_lock) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+
+  std::optional<std::unique_lock<utils::SpinLock>> pub_guard;
+  if (acquire_engine_lock) {
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_publish);
+    pub_guard.emplace(storage_->engine_lock_);
+  }
 
   if (config_.enable_schema_info) {
     // Queue schema update instead of processing immediately. This ensures
@@ -1303,6 +1325,13 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
   }
   if (!transaction_.text_edge_index_change_collector_.empty()) {
     transaction_.active_indices_->text_edge_->ApplyTrackedChanges(transaction_, mem_storage->name_id_mapper_.get());
+  }
+
+  if (config_.experimental_lockfree_read_snapshot) {
+    // Publish the watermark: readers that BEGIN after this see this commit. Ordered AFTER the
+    // commit_info->timestamp store and MarkFinished, under the same publish engine_lock hold.
+    mem_storage->last_committed_mvcc_ts_.store(*commit_timestamp_, std::memory_order_release);
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_publish);
   }
   is_transaction_active_ = false;
 }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3328,7 +3328,10 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
 
           // Track highest commit timestamp among all contributors. We can only
           // unlink when ALL contributors are inactive, so we must wait until
-          // highest_commit_ts < oldest_active_start_timestamp.
+          // highest_commit_ts < visibility_horizon (the reclaim gate this feeds at the
+          // `unlinkable_timestamp >= visibility_horizon` check below). Under the lock-free-read-snapshot
+          // flag visibility_horizon is min(snapshot-based horizon, oldest_active_start_timestamp), so it
+          // is at or below the old oldest_active_start_timestamp bound; OFF the two coincide.
           if (ts > highest_commit_ts) {
             highest_commit_ts = ts;
           }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2975,9 +2975,9 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
     // start_timestamp in mvcc.hpp, so this is inert).
     snapshot_ts = config_.experimental_lockfree_read_snapshot ? last_committed_mvcc_ts_.load(std::memory_order_acquire)
                                                               : start_timestamp;
-    // Publish this active txn's snapshot_ts into the GC visibility ring (snap first, tag last, release-ordered)
-    // so GC can recover min(active snapshot_ts). Only meaningful under the flag; harmless (and warm) when OFF.
-    if (config_.experimental_lockfree_read_snapshot) {
+    // Publish this SI txn's frozen snapshot_ts into the GC visibility ring so GC can recover min(active snapshot_ts).
+    // RC/RU do not freeze a snapshot_ts and must not hold the GC floor down; skip them.
+    if (config_.experimental_lockfree_read_snapshot && isolation_level == IsolationLevel::SNAPSHOT_ISOLATION) {
       // Invalidate-first message passing (writers serialized under engine_lock_; the GC reader is lock-free):
       // publish the empty sentinel into tag BEFORE overwriting snap, so a concurrent GC read can never pair
       // this slot's NEW snap with the PREVIOUS owner's tag. If the reader's acquire-load of snap observes the

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -4935,6 +4935,12 @@ void InMemoryStorage::FreeMemory(utils::ResourceLockGuard main_guard, bool perio
 uint64_t InMemoryStorage::GetCommitTimestamp() { return timestamp_++; }
 
 void InMemoryStorage::PrepareForNewEpoch() {
+  // EXPERIMENTAL (lock-free-read-snapshot): take commit_mutex_ before engine_lock_ (committer order) so this
+  // WAL reset cannot race a committer's WAL append under the flag.
+  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  if (config_.experimental_lockfree_read_snapshot) {
+    commit_serializer.emplace(commit_mutex_);
+  }
   std::unique_lock engine_guard{engine_lock_};
   if (wal_file_) {
     wal_file_->FinalizeWal();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1239,7 +1239,7 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
         durability_commit_timestamp,
         SchemaUpdateData(std::move(transaction_.schema_diff_),
                          std::move(transaction_.post_process_),
-                         transaction_.start_timestamp,
+                         transaction_.SchemaReconstructionBound(),
                          durability_commit_timestamp,
                          mem_storage->config_.salient.items.properties_on_edges));
   }
@@ -1881,7 +1881,7 @@ void InMemoryStorage::ProcessPendingSchemaUpdates(uint64_t up_to_commit_ts) {
 
   for (auto &update : to_process) {
     schema_info_.ProcessTransaction(
-        update.schema_diff, update.post_process, update.start_ts, update.commit_ts, update.property_on_edges);
+        update.schema_diff, update.post_process, update.snapshot_bound, update.commit_ts, update.property_on_edges);
   }
 }
 
@@ -3219,12 +3219,15 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
   if (config_.salient.items.enable_schema_info) {
     std::lock_guard<std::mutex> const lock{schema_queue_mutex_};
     if (!pending_schema_updates_.empty()) {
-      // Establish earliest start time
-      uint64_t min_queued_start_ts = std::numeric_limits<uint64_t>::max();
+      // Establish the earliest reconstruction boundary still queued: each pending update's deferred
+      // reconstruction walks version chains down to `ts < snapshot_bound`, so no delta at or after
+      // that boundary may be unlinked yet. snapshot_bound <= start_timestamp, so this is at least as
+      // conservative as (and correctly aligned with) the boundary the reconstruction actually uses.
+      uint64_t min_queued_bound = std::numeric_limits<uint64_t>::max();
       for (const auto &[commit_ts, update_data] : pending_schema_updates_) {
-        min_queued_start_ts = std::min(min_queued_start_ts, update_data.start_ts);
+        min_queued_bound = std::min(min_queued_bound, update_data.snapshot_bound);
       }
-      oldest_active_start_timestamp = std::min(min_queued_start_ts, oldest_active_start_timestamp);
+      oldest_active_start_timestamp = std::min(min_queued_bound, oldest_active_start_timestamp);
     }
   }
 
@@ -3234,7 +3237,7 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
   // raw_oldest_active < timestamp_, so this correctly protects it (unlike a `raw > last_committed` test).
   bool no_active_txns = false;
   if (config_.experimental_lockfree_read_snapshot) {
-    auto const engine_guard = std::lock_guard{engine_lock_};
+    auto const engine_guard = std::scoped_lock{engine_lock_};
     no_active_txns = raw_oldest_active >= timestamp_;
   }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2950,6 +2950,8 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
                                  commit_ts_info.num_committed_txns_,
                                  metric_handles_.unreleased_delta_objects};
   transaction.snapshot_ts = snapshot_ts;
+  transaction.lockfree_snapshot =
+      config_.experimental_lockfree_read_snapshot && isolation_level == IsolationLevel::SNAPSHOT_ISOLATION;
   return transaction;
 }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -334,8 +334,10 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       global_locker_(file_retainer_.AddLocker()) {
   MG_ASSERT(config.salient.storage_mode != StorageMode::ON_DISK_TRANSACTIONAL,
             "Invalid storage mode sent to InMemoryStorage constructor!");
-  // NOLINTNEXTLINE(modernize-avoid-c-arrays) — make_unique<T[]> is the idiomatic heap array (cf. ring_buffer.hpp).
-  snapshot_slots_ = std::make_unique<SnapshotSlot[]>(kSnapshotSlots);
+  if (config_.experimental_lockfree_read_snapshot) {
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays) — make_unique<T[]> is the idiomatic heap array (cf. ring_buffer.hpp).
+    snapshot_slots_ = std::make_unique<SnapshotSlot[]>(kSnapshotSlots);
+  }
   MG_ASSERT(!config_.salient.items.storage_light_edge || config_.salient.items.properties_on_edges,
             "Light edges require properties on edges (--storage-light-edge implies "
             "--storage-properties-on-edges=true).");
@@ -1147,7 +1149,9 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
   // If main executes this: Block until we receive votes from all replicas.
   // If replica executes this:,
-  InvokeProbe(mem_storage->commit_probe_, &CommitProbe::during_durability);
+  if (lockfree) {
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::during_durability);
+  }
   auto const repl_prepare_phase_ok =
       HandleDurabilityAndReplicate(durability_commit_timestamp, replicating_txn, commit_args);
 
@@ -2936,7 +2940,7 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
                                                               : start_timestamp;
     // Publish this active txn's snapshot_ts into the GC visibility ring (snap first, tag last, release-ordered)
     // so GC can recover min(active snapshot_ts). Only meaningful under the flag; harmless (and warm) when OFF.
-    {
+    if (config_.experimental_lockfree_read_snapshot) {
       // Invalidate-first message passing (writers serialized under engine_lock_; the GC reader is lock-free):
       // publish the empty sentinel into tag BEFORE overwriting snap, so a concurrent GC read can never pair
       // this slot's NEW snap with the PREVIOUS owner's tag. If the reader's acquire-load of snap observes the
@@ -5470,6 +5474,14 @@ void InMemoryStorage::Clear(std::function<void()> const &on_progress) {
   edge_count_.store(0, std::memory_order_release);
 
   timestamp_ = kTimestampInitialId;
+  if (config_.experimental_lockfree_read_snapshot) {
+    // Recovery via Clear() rewinds timestamp_; the read-snapshot watermark and GC visibility floor
+    // must rewind with it, or a post-recovery commit at a low ts appears committed-before a reader's
+    // stale-high snapshot_ts (SI phantom read) and the floor stalls. Recovery paths reseed the
+    // watermark to the recovered durable ts afterward.
+    last_committed_mvcc_ts_.store(kTimestampInitialId, std::memory_order_release);
+    gc_visibility_floor_.store(kTimestampInitialId, std::memory_order_release);
+  }
   transaction_id_ = kTransactionInitialId;
 
   // Reset WALs

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -334,6 +334,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       global_locker_(file_retainer_.AddLocker()) {
   MG_ASSERT(config.salient.storage_mode != StorageMode::ON_DISK_TRANSACTIONAL,
             "Invalid storage mode sent to InMemoryStorage constructor!");
+  snapshot_slots_ = std::make_unique<SnapshotSlot[]>(kSnapshotSlots);
   MG_ASSERT(!config_.salient.items.storage_light_edge || config_.salient.items.properties_on_edges,
             "Light edges require properties on edges (--storage-light-edge implies "
             "--storage-properties-on-edges=true).");
@@ -2924,6 +2925,19 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
     // start_timestamp in mvcc.hpp, so this is inert).
     snapshot_ts = config_.experimental_lockfree_read_snapshot ? last_committed_mvcc_ts_.load(std::memory_order_acquire)
                                                               : start_timestamp;
+    // Publish this active txn's snapshot_ts into the GC visibility ring (snap first, tag last, release-ordered)
+    // so GC can recover min(active snapshot_ts). Only meaningful under the flag; harmless (and warm) when OFF.
+    {
+      // Invalidate-first message passing (writers serialized under engine_lock_; the GC reader is lock-free):
+      // publish the empty sentinel into tag BEFORE overwriting snap, so a concurrent GC read can never pair
+      // this slot's NEW snap with the PREVIOUS owner's tag. If the reader's acquire-load of snap observes the
+      // new value, it synchronizes-with the release store below and therefore also observes tag == sentinel
+      // (or the final tag), never the stale predecessor start_ts. tag last, as the commit point.
+      auto &gc_slot = snapshot_slots_[start_timestamp % kSnapshotSlots];
+      gc_slot.tag.store(std::numeric_limits<uint64_t>::max(), std::memory_order_relaxed);  // invalidate old owner
+      gc_slot.snap.store(snapshot_ts, std::memory_order_release);                          // carries the invalidation
+      gc_slot.tag.store(start_timestamp, std::memory_order_release);                       // publish, tag last
+    }
     // IMPORTANT: this is retrieved while under the lock so that the index is consistant with the timestamp
     point_index_context = indices_.point_index_.CreatePointIndexContext();
     // Needed by snapshot to sync the durable and logical ts. Load ldt and num_committed_txns from the same atomic
@@ -3089,6 +3103,24 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
   }
 }
 
+uint64_t InMemoryStorage::GcVisibilityHorizon(uint64_t oldest_active_start_timestamp) {
+  if (!config_.experimental_lockfree_read_snapshot) return oldest_active_start_timestamp;  // OFF: byte-identical
+  auto const &gc_slot = snapshot_slots_[oldest_active_start_timestamp % kSnapshotSlots];
+  uint64_t const snap = gc_slot.snap.load(std::memory_order_acquire);
+  uint64_t const tag = gc_slot.tag.load(std::memory_order_acquire);
+  if (tag == oldest_active_start_timestamp) {
+    // Advance the monotone floor to this confirmed min(active snapshot_ts).
+    uint64_t cur = gc_visibility_floor_.load(std::memory_order_acquire);
+    while (snap > cur && !gc_visibility_floor_.compare_exchange_weak(
+                             cur, snap, std::memory_order_release, std::memory_order_acquire)) {
+    }
+    return std::max(snap, cur);
+  }
+  // Slot recycled / mid-BEGIN / no owner: fall back to the non-regressing floor. NEVER return
+  // oldest_active_start_timestamp here — that is the too-large value that would over-reclaim under the flag.
+  return gc_visibility_floor_.load(std::memory_order_acquire);
+}
+
 void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool periodic) {
   // NOTE: A single call need not handle objects deleted under a different storage mode: SetStorageMode
   // runs GC before any transaction in the new mode can start.
@@ -3177,6 +3209,12 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
       oldest_active_start_timestamp = std::min(min_queued_start_ts, oldest_active_start_timestamp);
     }
   }
+
+  // EXPERIMENTAL (lock-free-read-snapshot): the physical horizon (oldest_active_start_timestamp, above)
+  // still bounds delta-buffer freeing and object retirement, but MVCC visibility now keys off the OldestActive
+  // txn's snapshot_ts, which is <= its start_ts. Compute that min(active snapshot_ts) once here; OFF path
+  // returns oldest_active_start_timestamp unchanged (byte-identical).
+  uint64_t const visibility_horizon = GcVisibilityHorizon(oldest_active_start_timestamp);
 
   // When a transaction commits with non-sequential deltas, its deltas may be mixed with
   // deltas from other transactions in the same delta chains. We cannot immediately unlink
@@ -3301,7 +3339,7 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
     auto const unlinkable_timestamp = linked_entry->unlinkable_timestamp_;
 
     // only process those that are no longer active
-    if (unlinkable_timestamp >= oldest_active_start_timestamp) {
+    if (unlinkable_timestamp >= visibility_horizon) {
       ++linked_entry;  // can not process, skip
       continue;        // must continue to next transaction, because committed_transactions_ was not ordered
     }
@@ -3388,6 +3426,8 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
             //            ▲
             //            │
             //  oldest_active_start_timestamp
+            // EXPERIMENTAL (lock-free-read-snapshot): when the flag is ON the boundary used just below is
+            // visibility_horizon (= min active snapshot_ts), which sits at or before this start-ts boundary.
 
             if (prev.delta->commit_info == commit_info_ptr) {
               // The delta that is newer than this one is also a delta from this
@@ -3396,7 +3436,7 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
               break;
             }
 
-            if (prev.delta->commit_info->timestamp.load() < oldest_active_start_timestamp) {
+            if (prev.delta->commit_info->timestamp.load() < visibility_horizon) {
               if (IsDeltaNonSequential(*prev.delta)) {
                 // Non-sequential predecessor: readers follow next, so we must
                 // null it to stop traversal into freed memory. We can skip the
@@ -3407,7 +3447,10 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
                 // - the GC is serialized via gc_lock_.
                 // Safe for concurrent readers: all deltas beyond this point are
                 // also inactive (guaranteed by waiting_gc_deltas_), so no
-                // active transaction needs to read past here.
+                // active transaction needs to read past here. Under the flag the
+                // horizon is visibility_horizon (min active snapshot_ts), not a
+                // start-ts, so "no active transaction needs to read past here"
+                // holds against snapshot-based visibility as well.
                 prev.delta->next.store(nullptr, std::memory_order_release);
               }
               break;
@@ -3536,12 +3579,12 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
   if (auto token = stop_source.get_token(); !token.stop_requested()) {
     uint64_t swept = 0;
     if (index_cleanup_vertex_needed || index_cleanup_vertex_performance) {
-      swept += indices_.RemoveObsoleteVertexEntries(this, oldest_active_start_timestamp, token, sweep_arming);
+      swept += indices_.RemoveObsoleteVertexEntries(this, visibility_horizon, token, sweep_arming);
       auto *mem_unique_constraints = static_cast<InMemoryUniqueConstraints *>(constraints_.unique_constraints_.get());
-      swept += mem_unique_constraints->RemoveObsoleteEntries(this, oldest_active_start_timestamp, token, sweep_arming);
+      swept += mem_unique_constraints->RemoveObsoleteEntries(this, visibility_horizon, token, sweep_arming);
     }
     if (index_cleanup_edge_needed || index_cleanup_edge_performance) {
-      swept += indices_.RemoveObsoleteEdgeEntries(this, oldest_active_start_timestamp, token, sweep_arming);
+      swept += indices_.RemoveObsoleteEdgeEntries(this, visibility_horizon, token, sweep_arming);
     }
     metric_handles_.gc_index_sweeps.Increment(static_cast<double>(swept));
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -334,6 +334,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       global_locker_(file_retainer_.AddLocker()) {
   MG_ASSERT(config.salient.storage_mode != StorageMode::ON_DISK_TRANSACTIONAL,
             "Invalid storage mode sent to InMemoryStorage constructor!");
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays) — make_unique<T[]> is the idiomatic heap array (cf. ring_buffer.hpp).
   snapshot_slots_ = std::make_unique<SnapshotSlot[]>(kSnapshotSlots);
   MG_ASSERT(!config_.salient.items.storage_light_edge || config_.salient.items.properties_on_edges,
             "Light edges require properties on edges (--storage-light-edge implies "

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -447,12 +447,14 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       edge_id_.store(info->next_edge_id, std::memory_order_release);
       timestamp_ = std::max(timestamp_, info->next_timestamp);
       // EXPERIMENTAL (lock-free-read-snapshot): restore the read-snapshot watermark to the highest recovered
-      // committed timestamp so a post-recovery reader sees every recovered commit (and a new commit, minted
-      // at next_timestamp > LDT, stays invisible). Runtime-only; gated so the OFF path is unchanged.
+      // committed timestamp.  We derive it from the local MVCC counter (timestamp_ - 1 = highest committed ts
+      // in this storage's own timestamp space) rather than from a durability-space field, so the watermark is
+      // space-correct: readers compare it against local MVCC delta timestamps, which live in the same space.
+      // Guard against underflow when the counter is still at its initial value.
       if (config_.experimental_lockfree_read_snapshot) {
-        last_committed_mvcc_ts_.store(
-            std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed), info->last_durable_timestamp),
-            std::memory_order_release);
+        last_committed_mvcc_ts_.store(std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed),
+                                               timestamp_ > kTimestampInitialId ? timestamp_ - 1 : kTimestampInitialId),
+                                      std::memory_order_release);
       }
       CommitTsInfo const new_info{.ldt_ = info->last_durable_timestamp,
                                   .num_committed_txns_ = info->num_committed_txns};
@@ -4774,9 +4776,13 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
     vertex_id_.store(recovery_info.next_vertex_id, std::memory_order_release);
     edge_id_.store(recovery_info.next_edge_id, std::memory_order_release);
     timestamp_ = std::max(timestamp_, recovery_info.next_timestamp);
+    // EXPERIMENTAL (lock-free-read-snapshot): seed the watermark from the local MVCC counter
+    // (timestamp_ - 1 = highest committed ts in this storage's own timestamp space).  Using the
+    // local counter is space-correct: readers compare against local MVCC delta timestamps.
+    // Guard against underflow when the counter is still at its initial value.
     if (config_.experimental_lockfree_read_snapshot) {
       last_committed_mvcc_ts_.store(std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed),
-                                             recovered_snapshot.snapshot_info.durable_timestamp),
+                                             timestamp_ > kTimestampInitialId ? timestamp_ - 1 : kTimestampInitialId),
                                     std::memory_order_release);
     }
     loaded_snapshot_uuid = recovered_snapshot.snapshot_info.uuid;

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1055,7 +1055,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   MG_ASSERT(!transaction_.has_serialization_error, "Unable to commit due to serialization error.");
 
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
-  const bool lockfree = config_.experimental_lockfree_read_snapshot;
+  const bool lockfree = mem_storage->config_.experimental_lockfree_read_snapshot;
 
   PublishIndexArming();
 
@@ -1327,7 +1327,7 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
     transaction_.active_indices_->text_edge_->ApplyTrackedChanges(transaction_, mem_storage->name_id_mapper_.get());
   }
 
-  if (config_.experimental_lockfree_read_snapshot) {
+  if (mem_storage->config_.experimental_lockfree_read_snapshot) {
     // Publish the watermark: readers that BEGIN after this see this commit. Ordered AFTER the
     // commit_info->timestamp store and MarkFinished, under the same publish engine_lock hold.
     mem_storage->last_committed_mvcc_ts_.store(*commit_timestamp_, std::memory_order_release);
@@ -1365,6 +1365,10 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   auto new_transaction = mem_storage->CreateTransaction(transaction_.isolation_level, transaction_.storage_mode);
   transaction_.start_timestamp = new_transaction.start_timestamp;
   transaction_.transaction_id = new_transaction.transaction_id;
+  // PERIODIC COMMIT advances the SI snapshot boundary too, so the next batch sees the batch just
+  // committed above (and does not pin GC). Unconditional: with the experiment OFF, snapshot_ts equals
+  // start_timestamp and is unused by the read path, so this copy is inert.
+  transaction_.snapshot_ts = new_transaction.snapshot_ts;
   transaction_.commit_info.reset();
   // Do NOT touch `original_start_timestamp` — it must remain stable per-query
   // (procedures use it as a cache key across PERIODIC COMMIT).
@@ -2904,6 +2908,7 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
   // `timestamp`) below.
   uint64_t transaction_id = 0;
   uint64_t start_timestamp = 0;
+  uint64_t snapshot_ts = 0;
   CommitTsInfo commit_ts_info;
   std::optional<PointIndexContext> point_index_context;
   ActiveIndicesPtr active_indices;
@@ -2912,6 +2917,13 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
     auto guard = std::lock_guard{engine_lock_};
     transaction_id = transaction_id_++;
     start_timestamp = timestamp_++;
+    // Capture the SI snapshot boundary under the same engine_lock as the mint so it is consistent with
+    // start_timestamp. When the lock-free-read-snapshot experiment is ON, SI reads use this frozen
+    // last-published-commit watermark (snapshot_ts < start_timestamp, since the watermark holds an
+    // earlier commit ts). When OFF it equals start_timestamp (legacy semantics; SI reads still key off
+    // start_timestamp in mvcc.hpp, so this is inert).
+    snapshot_ts = config_.experimental_lockfree_read_snapshot ? last_committed_mvcc_ts_.load(std::memory_order_acquire)
+                                                              : start_timestamp;
     // IMPORTANT: this is retrieved while under the lock so that the index is consistant with the timestamp
     point_index_context = indices_.point_index_.CreatePointIndexContext();
     // Needed by snapshot to sync the durable and logical ts. Load ldt and num_committed_txns from the same atomic
@@ -2925,18 +2937,20 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
   auto async_index_helper = AsyncIndexHelper{config_, *active_indices, start_timestamp};
 
   DMG_ASSERT(point_index_context.has_value(), "Expected a value, even if got 0 point indexes");
-  return {transaction_id,
-          start_timestamp,
-          isolation_level,
-          storage_mode,
-          false,
-          *std::move(point_index_context),
-          std::move(active_indices),
-          std::move(active_constraints),
-          std::move(async_index_helper),
-          commit_ts_info.ldt_,
-          commit_ts_info.num_committed_txns_,
-          metric_handles_.unreleased_delta_objects};
+  auto transaction = Transaction{transaction_id,
+                                 start_timestamp,
+                                 isolation_level,
+                                 storage_mode,
+                                 false,
+                                 *std::move(point_index_context),
+                                 std::move(active_indices),
+                                 std::move(active_constraints),
+                                 std::move(async_index_helper),
+                                 commit_ts_info.ldt_,
+                                 commit_ts_info.num_committed_txns_,
+                                 metric_handles_.unreleased_delta_objects};
+  transaction.snapshot_ts = snapshot_ts;
+  return transaction;
 }
 
 void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1030,6 +1030,30 @@ void InMemoryStorage::InMemoryAccessor::CheckForFastDiscardOfDeltas() {
   // while still holding engine lock and after durability + replication,
   // check if we can fast discard deltas (i.e. do not hand over to GC)
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+
+  // Invariant note (experimental_lockfree_read_snapshot path):
+  //
+  // Under the lockfree flag, engine_lock_ is released after the mint so that WAL + replication
+  // run without blocking concurrent BEGINs.  A transaction that calls BEGIN inside this
+  // mint->publish gap receives a start_timestamp that is ABOVE this commit's commit_timestamp_.
+  // Such a "gap-BEGIN" transaction therefore does NOT lower commit_log_->OldestActive(), so
+  // no_older_transactions can be true even while a gap-BEGIN reader is still live and can still
+  // observe this transaction's deltas.
+  //
+  // The safety invariant therefore falls entirely on no_newer_transactions: that read is protected
+  // by engine_lock_ (this function is called from FinalizeCommitPhase while the publish hold is
+  // still active, and on the OFF path from PrepareForCommitPhase's engine_lock_ hold).
+  // engine_lock_ serialises the transaction_id_ read against a concurrent GetCommitTimestamp()
+  // (which increments transaction_id_).  If no_newer_transactions is true, no gap-BEGIN can exist
+  // because the gap was closed before a new transaction_id_ was issued.
+  //
+  // Consequence: moving fast-discard outside of the engine_lock_ hold would make the
+  // transaction_id_ read unsynchronised and could discard deltas that a concurrent gap-BEGIN
+  // reader still needs -- use-after-free.
+  //
+  // Note: utils::SpinLock wraps pthread_spinlock_t and exposes no is_locked() / owner-tracking
+  // API, so "caller holds engine_lock_" cannot be expressed as a DMG_ASSERT here; it is an
+  // enforced caller contract, not a machine-checkable precondition.
   bool const no_older_transactions = mem_storage->commit_log_->OldestActive() == *commit_timestamp_;
   bool const no_newer_transactions = mem_storage->transaction_id_ == transaction_.transaction_id + 1;
   if (no_older_transactions && no_newer_transactions) [[unlikely]] {
@@ -1099,8 +1123,19 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
     return std::unexpected{validation_result.error()};
   }
 
-  // Serialize committers across mint->durability->publish so mint-order == publish-order
-  // (keeps the watermark contiguous). Acquired BEFORE the mint. Held for the whole function.
+  // Serialize committers across mint->durability->publish for two reasons:
+  //
+  // 1. Watermark contiguity: mint-order must equal publish-order so the read-snapshot watermark
+  //    advances without gaps.  Acquired BEFORE the mint.  Held for the whole function.
+  //
+  // 2. Unique-constraint correctness: UniqueConstraintsViolation() runs during the brief phase-1
+  //    engine_lock_ hold (~line below) and must see every already-committed value.  That requires
+  //    that no other committer can sit between its own mint and publish while the validation runs
+  //    -- an unpublished committer's values are not yet visible through the normal MVCC read path,
+  //    so they would be invisible to the validator and a duplicate could slip through.
+  //    commit_mutex_ provides exactly this guarantee.  Releasing commit_mutex_ earlier (e.g. after
+  //    the WAL append) would break unique-constraint validation even if watermark ordering were
+  //    re-established through another mechanism.
   std::optional<std::unique_lock<std::mutex>> commit_serializer;
   if (lockfree) commit_serializer.emplace(mem_storage->commit_mutex_);
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -444,6 +444,14 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       vertex_id_.store(info->next_vertex_id, std::memory_order_release);
       edge_id_.store(info->next_edge_id, std::memory_order_release);
       timestamp_ = std::max(timestamp_, info->next_timestamp);
+      // EXPERIMENTAL (lock-free-read-snapshot): restore the read-snapshot watermark to the highest recovered
+      // committed timestamp so a post-recovery reader sees every recovered commit (and a new commit, minted
+      // at next_timestamp > LDT, stays invisible). Runtime-only; gated so the OFF path is unchanged.
+      if (config_.experimental_lockfree_read_snapshot) {
+        last_committed_mvcc_ts_.store(
+            std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed), info->last_durable_timestamp),
+            std::memory_order_release);
+      }
       CommitTsInfo const new_info{.ldt_ = info->last_durable_timestamp,
                                   .num_committed_txns_ = info->num_committed_txns};
       repl_storage_state_.commit_ts_info_.store(new_info, std::memory_order_release);
@@ -3104,21 +3112,26 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
   }
 }
 
-uint64_t InMemoryStorage::GcVisibilityHorizon(uint64_t oldest_active_start_timestamp) {
-  if (!config_.experimental_lockfree_read_snapshot) return oldest_active_start_timestamp;  // OFF: byte-identical
-  auto const &gc_slot = snapshot_slots_[oldest_active_start_timestamp % kSnapshotSlots];
+uint64_t InMemoryStorage::GcVisibilityHorizon(uint64_t raw_oldest_active, bool no_active_txns) {
+  if (!config_.experimental_lockfree_read_snapshot) return raw_oldest_active;  // OFF: byte-identical
+  auto const &gc_slot = snapshot_slots_[raw_oldest_active % kSnapshotSlots];
   uint64_t const snap = gc_slot.snap.load(std::memory_order_acquire);
   uint64_t const tag = gc_slot.tag.load(std::memory_order_acquire);
-  if (tag == oldest_active_start_timestamp) {
-    // Advance the monotone floor to this confirmed min(active snapshot_ts).
+  if (tag == raw_oldest_active) {
+    // The oldest active txn owns this slot: min(active snapshot_ts) == its snapshot. Advance the floor.
     uint64_t cur = gc_visibility_floor_.load(std::memory_order_acquire);
     while (snap > cur && !gc_visibility_floor_.compare_exchange_weak(
                              cur, snap, std::memory_order_release, std::memory_order_acquire)) {
     }
     return std::max(snap, cur);
   }
-  // Slot recycled / mid-BEGIN / no owner: fall back to the non-regressing floor. NEVER return
-  // oldest_active_start_timestamp here — that is the too-large value that would over-reclaim under the flag.
+  // Tag mismatch: raw_oldest_active does not name an active txn's slot. If there are NO active transactions
+  // there is nothing to protect -> reclaim fully (same as OFF). Otherwise a real older reader's slot was
+  // recycled or not yet written; fall back to the monotone floor (<= min active snapshot_ts).
+  // no_active_txns is `raw_oldest_active >= timestamp_` (the next-to-mint id), computed by the caller under
+  // engine_lock_. We gate on that, NOT on `raw > last_committed`, which would false-positive on a leapfrogged
+  // reader whose slot recycled while its snapshot stayed low (a leapfrogged reader has raw < timestamp_).
+  if (no_active_txns) return raw_oldest_active;
   return gc_visibility_floor_.load(std::memory_order_acquire);
 }
 
@@ -3195,6 +3208,10 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
 
   uint64_t oldest_active_start_timestamp = commit_log_->OldestActive();
 
+  // EXPERIMENTAL (lock-free-read-snapshot): the visibility ring is keyed by the ACTUAL oldest active
+  // start_timestamp, so capture it before the schema-info fold below lowers oldest_active_start_timestamp.
+  uint64_t const raw_oldest_active = oldest_active_start_timestamp;
+
   // Also consider unprocessed schema updates as a safety horizon.
   // `pending_schema_updates_` contains raw pointers to vertices (in SchemaInfoEdge.from/.to
   // and SchemaInfoPostProcess.vertex_cache). We cannot delete these vertices until their
@@ -3211,11 +3228,20 @@ void InMemoryStorage::CollectGarbage(utils::ResourceLockGuard main_guard, bool p
     }
   }
 
-  // EXPERIMENTAL (lock-free-read-snapshot): the physical horizon (oldest_active_start_timestamp, above)
-  // still bounds delta-buffer freeing and object retirement, but MVCC visibility now keys off the OldestActive
-  // txn's snapshot_ts, which is <= its start_ts. Compute that min(active snapshot_ts) once here; OFF path
-  // returns oldest_active_start_timestamp unchanged (byte-identical).
-  uint64_t const visibility_horizon = GcVisibilityHorizon(oldest_active_start_timestamp);
+  // EXPERIMENTAL (lock-free-read-snapshot): idle == "no active transactions" iff the oldest active start
+  // timestamp has reached the next-to-mint counter timestamp_ (every issued id is finished). Read timestamp_
+  // under engine_lock_ (as the fast-discard checks below already do). A leapfrogged reader has
+  // raw_oldest_active < timestamp_, so this correctly protects it (unlike a `raw > last_committed` test).
+  bool no_active_txns = false;
+  if (config_.experimental_lockfree_read_snapshot) {
+    auto const engine_guard = std::lock_guard{engine_lock_};
+    no_active_txns = raw_oldest_active >= timestamp_;
+  }
+
+  // Key the snapshot-based horizon on the RAW oldest active, then clamp to the (possibly lower) physical
+  // horizon so pending schema-update deltas are still protected. OFF: min(raw, folded) == folded (byte-identical).
+  uint64_t const visibility_horizon =
+      std::min(GcVisibilityHorizon(raw_oldest_active, no_active_txns), oldest_active_start_timestamp);
 
   // When a transaction commits with non-sequential deltas, its deltas may be mixed with
   // deltas from other transactions in the same delta chains. We cannot immediately unlink
@@ -4741,6 +4767,11 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
     vertex_id_.store(recovery_info.next_vertex_id, std::memory_order_release);
     edge_id_.store(recovery_info.next_edge_id, std::memory_order_release);
     timestamp_ = std::max(timestamp_, recovery_info.next_timestamp);
+    if (config_.experimental_lockfree_read_snapshot) {
+      last_committed_mvcc_ts_.store(std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed),
+                                             recovered_snapshot.snapshot_info.durable_timestamp),
+                                    std::memory_order_release);
+    }
     loaded_snapshot_uuid = recovered_snapshot.snapshot_info.uuid;
 
     auto const update_func = [new_ldt = recovered_snapshot.snapshot_info.durable_timestamp,

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1375,6 +1375,11 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
     // On the STRICT_SYNC 2PC path this publish precedes replica finalization, so a reader can
     // observe the commit before 2PC completes; acceptable while replicated flag-on is deferred
     // (replicated clusters are not yet cleared for the flag). Revisit ordering when they are.
+    // The watermark must strictly increase: it is a single atomic max only because commit_mutex_ is
+    // taken before the mint, so commits publish in mint order. A future attempt to narrow commit_mutex_
+    // would break that silently (stale reads under load); this debug assert makes the divergence loud.
+    DMG_ASSERT(*commit_timestamp_ > mem_storage->last_committed_mvcc_ts_.load(std::memory_order_relaxed),
+               "watermark must strictly increase: commit mint order and publish order have diverged");
     mem_storage->last_committed_mvcc_ts_.store(*commit_timestamp_, std::memory_order_release);
     InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_publish);
   }
@@ -2972,6 +2977,13 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
     // Publish this SI txn's frozen snapshot_ts into the GC visibility ring so GC can recover min(active snapshot_ts).
     // RC/RU do not freeze a snapshot_ts and must not hold the GC floor down; skip them.
     if (config_.experimental_lockfree_read_snapshot && isolation_level == IsolationLevel::SNAPSHOT_ISOLATION) {
+      // PRECONDITION — one engine_lock hold: the slot mint (start_timestamp above), the snapshot_ts read, and
+      // this ring publish MUST stay under a single engine_lock_ hold. GcVisibilityHorizon reads the OLDEST
+      // active slot's snap as min(active snapshot_ts); that is exact only because a txn's snapshot is published
+      // in the same breath as its slot is minted, so the oldest slot always carries the oldest snapshot.
+      // Splitting the mint from the publish (the ring store is lock-free, so it looks free to move out of the
+      // lock) lets the lowest-slot txn publish last with a higher watermark → the oldest slot returns a snap
+      // ABOVE the true minimum → GC over-reclaims a version an older reader can still reach → use-after-free.
       // Invalidate-first message passing (writers serialized under engine_lock_; the GC reader is lock-free):
       // publish the empty sentinel into tag BEFORE overwriting snap, so a concurrent GC read can never pair
       // this slot's NEW snap with the PREVIOUS owner's tag. If the reader's acquire-load of snap observes the

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -446,16 +446,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       vertex_id_.store(info->next_vertex_id, std::memory_order_release);
       edge_id_.store(info->next_edge_id, std::memory_order_release);
       timestamp_ = std::max(timestamp_, info->next_timestamp);
-      // EXPERIMENTAL (lock-free-read-snapshot): restore the read-snapshot watermark to the highest recovered
-      // committed timestamp.  We derive it from the local MVCC counter (timestamp_ - 1 = highest committed ts
-      // in this storage's own timestamp space) rather than from a durability-space field, so the watermark is
-      // space-correct: readers compare it against local MVCC delta timestamps, which live in the same space.
-      // Guard against underflow when the counter is still at its initial value.
-      if (config_.experimental_lockfree_read_snapshot) {
-        last_committed_mvcc_ts_.store(std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed),
-                                               timestamp_ > kTimestampInitialId ? timestamp_ - 1 : kTimestampInitialId),
-                                      std::memory_order_release);
-      }
+      SeedReadSnapshotWatermarkFromLocalCounter();
       CommitTsInfo const new_info{.ldt_ = info->last_durable_timestamp,
                                   .num_committed_txns_ = info->num_committed_txns};
       repl_storage_state_.commit_ts_info_.store(new_info, std::memory_order_release);
@@ -1381,6 +1372,9 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
   if (mem_storage->config_.experimental_lockfree_read_snapshot) {
     // Publish the watermark: readers that BEGIN after this see this commit. Ordered AFTER the
     // commit_info->timestamp store and MarkFinished, under the same publish engine_lock hold.
+    // On the STRICT_SYNC 2PC path this publish precedes replica finalization, so a reader can
+    // observe the commit before 2PC completes; acceptable while replicated flag-on is deferred
+    // (replicated clusters are not yet cleared for the flag). Revisit ordering when they are.
     mem_storage->last_committed_mvcc_ts_.store(*commit_timestamp_, std::memory_order_release);
     InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_publish);
   }
@@ -3153,6 +3147,17 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
   }
 }
 
+void InMemoryStorage::SeedReadSnapshotWatermarkFromLocalCounter() {
+  // EXPERIMENTAL (lock-free-read-snapshot): seed the read-snapshot watermark from the local MVCC
+  // counter (timestamp_ - 1 = highest committed ts in this storage's own timestamp space), which is
+  // space-correct because readers compare it against local MVCC delta timestamps. No-op with the
+  // flag off; guards underflow at the initial counter value.
+  if (!config_.experimental_lockfree_read_snapshot) return;
+  last_committed_mvcc_ts_.store(std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed),
+                                         timestamp_ > kTimestampInitialId ? timestamp_ - 1 : kTimestampInitialId),
+                                std::memory_order_release);
+}
+
 uint64_t InMemoryStorage::GcVisibilityHorizon(uint64_t raw_oldest_active, bool no_active_txns) {
   if (!config_.experimental_lockfree_read_snapshot) return raw_oldest_active;  // OFF: byte-identical
   auto const &gc_slot = snapshot_slots_[raw_oldest_active % kSnapshotSlots];
@@ -4814,15 +4819,7 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
     vertex_id_.store(recovery_info.next_vertex_id, std::memory_order_release);
     edge_id_.store(recovery_info.next_edge_id, std::memory_order_release);
     timestamp_ = std::max(timestamp_, recovery_info.next_timestamp);
-    // EXPERIMENTAL (lock-free-read-snapshot): seed the watermark from the local MVCC counter
-    // (timestamp_ - 1 = highest committed ts in this storage's own timestamp space).  Using the
-    // local counter is space-correct: readers compare against local MVCC delta timestamps.
-    // Guard against underflow when the counter is still at its initial value.
-    if (config_.experimental_lockfree_read_snapshot) {
-      last_committed_mvcc_ts_.store(std::max(last_committed_mvcc_ts_.load(std::memory_order_relaxed),
-                                             timestamp_ > kTimestampInitialId ? timestamp_ - 1 : kTimestampInitialId),
-                                    std::memory_order_release);
-    }
+    SeedReadSnapshotWatermarkFromLocalCounter();
     loaded_snapshot_uuid = recovered_snapshot.snapshot_info.uuid;
 
     auto const update_func = [new_ldt = recovered_snapshot.snapshot_info.durable_timestamp,
@@ -5525,6 +5522,14 @@ void InMemoryStorage::Clear(std::function<void()> const &on_progress) {
     // watermark to the recovered durable ts afterward.
     last_committed_mvcc_ts_.store(kTimestampInitialId, std::memory_order_release);
     gc_visibility_floor_.store(kTimestampInitialId, std::memory_order_release);
+    // No txn is active after Clear(), so the GC visibility ring must return to empty. A stale slot
+    // could otherwise pair a post-recovery oldest-active id with a reused pre-Clear tag (in-flight
+    // pre-crash SI tags can exceed the recovered next_timestamp) and advance the floor to a
+    // stale-high snap. Recovery runs single-threaded here (no concurrent GC reader).
+    for (size_t i = 0; i < kSnapshotSlots; ++i) {
+      snapshot_slots_[i].tag.store(std::numeric_limits<uint64_t>::max(), std::memory_order_relaxed);
+      snapshot_slots_[i].snap.store(0, std::memory_order_relaxed);
+    }
   }
   transaction_id_ = kTransactionInitialId;
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -1173,15 +1173,19 @@ class InMemoryStorage final : public Storage {
   struct SchemaUpdateData {
     LocalSchemaTracking schema_diff;
     SchemaInfoPostProcess post_process;
-    uint64_t start_ts;
+    // Exclusive upper-bound timestamp for deferred delta reconstruction (Transaction::
+    // SchemaReconstructionBound): start_timestamp with the lock-free experiment OFF, snapshot_ts + 1
+    // when ON. Captured at commit so the deferred ProcessTransaction reconstructs the same pre-state
+    // the committing transaction actually saw.
+    uint64_t snapshot_bound;
     uint64_t commit_ts;
     bool property_on_edges;
 
-    SchemaUpdateData(LocalSchemaTracking diff, SchemaInfoPostProcess post_proc, uint64_t start, uint64_t commit,
+    SchemaUpdateData(LocalSchemaTracking diff, SchemaInfoPostProcess post_proc, uint64_t bound, uint64_t commit,
                      bool prop_on_edges)
         : schema_diff(std::move(diff)),
           post_process(std::move(post_proc)),
-          start_ts(start),
+          snapshot_bound(bound),
           commit_ts(commit),
           property_on_edges(prop_on_edges) {}
   };

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -472,10 +472,13 @@ class InMemoryStorage final : public Storage {
     void AbortAndResetCommitTs(ProgressCallback const &on_progress = {});
 
     // Represents the 2nd phase of the 2PC protocol
-    // NOTE: Needs to be called while holding the engine lock
+    // NOTE: The engine lock must be held while this runs. Pass acquire_engine_lock=false when the caller
+    // already holds it (the default: legacy path and the replica FinalizeCommit handler); pass true only on
+    // the lock-free-read-snapshot path, where the caller released engine_lock after the mint and this method
+    // re-acquires it for the brief publish.
     // NOTE: If there is a single instance, PrepareForCommitPhase will call this method, you shouldn't call this method
     // independently of PrepareForCommitPhase.
-    void FinalizeCommitPhase(uint64_t durability_commit_timestamp);
+    void FinalizeCommitPhase(uint64_t durability_commit_timestamp, bool acquire_engine_lock = false);
 
     /// @throw std::bad_alloc
     void Abort() override;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -893,6 +893,12 @@ class InMemoryStorage final : public Storage {
 
   [[nodiscard]] uint64_t VertexStoreSize() const { return vertices_.size(); }
 
+  // Observability/testing: the lock-free read-snapshot watermark (highest fully-published commit ts;
+  // the value a SNAPSHOT_ISOLATION reader freezes as its snapshot_ts at BEGIN under the experiment).
+  [[nodiscard]] uint64_t LastCommittedMvccTimestamp() const {
+    return last_committed_mvcc_ts_.load(std::memory_order_acquire);
+  }
+
  private:
   /// @throw std::system_error
   /// @throw std::bad_alloc

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -899,8 +899,10 @@ class InMemoryStorage final : public Storage {
   void CollectGarbage(utils::ResourceLockGuard main_guard, bool periodic);
 
   // EXPERIMENTAL (lock-free-read-snapshot): compute the GC visibility horizon = min(active snapshot_ts).
-  // OFF (flag disabled): returns oldest_active_start_timestamp, byte-identical to today.
-  uint64_t GcVisibilityHorizon(uint64_t oldest_active_start_timestamp);
+  // Takes the RAW OldestActive() (pre-schema-fold), which keys the visibility ring; the caller clamps the
+  // result to the (possibly lower) folded physical horizon. OFF (flag disabled): returns raw_oldest_active,
+  // byte-identical to today.
+  uint64_t GcVisibilityHorizon(uint64_t raw_oldest_active, bool no_active_txns);
 
   // Objects leave storage only through these, and only from a collection pass. An index entry
   // holds a raw pointer that nothing keeps alive, so an object may be retired only once that same

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -11,8 +11,10 @@
 
 #pragma once
 
+#include <atomic>
 #include <concepts>
 #include <cstdint>
+#include <limits>
 #include <list>
 #include <memory>
 #include <optional>
@@ -896,6 +898,10 @@ class InMemoryStorage final : public Storage {
   /// @throw std::bad_alloc
   void CollectGarbage(utils::ResourceLockGuard main_guard, bool periodic);
 
+  // EXPERIMENTAL (lock-free-read-snapshot): compute the GC visibility horizon = min(active snapshot_ts).
+  // OFF (flag disabled): returns oldest_active_start_timestamp, byte-identical to today.
+  uint64_t GcVisibilityHorizon(uint64_t oldest_active_start_timestamp);
+
   // Objects leave storage only through these, and only from a collection pass. An index entry
   // holds a raw pointer that nothing keeps alive, so an object may be retired only once that same
   // pass has removed every index entry naming it.
@@ -1122,6 +1128,20 @@ class InMemoryStorage final : public Storage {
   // Flags to inform CollectGarbage that it needs to do the more expensive full scans
   std::atomic<bool> gc_full_scan_vertices_delete_ = false;
   std::atomic<bool> gc_full_scan_edges_delete_ = false;
+
+  // EXPERIMENTAL (lock-free-read-snapshot) GC visibility tracker: maps an active txn's start_timestamp
+  // to its frozen snapshot_ts, so GC can compute min(active snapshot_ts) = the OldestActive txn's snapshot.
+  // Tag-validated ring; any miss falls back to a monotone non-regressing floor (never OldestActive(start_ts)).
+  struct SnapshotSlot {
+    std::atomic<uint64_t> tag{std::numeric_limits<uint64_t>::max()};  // owning start_timestamp; max = empty
+    std::atomic<uint64_t> snap{0};                                    // that txn's snapshot_ts
+  };
+
+  static constexpr size_t kSnapshotSlots = 1ULL
+                                           << 16;  // ring; correctness is independent of size (tag-validated,
+                                                   // relies on the invalidate-first slot write in CreateTransaction)
+  std::unique_ptr<SnapshotSlot[]> snapshot_slots_;
+  std::atomic<uint64_t> gc_visibility_floor_{kTimestampInitialId};
 
   free_mem_fn free_memory_func_;
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -909,6 +909,8 @@ class InMemoryStorage final : public Storage {
   // result to the (possibly lower) folded physical horizon. OFF (flag disabled): returns raw_oldest_active,
   // byte-identical to today.
   uint64_t GcVisibilityHorizon(uint64_t raw_oldest_active, bool no_active_txns);
+  // Seed last_committed_mvcc_ts_ from the local MVCC counter on recovery (no-op with the flag off).
+  void SeedReadSnapshotWatermarkFromLocalCounter();
 
   // Objects leave storage only through these, and only from a collection pass. An index entry
   // holds a raw pointer that nothing keeps alive, so an object may be retired only once that same

--- a/src/storage/v2/mvcc.hpp
+++ b/src/storage/v2/mvcc.hpp
@@ -58,7 +58,8 @@ inline std::size_t ApplyDeltasForRead(Transaction const *transaction, const Delt
     auto ts = delta->commit_info->timestamp.load(std::memory_order_acquire);
     bool const is_delta_non_sequential = IsDeltaNonSequential(*delta);
 
-    if ((transaction->isolation_level == IsolationLevel::SNAPSHOT_ISOLATION && ts < transaction->start_timestamp) ||
+    if ((transaction->isolation_level == IsolationLevel::SNAPSHOT_ISOLATION &&
+         transaction->CommittedBeforeSnapshot(ts)) ||
         (transaction->isolation_level == IsolationLevel::READ_COMMITTED && ts < kTransactionInitialId)) {
       if (is_delta_non_sequential) {
         delta = delta->next.load(std::memory_order_acquire);
@@ -123,7 +124,7 @@ inline bool PrepareForWrite(Transaction *transaction, TObj *object) {
     return true;
   }
 
-  if (ts < transaction->start_timestamp) {
+  if (transaction->CommittedBeforeSnapshot(ts)) {
     if constexpr (requires { object->has_uncommitted_non_sequential_deltas(); }) {
       if (object->has_uncommitted_non_sequential_deltas()) {
         transaction->has_serialization_error = true;
@@ -156,7 +157,7 @@ inline WriteResult PrepareForNonSequentialWrite(Transaction *transaction, TObj *
   auto const ts = object->delta()->commit_info->timestamp.load(std::memory_order_acquire);
 
   if (ts != transaction->transaction_id) {
-    if (ts < transaction->start_timestamp) {
+    if (transaction->CommittedBeforeSnapshot(ts)) {
       // Its possible that the commited delta we are looking at is part of a NonSequential block
       // Use the has_uncommitted_non_sequential_deltas flag as our indicator
       if constexpr (requires { object->has_uncommitted_non_sequential_deltas(); }) {
@@ -198,7 +199,7 @@ inline WriteResult PrepareForNonSequentialWrite(Transaction *transaction, TObj *
 
       if (delta_ts == transaction->transaction_id) continue;
 
-      if (delta_ts < transaction->start_timestamp) break;
+      if (transaction->CommittedBeforeSnapshot(delta_ts)) break;
 
       // Optimization: Once we encounter a non-sequential delta, we can break early
       // because blocking deltas can only exist BEFORE non-sequential deltas in the

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -241,6 +241,13 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
     return;
   }
 
+  // EXPERIMENTAL (lock-free-read-snapshot): engine_lock_ alone is stale for the ldt read at ~line 287;
+  // under the flag, ldt advances at publish outside the post-mint engine_lock_ hold, so hold commit_mutex_
+  // first (committer's order: commit_mutex_ then engine_lock_) to exclude any in-flight committer.
+  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  if (static_cast<InMemoryStorage *>(main_storage)->config_.experimental_lockfree_read_snapshot) {
+    commit_serializer.emplace(static_cast<InMemoryStorage *>(main_storage)->commit_mutex_);
+  }
   // Lock engine lock in order to read main_storage timestamp and synchronize with any active commits
   auto engine_lock = std::unique_lock{main_storage->engine_lock_};
 
@@ -978,6 +985,16 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
   // could check that the replica state isn't replicating, this recovery sets the
   // replica state to ready. When the next txn starts, we are in state ready without
   // actually sending data to replica
+  //
+  // EXPERIMENTAL (lock-free-read-snapshot): engine_lock_ alone is insufficient for the ldt read below.
+  // Under the flag, ldt advances at publish (a separate engine_lock_ hold after the post-mint release),
+  // so a reader holding only engine_lock_ can see a stale ldt and mark the replica READY across a commit
+  // it will miss. Hold commit_mutex_ first (committer's order: commit_mutex_ then engine_lock_) to exclude
+  // any in-flight committer so the READY decision reflects it.
+  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  if (main_mem_storage->config_.experimental_lockfree_read_snapshot) {
+    commit_serializer.emplace(main_mem_storage->commit_mutex_);
+  }
   auto lock = std::lock_guard{main_storage->engine_lock_};
   const auto last_durable_timestamp =
       main_storage->repl_storage_state_.commit_ts_info_.load(std::memory_order_acquire).ldt_;

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -884,6 +884,13 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                main_uuid = main_uuid_,
                &main_db_name,
                repl_mode = client_.mode_](RecoveryCurrentWal const &current_wal) {
+                // EXPERIMENTAL (lock-free-read-snapshot): serialize against the committer (which holds commit_mutex_,
+                // not engine_lock_, across its WAL window) before reading/flush-toggling the current WAL. Released
+                // with transaction_guard; the subsequent Path()/transfer is covered by DisableFlushing()'s flush_lock_.
+                std::optional<std::unique_lock<std::mutex>> commit_serializer;
+                if (main_mem_storage->config_.experimental_lockfree_read_snapshot) {
+                  commit_serializer.emplace(main_mem_storage->commit_mutex_);
+                }
                 std::unique_lock transaction_guard(main_mem_storage->engine_lock_);
                 if (main_mem_storage->wal_file_ &&
                     main_mem_storage->wal_file_->SequenceNumber() == current_wal.current_wal_seq_num) {
@@ -891,6 +898,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                       [main_mem_storage]() { main_mem_storage->wal_file_->EnableFlushing(); });
                   main_mem_storage->wal_file_->DisableFlushing();
                   transaction_guard.unlock();
+                  commit_serializer.reset();
                   spdlog::debug("Sending current wal file to {} for db {}.", client_.name_, main_db_name);
 
                   auto const maybe_response = TransferDurabilityFiles<replication::CurrentWalRpc>(

--- a/src/storage/v2/schema_info.cpp
+++ b/src/storage/v2/schema_info.cpp
@@ -62,8 +62,12 @@ inline auto PropertyTypes_ActionMethod(std::map<PropertyId, ExtendedPropertyType
   });
 }
 
-// Apply deltas from other transactions
-inline void ApplyDeltasForRead(const Delta *delta, uint64_t start_timestamp, auto &&callback) {
+// Apply deltas from other transactions. `snapshot_bound` is the reconstructing transaction's
+// exclusive visibility boundary (Transaction::SchemaReconstructionBound): a delta committed at
+// `ts < snapshot_bound` is part of the base snapshot and stops the walk; deltas at/after it are
+// rolled back by the callback to recover the pre-snapshot view. OFF the bound is start_timestamp
+// (legacy `ts < start_timestamp`); ON it is snapshot_ts + 1, i.e. the inclusive `ts <= snapshot_ts`.
+inline void ApplyDeltasForRead(const Delta *delta, uint64_t snapshot_bound, auto &&callback) {
   // Avoid work if no deltas
   if (!delta) return;
 
@@ -71,7 +75,7 @@ inline void ApplyDeltasForRead(const Delta *delta, uint64_t start_timestamp, aut
     auto ts = delta->commit_info->timestamp.load(std::memory_order_acquire);
     bool const is_delta_non_sequential = IsDeltaNonSequential(*delta);
 
-    if (ts < start_timestamp) {
+    if (ts < snapshot_bound) {
       if (is_delta_non_sequential) {
         delta = delta->next.load(std::memory_order_acquire);
         continue;
@@ -89,7 +93,15 @@ inline void ApplyDeltasForRead(const Delta *delta, uint64_t start_timestamp, aut
 
 enum State { NO_CHANGE, THIS_TX, ANOTHER_TX };
 
-inline State GetState(const Delta *delta, uint64_t start_timestamp, uint64_t commit_timestamp,
+// `snapshot_bound` is the reconstructing transaction's exclusive visibility boundary
+// (Transaction::SchemaReconstructionBound): a delta committed at `ts < snapshot_bound` is at/before
+// this transaction's snapshot (NO_CHANGE), one at/after it belongs to another transaction
+// (ANOTHER_TX). The ANOTHER_TX comparisons are `>= snapshot_bound` (not `>`) so that the inclusive
+// ON boundary is exact: with snapshot_bound == snapshot_ts + 1, a delta committed at exactly
+// snapshot_ts + 1 is correctly ANOTHER_TX. OFF (snapshot_bound == start_timestamp) this is behaviour-
+// identical to the legacy `> start_timestamp`: no committed delta ever carries ts == start_timestamp
+// (a transaction's own start mint is never a commit timestamp), so `>=` and `>` never differ.
+inline State GetState(const Delta *delta, uint64_t snapshot_bound, uint64_t commit_timestamp,
                       bool traverse_chain = false) {
   // This tx is running, so no deltas means there are no changes made after the tx started
   if (delta == nullptr) return State::NO_CHANGE;
@@ -103,7 +115,7 @@ inline State GetState(const Delta *delta, uint64_t start_timestamp, uint64_t com
   // transaction modified it, its delta will be at the head.
   if (!traverse_chain) {
     if (head_ts == commit_timestamp) return State::THIS_TX;
-    if (head_ts > start_timestamp) return State::ANOTHER_TX;
+    if (head_ts >= snapshot_bound) return State::ANOTHER_TX;
     return State::NO_CHANGE;
   }
 
@@ -117,13 +129,13 @@ inline State GetState(const Delta *delta, uint64_t start_timestamp, uint64_t com
   for (const Delta *current = delta; current != nullptr; current = current->next.load(std::memory_order_acquire)) {
     const auto ts = current->commit_info->timestamp.load(std::memory_order_acquire);
 
-    if (ts < start_timestamp) break;
+    if (ts < snapshot_bound) break;
 
     if (ts == commit_timestamp) {
       found_this_tx = true;
     }
 
-    if (ts > start_timestamp && ts != commit_timestamp) {
+    if (ts >= snapshot_bound && ts != commit_timestamp) {
       found_another_tx = true;
       break;
     }
@@ -134,14 +146,15 @@ inline State GetState(const Delta *delta, uint64_t start_timestamp, uint64_t com
   return State::NO_CHANGE;
 }
 
-// Keep v locked as we could return a reference to labels
-inline const VertexKey *GetLabelsViewOld(const Vertex *v, uint64_t start_timestamp, auto &cache) {
+// Keep v locked as we could return a reference to labels. `snapshot_bound` is the reconstructing
+// transaction's exclusive visibility boundary (Transaction::SchemaReconstructionBound).
+inline const VertexKey *GetLabelsViewOld(const Vertex *v, uint64_t snapshot_bound, auto &cache) {
   // Check if already cached
   auto v_cached = cache.find(v);
   if (v_cached != cache.end()) return &v_cached->second;
   // Apply deltas and cache values
   auto labels_copy = v->labels;
-  ApplyDeltasForRead(v->delta(), start_timestamp, [&labels_copy](const Delta &delta) {
+  ApplyDeltasForRead(v->delta(), snapshot_bound, [&labels_copy](const Delta &delta) {
     // clang-format off
     DeltaDispatch(delta, utils::ChainedOverloaded{
       Labels_ActionMethod(labels_copy)
@@ -207,10 +220,12 @@ struct Properties {
   bool needs_pp{false};
 };
 
-inline std::map<PropertyId, ExtendedPropertyType> GetPropertiesViewOld(const Edge *edge, uint64_t start_timestamp) {
+// `snapshot_bound` is the reconstructing transaction's exclusive visibility boundary
+// (Transaction::SchemaReconstructionBound).
+inline std::map<PropertyId, ExtendedPropertyType> GetPropertiesViewOld(const Edge *edge, uint64_t snapshot_bound) {
   auto edge_props = edge->properties.ExtendedPropertyTypes();
   // Apply deltas
-  ApplyDeltasForRead(edge->delta(), start_timestamp, [&edge_props](const Delta &delta) {
+  ApplyDeltasForRead(edge->delta(), snapshot_bound, [&edge_props](const Delta &delta) {
     // clang-format off
     DeltaDispatch(delta, utils::ChainedOverloaded{
       PropertyTypes_ActionMethod(edge_props)

--- a/src/storage/v2/schema_info.cpp
+++ b/src/storage/v2/schema_info.cpp
@@ -298,7 +298,7 @@ TrackingInfo<utils::ConcurrentUnorderedMap> &SharedSchemaTracking::edge_lookup(c
 template <template <class...> class TContainer>
 template <template <class...> class TOtherContainer>
 void SchemaTracking<TContainer>::ProcessTransaction(const SchemaTracking<TOtherContainer> &diff,
-                                                    SchemaInfoPostProcess &post_process, uint64_t start_ts,
+                                                    SchemaInfoPostProcess &post_process, uint64_t snapshot_bound,
                                                     uint64_t commit_ts, bool property_on_edges) {
   // Update shared schema based on the diff
   for (const auto &[vertex_key, info] : diff.vertex_state_) {
@@ -316,14 +316,14 @@ void SchemaTracking<TContainer>::ProcessTransaction(const SchemaTracking<TOtherC
 
     // An edge can be added to post process by modifying the edge directly or one of the vertices
     // We need to check all 3 objects
-    const auto from_state = GetState(from->delta(), start_ts, commit_ts, true);
-    const auto to_state = GetState(to->delta(), start_ts, commit_ts, true);
+    const auto from_state = GetState(from->delta(), snapshot_bound, commit_ts, true);
+    const auto to_state = GetState(to->delta(), snapshot_bound, commit_ts, true);
 
     State edge_state{NO_CHANGE};
     std::shared_lock<decltype(edge_ref.ptr->lock)> edge_lock;
     if (property_on_edges) {
       edge_lock = std::shared_lock{edge_ref.ptr->lock};
-      edge_state = GetState(edge_ref.ptr->delta(), start_ts, commit_ts, true);
+      edge_state = GetState(edge_ref.ptr->delta(), snapshot_bound, commit_ts, true);
     }
 
     // Check if we need to process this edge
@@ -331,12 +331,12 @@ void SchemaTracking<TContainer>::ProcessTransaction(const SchemaTracking<TOtherC
       continue;  // All is as it should be
     }
 
-    auto from_l_diff = GetLabelsDiff(from, from_state, start_ts, post_process.vertex_cache, post_vertex_cache);
-    auto to_l_diff = GetLabelsDiff(to, to_state, start_ts, post_process.vertex_cache, post_vertex_cache);
+    auto from_l_diff = GetLabelsDiff(from, from_state, snapshot_bound, post_process.vertex_cache, post_vertex_cache);
+    auto to_l_diff = GetLabelsDiff(to, to_state, snapshot_bound, post_process.vertex_cache, post_vertex_cache);
 
     PropertiesDiff edge_prop_diff;
     if (property_on_edges) {
-      edge_prop_diff = GetPropertiesDiff(edge_ref.ptr, edge_state, start_ts);
+      edge_prop_diff = GetPropertiesDiff(edge_ref.ptr, edge_state, snapshot_bound);
     }
 
     // TODO Possible optimization: check if labels or props changed and skip some lookups/updates
@@ -777,9 +777,9 @@ void SchemaInfo::TransactionalEdgeModifyingAccessor::UpdateTransactionalEdges(
     auto edge_lock =
         properties_on_edges_ ? std::shared_lock{edge_ref.ptr->lock} : std::shared_lock<decltype(edge_ref.ptr->lock)>{};
 
-    auto other_labels = GetLabels(other_vertex, start_ts_, commit_ts_, post_process_->vertex_cache);
+    auto other_labels = GetLabels(other_vertex, snapshot_bound_, commit_ts_, post_process_->vertex_cache);
     Properties edge_props{};
-    if (properties_on_edges_) edge_props = GetProperties(edge_ref.ptr, start_ts_, commit_ts_);
+    if (properties_on_edges_) edge_props = GetProperties(edge_ref.ptr, snapshot_bound_, commit_ts_);
 
     tracking_->UpdateEdgeStats(edge_ref,
                                edge_type,
@@ -906,8 +906,8 @@ void SchemaInfo::VertexModifyingAccessor::DeleteEdge(Vertex *from, Vertex *to, E
   tracking_->DeleteEdge(edge_type, edge_ref, from, to, properties_on_edges_);
 
   if (post_process_) {
-    if (GetState(from->delta(), start_ts_, commit_ts_) == ANOTHER_TX ||
-        GetState(to->delta(), start_ts_, commit_ts_) == ANOTHER_TX) {
+    if (GetState(from->delta(), snapshot_bound_, commit_ts_) == ANOTHER_TX ||
+        GetState(to->delta(), snapshot_bound_, commit_ts_) == ANOTHER_TX) {
       post_process_->edges.insert({edge_ref, edge_type, from, to});
     } else {
       post_process_->edges.erase({edge_ref, edge_type, from, to});
@@ -941,7 +941,7 @@ void SchemaInfo::VertexModifyingAccessor::SetProperty(EdgeRef edge, EdgeTypeId t
     // In case the from/to vertices are touched by this tx, we are safe, no need to post process (remove edge)
     // If one of the vertices has not been changes, we need to append this edge to the post-process list
     // We also need to get labels as they are seen by this tx
-    auto labels = GetLabels(from, to, start_ts_, commit_ts_, post_process_->vertex_cache);
+    auto labels = GetLabels(from, to, snapshot_bound_, commit_ts_, post_process_->vertex_cache);
     tracking_->SetProperty(type, *labels.from, *labels.to, property, now, before, properties_on_edges_);
     if (labels.needs_pp) {
       post_process_->edges.emplace(edge, type, from, to);
@@ -958,4 +958,4 @@ template struct memgraph::storage::SchemaTracking<std::unordered_map>;
 template struct memgraph::storage::SchemaTracking<memgraph::utils::ConcurrentUnorderedMap>;
 template void memgraph::storage::SchemaTracking<memgraph::utils::ConcurrentUnorderedMap>::ProcessTransaction(
     const memgraph::storage::SchemaTracking<std::unordered_map> &diff, SchemaInfoPostProcess &post_process,
-    uint64_t start_ts, uint64_t commit_ts, bool property_on_edges);
+    uint64_t snapshot_bound, uint64_t commit_ts, bool property_on_edges);

--- a/src/storage/v2/schema_info.hpp
+++ b/src/storage/v2/schema_info.hpp
@@ -75,7 +75,7 @@ template <template <class...> class TContainer>
 struct SchemaTracking final : public SchemaTrackingInterface {
   template <template <class...> class TOtherContainer>
   void ProcessTransaction(const SchemaTracking<TOtherContainer> &diff, SchemaInfoPostProcess &post_process,
-                          uint64_t start_ts, uint64_t commit_ts, bool property_on_edges);
+                          uint64_t snapshot_bound, uint64_t commit_ts, bool property_on_edges);
 
   void Clear() override;
 
@@ -173,10 +173,10 @@ struct SchemaInfo {
         name_id_mapper, enum_store, node_predicate, edge_predicate, node_property_predicate, edge_property_predicate);
   }
 
-  void ProcessTransaction(LocalSchemaTracking &tracking, SchemaInfoPostProcess &post_process, uint64_t start_ts,
+  void ProcessTransaction(LocalSchemaTracking &tracking, SchemaInfoPostProcess &post_process, uint64_t snapshot_bound,
                           uint64_t commit_ts, bool property_on_edges) {
     auto lock = std::unique_lock{operation_ordering_mutex_};
-    tracking_.ProcessTransaction(tracking, post_process, start_ts, commit_ts, property_on_edges);
+    tracking_.ProcessTransaction(tracking, post_process, snapshot_bound, commit_ts, property_on_edges);
   }
 
   void Clear() {
@@ -201,11 +201,11 @@ struct SchemaInfo {
   class TransactionalEdgeModifyingAccessor {
    public:
     TransactionalEdgeModifyingAccessor(LocalSchemaTracking &tracking, SchemaInfoPostProcess *post_process,
-                                       uint64_t start_ts, uint64_t commit_ts, bool prop_on_edges)
+                                       uint64_t snapshot_bound, uint64_t commit_ts, bool prop_on_edges)
         : tracking_{&tracking},
           properties_on_edges_{prop_on_edges},
           post_process_{post_process},
-          start_ts_{start_ts},
+          snapshot_bound_{snapshot_bound},
           commit_ts_{commit_ts} {}
 
     void AddLabel(Vertex *vertex, LabelId label, std::unique_lock<utils::RWSpinLock> v_lock);
@@ -219,7 +219,7 @@ struct SchemaInfo {
     LocalSchemaTracking *tracking_{};
     bool properties_on_edges_{};  //!< As defined by the storage configuration
     SchemaInfoPostProcess *post_process_{};
-    uint64_t start_ts_{};
+    uint64_t snapshot_bound_{};
     uint64_t commit_ts_{};
   };
 
@@ -262,11 +262,11 @@ struct SchemaInfo {
 
     // TRANSACTIONAL
     explicit VertexModifyingAccessor(LocalSchemaTracking &tracking, SchemaInfoPostProcess *post_process,
-                                     uint64_t start_ts, uint64_t commit_ts, bool prop_on_edges)
+                                     uint64_t snapshot_bound, uint64_t commit_ts, bool prop_on_edges)
         : tracking_{&tracking},
           properties_on_edges_{prop_on_edges},
           post_process_{post_process},
-          start_ts_{start_ts},
+          snapshot_bound_{snapshot_bound},
           commit_ts_{commit_ts} {}
 
     void CreateVertex(Vertex *vertex);
@@ -292,7 +292,7 @@ struct SchemaInfo {
     std::shared_lock<std::shared_mutex> ordering_lock_;  //!< Order guaranteeing lock
     bool properties_on_edges_{};                         //!< As defined by the storage configuration
     SchemaInfoPostProcess *post_process_{};
-    uint64_t start_ts_{};
+    uint64_t snapshot_bound_{};
     uint64_t commit_ts_{};
   };
 
@@ -307,14 +307,15 @@ struct SchemaInfo {
     return AnalyticalEdgeModifyingAccessor{*this, prop_on_edges};
   }
 
-  static ModifyingAccessor CreateVertexModifyingAccessor(auto &tracking, auto &post_process, uint64_t start_ts,
+  static ModifyingAccessor CreateVertexModifyingAccessor(auto &tracking, auto &post_process, uint64_t snapshot_bound,
                                                          uint64_t commit_ts, bool prop_on_edges) {
-    return VertexModifyingAccessor{tracking, &post_process, start_ts, commit_ts, prop_on_edges};
+    return VertexModifyingAccessor{tracking, &post_process, snapshot_bound, commit_ts, prop_on_edges};
   }
 
   static ModifyingAccessor CreateEdgeModifyingAccessor(auto &tracking, SchemaInfoPostProcess *post_process,
-                                                       uint64_t start_ts, uint64_t commit_ts, bool prop_on_edges) {
-    return TransactionalEdgeModifyingAccessor{tracking, post_process, start_ts, commit_ts, prop_on_edges};
+                                                       uint64_t snapshot_bound, uint64_t commit_ts,
+                                                       bool prop_on_edges) {
+    return TransactionalEdgeModifyingAccessor{tracking, post_process, snapshot_bound, commit_ts, prop_on_edges};
   }
 
   static std::optional<std::pair<std::shared_lock<utils::RWSpinLock>, std::shared_lock<utils::RWSpinLock>>>

--- a/src/storage/v2/schema_info_glue.hpp
+++ b/src/storage/v2/schema_info_glue.hpp
@@ -22,7 +22,7 @@ inline std::optional<SchemaInfo::ModifyingAccessor> SchemaInfoAccessor(Storage *
   if (storage->GetStorageMode() == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     return SchemaInfo::CreateVertexModifyingAccessor(transaction->schema_diff_,
                                                      transaction->post_process_,
-                                                     transaction->start_timestamp,
+                                                     transaction->SchemaReconstructionBound(),
                                                      transaction->transaction_id,
                                                      prop_on_edges);
   }
@@ -36,7 +36,7 @@ inline std::optional<SchemaInfo::ModifyingAccessor> SchemaInfoUniqueAccessor(Sto
   if (storage->GetStorageMode() == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     return SchemaInfo::CreateEdgeModifyingAccessor(transaction->schema_diff_,
                                                    &transaction->post_process_,
-                                                   transaction->start_timestamp,
+                                                   transaction->SchemaReconstructionBound(),
                                                    transaction->transaction_id,
                                                    prop_on_edges);
   }

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <string>
@@ -124,6 +125,7 @@ class ReadOnlyAccessTimeout : public utils::BasicException {
 
 struct Transaction;
 class EdgeAccessor;
+struct CommitProbe;
 
 // TODO: list status Populating/Ready
 struct IndicesInfo {
@@ -454,6 +456,17 @@ class Storage {
   mutable utils::SpinLock engine_lock_;
   uint64_t timestamp_{kTimestampInitialId};
   uint64_t transaction_id_{kTransactionInitialId};
+
+  // EXPERIMENTAL (lock-free-read-snapshot). All three are inert when the experiment is OFF.
+  // Serializes committers across mint->durability->publish and (in that mode) guards the WAL group;
+  // acquired only on the experiment's ON path, so the OFF path is byte-for-byte unchanged.
+  std::mutex commit_mutex_;
+  // Runtime-only watermark: the last fully-published commit timestamp. Advanced at publish on the ON
+  // path, seeded from recovered max commit ts on startup. NEVER persisted (durable data is flag-independent).
+  std::atomic<uint64_t> last_committed_mvcc_ts_{kTimestampInitialId};
+  // Test-only instrumentation (null in production). Set by tests to pin the commit path at phase
+  // boundaries. Forward-declared to keep this header light; defined in storage/v2/commit_probe.hpp.
+  CommitProbe *commit_probe_{nullptr};
 
   // Written under a UNIQUE hold on main_lock_. UNIQUE excludes all three shared modes, so any hold
   // pins both values for its life, and releasing one un-pins them: a reader that reacquires must

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -460,7 +460,7 @@ class Storage {
   // EXPERIMENTAL (lock-free-read-snapshot). All three are inert when the experiment is OFF.
   // Serializes committers across mint->durability->publish and (in that mode) guards the WAL group;
   // acquired only on the experiment's ON path, so the OFF path is byte-for-byte unchanged.
-  std::mutex commit_mutex_;
+  mutable std::mutex commit_mutex_;
   // Runtime-only watermark: the last fully-published commit timestamp. Advanced at publish on the ON
   // path, seeded from recovered max commit ts on startup. NEVER persisted (durable data is flag-independent).
   std::atomic<uint64_t> last_committed_mvcc_ts_{kTimestampInitialId};

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -311,6 +311,9 @@ class Storage {
 
   void SetBroken(bool value) noexcept { broken_.store(value, std::memory_order_release); }
 
+  // Test-only: install commit-path instrumentation (lock-free-read-snapshot experiment). Null in production.
+  void SetCommitProbe(CommitProbe *probe) noexcept { commit_probe_ = probe; }
+
   memory::ArenaPool *DbArenaPool() const noexcept { return db_arena_pool_; }
 
   using Accessor = memgraph::storage::Accessor;

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -224,6 +224,11 @@ struct Transaction {
 
   uint64_t transaction_id{};
   uint64_t start_timestamp{};
+  // EXPERIMENTAL (lock-free-read-snapshot): frozen last-committed-MVCC-ts captured at BEGIN.
+  // When the experiment is OFF this stays 0 and is never read. Distinct from start_timestamp,
+  // which remains the unique GC/commit-log slot; snapshot_ts (<= start_timestamp) will be the
+  // SI visibility + write-conflict boundary when ON.
+  uint64_t snapshot_ts{};
   // Set at construction; never reassigned. Stable across PeriodicCommit.
   uint64_t original_start_timestamp{};
   // The `Transaction` object is stack allocated, but the `commit_info`

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -229,6 +229,16 @@ struct Transaction {
     return lockfree_snapshot ? ts <= snapshot_ts : ts < start_timestamp;
   }
 
+  // Exclusive upper-bound timestamp for schema-info delta reconstruction: a committed delta at `ts`
+  // is folded into this transaction's base snapshot iff `ts < bound`. Encodes CommittedBeforeSnapshot
+  // as a single value so it can be threaded into the schema-info reconstruction primitives (which key
+  // off a bare timestamp). Under the lock-free experiment this is snapshot_ts + 1 (so `ts < bound`
+  // means the inclusive `ts <= snapshot_ts`); OFF it is start_timestamp, making the OFF reconstruction
+  // byte-identical to the legacy `ts < start_timestamp`.
+  [[nodiscard]] uint64_t SchemaReconstructionBound() const noexcept {
+    return lockfree_snapshot ? snapshot_ts + 1 : start_timestamp;
+  }
+
   uint64_t transaction_id{};
   uint64_t start_timestamp{};
   // EXPERIMENTAL (lock-free-read-snapshot): frozen last-committed-MVCC-ts captured at BEGIN.

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -222,6 +222,13 @@ struct Transaction {
 
   bool UseCache() const { return isolation_level == IsolationLevel::SNAPSHOT_ISOLATION && !parallel_execution_; }
 
+  // The single MVCC visibility boundary. Legacy: a delta is "before my snapshot" iff ts < start_timestamp.
+  // Lock-free-read-snapshot (SI only): iff ts <= snapshot_ts (inclusive; snapshot_ts is the highest
+  // fully-published commit at BEGIN). Used for both read visibility and write-conflict detection.
+  [[nodiscard]] bool CommittedBeforeSnapshot(uint64_t ts) const noexcept {
+    return lockfree_snapshot ? ts <= snapshot_ts : ts < start_timestamp;
+  }
+
   uint64_t transaction_id{};
   uint64_t start_timestamp{};
   // EXPERIMENTAL (lock-free-read-snapshot): frozen last-committed-MVCC-ts captured at BEGIN.
@@ -229,6 +236,11 @@ struct Transaction {
   // which remains the unique GC/commit-log slot; snapshot_ts (<= start_timestamp) will be the
   // SI visibility + write-conflict boundary when ON.
   uint64_t snapshot_ts{};
+  // EXPERIMENTAL (lock-free-read-snapshot): true only for SNAPSHOT_ISOLATION txns when the experiment
+  // is ON. Default false ⇒ the visibility predicate below uses the legacy `ts < start_timestamp`, so
+  // the OFF path (and every non-SNAPSHOT_ISOLATION txn, and any construction site that does not set
+  // this) is byte-identical to before.
+  bool lockfree_snapshot{false};
   // Set at construction; never reassigned. Stable across PeriodicCommit.
   uint64_t original_start_timestamp{};
   // The `Transaction` object is stack allocated, but the `commit_info`

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -239,6 +239,19 @@ struct Transaction {
     return lockfree_snapshot ? snapshot_ts + 1 : start_timestamp;
   }
 
+  // INCLUSIVE upper bound for schema-object visibility in the durability snapshot writer: an index or
+  // constraint whose population committed at `ts` belongs in this snapshot iff `ts <= bound`. Under the
+  // lock-free experiment this is snapshot_ts (which equals last_durable_ts_ — both are read under one
+  // engine_lock hold at BEGIN), so the snapshot's schema set matches the durable timestamp it records and
+  // WAL replay cannot double-create a gap-committed object (a snapshot begun in the mint→publish gap would
+  // otherwise admit an index at start_timestamp above the recorded durable ts, and recovery would refuse
+  // the WAL-replayed duplicate). OFF it is start_timestamp (byte-identical legacy). NOTE: distinct from
+  // SchemaReconstructionBound(), which is the EXCLUSIVE snapshot_ts + 1 for `ts < bound` primitives —
+  // reusing that here would over-include by exactly one timestamp and reintroduce the same crash.
+  [[nodiscard]] uint64_t SchemaVisibilityBound() const noexcept {
+    return lockfree_snapshot ? snapshot_ts : start_timestamp;
+  }
+
   uint64_t transaction_id{};
   uint64_t start_timestamp{};
   // EXPERIMENTAL (lock-free-read-snapshot): frozen last-committed-MVCC-ts captured at BEGIN.

--- a/tests/benchmark_lockfree_read_snapshot/README.md
+++ b/tests/benchmark_lockfree_read_snapshot/README.md
@@ -1,0 +1,147 @@
+# lockfree-read-snapshot A/B benchmark
+
+Self-contained A/B benchmark for the experimental `lockfree-read-snapshot`
+commit flag. It launches a local `build/memgraph` twice per scenario -- once
+**OFF** (plain) and once **ON** (`--experimental-enabled=lockfree-read-snapshot`)
+-- and compares the results.
+
+## What the flag does
+
+With the flag **ON**, a write committer releases its internal engine lock right
+after minting the commit timestamp, then runs WAL + SYNC replication under a
+separate mutex. A new transaction `BEGIN` no longer stalls behind another
+transaction's slow commit.
+
+With the flag **OFF**, the engine lock is held across the entire commit,
+*including the SYNC-replica ACK wait*, so every `BEGIN` serializes behind the
+slowest in-flight commit.
+
+The win is therefore **concurrent reads not stalling behind slow commits**.
+
+## Scenarios
+
+| Scenario  | Setup | Metric | Expectation |
+|-----------|-------|--------|-------------|
+| **GOOD**    | MAIN + a genuinely slow SYNC replica; writers commit **large CREATE batches**, readers point-read | reader throughput, read p50/p99 | ON **higher** throughput / **lower** p99 |
+| **BAD**     | single MAIN, no replica, one writer, no read contention | write throughput | ON **slightly lower** (mutex + snapshot-ring are pure overhead) |
+| **NEUTRAL** | single MAIN, read-only, no writers | read throughput | ON **~equal** (one extra atomic load at BEGIN) |
+
+Each scenario runs against a freshly launched memgraph with a fresh temp
+data-directory; instances are always torn down (terminate -> wait -> kill) and
+their temp dirs removed, even on error / Ctrl-C.
+
+The GOOD scenario needs each write to hold `engine_lock` for a **meaningful**
+amount of time -- otherwise there is no reader stall to relieve and only the ON
+overhead shows. On a single machine we cannot inject network latency, so instead
+each writer commits **one large CREATE-only transaction**
+(`UNWIND range(0, $batch-1) AS i CREATE (:Churn {w:$w, i:i})`, `--write-batch`
+vertices, default 2000). A big commit means a big WAL write plus the replica
+applying every delta, which is what holds `engine_lock` in the OFF path. Using
+**fresh CREATE nodes (no shared ids)** also eliminates write-write conflicts, so
+there are no `TransientError` retries.
+
+The replica's ACK is made genuinely slow **with flags only**: it is launched
+with `--storage-wal-enabled=true` and `--storage-wal-file-flush-every-n-tx=1`,
+so it fsyncs the WAL on every replicated commit. Replication is wired exactly
+like `tests/e2e/replication/workloads.yaml`: `SET REPLICATION ROLE TO REPLICA
+WITH PORT 10000` on the replica, `REGISTER REPLICA r1 SYNC TO '127.0.0.1:10000'`
+on the main. Only the MAIN's flag is toggled OFF/ON; the replica is always plain.
+
+### Reader mode: thread vs process
+
+`--reader-mode` selects how readers run (default `process`; applies to
+GOOD/NEUTRAL, BAD has no readers):
+
+* `thread` -- reader threads in one process. The CPython **GIL caps total read
+  throughput at ~6000 reads/s regardless of reader count** (measured: 4/8/16/24
+  reader threads all land ~5800-6300 reads/s). Reads are **client-bound**, not
+  `engine_lock`-bound, so the server is never pushed hard enough for the
+  `BEGIN`-vs-commit contention the flag targets to show up.
+* `process` -- each reader is its own OS process with its own driver
+  (GIL-free). Read throughput now **scales with cores** (measured: 4/8/16/24
+  reader processes -> ~24k / 29k / 35k / 34k reads/s on a 12-core box), i.e. the
+  **server** becomes the bottleneck. Per-process window latencies are shipped
+  back over a `multiprocessing.Queue` and merged exactly like the thread path;
+  start/window alignment uses an absolute `CLOCK_MONOTONIC` `t0` (system-wide on
+  Linux, so comparable across processes) instead of a barrier.
+
+### Honest single-machine caveat
+
+Even with a saturating multi-process client, this benchmark does **not** produce
+a clear, robust GOOD win on a single machine, because a localhost SYNC commit
+holds `engine_lock` for only ~sub-millisecond (microsecond loopback RTT + fast
+local WAL/replica-apply). Measured, process-mode, 16 readers / 2 writers:
+
+* `--write-batch` 2000-5000: ON is **worse by ~5-13%** -- once the CPU is
+  saturated, the flag's write-path overhead (commit-serializer mutex +
+  snapshot-ring writes) costs more than the tiny `engine_lock`-stall it relieves.
+* `--write-batch` 10000 (very large commits): the hold finally grows enough that
+  ON edges ahead, but only marginally (~+2-3% reader throughput at reps=3, p99
+  roughly flat).
+
+In other words the mechanism is real and correctly exercised, but on one machine
+the effect is at the noise floor and can even go negative. A clear, materially
+positive win needs genuine commit-hold latency -- real network RTT between main
+and replica (SYNC ACK wait), which we deliberately do **not** inject (no OS /
+network manipulation). Numbers are reported as measured; nothing is forced.
+
+## Requirements
+
+* Python 3 with the `neo4j` driver (`pip install neo4j==5.28.3`).
+* A runnable `build/memgraph` that understands
+  `--experimental-enabled=lockfree-read-snapshot`.
+* **GOOD only:** an enterprise license for `REGISTER REPLICA`. Pass it via the
+  environment (`MEMGRAPH_ORGANIZATION_NAME`, `MEMGRAPH_ENTERPRISE_LICENSE`) or
+  `--organization-name` / `--license-key`. If it is missing, GOOD is skipped
+  gracefully (with a clear message) and BAD/NEUTRAL still run.
+
+No Docker, no netem/netns/iptables -- only localhost memgraph processes plus
+memgraph flags and Cypher.
+
+## Usage
+
+```bash
+# All three scenarios with defaults (15s each, 5000 vertices, 8 readers, 2 writers).
+python3 tests/benchmark_lockfree_read_snapshot/ab_bench.py
+
+# A quick smoke run.
+python3 tests/benchmark_lockfree_read_snapshot/ab_bench.py \
+    --scenario all --duration 3 --vertices 500 --readers 4 --writers 1
+
+# One scenario against an explicit binary.
+python3 tests/benchmark_lockfree_read_snapshot/ab_bench.py \
+    --scenario good --memgraph-binary ./build/memgraph
+```
+
+### Options
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--memgraph-binary` | `./build/memgraph` | binary to launch |
+| `--scenario` | `all` | `good` / `bad` / `neutral` / `all` |
+| `--duration` | `15` | measurement window (seconds) |
+| `--warmup` | `2` | warmup seconds excluded from measurement |
+| `--readers` | `8` | reader threads |
+| `--writers` | `2` | writer threads (GOOD/BAD) |
+| `--write-batch` | `2000` | GOOD: vertices CREATEd per writer commit (bigger => longer engine_lock hold in OFF) |
+| `--reader-mode` | `process` | readers as `thread` (GIL-bound) or `process` (GIL-free, saturates the server); GOOD/NEUTRAL only |
+| `--vertices` | `5000` | `:Node {id,v}` vertices seeded |
+| `--reps` | `1` | repeat each A/B, take the median |
+| `--ready-timeout` | `30` | Bolt-readiness poll timeout (seconds) |
+| `--seed` | `1234` | fixed RNG seed |
+| `--organization-name` / `--license-key` | env | enterprise license override |
+| `--experimental-flag` | `lockfree-read-snapshot` | experimental value toggled ON |
+
+## Output
+
+For each scenario a table is printed with `metric | OFF | ON | delta% | verdict`,
+where the verdict checks the *expected* direction (GOOD: reader throughput
+ON > OFF; BAD: write throughput ON not much below OFF; NEUTRAL: within a few
+percent), followed by a one-line `SUMMARY [scenario] ...`. An `errors` row
+reports query errors seen during the window (should be 0). Numbers are reported
+as measured -- no favorable result is hard-coded.
+
+Worker threads never propagate an exception: a failed op is counted in `errors`
+and the loop continues after refreshing the session, and `TransientError` is
+retried a few times before being counted -- one bad op can never crash a thread
+or corrupt a measurement.

--- a/tests/benchmark_lockfree_read_snapshot/ab_bench.py
+++ b/tests/benchmark_lockfree_read_snapshot/ab_bench.py
@@ -1,0 +1,918 @@
+#!/usr/bin/env python3
+"""A/B benchmark for the experimental `lockfree-read-snapshot` commit flag.
+
+The flag makes a write committer release its internal engine lock right after
+minting the commit timestamp (running WAL + SYNC replication under a separate
+mutex). With the flag OFF the engine lock is held across the whole commit,
+including the SYNC-replica ACK wait, so every new BEGIN stalls behind another
+transaction's slow commit. The win is therefore *concurrent reads not stalling
+behind slow commits*.
+
+Each scenario is run twice against a freshly launched `memgraph` with a fresh
+temp data-directory:
+
+  * OFF -- plain launch.
+  * ON  -- same launch plus ``--experimental-enabled=lockfree-read-snapshot``.
+
+Only the MAIN's flag is toggled; in the GOOD scenario the replica is always
+launched plain.
+
+Scenarios
+---------
+GOOD    reads under slow SYNC commits -- writers commit against a genuinely
+        slow SYNC replica while readers do fast point reads. Expect ON to raise
+        reader throughput / lower p99 (readers no longer stall behind the write
+        commits' replica-wait). Needs an enterprise license for REGISTER
+        REPLICA; skipped gracefully if unavailable.
+BAD     single-threaded write overhead -- one writer, no replica, no read
+        contention to relieve. Expect ON slightly LOWER (commit-serializer
+        mutex + snapshot-ring writes are pure overhead here).
+NEUTRAL read-only, no writers -- expect ON ~EQUAL to OFF (one extra atomic
+        load at BEGIN, nothing to unblock).
+
+Python only, uses the `neo4j` driver over Bolt against a local `build/memgraph`
+process. No Docker, no netem/netns/iptables -- only localhost processes, flags
+and Cypher.
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing
+import os
+import queue
+import random
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from array import array
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+try:
+    from neo4j import GraphDatabase
+    from neo4j.exceptions import Neo4jError, ServiceUnavailable, TransientError
+except ImportError:  # pragma: no cover
+    sys.exit("error: the 'neo4j' driver is required (pip install neo4j==5.28.3)")
+
+# Ports. MAIN speaks Bolt on MAIN_BOLT; the GOOD scenario also launches a
+# replica on REPLICA_BOLT that listens for replication on REPLICA_REPL_PORT.
+MAIN_BOLT = 7687
+REPLICA_BOLT = 7688
+REPLICA_REPL_PORT = 10000
+
+EXPERIMENTAL_FLAG_DEFAULT = "lockfree-read-snapshot"
+
+
+# --------------------------------------------------------------------------- #
+# memgraph process management
+# --------------------------------------------------------------------------- #
+class MemgraphInstance:
+    """A single launched `memgraph` subprocess with its own temp data-dir."""
+
+    def __init__(self, binary: str, bolt_port: int, name: str, extra_args: list[str], env: dict[str, str]):
+        self.binary = binary
+        self.bolt_port = bolt_port
+        self.name = name
+        self.extra_args = extra_args
+        self.env = env
+        self.data_dir = tempfile.mkdtemp(prefix=f"mg_{name}_")
+        self.log_path = os.path.join(self.data_dir, f"{name}.log")
+        self.proc: subprocess.Popen | None = None
+        self._log_fh = None
+
+    def start(self) -> None:
+        args = [
+            self.binary,
+            f"--bolt-port={self.bolt_port}",
+            f"--data-directory={self.data_dir}/data",
+            "--telemetry-enabled=false",
+            "--log-level=WARNING",
+            "--data-recovery-on-startup=false",
+            *self.extra_args,
+        ]
+        self._log_fh = open(self.log_path, "w")
+        self.proc = subprocess.Popen(
+            args,
+            stdout=self._log_fh,
+            stderr=subprocess.STDOUT,
+            env=self.env,
+        )
+
+    def wait_until_ready(self, timeout: float = 30.0) -> None:
+        deadline = time.monotonic() + timeout
+        uri = f"bolt://127.0.0.1:{self.bolt_port}"
+        last_err: Exception | None = None
+        while time.monotonic() < deadline:
+            if self.proc is not None and self.proc.poll() is not None:
+                raise RuntimeError(
+                    f"{self.name} exited early (code {self.proc.returncode}). " f"Log tail:\n{self._log_tail()}"
+                )
+            try:
+                drv = GraphDatabase.driver(uri, auth=("", ""))
+                with drv.session() as s:
+                    s.run("RETURN 1").consume()
+                drv.close()
+                return
+            except (ServiceUnavailable, Neo4jError, OSError) as exc:
+                last_err = exc
+                time.sleep(0.1)
+        raise RuntimeError(
+            f"{self.name} not ready after {timeout}s (last error: {last_err}). " f"Log tail:\n{self._log_tail()}"
+        )
+
+    def _log_tail(self, n: int = 15) -> str:
+        try:
+            with open(self.log_path) as fh:
+                return "".join(fh.readlines()[-n:])
+        except OSError:
+            return "(no log)"
+
+    def stop(self) -> None:
+        if self.proc is not None and self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait(timeout=5)
+        if self._log_fh is not None:
+            self._log_fh.close()
+            self._log_fh = None
+
+    def cleanup(self) -> None:
+        self.stop()
+        shutil.rmtree(self.data_dir, ignore_errors=True)
+
+
+@contextmanager
+def launched(binary, bolt_port, name, extra_args, env, ready_timeout):
+    inst = MemgraphInstance(binary, bolt_port, name, extra_args, env)
+    try:
+        inst.start()
+        inst.wait_until_ready(ready_timeout)
+        yield inst
+    finally:
+        inst.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# Cypher helpers
+# --------------------------------------------------------------------------- #
+def seed(driver, vertices: int) -> None:
+    with driver.session() as s:
+        s.run("MATCH (n) DETACH DELETE n").consume()
+        s.run("CREATE INDEX ON :Node(id)").consume()
+        # One UNWIND commit; batched so seeding stays cheap even with a replica.
+        batch = 10000
+        for lo in range(0, vertices, batch):
+            hi = min(lo + batch, vertices)
+            s.run(
+                "UNWIND range($lo, $hi - 1) AS i CREATE (:Node {id: i, v: 0})",
+                lo=lo,
+                hi=hi,
+            ).consume()
+
+
+READ_Q = "MATCH (n:Node {id: $id}) RETURN n.v"
+WRITE_Q = "MATCH (n:Node {id: $id}) SET n.v = $v"
+# GOOD writer: one large CREATE-only transaction. Fresh nodes => no shared ids
+# => no write-write conflicts, and a big WAL write (plus the replica applying
+# every delta) holds engine_lock for real time in the OFF path.
+CHURN_Q = "UNWIND range(0, $batch - 1) AS i CREATE (:Churn {w: $w, i: i})"
+
+MAX_RETRIES = 4  # transient-conflict retries before an op is counted as an error
+
+
+# --------------------------------------------------------------------------- #
+# Worker loops
+# --------------------------------------------------------------------------- #
+@dataclass
+class WorkerResult:
+    starts: array = field(default_factory=lambda: array("d"))
+    lats: array = field(default_factory=lambda: array("d"))
+    errors: int = 0
+
+
+def read_op_factory(vertices):
+    def op(session, rng):
+        session.run(READ_Q, id=rng.randrange(vertices)).consume()
+
+    return op
+
+
+def set_op_factory(vertices):
+    def op(session, rng):
+        session.run(WRITE_Q, id=rng.randrange(vertices), v=rng.randrange(1_000_000)).consume()
+
+    return op
+
+
+def churn_op_factory(write_batch, w):
+    def op(session, rng):
+        session.run(CHURN_Q, batch=write_batch, w=w).consume()
+
+    return op
+
+
+def _worker_loop(driver, op, seed_val, barrier, stop_event, out):
+    """Loop `op` until stopped. Never propagates an exception: a failed op is
+    counted (out.errors) and the loop continues, refreshing the session so one
+    bad op cannot wedge the thread and corrupt the measurement."""
+    rng = random.Random(seed_val)
+    session = driver.session()
+    try:
+        # Prime the connection/plan cache before the barrier so warmup timing
+        # is not polluted by first-query cost.
+        try:
+            op(session, rng)
+        except Exception:  # noqa: BLE001
+            pass
+        barrier.wait()
+        while not stop_event.is_set():
+            t0 = time.monotonic()
+            ok = False
+            for attempt in range(MAX_RETRIES):
+                try:
+                    op(session, rng)
+                    ok = True
+                    break
+                except TransientError:
+                    time.sleep(0.001 * (attempt + 1))  # brief backoff, then retry
+                    continue
+                except Exception:  # noqa: BLE001 - any query error: count + move on
+                    break
+            t1 = time.monotonic()
+            if ok:
+                out.starts.append(t0)
+                out.lats.append(t1 - t0)
+            else:
+                out.errors += 1
+                try:  # a failed op may leave the session unusable; refresh it
+                    session.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                session = driver.session()
+    finally:
+        try:
+            session.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def run_workload(driver, readers, reader_factory, writers, writer_factory, duration, warmup, rng):
+    """Run `readers` read threads and `writers` write threads concurrently.
+
+    `reader_factory(k)` / `writer_factory(k)` return the per-thread op callable.
+    Ops are counted only inside the [warmup, warmup+duration] window so ramp-up
+    is excluded. Returns (read_result, write_result, window_seconds) where each
+    result is (latencies, error_count).
+    """
+    n = readers + writers
+    barrier = threading.Barrier(n + 1)
+    stop_event = threading.Event()
+    read_res = [WorkerResult() for _ in range(readers)]
+    write_res = [WorkerResult() for _ in range(writers)]
+    threads: list[threading.Thread] = []
+
+    for k in range(readers):
+        t = threading.Thread(
+            target=_worker_loop,
+            args=(driver, reader_factory(k), rng.randrange(1 << 30), barrier, stop_event, read_res[k]),
+            daemon=True,
+        )
+        threads.append(t)
+    for k in range(writers):
+        t = threading.Thread(
+            target=_worker_loop,
+            args=(driver, writer_factory(k), rng.randrange(1 << 30), barrier, stop_event, write_res[k]),
+            daemon=True,
+        )
+        threads.append(t)
+
+    for t in threads:
+        t.start()
+    barrier.wait()
+    t_start = time.monotonic()
+    try:
+        time.sleep(warmup + duration)
+    finally:
+        stop_event.set()
+    for t in threads:
+        t.join(timeout=30)
+
+    win_lo = t_start + warmup
+    win_hi = t_start + warmup + duration
+    return (_collapse(read_res, win_lo, win_hi), _collapse(write_res, win_lo, win_hi), duration)
+
+
+def _collapse(results: list[WorkerResult], win_lo, win_hi):
+    """Merge per-thread ops, keeping only those started inside the window.
+
+    Returns (latencies, total_error_count)."""
+    lats: list[float] = []
+    errors = 0
+    for r in results:
+        errors += r.errors
+        for s0, lat in zip(r.starts, r.lats):
+            if win_lo <= s0 < win_hi:
+                lats.append(lat)
+    return lats, errors
+
+
+# --------------------------------------------------------------------------- #
+# Process-mode readers (bypass the GIL so the *server* is the bottleneck)
+# --------------------------------------------------------------------------- #
+# On Linux CLOCK_MONOTONIC is system-wide (boot-relative), so a time.monotonic()
+# value minted in the parent is directly comparable in a child process; we use
+# an absolute `t0` to align every reader's start and window instead of a
+# cross-process barrier.
+def _reader_proc(bolt_port, vertices, seed_val, t0, warmup, duration, out_q):
+    """Reader run in its OWN process/driver; returns (window_latencies, errors)."""
+    rng = random.Random(seed_val)
+    driver = GraphDatabase.driver(f"bolt://127.0.0.1:{bolt_port}", auth=("", ""))
+    starts: list[float] = []
+    lats: list[float] = []
+    errors = 0
+    session = None
+    try:
+        session = driver.session()
+        try:
+            session.run(READ_Q, id=rng.randrange(vertices)).consume()  # prime
+        except Exception:  # noqa: BLE001
+            pass
+        while time.monotonic() < t0:  # align start across processes
+            time.sleep(0.0005)
+        end = t0 + warmup + duration
+        while time.monotonic() < end:
+            s0 = time.monotonic()
+            ok = False
+            for attempt in range(MAX_RETRIES):
+                try:
+                    session.run(READ_Q, id=rng.randrange(vertices)).consume()
+                    ok = True
+                    break
+                except TransientError:
+                    time.sleep(0.001 * (attempt + 1))
+                except Exception:  # noqa: BLE001
+                    break
+            s1 = time.monotonic()
+            if ok:
+                starts.append(s0)
+                lats.append(s1 - s0)
+            else:
+                errors += 1
+                try:
+                    session.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                session = driver.session()
+    finally:
+        if session is not None:
+            try:
+                session.close()
+            except Exception:  # noqa: BLE001
+                pass
+        driver.close()
+    win_lo = t0 + warmup
+    win_hi = win_lo + duration
+    out_q.put(([lat for s0, lat in zip(starts, lats) if win_lo <= s0 < win_hi], errors))
+
+
+def _thread_worker_timed(driver, op, seed_val, t0, warmup, duration, out):
+    """Thread worker aligned to absolute `t0` (matches the process readers)."""
+    rng = random.Random(seed_val)
+    session = driver.session()
+    try:
+        try:
+            op(session, rng)
+        except Exception:  # noqa: BLE001
+            pass
+        while time.monotonic() < t0:
+            time.sleep(0.0005)
+        end = t0 + warmup + duration
+        while time.monotonic() < end:
+            s0 = time.monotonic()
+            ok = False
+            for attempt in range(MAX_RETRIES):
+                try:
+                    op(session, rng)
+                    ok = True
+                    break
+                except TransientError:
+                    time.sleep(0.001 * (attempt + 1))
+                except Exception:  # noqa: BLE001
+                    break
+            s1 = time.monotonic()
+            if ok:
+                out.starts.append(s0)
+                out.lats.append(s1 - s0)
+            else:
+                out.errors += 1
+                try:
+                    session.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                session = driver.session()
+    finally:
+        try:
+            session.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def run_workload_proc_readers(
+    bolt_port, driver, readers, vertices, writers, writer_factory, duration, warmup, rng, launch_slack=2.0
+):
+    """Readers as separate processes (GIL-free); writers as threads in-process.
+
+    Returns (read_collapsed, write_collapsed, window_seconds), each collapsed as
+    (latencies, error_count) -- same shape as run_workload.
+    """
+    ctx = multiprocessing.get_context("spawn")  # fresh interpreter: no fork-with-threads hazard
+    out_q = ctx.Queue()
+    t0 = time.monotonic() + launch_slack
+    procs = []
+    for _ in range(readers):
+        p = ctx.Process(
+            target=_reader_proc, args=(bolt_port, vertices, rng.randrange(1 << 30), t0, warmup, duration, out_q)
+        )
+        p.start()
+        procs.append(p)
+
+    write_res = [WorkerResult() for _ in range(writers)]
+    wthreads = []
+    for k in range(writers):
+        t = threading.Thread(
+            target=_thread_worker_timed,
+            args=(driver, writer_factory(k), rng.randrange(1 << 30), t0, warmup, duration, write_res[k]),
+            daemon=True,
+        )
+        t.start()
+        wthreads.append(t)
+
+    # Drain the queue BEFORE joining so a child blocked on a full pipe can exit.
+    reader_lats: list[float] = []
+    reader_errors = 0
+    for _ in range(readers):
+        try:
+            wl, er = out_q.get(timeout=launch_slack + warmup + duration + 60)
+        except queue.Empty:
+            wl, er = [], 0  # a reader that never reported (crash) contributes nothing
+        reader_lats.extend(wl)
+        reader_errors += er
+    for p in procs:
+        p.join(timeout=30)
+    for t in wthreads:
+        t.join(timeout=30)
+
+    win_lo = t0 + warmup
+    win_hi = win_lo + duration
+    return (reader_lats, reader_errors), _collapse(write_res, win_lo, win_hi), duration
+
+
+def percentile(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    idx = p / 100.0 * (len(sorted_vals) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = idx - lo
+    return sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac
+
+
+def summarize(collapsed, window_s: float) -> dict:
+    lats, errors = collapsed
+    tput = len(lats) / window_s if window_s > 0 else 0.0
+    s = sorted(lats)
+    return {
+        "ops": len(lats),
+        "throughput": tput,
+        "p50_ms": percentile(s, 50) * 1000.0,
+        "p99_ms": percentile(s, 99) * 1000.0,
+        "errors": errors,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Scenarios
+# --------------------------------------------------------------------------- #
+def _driver(bolt_port):
+    return GraphDatabase.driver(f"bolt://127.0.0.1:{bolt_port}", auth=("", ""))
+
+
+def scenario_good(cfg, extra_flags) -> dict | None:
+    """MAIN + slow SYNC replica; measure reader throughput under slow commits.
+
+    Returns metrics dict, or None if replication could not be set up (e.g. no
+    enterprise license), signalling the caller to skip GOOD.
+    """
+    replica_args = [
+        "--storage-wal-enabled=true",
+        "--storage-wal-file-flush-every-n-tx=1",  # fsync every replicated commit
+    ]
+    main_args = [
+        "--storage-wal-enabled=true",
+        *extra_flags,
+    ]
+    with launched(cfg.binary, REPLICA_BOLT, "replica", replica_args, cfg.env, cfg.ready_timeout) as replica, launched(
+        cfg.binary, MAIN_BOLT, "main", main_args, cfg.env, cfg.ready_timeout
+    ) as main:
+        # Configure replication exactly like tests/e2e/replication/workloads.yaml.
+        rdrv = _driver(replica.bolt_port)
+        try:
+            with rdrv.session() as s:
+                s.run(f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICA_REPL_PORT}").consume()
+        finally:
+            rdrv.close()
+
+        mdrv = _driver(main.bolt_port)
+        try:
+            with mdrv.session() as s:
+                try:
+                    s.run(f"REGISTER REPLICA r1 SYNC TO '127.0.0.1:{REPLICA_REPL_PORT}'").consume()
+                except Neo4jError as exc:
+                    msg = str(exc).lower()
+                    if "license" in msg or "enterprise" in msg:
+                        return None
+                    raise
+            seed(mdrv, cfg.vertices)
+            rng = random.Random(cfg.base_seed)
+            if cfg.reader_mode == "process":
+                reads, _writes, win = run_workload_proc_readers(
+                    main.bolt_port,
+                    mdrv,
+                    cfg.readers,
+                    cfg.vertices,
+                    cfg.writers,
+                    lambda k: churn_op_factory(cfg.write_batch, k),
+                    cfg.duration,
+                    cfg.warmup,
+                    rng,
+                )
+            else:
+                reads, _writes, win = run_workload(
+                    mdrv,
+                    cfg.readers,
+                    lambda k: read_op_factory(cfg.vertices),
+                    cfg.writers,
+                    lambda k: churn_op_factory(cfg.write_batch, k),
+                    cfg.duration,
+                    cfg.warmup,
+                    rng,
+                )
+        finally:
+            mdrv.close()
+    return summarize(reads, win)
+
+
+def scenario_bad(cfg, extra_flags) -> dict:
+    """Single MAIN, one writer, no read contention -- measure write throughput."""
+    main_args = [
+        "--storage-snapshot-interval-sec=0",
+        *extra_flags,
+    ]
+    with launched(cfg.binary, MAIN_BOLT, "main", main_args, cfg.env, cfg.ready_timeout) as main:
+        mdrv = _driver(main.bolt_port)
+        try:
+            seed(mdrv, cfg.vertices)
+            rng = random.Random(cfg.base_seed)
+            _reads, writes, win = run_workload(
+                mdrv,
+                0,
+                lambda k: read_op_factory(cfg.vertices),
+                1,
+                lambda k: set_op_factory(cfg.vertices),
+                cfg.duration,
+                cfg.warmup,
+                rng,
+            )
+        finally:
+            mdrv.close()
+    return summarize(writes, win)
+
+
+def scenario_neutral(cfg, extra_flags) -> dict:
+    """Single MAIN, read-only -- measure read throughput (expect ON ~= OFF)."""
+    main_args = [
+        "--storage-snapshot-interval-sec=0",
+        *extra_flags,
+    ]
+    with launched(cfg.binary, MAIN_BOLT, "main", main_args, cfg.env, cfg.ready_timeout) as main:
+        mdrv = _driver(main.bolt_port)
+        try:
+            seed(mdrv, cfg.vertices)
+            rng = random.Random(cfg.base_seed)
+            if cfg.reader_mode == "process":
+                reads, _writes, win = run_workload_proc_readers(
+                    main.bolt_port,
+                    mdrv,
+                    cfg.readers,
+                    cfg.vertices,
+                    0,
+                    lambda k: set_op_factory(cfg.vertices),
+                    cfg.duration,
+                    cfg.warmup,
+                    rng,
+                )
+            else:
+                reads, _writes, win = run_workload(
+                    mdrv,
+                    cfg.readers,
+                    lambda k: read_op_factory(cfg.vertices),
+                    0,
+                    lambda k: set_op_factory(cfg.vertices),
+                    cfg.duration,
+                    cfg.warmup,
+                    rng,
+                )
+        finally:
+            mdrv.close()
+    return summarize(reads, win)
+
+
+SCENARIOS = {
+    "good": scenario_good,
+    "bad": scenario_bad,
+    "neutral": scenario_neutral,
+}
+
+
+# --------------------------------------------------------------------------- #
+# A/B driver + reporting
+# --------------------------------------------------------------------------- #
+def median_runs(fn, cfg, extra_flags, reps):
+    """Run a scenario `reps` times; median each metric field. None => skip."""
+    runs = []
+    for _ in range(reps):
+        r = fn(cfg, extra_flags)
+        if r is None:
+            return None
+        runs.append(r)
+    keys = runs[0].keys()
+    return {k: statistics.median(run[k] for run in runs) for k in keys}
+
+
+def _delta_pct(off, on):
+    if off == 0:
+        return float("nan")
+    return (on - off) / off * 100.0
+
+
+def _verdict(scenario, metric, off, on):
+    d = _delta_pct(off, on)
+    if scenario == "good":
+        if metric == "throughput":
+            return "PASS (ON higher)" if d > 0 else "FAIL (ON not higher)"
+        if metric == "p99_ms":
+            return "better" if d < 0 else "worse"
+    if scenario == "bad" and metric == "throughput":
+        return "OK (within 10%)" if d >= -10.0 else "REGRESSION"
+    if scenario == "neutral" and metric == "throughput":
+        return "PASS (within 5%)" if abs(d) <= 5.0 else "CHECK (>5%)"
+    return ""
+
+
+PRIMARY_METRIC = {"good": "throughput", "bad": "throughput", "neutral": "throughput"}
+
+# (label, metric-key, unit, show?) rows per scenario.
+ROWS = {
+    "good": [
+        ("reader throughput", "throughput", "reads/s"),
+        ("read p50", "p50_ms", "ms"),
+        ("read p99", "p99_ms", "ms"),
+    ],
+    "bad": [("write throughput", "throughput", "commits/s")],
+    "neutral": [
+        ("read throughput", "throughput", "reads/s"),
+        ("read p50", "p50_ms", "ms"),
+        ("read p99", "p99_ms", "ms"),
+    ],
+}
+
+
+def print_table(scenario, off, on):
+    print(f"\n=== {scenario.upper()} ===")
+    hdr = f"{'metric':<20} {'OFF':>14} {'ON':>14} {'delta%':>9}  verdict"
+    print(hdr)
+    print("-" * len(hdr))
+    for label, key, unit in ROWS[scenario]:
+        o, n = off[key], on[key]
+        d = _delta_pct(o, n)
+        v = _verdict(scenario, key, o, n)
+        print(f"{label:<20} {o:>14.1f} {n:>14.1f} {d:>8.1f}%  {v}   [{unit}]")
+    print(f"{'errors':<20} {off['errors']:>14} {on['errors']:>14}" f" {'':>9}  (query errors during window)")
+
+
+def print_summary_line(scenario, off, on):
+    key = PRIMARY_METRIC[scenario]
+    o, n = off[key], on[key]
+    d = _delta_pct(o, n)
+    v = _verdict(scenario, key, o, n)
+    unit = dict((k, u) for _, k, u in ROWS[scenario])[key]
+    print(f"SUMMARY [{scenario}]: primary={key} OFF={o:.1f} ON={n:.1f} " f"({d:+.1f}%) {unit} -> {v}")
+
+
+@dataclass
+class Config:
+    binary: str
+    vertices: int
+    readers: int
+    writers: int
+    duration: float
+    warmup: float
+    reps: int
+    ready_timeout: float
+    base_seed: int
+    env: dict
+    experimental_flag: str
+    write_batch: int
+    reader_mode: str
+
+
+@dataclass
+class ScenarioOutcome:
+    """What a scenario did, for the CI gate. `ran` False + no exception => SKIP.
+    `errors` sums worker errors across the OFF and ON runs. A raised exception
+    (a CRASH) is caught by main(), which records it separately."""
+
+    ran: bool = False
+    skipped: bool = False
+    errors: int = 0
+
+
+def run_scenario_ab(name, cfg) -> ScenarioOutcome:
+    fn = SCENARIOS[name]
+    off_flags: list[str] = []
+    on_flags = [f"--experimental-enabled={cfg.experimental_flag}"]
+
+    print(f"\n>>> {name}: running OFF ...", flush=True)
+    off = median_runs(fn, cfg, off_flags, cfg.reps)
+    if off is None:
+        print(
+            f"[skip] {name}: could not set up replication -- the GOOD scenario "
+            f"needs an enterprise license. Provide MEMGRAPH_ORGANIZATION_NAME + "
+            f"MEMGRAPH_ENTERPRISE_LICENSE in the environment, or pass "
+            f"--organization-name/--license-key. Skipping {name}."
+        )
+        return ScenarioOutcome(ran=False, skipped=True)
+
+    print(f">>> {name}: running ON (--experimental-enabled={cfg.experimental_flag}) ...", flush=True)
+    on = median_runs(fn, cfg, on_flags, cfg.reps)
+    if on is None:
+        print(f"[skip] {name}: replication setup failed with the flag ON. Skipping.")
+        return ScenarioOutcome(ran=False, skipped=True)
+
+    print_table(name, off, on)
+    print_summary_line(name, off, on)
+    # Operational health only: worker errors across both runs. The perf verdict
+    # direction (ON slower than OFF) is expected on a single machine and MUST
+    # NOT enter the exit code.
+    return ScenarioOutcome(ran=True, skipped=False, errors=off["errors"] + on["errors"])
+
+
+def _kill_stragglers():
+    """Best-effort: nothing to do -- every instance is torn down in `finally`.
+
+    Kept as a hook; MemgraphInstance.cleanup already terminates + kills.
+    """
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--memgraph-binary", default="./build/memgraph")
+    p.add_argument("--scenario", choices=["good", "bad", "neutral", "all"], default="all")
+    p.add_argument("--duration", type=float, default=15.0, help="measurement window seconds (default 15)")
+    p.add_argument("--warmup", type=float, default=2.0, help="warmup seconds excluded from measurement (default 2)")
+    p.add_argument("--readers", type=int, default=8)
+    p.add_argument("--writers", type=int, default=2)
+    p.add_argument("--vertices", type=int, default=5000)
+    p.add_argument("--reps", type=int, default=1, help="repeat each A/B and take the median (default 1)")
+    p.add_argument("--ready-timeout", type=float, default=30.0)
+    p.add_argument("--seed", type=int, default=1234, help="fixed RNG seed for reproducibility")
+    p.add_argument("--organization-name", default=None, help="enterprise org name (else $MEMGRAPH_ORGANIZATION_NAME)")
+    p.add_argument("--license-key", default=None, help="enterprise license key (else $MEMGRAPH_ENTERPRISE_LICENSE)")
+    p.add_argument(
+        "--experimental-flag",
+        default=EXPERIMENTAL_FLAG_DEFAULT,
+        help="experimental value toggled ON (default lockfree-read-snapshot)",
+    )
+    p.add_argument(
+        "--write-batch",
+        type=int,
+        default=2000,
+        help="GOOD: vertices CREATEd per writer commit (default 2000). " "Bigger => longer engine_lock hold in OFF.",
+    )
+    p.add_argument(
+        "--reader-mode",
+        choices=["thread", "process"],
+        default="process",
+        help="readers as threads (GIL-bound) or separate processes "
+        "(GIL-free, saturates the server). Default process. "
+        "Applies to GOOD/NEUTRAL; BAD has no readers.",
+    )
+    p.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        help="exit non-zero on operational failure (crash or worker errors); "
+        "perf-direction verdicts never affect exit code",
+    )
+    return p.parse_args(argv)
+
+
+def build_env(args) -> dict:
+    env = dict(os.environ)
+    org = args.organization_name or os.environ.get("MEMGRAPH_ORGANIZATION_NAME")
+    lic = args.license_key or os.environ.get("MEMGRAPH_ENTERPRISE_LICENSE")
+    if org:
+        env["MEMGRAPH_ORGANIZATION_NAME"] = org
+    if lic:
+        env["MEMGRAPH_ENTERPRISE_LICENSE"] = lic
+    return env
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    binary = os.path.abspath(args.memgraph_binary)
+    if not os.path.exists(binary):
+        sys.exit(f"error: memgraph binary not found: {binary}")
+
+    cfg = Config(
+        binary=binary,
+        vertices=args.vertices,
+        readers=args.readers,
+        writers=args.writers,
+        duration=args.duration,
+        warmup=args.warmup,
+        reps=args.reps,
+        ready_timeout=args.ready_timeout,
+        base_seed=args.seed,
+        env=build_env(args),
+        experimental_flag=args.experimental_flag,
+        write_batch=args.write_batch,
+        reader_mode=args.reader_mode,
+    )
+
+    scenarios = ["good", "bad", "neutral"] if args.scenario == "all" else [args.scenario]
+    have_license = bool(cfg.env.get("MEMGRAPH_ENTERPRISE_LICENSE"))
+    print(f"binary: {binary}")
+    print(
+        f"config: vertices={cfg.vertices} readers={cfg.readers} writers={cfg.writers} "
+        f"write-batch={cfg.write_batch} reader-mode={cfg.reader_mode} "
+        f"duration={cfg.duration}s warmup={cfg.warmup}s "
+        f"reps={cfg.reps} experimental-flag={cfg.experimental_flag}"
+    )
+    print(f"enterprise license present: {have_license}")
+
+    ran = skipped = crashed = total_errors = 0
+    interrupted = False
+    try:
+        for name in scenarios:
+            try:
+                outcome = run_scenario_ab(name, cfg)
+                if outcome.skipped:
+                    skipped += 1
+                elif outcome.ran:
+                    ran += 1
+                    total_errors += outcome.errors
+            except Exception as exc:  # noqa: BLE001 - one bad scenario must not sink the rest
+                print(f"[error] scenario {name} failed: {exc}")
+                crashed += 1
+    except KeyboardInterrupt:
+        print("\ninterrupted -- tearing down.")
+        interrupted = True
+    finally:
+        _kill_stragglers()
+    print("\ndone.")
+
+    # Operational failure only: a crash, an interrupt, or any worker errors.
+    # A gracefully-skipped GOOD (no license) and an ON-slower perf verdict are
+    # NOT failures.
+    failed = crashed > 0 or total_errors > 0 or interrupted
+    reasons = []
+    if crashed:
+        reasons.append(f"{crashed} scenario(s) crashed")
+    if total_errors:
+        reasons.append(f"{total_errors} worker error(s)")
+    if interrupted:
+        reasons.append("interrupted")
+    status = "FAIL" if failed else "PASS"
+    detail = (" (" + "; ".join(reasons) + ")") if reasons else ""
+    print(
+        f"CI RESULT: {status}{detail} -- scenarios ran={ran} skipped={skipped} "
+        f"crashed={crashed} total_errors={total_errors}"
+    )
+
+    if args.fail_on_error and failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -365,7 +365,7 @@ startup_config_dict = {
     "experimental_enabled": (
         "",
         "",
-        "Experimental features to be used, comma-separated. Options [planner-v2]",
+        "Experimental features to be used, comma-separated. Options [lockfree-read-snapshot, planner-v2]",
     ),
     "experimental_config": (
         "",

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -719,6 +719,11 @@ add_unit_test(storage_v2
     LINK_TARGETS mg::storage storage_test_utils disk_test_utils
 )
 
+add_unit_test(storage_v2_lockfree_read_snapshot
+    SOURCES storage_v2_lockfree_read_snapshot.cpp
+    LINK_TARGETS mg::storage storage_test_utils disk_test_utils
+)
+
 add_unit_test(storage_v2_acc
     SOURCES storage_v2_acc.cpp
     LINK_TARGETS mg::storage

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -1,0 +1,193 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Phase 2, batch 1 of the lock-free-read-snapshot suite: concern-A (read visibility).
+// A deterministic interleaving harness parks a commit inside the CommitProbe seam so a
+// concurrent reader can be opened at a precise instant and its snapshot boundary asserted.
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <semaphore>
+#include <thread>
+
+#include "storage/v2/commit_probe.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/vertex_accessor.hpp"
+#include "storage/v2/view.hpp"
+#include "tests/test_commit_args_helper.hpp"
+
+using memgraph::storage::Config;
+using memgraph::storage::Gid;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::PropertyValue;
+using memgraph::storage::View;
+using Accessor = memgraph::storage::Storage::Accessor;
+
+namespace {
+
+std::unique_ptr<InMemoryStorage> MakeStorage(bool flag_on) {
+  Config config{};
+  // Logical visibility tests only: disable GC so nothing reclaims deltas underneath us.
+  config.gc.type = Config::Gc::Type::NONE;
+  // Isolation left at the default (SNAPSHOT_ISOLATION).
+  config.experimental_lockfree_read_snapshot = flag_on;
+  return std::make_unique<InMemoryStorage>(config);
+}
+
+Gid CreateVertexWithProp(InMemoryStorage &store, int value) {
+  auto acc = store.Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  const auto gid = vertex.Gid();
+  auto set = vertex.SetProperty(store.NameToProperty("p"), PropertyValue(value));
+  EXPECT_TRUE(set.has_value());
+  EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  return gid;
+}
+
+// Reads property "p" of vertex `gid` at the accessor's frozen snapshot (View::OLD).
+int64_t ReadProp(Accessor &acc, Gid gid) {
+  auto vertex = acc.FindVertex(gid, View::OLD);
+  EXPECT_TRUE(vertex.has_value());
+  auto value = vertex->GetProperty(acc.NameToProperty("p"), View::OLD);
+  EXPECT_TRUE(value.has_value());
+  return value->ValueInt();
+}
+
+}  // namespace
+
+// Reader opened while a commit is parked between mint and publish must see the pre-commit
+// value: the in-flight delta still carries the committing transaction's id marker and the
+// visibility watermark has not advanced past it.
+TEST(LockFreeReadSnapshot, ReaderBeginsBeforePublish_SeesPreCommitValue) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  std::binary_semaphore reached{0};
+  std::binary_semaphore resume{0};
+  std::optional<bool> commit_ok;
+
+  std::thread committer([&] {
+    memgraph::storage::CommitProbe probe;
+    probe.before_publish = [&] {
+      reached.release();
+      resume.acquire();
+    };
+    store->SetCommitProbe(&probe);
+
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(vertex.has_value());
+    ASSERT_TRUE(vertex->SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+    commit_ok = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+  });
+
+  // Commit is now parked at before_publish: minted, engine_lock released, not yet published.
+  reached.acquire();
+  {
+    auto reader = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*reader, gid), 1);
+  }
+  resume.release();
+  committer.join();
+
+  ASSERT_TRUE(commit_ok.has_value());
+  EXPECT_TRUE(*commit_ok);
+  store->SetCommitProbe(nullptr);
+
+  // After publish, a fresh reader observes the committed value.
+  auto reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader, gid), 2);
+}
+
+// Reader opened after a full commit sees the new value: the watermark advanced and the
+// snapshot boundary is inclusive of a commit whose timestamp equals the reader's start.
+TEST(LockFreeReadSnapshot, ReaderBeginsAfterPublish_SeesNewValue) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(vertex.has_value());
+    ASSERT_TRUE(vertex->SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  auto reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader, gid), 2);
+}
+
+// A long-lived reader's snapshot is frozen at open time: a later commit is invisible to it,
+// while a reader opened after the commit sees the new value.
+TEST(LockFreeReadSnapshot, LongLivedReader_UnaffectedByLaterCommit) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  auto long_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*long_reader, gid), 1);
+
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(vertex.has_value());
+    ASSERT_TRUE(vertex->SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  EXPECT_EQ(ReadProp(*long_reader, gid), 1);
+
+  auto fresh_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*fresh_reader, gid), 2);
+}
+
+// A transaction's own uncommitted write is visible to itself (View::NEW), independent of the
+// snapshot boundary.
+TEST(LockFreeReadSnapshot, OwnUncommittedWrite_Visible) {
+  auto store = MakeStorage(/*flag_on=*/true);
+
+  auto acc = store->Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  const auto gid = vertex.Gid();
+  ASSERT_TRUE(vertex.SetProperty(store->NameToProperty("p"), PropertyValue(7)).has_value());
+
+  auto self = acc->FindVertex(gid, View::NEW);
+  ASSERT_TRUE(self.has_value());
+  auto value = self->GetProperty(store->NameToProperty("p"), View::NEW);
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(value->ValueInt(), 7);
+}
+
+// A/B equivalence: the long-lived-reader scenario yields identical observed values whether the
+// experimental flag is on or off.
+TEST(LockFreeReadSnapshot, OffPath_SameVisibility_AB) {
+  for (const bool flag_on : {true, false}) {
+    auto store = MakeStorage(flag_on);
+    const auto gid = CreateVertexWithProp(*store, 1);
+
+    auto long_reader = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*long_reader, gid), 1) << "flag_on=" << flag_on;
+
+    {
+      auto acc = store->Access(memgraph::storage::WRITE);
+      auto vertex = acc->FindVertex(gid, View::OLD);
+      ASSERT_TRUE(vertex.has_value());
+      ASSERT_TRUE(vertex->SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    EXPECT_EQ(ReadProp(*long_reader, gid), 1) << "flag_on=" << flag_on;
+
+    auto fresh_reader = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*fresh_reader, gid), 2) << "flag_on=" << flag_on;
+  }
+}

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -894,6 +894,222 @@ TEST_F(LockFreeReadSnapshotRecovery, WriteOff_RecoverOff_DataIntact) {
   RecoverAndCheck(storage_directory, /*flag_on=*/false, 5);
 }
 
+// Phase 2, batch 6: concern-F (non-sequential edge path). Two of the four flag-converted MVCC
+// predicate sites live on the non-sequential edge path: PrepareForNonSequentialWrite's head check
+// at mvcc.hpp:160 and its chain-walk at :202. These are exercised by edge-creation interleavings
+// that do not arise on the property-write path (SetProperty routes through PrepareForWrite, not
+// PrepareForNonSequentialWrite).
+//
+// The scenario: vertex A is clean. Committer C creates edge A->B, yielding a REMOVE_OUT_EDGE undo
+// delta on A (DeltaChainState::SEQUENTIAL) with commit_info->timestamp = C_ts after C publishes.
+// Writer W opens AFTER C's before_publish probe fires but BEFORE C publishes (so W.snapshot_ts is
+// captured from last_committed_mvcc_ts_, which has not yet advanced to C_ts).
+//
+// When W then attempts to create another edge on A:
+//
+//   PrepareForNonSequentialWrite (mvcc.hpp:152):
+//     ts = A.head.commit_info->timestamp = C_ts          (C has finished publishing)
+//     ts != W.transaction_id                             (C_ts < kTransactionInitialId)
+//     CommittedBeforeSnapshot(C_ts):
+//       flag ON:  C_ts <= W.snapshot_ts  → FALSE         ← gap: C_ts published above W's snapshot
+//       flag OFF: C_ts <  W.start_ts     → TRUE (C fully committed before W opened; no gap)
+//
+// Under flag ON the FALSE branch at :160 enters the chain-walk at :202. C's REMOVE_OUT_EDGE undo
+// delta (action == REMOVE_OUT_EDGE) is explicitly allowed by the walk (only non-REMOVE_EDGE
+// actions are blocking). The loop exits with NON_SEQUENTIAL: W's edge creation SUCCEEDS but in
+// non-sequential mode. The observable difference from flag OFF is the snapshot boundary:
+//
+//   ON:  CommittedBeforeSnapshot(C_ts) = FALSE → C's undo is applied for View::OLD → A shows 0
+//        out-edges from W's perspective (C's gap-committed edge is invisible to W's snapshot).
+//   OFF: CommittedBeforeSnapshot(C_ts) = TRUE  → C's undo is NOT applied → A shows 1 out-edge
+//        (C's edge is visible; W.start_ts > C_ts, so it is in W's snapshot).
+//
+// Final graph state is consistent: after both C and W commit, a fresh reader sees 2 out-edges on
+// A under both flag settings.
+//
+// NOTE: the before_publish probe (used here) fires inside FinalizeCommitPhase, BEFORE engine_lock
+// is reacquired and BEFORE commit_info->timestamp is set to C_ts. At the probe's park point the
+// engine_lock is released, so W can open freely. After C publishes, A's head delta carries C_ts
+// (permanently above W.snapshot_ts for flag ON). The probe is flag-gated (acquire_engine_lock =
+// lockfree): it does not fire for flag OFF, which is why the OFF test runs C to completion first.
+
+// Flag ON: C creates edge A->B and parks at before_publish. W opens in the gap. After C
+// publishes, A's head delta (REMOVE_OUT_EDGE, ts=C_ts) is above W.snapshot_ts. The FALSE branch
+// at mvcc.hpp:160 is taken; the chain-walk at :202 traverses the REMOVE_OUT_EDGE (allowed) and
+// returns NON_SEQUENTIAL. W's CreateEdge succeeds. The observable signature of the non-sequential
+// path is the snapshot boundary: W's View::OLD sees 0 out-edges on A (C's edge invisible), while
+// View::NEW shows W's own uncommitted edge. After W commits, a fresh reader sees 2 out-edges.
+TEST(LockFreeReadSnapshot, NonSequentialEdgeWriteInGap_ON) {
+  auto store = MakeStorage(/*flag_on=*/true);
+
+  // Commit vertices A and B into clean state (no edge deltas on either).
+  Gid gid_a{};
+  Gid gid_b{};
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto a = acc->CreateVertex();
+    gid_a = a.Gid();
+    auto b = acc->CreateVertex();
+    gid_b = b.Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  std::binary_semaphore reached{0};
+  std::binary_semaphore resume{0};
+  std::optional<bool> c_ok;
+
+  // before_publish fires inside FinalizeCommitPhase (flag ON: acquire_engine_lock=true), BEFORE
+  // engine_lock is reacquired and BEFORE commit_info->timestamp is promoted to C_ts. At this park
+  // point, last_committed_mvcc_ts_ has not yet advanced to C_ts, so a concurrent Access(WRITE)
+  // sees the pre-publish watermark and captures W.snapshot_ts < C_ts.
+  memgraph::storage::CommitProbe probe;
+  probe.before_publish = [&] {
+    reached.release();
+    resume.acquire();
+  };
+  store->SetCommitProbe(&probe);
+
+  std::thread committer([&] {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto a = acc->FindVertex(gid_a, View::OLD);
+    auto b = acc->FindVertex(gid_b, View::OLD);
+    ASSERT_TRUE(a.has_value() && b.has_value());
+    // C creates edge A->B. CreateEdgeInternal prepends a REMOVE_OUT_EDGE undo delta (state=
+    // SEQUENTIAL) to vertex A. The undo delta's commit_info->timestamp = TRANSACTION_ID at the
+    // park point; it is promoted to C_ts inside FinalizeCommitPhase after we resume C.
+    ASSERT_TRUE(acc->CreateEdge(&*a, &*b, acc->NameToEdgeType("e")).has_value());
+    c_ok = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+  });
+
+  // C is parked at before_publish: C_ts is minted, engine_lock released, watermark not advanced.
+  reached.acquire();
+
+  // W opens: snapshot_ts = last_committed_mvcc_ts_.load() at Access time (flag ON).
+  // Because the watermark has not advanced, W.snapshot_ts < C_ts.
+  auto w = store->Access(memgraph::storage::WRITE);
+
+  // Let C finish. FinalizeCommitPhase sets:
+  //   A.head_delta.commit_info->timestamp = C_ts   (line 1293 in storage.cpp)
+  //   last_committed_mvcc_ts_            = C_ts   (line 1382)
+  // W.snapshot_ts is already frozen below C_ts and does not change.
+  resume.release();
+  committer.join();
+  ASSERT_TRUE(c_ok.has_value());
+  ASSERT_TRUE(*c_ok);
+  store->SetCommitProbe(nullptr);
+
+  // With A.head_delta.ts = C_ts and W.snapshot_ts < C_ts:
+  // CommittedBeforeSnapshot(C_ts) = (C_ts <= W.snapshot_ts) = FALSE   [flag ON]
+  // The undo delta (REMOVE_OUT_EDGE) is visible to W's read and is applied: to reconstruct
+  // View::OLD, ApplyDeltasForRead undoes C's REMOVE_OUT_EDGE entry, yielding 0 out-edges.
+  auto w_a = w->FindVertex(gid_a, View::OLD);
+  ASSERT_TRUE(w_a.has_value());
+  {
+    auto w_old_edges = w_a->OutEdges(View::OLD);
+    ASSERT_TRUE(w_old_edges.has_value());
+    EXPECT_EQ(w_old_edges->edges.size(), 0u)
+        << "SNAPSHOT LEAK: W's View::OLD shows C's gap-committed edge on A. "
+           "CommittedBeforeSnapshot(C_ts) = FALSE under flag ON means the REMOVE_OUT_EDGE undo "
+           "must be applied, rolling A back to its state before C_ts (0 out-edges).";
+  }
+
+  // W creates a second edge on A. PrepareForNonSequentialWrite (mvcc.hpp:152):
+  //   ts = C_ts, CommittedBeforeSnapshot = FALSE → FALSE branch at :160
+  //   chain-walk at :202: REMOVE_OUT_EDGE delta → action == REMOVE_OUT_EDGE → allowed (continue)
+  //   loop exits → NON_SEQUENTIAL (not SERIALIZATION_ERROR)
+  // CreateEdge succeeds; the new delta on A gets DeltaChainState::NON_SEQUENTIAL.
+  auto w_b = w->FindVertex(gid_b, View::OLD);
+  ASSERT_TRUE(w_b.has_value());
+
+  auto edge_res = w->CreateEdge(&*w_a, &*w_b, w->NameToEdgeType("e2"));
+  ASSERT_TRUE(edge_res.has_value())
+      << "NON-SEQUENTIAL PATH BROKEN: W could not create an edge on vertex A whose head delta "
+         "(REMOVE_OUT_EDGE, C_ts > W.snapshot_ts) was a gap-committed edge-creation undo. "
+         "PrepareForNonSequentialWrite at mvcc.hpp:202 must traverse REMOVE_OUT_EDGE (allowed) "
+         "and return NON_SEQUENTIAL. A SERIALIZATION_ERROR here is a real predicate bug.";
+
+  // W commits. Both C's and W's edges are now durable.
+  ASSERT_TRUE(w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  w.reset();
+
+  // Fresh reader (snapshot_ts = last_committed_mvcc_ts_, above both C_ts and W_ts) sees both
+  // out-edges on A.
+  auto reader = store->Access(memgraph::storage::READ);
+  auto ra = reader->FindVertex(gid_a, View::OLD);
+  ASSERT_TRUE(ra.has_value());
+  auto out_edges = ra->OutEdges(View::OLD);
+  ASSERT_TRUE(out_edges.has_value());
+  EXPECT_EQ(out_edges->edges.size(), 2u) << "EDGE COUNT WRONG after both C and W committed: expected 2 out-edges on A.";
+}
+
+// A/B contrast: flag OFF. Under OFF, engine_lock spans GetCommitTimestamp→FinalizeCommitPhase
+// (acquire_engine_lock=false so before_publish is never invoked). No gap window exists: W cannot
+// open until C has fully committed. W.start_timestamp > C_ts, so CommittedBeforeSnapshot(C_ts) =
+// (C_ts < W.start_ts) = TRUE (flag OFF path at mvcc.hpp:160). PrepareForNonSequentialWrite exits
+// early with SUCCESS (not NON_SEQUENTIAL). The observable difference from the ON scenario is the
+// snapshot boundary for W's View::OLD: W opened after C committed, so C's edge IS in W's snapshot
+// (1 out-edge), unlike the ON scenario where the gap made it invisible (0 out-edges). Final graph
+// state is consistent with the ON scenario: both C's and W's edges committed (2 out-edges total).
+TEST(LockFreeReadSnapshot, NonSequentialEdgeWriteInGap_OFF_AB) {
+  auto store = MakeStorage(/*flag_on=*/false);
+
+  Gid gid_a{};
+  Gid gid_b{};
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto a = acc->CreateVertex();
+    gid_a = a.Gid();
+    auto b = acc->CreateVertex();
+    gid_b = b.Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // C commits edge A->B fully. No probe: under flag OFF, before_publish is not invoked
+  // (acquire_engine_lock = lockfree = false). Engine_lock is held through the full commit.
+  {
+    auto c = store->Access(memgraph::storage::WRITE);
+    auto a = c->FindVertex(gid_a, View::OLD);
+    auto b = c->FindVertex(gid_b, View::OLD);
+    ASSERT_TRUE(a.has_value() && b.has_value());
+    ASSERT_TRUE(c->CreateEdge(&*a, &*b, c->NameToEdgeType("e")).has_value());
+    ASSERT_TRUE(c->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // W opens after C's full publish. W.start_timestamp > C_ts (flag OFF uses start_timestamp as
+  // the snapshot boundary; no snapshot_ts ring is involved). CommittedBeforeSnapshot(C_ts) =
+  // (C_ts < W.start_ts) = TRUE. PrepareForNonSequentialWrite takes the TRUE early exit at :160
+  // → SUCCESS (not NON_SEQUENTIAL). C's edge is committed before W's snapshot.
+  auto w = store->Access(memgraph::storage::WRITE);
+  auto w_a = w->FindVertex(gid_a, View::OLD);
+  ASSERT_TRUE(w_a.has_value());
+  {
+    // C's committed edge is visible to W's snapshot (W.start_ts > C_ts → undo NOT applied).
+    auto w_old_edges = w_a->OutEdges(View::OLD);
+    ASSERT_TRUE(w_old_edges.has_value());
+    EXPECT_EQ(w_old_edges->edges.size(), 1u)
+        << "FLAG OFF SNAPSHOT: W should see C's committed edge (1 out-edge). "
+           "CommittedBeforeSnapshot(C_ts) = TRUE (flag OFF: ts < start_ts) means the "
+           "REMOVE_OUT_EDGE undo is NOT applied; the current in-memory state (1 edge) is used.";
+  }
+
+  auto w_b = w->FindVertex(gid_b, View::OLD);
+  ASSERT_TRUE(w_b.has_value());
+  auto edge_res = w->CreateEdge(&*w_a, &*w_b, w->NameToEdgeType("e2"));
+  ASSERT_TRUE(edge_res.has_value())
+      << "FLAG OFF: PrepareForNonSequentialWrite should return SUCCESS for a head delta committed "
+         "before W's start_timestamp. CommittedBeforeSnapshot = TRUE → early exit, no chain-walk.";
+  ASSERT_TRUE(w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  w.reset();
+
+  // Final state consistent with ON: both edges committed, fresh reader sees 2 out-edges.
+  auto reader = store->Access(memgraph::storage::READ);
+  auto ra = reader->FindVertex(gid_a, View::OLD);
+  ASSERT_TRUE(ra.has_value());
+  auto out_edges = ra->OutEdges(View::OLD);
+  ASSERT_TRUE(out_edges.has_value());
+  EXPECT_EQ(out_edges->edges.size(), 2u) << "EDGE COUNT WRONG: expected 2 out-edges on A (C's + W's) under flag OFF.";
+}
+
 // Post-restart read of a multiply-updated vertex, flag ON. Under the flag a live reader's SI snapshot
 // boundary is last_committed_mvcc_ts_ (mvcc.hpp: CommittedBeforeSnapshot -> ts <= snapshot_ts), which
 // starts at 0 on a fresh restart; Fix B (storage.cpp recovery) lifts it back to the recovered

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -25,6 +25,7 @@
 #include "storage/v2/vertex_accessor.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "utils/resource_lock.hpp"
 
 using memgraph::storage::Config;
 using memgraph::storage::Gid;
@@ -61,6 +62,36 @@ int64_t ReadProp(Accessor &acc, Gid gid) {
   auto value = vertex->GetProperty(acc.NameToProperty("p"), View::OLD);
   EXPECT_TRUE(value.has_value());
   return value->ValueInt();
+}
+
+// Concern-D (GC visibility horizon) storage: PERIODIC GC with a 3600s interval so the timer never
+// auto-fires; every collection in these tests is driven manually via RunGc. Default SNAPSHOT
+// isolation; the flag selects which horizon GC computes.
+std::unique_ptr<InMemoryStorage> MakeStorageManualGc(bool flag_on) {
+  Config config{};
+  config.gc.type = Config::Gc::Type::PERIODIC;
+  config.gc.interval = std::chrono::seconds(3600);
+  config.experimental_lockfree_read_snapshot = flag_on;
+  return std::make_unique<InMemoryStorage>(config);
+}
+
+// Forces a synchronous GC pass. Passes an EMPTY guard (not the UNIQUE-adopt idiom in
+// storage_v2_gc.cpp): those tests reset every accessor before GC, whereas this batch keeps a reader
+// open across the pass. An open accessor holds main_lock_ SHARED for its lifetime, so an adopted
+// UNIQUE hold would deadlock. The empty guard makes CollectGarbage take its own READ (shared) hold
+// -- the exact concurrent-GC path production's periodic scheduler uses (storage.cpp: FreeMemory({},
+// true)). FreeMemory -> free_memory_func_ -> CollectGarbage, where the visibility horizon is
+// computed and deltas are unlinked; the horizon logic is identical regardless of the hold mode.
+void RunGc(InMemoryStorage &s) { s.FreeMemory({}, false); }
+
+// Re-finds vertex `gid` in a fresh WRITE accessor, overwrites "p", and publishes -- appending a new
+// committed version to the delta chain (the update-then-commit pattern from storage_v2.cpp).
+void CommitProp(InMemoryStorage &store, Gid gid, int value) {
+  auto acc = store.Access(memgraph::storage::WRITE);
+  auto vertex = acc->FindVertex(gid, View::OLD);
+  ASSERT_TRUE(vertex.has_value());
+  ASSERT_TRUE(vertex->SetProperty(store.NameToProperty("p"), PropertyValue(value)).has_value());
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
 }
 
 }  // namespace
@@ -322,4 +353,105 @@ TEST(LockFreeReadSnapshot, SameGapScenario_OFF_WriteSucceeds_AB) {
 
   auto reader = store->Access(memgraph::storage::READ);
   EXPECT_EQ(ReadProp(*reader, gid), 3);
+}
+
+// Phase 2, batch 3: concern-D (GC visibility horizon). Validates the 1.4 GC split -- under the flag
+// GC's visibility horizon is min(active snapshot_ts), so a long-lived low-snapshot reader keeps
+// reading its own version even after newer versions are committed and GC unlinks the chain.
+
+// A long-lived reader R (snapshot sees X=1) survives two later commits (X=2, X=3) plus a GC pass:
+// the visibility horizon is pinned to R's snapshot_ts, so R's version is NOT unlinked and R still
+// reads 1. After R is released and GC runs again, a fresh reader reads the latest (3).
+TEST(LockFreeReadSnapshot, LongReaderVersionRetainedAcrossGc_ON) {
+  auto store = MakeStorageManualGc(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  auto long_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*long_reader, gid), 1);
+
+  CommitProp(*store, gid, 2);
+  CommitProp(*store, gid, 3);
+
+  RunGc(*store);
+
+  // CORE SAFETY ASSERTION: R's snapshot version must not have been reclaimed. A wrong value or a
+  // crash here means GC over-reclaimed past the visibility horizon -- a real feature bug, not a
+  // test problem. Do NOT weaken this.
+  EXPECT_EQ(ReadProp(*long_reader, gid), 1)
+      << "GC OVER-RECLAIM: long reader lost its snapshot version (X=1) after newer commits + GC. "
+         "The visibility horizon advanced past the oldest active snapshot_ts.";
+
+  long_reader.reset();
+  RunGc(*store);
+
+  auto fresh_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*fresh_reader, gid), 3);
+}
+
+// Two readers with different snapshots: R1 sees 1, R2 sees 2. The horizon is min(active snapshot_ts)
+// = R1's snapshot (the OldestActive txn), which protects BOTH older versions across GC. Releasing
+// R1 lifts the floor to R2; releasing R2 lets GC reclaim down to the latest.
+TEST(LockFreeReadSnapshot, MultipleReadersDifferentSnapshots_OldestHorizon_ON) {
+  auto store = MakeStorageManualGc(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  auto r1 = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*r1, gid), 1);
+
+  CommitProp(*store, gid, 2);
+  auto r2 = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*r2, gid), 2);
+
+  CommitProp(*store, gid, 3);
+
+  RunGc(*store);
+
+  // Horizon = R1's snapshot; both R1's version (1) and R2's version (2) are retained.
+  EXPECT_EQ(ReadProp(*r1, gid), 1)
+      << "GC OVER-RECLAIM: R1 lost its snapshot version (X=1); horizon advanced past the oldest active snapshot_ts.";
+  EXPECT_EQ(ReadProp(*r2, gid), 2)
+      << "GC OVER-RECLAIM: R2 lost its snapshot version (X=2) while R1 still pinned an older horizon.";
+
+  r1.reset();
+  RunGc(*store);
+
+  // R1 gone: floor rises to R2's snapshot. R2 still reads its version; a fresh reader reads latest.
+  EXPECT_EQ(ReadProp(*r2, gid), 2)
+      << "GC OVER-RECLAIM: R2 lost its snapshot version (X=2) after R1 released; horizon overshot R2's snapshot_ts.";
+  {
+    auto fresh_reader = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*fresh_reader, gid), 3);
+  }
+
+  r2.reset();
+  RunGc(*store);
+
+  auto fresh_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*fresh_reader, gid), 3);
+}
+
+// A/B equivalence to LongReaderVersionRetainedAcrossGc_ON with the flag OFF. The observable outcome
+// is identical: OFF pins the version via the start_ts horizon, ON via the snapshot_ts horizon. The
+// flag changes the horizon computation, not the observable read result.
+TEST(LockFreeReadSnapshot, LongReaderVersionRetainedAcrossGc_OFF_AB) {
+  auto store = MakeStorageManualGc(/*flag_on=*/false);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  auto long_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*long_reader, gid), 1);
+
+  CommitProp(*store, gid, 2);
+  CommitProp(*store, gid, 3);
+
+  RunGc(*store);
+
+  EXPECT_EQ(ReadProp(*long_reader, gid), 1)
+      << "GC OVER-RECLAIM (flag OFF): long reader lost its snapshot version (X=1); the start_ts horizon "
+         "failed to retain a version an active reader still needs.";
+
+  long_reader.reset();
+  RunGc(*store);
+
+  auto fresh_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*fresh_reader, gid), 3);
 }

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -909,10 +909,12 @@ TEST_F(LockFreeReadSnapshotRecovery, WriteOff_RecoverOff_DataIntact) {
 // EMPIRICAL NOTE (verified by A/B, both storage.cpp restore sites neutralized + rebuilt): in-memory
 // recovery reconstructs FLAT vertices -- both snapshot load (snapshot.cpp: Vertex{gid, nullptr} +
 // InitProperties) and WAL replay (wal.cpp: Vertex{gid, nullptr} + in-place SetProperty) leave
-// delta()==nullptr, so the read returns the in-place latest value regardless of snapshot_ts. This
-// test therefore still reads 4 with Fix B removed; it locks in correct recovered-read behavior but
-// does NOT on its own fail if Fix B regresses (no in-memory recovery path produces a committed delta
-// chain to expose the watermark). Do not weaken the value/count assertions.
+// delta()==nullptr, so the read returns the in-place latest value regardless of snapshot_ts. The
+// value/count assertions therefore still pass with Fix B removed (no committed delta chain to
+// expose the watermark). To close that gap the test NOW also asserts the watermark scalar directly:
+// LastCommittedMvccTimestamp() must be > 0 after recovery. A zero here is the exact Fix B
+// regression signature -- the reseed (last_committed_mvcc_ts_ <- last-durable-timestamp) was never
+// reached. Do not weaken either the value/count assertions or the watermark assertion.
 TEST_F(LockFreeReadSnapshotRecovery, RecoveredUpdateChain_ReadsLatestUnderFlagOn) {
   Gid gid{};
   {
@@ -959,6 +961,16 @@ TEST_F(LockFreeReadSnapshotRecovery, RecoveredUpdateChain_ReadsLatestUnderFlagOn
 
     auto store = std::make_unique<InMemoryStorage>(config);
     const auto p = store->NameToProperty("p");
+
+    // Non-vacuous: assert the recovery watermark was reseeded. A zero means Fix B
+    // (the last_committed_mvcc_ts_ <- last-durable-timestamp reseed in storage.cpp)
+    // regressed. The value/count assertions below still pass even without Fix B because
+    // in-memory recovery leaves delta()==nullptr (FLAT vertices), so this is the only
+    // assertion that directly catches the regression.
+    const uint64_t watermark = store->LastCommittedMvccTimestamp();
+    EXPECT_GT(watermark, 0u) << "Recovery watermark not reseeded: last_committed_mvcc_ts_ is 0 after restart. "
+                                "The reseed (last_committed_mvcc_ts_ <- last-durable-timestamp) in storage.cpp "
+                                "is missing or not reached -- Fix B regressed.";
 
     auto reader = store->Access(memgraph::storage::READ);
 

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -16,6 +16,8 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <optional>
 #include <semaphore>
@@ -498,6 +500,118 @@ TEST(LockFreeReadSnapshot, LongReaderVersionRetainedAcrossGc_OFF_AB) {
 
   auto fresh_reader = store->Access(memgraph::storage::READ);
   EXPECT_EQ(ReadProp(*fresh_reader, gid), 3);
+}
+
+// Phase 2, batch 3 (stress): concern-D racy surfaces under real concurrency. The deterministic
+// batch-1..4 tests park a single commit at a CommitProbe seam to assert one interleaving at a time;
+// this test instead drives the feature's shared mutable state -- the BEGIN-time snapshot-ring writes,
+// GC's concurrent reads of that ring at OldestActive, the read watermark, and the commit path -- with
+// many threads at once, with no probe. It is a crash/consistency smoke test under the normal build
+// and a race detector under ThreadSanitizer. kWriters committers mint fresh-vertex commits (no
+// write-write conflict, so every commit must succeed) while kReaders readers open frozen SI snapshots
+// and a GC thread collects garbage concurrently. Two invariants are asserted: (1) within one reader
+// accessor a repeated read of the same vertex's "p" returns the same value (a frozen snapshot is
+// stable), and (2) after every writer has joined, exactly kWriters*kWritesPerWriter vertices are
+// committed and all are visible -- none lost, none double-counted. Any crash, hang, or violated
+// invariant is a real feature bug, not a test problem. Do NOT weaken it.
+TEST(LockFreeReadSnapshot, ConcurrentReadersWritersGc_NoCrash_SnapshotStable_ON) {
+  auto store = MakeStorageManualGc(/*flag_on=*/true);
+  const auto p = store->NameToProperty("p");
+
+  constexpr int kWriters = 4;
+  constexpr int kReaders = 4;
+  constexpr int kWritesPerWriter = 500;
+
+  std::atomic<bool> stop{false};
+  std::atomic<uint64_t> committed{0};
+
+  auto writer_fn = [&](int writer_id) {
+    for (int i = 0; i < kWritesPerWriter; ++i) {
+      auto acc = store->Access(memgraph::storage::WRITE);
+      auto vertex = acc->CreateVertex();
+      // Globally unique value across all (writer, iteration) pairs; never re-used, so no writer ever
+      // collides with another and every commit is a clean fresh-vertex append.
+      const int value = writer_id * kWritesPerWriter + i;
+      ASSERT_TRUE(vertex.SetProperty(p, PropertyValue(value)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value())
+          << "concurrent fresh-vertex commit failed unexpectedly (writer " << writer_id << ", iter " << i << ")";
+      committed.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  auto reader_fn =
+      [&] {
+        while (!stop.load(std::memory_order_relaxed)) {
+          auto r = store->Access(memgraph::storage::READ);
+
+          // Snapshot-stability invariant: the first vertex's "p" read twice within this one accessor must
+          // agree. A frozen SI snapshot may not shift under concurrent commits/GC. Guard against an empty
+          // graph (no committed vertex yet) by skipping the check that iteration.
+          std::optional<memgraph::storage::VertexAccessor> first;
+          for (auto vertex : r->Vertices(View::OLD)) {
+            first.emplace(vertex);
+            break;
+          }
+          if (first.has_value()) {
+            auto v1 = first->GetProperty(p, View::OLD);
+            ASSERT_TRUE(v1.has_value());
+            const int64_t read1 = v1->ValueInt();
+            // A little unrelated work between the two reads to widen the window for a racing writer/GC.
+            int64_t churn = 0;
+            for (int k = 0; k < 32; ++k) churn += k;
+            (void)churn;
+            auto v2 = first->GetProperty(p, View::OLD);
+            ASSERT_TRUE(v2.has_value());
+            ASSERT_EQ(read1, v2->ValueInt())
+                << "SNAPSHOT INSTABILITY: two reads of the same vertex's \"p\" within one frozen SI accessor "
+                   "returned different values. A committed write or GC mutated a version the reader's snapshot "
+                   "still pins -- a real feature bug, not a test problem.";
+          }
+
+          // Full concurrent walk of the version chains: every visible vertex must yield a valid int for
+          // "p". This is the surface GC unlinks under; a crash or a missing property here is a bug.
+          for (auto vertex : r->Vertices(View::OLD)) {
+            auto value = vertex.GetProperty(p, View::OLD);
+            ASSERT_TRUE(value.has_value());
+            (void)value->ValueInt();
+          }
+          // r closes here, releasing its snapshot so the GC horizon can advance.
+        }
+      };
+
+  auto gc_fn = [&] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      // GC concurrent with live readers/writers is exactly the path that reads the snapshot ring at
+      // OldestActive to compute the visibility horizon.
+      RunGc(*store);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  };
+
+  std::vector<std::thread> readers;
+  readers.reserve(kReaders);
+  for (int i = 0; i < kReaders; ++i) readers.emplace_back(reader_fn);
+  std::thread gc(gc_fn);
+
+  std::vector<std::thread> writers;
+  writers.reserve(kWriters);
+  for (int i = 0; i < kWriters; ++i) writers.emplace_back(writer_fn, i);
+  for (auto &w : writers) w.join();
+
+  // Writers are done; stop the open-ended readers and GC.
+  stop.store(true, std::memory_order_relaxed);
+  for (auto &r : readers) r.join();
+  gc.join();
+
+  ASSERT_EQ(committed.load(), static_cast<uint64_t>(kWriters) * kWritesPerWriter);
+
+  // Every committed vertex is visible exactly once at a fresh snapshot: nothing was lost to a racing
+  // GC pass and nothing was double-counted by a torn snapshot-ring write.
+  auto final_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(CountVertices(*final_reader), static_cast<int64_t>(committed.load()))
+      << "COMMIT/VISIBILITY LOSS: the fresh-snapshot vertex count does not match the number of committed "
+         "transactions. A committed vertex was lost or double-counted under concurrent commits + GC + reads "
+         "-- a real feature bug, not a test problem.";
 }
 
 // Phase 2, batch 4: concern-E (abort semantics). A committer that mints a commit timestamp and then

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -893,3 +893,86 @@ TEST_F(LockFreeReadSnapshotRecovery, WriteOff_RecoverOff_DataIntact) {
   WriteDurable(storage_directory, /*flag_on=*/false);
   RecoverAndCheck(storage_directory, /*flag_on=*/false, 5);
 }
+
+// Post-restart read of a multiply-updated vertex, flag ON. Under the flag a live reader's SI snapshot
+// boundary is last_committed_mvcc_ts_ (mvcc.hpp: CommittedBeforeSnapshot -> ts <= snapshot_ts), which
+// starts at 0 on a fresh restart; Fix B (storage.cpp recovery) lifts it back to the recovered
+// last-durable-timestamp. The concern being guarded is that a reader whose snapshot_ts froze at 0
+// would reject any recovered value carried by a committed delta (commit ts > 0) and revert to the
+// oldest version in the chain.
+//
+// The vertex is driven through FOUR separate committed transactions (p = 1,2,3,4) persisted via WAL
+// replay -- an early forced snapshot captures p=1 and p=2,3,4 land as WAL deltas replayed on restart,
+// the recovery path most likely to rebuild a version chain. The post-restart reader must read the
+// LATEST value 4, with exactly the one recovered vertex present.
+//
+// EMPIRICAL NOTE (verified by A/B, both storage.cpp restore sites neutralized + rebuilt): in-memory
+// recovery reconstructs FLAT vertices -- both snapshot load (snapshot.cpp: Vertex{gid, nullptr} +
+// InitProperties) and WAL replay (wal.cpp: Vertex{gid, nullptr} + in-place SetProperty) leave
+// delta()==nullptr, so the read returns the in-place latest value regardless of snapshot_ts. This
+// test therefore still reads 4 with Fix B removed; it locks in correct recovered-read behavior but
+// does NOT on its own fail if Fix B regresses (no in-memory recovery path produces a committed delta
+// chain to expose the watermark). Do not weaken the value/count assertions.
+TEST_F(LockFreeReadSnapshotRecovery, RecoveredUpdateChain_ReadsLatestUnderFlagOn) {
+  Gid gid{};
+  {
+    Config config{};
+    config.durability.storage_directory = storage_directory;
+    config.durability.recover_on_startup = false;
+    config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+    config.experimental_lockfree_read_snapshot = true;
+
+    auto store = std::make_unique<InMemoryStorage>(config);
+    const auto p = store->NameToProperty("p");
+
+    // Create the vertex at p=1 and commit.
+    {
+      auto acc = store->Access(memgraph::storage::WRITE);
+      auto vertex = acc->CreateVertex();
+      gid = vertex.Gid();
+      ASSERT_TRUE(vertex.SetProperty(p, PropertyValue(1)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    // Snapshot the p=1 baseline so the subsequent updates persist as WAL deltas, not folded into the
+    // snapshot -- the recovery path most likely to rebuild a version chain.
+    ASSERT_TRUE(store->CreateSnapshot(/*force=*/true).has_value());
+
+    // Three more separate committed transactions: p = 2, 3, 4. In a live store this is a four-version
+    // MVCC delta chain on the vertex.
+    for (const int value : {2, 3, 4}) {
+      auto acc = store->Access(memgraph::storage::WRITE);
+      auto vertex = acc->FindVertex(gid, View::OLD);
+      ASSERT_TRUE(vertex.has_value());
+      ASSERT_TRUE(vertex->SetProperty(p, PropertyValue(value)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    store.reset();
+  }
+
+  // Restart with the flag ON and recover from snapshot + WAL.
+  {
+    Config config{};
+    config.durability.storage_directory = storage_directory;
+    config.durability.recover_on_startup = true;
+    config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+    config.experimental_lockfree_read_snapshot = true;
+
+    auto store = std::make_unique<InMemoryStorage>(config);
+    const auto p = store->NameToProperty("p");
+
+    auto reader = store->Access(memgraph::storage::READ);
+
+    // Exactly one vertex survived recovery: the repeated updates targeted the same object.
+    EXPECT_EQ(CountVertices(*reader), 1);
+
+    auto vertex = reader->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(vertex.has_value());
+    auto value = vertex->GetProperty(p, View::OLD);
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(value->ValueInt(), 4)
+        << "RECOVERED-READ STALE: a post-restart reader read an older version of a multiply-updated "
+           "vertex instead of the latest. If recovery ever begins reconstructing a committed delta "
+           "chain, this means the reader's snapshot_ts is below the head commit ts -- i.e. the "
+           "recovery watermark restore (last_committed_mvcc_ts_ <- last-durable-timestamp) is missing.";
+  }
+}

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -894,6 +894,272 @@ TEST_F(LockFreeReadSnapshotRecovery, WriteOff_RecoverOff_DataIntact) {
   RecoverAndCheck(storage_directory, /*flag_on=*/false, 5);
 }
 
+// Phase 2, batch 7: concern-B (index-creation gap). Under the flag a label-property index is
+// built by scanning the vertex store at the accessor's frozen snapshot_ts (=
+// last_committed_mvcc_ts_ at AccessorOpen time). If a vertex committed in the window
+// (snapshot_ts, start_timestamp) -- i.e. it minted its ts and ran FinalizeCommitPhase steps
+// (set delta timestamps, update active indices) BEFORE the index was registered, but is still
+// parked at before_publish when CreateIndex opens -- it is invisible to PopulateIndex (its
+// delta ts > snapshot_ts under the flag-ON predicate) AND is not covered by the automatic
+// commit-time index update (because RegisterIndex had not yet run when it executed that step).
+// Result: the vertex is permanently absent from the index. Under flag-OFF the engine_lock is
+// held straight through GetCommitTimestamp→FinalizeCommitPhase, so a concurrent commit cannot
+// be interleaved into CreateIndex; the first-committed vertex is fully visible at start_ts.
+//
+// NOTE: This test is EXPECTED TO FAIL for flag_on=true (it reproduces a real bug). It will
+// turn green when the fix (e.g. a PopulateIndex re-pass using start_ts, or seeding
+// last_committed_mvcc_ts_ as the accessor's snapshot at index-scan time) is applied.
+
+// Helper: count vertices reachable via a label-property index scan on the given accessor.
+namespace {
+
+int64_t CountViaLabelPropertyIndex(Accessor &acc, LabelId label, memgraph::storage::PropertyId prop) {
+  const std::array paths = {memgraph::storage::PropertyPath{prop}};
+  int64_t n = 0;
+  for (auto v :
+       acc.Vertices(label, std::span<memgraph::storage::PropertyPath const>{paths.data(), paths.size()}, View::OLD)) {
+    (void)v;
+    ++n;
+  }
+  return n;
+}
+
+}  // namespace
+
+// Concurrent writers commit fresh (L, P) vertices while the main thread builds the
+// label-property index via ReadOnlyAccess(). ReadOnlyAccess() is exclusive with an in-flight
+// WRITE commit on main_lock_, so it blocks briefly per iteration until the current writer
+// finishes — there is no indefinite park and no deadlock. After all writers join, every
+// committed vertex must appear in the index: pre-seeded ones captured by PopulateIndex,
+// later ones picked up by commit-time index update.
+TEST(LockFreeReadSnapshot, IndexCreate_CompleteUnderConcurrentWrites_ON) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto label = store->NameToLabel("L");
+  const auto prop = store->NameToProperty("p");
+
+  constexpr int kSeed = 5;
+  constexpr int kWriters = 4;
+  constexpr int kWritesPerWriter = 50;
+
+  // Pre-seed vertices (negative p values, distinct from writer range) so PopulateIndex
+  // has committed rows to scan regardless of when the concurrent writers commit.
+  for (int i = 0; i < kSeed; ++i) {
+    CommitLabeledVertex(*store, label, -(i + 1));
+  }
+
+  std::atomic<int> committed{0};
+
+  auto writer_fn = [&](int writer_id) {
+    for (int i = 0; i < kWritesPerWriter; ++i) {
+      auto acc = store->Access(memgraph::storage::WRITE);
+      auto v = acc->CreateVertex();
+      ASSERT_TRUE(v.AddLabel(label).has_value());
+      // Globally unique value across all (writer_id, i) pairs; no write-write conflicts.
+      ASSERT_TRUE(v.SetProperty(prop, PropertyValue(writer_id * kWritesPerWriter + i)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+      committed.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  std::vector<std::thread> writers;
+  writers.reserve(kWriters);
+  for (int i = 0; i < kWriters; ++i) writers.emplace_back(writer_fn, i);
+
+  {
+    auto idx_acc = store->ReadOnlyAccess();
+    auto res = idx_acc->CreateIndex(label, {prop});
+    ASSERT_TRUE(res.has_value()) << "CreateIndex failed unexpectedly (flag_on=true).";
+    ASSERT_TRUE(idx_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  for (auto &w : writers) w.join();
+
+  const int64_t total = kSeed + committed.load(std::memory_order_relaxed);
+
+  auto reader = store->Access(memgraph::storage::READ);
+  const int64_t full_count = CountVertices(*reader);
+  ASSERT_EQ(full_count, total) << "FULL SCAN BUG (flag_on=true): expected " << total << " committed vertices.";
+
+  const int64_t index_count = CountViaLabelPropertyIndex(*reader, label, prop);
+  EXPECT_EQ(index_count, full_count)
+      << "INDEX COMPLETENESS FAILURE (flag_on=true): " << (full_count - index_count) << " of " << full_count
+      << " committed (L,P) vertices are missing from the label-property index. "
+         "Pre-seeded vertices must be captured by PopulateIndex; vertices committed after "
+         "CreateIndex must be picked up by the commit-time index update.";
+}
+
+// A/B counterpart with the flag OFF. The flag-OFF lock path (engine_lock held through
+// mint→publish) has no gap window; the completeness invariant is identical.
+TEST(LockFreeReadSnapshot, IndexCreate_CompleteUnderConcurrentWrites_OFF_AB) {
+  auto store = MakeStorage(/*flag_on=*/false);
+  const auto label = store->NameToLabel("L");
+  const auto prop = store->NameToProperty("p");
+
+  constexpr int kSeed = 5;
+  constexpr int kWriters = 4;
+  constexpr int kWritesPerWriter = 50;
+
+  for (int i = 0; i < kSeed; ++i) {
+    CommitLabeledVertex(*store, label, -(i + 1));
+  }
+
+  std::atomic<int> committed{0};
+
+  auto writer_fn = [&](int writer_id) {
+    for (int i = 0; i < kWritesPerWriter; ++i) {
+      auto acc = store->Access(memgraph::storage::WRITE);
+      auto v = acc->CreateVertex();
+      ASSERT_TRUE(v.AddLabel(label).has_value());
+      ASSERT_TRUE(v.SetProperty(prop, PropertyValue(writer_id * kWritesPerWriter + i)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+      committed.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  std::vector<std::thread> writers;
+  writers.reserve(kWriters);
+  for (int i = 0; i < kWriters; ++i) writers.emplace_back(writer_fn, i);
+
+  {
+    auto idx_acc = store->ReadOnlyAccess();
+    auto res = idx_acc->CreateIndex(label, {prop});
+    ASSERT_TRUE(res.has_value()) << "CreateIndex failed unexpectedly (flag_on=false).";
+    ASSERT_TRUE(idx_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  for (auto &w : writers) w.join();
+
+  const int64_t total = kSeed + committed.load(std::memory_order_relaxed);
+
+  auto reader = store->Access(memgraph::storage::READ);
+  const int64_t full_count = CountVertices(*reader);
+  ASSERT_EQ(full_count, total) << "FULL SCAN BUG (flag_on=false): expected " << total << " committed vertices.";
+
+  const int64_t index_count = CountViaLabelPropertyIndex(*reader, label, prop);
+  EXPECT_EQ(index_count, full_count) << "INDEX COMPLETENESS FAILURE (flag_on=false): " << (full_count - index_count)
+                                     << " of " << full_count
+                                     << " committed (L,P) vertices are missing from the label-property index.";
+}
+
+// Phase 2, batch 7 (GC horizon safety): Under flag-ON, the GC visibility horizon for SI
+// readers is min(active snapshot_ts). When a version is committed BEFORE the reader opens
+// (so the reader's snapshot_ts == that version's commit_ts), GC must retain that exact version
+// -- it is the one the reader needs to answer View::OLD queries. The [S, T_r) gap (where
+// S = snapshot_ts and T_r = start_ts, with S <= T_r) must not cause GC to use start_ts as
+// the floor, which would let it reclaim the S-version as "old".
+//
+// Sequence: CommitProp(2) → open long SI reader (snapshot_ts = T_2) → CommitProp(3) → RunGc
+// (horizon = T_2) → assert reader still reads 2. Then release reader, RunGc (horizon lifts),
+// fresh reader reads 3.
+TEST(LockFreeReadSnapshot, HorizonGapCommit_RetainsDeltaBetweenSnapshotAndStart_ON) {
+  auto store = MakeStorageManualGc(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  // Commit p=2 BEFORE the reader opens. Under flag-ON, the next Access(READ) will capture
+  // snapshot_ts = last_committed_mvcc_ts_ = T_2 (the commit ts of p=2). The gap
+  // [S=T_2, T_r=start_ts) arises because start_ts is minted after the snapshot load; it is
+  // always >= T_2 (and typically T_2 + 1 for a quiescent store). GC must use S = T_2 as the
+  // horizon for this reader, NOT T_r -- the p=2 version lives exactly at S and is what the
+  // reader returns for View::OLD.
+  CommitProp(*store, gid, 2);
+
+  auto long_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*long_reader, gid), 2);
+
+  // Commit p=3 while the reader is alive. The reader's snapshot_ts (T_2) is frozen; p=3 at
+  // T_3 > T_2 is invisible to the reader. GC horizon = T_2 (the oldest active snapshot_ts).
+  CommitProp(*store, gid, 3);
+
+  RunGc(*store);
+
+  // CORE SAFETY ASSERTION: p=2 was committed at exactly snapshot_ts = T_2. GC horizon = T_2
+  // means the p=2 version must be retained (its commit_ts == horizon; the reader needs it).
+  // A crash or wrong value here means GC over-reclaimed into the [S, T_r) gap -- it used
+  // start_ts (T_r > T_2) as the floor instead of snapshot_ts (T_2). This is a real feature
+  // bug, not a test problem. Do NOT weaken this assertion.
+  EXPECT_EQ(ReadProp(*long_reader, gid), 2)
+      << "GC OVER-RECLAIM: the long reader lost its snapshot version (p=2) after CommitProp(3) "
+         "plus GC. The GC horizon must be snapshot_ts (T_2), not start_ts (T_r > T_2). "
+         "Using start_ts as the floor would reclaim p=2 (T_2 < T_r, newer version p=3 exists), "
+         "leaving the SI reader with no accessible version at its snapshot.";
+
+  // Release the reader; the snapshot ring entry is gone. GC horizon lifts to T_3 (or beyond).
+  long_reader.reset();
+  RunGc(*store);
+
+  auto fresh_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*fresh_reader, gid), 3);
+}
+
+// Phase 2, batch 7 (V4 -- RC isolation does not depress GC floor): Under flag-ON, only
+// SNAPSHOT_ISOLATION transactions register in the lockfree snapshot ring
+// (transaction.lockfree_snapshot = flag_on && isolation == SI; see storage.cpp). A
+// READ_COMMITTED accessor therefore does NOT inject a stale snapshot_ts into the ring: its GC
+// footprint is its start_timestamp (same as flag-OFF). This means GC can advance freely past
+// the "committed-as-of-reader-open" tier, unlike with an SI reader whose frozen snapshot_ts
+// would pin the floor.
+//
+// Observable proxy (GcVisibilityHorizon() is private): we assert two properties:
+//   (1) RC semantics: the accessor sees the LATEST committed value on each read -- it is NOT
+//       frozen to the state at accessor-open time (which would signal an SI snapshot in use).
+//   (2) GC safety: after RunGc with only the RC reader as the sole active transaction, the
+//       reader still reads correctly (GC did not corrupt the live chain).
+//
+// TODO: expose InMemoryStorage::TestGcHorizon() returning the last value from
+// GcVisibilityHorizon() so we can directly assert horizon >= rc_reader.start_timestamp rather
+// than relying on the read-value proxy. Until that getter exists, this test is best-effort and
+// documents the intended behaviour.
+TEST(LockFreeReadSnapshot, NonSiReaderDoesNotPinGcFloorLow_ON) {
+  auto store = MakeStorageManualGc(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  CommitProp(*store, gid, 2);
+  CommitProp(*store, gid, 3);
+
+  // Open a READ_COMMITTED accessor. Its transaction.lockfree_snapshot = false (RC is excluded
+  // from the snapshot ring regardless of the flag). The GC horizon treats this txn at its
+  // start_timestamp, not at some older snapshot_ts -- so GC can advance past T_2 and T_3 once
+  // they have a newer version, without waiting for this reader to close.
+  auto rc_reader =
+      store->Access(memgraph::storage::READ, memgraph::storage::IsolationLevel::READ_COMMITTED, std::nullopt);
+
+  // (1) RC semantics: the reader's first access sees the current committed head (p=3). An SI
+  // reader opened at the same instant would also see 3 because last_committed_mvcc_ts_ == T_3
+  // at open time; the distinction surfaces on the SECOND read below, after CommitProp(4).
+  EXPECT_EQ(ReadProp(*rc_reader, gid), 3);
+
+  // Commit p=4 WHILE the RC reader is open. Under SI the reader would remain frozen at T_3 and
+  // still return 3. Under RC each read re-evaluates against the latest committed snapshot, so
+  // the next read must return 4.
+  CommitProp(*store, gid, 4);
+
+  // (1) RC semantics (distinguishing assertion): RC sees p=4; an SI reader would see p=3.
+  // If this returns 3, the isolation-level override was not applied (the accessor behaves like
+  // SI), and the subsequent GC-floor argument is moot.
+  EXPECT_EQ(ReadProp(*rc_reader, gid), 4)
+      << "RC ISOLATION MISS: expected p=4 (latest committed) but got a stale value. "
+         "The Access(READ, IsolationLevel::READ_COMMITTED, ...) override did not take effect; "
+         "the accessor is frozen like a SNAPSHOT_ISOLATION reader. Check that "
+         "transaction.lockfree_snapshot is false for RC and that View::OLD re-snapshots per read.";
+
+  // GC with only the RC reader as the sole active transaction. Horizon = rc_reader.start_ts
+  // (the RC txn does NOT depress the floor via a stale snapshot_ts). Under that horizon,
+  // p=1 (T_1) and p=2 (T_2) and p=3 (T_3) are all below start_ts and have a newer version
+  // (p=4) -- they are candidates for reclaim. p=4 (T_4) is the current head; it is kept.
+  RunGc(*store);
+
+  // (2) GC safety: the RC reader still reads correctly after GC.
+  EXPECT_EQ(ReadProp(*rc_reader, gid), 4)
+      << "RC READER BROKEN AFTER GC: expected p=4 (current head) but the RC accessor returned "
+         "a wrong value or crashed. GC must not reclaim the current head (p=4 has no successor).";
+
+  rc_reader.reset();
+  RunGc(*store);
+
+  auto fresh_reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*fresh_reader, gid), 4);
+}
+
 // Phase 2, batch 6: concern-F (non-sequential edge path). Two of the four flag-converted MVCC
 // predicate sites live on the non-sequential edge path: PrepareForNonSequentialWrite's head check
 // at mvcc.hpp:160 and its chain-walk at :202. These are exercised by edge-creation interleavings

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -15,10 +15,14 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <filesystem>
 #include <optional>
 #include <semaphore>
+#include <string>
 #include <thread>
 #include <variant>
+#include <vector>
 
 #include "storage/v2/commit_probe.hpp"
 #include "storage/v2/constraints/constraint_violation.hpp"
@@ -665,4 +669,113 @@ TEST(LockFreeReadSnapshot, AbortAfterMint_DoesNotAdvanceWatermark_OFF_AB) {
     EXPECT_EQ(CountVertices(*fresh), 2);
     EXPECT_FALSE(fresh->FindVertex(*gid_b, View::OLD).has_value());
   }
+}
+
+// Phase 2, batch 5: RECOV / INV-DURABLE. The flag is a runtime-only choice about how live readers
+// compute their snapshot boundary; it must never bleed into on-disk artifacts. A database written
+// with the flag ON must recover into an instance with the flag OFF, and vice versa. If a
+// cross-recovery case here loses or corrupts data, the flag leaked into durable state -- a real
+// design-invariant violation, not a test problem. Do NOT weaken these tests to make them pass.
+//
+// Durability idiom mirrors storage_v2_durability_inmemory.cpp: a plain InMemoryStorage over a
+// PERIODIC_SNAPSHOT_WITH_WAL storage_directory, an explicit forced CreateSnapshot so the data is on
+// disk before the storage is destroyed, then a second InMemoryStorage with recover_on_startup=true
+// on the same directory.
+
+namespace {
+
+// Builds durable storage on `dir` with the flag as given, writes 5 vertices carrying p = index,
+// commits, forces a snapshot so the dataset is persisted, then destroys the storage cleanly.
+void WriteDurable(const std::filesystem::path &dir, bool flag_on) {
+  Config config{};
+  config.durability.storage_directory = dir;
+  config.durability.recover_on_startup = false;
+  config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  config.experimental_lockfree_read_snapshot = flag_on;
+
+  auto store = std::make_unique<InMemoryStorage>(config);
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    for (int i = 0; i < 5; ++i) {
+      auto vertex = acc->CreateVertex();
+      ASSERT_TRUE(vertex.SetProperty(store->NameToProperty("p"), PropertyValue(i)).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // Force the snapshot so the dataset is on disk regardless of WAL flush timing.
+  ASSERT_TRUE(store->CreateSnapshot(/*force=*/true).has_value());
+  store.reset();
+}
+
+// Recovers a fresh InMemoryStorage on `dir` with the (possibly different) flag value and asserts the
+// recovered vertices carry exactly p = {0, .., expected_count-1}.
+void RecoverAndCheck(const std::filesystem::path &dir, bool flag_on, int expected_count) {
+  Config config{};
+  config.durability.storage_directory = dir;
+  config.durability.recover_on_startup = true;
+  config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  config.experimental_lockfree_read_snapshot = flag_on;
+
+  auto store = std::make_unique<InMemoryStorage>(config);
+  auto acc = store->Access(memgraph::storage::READ);
+
+  std::vector<int64_t> props;
+  for (auto vertex : acc->Vertices(View::OLD)) {
+    auto value = vertex.GetProperty(store->NameToProperty("p"), View::OLD);
+    ASSERT_TRUE(value.has_value());
+    props.push_back(value->ValueInt());
+  }
+  std::sort(props.begin(), props.end());
+
+  std::vector<int64_t> expected;
+  expected.reserve(expected_count);
+  for (int i = 0; i < expected_count; ++i) expected.push_back(i);
+
+  EXPECT_EQ(props, expected) << "CROSS-RECOVERY DATA MISMATCH: the recovered vertex/property set differs from what "
+                                "was written. The experimental_lockfree_read_snapshot flag leaked into durable "
+                                "state -- a real violation of the runtime-only invariant, not a test problem.";
+}
+
+// Per-test unique storage_directory, cleaned up on both ends of the test to avoid cross-test
+// contamination -- the remove_all cleanup idiom from DurabilityTest.
+class LockFreeReadSnapshotRecovery : public ::testing::Test {
+ protected:
+  void SetUp() override { Clear(); }
+
+  void TearDown() override { Clear(); }
+
+  void Clear() {
+    if (std::filesystem::exists(storage_directory)) std::filesystem::remove_all(storage_directory);
+  }
+
+  std::filesystem::path storage_directory{
+      std::filesystem::temp_directory_path() /
+      ("MG_test_unit_storage_v2_lockfree_read_snapshot_" +
+       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()))};
+};
+
+}  // namespace
+
+// Wrote with the feature ON, restarted with it OFF: the durable data is fully recovered.
+TEST_F(LockFreeReadSnapshotRecovery, WriteOn_RecoverOff_DataIntact) {
+  WriteDurable(storage_directory, /*flag_on=*/true);
+  RecoverAndCheck(storage_directory, /*flag_on=*/false, 5);
+}
+
+// Reverse direction: wrote with the feature OFF, restarted with it ON.
+TEST_F(LockFreeReadSnapshotRecovery, WriteOff_RecoverOn_DataIntact) {
+  WriteDurable(storage_directory, /*flag_on=*/false);
+  RecoverAndCheck(storage_directory, /*flag_on=*/true, 5);
+}
+
+// Sanity: ON -> ON round-trips.
+TEST_F(LockFreeReadSnapshotRecovery, WriteOn_RecoverOn_DataIntact) {
+  WriteDurable(storage_directory, /*flag_on=*/true);
+  RecoverAndCheck(storage_directory, /*flag_on=*/true, 5);
+}
+
+// Baseline: OFF -> OFF round-trips.
+TEST_F(LockFreeReadSnapshotRecovery, WriteOff_RecoverOff_DataIntact) {
+  WriteDurable(storage_directory, /*flag_on=*/false);
+  RecoverAndCheck(storage_directory, /*flag_on=*/false, 5);
 }

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -18,19 +18,26 @@
 #include <optional>
 #include <semaphore>
 #include <thread>
+#include <variant>
 
 #include "storage/v2/commit_probe.hpp"
+#include "storage/v2/constraints/constraint_violation.hpp"
+#include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/property_value.hpp"
+#include "storage/v2/storage_error.hpp"
 #include "storage/v2/vertex_accessor.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
 #include "utils/resource_lock.hpp"
 
 using memgraph::storage::Config;
+using memgraph::storage::ConstraintViolation;
 using memgraph::storage::Gid;
 using memgraph::storage::InMemoryStorage;
+using memgraph::storage::LabelId;
 using memgraph::storage::PropertyValue;
+using memgraph::storage::UniqueConstraints;
 using memgraph::storage::View;
 using Accessor = memgraph::storage::Storage::Accessor;
 
@@ -92,6 +99,39 @@ void CommitProp(InMemoryStorage &store, Gid gid, int value) {
   ASSERT_TRUE(vertex.has_value());
   ASSERT_TRUE(vertex->SetProperty(store.NameToProperty("p"), PropertyValue(value)).has_value());
   ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+}
+
+// Concern-E (abort semantics) helpers. Installs a UNIQUE(label, "p") constraint so a later duplicate
+// commit fails the UniqueConstraintsViolation gate -- the abort-after-mint path under test.
+void CreateUniquePConstraint(InMemoryStorage &store, LabelId label) {
+  auto acc = store.ReadOnlyAccess();
+  auto res = acc->CreateUniqueConstraint(label, {store.NameToProperty("p")});
+  EXPECT_TRUE(res.has_value());
+  EXPECT_EQ(res.value(), UniqueConstraints::CreationStatus::SUCCESS);
+  EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+}
+
+// Commits a fresh vertex carrying `label` and p=`value`; returns its gid. Seeds a row a later
+// duplicate must collide with under the UNIQUE constraint.
+Gid CommitLabeledVertex(InMemoryStorage &store, LabelId label, int value) {
+  auto acc = store.Access(memgraph::storage::WRITE);
+  auto vertex = acc->CreateVertex();
+  const auto gid = vertex.Gid();
+  EXPECT_TRUE(vertex.AddLabel(label).has_value());
+  EXPECT_TRUE(vertex.SetProperty(store.NameToProperty("p"), PropertyValue(value)).has_value());
+  EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  return gid;
+}
+
+// Number of vertices visible at the accessor's frozen snapshot. An aborted duplicate that leaked
+// into a reader's view would push this above the committed count.
+int64_t CountVertices(Accessor &acc) {
+  int64_t n = 0;
+  for (auto vertex : acc.Vertices(View::OLD)) {
+    (void)vertex;
+    ++n;
+  }
+  return n;
 }
 
 }  // namespace
@@ -454,4 +494,175 @@ TEST(LockFreeReadSnapshot, LongReaderVersionRetainedAcrossGc_OFF_AB) {
 
   auto fresh_reader = store->Access(memgraph::storage::READ);
   EXPECT_EQ(ReadProp(*fresh_reader, gid), 3);
+}
+
+// Phase 2, batch 4: concern-E (abort semantics). A committer that mints a commit timestamp and then
+// aborts must NOT advance the read watermark (last_committed_mvcc_ts_). The abort here is a UNIQUE
+// constraint violation, which storage.cpp checks AFTER GetCommitTimestamp mints the ts and returns
+// without ever reaching FinalizeCommitPhase -- so the minted ts is "wasted": the watermark advances
+// only on success, at the end of FinalizeCommitPhase. The observable invariant is that the aborted
+// transaction is invisible to every reader (before, during, and after the failed commit) and leaves
+// subsequent progress uncorrupted.
+
+// A minted-then-aborted duplicate is invisible to all readers and does not disturb later commits. B
+// duplicates published row A under UNIQUE(L, p): it mints a ts, fails the unique check, and aborts.
+// A reader opened before the failed commit and a fresh reader opened after it both see only A; a
+// later distinct-value commit C then advances normally -- proving the watermark never moved to B's
+// wasted ts.
+TEST(LockFreeReadSnapshot, AbortAfterMint_DoesNotAdvanceWatermark_ON) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto label = store->NameToLabel("L");
+  CreateUniquePConstraint(*store, label);
+
+  const auto gid_a = CommitLabeledVertex(*store, label, 1);
+
+  // Reader opened BEFORE the failing commit: its snapshot includes A only.
+  auto reader_before = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader_before, gid_a), 1);
+  EXPECT_EQ(CountVertices(*reader_before), 1);
+
+  // A duplicate of A: it mints a commit ts, then the UNIQUE check aborts it (no FinalizeCommitPhase).
+  std::optional<Gid> gid_b;
+  {
+    auto w = store->Access(memgraph::storage::WRITE);
+    auto vertex = w->CreateVertex();
+    gid_b = vertex.Gid();
+    ASSERT_TRUE(vertex.AddLabel(label).has_value());
+    ASSERT_TRUE(vertex.SetProperty(store->NameToProperty("p"), PropertyValue(1)).has_value());
+    auto res = w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+    ASSERT_FALSE(res.has_value()) << "the duplicate commit must fail the UNIQUE constraint";
+    EXPECT_EQ(std::get<ConstraintViolation>(res.error()).type, ConstraintViolation::Type::UNIQUE);
+  }
+
+  // The reader opened before the abort still sees exactly the pre-abort state.
+  EXPECT_EQ(ReadProp(*reader_before, gid_a), 1);
+  EXPECT_EQ(CountVertices(*reader_before), 1)
+      << "ABORTED-TXN LEAK: a reader opened before the failed commit observed the aborted vertex B.";
+  EXPECT_FALSE(reader_before->FindVertex(*gid_b, View::OLD).has_value());
+
+  // A fresh reader opened AFTER the abort also sees only A: the watermark never moved to B's ts.
+  {
+    auto fresh = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*fresh, gid_a), 1);
+    EXPECT_EQ(CountVertices(*fresh), 1)
+        << "WATERMARK ADVANCED ON ABORT: a reader opened after the failed commit saw the aborted "
+           "vertex B; the read watermark moved to B's wasted commit timestamp. This is a real feature "
+           "bug, not a test problem -- an aborted commit must not advance last_committed_mvcc_ts_.";
+    EXPECT_FALSE(fresh->FindVertex(*gid_b, View::OLD).has_value());
+  }
+
+  // Monotonic progress after the abort: a distinct-value commit C succeeds and is visible alongside A.
+  const auto gid_c = CommitLabeledVertex(*store, label, 2);
+  {
+    auto fresh = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*fresh, gid_a), 1);
+    EXPECT_EQ(ReadProp(*fresh, gid_c), 2);
+    EXPECT_EQ(CountVertices(*fresh), 2);
+    EXPECT_FALSE(fresh->FindVertex(*gid_b, View::OLD).has_value());
+  }
+}
+
+// Concern-E under concurrency. The mid-window CommitProbe choreography used elsewhere in this suite
+// is deliberately NOT used here: on the abort path the UNIQUE check runs BEFORE the after_mint seam.
+// In storage.cpp, GetCommitTimestamp mints under engine_lock, UniqueConstraintsViolation is checked
+// immediately after (still under engine_lock) and, on violation, aborts and returns -- all before
+// the InvokeProbe(after_mint) that only a surviving commit reaches. A constraint-aborting commit
+// therefore fires no probe, so its mint->abort window cannot be deterministically parked. Instead we
+// stress that window: a committer thread runs the aborting duplicate in a loop (each iteration wastes
+// a minted ts) while the main thread hammers reader opens. The invariant holds under every
+// interleaving -- no reader ever sees the aborted vertex, so every snapshot contains exactly one
+// vertex (A), and the many wasted mints never advance the watermark.
+TEST(LockFreeReadSnapshot, ReaderBeginsDuringAbortingCommitWindow_NeverSeesAborted_ON) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto label = store->NameToLabel("L");
+  CreateUniquePConstraint(*store, label);
+
+  const auto gid_a = CommitLabeledVertex(*store, label, 1);
+
+  constexpr int kIters = 500;
+  std::binary_semaphore start{0};
+  bool all_failed = true;
+  bool all_unique = true;
+
+  std::thread committer([&] {
+    start.acquire();
+    for (int i = 0; i < kIters; ++i) {
+      auto w = store->Access(memgraph::storage::WRITE);
+      auto vertex = w->CreateVertex();
+      EXPECT_TRUE(vertex.AddLabel(label).has_value());
+      EXPECT_TRUE(vertex.SetProperty(store->NameToProperty("p"), PropertyValue(1)).has_value());
+      auto res = w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+      all_failed = all_failed && !res.has_value();
+      if (!res.has_value()) {
+        all_unique = all_unique && std::get<ConstraintViolation>(res.error()).type == ConstraintViolation::Type::UNIQUE;
+      }
+    }
+  });
+
+  start.release();
+  for (int i = 0; i < kIters; ++i) {
+    auto reader = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(CountVertices(*reader), 1)
+        << "ABORTED-TXN LEAK: a reader opened during the aborting commit's window saw the aborted "
+           "vertex (iteration "
+        << i << "). A minted-but-aborted commit must never advance the read watermark.";
+    EXPECT_EQ(ReadProp(*reader, gid_a), 1);
+  }
+  committer.join();
+
+  EXPECT_TRUE(all_failed) << "every duplicate commit must fail the UNIQUE constraint";
+  EXPECT_TRUE(all_unique);
+
+  auto fresh = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(CountVertices(*fresh), 1);
+  EXPECT_EQ(ReadProp(*fresh, gid_a), 1);
+}
+
+// A/B equivalence with the flag OFF: the abort-after-mint semantics are identical. The UNIQUE check
+// is flag-independent (it runs in both modes), so a duplicate commit aborts the same way and leaves
+// the same observable state -- aborted B invisible, later C visible. No probe is needed off-path.
+TEST(LockFreeReadSnapshot, AbortAfterMint_DoesNotAdvanceWatermark_OFF_AB) {
+  auto store = MakeStorage(/*flag_on=*/false);
+  const auto label = store->NameToLabel("L");
+  CreateUniquePConstraint(*store, label);
+
+  const auto gid_a = CommitLabeledVertex(*store, label, 1);
+
+  auto reader_before = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader_before, gid_a), 1);
+  EXPECT_EQ(CountVertices(*reader_before), 1);
+
+  std::optional<Gid> gid_b;
+  {
+    auto w = store->Access(memgraph::storage::WRITE);
+    auto vertex = w->CreateVertex();
+    gid_b = vertex.Gid();
+    ASSERT_TRUE(vertex.AddLabel(label).has_value());
+    ASSERT_TRUE(vertex.SetProperty(store->NameToProperty("p"), PropertyValue(1)).has_value());
+    auto res = w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+    ASSERT_FALSE(res.has_value()) << "the duplicate commit must fail the UNIQUE constraint";
+    EXPECT_EQ(std::get<ConstraintViolation>(res.error()).type, ConstraintViolation::Type::UNIQUE);
+  }
+
+  EXPECT_EQ(ReadProp(*reader_before, gid_a), 1);
+  EXPECT_EQ(CountVertices(*reader_before), 1)
+      << "ABORTED-TXN LEAK (flag OFF): a reader opened before the failed commit observed aborted B.";
+  EXPECT_FALSE(reader_before->FindVertex(*gid_b, View::OLD).has_value());
+
+  {
+    auto fresh = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*fresh, gid_a), 1);
+    EXPECT_EQ(CountVertices(*fresh), 1)
+        << "ABORTED-TXN LEAK (flag OFF): a reader opened after the failed commit saw aborted B.";
+    EXPECT_FALSE(fresh->FindVertex(*gid_b, View::OLD).has_value());
+  }
+
+  const auto gid_c = CommitLabeledVertex(*store, label, 2);
+  {
+    auto fresh = store->Access(memgraph::storage::READ);
+    EXPECT_EQ(ReadProp(*fresh, gid_a), 1);
+    EXPECT_EQ(ReadProp(*fresh, gid_c), 2);
+    EXPECT_EQ(CountVertices(*fresh), 2);
+    EXPECT_FALSE(fresh->FindVertex(*gid_b, View::OLD).has_value());
+  }
 }

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -191,3 +191,135 @@ TEST(LockFreeReadSnapshot, OffPath_SameVisibility_AB) {
     EXPECT_EQ(ReadProp(*fresh_reader, gid), 2) << "flag_on=" << flag_on;
   }
 }
+
+// Phase 2, batch 2: concern-C (write-conflict / lost-update). The write-conflict predicate
+// shares the snapshot boundary with reads (Transaction::CommittedBeforeSnapshot): a delta whose
+// head commit ts is at/below the writer's snapshot is writable; one published above it is a
+// conflict. These tests pin the two happy-path directions and the lost-update interleaving.
+
+// A writer whose head commit sits at or below its snapshot must NOT be falsely aborted: X=1 is
+// published, so W's snapshot includes it (head ts <= W.snapshot), and W's overwrite commits.
+TEST(LockFreeReadSnapshot, WriterHappyPath_HeadBelowSnapshot_NoFalseAbort) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  auto w = store->Access(memgraph::storage::WRITE);
+  auto vertex = w->FindVertex(gid, View::OLD);
+  ASSERT_TRUE(vertex.has_value());
+  ASSERT_TRUE(vertex->SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+  ASSERT_TRUE(w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+  auto reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader, gid), 2);
+}
+
+// A transaction rewriting its OWN uncommitted delta is not a conflict: the head delta carries
+// this txn's transaction_id, so the second SetProperty is allowed. Commit publishes the last write.
+TEST(LockFreeReadSnapshot, WriterRewritesOwnUncommittedDelta_Succeeds) {
+  auto store = MakeStorage(/*flag_on=*/true);
+
+  auto w = store->Access(memgraph::storage::WRITE);
+  auto vertex = w->CreateVertex();
+  const auto gid = vertex.Gid();
+  ASSERT_TRUE(vertex.SetProperty(store->NameToProperty("p"), PropertyValue(1)).has_value());
+  ASSERT_TRUE(vertex.SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+  ASSERT_TRUE(w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+  auto reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader, gid), 2);
+}
+
+// THE lost-update test. A committer C is parked at after_mint (C_ts minted, engine_lock released,
+// watermark NOT yet advanced). A writer W is opened in that window: W's snapshot excludes C. After
+// C publishes X=2, W tries to overwrite the SAME vertex. Under the flag the head commit ts C_ts >
+// W.snapshot, so X is invisible to W and the write MUST conflict (serialization error) rather than
+// silently clobber C's value -- that is the lost update this feature prevents.
+TEST(LockFreeReadSnapshot, LostUpdatePrevented_GapCommitPublishesAfterSnapshot_ON) {
+  auto store = MakeStorage(/*flag_on=*/true);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  std::binary_semaphore reached{0};
+  std::binary_semaphore resume{0};
+  std::optional<bool> c_ok;
+
+  memgraph::storage::CommitProbe probe;
+  probe.after_mint = [&] {
+    reached.release();
+    resume.acquire();
+  };
+  store->SetCommitProbe(&probe);
+
+  std::thread committer([&] {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(vertex.has_value());
+    ASSERT_TRUE(vertex->SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+    c_ok = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+  });
+
+  // C has minted C_ts but not published; open W now so W's snapshot is below C_ts.
+  reached.acquire();
+  auto w = store->Access(memgraph::storage::WRITE);
+
+  // Let C finish publishing X=2, then confirm it committed.
+  resume.release();
+  committer.join();
+  ASSERT_TRUE(c_ok.has_value());
+  EXPECT_TRUE(*c_ok);
+  store->SetCommitProbe(nullptr);
+
+  // W now overwrites the same vertex. The conflict surfaces either at the mutation or at commit;
+  // capture whichever, and assert the write did NOT silently succeed.
+  auto w_vertex = w->FindVertex(gid, View::OLD);
+  ASSERT_TRUE(w_vertex.has_value());
+  auto set_res = w_vertex->SetProperty(store->NameToProperty("p"), PropertyValue(3));
+  bool serialization_observed = false;
+  if (!set_res.has_value()) {
+    EXPECT_EQ(set_res.error(), memgraph::storage::Error::SERIALIZATION_ERROR);
+    serialization_observed = true;
+  } else {
+    serialization_observed = !w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+  }
+  ASSERT_TRUE(serialization_observed)
+      << "LOST UPDATE: W overwrote a gap-committed value it never saw; no serialization error was raised. "
+         "This is a real feature bug, not a test problem -- the write-conflict predicate failed to reject a "
+         "head commit published above W's snapshot.";
+  w.reset();
+
+  // C's value survives; W's write was rejected, not clobbered over C.
+  auto reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader, gid), 2);
+}
+
+// A/B contrast to the test above with the flag OFF. Under OFF the write predicate is
+// `ts < start_timestamp`, so a committed head below the writer's start is writable -- OFF prevents
+// the lost update by a DIFFERENT mechanism: W SEES C's X=2 and updates on top of it (final X=3),
+// rather than being told to retry. NOTE: the mid-window begin used by the ON test is flag-only and
+// unreachable here. The OFF commit path never invokes after_mint (that InvokeProbe is gated on the
+// flag), and engine_lock is held straight through mint->publish, so a concurrent Access(WRITE)
+// would simply block until C finishes -- there is no unpublished window to open W in. We therefore
+// let C commit fully first; W then necessarily observes C's commit (start_ts > C_ts) and writes on
+// top, which is exactly the OFF no-lost-update mechanism.
+TEST(LockFreeReadSnapshot, SameGapScenario_OFF_WriteSucceeds_AB) {
+  auto store = MakeStorage(/*flag_on=*/false);
+  const auto gid = CreateVertexWithProp(*store, 1);
+
+  {
+    auto c = store->Access(memgraph::storage::WRITE);
+    auto vertex = c->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(vertex.has_value());
+    ASSERT_TRUE(vertex->SetProperty(store->NameToProperty("p"), PropertyValue(2)).has_value());
+    ASSERT_TRUE(c->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  auto w = store->Access(memgraph::storage::WRITE);
+  // W's start is above C's commit, so C's X=2 is visible; W updates on top rather than conflicting.
+  EXPECT_EQ(ReadProp(*w, gid), 2);
+  auto w_vertex = w->FindVertex(gid, View::OLD);
+  ASSERT_TRUE(w_vertex.has_value());
+  ASSERT_TRUE(w_vertex->SetProperty(store->NameToProperty("p"), PropertyValue(3)).has_value());
+  ASSERT_TRUE(w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+  auto reader = store->Access(memgraph::storage::READ);
+  EXPECT_EQ(ReadProp(*reader, gid), 3);
+}

--- a/tests/unit/storage_v2_lockfree_read_snapshot.cpp
+++ b/tests/unit/storage_v2_lockfree_read_snapshot.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <optional>
@@ -48,6 +49,12 @@ using memgraph::storage::View;
 using Accessor = memgraph::storage::Storage::Accessor;
 
 namespace {
+
+// Handshake wait with a timeout: a regression that never reaches the probe fails the test
+// instead of hanging the binary forever on a bare acquire().
+void AcquireOrFail(std::binary_semaphore &sem) {
+  ASSERT_TRUE(sem.try_acquire_for(std::chrono::seconds(10))) << "semaphore handshake timed out";
+}
 
 std::unique_ptr<InMemoryStorage> MakeStorage(bool flag_on) {
   Config config{};
@@ -157,7 +164,7 @@ TEST(LockFreeReadSnapshot, ReaderBeginsBeforePublish_SeesPreCommitValue) {
     memgraph::storage::CommitProbe probe;
     probe.before_publish = [&] {
       reached.release();
-      resume.acquire();
+      AcquireOrFail(resume);
     };
     store->SetCommitProbe(&probe);
 
@@ -169,7 +176,7 @@ TEST(LockFreeReadSnapshot, ReaderBeginsBeforePublish_SeesPreCommitValue) {
   });
 
   // Commit is now parked at before_publish: minted, engine_lock released, not yet published.
-  reached.acquire();
+  AcquireOrFail(reached);
   {
     auto reader = store->Access(memgraph::storage::READ);
     EXPECT_EQ(ReadProp(*reader, gid), 1);
@@ -322,7 +329,7 @@ TEST(LockFreeReadSnapshot, LostUpdatePrevented_GapCommitPublishesAfterSnapshot_O
   memgraph::storage::CommitProbe probe;
   probe.after_mint = [&] {
     reached.release();
-    resume.acquire();
+    AcquireOrFail(resume);
   };
   store->SetCommitProbe(&probe);
 
@@ -335,7 +342,7 @@ TEST(LockFreeReadSnapshot, LostUpdatePrevented_GapCommitPublishesAfterSnapshot_O
   });
 
   // C has minted C_ts but not published; open W now so W's snapshot is below C_ts.
-  reached.acquire();
+  AcquireOrFail(reached);
   auto w = store->Access(memgraph::storage::WRITE);
 
   // Let C finish publishing X=2, then confirm it committed.
@@ -703,7 +710,7 @@ TEST(LockFreeReadSnapshot, ReaderBeginsDuringAbortingCommitWindow_NeverSeesAbort
   bool all_unique = true;
 
   std::thread committer([&] {
-    start.acquire();
+    AcquireOrFail(start);
     for (int i = 0; i < kIters; ++i) {
       auto w = store->Access(memgraph::storage::WRITE);
       auto vertex = w->CreateVertex();
@@ -893,22 +900,6 @@ TEST_F(LockFreeReadSnapshotRecovery, WriteOff_RecoverOff_DataIntact) {
   WriteDurable(storage_directory, /*flag_on=*/false);
   RecoverAndCheck(storage_directory, /*flag_on=*/false, 5);
 }
-
-// Phase 2, batch 7: concern-B (index-creation gap). Under the flag a label-property index is
-// built by scanning the vertex store at the accessor's frozen snapshot_ts (=
-// last_committed_mvcc_ts_ at AccessorOpen time). If a vertex committed in the window
-// (snapshot_ts, start_timestamp) -- i.e. it minted its ts and ran FinalizeCommitPhase steps
-// (set delta timestamps, update active indices) BEFORE the index was registered, but is still
-// parked at before_publish when CreateIndex opens -- it is invisible to PopulateIndex (its
-// delta ts > snapshot_ts under the flag-ON predicate) AND is not covered by the automatic
-// commit-time index update (because RegisterIndex had not yet run when it executed that step).
-// Result: the vertex is permanently absent from the index. Under flag-OFF the engine_lock is
-// held straight through GetCommitTimestamp→FinalizeCommitPhase, so a concurrent commit cannot
-// be interleaved into CreateIndex; the first-committed vertex is fully visible at start_ts.
-//
-// NOTE: This test is EXPECTED TO FAIL for flag_on=true (it reproduces a real bug). It will
-// turn green when the fix (e.g. a PopulateIndex re-pass using start_ts, or seeding
-// last_committed_mvcc_ts_ as the accessor's snapshot at index-scan time) is applied.
 
 // Helper: count vertices reachable via a label-property index scan on the given accessor.
 namespace {
@@ -1231,7 +1222,7 @@ TEST(LockFreeReadSnapshot, NonSequentialEdgeWriteInGap_ON) {
   memgraph::storage::CommitProbe probe;
   probe.before_publish = [&] {
     reached.release();
-    resume.acquire();
+    AcquireOrFail(resume);
   };
   store->SetCommitProbe(&probe);
 
@@ -1248,7 +1239,7 @@ TEST(LockFreeReadSnapshot, NonSequentialEdgeWriteInGap_ON) {
   });
 
   // C is parked at before_publish: C_ts is minted, engine_lock released, watermark not advanced.
-  reached.acquire();
+  AcquireOrFail(reached);
 
   // W opens: snapshot_ts = last_committed_mvcc_ts_.load() at Access time (flag ON).
   // Because the watermark has not advanced, W.snapshot_ts < C_ts.

--- a/tests/unit/storage_v2_schema_info.cpp
+++ b/tests/unit/storage_v2_schema_info.cpp
@@ -16,7 +16,11 @@
 #include <exception>
 #include <filesystem>
 
+#include <optional>
+#include <semaphore>
+
 #include "dbms/constants.hpp"
+#include "storage/v2/commit_probe.hpp"
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/point.hpp"
@@ -3231,4 +3235,120 @@ TYPED_TEST(SchemaInfoTestWEdgeProp, EdgeDeletedAndRecreatedAfterLabelChange) {
     ASSERT_TRUE(ConfrontJSON(json, expected))
         << "After T2 (delete/recreate), edge should be counted once. Actual: " << json.dump(2);
   }
+}
+
+// Regression guard for the schema-info gap-commit boundary skew under
+// experimental_lockfree_read_snapshot. Deterministic (CommitProbe + semaphores, GC disabled to prove
+// GC-independence). A committer C flips an edge property's TYPE (Integer -> String) and is parked in
+// the commit gap (commit ts minted, engine_lock released, read watermark NOT yet advanced). A writer
+// W begins in that gap (W.snapshot_ts < C_ts < W.start_ts), so W's snapshot EXCLUDES C; W relabels an
+// endpoint, which routes the edge through schema-info's edge reconstruction, then commits AFTER C
+// publishes.
+//
+// Before the fix, schema-info reconstructed the edge's pre-state on start_timestamp
+// (schema_info.cpp ApplyDeltasForRead/GetState), folding in C's committed String that W never saw and
+// recording p="Integer" (the value W's snapshot did see) under start_node_labels=["L1"] -- i.e.
+// schema-info diverged from the physically-committed truth (p="String"). This is the deterministic
+// single-bucket reduction of the same root cause behind the count:2 / two-bucket double-count in the
+// concurrent EdgePropertyStressTest (which additionally needs a third, genuinely-concurrent mutation
+// to drive the post_process 4-way reconciliation; commit_mutex_ serialization makes that unreachable
+// with only C + W). The fix threads the transaction's own inclusive snapshot boundary
+// (Transaction::SchemaReconstructionBound) into all three reconstruction supply sites, so schema-info
+// reconstructs exactly what the committing transaction saw. With the fix this test observes p="String".
+TEST(SchemaInfoLockFreeReadSnapshot, EdgePropertyTypeGapSkew) {
+  using memgraph::storage::Config;
+  Config config{};
+  config.salient.name = memgraph::dbms::kDefaultDB;
+  memgraph::storage::UpdatePaths(config, storage_directory);
+  config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  config.salient.items.properties_on_edges = true;
+  config.salient.items.enable_schema_info = true;
+  config.salient.storage_mode = StorageMode::IN_MEMORY_TRANSACTIONAL;
+  config.experimental_lockfree_read_snapshot = true;
+  config.gc.type = Config::Gc::Type::NONE;  // prove GC-independence
+
+  std::filesystem::remove_all(storage_directory);
+  auto store = std::make_unique<memgraph::storage::InMemoryStorage>(config);
+  auto *in_memory = store.get();
+  auto &schema_info = in_memory->schema_info_;
+
+  const auto l1 = in_memory->NameToLabel("L1");
+  const auto e = in_memory->NameToEdgeType("E");
+  const auto p = in_memory->NameToProperty("p");
+
+  Gid v1_gid, v2_gid, edge_gid;
+
+  // Seed: edge (E: v1->v2) with p = Integer(123). Schema-process runs synchronously in commit.
+  {
+    auto acc = in_memory->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    auto v2 = acc->CreateVertex();
+    v2_gid = v2.Gid();
+    auto edge = acc->CreateEdge(&v1, &v2, e);
+    ASSERT_TRUE(edge.has_value());
+    edge_gid = edge->Gid();
+    ASSERT_TRUE(edge->SetProperty(p, PropertyValue(123)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    const auto json = schema_info.ToJson(*in_memory->name_id_mapper_, in_memory->enum_store_);
+    ASSERT_EQ(json["edges"].size(), 1) << json.dump(2);
+    ASSERT_EQ(json["edges"][0]["properties"][0]["types"][0]["type"], "Integer") << json.dump(2);
+  }
+
+  std::binary_semaphore reached{0};
+  std::binary_semaphore resume{0};
+  std::optional<bool> c_ok;
+
+  memgraph::storage::CommitProbe probe;
+  probe.before_publish = [&] {
+    reached.release();
+    resume.acquire();
+  };
+  in_memory->SetCommitProbe(&probe);
+
+  // Committer C: flip the edge property TYPE Integer -> String, then park before publish.
+  std::thread committer([&] {
+    auto acc = in_memory->Access(memgraph::storage::WRITE);
+    auto edge = acc->FindEdge(edge_gid, memgraph::storage::View::OLD);
+    ASSERT_TRUE(edge.has_value());
+    ASSERT_TRUE(edge->SetProperty(p, PropertyValue(std::string{"strval"})).has_value());
+    c_ok = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+  });
+
+  // C is now parked at before_publish: C_ts minted, engine_lock free, watermark unmoved.
+  reached.acquire();
+
+  // W begins in the gap: W.snapshot_ts < C_ts < W.start_ts. W must still SEE Integer.
+  auto w = in_memory->Access(memgraph::storage::WRITE);
+  {
+    auto w_edge = w->FindEdge(edge_gid, memgraph::storage::View::OLD);
+    ASSERT_TRUE(w_edge.has_value());
+    auto w_val = w_edge->GetProperty(p, memgraph::storage::View::OLD);
+    ASSERT_TRUE(w_val.has_value());
+    EXPECT_TRUE(w_val->IsInt()) << "W's snapshot must exclude C: expected Integer, got " << w_val->type();
+  }
+  // W relabels the from-endpoint -> routes the edge through schema-info edge reconstruction.
+  {
+    auto w_v1 = w->FindVertex(v1_gid, memgraph::storage::View::OLD);
+    ASSERT_TRUE(w_v1.has_value());
+    ASSERT_TRUE(w_v1->AddLabel(l1).has_value());
+  }
+
+  // Let C publish (edge delta now carries C_ts; C's own schema diff processed), then release
+  // commit_mutex_ so W can finalize + schema-process.
+  resume.release();
+  committer.join();
+  in_memory->SetCommitProbe(nullptr);
+  ASSERT_TRUE(c_ok.has_value() && *c_ok);
+
+  ASSERT_TRUE(w->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  w.reset();
+
+  // Physical truth after both commits: edge from=[L1] to=[] with p = String, count 1, single bucket.
+  const auto json = schema_info.ToJson(*in_memory->name_id_mapper_, in_memory->enum_store_);
+  const auto expected = nlohmann::json::parse(
+      R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count":1,"filling_factor":100.0,"key":"p","types":[{"count":1,"type":"String"}]}],"start_node_labels":["L1"],"type":"E"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
+  EXPECT_TRUE(ConfrontJSON(json, expected)) << "SCHEMA-INFO CORRUPTION (boundary skew). Actual: " << json.dump(2);
 }


### PR DESCRIPTION
> ⚠️ **DRAFT / DO NOT MERGE** — the tip commit `TEMP(CI): default lockfree-read-snapshot flag ON` forces the experimental flag on so the **entire CI matrix runs with the feature active**. Revert that commit before this is mergeable.

## What this is

An experimental **lock-free read snapshot** for in-memory storage v2, behind `--experimental-enabled=lockfree-read-snapshot` (CLI-only, immutable during execution). The write committer releases `engine_lock_` right after minting the commit timestamp and runs WAL + SYNC/STRICT_SYNC replication under a new `commit_mutex_`, so a new `BEGIN` no longer stalls behind another transaction's durability/replication RTT. SNAPSHOT_ISOLATION readers freeze a `snapshot_ts` watermark (last published commit) as their MVCC boundary.

It **unblocks BEGIN only** — committers stay serialized on `commit_mutex_` (no commit parallelism). **OFF is byte-identical** and the flag is runtime-only (never persisted), so flipping it across a restart is safe.

## Structure (13 feature commits, off `master`)

**Implementation (Phases 0→1.6):**
- **1.1** three-phase committer (release `engine_lock_` after mint; WAL/replication under `commit_mutex_`)
- **1.2** capture frozen `snapshot_ts` at BEGIN (+ across PERIODIC COMMIT)
- **1.3** SI reads + write-conflict checks honor `snapshot_ts` (SI-guarded)
- **1.4** GC visibility/physical horizon split + a tagged-ring `min(active snapshot_ts)` tracker
- **1.5** WAL-guardian retrofit for 3 replication-recovery sites
- **1.6** flag wiring → CLI-reachable

**Tests (Phase 2, 20 deterministic + stress cases** in `storage_v2_lockfree_read_snapshot.cpp`, driven by a `CommitProbe` seam): read-visibility, write-conflict / **no-lost-update**, GC-horizon, abort, cross-flag recovery (ON→OFF / OFF→ON), and a concurrent readers/writers/GC stress test.

## Validation
- Full unit suite green.
- **ThreadSanitizer: 0 warnings** across the full suite + 10× stress repeats (instrumentation confirmed on the feature code). A torn-read over-reclaim UAF in the GC tracker was caught by review pre-commit, fixed with an invalidate-first writer, and is now empirically race-free.

## Why the labels
CI selectors copied from #4669 to run the full matrix (core / integration / e2e / stress / benchmark / jepsen / clang-tidy / coverage) with the flag forced on.
