### PR TITLE
test(query): size the string-predicate fixture for exact index counts

### DIFF
--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -617,7 +617,10 @@ class QueryCostEstimatorStringPredicates : public ::testing::Test {
   Parameters parameters_;
   int symbol_count = 0;
 
-  static constexpr int kStringCount = 1000;
+  // The index count a range estimate returns is exact only while the index stays under the size
+  // at which SkipListLayerForCountEstimation starts sampling upper skip-list layers. Above it the
+  // estimate is a random sample whose spread swamps the ratios these tests compare.
+  static constexpr int kStringCount = 400;
 
   void SetUp() override {
     {


### PR DESCRIPTION
A range estimate over a property index is only exact while the index is small
enough that the skip list counts every node; past that size it samples upper
layers and scales the sample, and the spread of that sample is wide enough to
put the ratios this fixture asserts on either side of their thresholds. Holding
the index below the sampling size makes the counts, and so the tests, exact.
