### PR TITLE
CI: move query module tests into core job + diff input changes

### DIFF
--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -11,37 +11,59 @@ on:
       community_core:
         type: boolean
         default: true
-        description: ""
+        description: "Community: Core"
       coverage_core:
         type: boolean
         default: true
-        description: ""
+        description: "Coverage: Core"
       debug_core:
         type: boolean
         default: true
-        description: ""
+        description: "Debug: Core"
       debug_integration:
         type: boolean
         default: true
-        description: ""
+        description: "Debug: Integration"
       jepsen_core:
         type: boolean
         default: true
-        description: ""
-      release:
-        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress)'
-        default: 'core,e2e,stress'
+        description: "Jepsen: Core"
+      release_core:
+        type: boolean
+        default: true
+        description: "Release: Core"
+      release_benchmark:
+        type: boolean
+        default: false
+        description: "Release: Benchmark"
+      release_e2e:
+        type: boolean
+        default: true
+        description: "Release: E2E"
+      release_stress:
+        type: boolean
+        default: true
+        description: "Release: Stress"
       malloc_build:
         type: boolean
         default: true
-      mage:
-        type: string
-        default: 'amd'
-        description: 'Comma-separated list of architectures to run the mage tests on (e.g. amd,arm,cuda). Use "none" to skip all mage tests.'
+        description: "Malloc: Build"
+      mage_amd:
+        type: boolean
+        default: true
+        description: "MAGE: AMD"
+      mage_arm:
+        type: boolean
+        default: false
+        description: "MAGE: ARM"
+      mage_cuda:
+        type: boolean
+        default: false
+        description: "MAGE: CUDA"
       mgcxx_unit:
         type: boolean
         default: true
-        description: "Run the mgcxx tests."
+        description: "MGCXX: Unit"
       flakiness_runs:
         type: number
         default: 3

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -29,8 +29,8 @@ on:
         default: true
         description: ""
       release:
-        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress,query_modules)'
-        default: 'core,e2e,stress,query_modules'
+        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress)'
+        default: 'core,e2e,stress'
       malloc_build:
         type: boolean
         default: true
@@ -61,7 +61,6 @@ jobs:
       run_release_benchmark: ${{ steps.setup.outputs.run_release_benchmark}}
       run_release_e2e: ${{ steps.setup.outputs.run_release_e2e }}
       run_release_stress: ${{ steps.setup.outputs.run_release_stress }}
-      run_release_query_modules: ${{ steps.setup.outputs.run_release_query_modules }}
       run_malloc_build: ${{ steps.setup.outputs.run_malloc_build }}
       run_mage_amd: ${{ steps.setup.outputs.run_mage_amd }}
       run_mage_arm: ${{ steps.setup.outputs.run_mage_arm }}
@@ -174,7 +173,6 @@ jobs:
       run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark =='true' && github.event_name == 'workflow_dispatch' }}
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
-      run_query_modules: ${{ needs.DiffSetup.outputs.run_release_query_modules }}
       run_id: "${{ matrix.run_no }}"
       ref: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/check_python_versions.yaml
+++ b/.github/workflows/check_python_versions.yaml
@@ -32,7 +32,7 @@ on:
             release:
                 type: boolean
                 default: true
-                description: "Run the Release core + e2e + query_modules suites across the matrix (benchmark/stress skipped)."
+                description: "Run the Release core + e2e suites across the matrix (benchmark/stress skipped)."
             malloc:
                 type: boolean
                 default: true
@@ -150,7 +150,6 @@ jobs:
             run_benchmark: "false"
             run_e2e: "true"
             run_stress: "false"
-            run_query_modules: "true"
             python_build_version: ${{ matrix.python_build }}
             python_runtime_version: ${{ matrix.python_runtime }}
             run_id: "b${{ matrix.python_build }}-r${{ matrix.python_runtime }}"

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -11,32 +11,63 @@ on:
       community_core:
         type: boolean
         default: true
