### PR TITLE
refactor(query): give comparability a header of its own

### DIFF
--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -97,6 +97,7 @@ target_sources(mg-query
     procedure/mg_procedure_impl.cpp
     procedure/module.cpp
     query_user.cpp
+    relations/equality.cpp
     serialization/property_value.cpp
     stream/common.cpp
     stream/sources.cpp

--- a/src/query/relations/comparability.hpp
+++ b/src/query/relations/comparability.hpp
@@ -1,0 +1,134 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/// @file
+/// Comparability: one of the four relations openCypher defines over values, the
+/// one `<`, `<=`, `>` and `>=` read.
+///
+/// It is partial. Two values it cannot place answer Null, and a type it does
+/// not admit at all raises. This is where it parts from orderability, which
+/// must place every pair because a sort is undefined without that.
+#pragma once
+
+#include "query/typed_value.hpp"
+
+namespace memgraph::query::relations::comparability {
+
+/// Whether this relation admits a type at all.
+///
+/// The cases are listed rather than defaulted so that a type added to the value
+/// has to be placed here deliberately.
+constexpr bool Admits(TypedValue::Type type) {
+  switch (type) {
+    case TypedValue::Type::Null:
+    case TypedValue::Type::Int:
+    case TypedValue::Type::Double:
+    case TypedValue::Type::String:
+    case TypedValue::Type::Date:
+    case TypedValue::Type::LocalTime:
+    case TypedValue::Type::LocalDateTime:
+    case TypedValue::Type::ZonedDateTime:
+    case TypedValue::Type::Duration:
+      return true;
+
+    case TypedValue::Type::Bool:
+    case TypedValue::Type::List:
+    case TypedValue::Type::Map:
+    case TypedValue::Type::Vertex:
+    case TypedValue::Type::Edge:
+    case TypedValue::Type::VirtualEdge:
+    case TypedValue::Type::VirtualNode:
+    case TypedValue::Type::Path:
+    case TypedValue::Type::Graph:
+    case TypedValue::Type::VirtualGraph:
+    case TypedValue::Type::Function:
+    case TypedValue::Type::Enum:
+    case TypedValue::Type::Point2d:
+    case TypedValue::Type::Point3d:
+      return false;
+  }
+}
+
+constexpr bool IsTemporal(TypedValue::Type type) {
+  switch (type) {
+    case TypedValue::Type::Date:
+    case TypedValue::Type::LocalTime:
+    case TypedValue::Type::LocalDateTime:
+    case TypedValue::Type::ZonedDateTime:
+    case TypedValue::Type::Duration:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// TODO: make it faster
+/// Whether `a` orders before `b`, or Null where that cannot be decided.
+///
+/// The answer carries the memory resource `a` was allocated from, since the two
+/// values need not share one.
+///
+/// @throw TypedValueException for a pair of types this relation does not admit.
+inline TypedValue Less(const TypedValue &a, const TypedValue &b) {
+  if (!Admits(a.type()) || !Admits(b.type())) {
+    if ((is_canonical(a.type()) || is_canonical(b.type())) && (a.type() != b.type())) return {};
+    throw TypedValueException("Invalid 'less' operand types({} + {})", a.type(), b.type());
+  }
+
+  if (a.IsNull() || b.IsNull()) {
+    return TypedValue(a.get_allocator());
+  }
+
+  if (a.IsString() || b.IsString()) {
+    if (a.type() != b.type()) {
+      return {};
+    } else {
+      return TypedValue(a.ValueString() < b.ValueString(), a.get_allocator());
+    }
+  }
+
+  // A filter compares numbers and strings far more often than temporals, and
+  // saying so keeps the temporal cases off the path the common ones take.
+  if (IsTemporal(a.type()) || IsTemporal(b.type())) [[unlikely]] {
+    if (a.type() != b.type()) {
+      return {};
+    }
+
+    switch (a.type()) {
+      case TypedValue::Type::Date:
+        // NOLINTNEXTLINE(modernize-use-nullptr)
+        return TypedValue(a.ValueDate() < b.ValueDate(), a.get_allocator());
+      case TypedValue::Type::LocalTime:
+        // NOLINTNEXTLINE(modernize-use-nullptr)
+        return TypedValue(a.ValueLocalTime() < b.ValueLocalTime(), a.get_allocator());
+      case TypedValue::Type::LocalDateTime:
+        // NOLINTNEXTLINE(modernize-use-nullptr)
+        return TypedValue(a.ValueLocalDateTime() < b.ValueLocalDateTime(), a.get_allocator());
+      case TypedValue::Type::ZonedDateTime:
+        // NOLINTNEXTLINE(modernize-use-nullptr)
+        return TypedValue(a.ValueZonedDateTime() < b.ValueZonedDateTime(), a.get_allocator());
+      case TypedValue::Type::Duration:
+        // NOLINTNEXTLINE(modernize-use-nullptr)
+        return TypedValue(a.ValueDuration() < b.ValueDuration(), a.get_allocator());
+      default:
+        LOG_FATAL("Invalid temporal type");
+    }
+  }
+
+  // at this point we only have int and double
+  if (a.IsDouble() || b.IsDouble()) {
+    return TypedValue(ToDouble(a) < ToDouble(b), a.get_allocator());
+  } else {
+    return TypedValue(a.ValueInt() < b.ValueInt(), a.get_allocator());
+  }
+}
+
+}  // namespace memgraph::query::relations::comparability

--- a/src/query/relations/equality.cpp
+++ b/src/query/relations/equality.cpp
@@ -1,0 +1,52 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "query/relations/equality.hpp"
+
+#include <algorithm>
+
+namespace memgraph::query::relations::equality {
+
+TypedValue EqualOfContainers(const TypedValue &a, const TypedValue &b) {
+  switch (a.type()) {
+    case TypedValue::Type::List: {
+      // A list is equal only to a list of the same length holding equal
+      // elements, so `2 = [2]` is false however deeply either side is nested.
+      // Neo4j differs here, answering true for `2 = [2]` and for
+      // `[[2]] = [[[[[[2]]]]]]`.
+      const auto &list_a = a.ValueList();
+      const auto &list_b = b.ValueList();
+      if (list_a.size() != list_b.size()) return TypedValue(false, a.get_allocator());
+      // Elements are compared by equivalence rather than by equality, which is
+      // two-valued, so a list comparison never answers Null:
+      //    [1] == [null] -> false
+      //    [null] == [null] -> true
+      return TypedValue(std::equal(list_a.begin(), list_a.end(), list_b.begin(), TypedValue::BoolEqual{}),
+                        a.get_allocator());
+    }
+    case TypedValue::Type::Map: {
+      const auto &map_a = a.ValueMap();
+      const auto &map_b = b.ValueMap();
+      if (map_a.size() != map_b.size()) return TypedValue(false, a.get_allocator());
+      for (const auto &kv_a : map_a) {
+        auto found_b_it = map_b.find(kv_a.first);
+        if (found_b_it == map_b.end()) return TypedValue(false, a.get_allocator());
+        TypedValue comparison = Equal(kv_a.second, found_b_it->second);
+        if (comparison.IsNull() || !comparison.ValueBool()) return TypedValue(false, a.get_allocator());
+      }
+      return TypedValue(true, a.get_allocator());
+    }
+    default:
+      LOG_FATAL("Unhandled container comparison");
+  }
+}
+
+}  // namespace memgraph::query::relations::equality

--- a/src/query/relations/equality.hpp
+++ b/src/query/relations/equality.hpp
@@ -1,0 +1,99 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/// @file
+/// Equality: one of the four relations openCypher defines over values, the one
+/// `=`, `<>`, `IN` and a CASE each read.
+///
+/// It is three-valued: a comparison turning on a Null answers Null and decides
+/// nothing. That is its difference from equivalence, which holds a Null
+/// equivalent to a Null, and which a hash container reads.
+#pragma once
+
+#include "query/typed_value.hpp"
+// typed_value.hpp only forward-declares these, and equality reads the identity
+// out of each.
+#include "query/path.hpp"
+#include "query/virtual_edge.hpp"
+#include "query/virtual_node.hpp"
+
+namespace memgraph::query::relations::equality {
+
+/// The two cases that walk what they hold, and so reach this relation again.
+///
+/// Out of line so that Equal does not call itself. A compiler will not inline a
+/// function that recurses, whichever case reaches the recursion.
+TypedValue EqualOfContainers(const TypedValue &a, const TypedValue &b);
+
+/// Whether two values are equal, or Null where that cannot be decided.
+///
+/// The answer carries the memory resource `a` was allocated from, since the two
+/// values need not share one.
+///
+/// @throw TypedValueException for a pair no equality is defined over.
+inline TypedValue Equal(const TypedValue &a, const TypedValue &b) {
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.get_allocator());
+
+  // check we have values that can be compared
+  // this means that either they're the same type, or (int, double) combo
+  if ((a.type() != b.type() && !(a.IsNumeric() && b.IsNumeric()))) return TypedValue(false, a.get_allocator());
+
+  switch (a.type()) {
+    case TypedValue::Type::Bool:
+      return TypedValue(a.ValueBool() == b.ValueBool(), a.get_allocator());
+    case TypedValue::Type::Int:
+      if (b.IsDouble())
+        return TypedValue(ToDouble(a) == ToDouble(b), a.get_allocator());
+      else
+        return TypedValue(a.ValueInt() == b.ValueInt(), a.get_allocator());
+    case TypedValue::Type::Double:
+      return TypedValue(ToDouble(a) == ToDouble(b), a.get_allocator());
+    case TypedValue::Type::String:
+      return TypedValue(a.ValueString() == b.ValueString(), a.get_allocator());
+    case TypedValue::Type::Vertex:
+      return TypedValue(a.ValueVertex() == b.ValueVertex(), a.get_allocator());
+    case TypedValue::Type::Edge:
+      return TypedValue(a.ValueEdge() == b.ValueEdge(), a.get_allocator());
+    case TypedValue::Type::VirtualEdge:
+      return TypedValue(a.ValueVirtualEdge() == b.ValueVirtualEdge(), a.get_allocator());
+    case TypedValue::Type::VirtualNode:
+      return TypedValue(a.ValueVirtualNode() == b.ValueVirtualNode(), a.get_allocator());
+    case TypedValue::Type::List:
+    case TypedValue::Type::Map:
+      return EqualOfContainers(a, b);
+    case TypedValue::Type::Path:
+      return TypedValue(a.ValuePath() == b.ValuePath(), a.get_allocator());
+    case TypedValue::Type::Date:
+      return TypedValue(a.ValueDate() == b.ValueDate(), a.get_allocator());
+    case TypedValue::Type::LocalTime:
+      return TypedValue(a.ValueLocalTime() == b.ValueLocalTime(), a.get_allocator());
+    case TypedValue::Type::LocalDateTime:
+      return TypedValue(a.ValueLocalDateTime() == b.ValueLocalDateTime(), a.get_allocator());
+    case TypedValue::Type::ZonedDateTime:
+      return TypedValue(a.ValueZonedDateTime() == b.ValueZonedDateTime(), a.get_allocator());
+    case TypedValue::Type::Duration:
+      return TypedValue(a.ValueDuration() == b.ValueDuration(), a.get_allocator());
+    case TypedValue::Type::Enum:
+      return TypedValue(a.ValueEnum() == b.ValueEnum(), a.get_allocator());
+    case TypedValue::Type::Point2d:
+      return TypedValue(a.ValuePoint2d() == b.ValuePoint2d(), a.get_allocator());
+    case TypedValue::Type::Point3d:
+      return TypedValue(a.ValuePoint3d() == b.ValuePoint3d(), a.get_allocator());
+    case TypedValue::Type::Graph:
+    case TypedValue::Type::VirtualGraph:
+      throw TypedValueException("Unsupported comparison operator");
+    case TypedValue::Type::Function:
+    case TypedValue::Type::Null:
+      LOG_FATAL("Unhandled comparison for types");
+  }
+}
+
+}  // namespace memgraph::query::relations::equality

--- a/src/query/relations/equivalence.hpp
+++ b/src/query/relations/equivalence.hpp
@@ -1,0 +1,43 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/// @file
+/// Equivalence: one of the four relations openCypher defines over values, the
+/// one DISTINCT and grouping read, and the one a hash container is keyed by.
+///
+/// It is two-valued where equality is three-valued: a Null it holds equivalent
+/// to a Null, where equality answers Null and decides nothing.
+#pragma once
+
+#include <cstddef>
+
+#include "query/relations/equality.hpp"
+#include "query/typed_value.hpp"
+
+namespace memgraph::query::relations::equivalence {
+
+inline bool Equivalent(const TypedValue &lhs, const TypedValue &rhs) {
+  if (lhs.IsNull() && rhs.IsNull()) return true;
+  TypedValue equality_result = equality::Equal(lhs, rhs);
+  DMG_ASSERT(equality_result.type() == TypedValue::Type::Bool || equality_result.type() == TypedValue::Type::Null,
+             "Equality between two TypedValues must result in either Null or Bool");
+  return equality_result.type() == TypedValue::Type::Bool && equality_result.ValueBool();
+}
+
+/// A hash agreeing with Equivalent: two equivalent values hash alike.
+///
+/// Declared beside the relation it has to agree with, since a change to one
+/// that is not made to the other is silent until a lookup misses. Defined out
+/// of line, because it is built from a collection hash this header would
+/// otherwise have to pull in.
+size_t Hash(const TypedValue &value);
+
+}  // namespace memgraph::query::relations::equivalence

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -22,6 +22,8 @@
 
 #include "query/fmt.hpp"
 #include "query/graph.hpp"
+#include "query/relations/equality.hpp"
+#include "query/relations/equivalence.hpp"
 #include "query/virtual_edge.hpp"
 #include "query/virtual_graph.hpp"
 #include "query/virtual_node.hpp"
@@ -1727,88 +1729,10 @@ TypedValue operator<(const TypedValue &a, const TypedValue &b) {
 }
 
 TypedValue operator==(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
-
-  // check we have values that can be compared
-  // this means that either they're the same type, or (int, double) combo
-  if ((a.type() != b.type() && !(a.IsNumeric() && b.IsNumeric()))) return TypedValue(false, a.alloc_);
-
-  switch (a.type()) {
-    case TypedValue::Type::Bool:
-      return TypedValue(a.ValueBool() == b.ValueBool(), a.alloc_);
-    case TypedValue::Type::Int:
-      if (b.IsDouble())
-        return TypedValue(ToDouble(a) == ToDouble(b), a.alloc_);
-      else
-        return TypedValue(a.ValueInt() == b.ValueInt(), a.alloc_);
-    case TypedValue::Type::Double:
-      return TypedValue(ToDouble(a) == ToDouble(b), a.alloc_);
-    case TypedValue::Type::String:
-      return TypedValue(a.ValueString() == b.ValueString(), a.alloc_);
-    case TypedValue::Type::Vertex:
-      return TypedValue(a.ValueVertex() == b.ValueVertex(), a.alloc_);
-    case TypedValue::Type::Edge:
-      return TypedValue(a.ValueEdge() == b.ValueEdge(), a.alloc_);
-    case TypedValue::Type::VirtualEdge:
-      return TypedValue(a.ValueVirtualEdge() == b.ValueVirtualEdge(), a.alloc_);
-    case TypedValue::Type::VirtualNode:
-      return TypedValue(a.ValueVirtualNode() == b.ValueVirtualNode(), a.alloc_);
-    case TypedValue::Type::List: {
-      // We are not compatible with neo4j at this point. In neo4j 2 = [2]
-      // compares
-      // to true. That is not the end of unselfishness of developers at neo4j so
-      // they allow us to use as many braces as we want to get to the truth in
-      // list comparison, so [[2]] = [[[[[[2]]]]]] compares to true in neo4j as
-      // well. Because, why not?
-      // At memgraph we prefer sanity so [1,2] = [1,2] compares to true and
-      // 2 = [2] compares to false.
-      const auto &list_a = a.ValueList();
-      const auto &list_b = b.ValueList();
-      if (list_a.size() != list_b.size()) return TypedValue(false, a.alloc_);
-      // two arrays are considered equal (by neo) if all their
-      // elements are bool-equal. this means that:
-      //    [1] == [null] -> false
-      //    [null] == [null] -> true
-      // in that sense array-comparison never results in Null
-      return TypedValue(std::equal(list_a.begin(), list_a.end(), list_b.begin(), TypedValue::BoolEqual{}), a.alloc_);
-    }
-    case TypedValue::Type::Map: {
-      const auto &map_a = a.ValueMap();
-      const auto &map_b = b.ValueMap();
-      if (map_a.size() != map_b.size()) return TypedValue(false, a.alloc_);
-      for (const auto &kv_a : map_a) {
-        auto found_b_it = map_b.find(kv_a.first);
-        if (found_b_it == map_b.end()) return TypedValue(false, a.alloc_);
-        TypedValue comparison = kv_a.second == found_b_it->second;
-        if (comparison.IsNull() || !comparison.ValueBool()) return TypedValue(false, a.alloc_);
-      }
-      return TypedValue(true, a.alloc_);
-    }
-    case TypedValue::Type::Path:
-      return TypedValue(a.ValuePath() == b.ValuePath(), a.alloc_);
-    case TypedValue::Type::Date:
-      return TypedValue(a.ValueDate() == b.ValueDate(), a.alloc_);
-    case TypedValue::Type::LocalTime:
-      return TypedValue(a.ValueLocalTime() == b.ValueLocalTime(), a.alloc_);
-    case TypedValue::Type::LocalDateTime:
-      return TypedValue(a.ValueLocalDateTime() == b.ValueLocalDateTime(), a.alloc_);
-    case TypedValue::Type::ZonedDateTime:
-      return TypedValue(a.ValueZonedDateTime() == b.ValueZonedDateTime(), a.alloc_);
-    case TypedValue::Type::Duration:
-      return TypedValue(a.ValueDuration() == b.ValueDuration(), a.alloc_);
-    case TypedValue::Type::Enum:
-      return TypedValue(a.ValueEnum() == b.ValueEnum(), a.alloc_);
-    case TypedValue::Type::Point2d:
-      return TypedValue(a.ValuePoint2d() == b.ValuePoint2d(), a.alloc_);
-    case TypedValue::Type::Point3d:
-      return TypedValue(a.ValuePoint3d() == b.ValuePoint3d(), a.alloc_);
-    case TypedValue::Type::Graph:
-    case TypedValue::Type::VirtualGraph:
-      throw TypedValueException("Unsupported comparison operator");
-    case TypedValue::Type::Function:
-    case TypedValue::Type::Null:
-      LOG_FATAL("Unhandled comparison for types");
-  }
+  // Inlined here on purpose. The relation is reached through this operator by
+  // every caller, and the project builds without sibling-call optimisation, so
+  // forwarding to it would cost a call frame on every comparison.
+  [[clang::always_inline]] return relations::equality::Equal(a, b);
 }
 
 TypedValue operator!(const TypedValue &a) {
@@ -2083,14 +2007,14 @@ TypedValue operator^(const TypedValue &a, const TypedValue &b) {
 }
 
 bool TypedValue::BoolEqual::operator()(const TypedValue &lhs, const TypedValue &rhs) const {
-  if (lhs.IsNull() && rhs.IsNull()) return true;
-  TypedValue equality_result = lhs == rhs;
-  DMG_ASSERT(equality_result.type() == TypedValue::Type::Bool || equality_result.type() == TypedValue::Type::Null,
-             "Equality between two TypedValues must result in either Null or Bool");
-  return equality_result.type() == TypedValue::Type::Bool && equality_result.ValueBool();
+  return relations::equivalence::Equivalent(lhs, rhs);
 }
 
-size_t TypedValue::Hash::operator()(const TypedValue &value) const {
+size_t TypedValue::Hash::operator()(const TypedValue &value) const { return relations::equivalence::Hash(value); }
+
+namespace relations::equivalence {
+
+size_t Hash(const TypedValue &value) {
   switch (value.type()) {
     case TypedValue::Type::Null:
       return 31;
@@ -2111,13 +2035,13 @@ size_t TypedValue::Hash::operator()(const TypedValue &value) const {
     case TypedValue::Type::String:
       return std::hash<std::string_view>{}(value.ValueString());
     case TypedValue::Type::List: {
-      return utils::FnvCollection<TypedValue::TVector, TypedValue, Hash>{}(value.ValueList());
+      return utils::FnvCollection<TypedValue::TVector, TypedValue, TypedValue::Hash>{}(value.ValueList());
     }
     case TypedValue::Type::Map: {
       size_t hash = 6'543'457;
       for (const auto &kv : value.ValueMap()) {
         hash ^= std::hash<std::string_view>{}(kv.first);
-        hash ^= this->operator()(kv.second);
+        hash ^= Hash(kv.second);
       }
       return hash;
     }
@@ -2160,6 +2084,8 @@ size_t TypedValue::Hash::operator()(const TypedValue &value) const {
   }
   LOG_FATAL("Unhandled TypedValue.type() in hash function");
 }
+
+}  // namespace relations::equivalence
 
 auto GetCRS(TypedValue const &tv) -> std::optional<storage::CoordinateReferenceSystem> {
   switch (tv.type()) {

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -22,6 +22,7 @@
 
 #include "query/fmt.hpp"
 #include "query/graph.hpp"
+#include "query/relations/comparability.hpp"
 #include "query/relations/equality.hpp"
 #include "query/relations/equivalence.hpp"
 #include "query/virtual_edge.hpp"
@@ -1633,99 +1634,11 @@ double ToDouble(const TypedValue &value) {
   }
 }
 
-namespace {
-bool IsTemporalType(const TypedValue::Type type) {
-  static constexpr std::array temporal_types{TypedValue::Type::Date,
-                                             TypedValue::Type::LocalTime,
-                                             TypedValue::Type::LocalDateTime,
-                                             TypedValue::Type::ZonedDateTime,
-                                             TypedValue::Type::Duration};
-  return std::ranges::any_of(temporal_types, [type](const auto temporal_type) { return temporal_type == type; });
-};
-
-}  // namespace
-
-// TODO: make it faster
 TypedValue operator<(const TypedValue &a, const TypedValue &b) {
-  auto is_legal = [](TypedValue::Type type) {
-    switch (type) {
-      case TypedValue::Type::Null:
-      case TypedValue::Type::Int:
-      case TypedValue::Type::Double:
-      case TypedValue::Type::String:
-      case TypedValue::Type::Date:
-      case TypedValue::Type::LocalTime:
-      case TypedValue::Type::LocalDateTime:
-      case TypedValue::Type::ZonedDateTime:
-      case TypedValue::Type::Duration:
-        return true;
-
-      case TypedValue::Type::Bool:
-      case TypedValue::Type::List:
-      case TypedValue::Type::Map:
-      case TypedValue::Type::Vertex:
-      case TypedValue::Type::Edge:
-      case TypedValue::Type::VirtualEdge:
-      case TypedValue::Type::VirtualNode:
-      case TypedValue::Type::Path:
-      case TypedValue::Type::Graph:
-      case TypedValue::Type::VirtualGraph:
-      case TypedValue::Type::Function:
-      case TypedValue::Type::Enum:
-      case TypedValue::Type::Point2d:
-      case TypedValue::Type::Point3d:
-        return false;
-    }
-  };
-  if (!is_legal(a.type()) || !is_legal(b.type())) {
-    if ((is_canonical(a.type()) || is_canonical(b.type())) && (a.type() != b.type())) return {};
-    throw TypedValueException("Invalid 'less' operand types({} + {})", a.type(), b.type());
-  }
-
-  if (a.IsNull() || b.IsNull()) {
-    return TypedValue(a.alloc_);
-  }
-
-  if (a.IsString() || b.IsString()) {
-    if (a.type() != b.type()) {
-      return {};
-    } else {
-      return TypedValue(a.ValueString() < b.ValueString(), a.alloc_);
-    }
-  }
-
-  if (IsTemporalType(a.type()) || IsTemporalType(b.type())) {
-    if (a.type() != b.type()) {
-      return {};
-    }
-
-    switch (a.type()) {
-      case TypedValue::Type::Date:
-        // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueDate() < b.ValueDate(), a.alloc_);
-      case TypedValue::Type::LocalTime:
-        // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueLocalTime() < b.ValueLocalTime(), a.alloc_);
-      case TypedValue::Type::LocalDateTime:
-        // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueLocalDateTime() < b.ValueLocalDateTime(), a.alloc_);
-      case TypedValue::Type::ZonedDateTime:
-        // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueZonedDateTime() < b.ValueZonedDateTime(), a.alloc_);
-      case TypedValue::Type::Duration:
-        // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueDuration() < b.ValueDuration(), a.alloc_);
-      default:
-        LOG_FATAL("Invalid temporal type");
-    }
-  }
-
-  // at this point we only have int and double
-  if (a.IsDouble() || b.IsDouble()) {
-    return TypedValue(ToDouble(a) < ToDouble(b), a.alloc_);
-  } else {
-    return TypedValue(a.ValueInt() < b.ValueInt(), a.alloc_);
-  }
+  // Inlined here on purpose. The relation is reached through this operator by
+  // every caller, and the project builds without sibling-call optimisation, so
+  // forwarding to it would cost a call frame on every comparison.
+  [[clang::always_inline]] return relations::comparability::Less(a, b);
 }
 
 TypedValue operator==(const TypedValue &a, const TypedValue &b) {

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -831,6 +831,9 @@ constexpr bool is_canonical(TypedValue::Type type) {
   }
 }
 
+/// @throw TypedValueException unless the value is an Int or a Double.
+double ToDouble(const TypedValue &value);
+
 void to_json(nlohmann::json &j, TypedValue const &value);
 void from_json(nlohmann::json const &j, TypedValue &value);
 

--- a/src/storage/v2/property_value.cppm
+++ b/src/storage/v2/property_value.cppm
@@ -17,6 +17,7 @@ module;
 #include <memory>
 #include <memory_resource>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -66,8 +67,13 @@ inline bool AreComparableTypes(PropertyValueType a, PropertyValueType b) {
          (a == PropertyValueType::Double && b == PropertyValueType::Int);
 }
 
-inline std::partial_ordering CompareNumericValues(const std::variant<int, double> &a,
-                                                  const std::variant<int, double> &b) {
+/// Orders two numbers, whichever numeric types the two variants hold.
+///
+/// The two variants need not hold the same types. A list that boxes its
+/// elements stores an integer wider than one that packs them, so comparing the
+/// two means reading each at the width it is stored at.
+template <typename... Lhs, typename... Rhs>
+inline std::partial_ordering CompareNumericValues(const std::variant<Lhs...> &a, const std::variant<Rhs...> &b) {
   return std::visit(
       [](const auto &val_a, const auto &val_b) -> std::partial_ordering { return val_a <=> val_b; }, a, b);
 }
@@ -906,14 +912,19 @@ using PropertyValue = PropertyValueImpl<std::pmr::polymorphic_allocator<std::byt
 }  // namespace pmr
 
 /// Helper function to extract numeric value from any list type at given index
+///
+/// Integers are read at their full width. A boxed list stores each element at
+/// that width, so reading one narrower would turn two elements that differ only
+/// above the narrower width into the same value, and the lists holding them
+/// would compare equal.
 template <typename Alloc, typename KeyType, typename VectorIndexIdType>
-inline std::optional<std::variant<int, double>> GetNumericValueAt(
+inline std::optional<std::variant<int64_t, double>> GetNumericValueAt(
     const PropertyValueImpl<Alloc, KeyType, VectorIndexIdType> &list, size_t index) {
   switch (list.type()) {
     case PropertyValueType::List: {
       auto const &list_val = list.ValueList();
       if (list_val[index].IsInt()) {
-        return static_cast<int>(list_val[index].ValueInt());
+        return list_val[index].ValueInt();
       }
       if (list_val[index].IsDouble()) {
         return list_val[index].ValueDouble();
@@ -929,8 +940,20 @@ inline std::optional<std::variant<int, double>> GetNumericValueAt(
       return list_val[index];
     }
     case PropertyValueType::NumericList: {
-      auto const &list_val = list.ValueNumericList();
-      return list_val[index];
+      // This representation packs its integers narrower than a boxed list stores
+      // them, so widen it to compare the two.
+      //
+      // Read through a pointer rather than by value: the accessor that returns
+      // the value raises when asked for the alternative the element does not
+      // hold, and this comparison is reached from one declared not to raise.
+      auto const &packed = list.ValueNumericList()[index];
+      if (auto const *as_int = std::get_if<int>(&packed)) {
+        return static_cast<int64_t>(*as_int);
+      }
+      if (auto const *as_double = std::get_if<double>(&packed)) {
+        return *as_double;
+      }
+      std::unreachable();
     }
     default:
       throw PropertyValueException("Invalid list type");
@@ -948,12 +971,12 @@ inline std::weak_ordering CompareLists(const PropertyValueImpl<Alloc, KeyType, V
     return size1 <=> size2;
   }
 
-  auto extract_type = [](const std::optional<std::variant<int, double>> &val,
+  auto extract_type = [](const std::optional<std::variant<int64_t, double>> &val,
                          const PropertyValueImpl<Alloc, KeyType, VectorIndexIdType> &list,
 
                          auto index) {
     if (val) {
-      if (std::holds_alternative<int>(*val)) {
+      if (std::holds_alternative<int64_t>(*val)) {
         return PropertyValueType::Int;
       }
       return PropertyValueType::Double;

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -88,6 +88,9 @@ target_link_libraries(${test_prefix}storage_v2_gc2 mg::storage)
 add_benchmark(storage_v2_property_store.cpp)
 target_link_libraries(${test_prefix}storage_v2_property_store mg::storage)
 
+add_benchmark(storage_v2_property_compare.cpp)
+target_link_libraries(${test_prefix}storage_v2_property_compare mg::storage)
+
 add_benchmark(storage_v2_enum_store_bench.cpp)
 target_link_libraries(${test_prefix}storage_v2_enum_store_bench mg::storage)
 

--- a/tests/benchmark/query/typed_value_ops.cpp
+++ b/tests/benchmark/query/typed_value_ops.cpp
@@ -9,49 +9,145 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// What a query value costs to copy, move, destroy and compare, one case per type it can hold.
+// What a query value costs to copy, move, destroy, and compare.
 //
-// A row of expression evaluation builds and destroys a value per node it walks, so these are among
-// the most frequently executed instructions in the engine. What each of them costs depends on what
-// the value holds: a type owning an allocation and a type owning nothing take different work.
+// A row of expression evaluation builds and destroys a value per node it walks, and a filter, a
+// DISTINCT and an ORDER BY each compare two of them per row, so these are among the most frequently
+// executed instructions in the engine.
 //
-// Which is why every type gets a case, not only the ones expected to gain. A change that treats the
-// types differently pays for telling them apart, and that cost lands on the types that do not gain.
-// The measurement to protect is therefore not that one number falls, but that no other rises, and
-// that is invisible unless a string is measured beside an integer.
+// Cypher compares two values by four different relations, and they are measured apart because they
+// answer differently and are reached from different places: `=` and `IN` ask equality, DISTINCT and
+// grouping ask equivalence, `<` and its three siblings ask comparability, and ORDER BY asks
+// orderability.
+//
+// There is a case per type, so a change that costs something to tell types apart shows up on the
+// types that gain nothing from it. What each operation costs depends on what the value holds: a
+// type owning an allocation and a type owning nothing take different work.
 
 #include <benchmark/benchmark.h>
 
+#include <algorithm>
+#include <limits>
+#include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "query/common.hpp"
 #include "query/typed_value.hpp"
 #include "utils/memory.hpp"
 
 namespace {
 
+using memgraph::query::OrderedTypedValueCompare;
+using memgraph::query::Ordering;
 using memgraph::query::TypedValue;
 
 memgraph::utils::MemoryResource *Mem() { return memgraph::utils::NewDeleteResource(); }
 
-TypedValue Make(std::string_view what) {
-  if (what == "Int") return TypedValue{int64_t{7'000'000}, Mem()};
-  if (what == "Double") return TypedValue{33.14907, Mem()};
-  if (what == "Bool") return TypedValue{true, Mem()};
-  if (what == "String") return TypedValue{std::string{"region_3"}, Mem()};
-  if (what == "Date") return TypedValue{memgraph::utils::Date{std::chrono::microseconds{86'400'000'000}}, Mem()};
-  if (what == "List") {
-    auto items = std::vector<TypedValue>{};
-    for (int i = 0; i != 8; ++i) items.emplace_back(int64_t{i}, Mem());
-    return TypedValue{std::move(items), Mem()};
-  }
-  MG_ASSERT(false, "unknown type name");
-  return TypedValue{Mem()};
+using Pair = std::pair<TypedValue, TypedValue>;
+
+TypedValue ListOfInts(int64_t last) {
+  auto items = std::vector<TypedValue>{};
+  items.reserve(8);
+  for (int64_t i = 0; i != 7; ++i) items.emplace_back(i, Mem());
+  items.emplace_back(last, Mem());
+  return TypedValue{std::move(items), Mem()};
 }
 
+/// One type per pair of values.
+///
+/// A shape is a type rather than a string, so a misspelled name fails to compile instead of
+/// registering a benchmark that aborts when it runs. The two values in each pair differ, as two
+/// values reaching a comparison usually do.
+struct Int {
+  static Pair Make() { return {TypedValue{int64_t{7'000'000}, Mem()}, TypedValue{int64_t{6'000'000}, Mem()}}; }
+};
+
+struct Double {
+  static Pair Make() { return {TypedValue{33.14907, Mem()}, TypedValue{33.14908, Mem()}}; }
+};
+
+struct Bool {
+  static Pair Make() { return {TypedValue{true, Mem()}, TypedValue{false, Mem()}}; }
+};
+
+struct String {
+  static Pair Make() {
+    return {TypedValue{std::string{"region_3"}, Mem()}, TypedValue{std::string{"region_4"}, Mem()}};
+  }
+};
+
+struct Date {
+  static Pair Make() {
+    using memgraph::utils::Date;
+    return {TypedValue{Date{std::chrono::microseconds{86'400'000'000}}, Mem()},
+            TypedValue{Date{std::chrono::microseconds{172'800'000'000}}, Mem()}};
+  }
+};
+
+/// Elements that differ at the end, so a comparison walks the whole list rather than settling on
+/// the first pair it looks at.
+struct List {
+  static Pair Make() { return {ListOfInts(7), ListOfInts(8)}; }
+};
+
+/// Two numbers of unlike types, which the comparison widens before it can answer.
+struct IntAgainstDouble {
+  static Pair Make() { return {TypedValue{int64_t{499}, Mem()}, TypedValue{500.0, Mem()}}; }
+};
+
+/// A number that compares as unordered against every other, which is the one pair the ordering
+/// answers differently from a plain three-way comparison.
+struct NaN {
+  static Pair Make() { return {TypedValue{std::numeric_limits<double>::quiet_NaN(), Mem()}, TypedValue{1.0, Mem()}}; }
+};
+
+TypedValue MapOfInts(bool with_null) {
+  auto entries = std::map<std::string, TypedValue>{};
+  for (int i = 0; i != 4; ++i) entries.emplace("k" + std::to_string(i), TypedValue{int64_t{i}, Mem()});
+  if (with_null) entries.emplace("n", TypedValue{Mem()});
+  return TypedValue{std::move(entries), Mem()};
+}
+
+struct Map {
+  static Pair Make() { return {MapOfInts(false), MapOfInts(false)}; }
+};
+
+/// A container holding a null, where the two relations part company: equality cannot decide such a
+/// pair while equivalence can.
+struct MapHoldingNull {
+  static Pair Make() { return {MapOfInts(true), MapOfInts(true)}; }
+};
+
+struct ListHoldingNull {
+  static Pair Make() {
+    auto with_null = [] {
+      auto items = std::vector<TypedValue>{};
+      for (int64_t i = 0; i != 8; ++i) items.emplace_back(i, Mem());
+      items.emplace_back(Mem());
+      return TypedValue{std::move(items), Mem()};
+    };
+    return {with_null(), with_null()};
+  }
+};
+
+/// Lists inside a list, which is where a relation that recurses pays for the recursion.
+struct NestedList {
+  static Pair Make() {
+    auto nested = [] {
+      auto outer = std::vector<TypedValue>{};
+      for (int i = 0; i != 4; ++i) outer.emplace_back(ListOfInts(7));
+      return TypedValue{std::move(outer), Mem()};
+    };
+    return {nested(), nested()};
+  }
+};
+
 // Copying is where a type that owns an allocation parts company with one that does not.
-void CopyConstruct(benchmark::State &state, std::string_view what) {
-  auto const source = Make(what);
+template <typename Shape>
+void CopyConstruct(benchmark::State &state) {
+  auto const source = Shape::Make().first;
   for (auto _ : state) {
     auto copy = TypedValue{source, Mem()};
     benchmark::DoNotOptimize(copy);
@@ -61,8 +157,9 @@ void CopyConstruct(benchmark::State &state, std::string_view what) {
 
 // A frame write: move a value into a slot that already holds one. Both the type being overwritten
 // and the type arriving decide whether this can be done where it stands.
-void MoveAssign(benchmark::State &state, std::string_view what) {
-  auto const source = Make(what);
+template <typename Shape>
+void MoveAssign(benchmark::State &state) {
+  auto const source = Shape::Make().first;
   auto slot = TypedValue{Mem()};
   for (auto _ : state) {
     auto fresh = TypedValue{source, Mem()};
@@ -77,8 +174,9 @@ void MoveAssign(benchmark::State &state, std::string_view what) {
 // The value has to be made to escape before its scope closes. A type whose destructor does nothing
 // and whose construction the compiler can see through is otherwise dead, and the loop measures an
 // empty body - which reads as an enormous gain from any change that makes a destructor trivial.
-void ConstructDestroy(benchmark::State &state, std::string_view what) {
-  auto const source = Make(what);
+template <typename Shape>
+void ConstructDestroy(benchmark::State &state) {
+  auto const source = Shape::Make().first;
   for (auto _ : state) {
     {
       auto copy = TypedValue{source, Mem()};
@@ -89,49 +187,142 @@ void ConstructDestroy(benchmark::State &state, std::string_view what) {
   state.SetItemsProcessed(state.iterations());
 }
 
-// `a > b` between two numbers, the comparison a filter runs once per row.
-void CompareNumbers(benchmark::State &state) {
-  auto const lhs = TypedValue{500.0, Mem()};
-  auto const rhs = TypedValue{int64_t{499}, Mem()};
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(lhs > rhs);
-    benchmark::DoNotOptimize(lhs < rhs);
-    benchmark::DoNotOptimize(lhs >= rhs);
-    benchmark::DoNotOptimize(lhs <= rhs);
-  }
-  state.SetItemsProcessed(state.iterations() * 4);
+// The four ordered comparisons, measured apart because they are not written alike: one of them is
+// a single comparison, and the others reach their answer through two or three of it. A change to
+// how they are written moves them by different amounts, and measuring them together would let a
+// gain on one hide a loss on another.
+template <typename Shape>
+void Less(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  for (auto _ : state) benchmark::DoNotOptimize(lhs < rhs);
+  state.SetItemsProcessed(state.iterations());
 }
 
-// The same between two strings, which take the general path and must not be slowed by anything done
-// for the numbers.
-void CompareStrings(benchmark::State &state) {
-  auto const lhs = TypedValue{std::string{"region_3"}, Mem()};
-  auto const rhs = TypedValue{std::string{"region_4"}, Mem()};
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(lhs > rhs);
-    benchmark::DoNotOptimize(lhs < rhs);
-    benchmark::DoNotOptimize(lhs >= rhs);
-    benchmark::DoNotOptimize(lhs <= rhs);
-  }
-  state.SetItemsProcessed(state.iterations() * 4);
+template <typename Shape>
+void LessEqual(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  for (auto _ : state) benchmark::DoNotOptimize(lhs <= rhs);
+  state.SetItemsProcessed(state.iterations());
 }
 
-#define FOR_EACH_TYPE(op)                                                \
-  BENCHMARK_CAPTURE(op, Int, "Int")->Unit(benchmark::kNanosecond);       \
-  BENCHMARK_CAPTURE(op, Double, "Double")->Unit(benchmark::kNanosecond); \
-  BENCHMARK_CAPTURE(op, Bool, "Bool")->Unit(benchmark::kNanosecond);     \
-  BENCHMARK_CAPTURE(op, Date, "Date")->Unit(benchmark::kNanosecond);     \
-  BENCHMARK_CAPTURE(op, String, "String")->Unit(benchmark::kNanosecond); \
-  BENCHMARK_CAPTURE(op, List, "List")->Unit(benchmark::kNanosecond);
+template <typename Shape>
+void Greater(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  for (auto _ : state) benchmark::DoNotOptimize(lhs > rhs);
+  state.SetItemsProcessed(state.iterations());
+}
+
+template <typename Shape>
+void GreaterEqual(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  for (auto _ : state) benchmark::DoNotOptimize(lhs >= rhs);
+  state.SetItemsProcessed(state.iterations());
+}
+
+// Equality, the relation `=` and `IN` are answered by, asked of two values that are the same.
+//
+// Two values that differ are separated by the first element that differs, which for a container
+// measures how quickly the walk gives up rather than what the walk costs. A probe reaching a
+// populated bucket, or a row matching a filter, compares the whole of both values.
+template <typename Shape>
+void Equality(benchmark::State &state) {
+  auto const lhs = Shape::Make().first;
+  auto const rhs = TypedValue{lhs, Mem()};
+  for (auto _ : state) benchmark::DoNotOptimize(lhs == rhs);
+  state.SetItemsProcessed(state.iterations());
+}
+
+// Equivalence, the relation DISTINCT and grouping are answered by, and the hottest of the four: a
+// hash set of query values calls it on every probe that reaches a populated bucket.
+template <typename Shape>
+void Equivalence(benchmark::State &state) {
+  auto const lhs = Shape::Make().first;
+  auto const rhs = TypedValue{lhs, Mem()};
+  auto const equal = TypedValue::BoolEqual{};
+  for (auto _ : state) benchmark::DoNotOptimize(equal(lhs, rhs));
+  state.SetItemsProcessed(state.iterations());
+}
+
+// Orderability, the relation ORDER BY is answered by. A sort calls it once per comparison, which is
+// the granularity that decides where it may be defined.
+template <typename Shape>
+void Orderability(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  auto const compare = OrderedTypedValueCompare{Ordering::ASC};
+  for (auto _ : state) benchmark::DoNotOptimize(compare(lhs, rhs));
+  state.SetItemsProcessed(state.iterations());
+}
+
+// What the relation exists for. A per-comparison figure alone hides how often a sort calls it, and
+// a sort is where the cost is actually paid.
+void SortColumn(benchmark::State &state) {
+  auto source = std::vector<TypedValue>{};
+  for (int i = 0; i != 4; ++i) {
+    source.emplace_back(int64_t{7 - i}, Mem());
+    source.emplace_back(0.5 * static_cast<double>(i), Mem());
+    source.emplace_back(Mem());
+  }
+  auto const compare = OrderedTypedValueCompare{Ordering::ASC};
+  for (auto _ : state) {
+    auto values = source;
+    std::ranges::sort(values,
+                      [&compare](TypedValue const &a, TypedValue const &b) { return std::is_lt(compare(a, b)); });
+    benchmark::DoNotOptimize(values);
+  }
+  state.SetItemsProcessed(state.iterations() * static_cast<int64_t>(source.size()));
+}
+
+// The label comes from the same token that selects the shape, so the two cannot disagree.
+#define SHAPE(bench, shape) BENCHMARK_TEMPLATE(bench, shape)->Name(#bench "/" #shape)->Unit(benchmark::kNanosecond)
+
+#define FOR_EACH_TYPE(bench) \
+  SHAPE(bench, Int);         \
+  SHAPE(bench, Double);      \
+  SHAPE(bench, Bool);        \
+  SHAPE(bench, Date);        \
+  SHAPE(bench, String);      \
+  SHAPE(bench, List);
 
 FOR_EACH_TYPE(CopyConstruct)
 FOR_EACH_TYPE(MoveAssign)
 FOR_EACH_TYPE(ConstructDestroy)
+FOR_EACH_TYPE(Equality)
+FOR_EACH_TYPE(Equivalence)
+FOR_EACH_TYPE(Orderability)
+
+// Only the types these four answer for. A pair they refuse throws out of the loop, which would
+// abort the run rather than measure anything.
+#define FOR_EACH_COMPARABLE_TYPE(bench) \
+  SHAPE(bench, Int);                    \
+  SHAPE(bench, Double);                 \
+  SHAPE(bench, Date);                   \
+  SHAPE(bench, String);                 \
+  SHAPE(bench, IntAgainstDouble);
+
+FOR_EACH_COMPARABLE_TYPE(Less)
+FOR_EACH_COMPARABLE_TYPE(LessEqual)
+FOR_EACH_COMPARABLE_TYPE(Greater)
+FOR_EACH_COMPARABLE_TYPE(GreaterEqual)
+
+// The container shapes the two sameness relations disagree about, which a sweep over scalars cannot
+// reach.
+#define FOR_EACH_CONTAINER(bench) \
+  SHAPE(bench, Map);              \
+  SHAPE(bench, MapHoldingNull);   \
+  SHAPE(bench, ListHoldingNull);  \
+  SHAPE(bench, NestedList);
+
+FOR_EACH_CONTAINER(Equality)
+FOR_EACH_CONTAINER(Equivalence)
+
+SHAPE(Orderability, NaN);
+SHAPE(Orderability, IntAgainstDouble);
+BENCHMARK(SortColumn)->Unit(benchmark::kNanosecond);
 
 #undef FOR_EACH_TYPE
-
-BENCHMARK(CompareNumbers)->Unit(benchmark::kNanosecond);
-BENCHMARK(CompareStrings)->Unit(benchmark::kNanosecond);
+#undef FOR_EACH_COMPARABLE_TYPE
+#undef FOR_EACH_CONTAINER
+#undef SHAPE
 
 }  // namespace
 

--- a/tests/benchmark/storage_v2_property_compare.cpp
+++ b/tests/benchmark/storage_v2_property_compare.cpp
@@ -1,0 +1,254 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Benchmarks the two comparisons an index makes over stored values: the one it
+// walks the skip list with, which compares decoded values, and the one that
+// confirms the entry it lands on, which compares the stored bytes without
+// decoding them. Both run on every lookup.
+//
+// There is a case per type, so a change that costs something to tell types
+// apart shows up on the types that gain nothing from it. The two values in each
+// pair differ, as real index keys do: comparing a value with itself can exit
+// early on a length or an equality check, which would measure the shortcut
+// rather than the comparison.
+
+#include <chrono>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include "storage/v2/enum.hpp"
+#include "storage/v2/point.hpp"
+#include "storage/v2/property_store.hpp"
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/temporal.hpp"
+#include "utils/temporal.hpp"
+
+namespace {
+
+using memgraph::storage::CoordinateReferenceSystem;
+using memgraph::storage::Enum;
+using memgraph::storage::EnumTypeId;
+using memgraph::storage::EnumValueId;
+using memgraph::storage::IntListTag;
+using memgraph::storage::Point2d;
+using memgraph::storage::Point3d;
+using memgraph::storage::PropertyId;
+using memgraph::storage::PropertyStore;
+using memgraph::storage::PropertyValue;
+using memgraph::storage::TemporalData;
+using memgraph::storage::TemporalType;
+using memgraph::storage::ZonedTemporalData;
+using memgraph::storage::ZonedTemporalType;
+
+/// Holds each element as a value of its own. This is what a query hands the
+/// store, and the only representation a list with a non-numeric element can
+/// use.
+struct Boxed {};
+
+/// Builds a list of the given elements.
+///
+/// The element type is deduced. The representation defaults to boxed; passing
+/// `IntListTag` packs the elements instead.
+template <typename Representation = Boxed, typename... Ts>
+PropertyValue ListOf(Ts &&...values) {
+  auto elements = std::vector<PropertyValue>{};
+  elements.reserve(sizeof...(Ts));
+  (elements.emplace_back(std::forward<Ts>(values)), ...);
+  if constexpr (std::is_same_v<Representation, Boxed>) {
+    return PropertyValue{std::move(elements)};
+  } else {
+    return PropertyValue{Representation{}, std::move(elements)};
+  }
+}
+
+/// The two operands a comparison is asked about.
+using Pair = std::pair<PropertyValue, PropertyValue>;
+
+/// One type per pair of values.
+///
+/// A shape is a type rather than a string, so a misspelled name fails to
+/// compile instead of registering a benchmark that aborts when it runs.
+struct Int {
+  static Pair Make() { return {PropertyValue{int64_t{7}}, PropertyValue{int64_t{9}}}; }
+};
+
+struct Double {
+  static Pair Make() { return {PropertyValue{1.5}, PropertyValue{2.5}}; }
+};
+
+struct Bool {
+  static Pair Make() { return {PropertyValue{false}, PropertyValue{true}}; }
+};
+
+struct String {
+  static Pair Make() { return {PropertyValue{"alpha"}, PropertyValue{"bravo"}}; }
+};
+
+struct LongString {
+  static Pair Make() { return {PropertyValue{std::string(64, 'a') + "1"}, PropertyValue{std::string(64, 'a') + "2"}}; }
+};
+
+struct Temporal {
+  static Pair Make() {
+    return {PropertyValue{TemporalData{TemporalType::Date, 10}}, PropertyValue{TemporalData{TemporalType::Date, 20}}};
+  }
+};
+
+/// Both in the same zone, so the comparison is decided by the instant rather
+/// than by the zone that precedes it.
+struct ZonedTemporal {
+  static Pair Make() {
+    auto const zone = memgraph::utils::Timezone{std::chrono::minutes{60}};
+    auto const at = [&zone](int64_t microseconds) {
+      return PropertyValue{
+          ZonedTemporalData{ZonedTemporalType::ZonedDateTime, memgraph::utils::AsSysTime(microseconds), zone}};
+    };
+    return {at(10), at(20)};
+  }
+};
+
+struct Enumeration {
+  static Pair Make() {
+    return {PropertyValue{Enum{EnumTypeId{2}, EnumValueId{10}}}, PropertyValue{Enum{EnumTypeId{2}, EnumValueId{20}}}};
+  }
+};
+
+/// Same reference system, so the comparison reaches the coordinates.
+struct Point2 {
+  static Pair Make() {
+    return {PropertyValue{Point2d{CoordinateReferenceSystem::Cartesian_2d, 1.0, 2.0}},
+            PropertyValue{Point2d{CoordinateReferenceSystem::Cartesian_2d, 1.0, 3.0}}};
+  }
+};
+
+struct Point3 {
+  static Pair Make() {
+    return {PropertyValue{Point3d{CoordinateReferenceSystem::Cartesian_3d, 1.0, 2.0, 3.0}},
+            PropertyValue{Point3d{CoordinateReferenceSystem::Cartesian_3d, 1.0, 2.0, 4.0}}};
+  }
+};
+
+/// Same keys, so the comparison reaches the value that differs rather than
+/// deciding on a key.
+struct Map {
+  static Pair Make() {
+    auto const of = [](int64_t value) {
+      return PropertyValue{PropertyValue::map_t{{PropertyId::FromUint(1), PropertyValue{int64_t{7}}},
+                                                {PropertyId::FromUint(2), PropertyValue{value}}}};
+    };
+    return {of(8), of(9)};
+  }
+};
+
+/// Same length, so the comparison has to reach the element that differs rather
+/// than deciding on the lengths.
+struct List {
+  static Pair Make() { return {ListOf(1, 2, 3, 4), ListOf(1, 2, 3, 5)}; }
+};
+
+/// Different lengths, but an element separates them before the lengths are
+/// reached.
+struct ListOfUnlikeLengths {
+  static Pair Make() { return {ListOf(1, 2), ListOf(1, 2, 3, 4)}; }
+};
+
+struct ListOfStrings {
+  static Pair Make() { return {ListOf("a", "b"), ListOf("a", "c")}; }
+};
+
+/// One list packs its elements, the other boxes them. This is what a stored
+/// column meets when a query hands it a list, and the only case compared
+/// element by element rather than by representation.
+struct PackedAgainstBoxed {
+  static Pair Make() { return {ListOf<IntListTag>(1, 2, 3, 4), ListOf(1, 2, 3, 5)}; }
+};
+
+struct PackedAgainstBoxedUnlikeLengths {
+  static Pair Make() { return {ListOf<IntListTag>(1, 2), ListOf(1, 2, 3, 4)}; }
+};
+
+/// Different types, which are ordered by type alone without either value being
+/// read.
+struct UnlikeTypes {
+  static Pair Make() { return {PropertyValue{int64_t{7}}, PropertyValue{"seven"}}; }
+};
+
+// The comparison an index walks its entries with.
+template <typename Shape>
+void Ordering(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  for (auto _ : state) benchmark::DoNotOptimize(lhs <=> rhs);
+  state.SetItemsProcessed(state.iterations());
+}
+
+// The same question asked of the stored bytes, which is how a scan confirms the
+// entry it landed on.
+template <typename Shape>
+void EncodedSameness(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  auto const property = PropertyId::FromUint(1);
+  auto store = PropertyStore{};
+  store.SetProperty(property, lhs);
+  for (auto _ : state) benchmark::DoNotOptimize(store.IsPropertyEqual(property, rhs));
+  state.SetItemsProcessed(state.iterations());
+}
+
+// The same, but asked about the value the store already holds, which is what a
+// lookup does when the candidate matches.
+//
+// Kept separate from the case above because the two differ when a mismatch is
+// found early: a candidate of another length or another type is rejected before
+// the bytes are compared, while a matching value is compared to the end. For
+// fixed-width types the two cost the same.
+template <typename Shape>
+void EncodedSamenessHit(benchmark::State &state) {
+  auto const [lhs, rhs] = Shape::Make();
+  auto const property = PropertyId::FromUint(1);
+  auto store = PropertyStore{};
+  store.SetProperty(property, lhs);
+  for (auto _ : state) benchmark::DoNotOptimize(store.IsPropertyEqual(property, lhs));
+  state.SetItemsProcessed(state.iterations());
+}
+
+// The label comes from the same token that selects the shape, so the two cannot
+// disagree.
+#define SHAPE(bench, shape) BENCHMARK_TEMPLATE(bench, shape)->Name(#bench "/" #shape)->Unit(benchmark::kNanosecond)
+
+#define FOR_EACH_SHAPE(bench)                    \
+  SHAPE(bench, Int);                             \
+  SHAPE(bench, Double);                          \
+  SHAPE(bench, Bool);                            \
+  SHAPE(bench, String);                          \
+  SHAPE(bench, LongString);                      \
+  SHAPE(bench, Temporal);                        \
+  SHAPE(bench, ZonedTemporal);                   \
+  SHAPE(bench, Enumeration);                     \
+  SHAPE(bench, Point2);                          \
+  SHAPE(bench, Point3);                          \
+  SHAPE(bench, Map);                             \
+  SHAPE(bench, List);                            \
+  SHAPE(bench, ListOfUnlikeLengths);             \
+  SHAPE(bench, ListOfStrings);                   \
+  SHAPE(bench, PackedAgainstBoxed);              \
+  SHAPE(bench, PackedAgainstBoxedUnlikeLengths); \
+  SHAPE(bench, UnlikeTypes);
+
+FOR_EACH_SHAPE(Ordering)
+FOR_EACH_SHAPE(EncodedSameness)
+FOR_EACH_SHAPE(EncodedSamenessHit)
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/tests/unit/property_value_v2.cpp
+++ b/tests/unit/property_value_v2.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory_resource>
 #include <sstream>
 
@@ -710,6 +711,32 @@ TEST(PropertyValue, Equal) {
       }
     }
   }
+}
+
+TEST(PropertyValue, AListIsOrderedByEveryBitOfTheIntegersItHolds) {
+  // Two lists holding integers that differ only above 32 bits are not equal, and
+  // are ordered by which integer is larger.
+  auto const boxed = [](std::vector<int64_t> const &numbers) {
+    auto elements = std::vector<PropertyValue>{};
+    for (auto const number : numbers) elements.emplace_back(number);
+    return PropertyValue{elements};
+  };
+  auto const packed = [](std::vector<int64_t> const &numbers) {
+    auto elements = std::vector<PropertyValue>{};
+    for (auto const number : numbers) elements.emplace_back(number);
+    return PropertyValue{IntListTag{}, elements};
+  };
+
+  // The boxed element differs from the packed one only above the low 32 bits.
+  auto const big = int64_t{1} << 32;
+  EXPECT_TRUE(std::is_gt(boxed({big}) <=> packed({0})));
+  EXPECT_TRUE(std::is_lt(packed({0}) <=> boxed({big})));
+  EXPECT_FALSE(boxed({big}) == packed({0}));
+
+  // And one no narrower integer can hold at all.
+  auto const huge = std::numeric_limits<int64_t>::max();
+  EXPECT_TRUE(std::is_gt(boxed({huge}) <=> packed({1})));
+  EXPECT_FALSE(boxed({huge}) == packed({1}));
 }
 
 TEST(PropertyValue, EqualMap) {


### PR DESCRIPTION
Comparability gets a header naming what it answers, alongside the two relations
already there. `operator<` reaches the relation there, and the three operators
written in terms of it follow, so no caller changes and no answer changes, which
is what the unchanged tests show.

Two things the relation needs are stated where it can see them. Which types it
admits at all is a named predicate rather than a lambda buried in the body, and
the temporal test it uses moves with it: that test had internal linkage, so a
header could not have called it, and nothing else did. The temporal cases are
marked as the rarer branch, which keeps them off the path a comparison of two
numbers or two strings takes. Comparability is partial, answering Null for a
pair it cannot place and raising for a type it does not admit, which is where it
parts from the ordering a sort needs.

