### PR TITLE
perf: keep the label verdict for a node and step in path.expand_config

### DIFF
--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -424,10 +424,31 @@ void Path::PathHelper::ParseNodeFilters(const mgp::Map &config, const mgp::Graph
 }
 
 // Cyclic, so the sequence repeats for as long as the walk goes on.
-const Path::LabelStep &Path::PathHelper::LabelStepAt(const int64_t depth) const {
+int64_t Path::PathHelper::LabelStepIndexAt(const int64_t depth) const {
   const int64_t position = config_.begin_sequence_at_start ? depth : depth - 1;
   // Depth 0 with the sequence starting one node out never reaches here: EvaluateLabels bypasses it.
-  return config_.label_steps[position % static_cast<int64_t>(config_.label_steps.size())];
+  return position % static_cast<int64_t>(config_.label_steps.size());
+}
+
+const Path::LabelStep &Path::PathHelper::LabelStepAt(const int64_t depth) const {
+  return config_.label_steps[LabelStepIndexAt(depth)];
+}
+
+Path::LabelBools Path::PathHelper::CachedLabelBools(const mgp::Node &node, const int64_t depth) const {
+  const int64_t step_index = LabelStepIndexAt(depth);
+  // A graph-wide rule reaches each node once, so a cache would only ever be written to.
+  if (GlobalUniqueness()) {
+    return GetLabelBools(node, config_.label_steps[step_index]);
+  }
+  if (label_bools_cache_.size() != config_.label_steps.size()) {
+    label_bools_cache_.resize(config_.label_steps.size());
+  }
+  auto &cache = label_bools_cache_[static_cast<size_t>(step_index)];
+  const int64_t id = node.Id().AsInt();
+  if (const auto it = cache.find(id); it != cache.end()) {
+    return it->second;
+  }
+  return cache.emplace(id, GetLabelBools(node, config_.label_steps[step_index])).first->second;
 }
 
 const Path::RelStep &Path::PathHelper::RelStepAt(const int64_t depth) const {
@@ -486,7 +507,7 @@ Path::Evaluation Path::PathHelper::EvaluateLabels(const mgp::Node &node, const i
   }
 
   const LabelStep &step = LabelStepAt(depth);
-  const LabelBools label_bools = GetLabelBools(node, step);
+  const LabelBools label_bools = CachedLabelBools(node, depth);
   // Below the lower bound a node cannot be returned, but the walk still passes through it -- including
   // through a terminator, which ends the walk only once it could be returned.
   const bool below_min_hops = depth < config_.min_hops;

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -201,6 +201,9 @@ class PathHelper {
   [[nodiscard]] bool StepAdmitsDirection(int64_t depth, bool outgoing) const;
 
   [[nodiscard]] static LabelBools GetLabelBools(const mgp::Node &node, const LabelStep &step);
+  // Same answer for the same node and step, and a path-scoped walk re-enters a node once per path
+  // that reaches it, so the verdict is kept rather than re-read from storage.
+  [[nodiscard]] LabelBools CachedLabelBools(const mgp::Node &node, int64_t depth) const;
 
   // Whether to return the node, and whether to walk on through it.
   [[nodiscard]] Evaluation Evaluate(const mgp::Node &node, int64_t depth) const;
@@ -248,6 +251,9 @@ class PathHelper {
 
   // The step a node at `depth`, or a relationship out of a node at `depth`, is tested against.
   [[nodiscard]] const LabelStep &LabelStepAt(int64_t depth) const;
+  [[nodiscard]] int64_t LabelStepIndexAt(int64_t depth) const;
+  // One map per label step; empty under a graph-wide uniqueness rule, which visits a node once.
+  mutable std::vector<std::unordered_map<int64_t, LabelBools>> label_bools_cache_;
   [[nodiscard]] const RelStep &RelStepAt(int64_t depth) const;
 
   [[nodiscard]] bool EndNodesOnly() const { return config_.end_nodes_only; }

--- a/tests/mage/e2e/path_test/test_expand_config_label_step_per_depth/input.cyp
+++ b/tests/mage/e2e/path_test/test_expand_config_label_step_per_depth/input.cyp
@@ -1,0 +1,1 @@
+CREATE (s:Node {name:'S'}), (m:Node:B {name:'M'}), (x:Node:B {name:'X'}) CREATE (s)-[:R]->(x), (s)-[:R]->(m), (m)-[:R]->(x);

--- a/tests/mage/e2e/path_test/test_expand_config_label_step_per_depth/test.yml
+++ b/tests/mage/e2e/path_test/test_expand_config_label_step_per_depth/test.yml
@@ -1,0 +1,13 @@
+# The label sequence repeats, so X is judged against 'B' when the walk reaches it at depth 1 and
+# against 'A' when it reaches it at depth 2 -- allowed the first way, pruned the second. A verdict
+# remembered for X alone, without the step it was reached at, would wrongly return S-M-X too.
+query: >
+  MATCH (s:Node {name: "S"})
+  CALL path.expand_config(s, {labelFilter: 'A,B', minHops: 1, maxHops: 2})
+  YIELD result
+  WITH result ORDER BY [n IN nodes(result) | n.name]
+  RETURN [n IN nodes(result) | n.name] AS names;
+
+output:
+  - names: ["S", "M"]
+  - names: ["S", "X"]


### PR DESCRIPTION
> **Review view — do not merge this on its own.** These commits land through **#4727**, which carries all six. This PR exists so this one change can be reviewed and discussed separately.

Caches the label-filter verdict per (label step, node) for the duration of one `path.expand_config` call.

**How.** Reading a node's labels copies the vertex out of storage and then re-reads the label list once per label. A path-scoped uniqueness rule re-enters the same node once for every path that reaches it, and the verdict is identical every time, so the walk was re-deriving one of a few thousand answers millions of times. `PathHelper::CachedLabelBools` keeps it.

Keyed on the step as well as the node, because the label sequence repeats and the same node gets a different verdict at different depths — a new e2e test (`test_expand_config_label_step_per_depth`) pins that, and fails if the step is dropped from the key. Skipped entirely under a graph-wide uniqueness rule, which reaches each node once and would only ever write to the cache.

**Why.** 12.5s to 8.3s on a 4425-node topology, unchanged results. Costs memory bounded by (label steps x nodes visited).

Stacked on #4721.