-      coverage:
-        description: 'Comma-separated list of coverage tests to run (e.g. core,clang_tidy). Use "none" to skip all coverage tests.'
-        default: 'core,clang_tidy'
+        description: "Community: Core"
+      coverage_core:
+        type: boolean
+        default: true
+        description: "Coverage: Core"
+      coverage_clang_tidy:
+        type: boolean
+        default: true
+        description: "Coverage: Clang-Tidy"
       debug_core:
         type: boolean
         default: true
+        description: "Debug: Core"
       debug_integration:
         type: boolean
         default: true
+        description: "Debug: Integration"
       jepsen_core:
         type: boolean
         default: true
-      release:
-        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress). Use "none" to skip all release tests.'
-        default: 'core,benchmark,e2e,stress'
+        description: "Jepsen: Core"
+      release_core:
+        type: boolean
+        default: true
+        description: "Release: Core"
+      release_benchmark:
+        type: boolean
+        default: true
+        description: "Release: Benchmark"
+      release_e2e:
+        type: boolean
+        default: true
+        description: "Release: E2E"
+      release_stress:
+        type: boolean
+        default: true
+        description: "Release: Stress"
       malloc_build:
         type: boolean
         default: true
-      mage:
-        type: string
-        default: 'amd,arm,cuda'
-        description: 'Comma-separated list of architectures to run the mage tests on (e.g. amd,arm,cuda). Use "none" to skip all mage tests.'
+        description: "Malloc: Build"
+      mage_amd:
+        type: boolean
+        default: true
+        description: "MAGE: AMD"
+      mage_arm:
+        type: boolean
+        default: true
+        description: "MAGE: ARM"
+      mage_cuda:
+        type: boolean
+        default: true
+        description: "MAGE: CUDA"
       mgcxx_unit:
         type: boolean
         default: true
-        description: "Run the mgcxx tests."
+        description: "MGCXX: Unit"
       python_build_version:
         type: string
         default: ''
@@ -50,34 +81,63 @@ on:
       community_core:
         type: boolean
         default: true
-      coverage:
-        description: 'Comma-separated list of coverage tests to run (e.g. core,clang_tidy). Use "none" to skip all coverage tests.'
-        default: 'core,clang_tidy'
-        type: string
+        description: "Community: Core"
+      coverage_core:
+        type: boolean
+        default: true
+        description: "Coverage: Core"
+      coverage_clang_tidy:
+        type: boolean
+        default: true
+        description: "Coverage: Clang-Tidy"
       debug_core:
         type: boolean
         default: true
+        description: "Debug: Core"
       debug_integration:
         type: boolean
         default: true
+        description: "Debug: Integration"
       jepsen_core:
         type: boolean
         default: true
-      release:
-        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress). Use "none" to skip all release tests.'
-        default: 'core,benchmark,e2e,stress'
-        type: string
+        description: "Jepsen: Core"
+      release_core:
+        type: boolean
+        default: true
+        description: "Release: Core"
+      release_benchmark:
+        type: boolean
+        default: true
+        description: "Release: Benchmark"
+      release_e2e:
+        type: boolean
+        default: true
+        description: "Release: E2E"
+      release_stress:
+        type: boolean
+        default: true
+        description: "Release: Stress"
       malloc_build:
         type: boolean
         default: true
-      mage:
-        type: string
-        default: 'amd,arm,cuda'
-        description: 'Comma-separated list of architectures to run the mage tests on (e.g. amd,arm,cuda). Use "none" to skip all mage tests.'
+        description: "Malloc: Build"
+      mage_amd:
+        type: boolean
+        default: true
+        description: "MAGE: AMD"
+      mage_arm:
+        type: boolean
+        default: true
+        description: "MAGE: ARM"
+      mage_cuda:
+        type: boolean
+        default: true
+        description: "MAGE: CUDA"
       mgcxx_unit:
         type: boolean
         default: true
