### PR TITLE
perf(bolt,storage): adaptive engine-lock admission — gate reschedule on pool work (supersedes #4669, #4684)

### DIFF
--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -58,6 +58,12 @@ class Session {
  public:
   using TEncoder = Encoder<ChunkedEncoderBuffer<TOutputStream>>;
 
+  // Fairness caps: after this many reschedules the pending-BEGIN / pending-PREPARE path falls back to a
+  // blocking engine-lock acquire so neither request can starve indefinitely.  Exposed as public so tests
+  // can reference the constant directly instead of hardcoding the literal.
+  static constexpr uint32_t kBeginRescheduleCap = 32;
+  static constexpr uint32_t kPrepareRescheduleCap = 32;
+
   /**
    * @brief Construct a new Session object
    *
@@ -212,6 +218,10 @@ class Session {
     memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
     const bool cap_reached = pending_begin_retries_ >= kBeginRescheduleCap;
     // Block on fairness cap OR when the pool has gone quiet (no pending work to yield to).
+    // Timeout semantics: the storage-access timeout is enforced by the Blocking Access at this
+    // cap/quiet fallback (on main_lock_); the reschedule window is bounded by the cap so it cannot
+    // meaningfully outrun that timeout. engine_lock_ itself has no acquire timeout on either path
+    // (unchanged from master).
     const auto mode = (cap_reached || !impl.PoolHasPendingWork()) ? memgraph::storage::EngineLockMode::Blocking
                                                                   : memgraph::storage::EngineLockMode::TryBounded;
     const Value &extra = *pending_begin_extra_;  // reference, NOT move -- may need it again on reschedule
@@ -347,8 +357,6 @@ class Session {
 
   // Times FinishPendingBegin_ lost the bounded-try engine-lock race for the current BEGIN; reset on a fresh stash.
   uint32_t pending_begin_retries_{0};
-  // After this many reschedules, FinishPendingBegin_ does one blocking acquire (fairness: a BEGIN cannot starve).
-  static constexpr uint32_t kBeginRescheduleCap = 32;
 
   // Cleared once the PREPARE completes (header sent) or fails. Mutually exclusive with pending_begin_extra_
   // (state_ is single-valued, so a BEGIN and a PREPARE step cannot both be mid-flight on the same session).
@@ -356,8 +364,6 @@ class Session {
 
   // Times FinishPendingPrepare_ lost the bounded-try engine-lock race for the current PREPARE; reset on a fresh stash.
   uint32_t pending_prepare_retries_{0};
-  // After this many reschedules, FinishPendingPrepare_ does one blocking acquire (fairness: a PREPARE cannot starve).
-  static constexpr uint32_t kPrepareRescheduleCap = 32;
 
   const std::string kTimestampFormat = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}";
   const std::string session_uuid_;  //!< unique identifier of the session (auto generated)

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -26,6 +26,8 @@
 #include "communication/bolt/v1/states/handshake.hpp"
 #include "communication/bolt/v1/states/init.hpp"
 #include "communication/metrics.hpp"
+#include "query/exceptions.hpp"        // WouldBlockInlineException (pending-BEGIN reschedule signal)
+#include "storage/v2/access_type.hpp"  // storage::EngineLockMode (BeginTransaction engine-mode arg)
 #include "utils/exceptions.hpp"
 #include "utils/session_context.hpp"
 #include "utils/timestamp.hpp"
@@ -120,6 +122,12 @@ class Session {
       // We are here, so the query will have the correct priority; just fall down to execute any other requests
     }
 
+    if (state_ == State::PendingPrepare) {
+      // Stop before the dechunk loop so a message pipelined behind the PREPARE can't run before it finishes; DoWork
+      // hands the completion to the pool. PREPARE surfaces only here (driven at the top of Execute_, not the switch).
+      return true;  // more data to process
+    }
+
     ChunkState chunk_state;
     while ((chunk_state = decoder_buffer_.GetChunk()) != ChunkState::Partial) {
       if (chunk_state == ChunkState::Whole) {
@@ -157,6 +165,12 @@ class Session {
         return true;  // more data to process
       }
 
+      if (state_ == State::PendingBegin) {
+        // HandleBegin stashed a would-block BEGIN. Stop the dechunk loop WITHOUT reading the next chunk so a
+        // message pipelined behind the BEGIN can't run before it finishes; DoWork hands the completion to the pool.
+        return true;  // more data to process
+      }
+
       if (state_ == State::Close) [[unlikely]] {
         // State::Close is handled here because we always want to check for
         // it after the above select. If any of the states above return a
@@ -170,6 +184,118 @@ class Session {
   void HandleError() {
     if (!at_least_one_run_) {
       spdlog::info("Sudden connection loss. Make sure the client supports Memgraph.");
+    }
+  }
+
+  // Used by DoWork to hand a stashed would-block BEGIN off to the pool instead of continuing the dechunk loop.
+  bool HasPendingBegin() const { return pending_begin_extra_.has_value(); }
+
+  // Decides whether the post-BEGIN resume re-enters the worker (DoWork) or waits for the next async read (DoRead).
+  bool HasBufferedData() const { return input_stream_.size() > 0; }
+
+  // Stash the BEGIN's decoded extras after HandleBegin's bounded-try acquire bailed with WouldBlock, so
+  // FinishPendingBegin_ can retry the Access on the pool without re-decoding.
+  void StashPendingBegin(Value extra) {
+    pending_begin_extra_ = std::move(extra);
+    pending_begin_retries_ = 0;
+  }
+
+  // Pool-side completion of a BEGIN that HandleBegin bailed on with WouldBlock. Retries the Access with a
+  // bounded-try acquire (Blocking after kBeginRescheduleCap, so it can't starve); on loss returns Reschedule
+  // with the stash intact. Emits the BEGIN's one and only SUCCESS -- never on HandleBegin's bail path.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  PendingBeginOutcome FinishPendingBegin_(TImpl &impl) {
+    MG_ASSERT(pending_begin_extra_.has_value(), "FinishPendingBegin_ without a pending BEGIN");
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+    const bool cap_reached = pending_begin_retries_ >= kBeginRescheduleCap;
+    // Block on fairness cap OR when the pool has gone quiet (no pending work to yield to).
+    const auto mode = (cap_reached || !impl.PoolHasPendingWork()) ? memgraph::storage::EngineLockMode::Blocking
+                                                                  : memgraph::storage::EngineLockMode::TryBounded;
+    const Value &extra = *pending_begin_extra_;  // reference, NOT move -- may need it again on reschedule
+    try {
+      impl.Configure(
+          extra.ValueMap());  // idempotent on identical extras (early-outs), so safe to re-run across reschedules
+      impl.BeginTransaction(extra.ValueMap(), mode);
+      if (!encoder_.MessageSuccess({})) {
+        state_ = State::Close;
+        pending_begin_extra_.reset();
+        return PendingBeginOutcome::ClientError;
+      }
+      state_ = State::Idle;
+      pending_begin_extra_.reset();
+      return PendingBeginOutcome::Done;
+    } catch (const memgraph::query::WouldBlockInlineException &) {
+      // Only TryBounded throws this; Blocking (at the cap or on an idle pool) never does, so either condition
+      // terminates the reschedule loop.
+      ++pending_begin_retries_;
+      return PendingBeginOutcome::Reschedule;  // pending_begin_extra_ intentionally NOT reset
+    } catch (const std::exception &e) {
+      state_ = HandleFailure(impl, e);
+      pending_begin_extra_.reset();
+      return PendingBeginOutcome::ClientError;
+    }
+  }
+
+  // Used by DoWork to hand a stashed would-block PREPARE off to the pool instead of continuing the dechunk loop.
+  bool HasPendingPrepare() const { return pending_prepare_; }
+
+  // Flag a PREPARE whose bounded-try acquire bailed with WouldBlock. The parse stays in SessionHL::parsed_res_
+  // (re-runnable), so the bolt layer only records that a completion is owed plus a fresh retry count.
+  void StashPendingPrepare() {
+    pending_prepare_ = true;
+    pending_prepare_retries_ = 0;
+  }
+
+  // Emits the RUN header (field names + optional qid) as the PREPARE's single SUCCESS. Shared by HandlePrepare's
+  // inline path and FinishPendingPrepare_'s pool path so that one header is byte-identical whichever path runs.
+  bool SendPrepareHeader(const std::vector<std::string> &header, std::optional<int> qid) {
+    std::vector<Value> vec;
+    map_t data;
+    vec.reserve(header.size());
+    for (const auto &field : header) vec.emplace_back(field);
+    data.emplace("fields", std::move(vec));
+    if (version_.major > 1 && qid) {
+      data.emplace("qid", Value{*qid});
+    }
+    return encoder_.MessageSuccess(data);
+  }
+
+  // Pool-side completion of a PREPARE that HandlePrepare bailed on with WouldBlock. Retries InterpretPrepare with a
+  // bounded-try acquire (Blocking after kPrepareRescheduleCap, so it can't starve); on loss returns Reschedule with
+  // parsed_res_ intact. Emits the PREPARE's one and only header SUCCESS -- never on HandlePrepare's bail path.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  PendingPrepareOutcome FinishPendingPrepare_(TImpl &impl) {
+    MG_ASSERT(pending_prepare_, "FinishPendingPrepare_ without a pending PREPARE");
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+    const bool cap_reached = pending_prepare_retries_ >= kPrepareRescheduleCap;
+    // Block on fairness cap OR when the pool has gone quiet (no pending work to yield to).
+    const auto mode = (cap_reached || !impl.PoolHasPendingWork()) ? memgraph::storage::EngineLockMode::Blocking
+                                                                  : memgraph::storage::EngineLockMode::TryBounded;
+    try {
+      auto [header, qid] = impl.InterpretPrepare(mode);  // consumes parsed_res_ on success
+      if (!SendPrepareHeader(header, qid)) {
+        state_ = State::Close;
+        pending_prepare_ = false;
+        return PendingPrepareOutcome::ClientError;
+      }
+      state_ = State::Result;
+      pending_prepare_ = false;
+      return PendingPrepareOutcome::Done;
+    } catch (const memgraph::query::WouldBlockInlineException &) {
+      // Only TryBounded throws this; Blocking (at the cap or on an idle pool) never does, so either condition
+      // terminates the reschedule loop. parsed_res_ stays intact in SessionHL and pending_prepare_ stays true.
+      ++pending_prepare_retries_;
+      return PendingPrepareOutcome::Reschedule;
+    } catch (const std::exception &e) {
+      state_ = HandleFailure(impl, e);
+      pending_prepare_ = false;
+      return PendingPrepareOutcome::ClientError;
     }
   }
 
@@ -216,6 +342,23 @@ class Session {
   }
 
  private:
+  // BEGIN extras stashed on a WouldBlock bail, carried across the worker->pool reschedule (retry without re-decoding).
+  std::optional<Value> pending_begin_extra_{};
+
+  // Times FinishPendingBegin_ lost the bounded-try engine-lock race for the current BEGIN; reset on a fresh stash.
+  uint32_t pending_begin_retries_{0};
+  // After this many reschedules, FinishPendingBegin_ does one blocking acquire (fairness: a BEGIN cannot starve).
+  static constexpr uint32_t kBeginRescheduleCap = 32;
+
+  // Cleared once the PREPARE completes (header sent) or fails. Mutually exclusive with pending_begin_extra_
+  // (state_ is single-valued, so a BEGIN and a PREPARE step cannot both be mid-flight on the same session).
+  bool pending_prepare_{false};
+
+  // Times FinishPendingPrepare_ lost the bounded-try engine-lock race for the current PREPARE; reset on a fresh stash.
+  uint32_t pending_prepare_retries_{0};
+  // After this many reschedules, FinishPendingPrepare_ does one blocking acquire (fairness: a PREPARE cannot starve).
+  static constexpr uint32_t kPrepareRescheduleCap = 32;
+
   const std::string kTimestampFormat = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}";
   const std::string session_uuid_;  //!< unique identifier of the session (auto generated)
   const std::string login_timestamp_;

--- a/src/communication/bolt/v1/state.hpp
+++ b/src/communication/bolt/v1/state.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -49,6 +49,20 @@ enum class State : uint8_t {
   Result,
 
   /**
+   * A BEGIN whose engine-lock acquire would block has been decoded and stashed; its completion is
+   * being run out-of-band on a pool worker. Execute_ returns to the dechunk loop's caller without
+   * touching any message buffered behind the BEGIN, so ordering is preserved until the BEGIN finishes.
+   */
+  PendingBegin,
+
+  /**
+   * A PREPARE (Parsed->Result) whose engine-lock acquire would block has been decoded and parsed; its
+   * completion runs out-of-band on a pool worker (never the strand). Execute_ returns without touching any message
+   * buffered behind the PREPARE, so ordering is preserved; the parse is held in SessionHL::parsed_res_ (re-runnable).
+   */
+  PendingPrepare,
+
+  /**
    * This state handles errors, if client handles error response correctly next
    * state is Idle.
    */
@@ -61,4 +75,16 @@ enum class State : uint8_t {
    */
   Close,
 };
+
+// Outcome of the pool-side completion of a would-block BEGIN (FinishPendingBegin_).
+// Done        - the BEGIN completed and SUCCESS was sent.
+// ClientError - send failed or the begin threw; state moved to Close/Error.
+// Reschedule  - the bounded-try engine-lock acquire lost the race; extras stay stashed, re-post to the pool.
+enum class PendingBeginOutcome : uint8_t { Done, ClientError, Reschedule };
+
+// Outcome of the pool-side completion of a would-block PREPARE (FinishPendingPrepare_).
+// Done        - the PREPARE completed and the header SUCCESS was sent.
+// ClientError - send failed or the prepare threw; state moved to Close/Error.
+// Reschedule  - the bounded-try engine-lock acquire lost the race; parsed_res_ stays intact, re-post to the pool.
+enum class PendingPrepareOutcome : uint8_t { Done, ClientError, Reschedule };
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -27,6 +27,8 @@
 #include "communication/exceptions.hpp"
 #include "license/license_sender.hpp"
 #include "metrics/prometheus_metrics.hpp"
+#include "query/exceptions.hpp"
+#include "storage/v2/access_type.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/logging.hpp"
 #include "utils/memory_tracker.hpp"
@@ -212,26 +214,20 @@ inline State HandleFailure(TSession &session, const std::exception &e) {
 template <typename TSession>
 State HandlePrepare(TSession &session) {
   try {
-    // Interpret can throw.
-    const auto [header, qid] = session.InterpretPrepare();
-    // Convert std::string to Value
-    std::vector<Value> vec;
-    map_t data;
-    vec.reserve(header.size());
-    for (auto &i : header) vec.emplace_back(std::move(i));
-    data.emplace("fields", std::move(vec));
-    if (session.version_.major > 1) {
-      if (qid) {
-        data.emplace("qid", Value{*qid});
-      }
-    }
-
-    // Send the header.
-    if (!session.encoder_.MessageSuccess(data)) {
+    // Interpret can throw. Gated acquire (TryBounded when pool has queued work to yield to, else Blocking) so
+    // this pool worker reschedules instead of busy-spinning behind a write commit: on contention InterpretPrepare
+    // throws WouldBlock, parsed_res_ left intact.
+    const auto [header, qid] = session.InterpretPrepare(session.AdmissionEngineLockMode());
+    // Send the header (exactly one SUCCESS). The PendingPrepare bail below must NOT send it.
+    if (!session.SendPrepareHeader(header, qid)) {
       spdlog::trace("Couldn't send query header!");
       return State::Close;
     }
     return State::Result;
+  } catch (const memgraph::query::WouldBlockInlineException &) {
+    // parsed_res_ is intact (re-runnable); the pool retries via FinishPendingPrepare_, which emits the one SUCCESS.
+    session.StashPendingPrepare();
+    return State::PendingPrepare;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }
@@ -436,12 +432,20 @@ State HandleBegin(TSession &session, const State state, const Marker marker) {
 
   try {
     session.Configure(extra.ValueMap());
-    session.BeginTransaction(extra.ValueMap());
+    // Gated engine-lock acquire (TryBounded when pool has queued work to yield to, else Blocking): rather than
+    // busy-spin this pool worker behind a long write commit's durability hold, bail with WouldBlockInlineException
+    // on contention and let the completion reschedule. Quiet pools take Blocking directly — zero regression.
+    session.BeginTransaction(extra.ValueMap(), session.AdmissionEngineLockMode());
     if (!session.encoder_.MessageSuccess({})) {
       spdlog::trace("Couldn't send success message!");
       return State::Close;
     }
     return State::Idle;
+  } catch (const memgraph::query::WouldBlockInlineException &) {
+    // Accessor-first reorder left interpreter txn state pristine (no id consumed), so the pool can retry.
+    // Do NOT MessageSuccess here -- the one SUCCESS is emitted by FinishPendingBegin_ when the BEGIN completes.
+    session.StashPendingBegin(std::move(extra));
+    return State::PendingBegin;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -436,6 +436,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
 
   // Completes a would-block BEGIN on the POOL (AddTask, never the strand): Reschedule re-posts so the worker never
   // blocks behind a slow commit; a terminal outcome resumes DoWork/DoRead. FinishPendingBegin emits SUCCESS once.
+  // LOW priority + non-productive: admission retry must not compete with real work or hold the gate open.
   void PostFinishPendingBegin() {
     session_context_->AddTask(
         [shared_this = shared_from_this()](const auto /*thread_priority*/) {
@@ -458,10 +459,12 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                               [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
           }
         },
-        session_.ApproximateQueryPriority());
+        utils::Priority::LOW,
+        /*productive=*/false);
   }
 
   // PREPARE mirror of PostFinishPendingBegin above; FinishPendingPrepare emits the run header (not SUCCESS) once.
+  // LOW priority + non-productive: admission retry must not compete with real work or hold the gate open.
   void PostFinishPendingPrepare() {
     session_context_->AddTask(
         [shared_this = shared_from_this()](const auto /*thread_priority*/) {
@@ -484,7 +487,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                               [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
           }
         },
-        session_.ApproximateQueryPriority());
+        utils::Priority::LOW,
+        /*productive=*/false);
   }
 
   void OnError(const boost::system::error_code &ec) {

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -43,6 +43,7 @@
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/system/detail/error_code.hpp>
 
+#include "communication/bolt/v1/state.hpp"
 #include "communication/buffer.hpp"
 #include "communication/context.hpp"
 #include "communication/exceptions.hpp"
@@ -379,6 +380,15 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     try {
       // Execute until all data has been read
       while (session_.Execute()) {
+        // Websocket runs the bolt state machine inline on the strand; a parked BEGIN keeps Execute() returning true.
+        // Drive it terminal here -- the pool resume (DoWork/DoRead) would take this connection off the websocket read
+        // loop.
+        while (session_.HasPendingBegin()) {
+          session_.FinishPendingBegin();
+        }
+        while (session_.HasPendingPrepare()) {
+          session_.FinishPendingPrepare();
+        }
       }
       // Handled all data,  async wait for new incoming data
       DoReadAsio();
@@ -393,6 +403,17 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           try {
             while (true) {
               if (shared_this->session_.Execute()) {
+                if (shared_this->session_.HasPendingBegin()) {
+                  // BEGIN's engine-lock acquire would block: finish it off the worker via the pool
+                  // (PostFinishPendingBegin). Return now so no message pipelined behind the BEGIN runs first.
+                  shared_this->PostFinishPendingBegin();
+                  return;
+                }
+                if (shared_this->session_.HasPendingPrepare()) {
+                  // As the BEGIN bail above, for PREPARE: return so nothing pipelined behind it runs first.
+                  shared_this->PostFinishPendingPrepare();
+                  return;
+                }
                 // Check if we can just steal this task (loop through)
                 if (thread_priority > shared_this->session_.ApproximateQueryPriority()) {
                   // Task priority lower; reschedule
@@ -404,6 +425,59 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                 shared_this->DoRead();
                 return;
               }
+            }
+          } catch (const std::exception & /* unused */) {
+            boost::asio::post(shared_this->strand_,
+                              [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
+          }
+        },
+        session_.ApproximateQueryPriority());
+  }
+
+  // Completes a would-block BEGIN on the POOL (AddTask, never the strand): Reschedule re-posts so the worker never
+  // blocks behind a slow commit; a terminal outcome resumes DoWork/DoRead. FinishPendingBegin emits SUCCESS once.
+  void PostFinishPendingBegin() {
+    session_context_->AddTask(
+        [shared_this = shared_from_this()](const auto /*thread_priority*/) {
+          try {
+            switch (shared_this->session_.FinishPendingBegin()) {
+              case memgraph::communication::bolt::PendingBeginOutcome::Reschedule:
+                shared_this->PostFinishPendingBegin();  // re-post to the POOL, never post(strand_)
+                return;
+              case memgraph::communication::bolt::PendingBeginOutcome::Done:
+              case memgraph::communication::bolt::PendingBeginOutcome::ClientError:
+                if (shared_this->session_.HasBufferedData()) {
+                  shared_this->DoWork();
+                } else {
+                  shared_this->DoRead();
+                }
+                return;
+            }
+          } catch (const std::exception & /* unused */) {
+            boost::asio::post(shared_this->strand_,
+                              [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
+          }
+        },
+        session_.ApproximateQueryPriority());
+  }
+
+  // PREPARE mirror of PostFinishPendingBegin above; FinishPendingPrepare emits the run header (not SUCCESS) once.
+  void PostFinishPendingPrepare() {
+    session_context_->AddTask(
+        [shared_this = shared_from_this()](const auto /*thread_priority*/) {
+          try {
+            switch (shared_this->session_.FinishPendingPrepare()) {
+              case memgraph::communication::bolt::PendingPrepareOutcome::Reschedule:
+                shared_this->PostFinishPendingPrepare();  // re-post to the POOL, never post(strand_)
+                return;
+              case memgraph::communication::bolt::PendingPrepareOutcome::Done:
+              case memgraph::communication::bolt::PendingPrepareOutcome::ClientError:
+                if (shared_this->session_.HasBufferedData()) {
+                  shared_this->DoWork();
+                } else {
+                  shared_this->DoRead();
+                }
+                return;
             }
           } catch (const std::exception & /* unused */) {
             boost::asio::post(shared_this->strand_,

--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -22,6 +22,7 @@
 #include "query/stream/streams.hpp"
 #include "query/trigger.hpp"
 #include "storage/v2/disk/storage.hpp"
+#include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 #include "storage/v2/storage_mode.hpp"
 #include "storage/v2/ttl.hpp"
@@ -67,6 +68,16 @@ std::unique_ptr<storage::Accessor> Database::Access(storage::StorageAccessType r
                                                     std::optional<storage::IsolationLevel> override_isolation_level,
                                                     std::optional<std::chrono::milliseconds> timeout) {
   return storage_->Access(rw_type, override_isolation_level, timeout);
+}
+
+std::unique_ptr<storage::Accessor> Database::TryAccess(storage::StorageAccessType rw_type,
+                                                       std::optional<storage::IsolationLevel> override_isolation_level,
+                                                       storage::EngineLockMode engine_mode) {
+  auto *in_memory = dynamic_cast<storage::InMemoryStorage *>(storage_.get());
+  if (in_memory == nullptr) {
+    return nullptr;
+  }
+  return in_memory->TryAccess(rw_type, override_isolation_level, engine_mode);
 }
 
 std::unique_ptr<storage::Accessor> Database::UniqueAccess(

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -91,6 +91,14 @@ class Database {
                                             std::optional<storage::IsolationLevel> override_isolation_level = {},
                                             std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
+  // Non-blocking accessor for the bounded-try BEGIN fast path: returns a READ/WRITE accessor if the
+  // storage lock can be taken without blocking, or nullptr if it would block (a DDL/UNIQUE holder)
+  // OR the storage is not in-memory (only InMemoryStorage offers the probe). Callers must fall back
+  // to the blocking Access() path on nullptr; this is a one-shot try, never a poll loop.
+  std::unique_ptr<storage::Accessor> TryAccess(
+      storage::StorageAccessType rw_type, std::optional<storage::IsolationLevel> override_isolation_level = {},
+      storage::EngineLockMode engine_mode = storage::EngineLockMode::TryBounded);
+
   std::unique_ptr<storage::Accessor> UniqueAccess(std::optional<storage::IsolationLevel> override_isolation_level = {},
                                                   std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 

--- a/src/glue/SessionContext.hpp
+++ b/src/glue/SessionContext.hpp
@@ -45,9 +45,9 @@ struct Context {
 #endif
   utils::PriorityThreadPool *worker_pool_;
 
-  auto AddTask(auto &&task, utils::Priority priority) {
+  auto AddTask(auto &&task, utils::Priority priority, bool productive = true) {
     MG_ASSERT(worker_pool_, "Trying to add task to a non-existent worker pool");
-    return worker_pool_->ScheduledAddTask(std::forward<decltype(task)>(task), priority);
+    return worker_pool_->ScheduledAddTask(std::forward<decltype(task)>(task), priority, productive);
   }
 };
 }  // namespace memgraph::glue

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -567,25 +567,38 @@ void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, cons
   }
 }
 
-std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrepare() {
+std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrepare(storage::EngineLockMode try_mode) {
   if (!parsed_res_) {
     throw memgraph::communication::bolt::ClientError("Trying to prepare a query that was not parsed.");
   }
 
   try {
-    auto parsed_res = *std::move(parsed_res_);
-    parsed_res_.reset();
+    // Pass the parsed input by reference. Under TryBounded, Prepare throws WouldBlockInlineException
+    // before it moves from parsed_res_, so on a would-block parsed_res_ stays intact and this Prepare
+    // can be retried with the same parsed input. Only clear parsed_res_ once Prepare (and the
+    // authorization check) have succeeded and consumed it.
     auto result =
-        interpreter_.Prepare(std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
+        interpreter_.Prepare(parsed_res_->parsed_query, parsed_res_->get_params_pv, parsed_res_->extra, try_mode);
     interpreter_.CheckAuthorized(result.privileges, result.db);
-
+    parsed_res_.reset();
     return {std::move(result.headers), result.qid};
+  } catch (const memgraph::query::WouldBlockInlineException &) {
+    // The inline accessor acquire would block; parsed_res_ is untouched. Rethrow unchanged so the
+    // bolt layer can reschedule and retry this Prepare with the same parsed input.
+    throw;
   } catch (const memgraph::query::QueryException &e) {
+    parsed_res_.reset();
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {
+    parsed_res_.reset();
     // Count the number of specific exceptions thrown
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
+  } catch (...) {
+    // Any other failure consumes this parse (matching the pre-retry behaviour of resetting up front);
+    // only a would-block, handled above, retains parsed_res_.
+    parsed_res_.reset();
+    throw;
   }
 }
 
@@ -675,9 +688,9 @@ bolt_map_t SessionHL::CommitTransaction() {
   }
 }
 
-void SessionHL::BeginTransaction(const bolt_map_t &extra) {
+void SessionHL::BeginTransaction(const bolt_map_t &extra, storage::EngineLockMode try_mode) {
   try {
-    interpreter_.BeginTransaction(ToQueryExtras(extra));
+    interpreter_.BeginTransaction(ToQueryExtras(extra), try_mode);
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {
@@ -703,6 +716,7 @@ SessionHL::SessionHL(Context context, memgraph::communication::v2::InputStream *
                                                                                                    output_stream),
       interpreter_context_(context.ic),
       interpreter_(interpreter_context_),
+      worker_pool_(context.worker_pool_),
 #ifdef MG_ENTERPRISE
       audit_log_(context.audit_log),
       runtime_config_{this},

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -17,6 +17,7 @@
 #include "communication/v2/session.hpp"
 #include "glue/SessionContext.hpp"
 #include "query/interpreter.hpp"
+#include "storage/v2/access_type.hpp"
 
 namespace memgraph::glue {
 using bolt_value_t = memgraph::communication::bolt::Value;
@@ -69,7 +70,7 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   void Configure(const bolt_map_t &run_time_info);
 
-  void BeginTransaction(const bolt_map_t &extra);
+  void BeginTransaction(const bolt_map_t &extra, storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   bolt_map_t CommitTransaction();
 
@@ -77,7 +78,8 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   void InterpretParse(const std::string &query, bolt_map_t params, const bolt_map_t &extra);
 
-  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare();
+  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare(
+      storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   std::pair<std::vector<std::string>, std::optional<int>> Interpret(const std::string &query, const bolt_map_t &params,
                                                                     const bolt_map_t &extra) {
@@ -141,11 +143,26 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   inline bool Execute() { return Execute_(*this); }
 
+  inline memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return FinishPendingBegin_(*this); }
+
+  inline memgraph::communication::bolt::PendingPrepareOutcome FinishPendingPrepare() {
+    return FinishPendingPrepare_(*this);
+  }
+
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }
 
   metrics::DatabaseMetricHandles *GetMetricHandles() {
     auto &db_acc = interpreter_.current_db_.db_acc_;
     return db_acc ? (*db_acc)->metric_handles() : nullptr;
+  }
+
+  // True iff the pool has other queued work a freed worker could run. Gates reschedule-vs-block.
+  bool PoolHasPendingWork() const noexcept { return worker_pool_ != nullptr && worker_pool_->HasPendingWork(); }
+
+  // Admission engine-lock mode: TryBounded (reschedule) only when there is work to yield to; else
+  // Blocking (behave like master — no wasted try/reschedule when nothing else can run).
+  storage::EngineLockMode AdmissionEngineLockMode() const noexcept {
+    return PoolHasPendingWork() ? storage::EngineLockMode::TryBounded : storage::EngineLockMode::Blocking;
   }
 
  private:
@@ -161,8 +178,9 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   std::string GetCurrentUser() const;
 
-  memgraph::query::InterpreterContext *interpreter_context_;      // Global context used by all interpreters
-  memgraph::query::Interpreter interpreter_;                      // Session specific interpreter
+  memgraph::query::InterpreterContext *interpreter_context_;  // Global context used by all interpreters
+  memgraph::query::Interpreter interpreter_;                  // Session specific interpreter
+  memgraph::utils::PriorityThreadPool *worker_pool_{};  // Backing thread pool; gates TryBounded vs Blocking admission
   std::shared_ptr<query::QueryUserOrRole> session_user_or_role_;  // Connected user/role
 #ifdef MG_ENTERPRISE
   memgraph::audit::Log *audit_log_;

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -161,6 +161,8 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   // Admission engine-lock mode: TryBounded (reschedule) only when there is work to yield to; else
   // Blocking (behave like master — no wasted try/reschedule when nothing else can run).
+  // One-shot decision: once Blocking is chosen the worker commits to the acquire and does not
+  // re-evaluate if new work arrives mid-wait (bounded by the holding commit; the full fix is coroutines).
   storage::EngineLockMode AdmissionEngineLockMode() const noexcept {
     return PoolHasPendingWork() ? storage::EngineLockMode::TryBounded : storage::EngineLockMode::Blocking;
   }

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -67,6 +67,16 @@ class PeriodicCommitException : public QueryException {
   SPECIALIZE_GET_EXCEPTION_NAME(PeriodicCommitException)
 };
 
+// Internal control-flow signal for the bounded-try BEGIN fast path: thrown when a non-blocking
+// (try) storage-access attempt would block on a UNIQUE (DDL) holder, so the caller must fall back
+// to the blocking path. Deliberately NOT a QueryException -- it is caught only at the BEGIN call
+// site and never surfaces to the client.
+class WouldBlockInlineException : public utils::BasicException {
+ public:
+  WouldBlockInlineException() : utils::BasicException("inline transaction start would block") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(WouldBlockInlineException)
+};
+
 /**
  * @brief Base class of all query language related exceptions which can be retried.
  * All exceptions derived from this one will be interpreted as TransientError-s,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -195,7 +195,7 @@ TypedValue EvaluateConfigMapToTypedValue(std::unordered_map<Expression *, Expres
 // access
 void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-    storage::StorageAccessType acc_type) {
+    storage::StorageAccessType acc_type, storage::EngineLockMode try_mode) {
   if (!db_acc_) {
     throw DatabaseContextRequiredException("Database required for the transaction setup.");
   }
@@ -206,9 +206,14 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     case storage::StorageAccessType::READ:
       [[fallthrough]];
     case storage::StorageAccessType::WRITE:
-      db_transactional_accessor_ = db_acc->Access(acc_type,
-                                                  override_isolation_level,
-                                                  /*allow timeout*/ timeout);
+      if (try_mode == storage::EngineLockMode::Blocking) {
+        db_transactional_accessor_ = db_acc->Access(acc_type,
+                                                    override_isolation_level,
+                                                    /*allow timeout*/ timeout);
+      } else {
+        db_transactional_accessor_ = db_acc->TryAccess(acc_type, override_isolation_level, try_mode);
+        if (!db_transactional_accessor_) throw WouldBlockInlineException{};
+      }
       break;
     case storage::StorageAccessType::UNIQUE:
       db_transactional_accessor_ = db_acc->UniqueAccess(override_isolation_level, /*allow timeout*/ timeout);
@@ -3909,22 +3914,17 @@ auto CreateTimeoutTimer(QueryExtras const &extras, InterpreterConfig const &conf
 }
 
 PreparedQuery Interpreter::PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum,
-                                                   QueryExtras const &extras) {
+                                                   QueryExtras const &extras, storage::EngineLockMode try_mode) {
   std::function<void()> handler;
 
   switch (tx_query_enum) {
     case TransactionQuery::BEGIN: {
       // TODO: Evaluate doing move(extras). Currently the extras is very small, but this will be important if it ever
       // becomes large.
-      handler = [this, extras = extras] {
+      handler = [this, extras = extras, try_mode] {
         if (in_explicit_transaction_) {
           throw ExplicitTransactionUsageException("Nested transactions are not supported.");
         }
-        SetupInterpreterTransaction(extras);
-        // Multiple paths can lead to transaction BEGIN, so we need to reset the timer in the handler
-        current_timeout_timer_ = CreateTimeoutTimer(extras, interpreter_context_->config);
-        in_explicit_transaction_ = true;
-        expect_rollback_ = false;
         if (!current_db_.db_acc_)
           throw DatabaseContextRequiredException("No current database for transaction defined.");
         // Fail-closed on a broken database: an explicit transaction opens a data accessor and its queries
@@ -3933,8 +3933,15 @@ PreparedQuery Interpreter::PrepareTransactionQuery(Interpreter::TransactionQuery
         if ((*current_db_.db_acc_)->storage()->IsBroken()) {
           throw QueryException(kBrokenDatabaseError);
         }
-        SetupDatabaseTransaction(true,
-                                 extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE);
+        // Accessor first: on the try (bounded) path a would-block bail must leave interpreter txn state untouched
+        // (no id consumed, status still IDLE) so the caller can fall back to the blocking path.
+        SetupDatabaseTransaction(
+            true, extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE, try_mode);
+        SetupInterpreterTransaction(extras);
+        // Multiple paths can lead to transaction BEGIN, so we need to reset the timer in the handler
+        current_timeout_timer_ = CreateTimeoutTimer(extras, interpreter_context_->config);
+        in_explicit_transaction_ = true;
+        expect_rollback_ = false;
       };
     } break;
     case TransactionQuery::COMMIT: {
@@ -10199,9 +10206,9 @@ bool Interpreter::IsCurrentTransactionEmpty() const {
   return txn->deltas.empty() && txn->md_deltas.empty();
 }
 
-void Interpreter::BeginTransaction(QueryExtras const &extras) {
+void Interpreter::BeginTransaction(QueryExtras const &extras, storage::EngineLockMode try_mode) {
   ResetInterpreter();
-  auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras);
+  auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras, try_mode);
   prepared_query.query_handler(nullptr, {});
 }
 
@@ -10560,8 +10567,8 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
   std::optional<storage::StorageAccessType> accessor_type_;
 };
 
-Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParameters_fn params_getter,
-                                                QueryExtras const &extras) {
+Interpreter::PrepareResult Interpreter::Prepare(ParseRes &parse_res, UserParameters_fn &params_getter,
+                                                QueryExtras const &extras, storage::EngineLockMode try_mode) {
   std::optional<memory::DbArenaScope> db_arena_scope;
   if (current_db_.db_acc_) {
     db_arena_scope.emplace(current_db_.db_acc_->get());
@@ -10597,16 +10604,14 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     AdvanceCommand();
   } else {
     ResetInterpreter();
-    transaction_queries_->push_back(parsed_query.query_string);
     if (current_db_.db_transactional_accessor_ /* && !in_explicit_transaction_*/) {
       // If we're not in an explicit transaction block and we have an open
       // transaction, abort it since we're about to prepare a new query.
       AbortCommand(nullptr);
     }
-
-    SetupInterpreterTransaction(extras);
-    memgraph::logging::EmitSessionTraceEvent(
-        "Query [{}] associated with transaction [{}]", parsed_query.query_string, current_transaction_.value_or(0));
+    // The transaction_queries_ record and SetupInterpreterTransaction (consumes a tx id and marks
+    // the transaction ACTIVE) are deferred until after the storage accessor is acquired, below in
+    // the try block, so the acquire runs before any non-idempotent transaction setup.
   }
 
   auto *const cypher_query = utils::Downcast<CypherQuery>(parsed_query.query);
@@ -10796,7 +10801,8 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
         if (transaction_requirements.isolation_level_override_) {
           SetNextTransactionIsolationLevel(*transaction_requirements.isolation_level_override_);
         }
-        SetupDatabaseTransaction(transaction_requirements.could_commit_, *transaction_requirements.accessor_type_);
+        SetupDatabaseTransaction(
+            transaction_requirements.could_commit_, *transaction_requirements.accessor_type_, try_mode);
 
         // SET STORAGE MODE can land between the unlocked read of `storage_mode` and the accessor
         // taking its hold, leaving the access type chosen for a mode no longer in force: an index
@@ -10808,6 +10814,13 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
           throw StorageModeChangedDuringSetupException();
         }
       }
+
+      // Deferred from the autocommit branch above: the storage accessor is now held, so record the
+      // query and open the interpreter transaction (consumes the tx id, marks the status ACTIVE).
+      transaction_queries_->push_back(parsed_query.query_string);
+      SetupInterpreterTransaction(extras);
+      memgraph::logging::EmitSessionTraceEvent(
+          "Query [{}] associated with transaction [{}]", parsed_query.query_string, current_transaction_.value_or(0));
     }
 
     if (current_db_.db_acc_) {
@@ -11228,8 +11241,9 @@ void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privi
   }
 }
 
-void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type) {
-  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type);
+void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type,
+                                           storage::EngineLockMode try_mode) {
+  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type, try_mode);
 }
 
 void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -206,7 +206,11 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     case storage::StorageAccessType::READ:
       [[fallthrough]];
     case storage::StorageAccessType::WRITE:
-      if (try_mode == storage::EngineLockMode::Blocking) {
+      // TryBounded is an in-memory-only fast path: DiskStorage has no non-blocking mint (CreateTransaction
+      // asserts Blocking, TryAccess returns nullptr), so on disk take the blocking Access rather than bail
+      // and reschedule on every query.
+      if (try_mode == storage::EngineLockMode::Blocking ||
+          db_acc->GetStorageMode() == storage::StorageMode::ON_DISK_TRANSACTIONAL) {
         db_transactional_accessor_ = db_acc->Access(acc_type,
                                                     override_isolation_level,
                                                     /*allow timeout*/ timeout);

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10601,6 +10601,10 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes &parse_res, UserParamet
 
   MG_ASSERT(std::holds_alternative<ParseInfo>(parse_res), "Unkown ParseRes type");
 
+  // parse_info/parsed_query alias into parse_res (a non-const ref, moved-from only on the success path).
+  // INVARIANT for the TryBounded bail: nothing below may move-from parse_res before the accessor is
+  // acquired in SetupDatabaseTransaction, or a would-block bail would leave parse_res unusable for the
+  // retry. Today the first move happens only after that point.
   auto &parse_info = std::get<ParseInfo>(parse_res);
   auto &parsed_query = parse_info.parsed_query;
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3937,11 +3937,18 @@ PreparedQuery Interpreter::PrepareTransactionQuery(Interpreter::TransactionQuery
         if ((*current_db_.db_acc_)->storage()->IsBroken()) {
           throw QueryException(kBrokenDatabaseError);
         }
-        // Accessor first: on the try (bounded) path a would-block bail must leave interpreter txn state untouched
-        // (no id consumed, status still IDLE) so the caller can fall back to the blocking path.
-        SetupDatabaseTransaction(
-            true, extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE, try_mode);
-        SetupInterpreterTransaction(extras);
+        // Mint order is mode-dependent: Blocking cannot bail so mint first (transaction is visible/killable during
+        // the lock wait); TryBounded may throw WouldBlockInlineException so accessor comes first to satisfy M3
+        // (no id consumed, status still IDLE on a bail).
+        if (try_mode == storage::EngineLockMode::Blocking) {
+          SetupInterpreterTransaction(extras);
+          SetupDatabaseTransaction(
+              true, extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE, try_mode);
+        } else {
+          SetupDatabaseTransaction(
+              true, extras.is_read ? storage::StorageAccessType::READ : storage::StorageAccessType::WRITE, try_mode);
+          SetupInterpreterTransaction(extras);
+        }
         // Multiple paths can lead to transaction BEGIN, so we need to reset the timer in the handler
         current_timeout_timer_ = CreateTimeoutTimer(extras, interpreter_context_->config);
         in_explicit_transaction_ = true;
@@ -10801,10 +10808,22 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes &parse_res, UserParamet
         }
       }
 
+      // Mints the tx id, marks ACTIVE, and records the query string. Called at most once per query.
+      bool interpreter_txn_opened = false;
+      auto open_interpreter_txn = [&] {
+        transaction_queries_->push_back(parsed_query.query_string);
+        SetupInterpreterTransaction(extras);
+        memgraph::logging::EmitSessionTraceEvent(
+            "Query [{}] associated with transaction [{}]", parsed_query.query_string, current_transaction_.value_or(0));
+        interpreter_txn_opened = true;
+      };
+
       if (transaction_requirements.accessor_type_) {
         if (transaction_requirements.isolation_level_override_) {
           SetNextTransactionIsolationLevel(*transaction_requirements.isolation_level_override_);
         }
+        // Blocking cannot bail: mint first so the query is visible/killable during the lock wait.
+        if (try_mode == storage::EngineLockMode::Blocking) open_interpreter_txn();
         SetupDatabaseTransaction(
             transaction_requirements.could_commit_, *transaction_requirements.accessor_type_, try_mode);
 
@@ -10819,12 +10838,8 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes &parse_res, UserParamet
         }
       }
 
-      // Deferred from the autocommit branch above: the storage accessor is now held, so record the
-      // query and open the interpreter transaction (consumes the tx id, marks the status ACTIVE).
-      transaction_queries_->push_back(parsed_query.query_string);
-      SetupInterpreterTransaction(extras);
-      memgraph::logging::EmitSessionTraceEvent(
-          "Query [{}] associated with transaction [{}]", parsed_query.query_string, current_transaction_.value_or(0));
+      // TryBounded and no-accessor queries mint here (exactly once).
+      if (!interpreter_txn_opened) open_interpreter_txn();
     }
 
     if (current_db_.db_acc_) {
@@ -11205,6 +11220,9 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes &parse_res, UserParamet
             .privileges = query_execution->prepared_query->privileges,
             .qid = qid,
             .db = query_execution->prepared_query->db};
+  } catch (const WouldBlockInlineException &) {
+    // Reschedule signal, not a query failure — rethrow before failure accounting.
+    throw;
   } catch (const utils::BasicException &e) {
     memgraph::logging::EmitSessionTraceEvent("Failed query: {}", e.what());
     // query_execution holds the query string copy that survives Prepare* moving it out.
@@ -11247,7 +11265,10 @@ void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privi
 
 void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type,
                                            storage::EngineLockMode try_mode) {
-  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type, try_mode);
+  // Peek (do not consume) so a WouldBlockInlineException bail leaves the one-shot override intact for
+  // the retry; consume only after the accessor is successfully acquired.
+  current_db_.SetupDatabaseTransaction(PeekIsolationLevelOverride(), couldCommit, acc_type, try_mode);
+  next_transaction_isolation_level.reset();
 }
 
 void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {
@@ -11802,14 +11823,8 @@ void Interpreter::AbortCommand(std::unique_ptr<QueryExecution> *query_execution)
   }
 }
 
-std::optional<storage::IsolationLevel> Interpreter::GetIsolationLevelOverride() {
-  if (next_transaction_isolation_level) {
-    const auto isolation_level = *next_transaction_isolation_level;
-    next_transaction_isolation_level.reset();
-    return isolation_level;
-  }
-
-  return interpreter_isolation_level;
+std::optional<storage::IsolationLevel> Interpreter::PeekIsolationLevelOverride() const {
+  return next_transaction_isolation_level.has_value() ? next_transaction_isolation_level : interpreter_isolation_level;
 }
 
 void Interpreter::SetNextTransactionIsolationLevel(const storage::IsolationLevel isolation_level) {

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -263,7 +263,8 @@ struct CurrentDB {
   CurrentDB &operator=(CurrentDB const &) = delete;
 
   void SetupDatabaseTransaction(std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE);
+                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE,
+                                storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {
@@ -391,7 +392,12 @@ class Interpreter final {
 
   Interpreter::ParseRes Parse(const std::string &query, UserParameters_fn params_getter, QueryExtras const &extras);
 
-  Interpreter::PrepareResult Prepare(ParseRes parse_res, UserParameters_fn params_getter, QueryExtras const &extras);
+  // parse_res and params_getter are taken by non-const reference: they are only moved-from on the
+  // success path, after the storage accessor is acquired. If the acquire bails with
+  // WouldBlockInlineException (TryBounded mode) they are left untouched, so the caller can retry
+  // Prepare with the same parsed input.
+  Interpreter::PrepareResult Prepare(ParseRes &parse_res, UserParameters_fn &params_getter, QueryExtras const &extras,
+                                     storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   /**
    * Prepare a query for execution.
@@ -406,7 +412,9 @@ class Interpreter final {
     // Split Prepare in two (Parse and Prepare)
     // This allows us to parse, deduce priority and schedule accordingly
     // Leaving this one-shot version for back-compatiblity
-    return Prepare(Parse(query, params_getter, extras), params_getter, extras);
+    // parse_res must be an lvalue: the ParseRes overload binds it by reference.
+    auto parse_res = Parse(query, params_getter, extras);
+    return Prepare(parse_res, params_getter, extras);
   }
 
   /**
@@ -462,7 +470,8 @@ class Interpreter final {
   std::map<std::string, TypedValue> Pull(TStream *result_stream, std::optional<int> n = {},
                                          std::optional<int> qid = {});
 
-  void BeginTransaction(QueryExtras const &extras = {});
+  void BeginTransaction(QueryExtras const &extras = {},
+                        storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 
   std::optional<uint64_t> GetTransactionId() const;
 
@@ -690,7 +699,8 @@ class Interpreter final {
 
   static void AppendNotificationToSummary(const Notification &notification, std::map<std::string, TypedValue> &summary);
 
-  PreparedQuery PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum, QueryExtras const &extras = {});
+  PreparedQuery PrepareTransactionQuery(Interpreter::TransactionQuery tx_query_enum, QueryExtras const &extras = {},
+                                        storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
   void Commit();
   // Resets tx-tracking left ACTIVE by SetupInterpreterTransaction when NOTHING skips Commit()/Abort()'s cleanup.
   void FinishAutocommitNothing();
@@ -706,7 +716,8 @@ class Interpreter final {
   std::optional<std::function<void(std::string_view)>> on_change_{};
   void SetupInterpreterTransaction(const QueryExtras &extras);
   void SetupDatabaseTransaction(bool couldCommit,
-                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE);
+                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE,
+                                storage::EngineLockMode try_mode = storage::EngineLockMode::Blocking);
 };
 
 template <typename TStream>

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -706,7 +706,7 @@ class Interpreter final {
   void FinishAutocommitNothing();
   void AdvanceCommand();
   void AbortCommand(std::unique_ptr<QueryExecution> *query_execution);
-  std::optional<storage::IsolationLevel> GetIsolationLevelOverride();
+  std::optional<storage::IsolationLevel> PeekIsolationLevelOverride() const;
 
   size_t ActiveQueryExecutions() {
     return std::ranges::count_if(query_executions_,

--- a/src/storage/v2/access_type.hpp
+++ b/src/storage/v2/access_type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -22,5 +22,10 @@ enum StorageAccessType : uint8_t {
   READ = 3,       // Either reads the data of storage, or a metadata operation that doesn't require unique access
   READ_ONLY = 4,  // Ensures writers have gone
 };
+
+// engine_lock_ acquisition for CreateTransaction: Blocking waits indefinitely (default);
+// TryBounded spin-tries ~2us then throws (pool BEGIN fallback that reschedules on throw).
+// Kept in this leaf header so protocol/dbms callers that only name the enum need not pull storage.hpp.
+enum class EngineLockMode : uint8_t { Blocking, TryBounded };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2492,7 +2492,9 @@ auto DiskStorage::DiskAccessor::PointVertices(LabelId /*label*/, PropertyId /*pr
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PointIndexStorage DiskStorage::empty_point_index_ = PointIndexStorage{};
 
-Transaction DiskStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) {
+Transaction DiskStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                           EngineLockMode engine_mode) {
+  MG_ASSERT(engine_mode == EngineLockMode::Blocking, "DiskStorage has no non-blocking transaction mint");
   /// We acquire the transaction engine lock here because we access (and
   /// modify) the transaction engine variables (`transaction_id` and
   /// `timestamp`) below.

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -628,7 +628,8 @@ class DiskStorage final : public Storage {
 
   RocksDBStorage *GetRocksDBStorage() const { return kvstore_.get(); }
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                EngineLockMode engine_mode = EngineLockMode::Blocking) override;
 
   void SetEdgeImportMode(EdgeImportMode edge_import_status);
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -69,6 +69,7 @@
 #include "utils/on_scope_exit.hpp"
 #include "utils/resource_lock.hpp"
 #include "utils/scheduler.hpp"
+#include "utils/spin_lock.hpp"
 #include "utils/stat.hpp"
 #include "utils/temporal.hpp"
 #include "utils/variant_helpers.hpp"
@@ -612,8 +613,9 @@ void InMemoryStorage::UpdateLabelCount(LabelId const label, int64_t const change
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryStorage *storage,
                                                     std::optional<IsolationLevel> override_isolation_level,
-                                                    utils::ResourceLockGuard guard)
-    : Accessor(storage, override_isolation_level, std::move(guard)), config_(storage->config_.salient.items) {}
+                                                    utils::ResourceLockGuard guard, EngineLockMode engine_mode)
+    : Accessor(storage, override_isolation_level, std::move(guard), engine_mode),
+      config_(storage->config_.salient.items) {}
 
 InMemoryStorage::InMemoryAccessor::InMemoryAccessor(InMemoryAccessor &&other) noexcept
     : Accessor(std::move(other)), config_(other.config_) {}
@@ -2867,7 +2869,8 @@ std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::FindEdge(Gid edge
   return EdgeAccessor::Create(edge_ref, edge_type, from, to, storage_, &transaction_, view);
 }
 
-Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) {
+Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                               EngineLockMode engine_mode) {
   // We acquire the transaction engine lock here because we access (and
   // modify) the transaction engine variables (`transaction_id` and
   // `timestamp`) below.
@@ -2878,7 +2881,21 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
   ActiveIndicesPtr active_indices;
   ActiveConstraintsPtr active_constraints;
   {
-    auto guard = std::lock_guard{engine_lock_};
+    // Acquire must precede every mutation below: a contended TryBounded probe throws having
+    // changed nothing -- no transaction_id_/timestamp_ bump, no index/constraint read.
+    constexpr auto kBeginEngineTryBudget = std::chrono::microseconds{2};
+    std::unique_lock<utils::SpinLock> guard;
+    switch (engine_mode) {
+      case EngineLockMode::Blocking:
+        guard = std::unique_lock{engine_lock_};
+        break;
+      case EngineLockMode::TryBounded:
+        // BoundedTryLock returns false WITHOUT holding the lock on timeout, so throwing leaks nothing;
+        // on success it owns the lock -- adopt it so the scope-exit RAII unlock stays correct.
+        if (!utils::BoundedTryLock(engine_lock_, kBeginEngineTryBudget)) throw TransactionEngineWouldBlock{};
+        guard = std::unique_lock{engine_lock_, std::adopt_lock};
+        break;
+    }
     transaction_id = transaction_id_++;
     start_timestamp = timestamp_++;
     // IMPORTANT: this is retrieved while under the lock so that the index is consistant with the timestamp
@@ -4835,10 +4852,20 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
 }
 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccess(StorageAccessType rw_type,
-                                                              std::optional<IsolationLevel> override_isolation_level) {
-  utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::try_to_lock};
-  if (!guard.owns_lock()) return nullptr;
-  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{this, override_isolation_level, std::move(guard)});
+                                                              std::optional<IsolationLevel> override_isolation_level,
+                                                              EngineLockMode engine_mode) {
+  // Bounded-try main_lock_ too (not just engine_lock_): a brief exclusive hold -- a transient UNIQUE
+  // that gates shared acquirers under writer-preference -- should ride out within a tiny budget rather
+  // than fail instantly (std::try_to_lock) and force an admission reschedule. Mirrors engine_lock_'s ~2us try.
+  constexpr auto kMainLockTryBudget = std::chrono::microseconds{2};
+  utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::defer_lock};
+  if (!guard.try_lock_for(kMainLockTryBudget)) return nullptr;
+  try {
+    return std::unique_ptr<InMemoryAccessor>(
+        new InMemoryAccessor{this, override_isolation_level, std::move(guard), engine_mode});
+  } catch (const TransactionEngineWouldBlock &) {
+    return nullptr;  // engine lock contended (e.g. a write-commit's durability phase); caller falls back to pool
+  }
 }
 
 void InMemoryStorage::CreateSnapshotHandler(

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -167,7 +167,7 @@ class InMemoryStorage final : public Storage {
 
     /// Takes ownership of a hold the caller acquired; see Accessor's constructor.
     explicit InMemoryAccessor(InMemoryStorage *storage, std::optional<IsolationLevel> override_isolation_level,
-                              utils::ResourceLockGuard guard);
+                              utils::ResourceLockGuard guard, EngineLockMode engine_mode = EngineLockMode::Blocking);
 
     std::expected<void, ConstraintViolation> ExistenceConstraintsViolation() const;
 
@@ -811,7 +811,8 @@ class InMemoryStorage final : public Storage {
   /// InMemoryStorage's alone: DiskStorage has no probe rather than one that always fails, so a
   /// caller polling it would spin instead of learning that it should just block.
   std::unique_ptr<Accessor> TryAccess(StorageAccessType rw_type,
-                                      std::optional<IsolationLevel> override_isolation_level = {});
+                                      std::optional<IsolationLevel> override_isolation_level = {},
+                                      EngineLockMode engine_mode = EngineLockMode::TryBounded);
 
   void FreeMemory(utils::ResourceLockGuard main_guard, bool periodic) override;
 
@@ -852,7 +853,8 @@ class InMemoryStorage final : public Storage {
   void CreateSnapshotHandler(
       std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb);
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                EngineLockMode engine_mode = EngineLockMode::Blocking) override;
 
   void SetStorageMode(StorageMode storage_mode);
 

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -121,14 +121,14 @@ std::unique_ptr<Accessor> Storage::ReadOnlyAccess(std::optional<IsolationLevel> 
 std::unique_ptr<Accessor> Storage::ReadOnlyAccess() { return ReadOnlyAccess({}, std::nullopt); }
 
 Storage::Accessor::Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level,
-                            utils::ResourceLockGuard guard)
+                            utils::ResourceLockGuard guard, EngineLockMode engine_mode)
     : storage_(storage),
       // The hold is taken before the transaction is created, so a freshly created transaction can
       // never dangle in an active state during an exclusive operation.
       guard_(std::move(guard)),
       // Both reads are under guard_, already constructed above, so the hold pins them.
       transaction_(storage->CreateTransaction(override_isolation_level.value_or(storage->isolation_level_),
-                                              storage->storage_mode_)),
+                                              storage->storage_mode_, engine_mode)),
       is_transaction_active_(true),
       original_access_type_(ToAccessType(guard_.type())) {
   DMG_ASSERT(guard_.owns_lock() && guard_.mutex() == std::addressof(storage_->main_lock_),

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -12,6 +12,8 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
+#include <exception>
 #include <optional>
 #include <set>
 #include <string>
@@ -44,6 +46,9 @@
 #include "storage/v2/vertices_iterable.hpp"
 #include "utils/resource_lock.hpp"
 #include "utils/synchronized_metadata_store.hpp"
+
+// Test fixture (global ns, tests/unit/storage_v2.cpp); forward-declared for the friend below.
+class StorageEngineLockContentionTest;
 
 namespace memgraph::metrics {
 struct DatabaseMetricHandles;
@@ -280,6 +285,8 @@ class Storage {
   friend class ReplicationServer;
   friend class ReplicationStorageClient;
   friend class VectorIndex;
+  // Test-only: fixture holds engine_lock_ to exercise the non-blocking TryAccess bail.
+  friend class ::StorageEngineLockContentionTest;
 
  public:
   Storage(Config config, StorageMode storage_mode, PlanInvalidatorPtr invalidator,
@@ -387,7 +394,8 @@ class Storage {
 
   virtual void UpdateLabelCount(LabelId label, int64_t change) = 0;
 
-  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) = 0;
+  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
+                                        EngineLockMode engine_mode = EngineLockMode::Blocking) = 0;
 
   virtual void PrepareForNewEpoch() = 0;
 
@@ -538,11 +546,19 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
 utils::ResourceLockGuard AcquireGuardOrThrow(Storage *storage, StorageAccessType rw_type,
                                              std::optional<std::chrono::milliseconds> timeout);
 
+// Thrown by CreateTransaction under TryBounded when engine_lock_ is held by a concurrent commit/GC;
+// caught in TryAccess (returns nullptr) and never surfaces to callers.
+struct TransactionEngineWouldBlock final : std::exception {
+  const char *what() const noexcept override { return "transaction engine lock busy"; }
+};
+
 class Accessor {
  public:
   /// Takes ownership of a hold on `storage`'s main_lock_. The caller acquires it: blocking with a
   /// timeout via AcquireGuardOrThrow, or non-blocking via a try_to_lock guard. Construction itself
-  /// never blocks and never fails, so a probe can decide whether to build an accessor at all.
+  /// never blocks and never fails, EXCEPT on a non-blocking `engine_mode`: TryBounded bounded-tries
+  /// the transaction-engine lock and throws TransactionEngineWouldBlock if it is contended, so a
+  /// probe can decide whether to build an accessor at all without blocking.
   ///
   /// The access type comes from the guard, not alongside it. It is recorded as
   /// original_access_type_, which the WAL carries to replicas to pick the mode they replay under,
@@ -552,7 +568,8 @@ class Accessor {
   /// The isolation level and storage mode are read from `storage` under the guard rather than
   /// passed in: SetIsolationLevel and SetStorageMode write them under UNIQUE, so a caller reading
   /// them before acquiring could build a transaction against a mode that has since changed.
-  Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level, utils::ResourceLockGuard guard);
+  Accessor(Storage *storage, std::optional<IsolationLevel> override_isolation_level, utils::ResourceLockGuard guard,
+           EngineLockMode engine_mode = EngineLockMode::Blocking);
 
   Accessor(const Accessor &) = delete;
   Accessor &operator=(const Accessor &) = delete;

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -89,6 +89,7 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
     pool_.emplace_back([this, i, &barrier, thread_init_callback]() {
       // Divide work by each thread
       workers_[i] = std::make_unique<Worker>();
+      workers_[i]->productive_pending_ = &productive_pending_;
       barrier.arrive_and_wait();
       // Call user-defined thread initialization callback (e.g., to register with Python interpreter)
       if (thread_init_callback) {
@@ -101,6 +102,7 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
   for (size_t i = 0; i < high_priority_threads_count; ++i) {
     pool_.emplace_back([this, i, &barrier, thread_init_callback]() {
       hp_workers_[i] = std::make_unique<Worker>();
+      hp_workers_[i]->productive_pending_ = &productive_pending_;
       barrier.arrive_and_wait();
       // Call user-defined thread initialization callback (e.g., to register with Python interpreter)
       if (thread_init_callback) {
@@ -132,7 +134,11 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
                         if (worker->work_.empty() || worker_last_task != worker->last_task_) continue;
                         // Update flag as soon as possible
                         worker->has_pending_work_.store(worker->work_.size() > 1, std::memory_order_release);
-                        Worker::Work work{.id = worker->work_.top().id, .work = std::move(worker->work_.top().work)};
+                        const bool prod = worker->work_.top().productive;
+                        Worker::Work work{.id = worker->work_.top().id,
+                                          .work = std::move(worker->work_.top().work),
+                                          .productive = prod};
+                        if (prod) productive_pending_.fetch_sub(1, std::memory_order_relaxed);
                         worker->work_.pop();
                         l.unlock();
 
@@ -143,14 +149,14 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
                             static size_t last_hp_thread = 0;
                             auto &hp_worker = hp_workers_[hp_workers_num > 1 ? last_hp_thread++ % hp_workers_num : 0];
                             if (!hp_worker->has_pending_work_) {
-                              hp_worker->push(std::move(work.work), work.id);
+                              hp_worker->push(std::move(work.work), work.id, work.productive);
                               continue;
                             }
                           }
                           // No hot thread and low priority work, schedule to the next lp worker
                           tid = (worker_id + 1) % workers_num;
                         }
-                        workers_[*tid]->push(std::move(work.work), work.id);
+                        workers_[*tid]->push(std::move(work.work), work.id, work.productive);
                       }
                     }
                   });
@@ -180,7 +186,7 @@ void PriorityThreadPool::ShutDown() {
   }
 }
 
-void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, const Priority priority) {
+void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, Priority priority, bool productive) {
   if (pool_stop_source_.stop_requested()) [[unlikely]] {
     return;
   }
@@ -195,23 +201,22 @@ void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, const Priority
     // If no hot thread found, give it to the next thread
     tid = last_wid_++ % max_wakeup_thread;
   }
-  workers_[*tid]->push(std::move(new_task), id);
+  workers_[*tid]->push(std::move(new_task), id, productive);
   // High priority tasks are marked and given to mixed priority threads (at front of the queue)
   // HP threads are going to steal this work if not executed in time
 }
 
 bool PriorityThreadPool::HasPendingWork() const noexcept {
-  // Scan only mixed-work workers: hp_workers_ handle pings/health, not the yield-able backlog.
-  for (const auto &w : workers_) {
-    if (w->has_pending_work_.load(std::memory_order_relaxed)) return true;
-  }
-  return false;
+  // Productive (non-admission) queued work only: admission re-posts carry productive=false and never
+  // touch productive_pending_, so a reschedule storm cannot keep this gate open (see NB-3).
+  return productive_pending_.load(std::memory_order_relaxed) > 0;
 }
 
-void PriorityThreadPool::Worker::push(TaskSignature new_task, TaskID id) {
+void PriorityThreadPool::Worker::push(TaskSignature new_task, TaskID id, bool productive) {
   {
     auto l = std::unique_lock{mtx_};
-    work_.emplace(id, std::move(new_task));
+    if (productive && productive_pending_) productive_pending_->fetch_add(1, std::memory_order_relaxed);
+    work_.emplace(id, std::move(new_task), productive);
   }
   has_pending_work_ = true;
   cv_.notify_one();
@@ -257,6 +262,7 @@ void PriorityThreadPool::Worker::operator()(const uint16_t worker_id,
   auto pop_task = [&] {
     has_pending_work_.store(work_.size() > 1, std::memory_order::release);
     last_task_.store(work_.top().id, std::memory_order_release);
+    if (work_.top().productive && productive_pending_) productive_pending_->fetch_sub(1, std::memory_order_relaxed);
     task = std::move(work_.top().work);
     work_.pop();
   };
@@ -308,6 +314,8 @@ void PriorityThreadPool::Worker::operator()(const uint16_t worker_id,
 
         // Move work to current thread
         last_task_.store(worker->work_.top().id, std::memory_order_release);
+        if (worker->work_.top().productive && productive_pending_)
+          productive_pending_->fetch_sub(1, std::memory_order_relaxed);
         task = std::move(worker->work_.top().work);
 
         worker->work_.pop();

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -200,6 +200,14 @@ void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, const Priority
   // HP threads are going to steal this work if not executed in time
 }
 
+bool PriorityThreadPool::HasPendingWork() const noexcept {
+  // Scan only mixed-work workers: hp_workers_ handle pings/health, not the yield-able backlog.
+  for (const auto &w : workers_) {
+    if (w->has_pending_work_.load(std::memory_order_relaxed)) return true;
+  }
+  return false;
+}
+
 void PriorityThreadPool::Worker::push(TaskSignature new_task, TaskID id) {
   {
     auto l = std::unique_lock{mtx_};

--- a/src/utils/priority_thread_pool.hpp
+++ b/src/utils/priority_thread_pool.hpp
@@ -137,7 +137,7 @@ class PriorityThreadPool {
 
   void ShutDown();
 
-  void ScheduledAddTask(TaskSignature new_task, Priority priority);
+  void ScheduledAddTask(TaskSignature new_task, Priority priority, bool productive = true);
 
   void ScheduledCollection(TaskCollection &collection) {
     for (size_t i = 0; i < collection.Size(); ++i) {
@@ -151,10 +151,9 @@ class PriorityThreadPool {
 
   uint64_t GetNumWorkers() const { return workers_.size() + hp_workers_.size(); }
 
-  // True iff any mixed-work worker currently has queued (not-yet-running) backlog — i.e. there is
-  // work a freed worker could run. Approximate + lock-free (relaxed loads); used to gate admission
-  // reschedule vs block. A task currently executing is not counted (it was dequeued), so this reports
-  // only OTHER pending work.
+  // True iff the pool has queued productive (non-admission) tasks. Reads productive_pending_ via
+  // relaxed atomic; used to gate admission reschedule — admission re-posts are non-productive and
+  // do not increment the counter, so a pure-admission storm cannot hold the gate open.
   bool HasPendingWork() const noexcept;
 
   // Single worker implementation
@@ -171,11 +170,12 @@ class PriorityThreadPool {
     struct Work {
       TaskID id;                   // ID used to order (issued by the pool)
       mutable TaskSignature work;  // mutable so it can be moved from the queue
+      bool productive{true};       // false for admission retries; excluded from productive_pending_
 
       bool operator<(const Work &other) const { return id < other.id; }
     };
 
-    void push(TaskSignature new_task, TaskID id);
+    void push(TaskSignature new_task, TaskID id, bool productive = true);
 
     void stop();
 
@@ -194,6 +194,9 @@ class PriorityThreadPool {
     // Used by monitor to decide if worker is blocked
     std::atomic<TaskID> last_task_{0};
 
+    // Pool-owned counter; set once after construction, never null at task time.
+    std::atomic<int64_t> *productive_pending_{nullptr};
+
     friend class PriorityThreadPool;
   };
 
@@ -210,6 +213,11 @@ class PriorityThreadPool {
 
   std::atomic<TaskID> task_id_;     // Generates a unique tasks id | MSB signals high priority
   std::atomic<uint16_t> last_wid_;  // Used to pick next worker
+
+  // Counts queued productive tasks (excludes admission retries). Increment in push, decrement at
+  // every pop that does not re-push. Balance: rebalance = pop(-1)+push(+1) = 0; run = push(+1)+pop(-1) = 0.
+  // May be positive at shutdown for unrun tasks — irrelevant to the gate.
+  alignas(64) std::atomic<int64_t> productive_pending_{0};
 };
 
 class CollectionScheduler {

--- a/src/utils/priority_thread_pool.hpp
+++ b/src/utils/priority_thread_pool.hpp
@@ -151,6 +151,12 @@ class PriorityThreadPool {
 
   uint64_t GetNumWorkers() const { return workers_.size() + hp_workers_.size(); }
 
+  // True iff any mixed-work worker currently has queued (not-yet-running) backlog — i.e. there is
+  // work a freed worker could run. Approximate + lock-free (relaxed loads); used to gate admission
+  // reschedule vs block. A task currently executing is not counted (it was dequeued), so this reports
+  // only OTHER pending work.
+  bool HasPendingWork() const noexcept;
+
   // Single worker implementation
   class Worker {
    public:

--- a/src/utils/spin_lock.hpp
+++ b/src/utils/spin_lock.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,6 +12,8 @@
 #pragma once
 
 #include <pthread.h>
+
+#include <chrono>
 
 #include "utils/logging.hpp"
 
@@ -66,4 +68,24 @@ class SpinLock {
  private:
   pthread_spinlock_t lock_;
 };
+
+// Spin-try to acquire `lock` for up to `budget`; returns true iff acquired. Lets a caller
+// bail-and-reschedule instead of spinning behind a long holder; keep budget SMALL -- a large one wastes CPU.
+inline bool BoundedTryLock(SpinLock &lock, std::chrono::nanoseconds budget) {
+  if (lock.try_lock()) return true;
+  const auto deadline = std::chrono::steady_clock::now() + budget;
+  do {
+    // Arch CPU-relax hint (mirrors yielder.hpp PAUSE), compiler barrier elsewhere. Not reused because
+    // yielder.hpp #undef's PAUSE and pulls in <thread> + a stateful backoff loop we don't want here.
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__)
+    asm volatile("yield" ::: "memory");
+#else
+    asm volatile("" ::: "memory");
+#endif
+    if (lock.try_lock()) return true;
+  } while (std::chrono::steady_clock::now() < deadline);
+  return false;
+}
 }  // namespace memgraph::utils

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -18,6 +18,7 @@
 #include "communication/bolt/v1/session.hpp"
 #include "communication/exceptions.hpp"
 #include "query/exceptions.hpp"
+#include "storage/v2/access_type.hpp"  // storage::EngineLockMode (BeginTransaction engine-mode arg)
 #include "utils/logging.hpp"
 
 using memgraph::communication::bolt::ChunkedEncoderBuffer;
@@ -69,7 +70,16 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
     throw ClientError("client sent invalid query");
   }
 
-  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare() {
+  std::pair<std::vector<std::string>, std::optional<int>> InterpretPrepare(
+      memgraph::storage::EngineLockMode try_mode = memgraph::storage::EngineLockMode::Blocking) {
+    // Pool bounded-try (mirrors BeginTransaction): lose the engine-lock race for the first N TryBounded
+    // attempts, then succeed. The first loss bails HandlePrepare into State::PendingPrepare; the rest make
+    // FinishPendingPrepare_ return Reschedule. Blocking (the fairness-cap fallback) is never gated, so the
+    // reschedule loop is guaranteed to terminate.
+    if (try_mode == memgraph::storage::EngineLockMode::TryBounded && try_bounded_fail_count_ > 0) {
+      --try_bounded_fail_count_;
+      throw memgraph::query::WouldBlockInlineException{};
+    }
     if (query_ == kQueryReturn42 || query_ == kQueryEmpty || query_ == kQueryReturnMultiple) {
       return {{"result_name"}, {}};
     }
@@ -114,7 +124,16 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   bolt_map_t Discard(std::optional<int> /*unused*/, std::optional<int> /*unused*/) { return {}; }
 
-  void BeginTransaction(const bolt_map_t &extra) {
+  void BeginTransaction(const bolt_map_t &extra,
+                        memgraph::storage::EngineLockMode mode = memgraph::storage::EngineLockMode::Blocking) {
+    // Pool bounded-try: simulate losing the engine-lock race for the first N attempts, then succeed. The
+    // first loss happens inside HandleBegin (the BEGIN goes State::PendingBegin); the rest happen inside
+    // FinishPendingBegin_ (each returns Reschedule). Blocking (the fairness-cap fallback) never throws
+    // WouldBlock, so it is intentionally NOT gated here -- that is what guarantees the loop terminates.
+    if (mode == memgraph::storage::EngineLockMode::TryBounded && try_bounded_fail_count_ > 0) {
+      --try_bounded_fail_count_;
+      throw memgraph::query::WouldBlockInlineException{};
+    }
     if (extra.contains("tx_metadata")) {
       auto const &metadata = extra.at("tx_metadata").ValueMap();
       if (!metadata.empty()) md_ = metadata;
@@ -170,6 +189,21 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
 
   void TestHook_ShouldAbort() { should_abort_ = true; }
 
+  // Make the next `n` TryBounded engine-lock acquires lose the race, then succeed. Drives the HandleBegin /
+  // HandlePrepare bail + FinishPendingBegin_ / FinishPendingPrepare_ reschedule paths deterministically.
+  void TestHook_FailBoundedTries(int n) { try_bounded_fail_count_ = n; }
+
+  // Simulate an idle pool (no queued work): AdmissionEngineLockMode returns Blocking, bypassing the
+  // TryBounded + reschedule path entirely.
+  void TestHook_SetPoolIdle() { pool_has_pending_work_ = false; }
+
+  bool PoolHasPendingWork() const noexcept { return pool_has_pending_work_; }
+
+  memgraph::storage::EngineLockMode AdmissionEngineLockMode() const noexcept {
+    return pool_has_pending_work_ ? memgraph::storage::EngineLockMode::TryBounded
+                                  : memgraph::storage::EngineLockMode::Blocking;
+  }
+
   void Execute() {
     while (Execute_(*this)) {
       // Execute now exists on result, so it can be schduled again.
@@ -177,10 +211,22 @@ class TestSession final : public Session<TestInputStream, TestOutputStream> {
     }
   }
 
+  // Run the dechunk loop exactly once (one Execute_ pass), mirroring communication/v2 DoWork's single
+  // Execute() call so a test can observe the mid-batch bail into State::PendingBegin. The naive Execute()
+  // above would keep re-entering while the BEGIN is parked, so the pending-BEGIN path must be stepped.
+  bool ExecuteStep() { return Execute_(*this); }
+
+  memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return FinishPendingBegin_(*this); }
+
+  memgraph::communication::bolt::PendingPrepareOutcome FinishPendingPrepare() { return FinishPendingPrepare_(*this); }
+
  private:
   std::string query_;
   bolt_map_t md_;
   bool should_abort_ = false;
+  int try_bounded_fail_count_{0};
+  // Default true: existing reschedule tests exercise the TryBounded path unchanged.
+  bool pool_has_pending_work_{true};
 };
 
 // TODO: This could be done in fixture.
@@ -1325,4 +1371,318 @@ TEST(BoltSession, PartialStream) {
     auto const find_msg = std::search(cbegin(output), cend(output), cbegin(error_msg), cend(error_msg));
     EXPECT_NE(find_msg, cend(output));
   }
+}
+
+// ---------------------------------------------------------------------------
+// Pending-BEGIN reschedule (pool-native, no strand inline). A BEGIN whose bounded-try engine-lock
+// acquire loses the race bails out of HandleBegin into State::PendingBegin (stashing its decoded
+// extras); the completion is retried out-of-band via FinishPendingBegin(), which reschedules on each
+// further loss and, past the fairness cap, does one blocking acquire so the BEGIN cannot starve.
+// ---------------------------------------------------------------------------
+
+// A minimal single-chunk BEGIN with an empty extras map, pre-framed (chunk header + end marker) so it
+// can be written straight into the input stream:
+//   0x00 0x03           chunk size 3
+//   0xB1                TinyStruct1
+//   0x11                Begin signature
+//   0xA0                empty TinyMap (extras)
+//   0x00 0x00           end-of-message terminator
+static constexpr std::array<uint8_t, 7> begin_bytes{0x00, 0x03, 0xB1, 0x11, 0xA0, 0x00, 0x00};
+
+using memgraph::communication::bolt::PendingBeginOutcome;
+
+TEST(BoltSession, PendingBeginReschedulesThenCompletesWithOneSuccess) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // 4 bounded-try losses: the 1st is consumed by HandleBegin (BEGIN -> PendingBegin), leaving 3 losses
+  // for FinishPendingBegin -> exactly 3 Reschedule outcomes before the 4th attempt wins.
+  constexpr int kExpectedReschedules = 3;
+  session.TestHook_FailBoundedTries(kExpectedReschedules + 1);
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  output.clear();
+
+  // One dechunk pass: HandleBegin bails with WouldBlock, stashes the extras, parks in PendingBegin.
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingBegin);
+  EXPECT_TRUE(session.HasPendingBegin());
+  EXPECT_TRUE(output.empty());  // no SUCCESS emitted on the bail path
+
+  // Each lost bounded-try returns Reschedule and MUST keep the extras stashed (HasPendingBegin stays
+  // true); a premature reset would trip FinishPendingBegin_'s MG_ASSERT on the next attempt.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;  // fail loudly instead of looping forever if the retry logic regresses
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingBegin();
+    if (outcome == PendingBeginOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingBeginOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingBegin());  // stash survives across reschedules
+    EXPECT_TRUE(output.empty());             // no reply while rescheduling
+    EXPECT_EQ(session.state_, State::PendingBegin);
+    ++reschedules;
+  }
+
+  // Reverting the reschedule (e.g. HandleBegin/FinishPendingBegin blocking instead of bailing) breaks
+  // this exact count -> the test is mutation-checkable.
+  EXPECT_EQ(reschedules, kExpectedReschedules);
+  EXPECT_FALSE(session.HasPendingBegin());  // stash consumed on the terminal Done
+  EXPECT_EQ(session.state_, State::Idle);
+  // Exactly ONE SUCCESS, emitted only by FinishPendingBegin on Done (empty extras -> canonical frame).
+  ASSERT_EQ(output.size(), sizeof(success_resp));
+  CheckSuccessMessage(output, /*clear=*/false);
+}
+
+TEST(BoltSession, PendingBeginFairnessCapForcesBlockingTerminal) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // EVERY bounded-try loses the race: only the fairness cap can end the loop.
+  session.TestHook_FailBoundedTries(1000);
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  output.clear();
+
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingBegin);
+  EXPECT_TRUE(session.HasPendingBegin());
+  EXPECT_TRUE(output.empty());
+
+  // Under unbounded contention the pool-side completion must still terminate: after kBeginRescheduleCap
+  // reschedules FinishPendingBegin_ does one Blocking acquire (which is never gated by the fail hook and
+  // never throws WouldBlock), completing the BEGIN. Count the reschedules to prove it is the cap -- not a
+  // lucky bounded-try -- that breaks the loop. kBeginRescheduleCap is private, so the expected count is a
+  // literal kept in sync with it.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingBegin();
+    if (outcome == PendingBeginOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingBeginOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingBegin());
+    EXPECT_TRUE(output.empty());
+    EXPECT_EQ(session.state_, State::PendingBegin);
+    ++reschedules;
+  }
+  EXPECT_EQ(reschedules, 32);  // == kBeginRescheduleCap; the terminal Blocking acquire fires on the next call
+  EXPECT_FALSE(session.HasPendingBegin());
+  EXPECT_EQ(session.state_, State::Idle);
+  ASSERT_EQ(output.size(), sizeof(success_resp));  // exactly one SUCCESS, from the Blocking fallback
+  CheckSuccessMessage(output, /*clear=*/false);
+}
+
+TEST(BoltSession, PendingBeginHoldsBackPipelinedMessageUntilItCompletes) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // One loss (consumed by HandleBegin) is enough to force the BEGIN onto the pending path; the first
+  // FinishPendingBegin then wins. Keeps this test focused on ordering, not on the reschedule count.
+  session.TestHook_FailBoundedTries(1);
+  // A BEGIN immediately followed by a RUN, in one buffer, with the engine lock "contended".
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  output.clear();
+
+  // One dechunk pass stops at the BEGIN: Execute_ returns at State::PendingBegin WITHOUT reading the RUN
+  // chunk, so the RUN is neither decoded nor answered while the BEGIN is outstanding.
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingBegin);
+  EXPECT_TRUE(session.HasPendingBegin());
+  EXPECT_TRUE(output.empty());             // no SUCCESS for the BEGIN yet, and the RUN was not processed
+  EXPECT_TRUE(session.HasBufferedData());  // the RUN is still queued behind the parked BEGIN
+
+  // Complete the BEGIN: exactly one SUCCESS (empty extras -> canonical frame). The RUN is STILL unread.
+  ASSERT_EQ(session.FinishPendingBegin(), PendingBeginOutcome::Done);
+  EXPECT_EQ(session.state_, State::Idle);
+  EXPECT_FALSE(session.HasPendingBegin());
+  ASSERT_EQ(output.size(), sizeof(success_resp));  // only the BEGIN's SUCCESS -- the RUN produced nothing
+  CheckSuccessMessage(output, /*clear=*/true);
+
+  // Only now, after the BEGIN finished, does the resume process the pipelined RUN -- proving ordering.
+  session.Execute();
+  EXPECT_EQ(session.state_, State::Result);  // RUN parsed+prepared, awaiting PULL
+  CheckSuccessMessage(output, /*clear=*/false);
+}
+
+TEST(BoltSession, PendingBeginGatedToBlockWhenPoolIdle) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // Pool is quiet: AdmissionEngineLockMode returns Blocking. Even though the bounded-try fail hook is armed,
+  // BeginTransaction is called with Blocking (not TryBounded) and never throws WouldBlock.
+  session.TestHook_SetPoolIdle();
+  session.TestHook_FailBoundedTries(10);  // would produce 10 reschedules on a busy pool, but mode is Blocking
+  input_stream.Write(begin_bytes.data(), begin_bytes.size());
+  output.clear();
+
+  // One dechunk pass: HandleBegin acquires Blocking and completes the BEGIN inline, so the loop drains and
+  // Execute_ returns false. A PendingBegin bail (the busy-pool reschedule path) would instead return true --
+  // asserting false is what proves the gate took the Blocking path, not the reschedule path.
+  ASSERT_FALSE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::Idle);
+  EXPECT_FALSE(session.HasPendingBegin());
+  // Exactly one SUCCESS, emitted inline by HandleBegin (not the pending path).
+  ASSERT_EQ(output.size(), sizeof(success_resp));
+  CheckSuccessMessage(output, /*clear=*/false);
+}
+
+// ---------------------------------------------------------------------------
+// Pending-PREPARE reschedule (pool-native, no strand inline). A RUN is first parsed (State::Parsed); the
+// follow-up PREPARE, whose bounded-try engine-lock acquire loses the race, bails out of HandlePrepare into
+// State::PendingPrepare (parse retained in SessionHL::parsed_res_). The completion is retried out-of-band via
+// FinishPendingPrepare(), which reschedules on each further loss and, past the fairness cap, does one blocking
+// acquire so the PREPARE cannot starve. Its single header SUCCESS is emitted only on the terminal Done.
+// ---------------------------------------------------------------------------
+
+using memgraph::communication::bolt::PendingPrepareOutcome;
+
+// Count whole bolt frames in `output`, consuming it. A frame is a 2-byte length header, `len` payload bytes,
+// then the 2-byte end marker; used to prove "exactly one header" without pinning exact payload bytes.
+static int DrainFrameCount(std::vector<uint8_t> &output) {
+  int frames = 0;
+  while (output.size() > 0) {
+    const int len = (output[0] << 8) + output[1];
+    output.erase(output.begin(), output.begin() + len + 4);
+    ++frames;
+  }
+  return frames;
+}
+
+TEST(BoltSession, PendingPrepareReschedulesThenCompletesWithOneHeader) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // 4 bounded-try losses: the 1st is consumed by HandlePrepare (PREPARE -> PendingPrepare), leaving 3 for
+  // FinishPendingPrepare -> exactly 3 Reschedule outcomes before the 4th attempt wins.
+  constexpr int kExpectedReschedules = 3;
+  session.TestHook_FailBoundedTries(kExpectedReschedules + 1);
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  output.clear();
+
+  // First dechunk pass parses the RUN (State::Parsed); the second drives HandlePrepare, whose bounded-try
+  // acquire loses and parks the PREPARE in State::PendingPrepare (parse retained in parsed_res_).
+  ASSERT_TRUE(session.ExecuteStep());
+  ASSERT_EQ(session.state_, State::Parsed);
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingPrepare);
+  EXPECT_TRUE(session.HasPendingPrepare());
+  EXPECT_TRUE(output.empty());  // no header emitted on the bail path
+
+  // Each lost bounded-try returns Reschedule and MUST keep the PREPARE pending (parse retained); a premature
+  // reset would trip FinishPendingPrepare_'s MG_ASSERT on the next attempt.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;  // fail loudly instead of looping forever if the retry logic regresses
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingPrepare();
+    if (outcome == PendingPrepareOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingPrepareOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingPrepare());  // pending state survives across reschedules
+    EXPECT_TRUE(output.empty());               // no header while rescheduling
+    EXPECT_EQ(session.state_, State::PendingPrepare);
+    ++reschedules;
+  }
+
+  // Making HandlePrepare/FinishPendingPrepare block instead of bail (never reaching PendingPrepare) breaks this
+  // exact count -> the test is mutation-checkable.
+  EXPECT_EQ(reschedules, kExpectedReschedules);
+  EXPECT_FALSE(session.HasPendingPrepare());  // pending flag cleared on the terminal Done
+  EXPECT_EQ(session.state_, State::Result);
+  // Exactly ONE header SUCCESS, emitted only by FinishPendingPrepare on Done.
+  CheckSuccessMessage(output, /*clear=*/false);
+  EXPECT_EQ(DrainFrameCount(output), 1);
+}
+
+TEST(BoltSession, PendingPrepareFairnessCapForcesBlockingTerminal) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // EVERY bounded-try loses the race: only the fairness cap can end the loop.
+  session.TestHook_FailBoundedTries(1000);
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  output.clear();
+
+  ASSERT_TRUE(session.ExecuteStep());
+  ASSERT_EQ(session.state_, State::Parsed);
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingPrepare);
+  EXPECT_TRUE(session.HasPendingPrepare());
+  EXPECT_TRUE(output.empty());
+
+  // Under unbounded contention the pool-side completion must still terminate: after kPrepareRescheduleCap
+  // reschedules FinishPendingPrepare_ does one Blocking acquire (never gated by the fail hook, never throws
+  // WouldBlock), completing the PREPARE. Count the reschedules to prove it is the cap -- not a lucky
+  // bounded-try -- that breaks the loop. kPrepareRescheduleCap is private, so the expected count is a literal
+  // kept in sync with it.
+  int reschedules = 0;
+  constexpr int kSafetyBound = 100;
+  for (int i = 0; i < kSafetyBound; ++i) {
+    const auto outcome = session.FinishPendingPrepare();
+    if (outcome == PendingPrepareOutcome::Done) break;
+    ASSERT_EQ(outcome, PendingPrepareOutcome::Reschedule);
+    EXPECT_TRUE(session.HasPendingPrepare());
+    EXPECT_TRUE(output.empty());
+    EXPECT_EQ(session.state_, State::PendingPrepare);
+    ++reschedules;
+  }
+  EXPECT_EQ(reschedules, 32);  // == kPrepareRescheduleCap; the terminal Blocking acquire fires on the next call
+  EXPECT_FALSE(session.HasPendingPrepare());
+  EXPECT_EQ(session.state_, State::Result);
+  CheckSuccessMessage(output, /*clear=*/false);  // exactly one header, from the Blocking fallback
+  EXPECT_EQ(DrainFrameCount(output), 1);
+}
+
+TEST(BoltSession, PendingPrepareHoldsBackPipelinedMessageUntilItCompletes) {
+  INIT_VARS;
+
+  ExecuteHandshake(input_stream, session, output, v4::handshake_req, v4::handshake_resp);
+  ExecuteInit(input_stream, session, output, true);
+  ASSERT_EQ(session.state_, State::Idle);
+
+  // One loss (consumed by HandlePrepare) forces the PREPARE onto the pending path; the first
+  // FinishPendingPrepare then wins. Keeps this test focused on ordering, not on the reschedule count.
+  session.TestHook_FailBoundedTries(1);
+  // A RUN immediately followed by its PULL, in one buffer, with the engine lock "contended".
+  WriteRunRequest(input_stream, kQueryReturn42, /*is_v4=*/true);
+  WriteChunkHeader(input_stream, sizeof(v4::pullall_req));
+  input_stream.Write(v4::pullall_req, sizeof(v4::pullall_req));
+  WriteChunkTail(input_stream);
+  output.clear();
+
+  // First pass parses the RUN; the second bails the PREPARE into PendingPrepare. Neither reads the pipelined
+  // PULL: Execute_ stops at PendingPrepare BEFORE the dechunk loop, so the PULL stays queued and unanswered.
+  ASSERT_TRUE(session.ExecuteStep());
+  ASSERT_EQ(session.state_, State::Parsed);
+  ASSERT_TRUE(session.ExecuteStep());
+  EXPECT_EQ(session.state_, State::PendingPrepare);
+  EXPECT_TRUE(session.HasPendingPrepare());
+  EXPECT_TRUE(output.empty());             // no header for the PREPARE yet, and the PULL was not processed
+  EXPECT_TRUE(session.HasBufferedData());  // the PULL is still queued behind the parked PREPARE
+
+  // Complete the PREPARE: exactly one header SUCCESS. The PULL is STILL unread.
+  ASSERT_EQ(session.FinishPendingPrepare(), PendingPrepareOutcome::Done);
+  EXPECT_EQ(session.state_, State::Result);
+  EXPECT_FALSE(session.HasPendingPrepare());
+  CheckSuccessMessage(output, /*clear=*/false);  // only the PREPARE's header -- the PULL produced nothing
+  EXPECT_EQ(DrainFrameCount(output), 1);
+
+  // Only now, after the PREPARE finished, does the resume process the pipelined PULL -- proving ordering.
+  session.Execute();
+  EXPECT_EQ(session.state_, State::Idle);  // PULL drained the RUN's result
+  EXPECT_EQ(DrainFrameCount(output), 2);   // RECORD(42) + SUCCESS from the pipelined PULL
 }

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -1455,8 +1455,7 @@ TEST(BoltSession, PendingBeginFairnessCapForcesBlockingTerminal) {
   // Under unbounded contention the pool-side completion must still terminate: after kBeginRescheduleCap
   // reschedules FinishPendingBegin_ does one Blocking acquire (which is never gated by the fail hook and
   // never throws WouldBlock), completing the BEGIN. Count the reschedules to prove it is the cap -- not a
-  // lucky bounded-try -- that breaks the loop. kBeginRescheduleCap is private, so the expected count is a
-  // literal kept in sync with it.
+  // lucky bounded-try -- that breaks the loop.
   int reschedules = 0;
   constexpr int kSafetyBound = 100;
   for (int i = 0; i < kSafetyBound; ++i) {
@@ -1468,7 +1467,8 @@ TEST(BoltSession, PendingBeginFairnessCapForcesBlockingTerminal) {
     EXPECT_EQ(session.state_, State::PendingBegin);
     ++reschedules;
   }
-  EXPECT_EQ(reschedules, 32);  // == kBeginRescheduleCap; the terminal Blocking acquire fires on the next call
+  // Loop count tied to the cap: the terminal Blocking acquire fires on the next call.
+  EXPECT_EQ(reschedules, TestSession::kBeginRescheduleCap);
   EXPECT_FALSE(session.HasPendingBegin());
   EXPECT_EQ(session.state_, State::Idle);
   ASSERT_EQ(output.size(), sizeof(success_resp));  // exactly one SUCCESS, from the Blocking fallback
@@ -1627,8 +1627,7 @@ TEST(BoltSession, PendingPrepareFairnessCapForcesBlockingTerminal) {
   // Under unbounded contention the pool-side completion must still terminate: after kPrepareRescheduleCap
   // reschedules FinishPendingPrepare_ does one Blocking acquire (never gated by the fail hook, never throws
   // WouldBlock), completing the PREPARE. Count the reschedules to prove it is the cap -- not a lucky
-  // bounded-try -- that breaks the loop. kPrepareRescheduleCap is private, so the expected count is a literal
-  // kept in sync with it.
+  // bounded-try -- that breaks the loop.
   int reschedules = 0;
   constexpr int kSafetyBound = 100;
   for (int i = 0; i < kSafetyBound; ++i) {
@@ -1640,7 +1639,8 @@ TEST(BoltSession, PendingPrepareFairnessCapForcesBlockingTerminal) {
     EXPECT_EQ(session.state_, State::PendingPrepare);
     ++reschedules;
   }
-  EXPECT_EQ(reschedules, 32);  // == kPrepareRescheduleCap; the terminal Blocking acquire fires on the next call
+  // Loop count tied to the cap: the terminal Blocking acquire fires on the next call.
+  EXPECT_EQ(reschedules, TestSession::kPrepareRescheduleCap);
   EXPECT_FALSE(session.HasPendingPrepare());
   EXPECT_EQ(session.state_, State::Result);
   CheckSuccessMessage(output, /*clear=*/false);  // exactly one header, from the Blocking fallback

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3212,10 +3212,19 @@ class StorageEngineLockContentionTest : public ::testing::Test {
       .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
 
   // TEST_F's body runs in a class derived from this fixture, and friendship is not inherited, so the
-  // private engine_lock_ access must live in a member of the befriended fixture itself.
+  // private engine_lock_ / main_lock_ access must live in members of the befriended fixture itself.
   void LockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.lock(); }
 
   void UnlockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.unlock(); }
+
+  // Takes main_lock_ in UNIQUE (exclusive) mode via ResourceLock::lock(), which is the same hold a
+  // concurrent DDL / schema-only operation acquires. UNIQUE is admitted only when the lock is fully
+  // UNLOCKED and blocks every shared mode (READ, WRITE, READ_ONLY) on admission; see
+  // ResourceLock::can_acquire<UNIQUE> and can_acquire<READ/WRITE/READ_ONLY> in resource_lock.hpp.
+  void LockMainExclusive() { static_cast<memgraph::storage::Storage &>(store).main_lock_.lock(); }
+
+  // Releases the UNIQUE hold taken by LockMainExclusive via ResourceLock::unlock().
+  void UnlockMain() { static_cast<memgraph::storage::Storage &>(store).main_lock_.unlock(); }
 };
 
 // A TryBounded TryAccess bails with nullptr while engine_lock_ is held; once released the lock is
@@ -3241,4 +3250,45 @@ TEST_F(StorageEngineLockContentionTest, EngineLockHeldMakesTryBoundedAccessBailA
   auto blocking_acc = store.Access(READ);
   ASSERT_NE(blocking_acc, nullptr);
   EXPECT_NO_THROW(blocking_acc->Abort());
+}
+
+// A TryBounded TryAccess bails with nullptr while main_lock_ is held exclusively; once released
+// the lock is reusable (no leak/poison) via a fresh TryAccess. The UNIQUE hold simulates a
+// concurrent DDL or schema-only operation that takes main_lock_ exclusively; READ and WRITE
+// TryAccess probes must both bail because can_acquire<READ/WRITE> requires state != UNIQUE.
+TEST_F(StorageEngineLockContentionTest, MainLockHeldMakesTryBoundedAccessBail) {
+  using namespace memgraph::storage;
+
+  // Hold main_lock_ in UNIQUE (exclusive) mode, as a concurrent DDL operation would.
+  LockMainExclusive();
+  // Both WRITE and READ probes must bail: they try main_lock_ first (before engine_lock_), and
+  // UNIQUE is in the way — can_acquire<WRITE> and can_acquire<READ> both require state != UNIQUE.
+  EXPECT_EQ(store.TryAccess(WRITE), nullptr);
+  EXPECT_EQ(store.TryAccess(READ), nullptr);
+  UnlockMain();
+
+  // Once the exclusive hold is released, a READ probe must succeed, proving nothing leaked or
+  // was poisoned by the two bailed attempts.
+  auto after = store.TryAccess(READ);
+  ASSERT_NE(after, nullptr);
+  EXPECT_NO_THROW(after->Abort());
+  after.reset();  // destroy the accessor to release its READ hold on main_lock_
+}
+
+// With nothing held (fresh fixture, no lock helpers called), a TryBounded TryAccess wins on
+// the very first probe for both WRITE and READ — it never has to bail or time out. This pins
+// the neutrality property: the reschedule path costs nothing when uncontended.
+TEST_F(StorageEngineLockContentionTest, UncontendedTryBoundedAccessSucceedsFirstTry) {
+  using namespace memgraph::storage;
+
+  // No lock is held; the first bounded-try probe on both main_lock_ and engine_lock_ must succeed.
+  auto write_acc = store.TryAccess(WRITE);
+  ASSERT_NE(write_acc, nullptr);
+  EXPECT_NO_THROW(write_acc->Abort());
+  write_acc.reset();  // release the WRITE hold on main_lock_ before the next probe
+
+  auto read_acc = store.TryAccess(READ);
+  ASSERT_NE(read_acc, nullptr);
+  EXPECT_NO_THROW(read_acc->Abort());
+  read_acc.reset();
 }

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -3198,3 +3198,47 @@ TEST_F(StorageTryAccessTest, ReadOnlyHeldBlocksNewWrite) {
   ASSERT_NE(write_acc, nullptr);
   EXPECT_NO_THROW(write_acc->Abort());
 }
+
+// TryAccess is non-blocking on the transaction-engine lock: it defaults to EngineLockMode::TryBounded,
+// so CreateTransaction bounded-spins engine_lock_ (2us) and, on failure, throws
+// TransactionEngineWouldBlock, which TryAccess turns into nullptr so the BEGIN caller reschedules onto
+// the pool instead of busy-spinning a worker. The StorageTryAccessTest cases above cover the free
+// (acquire succeeds) side; this covers the contended side deterministically: utils::SpinLock is
+// non-recursive, so a single test thread that already holds engine_lock_ forces the bounded acquire to
+// time out. A blocking Access must still succeed once the lock is released.
+class StorageEngineLockContentionTest : public ::testing::Test {
+ protected:
+  memgraph::storage::InMemoryStorage store{memgraph::storage::Config{
+      .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}}};
+
+  // TEST_F's body runs in a class derived from this fixture, and friendship is not inherited, so the
+  // private engine_lock_ access must live in a member of the befriended fixture itself.
+  void LockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.lock(); }
+
+  void UnlockEngine() { static_cast<memgraph::storage::Storage &>(store).engine_lock_.unlock(); }
+};
+
+// A TryBounded TryAccess bails with nullptr while engine_lock_ is held; once released the lock is
+// reusable (no leak/poison) via both a fresh TryAccess and a blocking Access.
+TEST_F(StorageEngineLockContentionTest, EngineLockHeldMakesTryBoundedAccessBailAndLeavesLockReusable) {
+  using namespace memgraph::storage;
+
+  // Hold the transaction-engine lock, as a concurrent write-commit's durability phase would.
+  LockEngine();
+  // A TryBounded probe must bail (return nullptr) rather than busy-spin the pool worker.
+  EXPECT_EQ(store.TryAccess(READ), nullptr);
+  EXPECT_EQ(store.TryAccess(WRITE), nullptr);
+  UnlockEngine();
+
+  // Once released, the bounded-try probe succeeds and yields a usable accessor.
+  auto try_acc = store.TryAccess(READ);
+  ASSERT_NE(try_acc, nullptr);
+  EXPECT_NO_THROW(try_acc->Abort());
+  try_acc.reset();
+
+  // A blocking Access (EngineLockMode::Blocking, the default) also succeeds against the free lock; it is
+  // the path the BEGIN falls back to at the fairness cap and never throws TransactionEngineWouldBlock.
+  auto blocking_acc = store.Access(READ);
+  ASSERT_NE(blocking_acc, nullptr);
+  EXPECT_NO_THROW(blocking_acc->Abort());
+}

--- a/tests/unit/utils_priority_thread_pool.cpp
+++ b/tests/unit/utils_priority_thread_pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -469,6 +469,81 @@ TEST(TaskCollection, LargeTaskSet) {
   // Wait for all tasks to complete
   collection.Wait();
   ASSERT_EQ(counter.load(), num_tasks);
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Verifies the NB-3 admission-gate contract for HasPendingWork():
+//   - productive=false tasks (admission re-posts) never increment productive_pending_,
+//     so they cannot hold the gate open even when queued.
+//   - productive=true tasks (real queries) immediately open the gate on submission.
+TEST(PriorityThreadPool, HasPendingWorkCountsProductiveNotAdmissionReposts) {
+  using namespace memgraph;
+
+  // 4 mixed workers, 1 HP worker.
+  constexpr int kN = 4;
+  utils::PriorityThreadPool pool{kN, 1};
+
+  std::atomic<int> occupied{0};
+  std::atomic<bool> release{false};
+
+  // Occupy all kN mixed workers with non-productive tasks (productive=false) so that
+  // productive_pending_ stays at zero throughout the occupancy phase.
+  // Submit ONE blocking occupier per worker, and wait (with real sleeps so the worker threads get
+  // a timeslice) for it to actually start before submitting the next. Because the already-started
+  // occupiers are blocked on `release`, a fresh occupier can only land on a still-free worker, so
+  // this deterministically fills all kN distinct mixed workers. Bounded so a broken pool fails fast.
+  for (int k = 1; k <= kN; ++k) {
+    pool.ScheduledAddTask(
+        [&](utils::Priority) {
+          occupied.fetch_add(1, std::memory_order_acq_rel);
+          while (!release.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          }
+        },
+        utils::Priority::LOW,
+        /*productive=*/false);
+    for (int waited = 0; occupied.load(std::memory_order_acquire) < k && waited < 5000; ++waited) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(occupied.load(std::memory_order_acquire), k) << "worker " << k << " did not start in time";
+  }
+
+  // All kN workers are now spinning on `release`.  No productive task has ever been
+  // submitted, so productive_pending_ must be zero and the gate must be closed.
+  ASSERT_FALSE(pool.HasPendingWork());
+
+  // Submit an admission re-post (productive=false).  It queues behind a busy worker
+  // but must NOT open the gate — push() skips the counter increment for non-productive
+  // tasks (priority_thread_pool.cpp Worker::push, guarded by `productive` flag).
+  pool.ScheduledAddTask([](utils::Priority) {}, utils::Priority::LOW, /*productive=*/false);
+  ASSERT_FALSE(pool.HasPendingWork());
+
+  // Submit a real productive task (productive=true).  push() increments productive_pending_
+  // before returning, so HasPendingWork() must be true immediately after this call.
+  std::atomic<bool> productive_ran{false};
+  pool.ScheduledAddTask([&](utils::Priority) { productive_ran.store(true, std::memory_order_release); },
+                        utils::Priority::LOW,
+                        /*productive=*/true);
+  ASSERT_TRUE(pool.HasPendingWork());
+
+  // Release all occupiers so the pool can drain.  With release==true, any extra
+  // non-productive occupiers still in queues will also exit immediately when picked up.
+  release.store(true, std::memory_order_release);
+
+  // Wait (bounded) for the productive task to complete.  The pop_task lambda in the
+  // worker decrements productive_pending_ BEFORE calling the task body, so by the
+  // time we observe productive_ran==true via acquire, the decrement is already visible
+  // (sequenced-before + release/acquire pairing).
+  constexpr int kMaxPollIter = 100'000;
+  for (int i = 0; i < kMaxPollIter && !productive_ran.load(std::memory_order_acquire); ++i) {
+    std::this_thread::yield();
+  }
+  ASSERT_TRUE(productive_ran.load(std::memory_order_acquire)) << "productive task never ran within poll bound";
+  // productive_pending_ was decremented at pop (before task body ran), so the gate
+  // must be closed again now that we have the acquire visibility on productive_ran.
+  ASSERT_FALSE(pool.HasPendingWork());
 
   pool.ShutDown();
   pool.AwaitShutdown();


### PR DESCRIPTION
## What & why

Transaction admission (explicit `BEGIN` and autocommit `PREPARE`) bounded-tries `engine_lock_` and, on contention, reschedules onto the pool instead of spinning behind a stalled write commit. That relieves the read-throughput collapse under slow commits — **but only pays off when the freed worker has other work to run**. With nothing to yield to (write-only / low concurrency) it is pure tax (spin the try budget, re-dispatch up to the fairness cap, then block anyway), which showed up as an mgbench **write-throughput regression**.

This PR adds a **load gate**: reschedule only when the pool actually has queued work to yield to; otherwise acquire `Blocking` (exactly master's pre-existing behaviour). Result — write-only is byte-for-byte master (regression gone), read-during-stall keeps the win.

**Supersedes #4669 and #4684** — this is a self-contained reimplementation on current `master` (no dependency on those branches). Please close #4669/#4684 in favour of this.

## Mechanism
- **storage:** `EngineLockMode{Blocking,TryBounded}`, `utils::BoundedTryLock`; `CreateTransaction`/`TryAccess` bounded-try `main_lock_` then `engine_lock_` and bail (`TransactionEngineWouldBlock` → `nullptr` → `WouldBlockInlineException`).
- **query:** `Prepare(ParseRes&, …, try_mode)` with accessor-first reorder so a would-block bail consumes no tx id; `SetupDatabaseTransaction` routes READ/WRITE via `TryAccess` under `TryBounded`.
- **bolt:** `State::PendingBegin` / `PendingPrepare` + pool-side `FinishPending*_` retry with a fairness cap; websocket inline-drain guard.

## The gate (the fix)
`PriorityThreadPool::HasPendingWork()` (OR of the mixed workers' backlog flags — a running admission was dequeued, so it counts only *other* queued work). `SessionHL::AdmissionEngineLockMode()` picks `TryBounded` iff there's work to yield to, else `Blocking`. Applied at `HandleBegin`/`HandlePrepare` and both `FinishPending*_` retries.

## Also fixed (audit)
On **disk storage**, `CreateTransaction` has no non-blocking mint (it asserts `Blocking`, `Database::TryAccess` returns `nullptr`), yet admission routed every READ/WRITE through `TryAccess(TryBounded)` — so on disk under load every query bailed → rescheduled to the cap → blocked. `SetupDatabaseTransaction` now takes the blocking path directly when `GetStorageMode() == ON_DISK_TRANSACTIONAL`.

## Tests
- bolt (`bolt_session`): PendingBegin/PendingPrepare reschedule, fairness cap, pipelined-ordering, and `PendingBeginGatedToBlockWhenPoolIdle` (the gate).
- storage (`storage_v2`): `EngineLock`/`MainLock` bounded-try bail while held + reusable after release, and uncontended first-try success.
- Local (toolchain-v8): `memgraph` clean, `bolt_session` 42/42, `storage_v2` 66/66.

## Perf
Self-contained microbench (real spinlock, 8 workers, 7 reps): write-only returns to **100% of master** (0 reschedules); reads-during-stall keep **+31%…+154%** total useful work while cutting acquire spin-CPU **~90%**. Full-scale mgbench validation on the perf box to follow.
