### PR TITLE
fix: authenticate GitHub clones for Jepsen refresh and EKS stress tests in CI

### DIFF
--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -1328,6 +1328,8 @@ jobs:
         run: echo "OS=ubuntu-24.04" >> $GITHUB_ENV
 
       - name: Refresh Jepsen Cluster
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd tests/jepsen
           ./run.sh cluster-refresh --nodes-no 6

--- a/.github/workflows/reusable_stress_tests.yaml
+++ b/.github/workflows/reusable_stress_tests.yaml
@@ -541,6 +541,7 @@ jobs:
           MEMGRAPH_IMAGE: ${{ env.MEMGRAPH_IMAGE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.EKS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EKS_AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload stress test logs
         if: always()

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -413,9 +413,10 @@ emit_cache_volumes() {
   fi
 }
 
-# GITHUB_TOKEN is forwarded into the container so in-container git fetches from
-# github.com are authenticated (see github_auth_in_container). Anonymous clones
-# from the shared runner IP get rate-limited with a 401.
+# GITHUB_TOKEN is forwarded into the container for in-container GitHub API use
+# (e.g. release/get_version.py); git fetches are authenticated via
+# github_auth_in_container. Anonymous access from the shared runner IP gets
+# rate-limited.
 github_token_enabled() {
   [[ -n "${GITHUB_TOKEN:-}" ]]
 }
@@ -469,17 +470,20 @@ cleanup_compose_override() {
   fi
 }
 
-# Point git at the forwarded GITHUB_TOKEN via a credential helper that reads it
-# from the environment at fetch time. Written once to the system-wide
-# /etc/gitconfig so every later `docker exec`, whether -u mg or -u root (e.g.
-# package.sh runs as root), and any nested clone (mgconsole's ExternalProjects)
-# is covered without touching individual commands.
+# Make in-container git send GITHUB_TOKEN preemptively on every github.com
+# request (same header actions/checkout uses). GitHub's rate-limit reply is an
+# in-protocol error, not a 401, so a credential helper would never be consulted.
+# Written once to the system-wide /etc/gitconfig so every later `docker exec`,
+# whether -u mg or -u root (package.sh runs as root), and any nested clone
+# (mgconsole's ExternalProjects) is covered. The container is ephemeral.
 github_auth_in_container() {
   local container=$1
   if github_token_enabled; then
     echo "Configuring authenticated github.com access in $container..."
-    docker exec -u root "$container" git config --system credential.https://github.com.helper \
-      '!f() { echo "username=x-access-token"; echo "password=$GITHUB_TOKEN"; }; f'
+    local auth_b64
+    auth_b64="$(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 -w0)"
+    docker exec -u root "$container" git config --system http.https://github.com/.extraheader \
+      "AUTHORIZATION: basic $auth_b64"
   fi
 }
 

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -481,7 +481,7 @@ github_auth_in_container() {
   if github_token_enabled; then
     echo "Configuring authenticated github.com access in $container..."
     local auth_b64
-    auth_b64="$(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 -w0)"
+    auth_b64="$(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')"
     docker exec -u root "$container" git config --system http.https://github.com/.extraheader \
       "AUTHORIZATION: basic $auth_b64"
   fi

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -114,11 +114,13 @@ if ! command -v docker > /dev/null 2>&1 || ! command -v docker compose > /dev/nu
 fi
 
 # Authenticate github.com access when GITHUB_TOKEN is set (CI): anonymous clones
-# from the shared runner IP get rate-limited with a 401. Per-command `-c` keeps
-# the runner's global git config untouched.
+# from the shared runner IP get rate-limited. The header is sent preemptively
+# (same as actions/checkout) because GitHub's rate-limit reply is an in-protocol
+# error, not a 401, so a credential helper would never be consulted.
+# Per-command `-c` keeps the runner's global git config untouched.
 GIT_GH=(git)
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-  GIT_GH+=(-c 'credential.https://github.com.helper=!f() { echo "username=x-access-token"; echo "password=$GITHUB_TOKEN"; }; f')
+  GIT_GH+=(-c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 -w0)")
 fi
 
 if [ ! -d "$script_dir/jepsen" ]; then

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -120,7 +120,7 @@ fi
 # Per-command `-c` keeps the runner's global git config untouched.
 GIT_GH=(git)
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-  GIT_GH+=(-c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 -w0)")
+  GIT_GH+=(-c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')")
 fi
 
 if [ ! -d "$script_dir/jepsen" ]; then

--- a/tests/stress/ha/eks/deployment/deployment.sh
+++ b/tests/stress/ha/eks/deployment/deployment.sh
@@ -228,8 +228,19 @@ install_ebs_csi_driver() {
         return 0
     fi
 
+    # kustomize fetches the remote base with its own `git fetch`; in CI (GITHUB_TOKEN
+    # set) authenticate it via git's env-config so the shared runner IP isn't rate-limited.
+    local -a git_auth_env=()
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        git_auth_env=(
+            GIT_CONFIG_COUNT=1
+            GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 -w0)"
+        )
+    fi
+
     # Install EBS CSI driver
-    kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-1.25"
+    env "${git_auth_env[@]}" kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-1.25"
 
     if [[ $? -ne 0 ]]; then
         log_error "Failed to install EBS CSI driver"

--- a/tests/stress/ha/eks/deployment/deployment.sh
+++ b/tests/stress/ha/eks/deployment/deployment.sh
@@ -232,10 +232,12 @@ install_ebs_csi_driver() {
     # set) authenticate it via git's env-config so the shared runner IP isn't rate-limited.
     local -a git_auth_env=()
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        local auth_b64
+        auth_b64="$(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')"
         git_auth_env=(
             GIT_CONFIG_COUNT=1
             GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
-            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf '%s' "x-access-token:$GITHUB_TOKEN" | base64 -w0)"
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $auth_b64"
         )
     fi
 


### PR DESCRIPTION
GitHub has started limiting unauthenticated clones and returning this message:

`fatal: remote error: GitHub is temporarily limiting some unauthenticated downloads to protect the stability of the platform. Please retry later or authenticate.`

This breaks CI, currently specifically in the Jepsen refresh steps (#4729 addressed authentication failures within mgbuild containers and handled the 401 from  GitHub's API which has changed over night) and in the EKS stress tests.



