### PR TITLE
fix: Speed up replication performance

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -229,121 +229,121 @@ jobs:
             $BRANCH_NAME \
             mgbench
 
-      - name: Run and upload load_parquet benchmark
-        id: load-parquet
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            mgbench-load-parquet \
-            load-parquet \
-            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME
+      # - name: Run and upload load_parquet benchmark
+      #   id: load-parquet
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       mgbench-load-parquet \
+      #       load-parquet \
+      #       ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME
 
-      - name: Run and upload mgbench-vector-search-index
-        id: mgbench-vector-search-index
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            mgbench-vector-search-index \
-            vector-search-index \
-            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            mgbench
+      # - name: Run and upload mgbench-vector-search-index
+      #   id: mgbench-vector-search-index
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       mgbench-vector-search-index \
+      #       vector-search-index \
+      #       ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       mgbench
 
-      - name: Run and upload mgbench-vector-search-edge-index
-        id: mgbench-vector-search-edge-index
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            mgbench-vector-search-edge-index \
-            vector-search-edge-index \
-            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            mgbench
+      # - name: Run and upload mgbench-vector-search-edge-index
+      #   id: mgbench-vector-search-edge-index
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       mgbench-vector-search-edge-index \
+      #       vector-search-edge-index \
+      #       ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       mgbench
 
-      - name: Run and upload mgbench-text-search-index
-        id: mgbench-text-search-index
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            mgbench-text-search-index \
-            text-search-index \
-            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            mgbench
+      # - name: Run and upload mgbench-text-search-index
+      #   id: mgbench-text-search-index
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       mgbench-text-search-index \
+      #       text-search-index \
+      #       ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       mgbench
 
-      - name: Run and upload mgbench-text-search-edge-index
-        id: mgbench-text-search-edge-index
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            mgbench-text-search-edge-index \
-            text-search-edge-index \
-            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            mgbench
+      # - name: Run and upload mgbench-text-search-edge-index
+      #   id: mgbench-text-search-edge-index
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       mgbench-text-search-edge-index \
+      #       text-search-edge-index \
+      #       ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       mgbench
 
-      - name: Run and upload macro benchmarks
-        id: macro-benchmark
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            macro-benchmark \
-            macro_benchmark \
-            .harness_summary \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            macro_benchmark
+      # - name: Run and upload macro benchmarks
+      #   id: macro-benchmark
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       macro-benchmark \
+      #       macro_benchmark \
+      #       .harness_summary \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       macro_benchmark
 
-      - name: Run and upload mgbench-supernode
-        id: mgbench-supernode
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            mgbench-supernode \
-            supernode \
-            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            mgbench
+      # - name: Run and upload mgbench-supernode
+      #   id: mgbench-supernode
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       mgbench-supernode \
+      #       supernode \
+      #       ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       mgbench
 
-      - name: Run and upload mgbench
-        id: mgbench
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            mgbench \
-            mgbench \
-            ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            mgbench
+      # - name: Run and upload mgbench
+      #   id: mgbench
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       mgbench \
+      #       mgbench \
+      #       ${{ env.DEFAULT_MGBENCH_EXPORT_RESULTS_FILE }} \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       mgbench
 
-      - name: Run extended planner optimizations mgbench
-        id: planner
-        continue-on-error: true
-        run: |
-          ./tools/ci/loop-benchmark.sh \
-            "mgbench --dataset pokec_planner_optimizations --size medium" \
-            mgbench-planner-optimizations \
-            benchmark_result_extended.json \
-            ${{ github.run_id }} \
-            ${{ github.run_number }} \
-            $BRANCH_NAME \
-            mgbench
+      # - name: Run extended planner optimizations mgbench
+      #   id: planner
+      #   continue-on-error: true
+      #   run: |
+      #     ./tools/ci/loop-benchmark.sh \
+      #       "mgbench --dataset pokec_planner_optimizations --size medium" \
+      #       mgbench-planner-optimizations \
+      #       benchmark_result_extended.json \
+      #       ${{ github.run_id }} \
+      #       ${{ github.run_number }} \
+      #       $BRANCH_NAME \
+      #       mgbench
 
       - name: Stop mgbuild container
         if: always()

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -232,6 +232,7 @@ void LogWrongMain(utils::UUID const &current_main_uuid, const utils::UUID &main_
 }  // namespace
 
 TwoPCCache InMemoryReplicationHandlers::two_pc_cache_;
