### PR TITLE
refactor(storage): share one `CleanupAllIndices` across index types

### DIFF
--- a/src/storage/v2/inmemory/all_indices_cleanup.hpp
+++ b/src/storage/v2/inmemory/all_indices_cleanup.hpp
@@ -1,0 +1,46 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <range/v3/algorithm/all_of.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/filter.hpp>
+
+#include "utils/rw_lock.hpp"
+#include "utils/synchronized.hpp"
+
+namespace memgraph::storage {
+
+/// Drops entries from `all_indices` that nothing but `all_indices` still holds.
+///
+/// `refcount_of` maps an entry to the use count of the shared_ptr it carries; entries differ per
+/// index type (a struct member, a pair's second, or the pointer itself), the reaping rule does not.
+///
+/// A shared_ptr held anywhere else keeps its entry in the list until that holder releases it.
+/// An index must appear in `all_indices` at most once, or the duplicate is never reapable.
+template <typename Entry, typename Proj>
+void CleanupAllIndices(
+    utils::Synchronized<std::shared_ptr<std::vector<Entry> const>, utils::WritePrioritizedRWLock> &all_indices,
+    Proj refcount_of) {
+  all_indices.WithLock([&](std::shared_ptr<std::vector<Entry> const> &indices) {
+    auto keep_condition = [&](Entry const &entry) { return refcount_of(entry) != 1; };
+    if (!ranges::all_of(*indices, keep_condition)) {
+      indices =
+          std::make_shared<std::vector<Entry>>(*indices | ranges::views::filter(keep_condition) | ranges::to_vector);
+    }
+  });
+}
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -18,14 +18,12 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/all_indices_cleanup.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/interesting_ids.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/property_value_utils.hpp"
 #include "utils/counter.hpp"
-
-namespace r = ranges;
-namespace rv = r::views;
 
 namespace {
 
@@ -278,7 +276,7 @@ auto InMemoryEdgePropertyIndex::DropIndex(PropertyId property, ActiveIndicesUpda
         indices_container = std::move(new_container);
         return evicted_entry;
       });
-  CleanupAllIndicies();
+  CleanupAllIndices();
   return evicted;
 }
 
@@ -309,7 +307,7 @@ uint64_t InMemoryEdgePropertyIndex::RemoveObsoleteEntries(Storage *storage, uint
                                                           std::stop_token token, IndexArming const &arming) {
   auto maybe_stop = utils::ResettableCounter(2048);
 
-  CleanupAllIndicies();
+  CleanupAllIndices();
 
   auto cpy = all_indices_.ReadCopy();
   if (cpy->empty()) return 0;
@@ -465,7 +463,7 @@ void InMemoryEdgePropertyIndex::Iterable::Iterator::AdvanceUntilValid() {
 
 void InMemoryEdgePropertyIndex::RunGC() {
   // Remove indicies that are not used by any txn
-  CleanupAllIndicies();
+  CleanupAllIndices();
 
   // For each skip_list remaining, run GC
   auto cpy = all_indices_.ReadCopy();
@@ -554,13 +552,8 @@ auto InMemoryEdgePropertyIndex::GetIndividualIndex(PropertyId property) const ->
       });
 }
 