-        description: "Run the mgcxx tests."
+        description: "MGCXX: Unit"
       python_build_version:
         type: string
         default: ''

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -24,8 +24,8 @@ on:
         type: boolean
         default: true
       release:
-        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress,query_modules). Use "none" to skip all release tests.'
-        default: 'core,benchmark,e2e,stress,query_modules'
+        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress). Use "none" to skip all release tests.'
+        default: 'core,benchmark,e2e,stress'
       malloc_build:
         type: boolean
         default: true
@@ -64,8 +64,8 @@ on:
         type: boolean
         default: true
       release:
-        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress,query_modules). Use "none" to skip all release tests.'
-        default: 'core,benchmark,e2e,stress,query_modules'
+        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress). Use "none" to skip all release tests.'
+        default: 'core,benchmark,e2e,stress'
         type: string
       malloc_build:
         type: boolean
@@ -106,7 +106,6 @@ jobs:
       run_release_benchmark: ${{ steps.setup.outputs.run_release_benchmark}}
       run_release_e2e: ${{ steps.setup.outputs.run_release_e2e }}
       run_release_stress: ${{ steps.setup.outputs.run_release_stress }}
-      run_release_query_modules: ${{ steps.setup.outputs.run_release_query_modules }}
       run_malloc_build: ${{ steps.setup.outputs.run_malloc_build }}
       run_mage_amd: ${{ steps.setup.outputs.run_mage_amd }}
       run_mage_arm: ${{ steps.setup.outputs.run_mage_arm }}
@@ -184,7 +183,6 @@ jobs:
       run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark }}
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
-      run_query_modules: ${{ needs.DiffSetup.outputs.run_release_query_modules }}
       python_build_version: ${{ inputs.python_build_version }}
       python_runtime_version: ${{ inputs.python_runtime_version }}
     secrets: inherit

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -27,10 +27,6 @@ on:
         type: string
         description: "Should the stress and durability tests be run? Default is true."
         default: "true"
-      run_query_modules:
-        type: string
-        description: "Should the query modules tests be run? Default is true."
-        default: "true"
       run_id:
         type: string
         description: "The ID of the run that triggered this workflow."
@@ -188,6 +184,42 @@ jobs:
           --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph unit
+
+      - name: Run query modules unit tests
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          test-memgraph query_modules_unit
+
+      - name: Run query modules e2e tests
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
+          --organization-name $MEMGRAPH_ORGANIZATION_NAME \
+          test-memgraph query_modules_e2e \
+          ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION}
+
+      - name: Copy query modules logs
+        if: failure()
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          copy --memgraph-logs --dest-dir build/memgraph-logs-query-modules
+
+      - name: Save query modules test data
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: "Query modules tests(Release build)${{ env.RUN_ID }}"
+          path: build/memgraph-logs-query-modules
 
       - name: Create enterprise DEB package
         run: |