+rpc::ProgressHeartbeat InMemoryReplicationHandlers::progress_heartbeat_;
 
 void InMemoryReplicationHandlers::Register(
     dbms::DbmsHandler *dbms_handler,
@@ -473,9 +474,11 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
   storage::replication::PrepareCommitRes res{false};
   {
     // Started before the abort below, not after: an interrupted 2PC leaves a transaction whose abort is O(deltas), and
-    // the first tick only fires one interval after construction. Scoped so the heartbeat is joined before the final
-    // response is written, since both write to res_builder and the socket behind it has no internal locking.
-    rpc::ProgressHeartbeat heartbeat{res_builder};
+    // the first tick only fires one interval after activation. The scope guard deactivates the reusable worker if an
+    // exception escapes; normal paths stop it before writing the final response because the socket has no locking.
+    auto &heartbeat = progress_heartbeat_;
+    heartbeat.Start(res_builder);
+    utils::OnScopeExit const stop_heartbeat{[] { progress_heartbeat_.Stop(); }};
 
     // Abort prev txn if needed
     // It could happen that the main instance died before sending finalize for the previous commit and then
@@ -660,14 +663,16 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
   }
 
   // Started before the abort below, not after: an interrupted 2PC leaves a transaction whose abort is O(deltas), and
-  // the first tick only fires one interval after construction. It also covers the Clear() further down, which takes
+  // the first tick only fires one interval after activation. It also covers the Clear() further down, which takes
   // long enough on a large tenant to exhaust the peer's budget on its own.
-  rpc::ProgressHeartbeat heartbeat{res_builder};
+  auto &heartbeat = progress_heartbeat_;
+  heartbeat.Start(res_builder);
+  utils::OnScopeExit const stop_heartbeat{[] { progress_heartbeat_.Stop(); }};
   // Progress only, never cancellation: if the peer goes away mid-recovery this must not abort. Unlike delta
   // application, whose work sits in a transaction that can no longer be reported as committed and will simply be
   // resent, the snapshot is already loaded here. Finishing the derived state advances the commit timestamp, so a
   // reconnecting main may only need WAL deltas from that point instead of resending the whole snapshot.
-  auto const record_progress = [&heartbeat] { heartbeat.RecordProgress(); };
+  auto const record_progress = [] { progress_heartbeat_.RecordProgress(); };
 
   AbortPrevTxnIfNeeded(storage, &heartbeat);
 
@@ -871,9 +876,11 @@ void InMemoryReplicationHandlers::WalFilesHandler(
   auto *storage = static_cast<storage::InMemoryStorage *>(db_acc->get()->storage());
 
   // Started before the abort below, not after: an interrupted 2PC leaves a transaction whose abort is
-  // O(deltas), and the first tick only fires one interval after construction.
-  rpc::ProgressHeartbeat heartbeat{res_builder};
-  auto const record_progress = [&heartbeat] { heartbeat.RecordProgress(); };
+  // O(deltas), and the first tick only fires one interval after activation.
+  auto &heartbeat = progress_heartbeat_;
+  heartbeat.Start(res_builder);
+  utils::OnScopeExit const stop_heartbeat{[] { progress_heartbeat_.Stop(); }};
+  auto const record_progress = [] { progress_heartbeat_.RecordProgress(); };
 
   AbortPrevTxnIfNeeded(storage, &heartbeat);
 
@@ -1033,9 +1040,11 @@ void InMemoryReplicationHandlers::CurrentWalHandler(
   auto *storage = static_cast<storage::InMemoryStorage *>(db_acc->get()->storage());
 
   // Started before the abort below, not after: an interrupted 2PC leaves a transaction whose abort is
-  // O(deltas), and the first tick only fires one interval after construction.
-  rpc::ProgressHeartbeat heartbeat{res_builder};
-  auto const record_progress = [&heartbeat] { heartbeat.RecordProgress(); };
+  // O(deltas), and the first tick only fires one interval after activation.
+  auto &heartbeat = progress_heartbeat_;
+  heartbeat.Start(res_builder);
+  utils::OnScopeExit const stop_heartbeat{[] { progress_heartbeat_.Stop(); }};
+  auto const record_progress = [] { progress_heartbeat_.RecordProgress(); };
 
   AbortPrevTxnIfNeeded(storage, &heartbeat);
 

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -113,6 +113,9 @@ class InMemoryReplicationHandlers {
       rpc::ProgressHeartbeat &heartbeat, bool two_phase_commit, bool loading_wal);
 
   static TwoPCCache two_pc_cache_;
+  // Replica data/recovery RPCs are serialized, so one persistent worker can serve every handler without creating and
+  // joining a thread for each request.
+  static rpc::ProgressHeartbeat progress_heartbeat_;
 };
 
 }  // namespace memgraph::dbms

--- a/src/rpc/progress_heartbeat.cpp
+++ b/src/rpc/progress_heartbeat.cpp
@@ -15,27 +15,58 @@
 #include "rpc/utils.hpp"
 
 #include <spdlog/spdlog.h>
+#include <stdexcept>
 
 namespace memgraph::rpc {
 
+ProgressHeartbeat::ProgressHeartbeat() = default;
+
 ProgressHeartbeat::ProgressHeartbeat(slk::Builder *res_builder, std::chrono::milliseconds const interval)
-    : res_builder_{res_builder} {
-  worker_ = std::jthread{[this, interval](std::stop_token token) { Run(std::move(token), interval); }};
+    : ProgressHeartbeat() {
+  Start(res_builder, interval);
 }
 
-ProgressHeartbeat::~ProgressHeartbeat() { Stop(); }
-
-void ProgressHeartbeat::Stop() noexcept {
-  if (!worker_.joinable()) return;
+ProgressHeartbeat::~ProgressHeartbeat() {
   worker_.request_stop();
   cv_.notify_all();
-  worker_.join();
+  if (worker_.joinable()) worker_.join();
 }
 
-void ProgressHeartbeat::Run(std::stop_token token, std::chrono::milliseconds const interval) {
+void ProgressHeartbeat::Start(slk::Builder *res_builder, std::chrono::milliseconds const interval) {
+  auto lock = std::lock_guard{mtx_};
+  if (active_) throw std::logic_error("ProgressHeartbeat is already active");
+  if (!worker_.joinable()) {
+    worker_ = std::jthread{[this](std::stop_token token) { Run(std::move(token)); }};
+  }
+
+  res_builder_ = res_builder;
+  interval_ = interval;
+  work_done_.store(false, std::memory_order_relaxed);
+  peer_gone_.store(false, std::memory_order_relaxed);
+  active_ = true;
+  cv_.notify_all();
+}
+
+void ProgressHeartbeat::Stop() noexcept {
+  auto lock = std::lock_guard{mtx_};
+  if (!active_) return;
+
+  active_ = false;
+  res_builder_ = nullptr;
+  work_done_.store(false, std::memory_order_relaxed);
+  cv_.notify_all();
+}
+
+void ProgressHeartbeat::Run(std::stop_token token) {
   auto lock = std::unique_lock{mtx_};
-  // wait_for returns the predicate's value: true means a stop was requested, false means the interval elapsed.
-  while (!cv_.wait_for(lock, token, interval, [&token] { return token.stop_requested(); })) {
+  while (!token.stop_requested()) {
+    cv_.wait(lock, token, [this] { return active_; });
+    if (token.stop_requested()) return;
+
+    auto const interval = interval_;
+    // A notification caused by Stop() or a subsequent Start() resets the interval for the active RPC.
+    if (cv_.wait_for(lock, token, interval, [this] { return !active_; })) continue;
+
     // Clearing as we read means the next tick only fires if the handler recorded something new in between. No new
     // work therefore means silence, which is what lets the peer's timeout still catch a wedged handler.
     if (!work_done_.exchange(false, std::memory_order_relaxed)) continue;
@@ -44,10 +75,11 @@ void ProgressHeartbeat::Run(std::stop_token token, std::chrono::milliseconds con
       SendInProgressMsg(res_builder_);
     } catch (SessionException const &e) {
       // Peer is gone, so there is nothing left to keep alive. Latch it so in-flight work can abandon early instead of
-      // finishing a job whose result can no longer be delivered.
+      // finishing a job whose result can no longer be delivered. Leave the worker idle for reuse by the next RPC.
       peer_gone_.store(true, std::memory_order_relaxed);
+      active_ = false;
+      res_builder_ = nullptr;
       spdlog::trace("Progress heartbeat stopped, peer connection is broken: {}", e.what());
-      return;
     } catch (std::exception const &e) {
       // Heartbeats are advisory: a failed send must never abort the work it is reporting on. The builder resets its
       // write position even when the flush throws (see slk::Builder::FlushInternal), so the next tick starts clean.

--- a/src/rpc/progress_heartbeat.hpp
+++ b/src/rpc/progress_heartbeat.hpp
@@ -32,12 +32,16 @@ namespace memgraph::rpc {
 //
 // This thread is the only writer of InProgressRes for its builder. The socket write behind slk::Builder is
 // unsynchronized, so a handler writing its final response at the same time would interleave segments on the wire.
-// Stop() must therefore run before the final response is written; the destructor calls it as a backstop.
+// Stop() must therefore run before the final response is written.
+//
+// The default-constructed form lazily starts an idle worker which can be reused across sequential RPCs with
+// Start()/Stop(). The builder constructor remains as a convenience for one-shot users.
 class ProgressHeartbeat {
  public:
   // min timeout of PrepareCommit,WalFiles,CurrentWal,SnapshotReq - 5s (buffer for network)
   static constexpr std::chrono::milliseconds kDefaultInterval{25000};
 
+  ProgressHeartbeat();
   explicit ProgressHeartbeat(slk::Builder *res_builder, std::chrono::milliseconds interval = kDefaultInterval);
   ~ProgressHeartbeat();
 
@@ -45,6 +49,9 @@ class ProgressHeartbeat {
   ProgressHeartbeat &operator=(ProgressHeartbeat const &) = delete;
   ProgressHeartbeat(ProgressHeartbeat &&) = delete;
   ProgressHeartbeat &operator=(ProgressHeartbeat &&) = delete;
+
+  // Activates the idle worker for a new RPC. Start() may only be called after the preceding RPC called Stop().
+  void Start(slk::Builder *res_builder, std::chrono::milliseconds interval = kDefaultInterval);
 
   // Records that the handler made progress. Sits on per-item paths (every delta, every vertex visited while
   // populating an index or validating a constraint.
@@ -54,13 +61,16 @@ class ProgressHeartbeat {
   // a job whose result can no longer be delivered.
   bool PeerGone() const noexcept { return peer_gone_.load(std::memory_order_relaxed); }
 
-  // Joins the heartbeat thread. Idempotent. Must run before the handler writes its final response.
+  // Makes the worker idle. Idempotent and synchronous with an in-flight heartbeat write. Must run before the handler
+  // writes its final response. The worker thread itself stays alive for the next Start().
   void Stop() noexcept;
 
  private:
-  void Run(std::stop_token token, std::chrono::milliseconds interval);
+  void Run(std::stop_token token);
 
-  slk::Builder *res_builder_;
+  slk::Builder *res_builder_{nullptr};
+  std::chrono::milliseconds interval_{kDefaultInterval};
+  bool active_{false};
 
   // Separate cache lines: the heartbeat thread clears work_done_ once per tick while population threads read
   // peer_gone_ on a per-item path, so sharing a line would let each tick invalidate the cancel check.
@@ -69,7 +79,7 @@ class ProgressHeartbeat {
 
   std::mutex mtx_;
   std::condition_variable_any cv_;
-  // Declared last so it starts only after every member it touches is initialised, and is joined first on destruction.
+  // Declared last so a lazily started worker only observes fully initialised members.
   std::jthread worker_;
 };
 

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -64,7 +64,10 @@ struct PrepareCommitReq {
 
   static void Load(PrepareCommitReq *self, slk::Reader *reader);
   static void Save(const PrepareCommitReq &self, slk::Builder *builder);
-  PrepareCommitReq() = default;
+
+  // RPC requests are default-constructed immediately before deserialization. Use nil placeholders rather than
+  // generating two random UUIDs that Load() overwrites.
+  PrepareCommitReq() : main_uuid{utils::UUID::Nil()}, storage_uuid{utils::UUID::Nil()} {}
 
   PrepareCommitReq(const utils::UUID &main_uuid_arg, const utils::UUID &storage_uuid_arg,
                    uint64_t const previous_commit_timestamp_arg, bool const two_phase_commit_arg,

--- a/src/utils/scheduler.cpp
+++ b/src/utils/scheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,6 +11,7 @@
 
 #include "utils/scheduler.hpp"
 
+#include <charconv>
 #include <ctime>
 
 #include "croncpp.h"
@@ -99,32 +100,26 @@ void Scheduler::SetInterval_(std::string_view cron_expr) {
 SchedulerInterval::SchedulerInterval(std::string str) {
   str = utils::Trim(str);
   if (str.empty()) return;  // Default period_or_cron -> evaluates to false
-  bool failure = false;
+
+  // A plain number is a period in seconds. Checked first and without exceptions: this runs for every
+  // scheduler on startup, and probing the cron parser with a period would throw as control flow.
+  auto const *begin = str.data() + (str.front() == '+' ? 1 : 0);
+  auto const *end = str.data() + str.size();
+  if (int64_t seconds{0};
+      begin != end && std::from_chars(begin, end, seconds) == std::from_chars_result{end, std::errc{}}) {
+    period_or_cron = PeriodStartTime{std::chrono::seconds(seconds), std::nullopt};
+    return;
+  }
+
 #ifdef MG_ENTERPRISE
-  // Try cron
   try {
     (void)cron::make_cron(str);
     period_or_cron = str;
     return;
   } catch (cron::bad_cronexpr & /* unused */) {
-    // Handled later on
-    failure = true;
+    // Not a cron expression either; fatal below.
   }
 #endif
-  try {
-    // Try period
-    size_t n_processed = 0;
-    const auto period = std::chrono::seconds(std::stol(str, &n_processed));
-    if (n_processed != str.size()) {
-      throw std::invalid_argument{"String contains non numerical characteres."};
-    }
-    period_or_cron = PeriodStartTime{period, std::nullopt};
-    return;
-  } catch (const std::invalid_argument & /* unused */) {
-    // Handled later on
-    failure = true;
-  }
-  MG_ASSERT(failure, "Failure not handled correctly.");
   LOG_FATAL("Scheduler setup not an interval or cron expression");
 }
 

--- a/src/utils/uuid.hpp
+++ b/src/utils/uuid.hpp
@@ -45,6 +45,10 @@ struct UUID {
 
   UUID() { uuid_generate(uuid.data()); }
 
+  // Returns the nil UUID without consulting the system random-number generator. This is useful for values that are
+  // about to be populated by deserialization.
+  static UUID Nil() { return UUID{arr_t{}}; }
+
   explicit operator std::string() const {
     // Note not using UUID_STR_LEN so we can build with older libuuid
     auto decoded = std::array<char, 37 /*UUID_STR_LEN*/>{};

--- a/tests/unit/rpc_progress_heartbeat.cpp
+++ b/tests/unit/rpc_progress_heartbeat.cpp
@@ -253,11 +253,14 @@ TEST(ProgressHeartbeatTest, StopIsIdempotentAndSafeWithoutProgress) {
     SumReq req;
     memgraph::rpc::LoadWithUpgrade(req, request_version, req_reader);
 
-    ProgressHeartbeat heartbeat{res_builder, kHeartbeatInterval};
+    ProgressHeartbeat heartbeat;
+    heartbeat.Start(res_builder, kHeartbeatInterval);
     heartbeat.Stop();
     heartbeat.Stop();
-    // Recording after the heartbeat stopped must not resurrect it or write anything.
+    // Recording after the heartbeat stopped must not resurrect it or leak progress into the next activation.
     heartbeat.RecordProgress();
+    heartbeat.Start(res_builder, kHeartbeatInterval);
+    std::this_thread::sleep_for(2 * kHeartbeatInterval);
     heartbeat.Stop();
 
     SumRes const res{5};


### PR DESCRIPTION
Reduces replication costs by:
- using a single per-process ProgressHeartbeat
- no UUID generation when creating a response
- avoiding throwing in the scheduler when parsing the argument
