### PR TITLE
fix(mgbench): make `--warm-up` work end to end

### DIFF
--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -56,20 +56,6 @@ SETUP_IN_MEMORY_ANALYTICAL_STORAGE_MODE = [
 ]
 
 
-def get_warmup_to_hot_queries(client):
-    match client.vendor:
-        case GraphVendors.MEMGRAPH | GraphVendors.NEO4J | GraphVendors.FALKORDB:
-            return [
-                ("CREATE ();", {}),
-                ("CREATE ()-[:TempEdge]->();", {}),
-                ("MATCH (n) RETURN count(n.prop) LIMIT 1;", {}),
-            ]
-        case GraphVendors.POSTGRESQL:
-            return []
-        case _:
-            raise Exception(f"Unknown vendor name {client.vendor} for warmup queries!")
-
-
 def parse_args():
     benchmark_parser = argparse.ArgumentParser(description="Benchmark arguments parser", add_help=False)
 
@@ -245,9 +231,10 @@ def parse_args():
 
     benchmark_parser.add_argument(
         "--workload-realistic",
-        nargs="*",
+        nargs=5,
         type=int,
         default=None,
+        metavar=("num_of_queries", "write", "read", "update", "analytical"),
         help="""Define combination that defines the realistic workload.
         Realistic workload can be run as a single configuration for all groups of queries,
         Pass the positional arguments as values of what percentage of
@@ -258,9 +245,10 @@ def parse_args():
 
     benchmark_parser.add_argument(
         "--workload-mixed",
-        nargs="*",
+        nargs=6,
         type=int,
         default=None,
+        metavar=("num_of_queries", "write", "read", "update", "analytical", "query"),
         help="""Mixed workload can be run on each query under some defined load.
         By passing one more positional argument, you are defining what percentage of that query
         will be in mixed workload, and this is executed for each query. The rest of the queries will be
@@ -381,6 +369,10 @@ def sanitize_args(args):
     assert (
         args.workload_realistic is None or args.workload_mixed is None
     ), "Cannot run both realistic and mixed workload, only one mode run at the time"
+    assert (
+        args.workload_realistic is None or args.workload_realistic[0] > 0
+    ), "--workload-realistic needs a query count above zero"
+    assert args.workload_mixed is None or args.workload_mixed[0] > 0, "--workload-mixed needs a query count above zero"
 
     # Auto-detect vendor binary if not specified and the installation type starts a local binary
     if (
@@ -543,7 +535,7 @@ def realistic_workload(
 
     rss_db = dataset.NAME + dataset.get_variant() + "_" + "realistic" + "_" + config_distribution
     vendor.start_db(rss_db)
-    warmup(benchmark_context.warm_up, client=client)
+    warmup(benchmark_context.warm_up, client=client, queries=prepared_queries)
 
     ret = client.execute(
         queries=prepared_queries,
@@ -621,7 +613,7 @@ def mixed_workload(
 
         rss_db = dataset.NAME + dataset.get_variant() + "_" + "mixed" + "_" + query + "_" + config_distribution
         vendor.start_db(rss_db)
-        warmup(benchmark_context.warm_up, client=client)
+        warmup(benchmark_context.warm_up, client=client, queries=prepared_queries)
 
         ret = client.execute(
             queries=prepared_queries,
@@ -644,18 +636,19 @@ def mixed_workload(
         results.set_value(*results_key, value=ret)
 
 
-def warmup(condition: str, client, queries: list = None):
+def warmup(condition: str, client, queries: list):
     if condition == DATABASE_CONDITION_HOT:
         log.log("Execute warm-up to match condition: {} ".format(condition))
-        warmup_to_hot_queries = get_warmup_to_hot_queries(client)
-        if len(queries) > 0:
+        warmup_to_hot_queries = client.get_warmup_to_hot_queries()
+        if warmup_to_hot_queries:
             client.execute(
                 queries=warmup_to_hot_queries,
                 num_workers=1,
             )
     elif condition == DATABASE_CONDITION_VULCANIC:
         log.log("Execute warm-up to match condition: {} ".format(condition))
-        client.execute(queries=queries)
+        if queries:
+            client.execute(queries=queries)
     else:
         log.log("No warm-up on condition: {} ".format(condition))
     log.log("Finished warm-up procedure to match database condition: {} ".format(condition))

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -154,6 +154,19 @@ class BaseClient(ABC):
     def execute(self):
         pass
 
+    def get_warmup_to_hot_queries(self) -> list:
+        match self._vendor:
+            case GraphVendors.MEMGRAPH | GraphVendors.NEO4J | GraphVendors.FALKORDB:
+                return [
+                    ("CREATE ();", {}),
+                    ("CREATE ()-[:TempEdge]->();", {}),
+                    ("MATCH (n) RETURN count(n.prop) LIMIT 1;", {}),
+                ]
+            case GraphVendors.POSTGRESQL:
+                return []
+            case _:
+                raise Exception(f"Unknown vendor name {self._vendor} for warmup queries!")
+
     def get_check_db_query(self) -> str:
         match self._vendor:
             case GraphVendors.MEMGRAPH | GraphVendors.NEO4J | GraphVendors.FALKORDB:


### PR DESCRIPTION
The `--warm-up` flag runs compulsory queries before measuring, so the database isn't cold for measured benchmarks. It was broken three ways:

- The code asked the client for its `vendor` name, but `BaseClient` only ever stored that as `_vendor`, so every `--warm-up hot` run crashed immediately with an `AttributeError`, on every workload path and every vendor. That has been the case since #2958 in June 2025; nothing in CI passes `--warm-up`, and `graph_bench.py` only runs hot and vulcanic when asked for them explicitly, so nobody hit it.

- Behind that crash sat a second bug. The line meant to skip the warm-up when there was nothing to run checked `queries` rather than the warm-up list itself, so it would have crashed too on the realistic and mixed paths, where `queries` is None. Nobody noticed because the first bug always fired first.

- `--warm-up vulcanic` crashed a third way, on those same two paths: they built the queries to run, then called `warmup()` without passing them. It worked on isolated workloads, which is why it looked less broken than hot.

The fix moves the warm-up query list onto `BaseClient`, next to the near-identical function that picks the health-check query, so it reads `_vendor` directly and needs no accessor. The skip check now looks at the list it actually runs, which also stops PostgreSQL, which has no warm-up queries, from running an empty batch. The vulcanic branch gets the same guard, so neither condition can hand the client an empty batch and fail later in JSON parsing. The two callers now pass the queries they already had, and `queries` loses the default that let the omission look legal.

`--workload-realistic` and `--workload-mixed` take `nargs=5` and `nargs=6`, matching what `graph_bench.py` already declares for the same two options. Argparse then rejects a wrong-length config with a usage message instead of letting it reach `random.choices` as a weights/population mismatch. A query count of zero is still rejected by an assert, because argparse cannot express it.