@@ -951,141 +983,3 @@ jobs:
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Release / Stress tests"
-
-  query_modules:
-    if: ${{ inputs.run_query_modules == 'true' }}
-    name: "Query modules tests"
-    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 60
-    steps:
-      - name: Set up repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: 0
-
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
-
-      - name: Build release binary
-        run: |
-          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.0)
-          echo "Linking with $LINK_THREADS threads"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          --build-type $BUILD_TYPE \
-          --threads 12 \
-          build-memgraph \
-          --link-threads $LINK_THREADS \
-          --split-debug \
-          ${PYTHON_BUILD_VERSION:+--python-build-version $PYTHON_BUILD_VERSION} \
-          ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION} \
-          --conan-remote $CONAN_REMOTE \
-          --conan-username $CONAN_USERNAME \
-          --conan-password $CONAN_PASSWORD
-
-      - name: Initialize tests
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          init-tests
-
-      - name: Run query modules unit tests
-        run: |
-          ./release/package/mgbuild.sh \
-            --toolchain $TOOLCHAIN \
-            --os $OS \
-            --arch $ARCH \
-            test-memgraph query_modules_unit
-
-      - name: Run query modules e2e tests
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
-          --organization-name $MEMGRAPH_ORGANIZATION_NAME \
-          test-memgraph query_modules_e2e \
-          ${PYTHON_RUNTIME_VERSION:+--python-runtime-version $PYTHON_RUNTIME_VERSION}
-
-      - name: Copy memgraph logs
-        if: failure()
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          copy --memgraph-logs --dest-dir build/memgraph-logs-query-modules
-
-      - name: Save test data
-        continue-on-error: true
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: failure()
-        with:
-          name: "Query modules tests(Release build)${{ env.RUN_ID }}"
-          path: build/memgraph-logs-query-modules
-
-      - name: Collect core dumps
-        if: failure()
-        continue-on-error: true
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
-        run: |
-          ./tools/ci/core-dumps/collect.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --run-id "${{ github.run_id }}" \
-          --job-id "${{ github.job }}-${{ github.run_attempt }}"
-
-      - name: Stop mgbuild container
-        if: always()
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          stop --remove
-
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
-        uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Release / Query modules tests"

--- a/.github/workflows/external_diff.yaml
+++ b/.github/workflows/external_diff.yaml
@@ -17,32 +17,63 @@ on:
       community_core:
         type: boolean
         default: true
-      coverage:
-        description: 'Comma-separated list of coverage tests to run (e.g. core,clang_tidy). Use "none" to skip all coverage tests.'
-        default: 'core,clang_tidy'
+        description: "Community: Core"
+      coverage_core:
+        type: boolean
+        default: true
+        description: "Coverage: Core"
+      coverage_clang_tidy:
+        type: boolean
+        default: true
+        description: "Coverage: Clang-Tidy"
       debug_core:
         type: boolean
         default: true
+        description: "Debug: Core"
       debug_integration:
         type: boolean
         default: true
+        description: "Debug: Integration"
       jepsen_core:
         type: boolean
         default: true
-      release:
-        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress,query_modules). Use "none" to skip all release tests.'
-        default: 'core,benchmark,e2e,stress,query_modules'
+        description: "Jepsen: Core"
+      release_core:
+        type: boolean
+        default: true
+        description: "Release: Core"
+      release_benchmark:
+        type: boolean
+        default: true
+        description: "Release: Benchmark"
+      release_e2e:
+        type: boolean
+        default: true
+        description: "Release: E2E"
+      release_stress:
+        type: boolean
+        default: true
+        description: "Release: Stress"
       malloc_build:
         type: boolean
         default: true
-      mage:
-        type: string
-        default: 'amd,arm,cuda'
-        description: 'Comma-separated list of architectures to run the mage tests on (e.g. amd,arm,cuda). Use "none" to skip all mage tests.'
+        description: "Malloc: Build"
+      mage_amd:
+        type: boolean
+        default: true
+        description: "MAGE: AMD"
+      mage_arm:
+        type: boolean
+        default: true
+        description: "MAGE: ARM"
+      mage_cuda:
+        type: boolean
+        default: true
+        description: "MAGE: CUDA"
       mgcxx_unit:
         type: boolean
         default: true
-        description: "Run the mgcxx tests."
+        description: "MGCXX: Unit"
 
 jobs:
   CallCreateStagingBranch:
@@ -57,13 +88,19 @@ jobs:
     uses: ./.github/workflows/diff.yaml
     with:
       community_core: ${{ inputs.community_core }}
-      coverage: ${{ inputs.coverage }}
+      coverage_core: ${{ inputs.coverage_core }}
+      coverage_clang_tidy: ${{ inputs.coverage_clang_tidy }}
       debug_core: ${{ inputs.debug_core }}
       debug_integration: ${{ inputs.debug_integration }}
       jepsen_core: ${{ inputs.jepsen_core }}
