### PR TITLE
chore: bump boost to 1.91.0

### DIFF
--- a/conan.lock
+++ b/conan.lock
@@ -43,7 +43,7 @@
         "cppitertools/2.2#387562fa5016e7692d673955f66d2e7a%1741517127.057",
         "civetweb/1.16#f4a42c8aa0bc0fe4bbe2a2270af0cea2%1750148475.207",
         "bzip2/1.0.8#c470882369c2d95c5c77e970c0c7e321%1762886692.465",
-        "boost/1.91.0-memgraph#5e904bc0648eba7160e97c7f6fc7d049%1787924063.0",
+        "boost/1.91.0-memgraph#e6b512f951f4cbf01f7603414a41cd95%1788282136.0",
         "benchmark/1.9.5#b885dc73ad67b40a55d45684d1c88ad1%1774363287.434",
         "aws-sdk-cpp/1.11.692#bd7bb8c05feab8e962413aef0768bb37%1782940101.827",
         "aws-crt-cpp/0.35.2#e11cf5e3d2a9273d4413bb5f8c6e502e%1763415447.617",
@@ -97,7 +97,7 @@
             "gflags/2.2.0-memgraph"
         ],
         "boost/[>=1.85.0 <=1.91.0]": [
-            "boost/1.91.0-memgraph#5e904bc0648eba7160e97c7f6fc7d049"
+            "boost/1.91.0-memgraph#e6b512f951f4cbf01f7603414a41cd95"
         ],
         "snappy/1.1.9": [
             "snappy/1.2.1"
@@ -106,7 +106,7 @@
             "libcurl/8.17.0"
         ],
         "boost/1.88.0": [
-            "boost/1.91.0-memgraph#5e904bc0648eba7160e97c7f6fc7d049"
+            "boost/1.91.0-memgraph#e6b512f951f4cbf01f7603414a41cd95"
         ],
         "libcurl/8.17.0": [
             "libcurl/8.17.0"

--- a/conan.lock
+++ b/conan.lock
@@ -43,7 +43,7 @@
         "cppitertools/2.2#387562fa5016e7692d673955f66d2e7a%1741517127.057",
         "civetweb/1.16#f4a42c8aa0bc0fe4bbe2a2270af0cea2%1750148475.207",
         "bzip2/1.0.8#c470882369c2d95c5c77e970c0c7e321%1762886692.465",
-        "boost/1.88.0-memgraph#df956186b5897f2ec57ef010206fccf1%1787038770.0058045",
+        "boost/1.91.0-memgraph#5e904bc0648eba7160e97c7f6fc7d049%1787924063.0",
         "benchmark/1.9.5#b885dc73ad67b40a55d45684d1c88ad1%1774363287.434",
         "aws-sdk-cpp/1.11.692#bd7bb8c05feab8e962413aef0768bb37%1782940101.827",
         "aws-crt-cpp/0.35.2#e11cf5e3d2a9273d4413bb5f8c6e502e%1763415447.617",
@@ -97,7 +97,7 @@
             "gflags/2.2.0-memgraph"
         ],
         "boost/[>=1.85.0 <=1.91.0]": [
-            "boost/1.88.0-memgraph#df956186b5897f2ec57ef010206fccf1"
+            "boost/1.91.0-memgraph#5e904bc0648eba7160e97c7f6fc7d049"
         ],
         "snappy/1.1.9": [
             "snappy/1.2.1"
@@ -106,7 +106,7 @@
             "libcurl/8.17.0"
         ],
         "boost/1.88.0": [
-            "boost/1.88.0-memgraph#df956186b5897f2ec57ef010206fccf1"
+            "boost/1.91.0-memgraph#5e904bc0648eba7160e97c7f6fc7d049"
         ],
         "libcurl/8.17.0": [
             "libcurl/8.17.0"

--- a/conan_recipes/recipes/boost/all/conandata.yml
+++ b/conan_recipes/recipes/boost/all/conandata.yml
@@ -1,11 +1,10 @@
 sources:
-  "1.88.0-memgraph":
+  "1.91.0-memgraph":
     url:
-      - "https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2"
-      - "https://sourceforge.net/projects/boost/files/boost/1.88.0/boost_1_88_0.tar.bz2"
-    sha256: "46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b"
+      - "https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2"
+    sha256: "de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5"
 patches:
-  "1.88.0-memgraph":
-    - patch_file: "patches/1.88.0-locale-iconv-library-option.patch"
+  "1.91.0-memgraph":
+    - patch_file: "patches/1.91.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"
       patch_type: "conan"

--- a/conan_recipes/recipes/boost/all/dependencies/dependencies-1.91.0-memgraph.yml
+++ b/conan_recipes/recipes/boost/all/dependencies/dependencies-1.91.0-memgraph.yml
@@ -27,7 +27,6 @@ configure_options:
 - regex
 - serialization
 - stacktrace
-- system
 - test
 - thread
 - timer
@@ -37,12 +36,14 @@ configure_options:
 dependencies:
   atomic: []
   charconv: []
-  chrono:
-  - system
+  chrono: []
   cobalt:
   - container
   - context
-  - system
+  cobalt_io:
+  - cobalt
+  cobalt_io_ssl:
+  - cobalt
   container: []
   context: []
   contract:
@@ -51,7 +52,6 @@ dependencies:
   coroutine:
   - context
   - exception
-  - system
   date_time: []
   exception: []
   fiber:
@@ -61,7 +61,6 @@ dependencies:
   - fiber
   filesystem:
   - atomic
-  - system
   graph:
   - math
   - random
@@ -78,7 +77,6 @@ dependencies:
   - regex
   json:
   - container
-  - system
   locale:
   - charconv
   - thread
@@ -87,9 +85,7 @@ dependencies:
   - date_time
   - exception
   - filesystem
-  - random
   - regex
-  - system
   - thread
   log_setup:
   - log
@@ -119,13 +115,11 @@ dependencies:
   prg_exec_monitor:
   - test
   process:
-  - filesystem
-  - system
   - context
+  - filesystem
   program_options: []
   python: []
-  random:
-  - system
+  random: []
   regex: []
   serialization: []
   stacktrace: []
@@ -143,7 +137,6 @@ dependencies:
   - stacktrace
   stacktrace_windbg_cached:
   - stacktrace
-  system: []
   test:
   - exception
   test_exec_monitor:
@@ -154,7 +147,6 @@ dependencies:
   - container
   - date_time
   - exception
-  - system
   timer: []
   type_erasure:
   - thread
@@ -162,8 +154,7 @@ dependencies:
   - prg_exec_monitor
   - test
   - test_exec_monitor
-  url:
-  - system
+  url: []
   wave:
   - filesystem
   - serialization
@@ -178,6 +169,10 @@ libs:
   - boost_chrono
   cobalt:
   - boost_cobalt
+  cobalt_io:
+  - boost_cobalt_io
+  cobalt_io_ssl:
+  - boost_cobalt_io_ssl
   container:
   - boost_container
   context:
@@ -260,8 +255,6 @@ libs:
   - boost_stacktrace_windbg
   stacktrace_windbg_cached:
   - boost_stacktrace_windbg_cached
-  system:
-  - boost_system
   test: []
   test_exec_monitor:
   - boost_test_exec_monitor
@@ -297,4 +290,4 @@ requirements:
 static_only:
 - boost_exception
 - boost_test_exec_monitor
-version: 1.88.0
+version: 1.91.0

--- a/conan_recipes/recipes/boost/all/patches/1.91.0-locale-iconv-library-option.patch
+++ b/conan_recipes/recipes/boost/all/patches/1.91.0-locale-iconv-library-option.patch
@@ -1,8 +1,8 @@
 diff --git a/libs/locale/build.jam b/libs/locale/build.jam
+index f1321db3..36899cdc 100644
 --- a/libs/locale/build.jam
 +++ b/libs/locale/build.jam
-@@ -10,7 +10,8 @@ import feature ;
-
+@@ -11,6 +11,7 @@ project /boost/locale
  # Features
 
  feature.feature boost.locale.iconv : on off : optional propagated ;

--- a/conan_recipes/recipes/boost/all/patches/1.91.0-locale-iconv-library-option.patch
+++ b/conan_recipes/recipes/boost/all/patches/1.91.0-locale-iconv-library-option.patch
@@ -1,8 +1,8 @@
 diff --git a/libs/locale/build.jam b/libs/locale/build.jam
-index f1321db3..36899cdc 100644
 --- a/libs/locale/build.jam
 +++ b/libs/locale/build.jam
-@@ -11,6 +11,7 @@ project /boost/locale
+@@ -10,7 +10,8 @@ import feature ;
+
  # Features
 
  feature.feature boost.locale.iconv : on off : optional propagated ;

--- a/conan_recipes/recipes/boost/config.yml
+++ b/conan_recipes/recipes/boost/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.88.0-memgraph":
+  "1.91.0-memgraph":
     folder: all

--- a/conanfile.py
+++ b/conanfile.py
@@ -95,7 +95,7 @@ class Memgraph(ConanFile):
         # early-return is memgraph-only.
         # force=True makes boost both a direct require (so CMakeDeps generates
         # full Boost::headers config) and overrides transitive boost ranges
-        self.requires("boost/1.88.0-memgraph", force=True)
+        self.requires("boost/1.91.0-memgraph", force=True)
         self.requires("fmt/12.2.0", force=True)
         self.requires("nlohmann_json/3.11.3-memgraph")
         self.requires("libuuid/1.0.3")

--- a/src/planner/bench/bench_extract.cpp
+++ b/src/planner/bench/bench_extract.cpp
@@ -70,8 +70,8 @@ struct CostModel {
     return CostResult::cartesian_product(
         *children[0], *children[1], [enode_id](DemandAlt const &l, DemandAlt const &r) {
           DemandSet req;
-          req.insert(l.required.begin(), l.required.end());
-          req.insert(r.required.begin(), r.required.end());
+          req.insert(boost::container::ordered_unique_range, l.required.begin(), l.required.end());
+          req.insert(boost::container::ordered_unique_range, r.required.begin(), r.required.end());
           return DemandAlt{.cost = 1.0 + l.cost + r.cost, .required = std::move(req), .enode_id = enode_id};
         });
   }


### PR DESCRIPTION
The recipe stays vendored for the b2 fixes; 1.91 brings three releases of fixes including the FreeBSD Boost.DLL program_location fix that landed in 1.89.

The extractor benchmark now merges its demand sets through the ordered unique range insert, because 1.91 adds a transparent flat_set insert taking a hint that makes the two-iterator form ambiguous.