### PR TITLE
perf: walk breadth-first once under a path-scoped rule in path.expand_config

### DIFF
--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -568,10 +568,6 @@ Path::Evaluation Path::PathHelper::Evaluate(const mgp::Node &node, const int64_t
 }
 
 bool Path::PathHelper::PathSizeOk(const int64_t path_size) const {
-  // Each pass emits its own depth only, so the passes partition the results.
-  if (config_.pass_depth >= 0 && path_size != config_.pass_depth) {
-    return false;
-  }
   return (path_size <= config_.max_hops) && (path_size >= config_.min_hops);
 }
 
@@ -953,9 +949,6 @@ void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size, const mgp::Node &
                               "; lower the upper hop bound to bound the traversal.");
   }
 
-  // Counts whether or not the filters keep it: this tells the driver a deeper pass has somewhere to go.
-  deepest_reached_ = std::max(deepest_reached_, path_size);
-
   const Evaluation evaluation = path_data_.helper_.Evaluate(node, path_size);
 
   if (evaluation.include && path_data_.helper_.PathSizeOk(path_size)) {
@@ -1120,37 +1113,123 @@ void Path::PathExpand::RunNodeGlobalBfs() {
   }
 }
 
-// Breadth-first emits every path of one length before any longer one, which is what makes a `limit`
-// return the shortest paths. It is driven by re-walking once per depth, so the traversal, the filters
-// and the uniqueness rule stay the ones the depth-first walk uses. A queue of partial paths would
-// instead hold the whole frontier, which here is as large as the result set it is about to build --
-// except under the node-global rule, which bounds it by the graph and gets its own walk.
-void Path::PathExpand::RunAlgorithm() {
-  if (path_data_.helper_.GlobalUniqueness() && path_data_.helper_.Bfs()) {
-    RunNodeGlobalBfs();
-    return;
+bool Path::PathExpand::OnBranch(const int64_t index, const int64_t key) const {
+  const bool node_keyed = IsNodeUniqueness(path_data_.helper_.GetUniqueness());
+  for (int64_t i = index; i != kNoParent; i = branches_[i].parent) {
+    const int64_t seen = node_keyed ? branches_[i].node_id : branches_[i].relationship_id;
+    if (seen == key) {
+      return true;
+    }
+  }
+  return false;
+}
+
+mgp::Path Path::PathExpand::BranchPath(const int64_t index) const {
+  std::vector<int64_t> chain;
+  for (int64_t i = index; i != kNoParent; i = branches_[i].parent) {
+    chain.push_back(i);
+  }
+  std::ranges::reverse(chain);
+
+  mgp::Path path{path_data_.graph_.GetNodeById(mgp::Id::FromInt(branches_[chain.front()].node_id))};
+  for (size_t step = 1; step < chain.size(); ++step) {
+    path.Expand(*branches_[chain[step]].from_parent);
+  }
+  return path;
+}
+
+void Path::PathExpand::ExpandBranch(const int64_t index, const mgp::Node & /*node*/, mgp::Relationships relationships,
+                                    const bool outgoing, std::queue<std::pair<int64_t, mgp::Node>> &frontier) {
+  // Read before the loop: pushing a branch can reallocate the vector out from under a reference.
+  const int64_t depth = branches_[index].depth;
+  const bool node_keyed = IsNodeUniqueness(path_data_.helper_.GetUniqueness());
+
+  for (const auto relationship : relationships) {
+    if (path_data_.LimitReached()) {
+      return;
+    }
+    path_data_.MaybeAbort();
+
+    if (!path_data_.helper_.RelationshipAdmitted(relationship.Type(), outgoing, depth)) {
+      continue;
+    }
+
+    mgp::Node next_node = outgoing ? relationship.To() : relationship.From();
+    const int64_t key = node_keyed ? next_node.Id().AsInt() : relationship.Id().AsInt();
+    if (OnBranch(index, key)) {
+      continue;
+    }
+
+    branches_.push_back({.node_id = next_node.Id().AsInt(),
+                         .relationship_id = relationship.Id().AsInt(),
+                         .parent = index,
+                         .depth = depth + 1,
+                         .from_parent = relationship});
+    frontier.emplace(static_cast<int64_t>(branches_.size()) - 1, std::move(next_node));
+  }
+}
+
+void Path::PathExpand::RunPathScopedBfs() {
+  std::queue<std::pair<int64_t, mgp::Node>> frontier;
+  for (const auto &node : path_data_.start_nodes_) {
+    if (path_data_.LimitReached()) {
+      return;
+    }
+    path_data_.MaybeAbort();
+    branches_.push_back({.node_id = node.Id().AsInt(),
+                         .relationship_id = kNoRelationship,
+                         .parent = kNoParent,
+                         .depth = 0,
+                         .from_parent = std::nullopt});
+    frontier.emplace(static_cast<int64_t>(branches_.size()) - 1, node);
   }
 
+  while (!frontier.empty()) {
+    if (path_data_.LimitReached()) {
+      return;
+    }
+    path_data_.MaybeAbort();
+
+    auto entry = std::move(frontier.front());
+    frontier.pop();
+    const int64_t index = entry.first;
+    const mgp::Node &node = entry.second;
+    const int64_t depth = branches_[index].depth;
+
+    const Evaluation evaluation = path_data_.helper_.Evaluate(node, depth);
+    if (evaluation.include && path_data_.helper_.PathSizeOk(depth)) {
+      Emit(BranchPath(index));
+      if (path_data_.LimitReached()) {
+        return;
+      }
+    }
+
+    if (!evaluation.expand || std::cmp_greater(depth + 1, path_data_.helper_.ExpansionCeiling())) {
+      continue;
+    }
+
+    if (path_data_.helper_.StepAdmitsDirection(depth, false)) {
+      ExpandBranch(index, node, node.InRelationships(), false, frontier);
+    }
+    if (path_data_.helper_.StepAdmitsDirection(depth, true)) {
+      ExpandBranch(index, node, node.OutRelationships(), true, frontier);
+    }
+  }
+}
+
+// Breadth-first emits every path of one length before any longer one, which is what makes a `limit`
+// return the shortest paths. Both walks below hold a tree of what they have reached rather than a
+// frontier of whole paths; they differ in what may not repeat, and so in how big that tree gets.
+void Path::PathExpand::RunAlgorithm() {
   if (!path_data_.helper_.Bfs()) {
     RunAllStarts();
     return;
   }
-
-  const int64_t min_hops = path_data_.helper_.MinHops();
-  const int64_t max_hops = path_data_.helper_.MaxHops();
-
-  for (int64_t depth = std::max(min_hops, int64_t{0}); depth <= max_hops; ++depth) {
-    deepest_reached_ = -1;
-    path_data_.helper_.SetPassDepth(depth);
-    RunAllStarts();
-    // Stop on the limit, or when nothing reached this depth -- nothing can then reach a greater one,
-    // which is what bounds the loop with no upper hop bound.
-    if (path_data_.LimitReached() || deepest_reached_ < depth) {
-      break;
-    }
+  if (path_data_.helper_.GlobalUniqueness()) {
+    RunNodeGlobalBfs();
+    return;
   }
-
-  path_data_.helper_.ClearPassDepth();
+  RunPathScopedBfs();
 }
 
 namespace {

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -177,7 +177,6 @@ struct Config {
   int64_t limit = kNoLimit;
   // The depth the breadth-first driver is walking, or -1 outside it. Deliberately does not touch
   // min_hops, which the label filters read to decide whether a terminator ends the walk.
-  int64_t pass_depth = -1;
   Uniqueness uniqueness = Uniqueness::kRelationshipPath;
   // An end or termination filter in any step puts every step in end-nodes-only mode, so a node a step
   // merely allowlists is walked through rather than returned.
@@ -227,14 +226,8 @@ class PathHelper {
   // Whether a mark survives the walk back out of a path, rather than being released with it.
   [[nodiscard]] bool GlobalUniqueness() const { return config_.uniqueness == Uniqueness::kNodeGlobal; }
 
-  void SetPassDepth(int64_t depth) { config_.pass_depth = depth; }
-
-  void ClearPassDepth() { config_.pass_depth = -1; }
-
   // The upper hop bound, narrowed to the depth being walked.
-  [[nodiscard]] int64_t ExpansionCeiling() const {
-    return config_.pass_depth < 0 ? config_.max_hops : std::min(config_.max_hops, config_.pass_depth);
-  }
+  [[nodiscard]] int64_t ExpansionCeiling() const { return config_.max_hops; }
 
   static void FilterLabel(std::string_view label, const LabelStep &step, LabelBools &label_bools);
   static LabelStep ParseLabelStep(const mgp::List &list_of_labels);
@@ -331,6 +324,31 @@ class PathExpand {
     int64_t depth;
   };
 
+  // One partial path of the path-scoped breadth-first walk. A path-scoped rule lets a node sit on many
+  // paths at once, so unlike TreeEntry there is one of these per partial path rather than per node --
+  // which is why it holds ids and no accessors: the objects would be the memory that costs.
+  struct Branch {
+    int64_t node_id;
+    int64_t relationship_id;  // kNoRelationship on a start node
+    int64_t parent;           // index into branches_, kNoParent on a start node
+    int64_t depth;
+    // The relationship this branch was reached by. Held rather than looked up again when the path is
+    // rebuilt: searching a node's relationships for a matching id costs more than the walk itself
+    // once most branches are returned.
+    std::optional<mgp::Relationship> from_parent;
+  };
+
+  static constexpr int64_t kNoParent = -1;
+  static constexpr int64_t kNoRelationship = std::numeric_limits<int64_t>::min();
+
+  void RunPathScopedBfs();
+  void ExpandBranch(int64_t index, const mgp::Node &node, mgp::Relationships relationships, bool outgoing,
+                    std::queue<std::pair<int64_t, mgp::Node>> &frontier);
+  // Walks the parent chain rather than a visited set: the rule is scoped to this path, not the walk.
+  [[nodiscard]] bool OnBranch(int64_t index, int64_t key) const;
+  // Rebuilds the path a branch stands for. Only emitted branches pay for it.
+  [[nodiscard]] mgp::Path BranchPath(int64_t index) const;
+
   void RunNodeGlobalBfs();
   void ExpandTreeEntry(int64_t index, int64_t depth, mgp::Relationships relationships, bool outgoing,
                        std::queue<int64_t> &frontier);
@@ -338,9 +356,8 @@ class PathExpand {
   [[nodiscard]] mgp::Path PathTo(int64_t index);
 
   PathData path_data_;
-  // Deepest path reached this pass; bounds the driver when no upper hop bound was given.
-  int64_t deepest_reached_ = -1;
   std::vector<TreeEntry> tree_;
+  std::vector<Branch> branches_;
 };
 
 class PathSubgraph {

--- a/tests/mage/e2e/path_test/test_expand_config_bfs_limit_takes_shortest/input.cyp
+++ b/tests/mage/e2e/path_test/test_expand_config_bfs_limit_takes_shortest/input.cyp
@@ -1,0 +1,1 @@
+CREATE (s:Node {name:'S'}), (a:Node {name:'A'}), (b:Node {name:'B'}), (c:Node {name:'C'}), (z:Node {name:'Z'}) CREATE (s)-[:R]->(a), (a)-[:R]->(b), (b)-[:R]->(c), (s)-[:R]->(z);

--- a/tests/mage/e2e/path_test/test_expand_config_bfs_limit_takes_shortest/test.yml
+++ b/tests/mage/e2e/path_test/test_expand_config_bfs_limit_takes_shortest/test.yml
@@ -1,0 +1,12 @@
+# A breadth-first walk returns every path of one length before any longer one, so a limit takes the
+# nearest nodes. A depth-first walk down the S-A-B-C chain would spend the limit on S-A and S-A-B.
+query: >
+  MATCH (s:Node {name: "S"})
+  CALL path.expand_config(s, {bfs: true, limit: 2, minHops: 1, maxHops: 3})
+  YIELD result
+  WITH result ORDER BY [n IN nodes(result) | n.name]
+  RETURN [n IN nodes(result) | n.name] AS names;
+
+output:
+  - names: ["S", "A"]
+  - names: ["S", "Z"]

--- a/tests/mage/e2e/path_test/test_expand_config_node_path_revisits_across_branches/input.cyp
+++ b/tests/mage/e2e/path_test/test_expand_config_node_path_revisits_across_branches/input.cyp
@@ -1,0 +1,1 @@
+CREATE (s:Node {name:'S'}), (a:Node {name:'A'}), (b:Node {name:'B'}), (d:Node {name:'D'}) CREATE (s)-[:R]->(a), (s)-[:R]->(b), (a)-[:R]->(d), (b)-[:R]->(d);

--- a/tests/mage/e2e/path_test/test_expand_config_node_path_revisits_across_branches/test.yml
+++ b/tests/mage/e2e/path_test/test_expand_config_node_path_revisits_across_branches/test.yml
@@ -1,0 +1,12 @@
+# NODE_PATH forbids a node repeating within one path, not across the walk, so D is returned once per
+# route that reaches it. A walk keeping one graph-wide visited set would return only the first.
+query: >
+  MATCH (s:Node {name: "S"})
+  CALL path.expand_config(s, {bfs: true, uniqueness: "NODE_PATH", minHops: 2, maxHops: 2})
+  YIELD result
+  WITH result ORDER BY [n IN nodes(result) | n.name]
+  RETURN [n IN nodes(result) | n.name] AS names;
+
+output:
+  - names: ["S", "A", "D"]
+  - names: ["S", "B", "D"]


### PR DESCRIPTION
> **Review view — do not merge this on its own.** These commits land through **#4727**, which carries all six. This PR exists so this one change can be reviewed and discussed separately.

Replaces the iterative-deepening driver behind `bfs: true` with a single breadth-first walk. This is the large one in the stack.

**How.** Breadth-first order was produced by re-running the whole depth-first walk once per depth, each pass keeping only paths of exactly that depth. That re-derives every shorter path on every later pass, and the passes do not stop where the answers do — they continue while any node is still reachable at that depth, which on a graph whose long paths never reach a terminator is most of the cost.

`RunPathScopedBfs` walks it once over a tree of partial paths. A path-scoped rule lets a node sit on many paths at once, so the tree holds an entry per partial path rather than per node. Uniqueness walks the parent chain instead of consulting a visited set. Each entry keeps the relationship it was reached by, so rebuilding a path is a walk up that chain. Retires the pass-depth machinery it replaces.

**On the memory/time trade this makes.** An earlier revision of this branch kept only ids per entry and rebuilt a path by searching each node's relationships for a matching id. That is much leaner, and it is fine when few branches are returned — but it costs ~2.8us per returned path, and a shallow unfiltered expansion returns nearly every branch it visits. Measured, that revision took a 1.65M-path expansion from 0.95s to 5.59s: a 6x regression, entirely in the rebuild, with the traversal itself measuring *faster* than the code it replaced. Holding the relationship removes it.

**Why.** Deep and selective is what this is for: 17.5s to 0.57s on a 4425-node topology, the same 732 paths with the same contents. The shallow 1.65M-path expansion is 1.27s against 1.51s on master, so it stays ahead of where it started while giving up some of the per-visit savings the earlier commits in this stack won there. Peak memory over idle on that query is 71MB against master's 56MB — the cost of holding the relationships.

Two new e2e tests pin the guarantees the rewrite has to keep: breadth-first ordering under `limit`, and a node appearing on several distinct paths under `NODE_PATH`. Both pass against the unpatched module too. 133 path e2e tests pass.

Stacked on #4722.