-      release: ${{ inputs.release }}
+      release_core: ${{ inputs.release_core }}
+      release_benchmark: ${{ inputs.release_benchmark }}
+      release_e2e: ${{ inputs.release_e2e }}
+      release_stress: ${{ inputs.release_stress }}
       malloc_build: ${{ inputs.malloc_build }}
-      mage: ${{ inputs.mage }}
+      mage_amd: ${{ inputs.mage_amd }}
+      mage_arm: ${{ inputs.mage_arm }}
+      mage_cuda: ${{ inputs.mage_cuda }}
       mgcxx_unit: ${{ inputs.mgcxx_unit }}
       ref: ${{ needs.CallCreateStagingBranch.outputs.staging_branch }}
     secrets: inherit

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -779,6 +779,24 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph unit
 
+      - name: Run query modules unit tests
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          test-memgraph query_modules_unit
+
+      - name: Run query modules e2e tests
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
+          --organization-name $MEMGRAPH_ORGANIZATION_NAME \
+          test-memgraph query_modules_e2e
+
       - name: Create enterprise DEB package
         run: |
           ./release/package/mgbuild.sh \
@@ -1566,117 +1584,6 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
-  release_query_modules_test:
-    if: ${{ inputs.run_release_tests == 'true' }}
-    name: "Release Query Modules Test"
-    runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
-
-    steps:
-      - name: Set up repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
-
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
-
-      - name: Build release binaries
-        run: |
-          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 2.0)
-          echo "Linking with $LINK_THREADS threads"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          --build-type $BUILD_TYPE \
-          build-memgraph \
-          --link-threads $LINK_THREADS \
-          --conan-remote $CONAN_REMOTE \
-          --conan-username $CONAN_USERNAME \
-          --conan-password $CONAN_PASSWORD
-
-      - name: Initialize tests
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          init-tests
-
-      - name: Run query modules unit tests
-        run: |
-          ./release/package/mgbuild.sh \
-            --toolchain $TOOLCHAIN \
-            --os $OS \
-            --arch $ARCH \
-            test-memgraph query_modules_unit
-
-      - name: Run query modules e2e tests
-        run: |
-          ./release/package/mgbuild.sh \
-            --toolchain $TOOLCHAIN \
-            --os $OS \
-            --arch $ARCH \
-            --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
-            --organization-name $MEMGRAPH_ORGANIZATION_NAME \
-            test-memgraph query_modules_e2e
-
-      - name: Collect core dumps
-        if: failure()
-        continue-on-error: true
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
-        run: |
-          ./tools/ci/core-dumps/collect.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --run-id "${{ github.run_id }}" \
-          --job-id "${{ github.job }}-${{ github.run_attempt }}"
-
-      - name: Stop mgbuild container
-        if: always()
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          stop --remove
-
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
   aggregate_results:
     name: "Aggregate Test Results"
     runs-on: [self-hosted]
@@ -1691,7 +1598,6 @@ jobs:
       - release_e2e_test
       - release_durability_stress_tests
       - release_jepsen_test
-      - release_query_modules_test
       - stress_test_large
     if: ${{ always() && inputs.run_release_tests == 'true' }}
     outputs:
@@ -1711,8 +1617,7 @@ jobs:
              [ "${{ needs.release_e2e_test.result }}" == "failure" ] || \
              [ "${{ needs.release_durability_stress_tests.result }}" == "failure" ] || \
              [ "${{ needs.release_jepsen_test.result }}" == "failure" ] || \
-             [ "${{ needs.stress_test_large.result }}" == "failure" ] || \
-             [ "${{ needs.release_query_modules_test.result }}" == "failure" ]; then
+             [ "${{ needs.stress_test_large.result }}" == "failure" ]; then
             echo "test_status=fail" >> $GITHUB_OUTPUT
           else
             echo "test_status=pass" >> $GITHUB_OUTPUT

