### PR TITLE
perf: iterate relationships by handle in the path.expand_config expansion loops

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -750,6 +750,9 @@ class Node {
   /// @brief Creates a Node from the copy of the given @ref mgp_vertex.
   explicit Node(const mgp_vertex *const_ptr);
 
+  /// Borrowed handle, for call sites that must avoid the copy every accessor here makes.
+  mgp_vertex *GetPtr() const;
+
   Node(const Node &other);
   Node(Node &&other) noexcept;
 
@@ -3183,6 +3186,8 @@ inline Node::~Node() {
 }
 
 inline bool Node::IsDeleted() const { return mgp::vertex_is_deleted(ptr_); }
+
+inline mgp_vertex *Node::GetPtr() const { return ptr_; }
 
 inline mgp::Id Node::Id() const { return Id::FromInt(mgp::vertex_get_id(ptr_).as_int); }
 

--- a/src/mage/cpp/path_module/algorithm/path.cpp
+++ b/src/mage/cpp/path_module/algorithm/path.cpp
@@ -888,6 +888,36 @@ void Path::Create(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result,
   }
 }
 
+namespace {
+// The C++ accessors copy a vertex or a relationship out of storage on construction, which the walk
+// cannot afford once per candidate relationship. Iterating the C handles keeps the copy for the
+// candidates that are actually taken; the handles are borrowed and live only until the next step.
+class BorrowedEdges {
+ public:
+  BorrowedEdges(mgp_vertex *vertex, bool outgoing)
+      : iterator_(outgoing ? mgp::MemHandlerCallback(mgp::vertex_iter_out_edges, vertex)
+                           : mgp::MemHandlerCallback(mgp::vertex_iter_in_edges, vertex)) {
+    if (iterator_ == nullptr) {
+      throw mg_exception::NotEnoughMemoryException();
+    }
+  }
+
+  BorrowedEdges(const BorrowedEdges &) = delete;
+  BorrowedEdges &operator=(const BorrowedEdges &) = delete;
+  BorrowedEdges(BorrowedEdges &&) = delete;
+  BorrowedEdges &operator=(BorrowedEdges &&) = delete;
+
+  ~BorrowedEdges() { mgp::edges_iterator_destroy(iterator_); }
+
+  mgp_edge *First() const { return mgp::edges_iterator_get(iterator_); }
+
+  mgp_edge *Next() const { return mgp::edges_iterator_next(iterator_); }
+
+ private:
+  mgp_edges_iterator *iterator_;
+};
+}  // namespace
+
 void Path::PathExpand::ExpandPath(mgp::Path &path, const mgp::Relationship &relationship, int64_t path_size,
                                   const int64_t uniqueness_key, const mgp::Node &next_node) {
   path.Expand(relationship);
@@ -900,9 +930,12 @@ void Path::PathExpand::ExpandPath(mgp::Path &path, const mgp::Relationship &rela
   path.Pop();
 }
 
-void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp::Relationships relationships, bool outgoing,
-                                               int64_t path_size) {
-  for (const auto relationship : relationships) {
+void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp_vertex *vertex, const bool outgoing,
+                                               const int64_t path_size) {
+  const bool node_keyed = IsNodeUniqueness(path_data_.helper_.GetUniqueness());
+
+  const BorrowedEdges edges{vertex, outgoing};
+  for (auto *edge = edges.First(); edge != nullptr; edge = edges.Next()) {
     if (path_data_.LimitReached()) {
       return;
     }
@@ -910,21 +943,18 @@ void Path::PathExpand::ExpandFromRelationships(mgp::Path &path, mgp::Relationshi
     // supernode's whole adjacency list is uninterruptible.
     path_data_.MaybeAbort();
 
-    // Under a node-keyed rule the uniqueness key is the node the relationship reaches, and reading its
-    // id means materialising it. The type test needs only a name the relationship already carries, so
-    // it goes first and keeps that construction off every relationship the filter rejects.
-    if (!path_data_.helper_.RelationshipAdmitted(relationship.Type(), outgoing, path_size)) {
+    // The type test needs only a name the relationship already carries; everything below it copies.
+    if (!path_data_.helper_.RelationshipAdmitted(mgp::edge_get_type(edge).name, outgoing, path_size)) {
       continue;
     }
 
-    // The walk needs this node twice over -- to key uniqueness on, and to filter once the path reaches
-    // it -- and building it copies a vertex out of storage. Build it once and hand it down.
-    const mgp::Node next_node = outgoing ? relationship.To() : relationship.From();
-    const int64_t uniqueness_key =
-        IsNodeUniqueness(path_data_.helper_.GetUniqueness()) ? next_node.Id().AsInt() : relationship.Id().AsInt();
-    if (!path_data_.visited_.contains(uniqueness_key)) {
-      ExpandPath(path, relationship, path_size, uniqueness_key, next_node);
+    auto *next_vertex = outgoing ? mgp::edge_get_to(edge) : mgp::edge_get_from(edge);
+    const int64_t uniqueness_key = node_keyed ? mgp::vertex_get_id(next_vertex).as_int : mgp::edge_get_id(edge).as_int;
+    if (path_data_.visited_.contains(uniqueness_key)) {
+      continue;
     }
+
+    ExpandPath(path, mgp::Relationship(edge), path_size, uniqueness_key, mgp::Node(next_vertex));
   }
 }
 
@@ -965,10 +995,10 @@ void Path::PathExpand::DFS(mgp::Path &path, int64_t path_size, const mgp::Node &
   // Reading an adjacency list costs a storage round trip and a copy of every relationship in it, all of
   // which a directed step then rejects. Ask the step first.
   if (path_data_.helper_.StepAdmitsDirection(path_size, false)) {
-    this->ExpandFromRelationships(path, node.InRelationships(), false, path_size);
+    this->ExpandFromRelationships(path, node.GetPtr(), false, path_size);
   }
   if (path_data_.helper_.StepAdmitsDirection(path_size, true)) {
-    this->ExpandFromRelationships(path, node.OutRelationships(), true, path_size);
+    this->ExpandFromRelationships(path, node.GetPtr(), true, path_size);
   }
 }
 
@@ -1138,34 +1168,37 @@ mgp::Path Path::PathExpand::BranchPath(const int64_t index) const {
   return path;
 }
 
-void Path::PathExpand::ExpandBranch(const int64_t index, const mgp::Node & /*node*/, mgp::Relationships relationships,
-                                    const bool outgoing, std::queue<std::pair<int64_t, mgp::Node>> &frontier) {
+void Path::PathExpand::ExpandBranch(const int64_t index, mgp_vertex *vertex, const bool outgoing,
+                                    std::queue<std::pair<int64_t, mgp::Node>> &frontier) {
   // Read before the loop: pushing a branch can reallocate the vector out from under a reference.
   const int64_t depth = branches_[index].depth;
   const bool node_keyed = IsNodeUniqueness(path_data_.helper_.GetUniqueness());
 
-  for (const auto relationship : relationships) {
+  const BorrowedEdges edges{vertex, outgoing};
+  for (auto *edge = edges.First(); edge != nullptr; edge = edges.Next()) {
     if (path_data_.LimitReached()) {
       return;
     }
     path_data_.MaybeAbort();
 
-    if (!path_data_.helper_.RelationshipAdmitted(relationship.Type(), outgoing, depth)) {
+    if (!path_data_.helper_.RelationshipAdmitted(mgp::edge_get_type(edge).name, outgoing, depth)) {
       continue;
     }
 
-    mgp::Node next_node = outgoing ? relationship.To() : relationship.From();
-    const int64_t key = node_keyed ? next_node.Id().AsInt() : relationship.Id().AsInt();
+    auto *next_vertex = outgoing ? mgp::edge_get_to(edge) : mgp::edge_get_from(edge);
+    const int64_t next_id = mgp::vertex_get_id(next_vertex).as_int;
+    const int64_t key = node_keyed ? next_id : mgp::edge_get_id(edge).as_int;
     if (OnBranch(index, key)) {
       continue;
     }
 
-    branches_.push_back({.node_id = next_node.Id().AsInt(),
-                         .relationship_id = relationship.Id().AsInt(),
+    branches_.push_back({.node_id = next_id,
+                         .relationship_id = mgp::edge_get_id(edge).as_int,
                          .parent = index,
                          .depth = depth + 1,
-                         .from_parent = relationship});
-    frontier.emplace(static_cast<int64_t>(branches_.size()) - 1, std::move(next_node));
+                         .from_parent = mgp::Relationship(edge)});
+    // The one node copy this loop makes, and only for a branch the walk is going to follow.
+    frontier.emplace(static_cast<int64_t>(branches_.size()) - 1, mgp::Node(next_vertex));
   }
 }
 
@@ -1209,10 +1242,10 @@ void Path::PathExpand::RunPathScopedBfs() {
     }
 
     if (path_data_.helper_.StepAdmitsDirection(depth, false)) {
-      ExpandBranch(index, node, node.InRelationships(), false, frontier);
+      ExpandBranch(index, node.GetPtr(), false, frontier);
     }
     if (path_data_.helper_.StepAdmitsDirection(depth, true)) {
-      ExpandBranch(index, node, node.OutRelationships(), true, frontier);
+      ExpandBranch(index, node.GetPtr(), true, frontier);
     }
   }
 }

--- a/src/mage/cpp/path_module/algorithm/path.hpp
+++ b/src/mage/cpp/path_module/algorithm/path.hpp
@@ -303,7 +303,7 @@ class PathExpand {
 
   void ExpandPath(mgp::Path &path, const mgp::Relationship &relationship, int64_t path_size, int64_t uniqueness_key,
                   const mgp::Node &next_node);
-  void ExpandFromRelationships(mgp::Path &path, mgp::Relationships relationships, bool outgoing, int64_t path_size);
+  void ExpandFromRelationships(mgp::Path &path, mgp_vertex *vertex, bool outgoing, int64_t path_size);
   void StartAlgorithm(const mgp::Node &node);
   void Parse(const mgp::Value &value);
   // Takes the node the path now ends at: the caller has just built it to key uniqueness on.
@@ -342,7 +342,7 @@ class PathExpand {
   static constexpr int64_t kNoRelationship = std::numeric_limits<int64_t>::min();
 
   void RunPathScopedBfs();
-  void ExpandBranch(int64_t index, const mgp::Node &node, mgp::Relationships relationships, bool outgoing,
+  void ExpandBranch(int64_t index, mgp_vertex *vertex, bool outgoing,
                     std::queue<std::pair<int64_t, mgp::Node>> &frontier);
   // Walks the parent chain rather than a visited set: the rule is scoped to this path, not the walk.
   [[nodiscard]] bool OnBranch(int64_t index, int64_t key) const;


### PR DESCRIPTION
> **Review view — do not merge this on its own.** These commits land through **#4727**, which carries all six. This PR exists so this one change can be reviewed and discussed separately.

Drops the C++ accessor layer from the two hot loops of `path.expand_config`, which was copying out of storage once per candidate relationship.

**How.** `Relationships::Iterator::operator*` constructs an `mgp::Relationship`, and `Relationship::To()`/`From()` construct an `mgp::Node` — each one a `mgp_edge_copy`/`mgp_vertex_copy` out of storage (`mgp.hpp:3151`, `:3304`). The expansion loops paid both for every candidate, including the ones the type filter rejects a line later.

`ExpandBranch` and `ExpandFromRelationships` now iterate the C handles through a small RAII `BorrowedEdges` guard. The handles are borrowed and valid only until the next step, which is all the loops need to read a type, an id and an endpoint id; an owning object is built only for a candidate the walk is going to follow.

**Header change.** Adds `Node::GetPtr()` to `include/mgp.hpp` — additive, inline, and the same borrowed-handle accessor `List::GetPtr()` already exposes. Since that header is shared, all 39 MAGE modules were rebuilt against it and compile clean.

**Why.** 0.57s to 0.45s on a 4425-node topology, the same 732 paths with the same contents, and no change in peak memory. The saving is the rejected candidates, so it tracks filter selectivity: a shallow expansion with no relationship filter, where every candidate is taken anyway, is unchanged. 133 path e2e tests pass.

Stacked on #4723.