### PR TITLE
fix: Temporarily disable CentOS 10 smoke testing while the image is broken

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -727,9 +727,9 @@ jobs:
           fi
           mage_rpm="$(ls -t output/memgraph-mage-[0-9]*.rpm | head -n 1)"
           cp -v "$mage_rpm" release/package/mage/memgraph-mage.rpm
+          # TODO(matt): add centos-10 when the image is fixed
           distros=(
             centos-9
-            centos-10
           )
           for distro in "${distros[@]}"; do
             case "$distro" in
@@ -1070,9 +1070,9 @@ jobs:
       - name: "Run Docker smoke tests (rpm)"
         if: ${{ inputs.run_smoke_tests && !inputs.cugraph && !inputs.cuda  && !inputs.malloc }}
         run: |
+          # TODO(matt): add centos-10 when the image is fixed
           distros=(
             centos-9
-            centos-10
           )
           for distro in "${distros[@]}"; do
             ./release/package/mgbuild.sh \


### PR DESCRIPTION
The latest Docker image from `quay.io/centos/centos:stream10` appears to have no `rootfs` and causes our CI to fail. Let's temporarily disable for the Diff workflow to be able continue.