--- a/tools/ci/diff_setup.py
+++ b/tools/ci/diff_setup.py
@@ -25,10 +25,10 @@ class DiffSetup:
                     release = inputs.pop("release", "")
                     # Check for "none" to skip all release tests
                     if release.lower() == "none":
-                        for test in ["core", "benchmark", "e2e", "stress", "query_modules"]:
+                        for test in ["core", "benchmark", "e2e", "stress"]:
                             self._gh_context["event"]["inputs"][f"release_{test}"] = "false"
                     else:
-                        for test in ["core", "benchmark", "e2e", "stress", "query_modules"]:
+                        for test in ["core", "benchmark", "e2e", "stress"]:
                             self._gh_context["event"]["inputs"][f"release_{test}"] = (
                                 "true" if test in release else "false"
                             )
@@ -83,7 +83,7 @@ class DiffSetup:
             "coverage": {"core": value, "clang_tidy": value},
             "debug": {"core": value, "integration": value},
             "jepsen": {"core": value},
-            "release": {"core": value, "benchmark": value, "e2e": value, "stress": value, "query_modules": value},
+            "release": {"core": value, "benchmark": value, "e2e": value, "stress": value},
             "malloc": {"build": value},
             "mage": {"amd": value, "arm": value, "cuda": False},
             "mgcxx": {"unit": value},

--- a/tools/ci/diff_setup.py
+++ b/tools/ci/diff_setup.py
@@ -19,42 +19,6 @@ class DiffSetup:
                 if not self._get_event_name():
                     raise KeyError
 
-                # reformat release key
-                inputs = self._get_workflow_dispatch_inputs()
-                if inputs:
-                    release = inputs.pop("release", "")
-                    # Check for "none" to skip all release tests
-                    if release.lower() == "none":
-                        for test in ["core", "benchmark", "e2e", "stress"]:
-                            self._gh_context["event"]["inputs"][f"release_{test}"] = "false"
-                    else:
-                        for test in ["core", "benchmark", "e2e", "stress"]:
-                            self._gh_context["event"]["inputs"][f"release_{test}"] = (
-                                "true" if test in release else "false"
-                            )
-
-                    # reformat coverage key
-                    coverage = inputs.pop("coverage", "")
-                    # Check for "none" to skip all coverage tests
-                    if coverage.lower() == "none":
-                        for test in ["core", "clang_tidy"]:
-                            self._gh_context["event"]["inputs"][f"coverage_{test}"] = "false"
-                    else:
-                        for test in ["core", "clang_tidy"]:
-                            self._gh_context["event"]["inputs"][f"coverage_{test}"] = (
-                                "true" if test in coverage else "false"
-                            )
-
-                    # reformat mage key
-                    mage = inputs.pop("mage", "")
-                    # Check for "none" to skip all mage tests
-                    if mage.lower() == "none":
-                        for arch in ["amd", "arm", "cuda"]:
-                            self._gh_context["event"]["inputs"][f"mage_{arch}"] = "false"
-                    else:
-                        for arch in ["amd", "arm", "cuda"]:
-                            self._gh_context["event"]["inputs"][f"mage_{arch}"] = "true" if arch in mage else "false"
-
         except FileNotFoundError:
             print(f"Error: file not found {self._gh_context_path}")
             sys.exit(1)


### PR DESCRIPTION
Query module unit and end to end tests currently have a whole build for ~45s of testing. This PR moves them into the `Release / Core` job to have one fewer build per diff workflow run. An equivalent change is mage for the daily/release candidate build.

The removal of the `Release / Query modules tests` job also means that the `CI -build=release -test=query_modules` label does nothing - use `CI -build=release -test=core` instead. NOTE: this change will require an update to the required checks for the merge queue.

Bonus change: GitHub now allows up to 25 inputs to a workflow, so the Diff inputs have been split up for convenience.

