### PR TITLE
perf: skip an adjacency list path.expand_config cannot use

### DIFF
--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -438,6 +438,18 @@ const Path::RelStep &Path::PathHelper::RelStepAt(const int64_t depth) const {
   return config_.rel_steps[position % static_cast<int64_t>(config_.rel_steps.size())];
 }
 
+// The direction test of RelationshipAdmitted, hoisted out of the per-relationship loop: it depends on
+// the step alone, so a step that admits nothing this way rules out the whole adjacency list at once.
+bool Path::PathHelper::StepAdmitsDirection(const int64_t depth, const bool outgoing) const {
+  const RelStep &step = RelStepAt(depth);
+  if (outgoing ? step.any_outgoing : step.any_incoming) {
+    return true;
+  }
+  const RelDirection wanted = outgoing ? RelDirection::kOutgoing : RelDirection::kIncoming;
+  return std::ranges::any_of(
+      step.types, [wanted](const auto &entry) { return entry.second == RelDirection::kAny || entry.second == wanted; });
+}
+
 bool Path::PathHelper::RelationshipAdmitted(std::string_view rel_type, const bool outgoing, const int64_t depth) const {
   const RelStep &step = RelStepAt(depth);
   const bool any_directed = outgoing ? step.any_outgoing : step.any_incoming;
@@ -938,8 +950,14 @@ void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size) {
     return;
   }
 
-  this->ExpandFromRelationships(path, node.InRelationships(), false, path_size);
-  this->ExpandFromRelationships(path, node.OutRelationships(), true, path_size);
+  // Reading an adjacency list costs a storage round trip and a copy of every relationship in it, all of
+  // which a directed step then rejects. Ask the step first.
+  if (path_data_.helper_.StepAdmitsDirection(path_size, false)) {
+    this->ExpandFromRelationships(path, node.InRelationships(), false, path_size);
+  }
+  if (path_data_.helper_.StepAdmitsDirection(path_size, true)) {
+    this->ExpandFromRelationships(path, node.OutRelationships(), true, path_size);
+  }
 }
 
 void Path::PathExpand::StartAlgorithm(const mgp::Node &node) {

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -197,6 +197,8 @@ class PathHelper {
 
   // Whether a relationship of this type, traversed this way out of a node at `depth`, may be followed.
   [[nodiscard]] bool RelationshipAdmitted(std::string_view rel_type, bool outgoing, int64_t depth) const;
+  // Whether the step for this depth admits anything at all in this direction.
+  [[nodiscard]] bool StepAdmitsDirection(int64_t depth, bool outgoing) const;
 
   [[nodiscard]] static LabelBools GetLabelBools(const mgp::Node &node, const LabelStep &step);
 

--- a/tests/mage/e2e/path_test/test_expand_config_mixed_direction_step/input.cyp
+++ b/tests/mage/e2e/path_test/test_expand_config_mixed_direction_step/input.cyp
@@ -1,0 +1,1 @@
+CREATE (a:Node {name:'A'}), (b:Node {name:'B'}), (c:Node {name:'C'}) CREATE (a)-[:R]->(b), (c)-[:OTHER]->(a);

--- a/tests/mage/e2e/path_test/test_expand_config_mixed_direction_step/test.yml
+++ b/tests/mage/e2e/path_test/test_expand_config_mixed_direction_step/test.yml
@@ -1,0 +1,13 @@
+# One step naming an outgoing type and an incoming one admits both directions, so the walk leaves A
+# along R and arrives at A along OTHER. Neither adjacency list may be skipped for naming the step's
+# other direction.
+query: >
+  MATCH (a:Node {name: "A"})
+  CALL path.expand_config(a, {relationshipFilter: 'R>|<OTHER', minHops: 1, maxHops: 1})
+  YIELD result
+  WITH result ORDER BY [n IN nodes(result) | n.name]
+  RETURN [n IN nodes(result) | n.name] AS names;
+
+output:
+  - names: ["A", "B"]
+  - names: ["A", "C"]


### PR DESCRIPTION
> Merges into **`perf/path-expand-config`** (#4727), not into master. #4727 is what reaches master, as one commit.
Stops `path.expand_config` reading a node's incoming (or outgoing) relationships when the relationship step for that depth cannot admit anything in that direction.

**How.** `RelationshipAdmitted` already tested direction, but once per relationship, after the whole adjacency list had been read and each relationship copied out of storage. The direction test depends only on the step, so `PathHelper::StepAdmitsDirection` hoists it out of the loop and `DFS` asks it before requesting the list.

**Why.** With a direction-marked filter such as `'a>,b,c>'`, two of the three steps reject one whole direction. The walk was paying a storage round trip and a relationship copy per candidate to learn that. On a 4425-node topology this is 17.6s to 13.1s with unchanged results.

First of five stacked PRs against `path.expand_config`; the rest build on this branch.