### PR TITLE
feat: Add OrcaRouter as a named LLM provider

### DIFF
--- a/src/mage/python/llm.py
+++ b/src/mage/python/llm.py
@@ -27,6 +27,12 @@ except ImportError:
 
 _DEFAULT_SYSTEM_PROMPT = "Complete the following text."
 
+# OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible AI gateway
+# that exposes its model namespace through the "orcarouter/" prefix. Model
+# names (e.g. "orcarouter/free") are forwarded to the gateway via LiteLLM's
+# "openai" provider, mirroring how LiteLLM treats the "openrouter/" prefix.
+_ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"
+
 
 @mgp.function
 def complete(
@@ -39,7 +45,11 @@ def complete(
     Args:
         text: Input text to summarize or complete (e.g. concatenated node texts).
         config: Optional configuration dictionary. Keys:
-        model: Model name (e.g. ollama/llama2, openai/gpt-4o-mini).
+        provider: Optional named provider. Currently supports "orcarouter" for
+                  the OrcaRouter AI gateway; defaults to LiteLLM's provider
+                  inferred from the model name.
+        model: Model name (e.g. ollama/llama2, openai/gpt-4o-mini,
+               orcarouter/free).
         api_base: Base URL for the API (e.g. http://localhost:11434 for Ollama).
         system_prompt: System prompt for the completion.
 
@@ -48,10 +58,13 @@ def complete(
 
     Environment:
         Set API key for your provider, e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY.
+        For the OrcaRouter provider set ORCAROUTER_API_KEY.
         Optional: LITELLM_MODEL to set default model.
 
     Example Cypher (Ollama):
         RETURN llm.complete("Hello", {model: "ollama/llama2", api_base: "http://localhost:11434"});
+    Example Cypher (OrcaRouter):
+        RETURN llm.complete("Hello", {provider: "orcarouter", model: "orcarouter/free"});
     """
     if not HAS_LITELLM:
         raise Exception("llm.complete requires litellm.")
@@ -75,6 +88,24 @@ def complete(
     }
     if api_base is not None and str(api_base).strip():
         completion_kwargs["api_base"] = str(api_base).strip()
+
+    if config.get("provider") == "orcarouter":
+        # Route the "orcarouter/" model namespace through the OrcaRouter
+        # gateway. LiteLLM resolves providers from the model prefix, so we
+        # prefix with "openai/" and point it at the gateway's OpenAI-compatible
+        # endpoint, mirroring how OpenRouter is wired up.
+        if not str(effective_model).startswith("orcarouter/"):
+            raise Exception(
+                'llm.complete: provider "orcarouter" requires a model with the '
+                '"orcarouter/" prefix, e.g. "orcarouter/free".'
+            )
+        completion_kwargs["model"] = "openai/" + effective_model
+        completion_kwargs["api_base"] = _ORCAROUTER_API_BASE
+        completion_kwargs["api_key"] = os.environ.get("ORCAROUTER_API_KEY")
+        if not completion_kwargs["api_key"]:
+            raise Exception(
+                'llm.complete: provider "orcarouter" requires the ' "ORCAROUTER_API_KEY environment variable."
+            )
 
     try:
         response = litellm_completion(**completion_kwargs)


### PR DESCRIPTION
Users of `llm.complete` can now call OrcaRouter as a first-class provider — `{provider: "orcarouter", model: "orcarouter/free"}` — instead of treating it as an anonymous custom base URL. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a named provider means Memgraph users can drive that whole stack straight from Cypher.

The change mirrors how LiteLLM (which `llm.py` already uses for model-agnostic completions) treats the `openrouter/` prefix: model names under `orcarouter/` are forwarded to the gateway through the `openai` provider with the OrcaRouter base URL and `ORCAROUTER_API_KEY`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verified locally: the new branch passes `flake8` (per CONTRIBUTING) and `black --check` with the repo's 120-char line length, and a live completion against `orcarouter/free` returned 200 with the expected content using `ORCAROUTER_API_KEY`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
