### PR TITLE
feat: cross_database as an Enterprise feature

### DIFF
--- a/src/mage/python/cross_database.py
+++ b/src/mage/python/cross_database.py
@@ -46,11 +46,25 @@ class Constants:
         "Cross database module with these parameters is already running. "
         "Please wait for it to finish before starting a new one."
     )
+    ENTERPRISE_LICENSE_ERROR = (
+        "To use the cross_database (migrate) module you need a valid Memgraph Enterprise license."
+    )
 
 
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
+
+def _check_enterprise_license() -> None:
+    """Cross-database migration is an enterprise-only feature.
+
+    The module is not even loaded without a valid license (see kEnterpriseModuleList in
+    src/query/procedure/module.cpp), so this guards the case of a license that expires or
+    is removed while the module is already loaded.
+    """
+    if not mgp.is_enterprise_valid():
+        raise RuntimeError(Constants.ENTERPRISE_LICENSE_ERROR)
 
 
 def _get_cache_key(start_ts: int, query: str, config: mgp.Map, params: mgp.Nullable[mgp.Any] = None) -> str:
@@ -331,6 +345,7 @@ def _init_bolt(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
+    _check_enterprise_license()
     _bolt_init_state(_bolt_state, ctx.graph.start_timestamp, label_or_rel_or_query, config, config_path, params)
 
 
@@ -375,6 +390,7 @@ def _init_neo4j(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
+    _check_enterprise_license()
     _bolt_init_state(
         _neo4j_state,
         ctx.graph.start_timestamp,
@@ -431,6 +447,8 @@ def init_migrate_mysql(
     params: mgp.Nullable[mgp.Any] = None,
 ):
     global mysql_dict
+
+    _check_enterprise_license()
 
     if params:
         _check_params_type(params)
@@ -536,6 +554,8 @@ def init_migrate_sql_server(
     params: mgp.Nullable[mgp.Any] = None,
 ):
     global sql_server_dict
+
+    _check_enterprise_license()
 
     if params:
         _check_params_type(params, (list, tuple))
@@ -647,6 +667,8 @@ def init_migrate_oracle_db(
     params: mgp.Nullable[mgp.Any] = None,
 ):
     global oracle_db_dict
+
+    _check_enterprise_license()
 
     if params:
         _check_params_type(params)
@@ -769,6 +791,8 @@ def init_migrate_postgresql(
 ):
     global postgres_dict
 
+    _check_enterprise_license()
+
     if params:
         _check_params_type(params, (list, tuple))
     else:
@@ -887,6 +911,8 @@ def init_migrate_s3(
     """
     global s3_dict
 
+    _check_enterprise_license()
+
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
@@ -988,6 +1014,8 @@ def init_migrate_arrow_flight(
     config_path: str = "",
 ):
     global flight_dict
+
+    _check_enterprise_license()
 
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
@@ -1094,6 +1122,8 @@ def init_migrate_duckdb(ctx: mgp.ProcCtx, query: str, setup_queries: mgp.Nullabl
     """
     global duckdb_dict
 
+    _check_enterprise_license()
+
     setup_queries_str = json.dumps(setup_queries, sort_keys=False) if setup_queries else ""
     cache_key = _get_cache_key(ctx.graph.start_timestamp, query, {}, setup_queries_str)
 
@@ -1178,6 +1208,8 @@ def init_migrate_servicenow(
     :param params: Optional query parameters for filtering results
     """
     global servicenow_dict
+
+    _check_enterprise_license()
 
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)

--- a/src/mage/python/cross_database.py
+++ b/src/mage/python/cross_database.py
@@ -1,3 +1,9 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Licensed as a Memgraph Enterprise file under the Memgraph Enterprise
+# License (the "License"); by using this file, you agree to be bound by the terms of the License, and you may not use
+# this file except in compliance with the License. You may obtain a copy of the License at https://memgraph.com/legal.
+
 import base64
 import csv
 import datetime
@@ -59,9 +65,11 @@ class Constants:
 def _check_enterprise_license() -> None:
     """Cross-database migration is an enterprise-only feature.
 
-    The module is not even loaded without a valid license (see kEnterpriseModuleList in
-    src/query/procedure/module.cpp), so this guards the case of a license that expires or
-    is removed while the module is already loaded.
+    Enterprise builds additionally refuse to load this module at all when no valid license
+    is present (kEnterpriseModuleList in src/query/procedure/module.cpp), but that check is
+    compiled out of community builds and only runs at load time. This is the per-call guard,
+    and therefore the one that covers community builds and licenses that expire or are
+    removed while the module is already loaded.
     """
     if not mgp.is_enterprise_valid():
         raise RuntimeError(Constants.ENTERPRISE_LICENSE_ERROR)

--- a/src/query/procedure/module.cpp
+++ b/src/query/procedure/module.cpp
@@ -1302,9 +1302,10 @@ const std::map<std::string, mgp_func, std::less<>> *PythonModule::Functions() co
 namespace {
 
 #ifdef MG_ENTERPRISE
-constexpr std::array<const char *, 5> kEnterpriseModuleList = {
+constexpr std::array<const char *, 6> kEnterpriseModuleList = {
     "betweenness_centrality_online",
     "community_detection_online",
+    "cross_database",
     "katz_centrality_online",
     "node2vec_online",
     "pagerank_online",


### PR DESCRIPTION
`cross_database` (AKA `migrate`) is now Enterprise-only.


