### PR TITLE
test(e2e): de-flake profile CPU-time consistency check

### DIFF
--- a/tests/e2e/parallel/test_profile.py
+++ b/tests/e2e/parallel/test_profile.py
@@ -217,8 +217,10 @@ class TestParallelProfileWarmup:
         First run may include thread pool initialization overhead.
         Subsequent runs should report similar CPU times.
         """
-        # Create test data
-        self.memgraph.execute_query("UNWIND range(1, 300) AS i CREATE (:ConsistNode {id: i})")
+        # Create enough data that a warm scan takes several ms of CPU. A small scan is sub-millisecond,
+        # and its run-to-run CPU time is dominated by scheduler/cache noise on shared CI runners -- the
+        # max/min ratio below is only a real signal once the absolute time clears NOISE_FLOOR_MS.
+        self.memgraph.execute_query("UNWIND range(1, 50000) AS i CREATE (:ConsistNode {id: i})")
 
         query = pq("MATCH (n:ConsistNode) RETURN n.id ORDER BY n.id")
 
@@ -241,8 +243,11 @@ class TestParallelProfileWarmup:
             for i, t in enumerate(warm_times):
                 assert t >= 0, f"Warm run {i+2} has invalid CPU time {t}"
 
-            # Warm runs should be within 10x of each other (conservative)
-            if all(t > 0 for t in warm_times):
+            # Warm runs should be within 10x of each other (conservative). Enforce this only once the
+            # measured CPU time is large enough to be meaningful: below NOISE_FLOOR_MS the reading is
+            # noise-dominated and the ratio is not a real signal (it flaked here at ratios ~10-12).
+            NOISE_FLOOR_MS = 3.0
+            if all(t >= NOISE_FLOOR_MS for t in warm_times):
                 max_ratio = max(warm_times) / min(warm_times)
                 assert max_ratio < 10, f"Warm run CPU times vary too much: {warm_times}, ratio={max_ratio:.2f}"
 


### PR DESCRIPTION
## Problem

`tests/e2e/parallel/test_profile.py::test_profile_multiple_runs_cpu_time_consistency` is flaky on shared CI runners. It scans **300 nodes** and asserts the warm-run `max/min` ScanChunk CPU-time ratio `< 10`. At that size the scan is **sub-millisecond**, so the reading is dominated by scheduler/cache noise, not real work.

Recent failures (both marginally over the bound):
- `ratio=10.56` — `[4.837434, 0.741052, 0.4582]` ms
- `ratio=11.53` — `[0.832595, 0.13717, 1.581804]` ms

Pre-existing (test added in #3394); **unrelated to any open PR** — it blocks the `Release / End to end tests` job fleet-wide.

## Fix

- **Scale the dataset to 50k nodes** so a warm scan takes several ms of CPU — real work dominates the jitter.
- **Gate the ratio assertion on a `NOISE_FLOOR_MS` floor** so it is only enforced when the absolute time is large enough to be a real signal (the `t >= 0` sanity check is retained).

Keeps the test's intent (catch gross run-to-run CPU-time inconsistency) while removing the noise-regime false failures.