### PR TITLE
perf: test the relationship type before the uniqueness key in path.expand_config

### DIFF
--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -900,12 +900,15 @@ void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp::Relationshi
     // supernode's whole adjacency list is uninterruptible.
     path_data_.MaybeAbort();
 
-    const int64_t uniqueness_key = UniquenessKey(relationship, outgoing);
-    if (path_data_.visited_.contains(uniqueness_key)) {
+    // Under a node-keyed rule the uniqueness key is the node the relationship reaches, and reading its
+    // id means materialising it. The type test needs only a name the relationship already carries, so
+    // it goes first and keeps that construction off every relationship the filter rejects.
+    if (!path_data_.helper_.RelationshipAdmitted(relationship.Type(), outgoing, path_size)) {
       continue;
     }
 
-    if (path_data_.helper_.RelationshipAdmitted(relationship.Type(), outgoing, path_size)) {
+    const int64_t uniqueness_key = UniquenessKey(relationship, outgoing);
+    if (!path_data_.visited_.contains(uniqueness_key)) {
       ExpandPath(path, relationship, path_size, uniqueness_key);
     }
   }


### PR DESCRIPTION
> **Review view — do not merge this on its own.** These commits land through **#4727**, which carries all six. This PR exists so this one change can be reviewed and discussed separately.

Reorders the two tests `path.expand_config` applies to a candidate relationship, so the cheap one runs first.

**How.** Under a node-keyed uniqueness rule the uniqueness key is the id of the node the relationship reaches, and reading it means materialising that node — a vertex copied out of storage for every candidate, including the ones the type filter is about to reject. The type test needs only a name the relationship already carries, so it now runs first and the node is built only where the walk will actually go.

**Why.** Pure reordering — both tests must pass for the walk to expand, so the set of expanded relationships is unchanged. Worth ~4% on a 4425-node topology.

Stacked on #4719.