### PR TITLE
perf: optimize KSHORTEST path expansion

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4175,6 +4175,8 @@ class KShortestPathsCursor : public Cursor {
         blocked_vertices_(mem),
         in_edges_(mem),
         out_edges_(mem),
+        trie_first_child_(1, kNoChild, mem),  // node 0 is the empty root, valid from construction
+        trie_children_(mem),
         path_gids_scratch_(mem),
         bfs_source_frontier_(mem),
         bfs_target_frontier_(mem),
@@ -4312,12 +4314,8 @@ class KShortestPathsCursor : public Cursor {
 
   struct PathComparator {
     bool operator()(const PathInfo &a, const PathInfo &b) const {
-      return a.edges.size() > b.edges.size();  // Min-heap: smaller costs have higher priority
+      return a.edges.size() > b.edges.size();  // Reversed: the heap serves the shortest path first
     }
-  };
-
-  struct EdgeAccessorHash {
-    size_t operator()(const EdgeAccessor &edge) const { return std::hash<storage::Gid>{}(edge.Gid()); }
   };
 
   struct VertexAccessorHash {
@@ -4369,7 +4367,9 @@ class KShortestPathsCursor : public Cursor {
   std::optional<VertexAccessor> current_source_;
   std::optional<VertexAccessor> current_target_;
 
-  // Per-deviation state for the inner search. Unweighted: `PathComparator` orders by hop count.
+  // The inner search skips these. Blocked edges are rebuilt for every deviation; blocked vertices
+  // are the root walked so far, so they only accumulate down the base path. There are no weights:
+  // `PathComparator` orders by hop count.
   utils::pmr::unordered_set<storage::Gid> blocked_edges_;
   utils::pmr::unordered_set<storage::Gid> blocked_vertices_;
   // Raw storage adjacency, kept across input rows (unlike `expansion_memo_`) so Yen's repeated inner
@@ -4380,6 +4380,19 @@ class KShortestPathsCursor : public Cursor {
   using CachedEdges = utils::pmr::vector<EdgeAccessor>;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> in_edges_;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> out_edges_;
+
+  // Trie of the found paths' edges: a root prefix's children are exactly the edges a deviation
+  // there must block. Children form an intrusive sibling list, so a node holds no container.
+  static constexpr uint32_t kNoChild = std::numeric_limits<uint32_t>::max();
+
+  struct TrieChild {
+    storage::Gid edge;
+    uint32_t node;
+    uint32_t next_sibling;
+  };
+
+  utils::pmr::vector<uint32_t> trie_first_child_;
+  utils::pmr::vector<TrieChild> trie_children_;
 
   // Probe buffer for `found_paths_set_`.
   utils::pmr::vector<storage::Gid> path_gids_scratch_;
@@ -4409,11 +4422,13 @@ class KShortestPathsCursor : public Cursor {
                                 ExpressionEvaluator &evaluator, ExecutionContext &context) {
     ResetState();
 
-    // Find the shortest path using Dijkstra's algorithm
+    // Seeds Yen's with the shortest path; the rest are deviations from it.
     auto shortest_path = ComputeShortestPath(source, target, upper_bound_, frame, evaluator, context);
     if (!shortest_path.edges.empty()) {
+      // Recorded before it is reachable as a base path: `ComputeNextShortestPath` walks
+      // `shortest_paths_.back()` down the trie and asserts the walk cannot miss.
+      AddPathToFoundSet(shortest_path);
       shortest_paths_.emplace_back(std::move(shortest_path));
-      AddPathToFoundSet(shortest_paths_.back());
       return true;
     }
     return false;
@@ -4423,16 +4438,41 @@ class KShortestPathsCursor : public Cursor {
                                ExpressionEvaluator &evaluator, ExecutionContext &context) {
     if (shortest_paths_.empty()) return false;
 
-    const auto &last_path = shortest_paths_.back();
+    // Scoped so the reference cannot outlive the loop. Nothing in it appends to
+    // `shortest_paths_`; the scope means that does not have to be re-checked.
+    {
+      const auto &base_path = shortest_paths_.back();
 
-    // Lawler: start where this path left its parent, not at 0. Its first `deviation_vertex_index`
-    // edges are the deviation root it was generated from, and that root was already a prefix of a
-    // found path, so accepting this path can only widen the blocked set at
-    // `deviation_vertex_index` or deeper - exactly the range below. It has to be the root rather
-    // than the parent's prefix, because one path can be generated at two depths and only the copy
-    // popped first sets the index.
-    for (size_t i = last_path.deviation_vertex_index; i < last_path.edges.size(); ++i) {
-      GenerateCandidatesFromDeviation(source, target, last_path, i, frame, evaluator, context);
+      // Lawler: start where this path left its parent, not at 0. Its first `first_deviation` edges
+      // are the deviation root it was generated from, and every edge of that root was already a
+      // trie child, so accepting this path can only have added children at `first_deviation` or
+      // deeper - exactly the range below. It has to be the root rather than the parent's prefix,
+      // because one path can be generated at two depths and only the copy popped first sets the
+      // index.
+      const size_t first_deviation = base_path.deviation_vertex_index;
+
+      blocked_vertices_.clear();
+      VertexAccessor deviation_vertex = source;
+      // The base path is itself a found path, so this walk never falls off the trie.
+      uint32_t trie_node = 0;
+
+      for (size_t i = 0UZ; i < base_path.edges.size(); ++i) {
+        if (i >= first_deviation) {
+          blocked_edges_.clear();
+          for (uint32_t c = trie_first_child_[trie_node]; c != kNoChild; c = trie_children_[c].next_sibling) {
+            blocked_edges_.insert(trie_children_[c].edge);
+          }
+          GenerateCandidatesFromDeviation(target, base_path, i, deviation_vertex, frame, evaluator, context);
+        }
+
+        blocked_vertices_.insert(deviation_vertex.Gid());
+        const auto &edge = base_path.edges[i];
+        deviation_vertex = (edge.From() == deviation_vertex) ? edge.To() : edge.From();
+        trie_node = TrieDescend(trie_node, edge.Gid());
+        // Checked in release too: a miss is `kNoChild`, and the next iteration would index the
+        // child array with it.
+        MG_ASSERT(trie_node != kNoChild, "the base path must be in the trie of found paths");
+      }
     }
 
     // Find the best candidate path
@@ -4450,30 +4490,24 @@ class KShortestPathsCursor : public Cursor {
         return false;
       }
       if (!IsPathInFoundSet(candidate)) {
+        AddPathToFoundSet(candidate);
         shortest_paths_.emplace_back(std::move(candidate));
-        AddPathToFoundSet(shortest_paths_.back());
         return true;
       }
     }
     return false;
   }
 
-  void GenerateCandidatesFromDeviation(const VertexAccessor &source, const VertexAccessor &target,
-                                       const PathInfo &base_path, size_t deviation_index, Frame &frame,
+  void GenerateCandidatesFromDeviation(const VertexAccessor &target, const PathInfo &base_path, size_t deviation_index,
+                                       const VertexAccessor &deviation_vertex, Frame &frame,
                                        ExpressionEvaluator &evaluator, ExecutionContext &context) {
-    // Set up blocked edges and vertices for this deviation
-    SetupBlockedElementsForDeviation(source, base_path, deviation_index);
-
-    // Get the deviation vertex
-    VertexAccessor deviation_vertex = GetVertexAtIndex(source, base_path, deviation_index);
-
     // The candidate's total is `deviation_index + spur_len`, so the spur gets what's left of it.
     auto spur_path = ComputeShortestPath(
         deviation_vertex, target, upper_bound_ - static_cast<int64_t>(deviation_index), frame, evaluator, context);
 
     if (spur_path.edges.empty()) return;
 
-    // Reserved: the arena does not reclaim the blocks a growing vector abandons.
+    // Reserved because the final size is known: one allocation instead of a realloc chain.
     PathInfo candidate_path(evaluator.GetMemoryResource());
     candidate_path.edges.reserve(deviation_index + spur_path.edges.size());
     candidate_path.edges.assign(base_path.edges.begin(),
@@ -4483,49 +4517,6 @@ class KShortestPathsCursor : public Cursor {
 
     candidate_paths_.push_back(std::move(candidate_path));
     std::ranges::push_heap(candidate_paths_, PathComparator{});
-  }
-
-  void SetupBlockedElementsForDeviation(const VertexAccessor &source, const PathInfo &base_path,
-                                        size_t deviation_index) {
-    blocked_edges_.clear();
-    blocked_vertices_.clear();
-
-    // Block the edge at deviation index from all previously found paths that share the same prefix
-    for (const auto &path : shortest_paths_) {
-      if (deviation_index < path.edges.size()) {
-        // Check if the path prefix matches up to deviation index
-        bool prefix_matches = true;
-        for (size_t i = 0UZ; i < deviation_index; ++i) {
-          if (i >= base_path.edges.size() || path.edges[i].Gid() != base_path.edges[i].Gid()) {
-            prefix_matches = false;
-            break;
-          }
-        }
-
-        if (prefix_matches) {
-          blocked_edges_.insert(path.edges[deviation_index].Gid());
-        }
-      }
-    }
-
-    // Block vertices in the root path (except the deviation vertex)
-    VertexAccessor current_vertex = source;
-    for (size_t i = 0UZ; i < deviation_index; ++i) {
-      blocked_vertices_.insert(current_vertex.Gid());
-      const auto &edge = base_path.edges[i];
-      current_vertex = (edge.From() == current_vertex) ? edge.To() : edge.From();
-    }
-  }
-
-  static VertexAccessor GetVertexAtIndex(const VertexAccessor &source, const PathInfo &path, size_t index) {
-    if (index == 0) return source;
-
-    VertexAccessor current = source;
-    for (size_t i = 0UZ; i < index && i < path.edges.size(); ++i) {
-      const auto &edge = path.edges[i];
-      current = (edge.From() == current) ? edge.To() : edge.From();
-    }
-    return current;
   }
 
   PathInfo ReconstructPath(const VertexAccessor &midpoint, utils::MemoryResource *memory) const {
@@ -4797,6 +4788,34 @@ class KShortestPathsCursor : public Cursor {
       path_gids.push_back(edge.Gid());
     }
     found_paths_set_.insert(std::move(path_gids));
+
+    uint32_t node = 0;
+    for (const auto &edge : path.edges) {
+      node = TrieDescendOrCreate(node, edge.Gid());
+    }
+  }
+
+  /// The child of `node` reached by `edge`, created if this is the first path to take it.
+  uint32_t TrieDescendOrCreate(uint32_t node, storage::Gid edge) {
+    for (uint32_t c = trie_first_child_[node]; c != kNoChild; c = trie_children_[c].next_sibling) {
+      if (trie_children_[c].edge == edge) return trie_children_[c].node;
+    }
+    // `kNoChild` is the sentinel, so it is also the ceiling on the node count. Reaching it needs
+    // tens of GB of trie, but the narrowing below would alias node 0 rather than fail.
+    DMG_ASSERT(trie_first_child_.size() < kNoChild, "KSHORTEST trie outgrew its 32-bit node ids");
+    const auto fresh = static_cast<uint32_t>(trie_first_child_.size());
+    trie_first_child_.push_back(kNoChild);
+    trie_children_.push_back(TrieChild{.edge = edge, .node = fresh, .next_sibling = trie_first_child_[node]});
+    trie_first_child_[node] = static_cast<uint32_t>(trie_children_.size() - 1);
+    return fresh;
+  }
+
+  /// The child of `node` reached by `edge`; `kNoChild` when no found path took it.
+  uint32_t TrieDescend(uint32_t node, storage::Gid edge) const {
+    for (uint32_t c = trie_first_child_[node]; c != kNoChild; c = trie_children_[c].next_sibling) {
+      if (trie_children_[c].edge == edge) return trie_children_[c].node;
+    }
+    return kNoChild;
   }
 
   void ResetState() {
@@ -4806,6 +4825,8 @@ class KShortestPathsCursor : public Cursor {
     current_path_index_ = 0;
     blocked_edges_.clear();
     blocked_vertices_.clear();
+    trie_children_.clear();
+    trie_first_child_.assign(1, kNoChild);  // node 0 is the empty root
     // Cleared per input row: the lambda may read outer variables, so verdicts don't survive a row.
     expansion_memo_.clear();
     ReleaseInnerSearchState();

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4425,8 +4425,13 @@ class KShortestPathsCursor : public Cursor {
 
     const auto &last_path = shortest_paths_.back();
 
-    // Generate candidate paths by deviating at each vertex of the last shortest path
-    for (size_t i = 0UZ; i < last_path.edges.size(); ++i) {
+    // Lawler: start where this path left its parent, not at 0. Its first `deviation_vertex_index`
+    // edges are the deviation root it was generated from, and that root was already a prefix of a
+    // found path, so accepting this path can only widen the blocked set at
+    // `deviation_vertex_index` or deeper - exactly the range below. It has to be the root rather
+    // than the parent's prefix, because one path can be generated at two depths and only the copy
+    // popped first sets the index.
+    for (size_t i = last_path.deviation_vertex_index; i < last_path.edges.size(); ++i) {
       GenerateCandidatesFromDeviation(source, target, last_path, i, frame, evaluator, context);
     }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4175,6 +4175,7 @@ class KShortestPathsCursor : public Cursor {
         blocked_vertices_(mem),
         in_edges_(mem),
         out_edges_(mem),
+        path_gids_scratch_(mem),
         bfs_source_frontier_(mem),
         bfs_target_frontier_(mem),
         bfs_source_next_(mem),
@@ -4358,7 +4359,8 @@ class KShortestPathsCursor : public Cursor {
 
   // State for K-shortest paths algorithm
   utils::pmr::vector<PathInfo> shortest_paths_;
-  std::priority_queue<PathInfo, utils::pmr::vector<PathInfo>, PathComparator> candidate_paths_;
+  // A heap by hand, not a `priority_queue`: its `top()` is const, so serving a candidate copies it.
+  utils::pmr::vector<PathInfo> candidate_paths_;
   utils::pmr::unordered_set<utils::pmr::vector<storage::Gid>, PathGidsHash> found_paths_set_;
   size_t current_path_index_ = 0;
 
@@ -4368,8 +4370,8 @@ class KShortestPathsCursor : public Cursor {
   std::optional<VertexAccessor> current_target_;
 
   // Per-deviation state for the inner search. Unweighted: `PathComparator` orders by hop count.
-  utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> blocked_edges_;
-  utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
+  utils::pmr::unordered_set<storage::Gid> blocked_edges_;
+  utils::pmr::unordered_set<storage::Gid> blocked_vertices_;
   // Raw storage adjacency, kept across input rows (unlike `expansion_memo_`) so Yen's repeated inner
   // searches don't re-fetch. Must stay unfiltered: a lambda reading an outer-row value would make
   // post-filter results wrong. Copied into an arena vector because `EdgeVertexAccessorResult` is not
@@ -4378,6 +4380,9 @@ class KShortestPathsCursor : public Cursor {
   using CachedEdges = utils::pmr::vector<EdgeAccessor>;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> in_edges_;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> out_edges_;
+
+  // Probe buffer for `found_paths_set_`.
+  utils::pmr::vector<storage::Gid> path_gids_scratch_;
 
   // The inner search's scratch, reused across the searches Yen's runs for one input row instead
   // of being rebuilt per call. This saves the allocation and the regrowth; it does not fix a leak,
@@ -4427,8 +4432,13 @@ class KShortestPathsCursor : public Cursor {
 
     // Find the best candidate path
     while (!candidate_paths_.empty()) {
-      PathInfo candidate = candidate_paths_.top();
-      candidate_paths_.pop();
+      std::ranges::pop_heap(candidate_paths_, PathComparator{});
+      // `const` here would bind the `std::move` below to the copy constructor rather than the
+      // move, which is the copy this operator exists to avoid. The check cannot see that through
+      // a pmr container's allocator-aware construction.
+      // NOLINTNEXTLINE(misc-const-correctness)
+      PathInfo candidate = std::move(candidate_paths_.back());
+      candidate_paths_.pop_back();
       // Handle upper bound
       if (candidate.edges.size() > upper_bound_) {
         // Next path is too long, stop generating candidates
@@ -4456,24 +4466,18 @@ class KShortestPathsCursor : public Cursor {
     auto spur_path = ComputeShortestPath(
         deviation_vertex, target, upper_bound_ - static_cast<int64_t>(deviation_index), frame, evaluator, context);
 
-    if (!spur_path.edges.empty()) {
-      // Combine the root path (up to deviation) with the spur path
-      PathInfo candidate_path(evaluator.GetMemoryResource());
+    if (spur_path.edges.empty()) return;
 
-      // Add edges from source to deviation vertex
-      for (size_t i = 0UZ; i < deviation_index; ++i) {
-        candidate_path.edges.push_back(base_path.edges[i]);
-      }
+    // Reserved: the arena does not reclaim the blocks a growing vector abandons.
+    PathInfo candidate_path(evaluator.GetMemoryResource());
+    candidate_path.edges.reserve(deviation_index + spur_path.edges.size());
+    candidate_path.edges.assign(base_path.edges.begin(),
+                                base_path.edges.begin() + static_cast<std::ptrdiff_t>(deviation_index));
+    candidate_path.edges.insert(candidate_path.edges.end(), spur_path.edges.begin(), spur_path.edges.end());
+    candidate_path.deviation_vertex_index = deviation_index;
 
-      // Add spur path edges
-      for (const auto &edge : spur_path.edges) {
-        candidate_path.edges.push_back(edge);
-      }
-
-      candidate_path.deviation_vertex_index = deviation_index;
-
-      candidate_paths_.push(std::move(candidate_path));
-    }
+    candidate_paths_.push_back(std::move(candidate_path));
+    std::ranges::push_heap(candidate_paths_, PathComparator{});
   }
 
   void SetupBlockedElementsForDeviation(const VertexAccessor &source, const PathInfo &base_path,
@@ -4494,7 +4498,7 @@ class KShortestPathsCursor : public Cursor {
         }
 
         if (prefix_matches) {
-          blocked_edges_.insert(path.edges[deviation_index]);
+          blocked_edges_.insert(path.edges[deviation_index].Gid());
         }
       }
     }
@@ -4502,7 +4506,7 @@ class KShortestPathsCursor : public Cursor {
     // Block vertices in the root path (except the deviation vertex)
     VertexAccessor current_vertex = source;
     for (size_t i = 0UZ; i < deviation_index; ++i) {
-      blocked_vertices_.insert(current_vertex);
+      blocked_vertices_.insert(current_vertex.Gid());
       const auto &edge = base_path.edges[i];
       current_vertex = (edge.From() == current_vertex) ? edge.To() : edge.From();
     }
@@ -4605,7 +4609,8 @@ class KShortestPathsCursor : public Cursor {
   bool ShouldExpand(const EdgeAccessor &edge, const VertexAccessor &expand_from, const VertexEdgeMapT &reached,
                     Frame &frame, ExpressionEvaluator &evaluator, ExecutionContext &context) {
     const VertexAccessor next = To == kTo ? edge.To() : edge.From();
-    if (blocked_edges_.contains(edge) || blocked_vertices_.contains(next) || reached.contains(next)) return false;
+    if (blocked_edges_.contains(edge.Gid()) || blocked_vertices_.contains(next.Gid()) || reached.contains(next))
+      return false;
 
     const VertexAccessor &inner_node = Backward ? expand_from : next;
     // Access check first: an edge the user cannot read must never make the lambda run on it.
@@ -4773,11 +4778,11 @@ class KShortestPathsCursor : public Cursor {
   }
 
   bool IsPathInFoundSet(const PathInfo &path) {
-    utils::pmr::vector<storage::Gid> path_gids(found_paths_set_.get_allocator());
+    path_gids_scratch_.clear();
     for (const auto &edge : path.edges) {
-      path_gids.push_back(edge.Gid());
+      path_gids_scratch_.push_back(edge.Gid());
     }
-    return found_paths_set_.contains(path_gids);
+    return found_paths_set_.contains(path_gids_scratch_);
   }
 
   void AddPathToFoundSet(const PathInfo &path) {
@@ -4791,7 +4796,7 @@ class KShortestPathsCursor : public Cursor {
 
   void ResetState() {
     shortest_paths_.clear();
-    while (!candidate_paths_.empty()) candidate_paths_.pop();
+    candidate_paths_.clear();
     found_paths_set_.clear();
     current_path_index_ = 0;
     blocked_edges_.clear();

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4175,7 +4175,13 @@ class KShortestPathsCursor : public Cursor {
         blocked_vertices_(mem),
         in_edges_(mem),
         out_edges_(mem),
-        expansion_memo_(mem) {}
+        bfs_source_frontier_(mem),
+        bfs_target_frontier_(mem),
+        bfs_source_next_(mem),
+        bfs_target_next_(mem),
+        expansion_memo_(mem),
+        bfs_in_edge_(mem),
+        bfs_out_edge_(mem) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
     OOMExceptionEnabler oom_exception;
@@ -4301,9 +4307,6 @@ class KShortestPathsCursor : public Cursor {
     size_t deviation_vertex_index;  // Index where this path deviates from parent
 
     explicit PathInfo(utils::MemoryResource *mem) : edges(mem), deviation_vertex_index(0) {}
-
-    PathInfo(const utils::pmr::vector<EdgeAccessor> &path_edges, size_t deviation_idx, utils::MemoryResource *mem)
-        : edges(path_edges.begin(), path_edges.end(), mem), deviation_vertex_index(deviation_idx) {}
   };
 
   struct PathComparator {
@@ -4376,6 +4379,16 @@ class KShortestPathsCursor : public Cursor {
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> in_edges_;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> out_edges_;
 
+  // The inner search's scratch, reused across the searches Yen's runs for one input row instead
+  // of being rebuilt per call. This saves the allocation and the regrowth; it does not fix a leak,
+  // because the arena recycles a pooled block and frees an unpooled one, so a per-call container
+  // was never retained. The reuse only pays within a row, so `ReleaseInnerSearchState` gives the
+  // capacity back at the row boundary.
+  utils::pmr::vector<VertexAccessor> bfs_source_frontier_;
+  utils::pmr::vector<VertexAccessor> bfs_target_frontier_;
+  utils::pmr::vector<VertexAccessor> bfs_source_next_;
+  utils::pmr::vector<VertexAccessor> bfs_target_next_;
+
   // Memoised `access check && filter lambda` verdicts. Sound across Yen's inner searches because the
   // blocked sets - the only per-deviation inputs - are checked outside the memo.
   utils::pmr::unordered_map<ExpansionKey, bool, ExpansionKeyHash> expansion_memo_;
@@ -4384,6 +4397,8 @@ class KShortestPathsCursor : public Cursor {
 
   // Bidirectional search state
   using VertexEdgeMapT = utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>>;
+  VertexEdgeMapT bfs_in_edge_;
+  VertexEdgeMapT bfs_out_edge_;
 
   bool InitializeKShortestPaths(const VertexAccessor &source, const VertexAccessor &target, Frame &frame,
                                 ExpressionEvaluator &evaluator, ExecutionContext &context) {
@@ -4504,14 +4519,14 @@ class KShortestPathsCursor : public Cursor {
     return current;
   }
 
-  static PathInfo ReconstructPath(const VertexAccessor &midpoint, const VertexEdgeMapT &in_edge,
-                                  const VertexEdgeMapT &out_edge, utils::MemoryResource *memory) {
-    utils::pmr::vector<EdgeAccessor> result(memory);
+  PathInfo ReconstructPath(const VertexAccessor &midpoint, utils::MemoryResource *memory) const {
+    PathInfo out(memory);
+    auto &result = out.edges;
     VertexAccessor current = midpoint;
 
     // Reconstruct the path from midpoint to source
-    while (in_edge.contains(current)) {
-      const auto &edge_opt = in_edge.at(current);
+    while (bfs_in_edge_.contains(current)) {
+      const auto &edge_opt = bfs_in_edge_.at(current);
       if (edge_opt) {
         const auto &edge = edge_opt.value();
         result.push_back(edge);
@@ -4526,8 +4541,8 @@ class KShortestPathsCursor : public Cursor {
 
     // Reconstruct the path from midpoint to target
     current = midpoint;
-    while (out_edge.contains(current)) {
-      const auto &edge_opt = out_edge.at(current);
+    while (bfs_out_edge_.contains(current)) {
+      const auto &edge_opt = bfs_out_edge_.at(current);
       if (edge_opt) {
         const auto &edge = edge_opt.value();
         result.push_back(edge);
@@ -4537,7 +4552,7 @@ class KShortestPathsCursor : public Cursor {
       }
     }
 
-    return PathInfo(result, 0, memory);
+    return out;
   }
 
   static constexpr bool kTo = true;
@@ -4619,28 +4634,19 @@ class KShortestPathsCursor : public Cursor {
     // perform better for real-world like graphs where the expansion front
     // grows exponentially, effectively reducing the exponent by half.
 
-    auto *pull_memory = evaluator.GetMemoryResource();
-    // Holds vertices at the current level of expansion from the source
-    // (target).
-    utils::pmr::vector<VertexAccessor> source_frontier(pull_memory);
-    utils::pmr::vector<VertexAccessor> target_frontier(pull_memory);
-
-    // Holds vertices we can expand to from `source_frontier`
-    // (`target_frontier`).
-    utils::pmr::vector<VertexAccessor> source_next(pull_memory);
-    utils::pmr::vector<VertexAccessor> target_next(pull_memory);
-
-    // Maps each vertex we visited expanding from the source (target) to the
-    // edge used. Necessary for path reconstruction.
-    VertexEdgeMapT in_edge(pull_memory);
-    VertexEdgeMapT out_edge(pull_memory);
+    bfs_source_frontier_.clear();
+    bfs_target_frontier_.clear();
+    bfs_source_next_.clear();
+    bfs_target_next_.clear();
+    bfs_in_edge_.clear();
+    bfs_out_edge_.clear();
 
     size_t current_length = 0;
 
-    source_frontier.emplace_back(source);
-    in_edge[source] = std::nullopt;
-    target_frontier.emplace_back(target);
-    out_edge[target] = std::nullopt;
+    bfs_source_frontier_.emplace_back(source);
+    bfs_in_edge_[source] = std::nullopt;
+    bfs_target_frontier_.emplace_back(target);
+    bfs_out_edge_[target] = std::nullopt;
 
     while (true) {
       AbortCheck(context);
@@ -4648,7 +4654,7 @@ class KShortestPathsCursor : public Cursor {
       ++current_length;
       if (std::cmp_greater(current_length, upper_bound)) return PathInfo(evaluator.GetMemoryResource());
 
-      for (const auto &vertex : source_frontier) {
+      for (const auto &vertex : bfs_source_frontier_) {
         if (context.hops_limit.IsLimitReached()) break;
         if (self_.common_.direction != EdgeAtom::Direction::IN) {
           if (!out_edges_.contains(vertex)) {
@@ -4661,14 +4667,14 @@ class KShortestPathsCursor : public Cursor {
                                            out_edges_.get_allocator().resource()));
           }
           for (const auto &edge : out_edges_.at(vertex)) {
-            if (!ShouldExpand<kTo, kForward>(edge, vertex, in_edge, frame, evaluator, context)) {
+            if (!ShouldExpand<kTo, kForward>(edge, vertex, bfs_in_edge_, frame, evaluator, context)) {
               continue;
             }
-            in_edge.emplace(edge.To(), edge);
-            if (out_edge.contains(edge.To())) {
-              return ReconstructPath(edge.To(), in_edge, out_edge, evaluator.GetMemoryResource());
+            bfs_in_edge_.emplace(edge.To(), edge);
+            if (bfs_out_edge_.contains(edge.To())) {
+              return ReconstructPath(edge.To(), evaluator.GetMemoryResource());
             }
-            source_next.push_back(edge.To());
+            bfs_source_next_.push_back(edge.To());
           }
         }
         if (self_.common_.direction != EdgeAtom::Direction::OUT) {
@@ -4682,21 +4688,21 @@ class KShortestPathsCursor : public Cursor {
                     in_edges_result.edges.begin(), in_edges_result.edges.end(), in_edges_.get_allocator().resource()));
           }
           for (const auto &edge : in_edges_.at(vertex)) {
-            if (!ShouldExpand<kFrom, kForward>(edge, vertex, in_edge, frame, evaluator, context)) {
+            if (!ShouldExpand<kFrom, kForward>(edge, vertex, bfs_in_edge_, frame, evaluator, context)) {
               continue;
             }
-            in_edge.emplace(edge.From(), edge);
-            if (out_edge.contains(edge.From())) {
-              return ReconstructPath(edge.From(), in_edge, out_edge, evaluator.GetMemoryResource());
+            bfs_in_edge_.emplace(edge.From(), edge);
+            if (bfs_out_edge_.contains(edge.From())) {
+              return ReconstructPath(edge.From(), evaluator.GetMemoryResource());
             }
-            source_next.push_back(edge.From());
+            bfs_source_next_.push_back(edge.From());
           }
         }
       }
 
-      if (source_next.empty()) return PathInfo(evaluator.GetMemoryResource());
-      source_frontier.clear();
-      std::swap(source_frontier, source_next);
+      if (bfs_source_next_.empty()) return PathInfo(evaluator.GetMemoryResource());
+      bfs_source_frontier_.clear();
+      std::swap(bfs_source_frontier_, bfs_source_next_);
 
       // Bottom-up step (expansion from the target).
       ++current_length;
@@ -4705,7 +4711,7 @@ class KShortestPathsCursor : public Cursor {
       // When expanding from the target we have to be careful which edge
       // endpoint we pass to `should_expand`, because everything is
       // reversed.
-      for (const auto &vertex : target_frontier) {
+      for (const auto &vertex : bfs_target_frontier_) {
         if (context.hops_limit.IsLimitReached()) break;
         if (self_.common_.direction != EdgeAtom::Direction::OUT) {
           if (!out_edges_.contains(vertex)) {
@@ -4718,14 +4724,14 @@ class KShortestPathsCursor : public Cursor {
                                            out_edges_.get_allocator().resource()));
           }
           for (const auto &edge : out_edges_.at(vertex)) {
-            if (!ShouldExpand<kTo, kBackward>(edge, vertex, out_edge, frame, evaluator, context)) {
+            if (!ShouldExpand<kTo, kBackward>(edge, vertex, bfs_out_edge_, frame, evaluator, context)) {
               continue;
             }
-            out_edge.emplace(edge.To(), edge);
-            if (in_edge.contains(edge.To())) {
-              return ReconstructPath(edge.To(), in_edge, out_edge, evaluator.GetMemoryResource());
+            bfs_out_edge_.emplace(edge.To(), edge);
+            if (bfs_in_edge_.contains(edge.To())) {
+              return ReconstructPath(edge.To(), evaluator.GetMemoryResource());
             }
-            target_next.push_back(edge.To());
+            bfs_target_next_.push_back(edge.To());
           }
         }
         if (self_.common_.direction != EdgeAtom::Direction::IN) {
@@ -4739,21 +4745,21 @@ class KShortestPathsCursor : public Cursor {
                     in_edges_result.edges.begin(), in_edges_result.edges.end(), in_edges_.get_allocator().resource()));
           }
           for (const auto &edge : in_edges_.at(vertex)) {
-            if (!ShouldExpand<kFrom, kBackward>(edge, vertex, out_edge, frame, evaluator, context)) {
+            if (!ShouldExpand<kFrom, kBackward>(edge, vertex, bfs_out_edge_, frame, evaluator, context)) {
               continue;
             }
-            out_edge.emplace(edge.From(), edge);
-            if (in_edge.contains(edge.From())) {
-              return ReconstructPath(edge.From(), in_edge, out_edge, evaluator.GetMemoryResource());
+            bfs_out_edge_.emplace(edge.From(), edge);
+            if (bfs_in_edge_.contains(edge.From())) {
+              return ReconstructPath(edge.From(), evaluator.GetMemoryResource());
             }
-            target_next.push_back(edge.From());
+            bfs_target_next_.push_back(edge.From());
           }
         }
       }
 
-      if (target_next.empty()) return PathInfo(evaluator.GetMemoryResource());
-      target_frontier.clear();
-      std::swap(target_frontier, target_next);
+      if (bfs_target_next_.empty()) return PathInfo(evaluator.GetMemoryResource());
+      bfs_target_frontier_.clear();
+      std::swap(bfs_target_frontier_, bfs_target_next_);
     }
   }
 
@@ -4776,6 +4782,7 @@ class KShortestPathsCursor : public Cursor {
 
   void AddPathToFoundSet(const PathInfo &path) {
     utils::pmr::vector<storage::Gid> path_gids(found_paths_set_.get_allocator());
+    path_gids.reserve(path.edges.size());
     for (const auto &edge : path.edges) {
       path_gids.push_back(edge.Gid());
     }
@@ -4791,8 +4798,24 @@ class KShortestPathsCursor : public Cursor {
     blocked_vertices_.clear();
     // Cleared per input row: the lambda may read outer variables, so verdicts don't survive a row.
     expansion_memo_.clear();
+    ReleaseInnerSearchState();
     // Makes `|K` per input row; `Pull` guards each serving site instead of returning early.
     n_returned_paths_ = 0;
+  }
+
+  // Releases the inner search's scratch instead of just emptying it. `clear()` keeps a hash
+  // table's bucket array and a vector's capacity, so without this one expensive row would leave
+  // every later search sweeping buckets sized for a search it never runs, and hold that memory for
+  // the life of the cursor. Called per row, so the reuse within a row still stands.
+  void ReleaseInnerSearchState() {
+    for (auto *frontier : {&bfs_source_frontier_, &bfs_target_frontier_, &bfs_source_next_, &bfs_target_next_}) {
+      frontier->clear();
+      frontier->shrink_to_fit();
+    }
+    for (auto *reached : {&bfs_in_edge_, &bfs_out_edge_}) {
+      reached->clear();
+      reached->rehash(0);
+    }
   }
 };
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4383,15 +4383,15 @@ class KShortestPathsCursor : public Cursor {
 
   // Trie of the found paths' edges: a root prefix's children are exactly the edges a deviation
   // there must block. Children form an intrusive sibling list, so a node holds no container.
-  static constexpr uint32_t kNoChild = std::numeric_limits<uint32_t>::max();
+  static constexpr uint64_t kNoChild = std::numeric_limits<uint64_t>::max();
 
   struct TrieChild {
     storage::Gid edge;
-    uint32_t node;
-    uint32_t next_sibling;
+    uint64_t node;
+    uint64_t next_sibling;
   };
 
-  utils::pmr::vector<uint32_t> trie_first_child_;
+  utils::pmr::vector<uint64_t> trie_first_child_;
   utils::pmr::vector<TrieChild> trie_children_;
 
   // Probe buffer for `found_paths_set_`.
@@ -4454,12 +4454,12 @@ class KShortestPathsCursor : public Cursor {
       blocked_vertices_.clear();
       VertexAccessor deviation_vertex = source;
       // The base path is itself a found path, so this walk never falls off the trie.
-      uint32_t trie_node = 0;
+      uint64_t trie_node = 0;
 
       for (size_t i = 0UZ; i < base_path.edges.size(); ++i) {
         if (i >= first_deviation) {
           blocked_edges_.clear();
-          for (uint32_t c = trie_first_child_[trie_node]; c != kNoChild; c = trie_children_[c].next_sibling) {
+          for (uint64_t c = trie_first_child_[trie_node]; c != kNoChild; c = trie_children_[c].next_sibling) {
             blocked_edges_.insert(trie_children_[c].edge);
           }
           GenerateCandidatesFromDeviation(target, base_path, i, deviation_vertex, frame, evaluator, context);
@@ -4789,30 +4789,29 @@ class KShortestPathsCursor : public Cursor {
     }
     found_paths_set_.insert(std::move(path_gids));
 
-    uint32_t node = 0;
+    uint64_t node = 0;
     for (const auto &edge : path.edges) {
       node = TrieDescendOrCreate(node, edge.Gid());
     }
   }
 
   /// The child of `node` reached by `edge`, created if this is the first path to take it.
-  uint32_t TrieDescendOrCreate(uint32_t node, storage::Gid edge) {
-    for (uint32_t c = trie_first_child_[node]; c != kNoChild; c = trie_children_[c].next_sibling) {
+  uint64_t TrieDescendOrCreate(uint64_t node, storage::Gid edge) {
+    for (uint64_t c = trie_first_child_[node]; c != kNoChild; c = trie_children_[c].next_sibling) {
       if (trie_children_[c].edge == edge) return trie_children_[c].node;
     }
-    // `kNoChild` is the sentinel, so it is also the ceiling on the node count. Reaching it needs
-    // tens of GB of trie, but the narrowing below would alias node 0 rather than fail.
-    DMG_ASSERT(trie_first_child_.size() < kNoChild, "KSHORTEST trie outgrew its 32-bit node ids");
-    const auto fresh = static_cast<uint32_t>(trie_first_child_.size());
+    // Ids are as wide as the vector's own index, so `fresh` cannot narrow and the only ceiling
+    // left is the sentinel - which a vector of these cannot reach before the allocator gives out.
+    const auto fresh = static_cast<uint64_t>(trie_first_child_.size());
     trie_first_child_.push_back(kNoChild);
     trie_children_.push_back(TrieChild{.edge = edge, .node = fresh, .next_sibling = trie_first_child_[node]});
-    trie_first_child_[node] = static_cast<uint32_t>(trie_children_.size() - 1);
+    trie_first_child_[node] = trie_children_.size() - 1;
     return fresh;
   }
 
   /// The child of `node` reached by `edge`; `kNoChild` when no found path took it.
-  uint32_t TrieDescend(uint32_t node, storage::Gid edge) const {
-    for (uint32_t c = trie_first_child_[node]; c != kNoChild; c = trie_children_[c].next_sibling) {
+  uint64_t TrieDescend(uint64_t node, storage::Gid edge) const {
+    for (uint64_t c = trie_first_child_[node]; c != kNoChild; c = trie_children_[c].next_sibling) {
       if (trie_children_[c].edge == edge) return trie_children_[c].node;
     }
     return kNoChild;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4173,10 +4173,8 @@ class KShortestPathsCursor : public Cursor {
         current_target_(std::nullopt),
         blocked_edges_(mem),
         blocked_vertices_(mem),
-        distances_(mem),
         in_edges_(mem),
         out_edges_(mem),
-        predecessors_(mem),
         expansion_memo_(mem) {}
 
   bool Pull(Frame &frame, ExecutionContext &context) override {
@@ -4366,10 +4364,9 @@ class KShortestPathsCursor : public Cursor {
   std::optional<VertexAccessor> current_source_;
   std::optional<VertexAccessor> current_target_;
 
-  // Dijkstra's algorithm state (reused for efficiency)
+  // Per-deviation state for the inner search. Unweighted: `PathComparator` orders by hop count.
   utils::pmr::unordered_set<EdgeAccessor, EdgeAccessorHash> blocked_edges_;
   utils::pmr::unordered_set<VertexAccessor, VertexAccessorHash> blocked_vertices_;
-  utils::pmr::unordered_map<VertexAccessor, double, VertexAccessorHash> distances_;
   // Raw storage adjacency, kept across input rows (unlike `expansion_memo_`) so Yen's repeated inner
   // searches don't re-fetch. Must stay unfiltered: a lambda reading an outer-row value would make
   // post-filter results wrong. Copied into an arena vector because `EdgeVertexAccessorResult` is not
@@ -4378,7 +4375,6 @@ class KShortestPathsCursor : public Cursor {
   using CachedEdges = utils::pmr::vector<EdgeAccessor>;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> in_edges_;
   utils::pmr::unordered_map<VertexAccessor, CachedEdges, VertexAccessorHash> out_edges_;
-  utils::pmr::unordered_map<VertexAccessor, std::optional<EdgeAccessor>, VertexAccessorHash> predecessors_;
 
   // Memoised `access check && filter lambda` verdicts. Sound across Yen's inner searches because the
   // blocked sets - the only per-deviation inputs - are checked outside the memo.
@@ -4793,8 +4789,6 @@ class KShortestPathsCursor : public Cursor {
     current_path_index_ = 0;
     blocked_edges_.clear();
     blocked_vertices_.clear();
-    distances_.clear();
-    predecessors_.clear();
     // Cleared per input row: the lambda may read outer variables, so verdicts don't survive a row.
     expansion_memo_.clear();
     // Makes `|K` per input row; `Pull` guards each serving site instead of returning early.

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -306,7 +306,9 @@ std::vector<std::pair<int, int>> GetFilteredEdgeList(const memgraph::query::Type
 }
 
 // Checks if the given path is actually a path from source to sink and if all
-// of its edges exist in the given edge list. Also ensures no edge is reused.
+// of its edges exist in the given edge list. Also ensures no edge is reused and
+// no vertex is revisited: KSHORTEST answers with loopless paths, and the
+// inner search's root-vertex blocking is what enforces that.
 template <class TPathAllocator>
 void CheckPath(memgraph::query::DbAccessor *dba, const memgraph::query::VertexAccessor &source,
                const memgraph::query::VertexAccessor &sink,
@@ -315,6 +317,7 @@ void CheckPath(memgraph::query::DbAccessor *dba, const memgraph::query::VertexAc
   if (path.empty()) return;
   memgraph::query::VertexAccessor curr = source;
   std::unordered_set<memgraph::storage::Gid> used_edges;
+  std::unordered_set<memgraph::storage::Gid> visited_vertices{source.Gid()};
 
   for (const auto &edge_tv : path) {
     ASSERT_TRUE(edge_tv.IsEdge());
@@ -325,6 +328,9 @@ void CheckPath(memgraph::query::DbAccessor *dba, const memgraph::query::VertexAc
 
     ASSERT_TRUE(edge.From() == curr || edge.To() == curr);
     auto next = edge.From() == curr ? edge.To() : edge.From();
+
+    ASSERT_TRUE(visited_vertices.insert(next.Gid()).second)
+        << "Vertex " << next.Gid() << " is revisited in path, which is not loopless";
 
     int from = GetProp(curr, "id", dba).ValueInt();
     int to = GetProp(next, "id", dba).ValueInt();

--- a/tests/unit/kshortest_common.hpp
+++ b/tests/unit/kshortest_common.hpp
@@ -64,6 +64,42 @@ const std::vector<std::tuple<int, int, std::string>> kEdges = {{0, 1, "a"},
                                                                {5, 4, "a"},
                                                                {5, 5, "b"}};
 
+// A 7-rung ladder: two rails of 7 vertices, joined at every step. It gives long paths and many
+// equal-length alternatives, so an accepted path's deviation index reaches 10 here where it never
+// passes 3 on the graph above. Depth is all it buys: measured over every pair, a trie node here
+// holds at most 3 children against the graph above's 4, so it widens the deviation range under
+// test and not the branching. No parallel edges and no self-loops, because the brute-force oracle
+// keys edges by (from, to) and could not match a graph that had them.
+const std::vector<int> kLadderVertexLocations = {0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1};
+const std::vector<std::tuple<int, int, std::string>> kLadderEdges = {{0, 1, "a"},
+                                                                     {1, 2, "a"},
+                                                                     {2, 3, "a"},
+                                                                     {3, 4, "a"},
+                                                                     {4, 5, "a"},
+                                                                     {5, 6, "a"},  // one rail
+                                                                     {7, 8, "a"},
+                                                                     {8, 9, "a"},
+                                                                     {9, 10, "a"},
+                                                                     {10, 11, "a"},
+                                                                     {11, 12, "a"},
+                                                                     {12, 13, "a"},  // the other
+                                                                     {0, 7, "b"},
+                                                                     {1, 8, "b"},
+                                                                     {2, 9, "b"},
+                                                                     {3, 10, "b"},
+                                                                     {4, 11, "b"},
+                                                                     {5, 12, "b"},
+                                                                     {6, 13, "b"}};  // the rungs
+
+// Depth is not the only thing a skipped deviation needs to show up. On the ladder every deviation
+// root stays productive, so a driver that stops deviating once the index is deep still reaches
+// every path. Here the roots interleave - a path accepted at a deep index still has a shorter
+// sibling waiting at a shallower one - and three of the pairs below lose a path when that root is
+// skipped. No parallel edges and no self-loops, for the same oracle reason as the ladder.
+const std::vector<int> kInterleavedVertexLocations = {0, 0, 1, 1, 2, 2, 0, 1};
+const std::vector<std::tuple<int, int, std::string>> kInterleavedEdges = {
+    {0, 4, "a"}, {0, 5, "a"}, {4, 3, "a"}, {1, 6, "a"}, {5, 4, "a"}, {5, 7, "a"}, {6, 7, "a"}, {3, 5, "a"}};
+
 // Filters input edge list by edge type and direction and returns a list of
 // pairs representing valid directed edges.
 std::vector<std::pair<int, int>> GetEdgeList(const std::vector<std::tuple<int, int, std::string>> &edges,
@@ -287,8 +323,9 @@ auto GetProp(const TRecord &rec, std::string prop, memgraph::query::DbAccessor *
 std::vector<std::pair<int, int>> GetFilteredEdgeList(const memgraph::query::TypedValue &blocked,
                                                      memgraph::query::EdgeAtom::Direction direction,
                                                      const std::vector<std::string> &edge_types,
-                                                     memgraph::query::DbAccessor *dba) {
-  auto edges = kEdges;
+                                                     memgraph::query::DbAccessor *dba,
+                                                     const std::vector<std::tuple<int, int, std::string>> &all_edges) {
+  auto edges = all_edges;
   // An edge is blocked in both directions, so drop it before accounting for direction.
   if (blocked.IsEdge()) {
     int from = GetProp(blocked.ValueEdge(), "from", dba).ValueInt();
@@ -394,9 +431,14 @@ class Database {
              const std::vector<std::tuple<int, int, std::string>> &edges) = 0;
   virtual ~Database() = default;
 
+  // The fixture graph is a parameter so a case can reach deviation indices the default 6-vertex
+  // graph cannot; `vertex_locations` sizes the graph, so its length is the vertex count.
   void KShortestTest(Database *db, int lower_bound, int upper_bound, memgraph::query::EdgeAtom::Direction direction,
                      std::vector<std::string> edge_types, int limit = -1,
-                     FilterLambdaType filter_lambda_type = FilterLambdaType::NONE) {
+                     FilterLambdaType filter_lambda_type = FilterLambdaType::NONE,
+                     const std::vector<int> &vertex_locations = kVertexLocations,
+                     const std::vector<std::tuple<int, int, std::string>> &graph_edges = kEdges) {
+    const int vertex_count = static_cast<int>(vertex_locations.size());
     spdlog::info("KShortestTest: lower_bound={}, upper_bound={}, direction={}, edge_types={}",
                  lower_bound,
                  upper_bound,
@@ -419,7 +461,7 @@ class Database {
     std::vector<memgraph::query::VertexAccessor> vertices;
     std::vector<memgraph::query::EdgeAccessor> edges;
 
-    std::tie(vertices, edges) = db->BuildGraph(&dba, kVertexLocations, kEdges);
+    std::tie(vertices, edges) = db->BuildGraph(&dba, vertex_locations, graph_edges);
     spdlog::info("KShortestTest: Built graph with {} vertices and {} edges", vertices.size(), edges.size());
 
     dba.AdvanceCommand();
@@ -519,14 +561,16 @@ class Database {
       spdlog::info("KShortestTest: Limit: {}", limit);
     }
 
-    if (upper_bound == -1) upper_bound = kVertexCount;
+    if (upper_bound == -1) upper_bound = vertex_count;
     const int effective_lower_bound = lower_bound != -1 ? lower_bound : 1;
     const int effective_upper_bound = upper_bound;
 
     // The paths Yen's algorithm finds in the subgraph the lambda leaves, within the length bounds.
     auto correct_paths_for = [&](const memgraph::query::TypedValue &blocked_entity, int source_id, int sink_id) {
-      auto paths = YenKShortestPaths(
-          kVertexCount, GetFilteredEdgeList(blocked_entity, direction, edge_types, &dba), source_id, sink_id);
+      auto paths = YenKShortestPaths(vertex_count,
+                                     GetFilteredEdgeList(blocked_entity, direction, edge_types, &dba, graph_edges),
+                                     source_id,
+                                     sink_id);
       // `paths` holds vertices, not edges, hence the -1 when comparing against the bounds.
       std::erase_if(paths, [&](const std::vector<int> &path) {
         return path.size() - 1 < static_cast<size_t>(effective_lower_bound) ||
@@ -540,8 +584,8 @@ class Database {
     {
       size_t expected_total = 0;
       for (const auto &blocked_entity : blocked_values) {
-        for (int source_id = 0; source_id < kVertexCount; ++source_id) {
-          for (int sink_id = 0; sink_id < kVertexCount; ++sink_id) {
+        for (int source_id = 0; source_id < vertex_count; ++source_id) {
+          for (int sink_id = 0; sink_id < vertex_count; ++sink_id) {
             if (source_id == sink_id) continue;
             const auto group = correct_paths_for(blocked_entity, source_id, sink_id).size();
             expected_total += limit == -1 ? group : std::min(group, static_cast<size_t>(limit));
@@ -580,7 +624,7 @@ class Database {
         continue;
       }
 
-      auto edges_filtered = GetFilteredEdgeList(blocked_entity, direction, edge_types, &dba);
+      auto edges_filtered = GetFilteredEdgeList(blocked_entity, direction, edge_types, &dba, graph_edges);
       auto correct_paths = correct_paths_for(blocked_entity, source_id, sink_id);
       spdlog::info("KShortestTest: Yen algorithm found {} paths", correct_paths.size());
 

--- a/tests/unit/kshortest_general.cpp
+++ b/tests/unit/kshortest_general.cpp
@@ -155,6 +155,48 @@ TEST_F(GeneralKShortestTestInMemory, KShortestWithLimit) {
   db_->KShortestTest(db_.get(), 2, -1, EdgeAtom::Direction::OUT, {}, 1);
 }
 
+// A dropped candidate shows up as a missing path only once deviations start deep, which the
+// 6-vertex fixture never does - it stops at index 3 where the ladder reaches 10. Runs the ladder
+// unbounded and checks the exact count and per-index length against the brute-force enumerator.
+// The bounded, truncated case below drives the same depth through the length bound and `| k`.
+TEST_F(GeneralKShortestTestInMemory, LadderMatchesOracleAtDepth) {
+  for (auto direction : {EdgeAtom::Direction::OUT, EdgeAtom::Direction::BOTH}) {
+    db_->KShortestTest(
+        db_.get(), -1, -1, direction, {}, -1, FilterLambdaType::NONE, kLadderVertexLocations, kLadderEdges);
+  }
+}
+
+// The unbounded case leaves the length bound, the `| k` truncation and the expansion memo out of
+// the deep regime entirely: with no bound the candidate-too-long return never fires, and with no
+// filter lambda the memo is never consulted. This case drives all three at deviation index 10, and
+// its `| k` truncates most of the groups it enumerates.
+TEST_F(GeneralKShortestTestInMemory, LadderBoundedAndTruncatedAtDepth) {
+  db_->KShortestTest(db_.get(),
+                     -1,
+                     12,
+                     EdgeAtom::Direction::BOTH,
+                     {},
+                     5,
+                     FilterLambdaType::USE_CTX,
+                     kLadderVertexLocations,
+                     kLadderEdges);
+}
+
+// Depth is not enough on its own: every deviation root on the ladder stays productive, so a driver
+// that stops deviating once the index is deep still reaches every path there. This graph's roots
+// interleave, and three of its pairs lose a path when such a root is skipped.
+TEST_F(GeneralKShortestTestInMemory, InterleavedRootsMatchOracle) {
+  db_->KShortestTest(db_.get(),
+                     -1,
+                     -1,
+                     EdgeAtom::Direction::BOTH,
+                     {},
+                     -1,
+                     FilterLambdaType::NONE,
+                     kInterleavedVertexLocations,
+                     kInterleavedEdges);
+}
+
 TEST_F(GeneralKShortestTestInMemory, InvertedRangeDoesNotSearch) {
   db_->KShortestTestInvertedRangeDoesNotSearch(db_.get());
 }


### PR DESCRIPTION
`KSHORTEST` path expansion was quadratic in `k`. It is now close to linear: on a deep,
selectively filtered expansion over a small sparse topology, `*KSHORTEST | 10000` goes
from **63s to 0.19s** and peak RSS from **199 MB to 122 MB**.

**Why.** Yen's driver rebuilt its blocked-element sets for every deviation of every
accepted path, and each rebuild walked every path found so far to prefix-compare it
against the base. `perf` put 50% of such a query in `SetupBlockedElementsForDeviation`
and a further 40% in the `EdgeAccessor::Gid()` calls its comparison makes, against 1.3%
in the inner bidirectional BFS.

**How.** Two commits carry the change:

- Start the deviation loop at `PathInfo::deviation_vertex_index` — Lawler's refinement —
  so a root the parent already covered is not re-deviated over. The field was already
  assigned and nothing read it; three lines. Accepting a path can only add trie children
  at `deviation_index` or deeper, which is exactly the range the loop still covers.
- Replace the rescan with a trie over the found paths' edge `Gid`s. A root prefix's node
  records which edges some found path took next, which is the set a deviation there must
  block, so walking the base path down the trie costs one step per deviation instead of
  one pass over every found path. The root's vertex set and the deviation vertex fold into
  the same walk, retiring `GetVertexAtIndex`.

Four smaller commits: the six containers `ComputeShortestPath` declared per call become
cursor members reused within an input row; serving a candidate moves instead of copying;
dead `distances_`/`predecessors_` go; and the trie's node ids are `uint64_t` rather than
`uint32_t`, where the `kNoChild` sentinel capped the node count.

**Measured.** Both binaries built from one worktree with identical flags, one query per
fresh server:

| fixture | k | before | after | | peak RSS before | after |
|---|---:|---:|---:|---|---:|---:|
| 12x12 grid | 8000 | 4.43s | 0.02s | **222x** | 330 MB | 116 MB |
| 25 diamonds in series, 50-hop paths | 2000 | 1.46s | 0.01s | **146x** | 472 MB | 90 MB |
| 200-rung ladder, undirected | 2000 | 30.79s | 1.39s | 22x | 2777 MB | 1340 MB |

Scaling is the point: 16x the `k` costs the old code 111x the time and this one about 2x.
The win is not confined to large `k` — on the grid, `| 10` is 2.2x, `| 50` 8x and `| 100`
12x. At `| 1` the deviation loop never runs, so the cost is unchanged.

**The one observable change.** Removing the redundant re-searches removes the duplicate
candidates they pushed onto the heap, and those duplicates shifted the pop order among
equal-length paths. So where `| k` truncates a group of tied paths, a **different member
of that group** can come back, at the same lengths. With no `| k`, or with only an upper
bound, the answer set is fully determined and identical. Serving a candidate also used to
copy onto `new_delete_resource()`, outside the memory tracker; it is now counted, so a
query that previously sat just under `--memory-limit` can reach it.

All in `src/query/plan/operator.cpp` inside `KShortestPathsCursor`.