### PR TITLE
refactor: build the node a relationship reaches once in path.expand_config

### DIFF
--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -871,18 +871,11 @@ void Path::Create(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result,
   }
 }
 
-int64_t Path::PathExpand::UniquenessKey(const mgp::Relationship &relationship, const bool outgoing) const {
-  if (IsNodeUniqueness(path_data_.helper_.GetUniqueness())) {
-    return (outgoing ? relationship.To() : relationship.From()).Id().AsInt();
-  }
-  return relationship.Id().AsInt();
-}
-
 void Path::PathExpand::ExpandPath(mgp::Path &path, const mgp::Relationship &relationship, int64_t path_size,
-                                  const int64_t uniqueness_key) {
+                                  const int64_t uniqueness_key, const mgp::Node &next_node) {
   path.Expand(relationship);
   path_data_.visited_.insert(uniqueness_key);
-  DFS(path, path_size + 1);
+  DFS(path, path_size + 1, next_node);
   // A path-scoped rule releases the mark on the way back out; a global one holds it for the whole walk.
   if (!path_data_.helper_.GlobalUniqueness()) {
     path_data_.visited_.erase(uniqueness_key);
@@ -907,9 +900,13 @@ void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp::Relationshi
       continue;
     }
 
-    const int64_t uniqueness_key = UniquenessKey(relationship, outgoing);
+    // The walk needs this node twice over -- to key uniqueness on, and to filter once the path reaches
+    // it -- and building it copies a vertex out of storage. Build it once and hand it down.
+    const mgp::Node next_node = outgoing ? relationship.To() : relationship.From();
+    const int64_t uniqueness_key =
+        IsNodeUniqueness(path_data_.helper_.GetUniqueness()) ? next_node.Id().AsInt() : relationship.Id().AsInt();
     if (!path_data_.visited_.contains(uniqueness_key)) {
-      ExpandPath(path, relationship, path_size, uniqueness_key);
+      ExpandPath(path, relationship, path_size, uniqueness_key, next_node);
     }
   }
 }
@@ -921,7 +918,7 @@ void Path::PathExpand::Emit(const mgp::Path &path) {
 }
 
 /*function used for traversal and filtering*/
-void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size) {
+void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size, const mgp::Node &node) {
   if (path_data_.LimitReached()) {
     return;
   }
@@ -934,8 +931,6 @@ void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size) {
     throw mgp::ValueException("Path expansion exceeded the maximum depth of " + std::to_string(kMaxExpandDepth) +
                               "; lower the upper hop bound to bound the traversal.");
   }
-
-  const mgp::Node node{path.GetNodeAt(path_size)};
 
   // Counts whether or not the filters keep it: this tells the driver a deeper pass has somewhere to go.
   deepest_reached_ = std::max(deepest_reached_, path_size);
@@ -970,7 +965,7 @@ void Path::PathExpand::StartAlgorithm(const mgp::Node &node) {
   if (mark_start) {
     path_data_.visited_.insert(node.Id().AsInt());
   }
-  DFS(path, 0);
+  DFS(path, 0, node);
   if (mark_start && !path_data_.helper_.GlobalUniqueness()) {
     path_data_.visited_.erase(node.Id().AsInt());
   }

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -301,13 +301,14 @@ class PathExpand {
   explicit PathExpand(PathData &&path_data) : path_data_(std::move(path_data)) {}
 
   // The id the uniqueness rule keys on when crossing `relationship`.
-  [[nodiscard]] int64_t UniquenessKey(const mgp::Relationship &relationship, bool outgoing) const;
 
-  void ExpandPath(mgp::Path &path, const mgp::Relationship &relationship, int64_t path_size, int64_t uniqueness_key);
+  void ExpandPath(mgp::Path &path, const mgp::Relationship &relationship, int64_t path_size, int64_t uniqueness_key,
+                  const mgp::Node &next_node);
   void ExpandFromRelationships(mgp::Path &path, mgp::Relationships relationships, bool outgoing, int64_t path_size);
   void StartAlgorithm(const mgp::Node &node);
   void Parse(const mgp::Value &value);
-  void DFS(mgp::Path &path, int64_t path_size);
+  // Takes the node the path now ends at: the caller has just built it to key uniqueness on.
+  void DFS(mgp::Path &path, int64_t path_size, const mgp::Node &node);
   void RunAlgorithm();
 
  private:


### PR DESCRIPTION
> **Review view — do not merge this on its own.** These commits land through **#4727**, which carries all six. This PR exists so this one change can be reviewed and discussed separately.

Removes a duplicated vertex copy in the `path.expand_config` walk.

**How.** The node a relationship reaches was built twice: once to read its id for the uniqueness key, then again from the path once the walk had stepped onto it. Both copy a vertex out of storage. It is now built in the one place that already holds the relationship and handed down to `DFS`, which retires `UniquenessKey`.

**Why.** No measurable time change on a 4425-node topology — the reordering in the parent PR already keeps this off the rejected relationships, so what remains is one copy per expanded relationship. Committed for the redundancy and the smaller surface, not for a number.

Stacked on #4720.