### PR TITLE
perf(slk): avoid copying builder buffer on move

### DIFF
--- a/src/slk/streams.cpp
+++ b/src/slk/streams.cpp
@@ -20,7 +20,9 @@
 
 namespace memgraph::slk {
 
-Builder::Builder(std::function<void(const uint8_t *, size_t, bool)> write_func) : write_func_(std::move(write_func)) {}
+Builder::Builder(std::function<void(const uint8_t *, size_t, bool)> write_func)
+    : write_func_(std::move(write_func)),
+      segment_(std::make_unique_for_overwrite<std::array<uint8_t, kSegmentMaxTotalSize>>()) {}
 
 bool Builder::IsEmpty() const { return pos_ == 0; }
 
@@ -31,9 +33,9 @@ void Builder::Save(const uint8_t *data, uint64_t size) {
     size_t const to_write = std::min(size, kSegmentMaxDataSize - pos_);
 
     if (file_data_) {
-      memcpy(segment_.data() + pos_, data + offset, to_write);
+      memcpy(segment_->data() + pos_, data + offset, to_write);
     } else {
-      memcpy(segment_.data() + sizeof(SegmentSize) + pos_, data + offset, to_write);
+      memcpy(segment_->data() + sizeof(SegmentSize) + pos_, data + offset, to_write);
     }
 
     size -= to_write;
@@ -49,7 +51,7 @@ void Builder::SaveFileBuffer(const uint8_t *data, uint64_t size) {
   while (size > 0) {
     FlushFileSegment();
     size_t const to_write = std::min(size, kSegmentMaxDataSize - pos_);
-    memcpy(segment_.data() + pos_, data + offset, to_write);
+    memcpy(segment_->data() + pos_, data + offset, to_write);
     size -= to_write;
     pos_ += to_write;
     offset += to_write;
@@ -58,7 +60,7 @@ void Builder::SaveFileBuffer(const uint8_t *data, uint64_t size) {
 
 // This should be invoked before preparing every file. The function writes kFileSegmentMask at the current position
 void Builder::PrepareForFileSending() {
-  memcpy(segment_.data() + pos_, &kFileSegmentMask, sizeof(SegmentSize));
+  memcpy(segment_->data() + pos_, &kFileSegmentMask, sizeof(SegmentSize));
   pos_ += sizeof(SegmentSize);
   file_data_ = true;
 }
@@ -70,7 +72,7 @@ void Builder::FlushInternal(size_t const size, bool const has_more) {
   // Callers that retry (e.g. recovery progress heartbeats) then start from a clean segment instead of tripping the
   // "buffer must be empty" guard.
   utils::OnScopeExit const reset_pos{[this] { pos_ = 0; }};
-  write_func_(segment_.data(), size, has_more);
+  write_func_(segment_->data(), size, has_more);
 }
 
 // Flushes data and resets position
@@ -81,7 +83,7 @@ void Builder::FlushFileSegment() {
 }
 
 void Builder::SaveFooter(uint64_t const total_size) {
-  memcpy(segment_.data() + total_size, &kFooter, sizeof(SegmentSize));
+  memcpy(segment_->data() + total_size, &kFooter, sizeof(SegmentSize));
 }
 
 void Builder::FlushSegment(bool const final_segment, bool const force_flush) {
@@ -97,7 +99,7 @@ void Builder::FlushSegment(bool const final_segment, bool const force_flush) {
 
   if (!file_data_) {
     SegmentSize const data_size = pos_;
-    memcpy(segment_.data(), &data_size, sizeof(SegmentSize));
+    memcpy(segment_->data(), &data_size, sizeof(SegmentSize));
   }
 
   if (final_segment) {

--- a/src/slk/streams.hpp
+++ b/src/slk/streams.hpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -45,7 +46,7 @@ static_assert(kSegmentMaxDataSize <= std::numeric_limits<SegmentSize>::max(),
 /// SLK splits binary data into segments. Segments are used to avoid the need to
 /// have all the encoded data in memory at once during the building process.
 /// That enables streaming during the building process and makes the whole
-/// process make zero memory allocations because only one static buffer is used.
+/// process use a single reusable buffer.
 /// During the reading process you must have all of the data in memory.
 ///
 /// SLK segments are just chunks of binary data. They start with a `size` field
@@ -66,7 +67,7 @@ class Builder {
   explicit Builder(std::function<void(const uint8_t *, size_t, bool)> write_func);
 
   Builder(Builder &&other, std::function<void(const uint8_t *, size_t, bool)> write_func)
-      : write_func_{std::move(write_func)}, pos_{std::exchange(other.pos_, 0)}, segment_{other.segment_} {
+      : write_func_{std::move(write_func)}, pos_{std::exchange(other.pos_, 0)}, segment_{std::move(other.segment_)} {
     other.write_func_ = [](const uint8_t *, size_t, bool) { /* Moved builder is defunct, no write possible */ };
   }
 
@@ -102,7 +103,7 @@ class Builder {
 
   std::function<void(const uint8_t *, size_t, bool)> write_func_;
   size_t pos_{0};
-  std::array<uint8_t, kSegmentMaxTotalSize> segment_;
+  std::unique_ptr<std::array<uint8_t, kSegmentMaxTotalSize>> segment_;
 };
 
 /// Exception that will be thrown if segments can't be decoded from the byte


### PR DESCRIPTION
## Summary
- heap-allocate the SLK builder segment buffer
- transfer buffer ownership when moving builders instead of copying 256 KiB
- avoid zero-initializing the write-only buffer