-void InMemoryEdgePropertyIndex::CleanupAllIndicies() {
-  all_indices_.WithLock([](std::shared_ptr<std::vector<AllIndicesEntry> const> &indices) {
-    auto keep_condition = [](AllIndicesEntry const &entry) { return entry.second.use_count() != 1; };
-    if (!r::all_of(*indices, keep_condition)) {
-      indices = std::make_shared<std::vector<AllIndicesEntry>>(*indices | rv::filter(keep_condition) | r::to_vector);
-    }
-  });
+void InMemoryEdgePropertyIndex::CleanupAllIndices() {
+  storage::CleanupAllIndices(all_indices_, [](AllIndicesEntry const &e) { return e.second.use_count(); });
 }
 
 InMemoryEdgePropertyIndex::ChunkedIterable::ChunkedIterable(

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -285,7 +285,7 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
  private:
   auto GetIndividualIndex(PropertyId property) const -> std::shared_ptr<IndividualIndex>;
 
-  void CleanupAllIndicies();
+  void CleanupAllIndices();
 
   metrics::GaugeHandle gauge_{};
 

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -18,6 +18,7 @@
 #include "storage/v2/edge_info_helpers.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/all_indices_cleanup.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/counter.hpp"
 
@@ -442,12 +443,7 @@ auto InMemoryEdgeTypeIndex::GetIndividualIndex(EdgeTypeId edge_type) const -> st
 }
 
 void InMemoryEdgeTypeIndex::CleanupAllIndices() {
-  all_indices_.WithLock([](std::shared_ptr<std::vector<AllIndicesEntry> const> &indices) {
-    auto keep_condition = [](AllIndicesEntry const &entry) { return entry.use_count() != 1; };
-    if (!r::all_of(*indices, keep_condition)) {
-      indices = std::make_shared<std::vector<AllIndicesEntry>>(*indices | rv::filter(keep_condition) | r::to_vector);
-    }
-  });
+  storage::CleanupAllIndices(all_indices_, [](AllIndicesEntry const &e) { return e.use_count(); });
 }
 
 InMemoryEdgeTypeIndex::ChunkedIterable::ChunkedIterable(

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -18,6 +18,7 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/all_indices_cleanup.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/interesting_ids.hpp"
 #include "storage/v2/property_constants.hpp"
@@ -585,12 +586,7 @@ auto InMemoryEdgeTypePropertyIndex::GetIndividualIndex(EdgeTypeId edge_type, Pro
 }
 
 void InMemoryEdgeTypePropertyIndex::CleanupAllIndices() {
-  all_indices_.WithLock([](std::shared_ptr<std::vector<AllIndicesEntry> const> &indices) {
-    auto keep_condition = [](AllIndicesEntry const &entry) { return entry.index_.use_count() != 1; };
-    if (!r::all_of(*indices, keep_condition)) {
-      indices = std::make_shared<std::vector<AllIndicesEntry>>(*indices | rv::filter(keep_condition) | r::to_vector);
-    }
-  });
+  storage::CleanupAllIndices(all_indices_, [](AllIndicesEntry const &e) { return e.index_.use_count(); });
 }
 
 InMemoryEdgeTypePropertyIndex::ChunkedIterable::ChunkedIterable(

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -10,17 +10,17 @@
 // licenses/APL.txt.
 
 #include "storage/v2/inmemory/label_index.hpp"
-#include <range/v3/all.hpp>
+
+#include <algorithm>
+
 #include "storage/v2/interesting_ids.hpp"
 
 #include "metrics/prometheus_metrics.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/all_indices_cleanup.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/counter.hpp"
-
-namespace r = ranges;
-namespace rv = r::views;
 
 namespace {
 void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_vertex,
@@ -453,14 +453,7 @@ void InMemoryLabelIndex::DropGraphClearIndices() {
 }
 
 void InMemoryLabelIndex::CleanupAllIndices() {
-  // By cleanup, we mean just cleanup of the all_indexes_
-  // If all_indexes_ is the only thing holding onto an IndividualIndex, we remove it
-  all_indices_.WithLock([](std::shared_ptr<std::vector<AllIndicesEntry> const> &indices) {
-    auto keep_condition = [](AllIndicesEntry const &entry) { return entry.index_.use_count() != 1; };
-    if (!ranges::all_of(*indices, keep_condition)) {
-      indices = std::make_shared<std::vector<AllIndicesEntry>>(*indices | rv::filter(keep_condition) | r::to_vector);
-    }
-  });
+  storage::CleanupAllIndices(all_indices_, [](AllIndicesEntry const &e) { return e.index_.use_count(); });
 }
 
 void InMemoryLabelIndex::ChunkedIterable::Iterator::AdvanceUntilValid() {

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1495,6 +1495,8 @@ void InMemoryLabelPropertyIndex::ActiveIndices::AbortEntries(AbortableInfo const
   abort_from(index_container_->desc_indices_);
 }
 
+// Not the shared CleanupAllIndices: this holds two vectors behind ForEach, and the refcount sits
+// behind a variant rather than a plain member.
 void InMemoryLabelPropertyIndex::CleanupAllIndices() {
   auto const cleanup = [](auto &indices) {
     auto keep_condition = [](auto const &entry) {

--- a/src/storage/v2/inmemory/vertex_property_index.cpp
+++ b/src/storage/v2/inmemory/vertex_property_index.cpp
@@ -15,12 +15,11 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/all_indices_cleanup.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/interesting_ids.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/counter.hpp"
-
-namespace r = ranges;  // NOLINT(misc-unused-alias-decls)
 
 namespace memgraph::storage {
 
@@ -466,12 +465,7 @@ auto InMemoryVertexPropertyIndex::GetIndividualIndex(PropertyId property) const 
 }
 
 void InMemoryVertexPropertyIndex::CleanupAllIndices() {
-  all_indices_.WithLock([](std::shared_ptr<std::vector<AllIndicesEntry> const> &indices) {
-    auto keep_condition = [](AllIndicesEntry const &entry) { return entry.second.use_count() != 1; };
-    if (!r::all_of(*indices, keep_condition)) {
-      indices = std::make_shared<std::vector<AllIndicesEntry>>(*indices | rv::filter(keep_condition) | r::to_vector);
-    }
-  });
+  storage::CleanupAllIndices(all_indices_, [](AllIndicesEntry const &e) { return e.second.use_count(); });
 }
 
 InMemoryVertexPropertyIndex::ChunkedIterable::ChunkedIterable(


### PR DESCRIPTION
Five in-memory index classes each had their own `CleanupAllIndices`, and the five bodies were identical apart from one detail: how an entry hands back the use count of the `shared_ptr` it carries. Some keep it in a struct member, one is the pointer itself, and two hold it in a pair. Everything else was copied prose, so a change to the reaping rule had to be made five times and was easy to make in only four.

They now call a single function template in `all_indices_cleanup.hpp`, taking the entry-to-refcount projection as its one parameter. The reaping rule itself is unchanged: drop an entry when nothing but the shared vector still holds it, and rebuild that vector under the lock only when something is actually reapable. The `all_of` fast path that avoids an allocation on the common no-op call is kept.

This also corrects the `CleanupAllIndicies` spelling in `InMemoryEdgePropertyIndex`.

Label-property keeps its own version, now with a comment saying why: it holds two vectors behind `ForEach` and reads the refcount through a variant, so it does not fit the same signature, and forcing it in would need a second abstraction.
