### PR TITLE
test(unit): give each test process its own storage directories

### DIFF
--- a/tests/unit/disk_test_utils.cpp
+++ b/tests/unit/disk_test_utils.cpp
@@ -27,7 +27,10 @@ namespace {
 // private to this process: test binaries run concurrently out of a shared working directory, and a
 // name two of them agree on has one deleting the other's storage mid-use.
 std::string DirectoryPrefix(const std::string &testName) {
-  return "rocksdb_" + testName + "_" + std::to_string(static_cast<int>(getpid())) + "_";
+  // Resolved once, so a directory is removed under the name it was created under even if the
+  // process forks in between, as a death test does.
+  static const std::string id = std::to_string(static_cast<int>(getpid()));
+  return "rocksdb_" + testName + "_" + id + "_";
 }
 }  // namespace
 

--- a/tests/unit/disk_test_utils.cpp
+++ b/tests/unit/disk_test_utils.cpp
@@ -12,35 +12,50 @@
 #include "disk_test_utils.hpp"
 
 #include <rocksdb/utilities/transaction_db.h>
+#include <unistd.h>
 #include <filesystem>
 #include <memory>
+#include <string>
 
 #include "dbms/constants.hpp"
 #include "storage/v2/disk/storage.hpp"
 
 namespace disk_test_utils {
 
+namespace {
+// These are relative to the working directory and are removed wholesale, so the prefix has to be
+// private to this process: test binaries run concurrently out of a shared working directory, and a
+// name two of them agree on has one deleting the other's storage mid-use.
+std::string DirectoryPrefix(const std::string &testName) {
+  return "rocksdb_" + testName + "_" + std::to_string(static_cast<int>(getpid())) + "_";
+}
+}  // namespace
+
 memgraph::storage::Config GenerateOnDiskConfig(const std::string &testName) {
-  return {.disk = {.main_storage_directory = "rocksdb_" + testName + "_db",
-                   .label_index_directory = "rocksdb_" + testName + "_label_index",
-                   .label_property_index_directory = "rocksdb_" + testName + "_label_property_index",
-                   .unique_constraints_directory = "rocksdb_" + testName + "_unique_constraints",
-                   .name_id_mapper_directory = "rocksdb_" + testName + "_name_id_mapper",
-                   .id_name_mapper_directory = "rocksdb_" + testName + "_id_name_mapper",
-                   .durability_directory = "rocksdb_" + testName + "_durability",
-                   .wal_directory = "rocksdb_" + testName + "_wal"},
+  const auto prefix = DirectoryPrefix(testName);
+  return {.disk = {.main_storage_directory = prefix + "db",
+                   .label_index_directory = prefix + "label_index",
+                   .label_property_index_directory = prefix + "label_property_index",
+                   .unique_constraints_directory = prefix + "unique_constraints",
+                   .name_id_mapper_directory = prefix + "name_id_mapper",
+                   .id_name_mapper_directory = prefix + "id_name_mapper",
+                   .durability_directory = prefix + "durability",
+                   .wal_directory = prefix + "wal"},
           .salient = {.name = memgraph::dbms::kDefaultDB}};
 }
 
 void RemoveRocksDbDirs(const std::string &testName) {
-  std::filesystem::remove_all("rocksdb_" + testName + "_db");
-  std::filesystem::remove_all("rocksdb_" + testName + "_label_index");
-  std::filesystem::remove_all("rocksdb_" + testName + "_label_property_index");
-  std::filesystem::remove_all("rocksdb_" + testName + "_unique_constraints");
-  std::filesystem::remove_all("rocksdb_" + testName + "_name_id_mapper");
-  std::filesystem::remove_all("rocksdb_" + testName + "_id_name_mapper");
-  std::filesystem::remove_all("rocksdb_" + testName + "_durability");
-  std::filesystem::remove_all("rocksdb_" + testName + "_wal");
+  const auto prefix = DirectoryPrefix(testName);
+  for (const auto *suffix : {"db",
+                             "label_index",
+                             "label_property_index",
+                             "unique_constraints",
+                             "name_id_mapper",
+                             "id_name_mapper",
+                             "durability",
+                             "wal"}) {
+    std::filesystem::remove_all(prefix + suffix);
+  }
 }
 
 uint64_t GetRealNumberOfEntriesInRocksDB(rocksdb::TransactionDB *disk_storage) {

--- a/tests/unit/query_streams.cpp
+++ b/tests/unit/query_streams.cpp
@@ -9,9 +9,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <unistd.h>
 #include <algorithm>
 #include <filesystem>
 #include <optional>
+#include <string>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -71,7 +73,10 @@ std::string GetDefaultStreamName() {
 }
 
 std::filesystem::path GetCleanDataDirectory() {
-  const auto path = std::filesystem::temp_directory_path() / "query-streams";
+  // Emptied on every fixture construction, so the path must be private to this process. A path
+  // shared with a concurrently running test deletes that test's storage out from under it.
+  const auto path =
+      std::filesystem::temp_directory_path() / ("query-streams-" + std::to_string(static_cast<int>(getpid())));
   std::filesystem::remove_all(path);
   return path;
 }

--- a/tests/unit/query_streams.cpp
+++ b/tests/unit/query_streams.cpp
@@ -73,10 +73,12 @@ std::string GetDefaultStreamName() {
 }
 
 std::filesystem::path GetCleanDataDirectory() {
-  // Emptied on every fixture construction, so the path must be private to this process. A path
+  // Emptied on every fixture construction, so the path must be private to this process: a path
   // shared with a concurrently running test deletes that test's storage out from under it.
-  const auto path =
-      std::filesystem::temp_directory_path() / ("query-streams-" + std::to_string(static_cast<int>(getpid())));
+  // Resolved once, so a directory is removed under the name it was created under even if the
+  // process forks in between.
+  static const std::string id = std::to_string(static_cast<int>(getpid()));
+  const auto path = std::filesystem::temp_directory_path() / ("query-streams-" + id);
   std::filesystem::remove_all(path);
   return path;
 }

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -34,11 +34,16 @@
 #include "utils/settings.hpp"
 
 namespace {
-// Emptied wholesale by the tests here, so the path must be private to this process. A path shared
-// with a concurrently running test deletes that test's storage out from under it.
-std::filesystem::path GetDataDirectory() {
-  return std::filesystem::temp_directory_path() / ("ttl-" + std::to_string(static_cast<int>(getpid())));
+// The storage directories here are emptied wholesale, so their names must be private to this
+// process: a name shared with a concurrently running test deletes that test's storage out from
+// under it. Resolved once, so a directory is removed under the name it was created under even if
+// the process forks in between.
+const std::string &ProcessId() {
+  static const std::string id = std::to_string(static_cast<int>(getpid()));
+  return id;
 }
+
+std::filesystem::path GetDataDirectory() { return std::filesystem::temp_directory_path() / ("ttl-" + ProcessId()); }
 
 std::filesystem::path GetCleanDataDirectory() {
   const auto path = GetDataDirectory();
@@ -610,8 +615,7 @@ TEST(TtlInfo, String) {
 TEST(TTLUserCheckTest, UserCheckFunctionality) {
   // Create a simple storage for testing
   memgraph::storage::Config config{};
-  config.durability.storage_directory =
-      std::filesystem::temp_directory_path() / ("ttl_user_check_test-" + std::to_string(static_cast<int>(getpid())));
+  config.durability.storage_directory = std::filesystem::temp_directory_path() / ("ttl_user_check_test-" + ProcessId());
   std::filesystem::remove_all(config.durability.storage_directory);
 
   memgraph::utils::Gatekeeper<memgraph::dbms::Database> db_gk{config};

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -10,8 +10,10 @@
 // licenses/APL.txt.
 
 #include <gtest/gtest.h>
+#include <unistd.h>
 #include <chrono>
 #include <filesystem>
+#include <string>
 #include <thread>
 #include <tuple>
 #include <type_traits>
@@ -32,8 +34,14 @@
 #include "utils/settings.hpp"
 
 namespace {
+// Emptied wholesale by the tests here, so the path must be private to this process. A path shared
+// with a concurrently running test deletes that test's storage out from under it.
+std::filesystem::path GetDataDirectory() {
+  return std::filesystem::temp_directory_path() / ("ttl-" + std::to_string(static_cast<int>(getpid())));
+}
+
 std::filesystem::path GetCleanDataDirectory() {
-  const auto path = std::filesystem::temp_directory_path() / "ttl";
+  const auto path = GetDataDirectory();
   std::filesystem::remove_all(path);
   return path;
 }
@@ -507,9 +515,9 @@ TYPED_TEST(TTLFixture, Edge) {
 
 // Needs user-defined timezone
 TEST(TtlInfo, PersistentTimezone) {
-  memgraph::utils::OnScopeExit clean_up([] { std::filesystem::remove_all("/tmp/ttl"); });
+  memgraph::utils::OnScopeExit clean_up([] { std::filesystem::remove_all(GetDataDirectory()); });
   {
-    memgraph::utils::Settings settings("/tmp/ttl");
+    memgraph::utils::Settings settings(GetDataDirectory());
     memgraph::flags::run_time::Initialize(settings);
     // Default value
     EXPECT_EQ(memgraph::flags::run_time::GetTimezone()->name(), "Etc/UTC");
@@ -519,7 +527,7 @@ TEST(TtlInfo, PersistentTimezone) {
   }
   {
     // Recover previous value
-    memgraph::utils::Settings settings("/tmp/ttl");
+    memgraph::utils::Settings settings(GetDataDirectory());
     memgraph::flags::run_time::Initialize(settings);
     EXPECT_EQ(memgraph::flags::run_time::GetTimezone()->name(), "Europe/Rome");
   }
@@ -527,8 +535,8 @@ TEST(TtlInfo, PersistentTimezone) {
 
 // Needs user-defined timezone
 TEST(TtlInfo, String) {
-  memgraph::utils::OnScopeExit clean_up([] { std::filesystem::remove_all("/tmp/ttl"); });
-  memgraph::utils::Settings settings("/tmp/ttl");
+  memgraph::utils::OnScopeExit clean_up([] { std::filesystem::remove_all(GetDataDirectory()); });
+  memgraph::utils::Settings settings(GetDataDirectory());
   memgraph::flags::run_time::Initialize(settings);
 
   {
@@ -602,7 +610,8 @@ TEST(TtlInfo, String) {
 TEST(TTLUserCheckTest, UserCheckFunctionality) {
   // Create a simple storage for testing
   memgraph::storage::Config config{};
-  config.durability.storage_directory = std::filesystem::temp_directory_path() / "ttl_user_check_test";
+  config.durability.storage_directory =
+      std::filesystem::temp_directory_path() / ("ttl_user_check_test-" + std::to_string(static_cast<int>(getpid())));
   std::filesystem::remove_all(config.durability.storage_directory);
 
   memgraph::utils::Gatekeeper<memgraph::dbms::Database> db_gk{config};


### PR DESCRIPTION
Several tests named their storage directory after the test alone, and each empties that directory when it sets up. Two processes using the same name therefore delete each other's storage mid-run, surfacing as RocksDB failing to open a file that has just been removed underneath it.

The directories are now private to the process that creates them. The widest case is the on-disk test helper, whose paths were relative to the working directory that every test binary shares, so this covers the disk-storage tests generally rather than only the two that were seen failing.
