### PR TITLE
refactor(query): find index hints with `ranges::any_of` instead of loops

### DIFF
--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -128,13 +128,8 @@ struct IndexHints {
 
   template <class TDbAccessor>
   bool HasLabelIndex(TDbAccessor *db, storage::LabelId label) const {
-    for (const auto &[index_type, label_hint, _] : label_index_hints_) {
-      auto label_id = db->NameToLabel(label_hint.name);
-      if (label_id == label) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(label_index_hints_,
+                               [&](auto const &hint) { return db->NameToLabel(hint.label_ix_.name) == label; });
   }
 
   template <class TDbAccessor>
@@ -158,24 +153,17 @@ struct IndexHints {
   // TODO: look into making index hints work for point indexes
   template <class TDbAccessor>
   bool HasPointIndex(TDbAccessor *db, storage::LabelId label, storage::PropertyId property) const {
-    for (const auto &[index_type, label_hint, property_hint] : point_index_hints_) {
-      auto label_id = db->NameToLabel(label_hint.name);
-      auto property_id = db->NameToProperty(property_hint[0].path[0].name);
-      if (label_id == label && property_id == property) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(point_index_hints_, [&](auto const &hint) {
+      return db->NameToLabel(hint.label_ix_.name) == label &&
+             db->NameToProperty(hint.property_ixs_[0].path[0].name) == property;
+    });
   }
 
   template <class TDbAccessor>
   bool HasVertexPropertyIndex(TDbAccessor *db, storage::PropertyId property) const {
-    for (const auto &[index_type, label_hint, property_ixs] : vertex_property_index_hints_) {
-      if (db->NameToProperty(property_ixs[0].path[0].name) == property) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(vertex_property_index_hints_, [&](auto const &hint) {
+      return db->NameToProperty(hint.property_ixs_[0].path[0].name) == property;
+    });
   }
 
   std::vector<IndexHint> label_index_hints_{};


### PR DESCRIPTION
Three of the IndexHints lookups walked their hint vector by hand to answer one question: does any hint match this label, or this property, or both. Each was six lines of loop, comparison, return true, return false, and each destructured three fields to read one or two of them.

They now say that directly with `std::ranges::any_of`, which is what the sibling plan rewriters already use. The file keeps range-v3 for the pipeline work it needs elsewhere.

HasLabelPropertiesIndex stays a loop. It builds a property id vector per hint and searches it, so it never was the same shape, and with the three lookalikes gone that difference is now visible instead of buried among them.