### PR TITLE
test(e2e): wait for the transactions a wildcard sweep is meant to kill

### DIFF
--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -61,6 +61,22 @@ def wait_for_transaction_count(cursor, expected_num_results: int, timeout_s: int
         time.sleep(0.1)
 
 
+def wait_for_query_count(cursor, query: str, expected_num_results: int, timeout_s: int = 10):
+    """Polls SHOW TRANSACTIONS until the expected number of transactions are running query.
+
+    A victim that runs several queries in turn is visible between them, so counting transactions
+    alone can be satisfied while a victim still has the query of interest ahead of it.
+    """
+    deadline = time.time() + timeout_s
+    while True:
+        results = execute_and_fetch_all(cursor, "SHOW TRANSACTIONS")
+        if sum(1 for result in results if query in result[2]) == expected_num_results:
+            return
+        if time.time() >= deadline:
+            assert False, f"Timed out waiting for {expected_num_results} transactions running {query}, saw {results}"
+        time.sleep(0.1)
+
+
 def process_function(cursor, queries: List[str]):
     try:
         for query in queries:
@@ -491,7 +507,9 @@ def test_wildcard_across_databases(request):
 
     # The sweeping session stays on the default database.
     admin_cursor = connect(username="admin", password="").cursor()
-    wait_for_transaction_count(admin_cursor, 3)
+    # Each victim runs USE DATABASE before the long query, so wait for the long queries themselves
+    # rather than for a count that the USE DATABASE transactions can satisfy on their own.
+    wait_for_query_count(admin_cursor, LONG_QUERY, 2)
 
     results = execute_and_fetch_all(admin_cursor, 'TERMINATE TRANSACTIONS "*"')
     assert len(results) == 2

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -62,10 +62,11 @@ def wait_for_transaction_count(cursor, expected_num_results: int, timeout_s: int
 
 
 def wait_for_query_count(cursor, query: str, expected_num_results: int, timeout_s: int = 10):
-    """Polls SHOW TRANSACTIONS until the expected number of transactions are running query.
+    """Polls SHOW TRANSACTIONS until that many transactions are running query.
 
-    A victim that runs several queries in turn is visible between them, so counting transactions
-    alone can be satisfied while a victim still has the query of interest ahead of it.
+    Every query a session runs is a transaction in its own right and is listed for as long as it
+    runs, commit included. A count of transactions can therefore be reached by an earlier query in
+    a session's sequence rather than by the one being waited for.
     """
     deadline = time.time() + timeout_s
     while True:
@@ -507,8 +508,9 @@ def test_wildcard_across_databases(request):
 
     # The sweeping session stays on the default database.
     admin_cursor = connect(username="admin", password="").cursor()
-    # Each victim runs USE DATABASE before the long query, so wait for the long queries themselves
-    # rather than for a count that the USE DATABASE transactions can satisfy on their own.
+    # Each victim switches database before starting its long query, and that switch is itself a
+    # listed transaction, so a count of transactions can be reached while neither long query has
+    # begun. The sweep below then has nothing of interest to kill, so wait for the long queries.
     wait_for_query_count(admin_cursor, LONG_QUERY, 2)
 
     results = execute_and_fetch_all(admin_cursor, 'TERMINATE TRANSACTIONS "*"')


### PR DESCRIPTION
The test that terminates transactions across databases waited for a number of transactions to be visible rather than for the long-running queries it then kills. Each victim switches database before starting its long query, and that switch is a transaction in its own right, listed for as long as it runs and commits. The number could therefore be reached while neither long query had begun, leaving the sweep nothing of interest to kill: it reported fewer terminations than expected, and the teardown could not drop a database that was still in use.

The wait now counts the transactions running that query, which is the condition the sweep depends on, so a switch that is still in flight no longer lets the test through early.
