### PR TITLE
fix(storage): make an index drop safe to roll back and to replay

### DIFF
--- a/ADRs/004_concurrent_index_creation.md
+++ b/ADRs/004_concurrent_index_creation.md
@@ -194,6 +194,60 @@ auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
 - **Rationale**: Allows concurrent writes during expensive population phase
 - **Constraint**: Only one downgrade per transaction (affects TTL)
 
+## Amendment: the two phases of an index drop
+
+**Date** September 4, 2026
+
+The three phases above give a creation its vocabulary, and each phase states what
+it may touch. A drop had no such vocabulary, and successive attempts to place its
+effect all read as plausible because there was no language in which to say where
+the effect belongs. It has two phases.
+
+### Phase 1: Decide (statement time)
+
+- Reads the catalogue and settles two things: that the index is there at all, and,
+  for a label-property index, which orders will go
+- Writes the metadata deltas that describe exactly that decision
+- Changes nothing else. The catalogue still holds the index, and the published
+  `ActiveIndices` snapshot still offers it
+
+The decision is fixed here and never revisited, because the log records are
+written here. Asking the catalogue again in phase 2 would let an index created in
+between be evicted with no record, and recovery would then bring back an index
+that had been dropped.
+
+### Phase 2: Evict (commit time)
+
+- Evicts the catalogue entry and publishes the new `ActiveIndices` snapshot,
+  together, under the index's own lock
+- Runs from a commit callback, so a transaction that aborts has nothing to undo
+
+Both halves have to wait, and this is the part that is not obvious. Publishing
+means publishing the catalogue, so an entry evicted in phase 1 is an entry that
+any *other* publisher hands out on the dropper's behalf, and a creation publishes
+during its own Register phase because that is what makes concurrent writers
+maintain what it registered. A writer admitted after such a publication captures
+an index set without the index and maintains nothing for it, so a drop that then
+rolls back restores the entry short of that writer's rows, with no error anywhere.
+
+### Why not exclude writers instead
+
+Holding writers off for the drop's whole transaction gives the same guarantee.
+It costs too much: READ_ONLY access requires the write count to be zero, and a
+data query is counted as a write even when it only reads, so a drop would fail
+whenever any transaction was open.
+
+### What separating the phases admits
+
+A drop evicts whatever the catalogue holds when it commits, which need not be the
+entry its statement decided about. Two drops can both decide, the first can commit
+and evict, the index can be re-created, and the second then evicts the new entry.
+This is a widening of what a drop can affect, not a safety defect: the snapshot
+never withholds a live index from a transaction that is beginning, the catalogue
+and the published snapshot never disagree, and the durable order replays to the
+same end state. It also means two transactions can both record a drop of one
+index, which is why replaying a drop tolerates the index being absent already.
+
 ## Future Improvements
 
 1. **Replica READ_ONLY Support**: Resolve delta ordering to enable `kReadOnlyAccess` in replication

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -1672,7 +1672,7 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
         [&](WalLabelIndexDrop const &data) {
           spdlog::trace("   Delta {}. Drop label index on :{}", current_delta_idx, data.label);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
-          if (!transaction->DropIndex(storage->NameToLabel(data.label)))
+          if (!transaction->DropIndex(storage->NameToLabel(data.label), storage::AbsentIndex::kIsRecorded))
             throw utils::BasicException("Failed to drop label index on :{}.", data.label);
         },
         [&](WalLabelIndexStatsSet const &data) {
@@ -1716,7 +1716,11 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
           auto property_paths = data.composite_property_paths.convert(mapper);
 
-          if (!transaction->DropIndex(storage->NameToLabel(data.label), std::move(property_paths))) {
+          // A WAL written before the order was recorded means the only order there was, ASC.
+          if (!transaction->DropIndex(storage->NameToLabel(data.label),
+                                      std::move(property_paths),
+                                      data.order.value_or(storage::IndexOrder::ASC),
+                                      storage::AbsentIndex::kIsRecorded)) {
             throw utils::BasicException(
                 "Failed to drop label+property index on :{} ({}).", data.label, data.composite_property_paths);
           }
@@ -1749,7 +1753,7 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
         [&](WalEdgeTypeIndexDrop const &data) {
           spdlog::trace("   Delta {}. Drop edge index on :{}", current_delta_idx, data.edge_type);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
-          if (!transaction->DropIndex(storage->NameToEdgeType(data.edge_type))) {
+          if (!transaction->DropIndex(storage->NameToEdgeType(data.edge_type), storage::AbsentIndex::kIsRecorded)) {
             throw utils::BasicException("Failed to drop edge index on :{}.", data.edge_type);
           }
         },
@@ -1767,8 +1771,9 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
         [&](WalEdgeTypePropertyIndexDrop const &data) {
           spdlog::trace("   Delta {}. Drop edge index on :{}({})", current_delta_idx, data.edge_type, data.property);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
-          if (!transaction->DropIndex(storage->NameToEdgeType(data.edge_type), storage->NameToProperty(data.property))
-                   .has_value()) {
+          if (!transaction->DropIndex(storage->NameToEdgeType(data.edge_type),
+                                      storage->NameToProperty(data.property),
+                                      storage::AbsentIndex::kIsRecorded)) {
             throw utils::BasicException(
                 "Failed to drop edge property index on :{}({}).", data.edge_type, data.property);
           }
@@ -1783,7 +1788,8 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
         [&](WalEdgePropertyIndexDrop const &data) {
           spdlog::trace("       Drop global edge index on ({})", data.property);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
-          if (!transaction->DropGlobalEdgeIndex(storage->NameToProperty(data.property))) {
+          if (!transaction->DropGlobalEdgeIndex(storage->NameToProperty(data.property),
+                                                storage::AbsentIndex::kIsRecorded)) {
             throw utils::BasicException("Failed to drop global edge property index on ({}).", data.property);
           }
         },
@@ -1797,7 +1803,8 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
         [&](WalVertexPropertyIndexDrop const &data) {
           spdlog::trace("       Drop global vertex property index on ({})", data.property);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
-          if (!transaction->DropGlobalVertexIndex(storage->NameToProperty(data.property))) {
+          if (!transaction->DropGlobalVertexIndex(storage->NameToProperty(data.property),
+                                                  storage::AbsentIndex::kIsRecorded)) {
             throw utils::BasicException("Failed to drop global vertex property index on ({}).", data.property);
           }
         },

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10510,9 +10510,7 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
       accessor_type_ = (index_query.action_ == IndexQuery::Action::CREATE) ? READ_ONLY : READ;
     } else if (storage_mode_ == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
       // Read-only either way, so reads run alongside: creation needs writers out for the whole
-      // population (see DowngradeToReadIfValid), and a drop takes effect at once but is undone by
-      // restoring the index exactly as captured, so a writer admitted before the commit would leave
-      // the restored index missing whatever it wrote.
+      // population (see DowngradeToReadIfValid), and a drop is held to the same access.
       accessor_type_ = READ_ONLY;
     } else {
       // ON_DISK_TRANSACTIONAL requires unique access

--- a/src/storage/v2/disk/edge_type_index.cpp
+++ b/src/storage/v2/disk/edge_type_index.cpp
@@ -31,7 +31,7 @@ bool DiskEdgeTypeIndex::ActiveIndices::IndexReady(EdgeTypeId /*edge_type*/) cons
   return false;
 }
 
-bool DiskEdgeTypeIndex::ActiveIndices::IndexRegistered(EdgeTypeId /*edge_type*/) const {
+bool DiskEdgeTypeIndex::ActiveIndices::IndexExists(EdgeTypeId /*edge_type*/) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return false;
 }

--- a/src/storage/v2/disk/edge_type_index.hpp
+++ b/src/storage/v2/disk/edge_type_index.hpp
@@ -22,7 +22,7 @@ class DiskEdgeTypeIndex : public EdgeTypeIndex {
   struct ActiveIndices : EdgeTypeIndex::ActiveIndices {
     bool IndexReady(EdgeTypeId edge_type) const override;
 
-    bool IndexRegistered(EdgeTypeId edge_type) const override;
+    bool IndexExists(EdgeTypeId edge_type) const override;
 
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<EdgeTypeId> override;
 

--- a/src/storage/v2/disk/edge_type_property_index.cpp
+++ b/src/storage/v2/disk/edge_type_property_index.cpp
@@ -27,6 +27,11 @@ bool DiskEdgeTypePropertyIndex::ActiveIndices::IndexReady(EdgeTypeId /*edge_type
   return false;
 }
 
+bool DiskEdgeTypePropertyIndex::ActiveIndices::IndexExists(EdgeTypeId /*edge_type*/, PropertyId /*property*/) const {
+  spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
+  return false;
+}
+
 std::vector<std::pair<EdgeTypeId, PropertyId>> DiskEdgeTypePropertyIndex::ActiveIndices::ListIndices(
     uint64_t start_timestamp) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");

--- a/src/storage/v2/disk/edge_type_property_index.hpp
+++ b/src/storage/v2/disk/edge_type_property_index.hpp
@@ -31,6 +31,8 @@ class DiskEdgeTypePropertyIndex : public EdgeTypePropertyIndex {
 
     bool IndexReady(EdgeTypeId edge_type, PropertyId property) const override;
 
+    bool IndexExists(EdgeTypeId edge_type, PropertyId property) const override;
+
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
 
     auto GetAbortProcessor() const -> AbortProcessor override;

--- a/src/storage/v2/disk/label_index.cpp
+++ b/src/storage/v2/disk/label_index.cpp
@@ -198,7 +198,7 @@ bool DiskLabelIndex::DropIndex(LabelId label, ActiveIndicesUpdater const &update
   return true;
 }
 
-bool DiskLabelIndex::ActiveIndices::IndexRegistered(LabelId label) const { return index_.contains(label); }
+bool DiskLabelIndex::ActiveIndices::IndexExists(LabelId label) const { return index_.contains(label); }
 
 bool DiskLabelIndex::ActiveIndices::IndexReady(LabelId label) const { return index_.contains(label); }
 

--- a/src/storage/v2/disk/label_index.hpp
+++ b/src/storage/v2/disk/label_index.hpp
@@ -36,7 +36,7 @@ class DiskLabelIndex : public storage::LabelIndex {
 
     void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override;
 
-    bool IndexRegistered(LabelId label) const override;
+    bool IndexExists(LabelId label) const override;
 
     bool IndexReady(LabelId label) const override;
 

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2257,7 +2257,8 @@ std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::Crea
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
 
-std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::DropIndex(LabelId label) {
+std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::DropIndex(LabelId label,
+                                                                                      AbsentIndex /*absent*/) {
   MG_ASSERT(type() == UNIQUE, "Create index requires a unique access to the storage!");
   auto *on_disk = static_cast<DiskStorage *>(storage_);
   auto *disk_label_index = static_cast<DiskLabelIndex *>(on_disk->indices_.label_index_.get());
@@ -2277,7 +2278,8 @@ std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::Drop
 }
 
 std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::DropIndex(
-    LabelId label, std::vector<storage::PropertyPath> &&properties, std::optional<IndexOrder> order) {
+    LabelId label, std::vector<storage::PropertyPath> &&properties, std::optional<IndexOrder> order,
+    AbsentIndex /*absent*/) {
   MG_ASSERT(type() == UNIQUE, "Create index requires a unique access to the storage!");
 
   if (properties.size() != 1) {
@@ -2310,19 +2312,21 @@ std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::Drop
   return {};
 }
 
-std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::DropIndex(EdgeTypeId /*edge_type*/) {
+std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::DropIndex(EdgeTypeId /*edge_type*/,
+                                                                                      AbsentIndex /*absent*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
 
 std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::DropIndex(EdgeTypeId /*edge_type*/,
-                                                                                      PropertyId /*property*/) {
+                                                                                      PropertyId /*property*/,
+                                                                                      AbsentIndex /*absent*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
 
 std::expected<void, StorageIndexDefinitionError> DiskStorage::DiskAccessor::DropGlobalEdgeIndex(
-    PropertyId /*property*/) {
+    PropertyId /*property*/, AbsentIndex /*absent*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -372,19 +372,25 @@ class DiskStorage final : public Storage {
       return std::unexpected{IndexDefinitionError{}};
     }
 
-    std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label) override;
+    std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
     std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label,
                                                                std::vector<storage::PropertyPath> &&properties,
-                                                               std::optional<IndexOrder> order = std::nullopt) override;
+                                                               std::optional<IndexOrder> order = std::nullopt,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
-    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type) override;
+    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
-    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property) override;
+    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
-    std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(PropertyId property) override;
+    std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(
+        PropertyId property, AbsentIndex absent = AbsentIndex::kFails) override;
 
-    std::expected<void, StorageIndexDefinitionError> DropGlobalVertexIndex(PropertyId /*property*/) override {
+    std::expected<void, StorageIndexDefinitionError> DropGlobalVertexIndex(
+        PropertyId /*property*/, AbsentIndex /*absent*/ = AbsentIndex::kFails) override {
       return std::unexpected{IndexDefinitionError{}};
     }
 

--- a/src/storage/v2/durability/metadata.hpp
+++ b/src/storage/v2/durability/metadata.hpp
@@ -99,18 +99,25 @@ void RemoveRecoveredIndexConstraint(std::vector<TObj> *list, TObj obj, const cha
 
 // Removes an index that a replayed drop refers to, tolerating its absence.
 //
-// An index drop takes effect on the live catalogue when the statement runs and
-// is recorded in the log only when the transaction commits. A snapshot whose
-// transaction begins between those two points therefore records the index as
-// already gone, while recording a durable timestamp below the drop's, so replay
-// resumes above the drop and applies it to a catalogue that never had it.
+// A drop decides that the index exists when its statement runs and evicts it
+// when it commits, so two transactions can both find it and both record a drop
+// of it. One of them evicts and the other has nothing left to evict, and the
+// log holds two drops of the same index either way. Replay of the second finds
+// the catalogue already without it.
 //
-// Refusing the replay makes such a snapshot unrecoverable, and the end state is
-// the same either way: the index is absent. Applying a drop to something already
-// absent is idempotent, so tolerating it is not a patch over corruption. It does
-// give up a canary for the case where an index really did vanish for another
-// reason, which is why this is separate from RemoveRecoveredIndexConstraint and
-// used only where a drop can legitimately arrive twice.
+// Snapshots written before the eviction moved to commit time reach the same
+// state by a different route, and recovery still has to read them: such a
+// snapshot records the index as already gone while recording a durable
+// timestamp below the drop's, so replay resumes above the drop and applies it
+// to a catalogue that never had it.
+//
+// Refusing either makes a recoverable database unrecoverable, and the end state
+// is the same as accepting: the index is absent. Applying a drop to something
+// already absent is idempotent, so tolerating it is not a patch over
+// corruption. It does give up a canary for an index that vanished for some
+// other reason, which is why this is separate from
+// RemoveRecoveredIndexConstraint and used only where a drop can legitimately
+// arrive twice.
 template <typename TObj>
 void RemoveRecoveredIndexIfPresent(std::vector<TObj> *list, TObj obj) {
   auto it = std::find(list->begin(), list->end(), obj);

--- a/src/storage/v2/durability/metadata.hpp
+++ b/src/storage/v2/durability/metadata.hpp
@@ -97,6 +97,29 @@ void RemoveRecoveredIndexConstraint(std::vector<TObj> *list, TObj obj, const cha
   }
 }
 
+// Removes an index that a replayed drop refers to, tolerating its absence.
+//
+// An index drop takes effect on the live catalogue when the statement runs and
+// is recorded in the log only when the transaction commits. A snapshot whose
+// transaction begins between those two points therefore records the index as
+// already gone, while recording a durable timestamp below the drop's, so replay
+// resumes above the drop and applies it to a catalogue that never had it.
+//
+// Refusing the replay makes such a snapshot unrecoverable, and the end state is
+// the same either way: the index is absent. Applying a drop to something already
+// absent is idempotent, so tolerating it is not a patch over corruption. It does
+// give up a canary for the case where an index really did vanish for another
+// reason, which is why this is separate from RemoveRecoveredIndexConstraint and
+// used only where a drop can legitimately arrive twice.
+template <typename TObj>
+void RemoveRecoveredIndexIfPresent(std::vector<TObj> *list, TObj obj) {
+  auto it = std::find(list->begin(), list->end(), obj);
+  if (it != list->end()) {
+    std::swap(*it, list->back());
+    list->pop_back();
+  }
+}
+
 // Helper function used to remove indices stats from the recovered
 // indices/constraints object.
 // @note multiple stats can be pushed one after the other; when removing, remove from the back

--- a/src/storage/v2/durability/metadata.hpp
+++ b/src/storage/v2/durability/metadata.hpp
@@ -99,25 +99,14 @@ void RemoveRecoveredIndexConstraint(std::vector<TObj> *list, TObj obj, const cha
 
 // Removes an index that a replayed drop refers to, tolerating its absence.
 //
-// A drop decides that the index exists when its statement runs and evicts it
-// when it commits, so two transactions can both find it and both record a drop
-// of it. One of them evicts and the other has nothing left to evict, and the
-// log holds two drops of the same index either way. Replay of the second finds
-// the catalogue already without it.
+// The log can legitimately hold two drops of one index: a drop settles that the index exists when
+// its statement runs and evicts when it commits, so two transactions can both record one. Older
+// snapshots reach the same place from the other side, recording the index as gone under a durable
+// timestamp below the drop's.
 //
-// Snapshots written before the eviction moved to commit time reach the same
-// state by a different route, and recovery still has to read them: such a
-// snapshot records the index as already gone while recording a durable
-// timestamp below the drop's, so replay resumes above the drop and applies it
-// to a catalogue that never had it.
-//
-// Refusing either makes a recoverable database unrecoverable, and the end state
-// is the same as accepting: the index is absent. Applying a drop to something
-// already absent is idempotent, so tolerating it is not a patch over
-// corruption. It does give up a canary for an index that vanished for some
-// other reason, which is why this is separate from
-// RemoveRecoveredIndexConstraint and used only where a drop can legitimately
-// arrive twice.
+// Applying a drop to something already absent is idempotent, so tolerating it hides no corruption.
+// It does give up a canary for an index that vanished for another reason, which is why the strict
+// RemoveRecoveredIndexConstraint stays in use everywhere else.
 template <typename TObj>
 void RemoveRecoveredIndexIfPresent(std::vector<TObj> *list, TObj obj) {
   auto it = std::find(list->begin(), list->end(), obj);

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1816,7 +1816,7 @@ std::optional<RecoveryInfo> LoadWal(
       },
       [&](WalLabelIndexDrop const &data) {
         auto label_id = LabelId::FromUint(name_id_mapper->NameToId(data.label));
-        RemoveRecoveredIndexConstraint(&indices_constraints->indices.label, label_id, "The label index doesn't exist!");
+        RemoveRecoveredIndexIfPresent(&indices_constraints->indices.label, label_id);
       },
       [&](WalEdgeTypeIndexCreate const &data) {
         auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(data.edge_type));
@@ -1825,8 +1825,7 @@ std::optional<RecoveryInfo> LoadWal(
       },
       [&](WalEdgeTypeIndexDrop const &data) {
         auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(data.edge_type));
-        RemoveRecoveredIndexConstraint(
-            &indices_constraints->indices.edge, edge_type_id, "The edge-type index doesn't exist!");
+        RemoveRecoveredIndexIfPresent(&indices_constraints->indices.edge, edge_type_id);
       },
       [&](WalEdgeTypePropertyIndexCreate const &data) {
         auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(data.edge_type));
@@ -1838,9 +1837,7 @@ std::optional<RecoveryInfo> LoadWal(
       [&](WalEdgeTypePropertyIndexDrop const &data) {
         auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(data.edge_type));
         auto property_id = PropertyId::FromUint(name_id_mapper->NameToId(data.property));
-        RemoveRecoveredIndexConstraint(&indices_constraints->indices.edge_type_property,
-                                       {edge_type_id, property_id},
-                                       "The edge-type + property index doesn't exist!");
+        RemoveRecoveredIndexIfPresent(&indices_constraints->indices.edge_type_property, {edge_type_id, property_id});
       },
       [&](WalEdgePropertyIndexCreate const &data) {
         auto property_id = PropertyId::FromUint(name_id_mapper->NameToId(data.property));
@@ -1850,9 +1847,7 @@ std::optional<RecoveryInfo> LoadWal(
       },
       [&](WalEdgePropertyIndexDrop const &data) {
         auto property_id = PropertyId::FromUint(name_id_mapper->NameToId(data.property));
-        RemoveRecoveredIndexConstraint(&indices_constraints->indices.edge_property,
-                                       {property_id},
-                                       "The global edge property index doesn't exist!");
+        RemoveRecoveredIndexIfPresent(&indices_constraints->indices.edge_property, {property_id});
       },
       [&](WalVertexPropertyIndexCreate const &data) {
         auto property_id = PropertyId::FromUint(name_id_mapper->NameToId(data.property));
@@ -1862,9 +1857,7 @@ std::optional<RecoveryInfo> LoadWal(
       },
       [&](WalVertexPropertyIndexDrop const &data) {
         auto property_id = PropertyId::FromUint(name_id_mapper->NameToId(data.property));
-        RemoveRecoveredIndexConstraint(&indices_constraints->indices.vertex_property,
-                                       {property_id},
-                                       "The global vertex property index doesn't exist!");
+        RemoveRecoveredIndexIfPresent(&indices_constraints->indices.vertex_property, {property_id});
       },
       [&](WalLabelIndexStatsSet const &data) {
         auto label_id = LabelId::FromUint(name_id_mapper->NameToId(data.label));
@@ -1894,8 +1887,7 @@ std::optional<RecoveryInfo> LoadWal(
         auto order = data.order.value_or(IndexOrder::ASC);
         auto &target = (order == IndexOrder::DESC) ? indices_constraints->indices.label_properties_desc
                                                    : indices_constraints->indices.label_properties;
-        RemoveRecoveredIndexConstraint(
-            &target, {label_id, std::move(prop_ids)}, "The label property index doesn't exist!");
+        RemoveRecoveredIndexIfPresent(&target, {label_id, std::move(prop_ids)});
       },
       [&](WalPointIndexCreate const &data) {
         auto label_id = LabelId::FromUint(name_id_mapper->NameToId(data.label));

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -75,7 +75,7 @@ struct EdgeTypeIndexActiveIndices {
   virtual auto ApproximateEdgeCount(EdgeTypeId edge_type) const -> uint64_t = 0;
 
   virtual bool IndexReady(EdgeTypeId edge_type) const = 0;
-  virtual bool IndexRegistered(EdgeTypeId edge_type) const = 0;
+  virtual bool IndexExists(EdgeTypeId edge_type) const = 0;
 
   virtual auto ListIndices(uint64_t start_timestamp) const -> std::vector<EdgeTypeId> = 0;
 

--- a/src/storage/v2/indices/edge_type_property_index.hpp
+++ b/src/storage/v2/indices/edge_type_property_index.hpp
@@ -99,6 +99,10 @@ struct EdgeTypePropertyIndexActiveIndices {
 
   virtual bool IndexReady(EdgeTypeId edge_type, PropertyId property) const = 0;
 
+  /// Whether the entry is in the catalogue at all, ready or not, which is the question a drop
+  /// asks: an index that is registered but not yet committed is still an index a drop evicts.
+  virtual bool IndexExists(EdgeTypeId edge_type, PropertyId property) const = 0;
+
   virtual auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> = 0;
 
   virtual auto GetAbortProcessor() const -> EdgeTypePropertyIndexAbortProcessor = 0;

--- a/src/storage/v2/indices/label_index.hpp
+++ b/src/storage/v2/indices/label_index.hpp
@@ -69,7 +69,7 @@ struct LabelIndexActiveIndices {
   // Not used for in-memory
   virtual void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) = 0;
 
-  virtual bool IndexRegistered(LabelId label) const = 0;
+  virtual bool IndexExists(LabelId label) const = 0;
 
   virtual bool IndexReady(LabelId label) const = 0;
 

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -193,35 +193,24 @@ bool InMemoryEdgePropertyIndex::CreateIndexOnePass(PropertyId property, utils::S
   return PublishIndex(property, 0);
 }
 
-bool InMemoryEdgePropertyIndex::InstallIndividualIndex_(PropertyId property, std::shared_ptr<IndividualIndex> entry,
-                                                        ActiveIndicesUpdater const &updater,
-                                                        bool register_in_all_indices) {
+bool InMemoryEdgePropertyIndex::RegisterIndex(PropertyId property, ActiveIndicesUpdater const &updater) {
   return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
     if (indices_container->indices_.find(property) != indices_container->indices_.cend()) return false;
     utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
     auto new_container = std::make_shared<IndicesContainer>(*indices_container);
-    auto [new_it, _] = new_container->indices_.emplace(property, std::move(entry));
+    auto [new_it, _] = new_container->indices_.emplace(property, std::make_shared<IndividualIndex>());
 
-    if (register_in_all_indices) {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    all_indices_.WithLock([&](auto &all_indices) {
+      auto new_all_indices = *all_indices;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-      all_indices_.WithLock([&](auto &all_indices) {
-        auto new_all_indices = *all_indices;
-        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-        new_all_indices.emplace_back(property, new_it->second);
-        all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
-      });
-    }
+      new_all_indices.emplace_back(property, new_it->second);
+      all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
+    });
     indices_container = std::move(new_container);
     updater(std::make_shared<ActiveIndices>(indices_container));
     return true;
   });
-}
-
-bool InMemoryEdgePropertyIndex::RegisterIndex(PropertyId property, ActiveIndicesUpdater const &updater) {
-  return InstallIndividualIndex_(property,
-                                 std::make_shared<IndividualIndex>(),
-                                 updater,
-                                 /*register_in_all_indices=*/true);
 }
 
 auto InMemoryEdgePropertyIndex::PopulateIndex(PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
@@ -284,20 +273,12 @@ auto InMemoryEdgePropertyIndex::DropIndex(PropertyId property, ActiveIndicesUpda
 
         auto new_container = std::make_shared<IndicesContainer>(*indices_container);
         new_container->indices_.erase(property);
-        indices_container = new_container;
-        updater(std::make_shared<ActiveIndices>(indices_container));
+        updater(std::make_shared<ActiveIndices>(new_container));
+        indices_container = std::move(new_container);
         return evicted_entry;
       });
   CleanupAllIndicies();
   return evicted;
-}
-
-void InMemoryEdgePropertyIndex::RestoreIndex(PropertyId property, std::shared_ptr<IndividualIndex> evicted,
-                                             ActiveIndicesUpdater const &updater) {
-  if (!evicted) return;
-  // register_in_all_indices=false: captured shared_ptr already kept the entry alive
-  // through CleanupAllIndices; re-appending would create an unreapable duplicate.
-  (void)InstallIndividualIndex_(property, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
 bool InMemoryEdgePropertyIndex::ActiveIndices::IndexExists(PropertyId property) const {

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -269,11 +269,8 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
   bool PublishIndex(PropertyId property, uint64_t commit_timestamp);
 
   /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
-  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
-  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
   [[nodiscard]] auto DropIndex(PropertyId property, ActiveIndicesUpdater const &updater)
       -> std::shared_ptr<IndividualIndex>;
-  void RestoreIndex(PropertyId property, std::shared_ptr<IndividualIndex> evicted, ActiveIndicesUpdater const &updater);
 
   /// Sweeps only the indexes whose property `arming` names, and returns how many that was.
   uint64_t RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token,
@@ -288,10 +285,6 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
  private:
   auto GetIndividualIndex(PropertyId property) const -> std::shared_ptr<IndividualIndex>;
 
-  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
-  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
-  bool InstallIndividualIndex_(PropertyId property, std::shared_ptr<IndividualIndex> entry,
-                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
   void CleanupAllIndicies();
 
   metrics::GaugeHandle gauge_{};

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -241,7 +241,7 @@ bool InMemoryEdgeTypeIndex::ActiveIndices::IndexReady(memgraph::storage::EdgeTyp
   return it->second->status_.IsReady();
 }
 
-bool InMemoryEdgeTypeIndex::ActiveIndices::IndexRegistered(EdgeTypeId edge_type) const {
+bool InMemoryEdgeTypeIndex::ActiveIndices::IndexExists(EdgeTypeId edge_type) const {
   return index_container_->indices_.contains(edge_type);
 }
 

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -164,14 +164,13 @@ auto InMemoryEdgeTypeIndex::PopulateIndex(EdgeTypeId edge_type, utils::SkipListD
   return {};
 }
 
-bool InMemoryEdgeTypeIndex::InstallIndividualIndex_(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> entry,
-                                                    ActiveIndicesUpdater const &updater, bool register_in_all_indices) {
+bool InMemoryEdgeTypeIndex::RegisterIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) {
   return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
     if (indices_container->indices_.find(edge_type) != indices_container->indices_.cend()) return false;
     auto new_container = std::make_shared<IndicesContainer>(*indices_container);
-    auto [new_it, _] = new_container->indices_.emplace(edge_type, std::move(entry));
+    auto [new_it, _] = new_container->indices_.emplace(edge_type, std::make_shared<IndividualIndex>());
 
-    if (register_in_all_indices) {
+    {
       const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
       all_indices_.WithLock([&](auto &all_indices) {
@@ -185,13 +184,6 @@ bool InMemoryEdgeTypeIndex::InstallIndividualIndex_(EdgeTypeId edge_type, std::s
     updater(std::make_shared<ActiveIndices>(indices_container));
     return true;
   });
-}
-
-bool InMemoryEdgeTypeIndex::RegisterIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) {
-  return InstallIndividualIndex_(edge_type,
-                                 std::make_shared<IndividualIndex>(),
-                                 updater,
-                                 /*register_in_all_indices=*/true);
 }
 
 bool InMemoryEdgeTypeIndex::PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp) {
@@ -218,20 +210,12 @@ auto InMemoryEdgeTypeIndex::DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater
 
         auto new_container = std::make_shared<IndicesContainer>(*indices_container);
         new_container->indices_.erase(edge_type);
-        indices_container = new_container;
-        updater(std::make_shared<ActiveIndices>(indices_container));
+        updater(std::make_shared<ActiveIndices>(new_container));
+        indices_container = std::move(new_container);
         return evicted_entry;
       });
   CleanupAllIndices();
   return evicted;
-}
-
-void InMemoryEdgeTypeIndex::RestoreIndex(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> evicted,
-                                         ActiveIndicesUpdater const &updater) {
-  if (!evicted) return;
-  // register_in_all_indices=false: captured shared_ptr already kept the entry alive
-  // through CleanupAllIndices; re-appending would create an unreapable duplicate.
-  (void)InstallIndividualIndex_(edge_type, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
 bool InMemoryEdgeTypeIndex::ActiveIndices::IndexReady(memgraph::storage::EdgeTypeId edge_type) const {

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -202,7 +202,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
     bool IndexReady(EdgeTypeId edge_type) const override;
 
-    bool IndexRegistered(EdgeTypeId edge_type) const override;
+    bool IndexExists(EdgeTypeId edge_type) const override;
 
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<EdgeTypeId> override;
 

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -240,12 +240,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   bool PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp);
 
   /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
-  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
-  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
   [[nodiscard]] auto DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater)
       -> std::shared_ptr<IndividualIndex>;
-  void RestoreIndex(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> evicted,
-                    ActiveIndicesUpdater const &updater);
 
   /// Sweeps nothing unless `arming` says an edge was created or removed, and returns how many
   /// indexes that was.
@@ -261,11 +257,6 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
  private:
   void CleanupAllIndices();
   auto GetIndividualIndex(EdgeTypeId edge_type) const -> std::shared_ptr<IndividualIndex>;
-
-  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
-  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
-  bool InstallIndividualIndex_(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> entry,
-                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
 
   metrics::GaugeHandle gauge_{};
   utils::Synchronized<std::shared_ptr<IndicesContainer const>, utils::WritePrioritizedRWLock> index_{

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -306,7 +306,7 @@ auto InMemoryEdgeTypePropertyIndex::PopulateIndex(EdgeTypeId edge_type, Property
   return {};
 }
 
-bool InMemoryEdgeTypePropertyIndex::ActiveIndices::IndexRegistered(EdgeTypeId edge_type, PropertyId property) const {
+bool InMemoryEdgeTypePropertyIndex::ActiveIndices::IndexExists(EdgeTypeId edge_type, PropertyId property) const {
   return index_container_->contains(std::make_pair(edge_type, property));
 }
 

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -306,6 +306,10 @@ auto InMemoryEdgeTypePropertyIndex::PopulateIndex(EdgeTypeId edge_type, Property
   return {};
 }
 
+bool InMemoryEdgeTypePropertyIndex::ActiveIndices::IndexRegistered(EdgeTypeId edge_type, PropertyId property) const {
+  return index_container_->contains(std::make_pair(edge_type, property));
+}
+
 bool InMemoryEdgeTypePropertyIndex::ActiveIndices::IndexReady(EdgeTypeId edge_type, PropertyId property) const {
   auto it = index_container_->find(std::make_pair(edge_type, property));
   if (it == index_container_->cend()) [[unlikely]] {

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -170,16 +170,14 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, EdgeRef &current_
 }
 }  // namespace
 
-bool InMemoryEdgeTypePropertyIndex::InstallIndividualIndex_(EdgeTypeId edge_type, PropertyId property,
-                                                            std::shared_ptr<IndividualIndex> entry,
-                                                            ActiveIndicesUpdater const &updater,
-                                                            bool register_in_all_indices) {
+bool InMemoryEdgeTypePropertyIndex::RegisterIndex(EdgeTypeId edge_type, PropertyId property,
+                                                  ActiveIndicesUpdater const &updater) {
   return index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) {
     if (index_container->contains({edge_type, property})) return false;
     auto new_container = std::make_shared<IndexContainer>(*index_container);
-    auto [new_it, _] = new_container->emplace(std::make_pair(edge_type, property), std::move(entry));
+    auto [new_it, _] = new_container->emplace(std::make_pair(edge_type, property), std::make_shared<IndividualIndex>());
 
-    if (register_in_all_indices) {
+    {
       const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
       all_indices_.WithLock([&](auto &all_indices) {
@@ -193,15 +191,6 @@ bool InMemoryEdgeTypePropertyIndex::InstallIndividualIndex_(EdgeTypeId edge_type
     updater(std::make_shared<ActiveIndices>(index_container));
     return true;
   });
-}
-
-bool InMemoryEdgeTypePropertyIndex::RegisterIndex(EdgeTypeId edge_type, PropertyId property,
-                                                  ActiveIndicesUpdater const &updater) {
-  return InstallIndividualIndex_(edge_type,
-                                 property,
-                                 std::make_shared<IndividualIndex>(),
-                                 updater,
-                                 /*register_in_all_indices=*/true);
 }
 
 bool InMemoryEdgeTypePropertyIndex::PublishIndex(EdgeTypeId edge_type, PropertyId property, uint64_t commit_timestamp) {
@@ -242,26 +231,13 @@ auto InMemoryEdgeTypePropertyIndex::DropIndex(EdgeTypeId edge_type, PropertyId p
         auto evicted_entry = it->second;
         auto new_container = std::make_shared<IndexContainer>(*index_container);
         new_container->erase({edge_type, property});
+        updater(std::make_shared<ActiveIndices>(new_container));
         index_container = std::move(new_container);
-        updater(std::make_shared<ActiveIndices>(index_container));
         return evicted_entry;
       });
 
   CleanupAllIndices();
   return evicted;
-}
-
-void InMemoryEdgeTypePropertyIndex::RestoreIndex(EdgeTypeId edge_type, PropertyId property,
-                                                 std::shared_ptr<IndividualIndex> evicted,
-                                                 ActiveIndicesUpdater const &updater) {
-  if (!evicted) return;
-  // register_in_all_indices=false: captured shared_ptr already kept the entry alive
-  // through CleanupAllIndices; re-appending would create an unreapable duplicate.
-  (void)InstallIndividualIndex_(edge_type,
-                                property,
-                                std::move(evicted),
-                                updater,
-                                /*register_in_all_indices=*/false);
 }
 
 auto InMemoryEdgeTypePropertyIndex::GetActiveIndices() const -> std::shared_ptr<EdgeTypePropertyIndex::ActiveIndices> {

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -228,6 +228,11 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
     bool IndexReady(EdgeTypeId edge_type, PropertyId property) const override;
 
+    /// Whether the entry is in the catalogue at all, ready or not. IndexReady answers a different
+    /// question, and a DROP has to ask this one: an index that is registered but not yet committed
+    /// is still an index a drop evicts.
+    bool IndexRegistered(EdgeTypeId edge_type, PropertyId property) const;
+
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
 
     Iterable Edges(EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -228,10 +228,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
     bool IndexReady(EdgeTypeId edge_type, PropertyId property) const override;
 
-    /// Whether the entry is in the catalogue at all, ready or not. IndexReady answers a different
-    /// question, and a DROP has to ask this one: an index that is registered but not yet committed
-    /// is still an index a drop evicts.
-    bool IndexRegistered(EdgeTypeId edge_type, PropertyId property) const;
+    bool IndexExists(EdgeTypeId edge_type, PropertyId property) const override;
 
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
 

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -261,12 +261,8 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
                           ActiveIndicesUpdater const &updater, ProgressCallback const &on_progress = {});
 
   /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
-  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
-  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
   [[nodiscard]] auto DropIndex(EdgeTypeId edge_type, PropertyId property, ActiveIndicesUpdater const &updater)
       -> std::shared_ptr<IndividualIndex>;
-  void RestoreIndex(EdgeTypeId edge_type, PropertyId property, std::shared_ptr<IndividualIndex> evicted,
-                    ActiveIndicesUpdater const &updater);
 
   /// Sweeps only the indexes whose property `arming` names, and returns how many that was.
   uint64_t RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token,
@@ -288,11 +284,6 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
  private:
   auto CleanupAllIndices() -> void;
   auto GetIndividualIndex(EdgeTypeId edge_type, PropertyId property) const -> std::shared_ptr<IndividualIndex>;
-
-  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
-  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
-  bool InstallIndividualIndex_(EdgeTypeId edge_type, PropertyId property, std::shared_ptr<IndividualIndex> entry,
-                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
 
   metrics::GaugeHandle gauge_{};
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -248,9 +248,7 @@ void InMemoryLabelIndex::RestoreIndex(LabelId label, std::shared_ptr<IndividualI
   (void)InstallIndividualIndex_(label, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
-bool InMemoryLabelIndex::ActiveIndices::IndexRegistered(LabelId label) const {
-  return index_container_->contains(label);
-}
+bool InMemoryLabelIndex::ActiveIndices::IndexExists(LabelId label) const { return index_container_->contains(label); }
 
 bool InMemoryLabelIndex::ActiveIndices::IndexReady(LabelId label) const {
   auto it = index_container_->find(label);

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -51,14 +51,13 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
 
 namespace memgraph::storage {
 
-bool InMemoryLabelIndex::InstallIndividualIndex_(LabelId label, std::shared_ptr<IndividualIndex> entry,
-                                                 ActiveIndicesUpdater const &updater, bool register_in_all_indices) {
+bool InMemoryLabelIndex::RegisterIndex(LabelId label, ActiveIndicesUpdater const &updater) {
   return index_.WithLock([&](std::shared_ptr<const IndexContainer> &index) {
     if (index->find(label) != index->cend()) return false;
     auto new_index = std::make_shared<IndexContainer>(*index);
-    auto [new_it, _] = new_index->try_emplace(label, std::move(entry));
+    auto [new_it, _] = new_index->try_emplace(label, std::make_shared<IndividualIndex>());
 
-    if (register_in_all_indices) {
+    {
       const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       all_indices_.WithLock([&](auto &all_indices) {
         auto new_all_indices = *all_indices;
@@ -72,10 +71,6 @@ bool InMemoryLabelIndex::InstallIndividualIndex_(LabelId label, std::shared_ptr<
     updater(std::make_shared<ActiveIndices>(index));
     return true;
   });
-}
-
-bool InMemoryLabelIndex::RegisterIndex(LabelId label, ActiveIndicesUpdater const &updater) {
-  return InstallIndividualIndex_(label, std::make_shared<IndividualIndex>(), updater, /*register_in_all_indices=*/true);
 }
 
 auto InMemoryLabelIndex::GetIndividualIndex(LabelId label) const -> std::shared_ptr<IndividualIndex> {
@@ -232,20 +227,12 @@ auto InMemoryLabelIndex::DropIndex(LabelId label, ActiveIndicesUpdater const &up
     auto evicted_entry = it->second;
     auto new_index = std::make_shared<IndexContainer>(*index);
     new_index->erase(label);
+    updater(std::make_shared<ActiveIndices>(new_index));
     index = std::move(new_index);
-    updater(std::make_shared<ActiveIndices>(index));
     return evicted_entry;
   });
   CleanupAllIndices();
   return evicted;
-}
-
-void InMemoryLabelIndex::RestoreIndex(LabelId label, std::shared_ptr<IndividualIndex> evicted,
-                                      ActiveIndicesUpdater const &updater) {
-  if (!evicted) return;
-  // register_in_all_indices=false: captured shared_ptr kept the entry alive through
-  // CleanupAllIndices; re-appending would create an unreapable duplicate.
-  (void)InstallIndividualIndex_(label, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
 bool InMemoryLabelIndex::ActiveIndices::IndexExists(LabelId label) const { return index_container_->contains(label); }

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -194,7 +194,7 @@ class InMemoryLabelIndex : public LabelIndex {
     // Not used for in-memory
     void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override {};
 
-    bool IndexRegistered(LabelId label) const override;
+    bool IndexExists(LabelId label) const override;
 
     bool IndexReady(LabelId label) const override;
 

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -72,10 +72,7 @@ class InMemoryLabelIndex : public LabelIndex {
                           ActiveIndicesUpdater const &updater, ProgressCallback const &on_progress = {});
 
   /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
-  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
-  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
   [[nodiscard]] auto DropIndex(LabelId label, ActiveIndicesUpdater const &updater) -> std::shared_ptr<IndividualIndex>;
-  void RestoreIndex(LabelId label, std::shared_ptr<IndividualIndex> evicted, ActiveIndicesUpdater const &updater);
 
   /// Sweeps only the indexes whose label `arming` names, and returns how many that was.
   uint64_t RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token,
@@ -249,11 +246,6 @@ class InMemoryLabelIndex : public LabelIndex {
  private:
   auto CleanupAllIndices() -> void;
   auto GetIndividualIndex(LabelId label) const -> std::shared_ptr<IndividualIndex>;
-
-  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
-  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
-  bool InstallIndividualIndex_(LabelId label, std::shared_ptr<IndividualIndex> entry,
-                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
 
   metrics::GaugeHandle gauge_{};
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -878,6 +878,20 @@ void InMemoryLabelPropertyIndex::CleanupStatsForDrop(IndexContainer const &new_i
   }
 }
 
+auto InMemoryLabelPropertyIndex::OrdersPresent(LabelId label, std::vector<PropertyPath> const &properties,
+                                               std::optional<IndexOrder> order) const -> DropResult {
+  return index_.WithReadLock([&](std::shared_ptr<IndexContainer const> const &index) -> DropResult {
+    bool const try_asc = !order || *order == IndexOrder::ASC;
+    bool const try_desc = !order || *order == IndexOrder::DESC;
+    auto const present = [&](auto const &per_label) {
+      auto const lit = per_label.find(label);
+      return lit != per_label.end() && lit->second.find(properties) != lit->second.end();
+    };
+    return {.dropped_asc = try_asc && present(index->asc_indices_),
+            .dropped_desc = try_desc && present(index->desc_indices_)};
+  });
+}
+
 auto InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
                                            ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order)
     -> DropCapture {

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -894,95 +894,25 @@ auto InMemoryLabelPropertyIndex::OrdersPresent(LabelId label, std::vector<Proper
 
 auto InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
                                            ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order)
-    -> DropCapture {
-  std::optional<AscIndexPtrVariant> asc_evicted;
-  std::optional<DescIndexPtrVariant> desc_evicted;
-  std::optional<PropertiesIndicesStats> stats_evicted;
+    -> DropResult {
   auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) -> DropResult {
     bool const try_asc = !order || *order == IndexOrder::ASC;
     bool const try_desc = !order || *order == IndexOrder::DESC;
-
-    // Capture the per-key shared_ptrs *before* the drop. They survive
-    // CleanupAllIndices via the captured ref and let us re-insert just our keys
-    // on abort without clobbering concurrent drops/creates of other keys.
-    if (try_asc) {
-      if (auto lit = index->asc_indices_.find(label); lit != index->asc_indices_.end()) {
-        if (auto pit = lit->second.find(properties); pit != lit->second.end()) asc_evicted = pit->second;
-      }
-    }
-    if (try_desc) {
-      if (auto lit = index->desc_indices_.find(label); lit != index->desc_indices_.end()) {
-        if (auto pit = lit->second.find(properties); pit != lit->second.end()) desc_evicted = pit->second;
-      }
-    }
 
     auto new_index = std::make_shared<IndexContainer>(*index);
     bool const dropped_asc =
         try_asc && DropFromOrder(new_index->asc_indices_, new_index->asc_reverse_lookup_, label, properties);
     bool const dropped_desc =
         try_desc && DropFromOrder(new_index->desc_indices_, new_index->desc_reverse_lookup_, label, properties);
-    if (!dropped_asc && !dropped_desc) {
-      asc_evicted.reset();
-      desc_evicted.reset();
-      return {};
-    }
-    if (!dropped_asc) asc_evicted.reset();
-    if (!dropped_desc) desc_evicted.reset();
+    if (!dropped_asc && !dropped_desc) return {};
 
-    // Capture the per-label stats slice before CleanupStatsForDrop erases it,
-    // so an aborted drop can re-emplace any keys it removed.
-    {
-      auto stats_ptr = stats_.Lock();
-      if (auto sit = stats_ptr->find(label); sit != stats_ptr->end()) {
-        stats_evicted = sit->second;
-      }
-    }
+    updater(std::make_shared<ActiveIndices>(new_index));
     CleanupStatsForDrop(*new_index, label, properties);
     index = std::move(new_index);
-    updater(std::make_shared<ActiveIndices>(index));
     return {.dropped_asc = dropped_asc, .dropped_desc = dropped_desc};
   });
   CleanupAllIndices();
-  return {.result = result,
-          .asc_evicted = std::move(asc_evicted),
-          .desc_evicted = std::move(desc_evicted),
-          .stats_evicted = std::move(stats_evicted)};
-}
-
-void InMemoryLabelPropertyIndex::RestoreIndex(LabelId label, std::vector<PropertyPath> properties,
-                                              std::optional<AscIndexPtrVariant> asc_evicted,
-                                              std::optional<DescIndexPtrVariant> desc_evicted,
-                                              std::optional<PropertiesIndicesStats> stats_evicted,
-                                              ActiveIndicesUpdater const &updater) {
-  if (!asc_evicted && !desc_evicted) return;
-  index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) {
-    auto already_present = [&](auto const &indices_map) -> bool {
-      auto lit = indices_map.find(label);
-      return lit != indices_map.end() && lit->second.contains(properties);
-    };
-    bool const skip_asc = !asc_evicted || already_present(index->asc_indices_);
-    bool const skip_desc = !desc_evicted || already_present(index->desc_indices_);
-    if (skip_asc && skip_desc) return;  // concurrent re-create won for both orders
-
-    // Two copies: first to mutate the per-order maps, second to rebuild the
-    // reverse_lookup (the IndexContainer copy ctor calls BuildReverseLookup).
-    IndexContainer mutated{*index};
-    if (!skip_asc) mutated.asc_indices_[label].emplace(properties, std::move(*asc_evicted));
-    if (!skip_desc) mutated.desc_indices_[label].emplace(properties, std::move(*desc_evicted));
-    auto new_index = std::make_shared<IndexContainer>(std::move(mutated));
-    index = std::move(new_index);
-    updater(std::make_shared<ActiveIndices>(index));
-  });
-
-  // Re-emplace any stats keys that were erased on drop, leaving any concurrent
-  // SetIndexStats writes to other keys untouched (emplace is a no-op on conflict).
-  if (stats_evicted) {
-    auto stats_ptr = stats_.Lock();
-    auto &dst = (*stats_ptr)[label];
-    for (auto const &[key, value] : *stats_evicted) {
-      dst.emplace(key, value);
-    }
-  }
+  return result;
 }
 
 bool InMemoryLabelPropertyIndex::ActiveIndices::IndexExists(LabelId label,

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -539,6 +539,16 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   [[nodiscard]] auto DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
                                ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order = std::nullopt)
       -> DropCapture;
+
+  /// Which of the orders `order` selects exist for (label, properties), reported in the same shape
+  /// a drop of them would return and without removing anything.
+  ///
+  /// A DROP statement needs this because it decides what to write to the log when the statement
+  /// runs and evicts when it commits, and the two have to agree. Asking again at commit would let
+  /// an order created in between be dropped and go unlogged, and recovery would then bring back an
+  /// index that was dropped.
+  [[nodiscard]] auto OrdersPresent(LabelId label, std::vector<PropertyPath> const &properties,
+                                   std::optional<IndexOrder> order = std::nullopt) const -> DropResult;
   void RestoreIndex(LabelId label, std::vector<PropertyPath> properties, std::optional<AscIndexPtrVariant> asc_evicted,
                     std::optional<DescIndexPtrVariant> desc_evicted,
                     std::optional<PropertiesIndicesStats> stats_evicted, ActiveIndicesUpdater const &updater);

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -522,23 +522,10 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   uint64_t RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token,
                                  IndexArming const &arming);
 
-  // Captures the evicted asc/desc IndividualIndex shared_ptrs so the caller can
-  // re-insert them on abort. Pair with RestoreIndex. The captured shared_ptrs
-  // also keep their entries alive in `all_indices_` past CleanupAllIndices, so
-  // RestoreIndex must NOT re-insert there.
-  struct DropCapture {
-    DropResult result;
-    std::optional<AscIndexPtrVariant> asc_evicted;    // nullopt if asc not dropped
-    std::optional<DescIndexPtrVariant> desc_evicted;  // nullopt if desc not dropped
-    // Per-label stats slice captured before CleanupStatsForDrop erased entries.
-    // nullopt if the label had no stats at drop time.
-    std::optional<PropertiesIndicesStats> stats_evicted;
-  };
-
   // `order == nullopt` drops both ASC and DESC entries for (label, properties).
   [[nodiscard]] auto DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
                                ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order = std::nullopt)
-      -> DropCapture;
+      -> DropResult;
 
   /// Which of the orders `order` selects exist for (label, properties), reported in the same shape
   /// a drop of them would return and without removing anything.
@@ -549,9 +536,6 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   /// index that was dropped.
   [[nodiscard]] auto OrdersPresent(LabelId label, std::vector<PropertyPath> const &properties,
                                    std::optional<IndexOrder> order = std::nullopt) const -> DropResult;
-  void RestoreIndex(LabelId label, std::vector<PropertyPath> properties, std::optional<AscIndexPtrVariant> asc_evicted,
-                    std::optional<DescIndexPtrVariant> desc_evicted,
-                    std::optional<PropertiesIndicesStats> stats_evicted, ActiveIndicesUpdater const &updater);
 
   std::vector<std::pair<LabelId, std::vector<PropertyPath>>> ClearIndexStats();
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2075,21 +2075,24 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_label_index = static_cast<InMemoryLabelIndex *>(in_memory->indices_.label_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-
-  // Done inside the wrapper to ensure plan cache invalidation is safe.
-  // Capture the evicted entry so an aborted DROP (e.g. STRICT_SYNC commit failure)
-  // can re-install it instead of leaving the index permanently gone on main.
-  std::shared_ptr<InMemoryLabelIndex::IndividualIndex> evicted;
-  storage_->invalidator_->invalidate_now([&] {
-    evicted = mem_label_index->DropIndex(label, updater);
-    return static_cast<bool>(evicted);
-  });
-  if (!evicted) {
+  if (!mem_label_index->GetActiveIndices()->IndexRegistered(label)) {
     return std::unexpected{IndexDefinitionError{}};
   }
-  transaction_.abort_callbacks_.Add([mem_label_index, label, updater, evicted]() mutable {
-    mem_label_index->RestoreIndex(label, std::move(evicted), updater);
-  });
+  // Evicting the entry and publishing the new snapshot happen together, inside the catalogue lock,
+  // and both wait for the commit. The eviction cannot run when the statement does: publishing means
+  // publishing the catalogue, so an entry missing from it is an entry any OTHER publisher hands out
+  // on this transaction's behalf, and registering an unrelated index publishes at statement time
+  // because a creation must. A writer admitted after that captures an index set without this index
+  // and maintains nothing for it, so a drop that then rolls back restores an index short of
+  // whatever that writer wrote.
+  //
+  // So nothing happens here but the check and the record. There is no abort callback because there
+  // is nothing to undo, and the drop is atomic: all that moved is when it happens.
+  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
+      [mem_label_index, label, updater](uint64_t /*commit_ts*/) {
+        return static_cast<bool>(mem_label_index->DropIndex(label, updater));
+      });
+  transaction_.commit_callbacks_.Add(std::move(publisher));
 
   transaction_.md_deltas.emplace_back(MetadataDelta::label_index_drop, label);
   // We don't care if there is a replication error because on main node the change will go through
@@ -2106,30 +2109,25 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
       static_cast<InMemoryLabelPropertyIndex *>(in_memory->indices_.label_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
 
-  LabelPropertyIndex::DropResult drop_result;
-  std::optional<InMemoryLabelPropertyIndex::AscIndexPtrVariant> asc_evicted;
-  std::optional<InMemoryLabelPropertyIndex::DescIndexPtrVariant> desc_evicted;
-  std::optional<InMemoryLabelPropertyIndex::PropertiesIndicesStats> stats_evicted;
-  storage_->invalidator_->invalidate_now([&] {
-    auto captured = mem_label_property_index->DropIndex(label, properties, updater, order);
-    drop_result = captured.result;
-    asc_evicted = std::move(captured.asc_evicted);
-    desc_evicted = std::move(captured.desc_evicted);
-    stats_evicted = std::move(captured.stats_evicted);
-    return static_cast<bool>(drop_result);
-  });
+  // See DropIndex(LabelId) above for why the eviction waits for the commit.
+  //
+  // The orders are settled here rather than at commit, because the log records written below have
+  // to describe what the commit will actually evict. Asking again at commit would let an order that
+  // another transaction created in between be evicted without a record, and recovery would then
+  // bring back an index that had been dropped.
+  auto const drop_result = mem_label_property_index->OrdersPresent(label, properties, order);
   if (!drop_result) {
     return std::unexpected{IndexDefinitionError{}};
   }
-  transaction_.abort_callbacks_.Add(
-      [mem_label_property_index, label, properties, updater, asc_evicted, desc_evicted, stats_evicted]() mutable {
-        mem_label_property_index->RestoreIndex(label,
-                                               std::move(properties),
-                                               std::move(asc_evicted),
-                                               std::move(desc_evicted),
-                                               std::move(stats_evicted),
-                                               updater);
+  auto const settled_order = [&]() -> std::optional<IndexOrder> {
+    if (drop_result.dropped_asc && drop_result.dropped_desc) return std::nullopt;
+    return drop_result.dropped_asc ? IndexOrder::ASC : IndexOrder::DESC;
+  }();
+  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
+      [mem_label_property_index, label, properties, updater, settled_order](uint64_t /*commit_ts*/) {
+        return static_cast<bool>(mem_label_property_index->DropIndex(label, properties, updater, settled_order).result);
       });
+  transaction_.commit_callbacks_.Add(std::move(publisher));
 
   if (drop_result.dropped_asc) {
     transaction_.md_deltas.emplace_back(MetadataDelta::label_property_index_drop,
@@ -2156,17 +2154,15 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(in_memory->indices_.edge_type_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
   // Done inside the wrapper to ensure plan cache invalidation is safe.
-  std::shared_ptr<InMemoryEdgeTypeIndex::IndividualIndex> evicted;
-  storage_->invalidator_->invalidate_now([&] {
-    evicted = mem_edge_type_index->DropIndex(edge_type, updater);
-    return static_cast<bool>(evicted);
-  });
-  if (!evicted) {
+  if (!mem_edge_type_index->GetActiveIndices()->IndexRegistered(edge_type)) {
     return std::unexpected{IndexDefinitionError{}};
   }
-  transaction_.abort_callbacks_.Add([mem_edge_type_index, edge_type, updater, evicted]() mutable {
-    mem_edge_type_index->RestoreIndex(edge_type, std::move(evicted), updater);
-  });
+  // See DropIndex(LabelId) above for why the eviction waits for the commit.
+  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
+      [mem_edge_type_index, edge_type, updater](uint64_t /*commit_ts*/) {
+        return static_cast<bool>(mem_edge_type_index->DropIndex(edge_type, updater));
+      });
+  transaction_.commit_callbacks_.Add(std::move(publisher));
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_index_drop, edge_type);
   return {};
 }
@@ -2185,17 +2181,17 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
       static_cast<InMemoryEdgeTypePropertyIndex *>(in_memory->indices_.edge_type_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
   // Done inside the wrapper to ensure plan cache invalidation is safe.
-  std::shared_ptr<InMemoryEdgeTypePropertyIndex::IndividualIndex> evicted;
-  storage_->invalidator_->invalidate_now([&] {
-    evicted = mem_edge_type_property_index->DropIndex(edge_type, property, updater);
-    return static_cast<bool>(evicted);
-  });
-  if (!evicted) {
+  if (!static_cast<InMemoryEdgeTypePropertyIndex::ActiveIndices *>(
+           mem_edge_type_property_index->GetActiveIndices().get())
+           ->IndexRegistered(edge_type, property)) {
     return std::unexpected{IndexDefinitionError{}};
   }
-  transaction_.abort_callbacks_.Add([mem_edge_type_property_index, edge_type, property, updater, evicted]() mutable {
-    mem_edge_type_property_index->RestoreIndex(edge_type, property, std::move(evicted), updater);
-  });
+  // See DropIndex(LabelId) above for why the eviction waits for the commit.
+  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
+      [mem_edge_type_property_index, edge_type, property, updater](uint64_t /*commit_ts*/) {
+        return static_cast<bool>(mem_edge_type_property_index->DropIndex(edge_type, property, updater));
+      });
+  transaction_.commit_callbacks_.Add(std::move(publisher));
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_property_index_drop, edge_type, property);
   return {};
 }
@@ -2214,17 +2210,15 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_property_index =
       static_cast<InMemoryEdgePropertyIndex *>(in_memory->indices_.edge_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  std::shared_ptr<InMemoryEdgePropertyIndex::IndividualIndex> evicted;
-  storage_->invalidator_->invalidate_now([&] {
-    evicted = mem_edge_property_index->DropIndex(property, updater);
-    return static_cast<bool>(evicted);
-  });
-  if (!evicted) {
+  if (!mem_edge_property_index->GetActiveIndices()->IndexExists(property)) {
     return std::unexpected{IndexDefinitionError{}};
   }
-  transaction_.abort_callbacks_.Add([mem_edge_property_index, property, updater, evicted]() mutable {
-    mem_edge_property_index->RestoreIndex(property, std::move(evicted), updater);
-  });
+  // See DropIndex(LabelId) above for why the eviction waits for the commit.
+  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
+      [mem_edge_property_index, property, updater](uint64_t /*commit_ts*/) {
+        return static_cast<bool>(mem_edge_property_index->DropIndex(property, updater));
+      });
+  transaction_.commit_callbacks_.Add(std::move(publisher));
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_edge_property_index_drop, property);
   return {};
@@ -2238,17 +2232,15 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_vertex_property_index =
       static_cast<InMemoryVertexPropertyIndex *>(in_memory->indices_.vertex_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  std::shared_ptr<InMemoryVertexPropertyIndex::IndividualIndex> evicted;
-  storage_->invalidator_->invalidate_now([&] {
-    evicted = mem_vertex_property_index->DropIndex(property, updater);
-    return static_cast<bool>(evicted);
-  });
-  if (!evicted) {
+  if (!mem_vertex_property_index->GetActiveIndices()->IndexExists(property)) {
     return std::unexpected{IndexDefinitionError{}};
   }
-  transaction_.abort_callbacks_.Add([mem_vertex_property_index, property, updater, evicted]() mutable {
-    mem_vertex_property_index->RestoreIndex(property, std::move(evicted), updater);
-  });
+  // See DropIndex(LabelId) above for why the eviction waits for the commit.
+  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
+      [mem_vertex_property_index, property, updater](uint64_t /*commit_ts*/) {
+        return static_cast<bool>(mem_vertex_property_index->DropIndex(property, updater));
+      });
+  transaction_.commit_callbacks_.Add(std::move(publisher));
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_vertex_property_index_drop, property);
   return {};

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2068,6 +2068,42 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   return {};
 }
 
+namespace {
+
+/// Sequences an index drop, which is the same sequence for every kind of index.
+///
+/// Two things about the order are load-bearing, and both are easy to lose when this is written out
+/// by hand once per index kind.
+///
+/// The existence of the index is settled HERE, where the caller goes on to write its log records,
+/// and never again. Asking the catalogue a second time from inside the commit callback would let an
+/// index created in between be evicted without a record, and recovery would then bring back an
+/// index that had been dropped.
+///
+/// The eviction and the publication of the new snapshot are left to one call on the index, which
+/// does both under the catalogue lock, and that call waits for the commit. Splitting them, or
+/// publishing a snapshot read earlier, lets another publisher hand out an uncommitted drop and
+/// costs the rollback guarantee: a writer admitted meanwhile would maintain nothing for the index,
+/// so restoring the entry on abort would restore it short of that writer's rows.
+///
+/// Returns the error a statement reports when there is no such index. The caller records its own
+/// metadata deltas, because which and how many of those there are is what differs between kinds.
+template <typename TIndex, typename... TArgs>
+[[nodiscard]] auto DropIndexOnCommit(Transaction &transaction, PlanInvalidator &invalidator, TIndex *index,
+                                     ActiveIndicesUpdater const &updater, TArgs... args)
+    -> std::expected<void, StorageIndexDefinitionError> {
+  if (!index->GetActiveIndices()->IndexExists(args...)) {
+    return std::unexpected{IndexDefinitionError{}};
+  }
+  auto publisher = invalidator.invalidate_for_timestamp_wrapper([index, updater, args...](uint64_t /*commit_ts*/) {
+    return static_cast<bool>(index->DropIndex(args..., updater));
+  });
+  transaction.commit_callbacks_.Add(std::move(publisher));
+  return {};
+}
+
+}  // namespace
+
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(LabelId label) {
   // UNIQUE access will be done only through schema.assert
   MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
@@ -2075,24 +2111,10 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_label_index = static_cast<InMemoryLabelIndex *>(in_memory->indices_.label_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  if (!mem_label_index->GetActiveIndices()->IndexRegistered(label)) {
-    return std::unexpected{IndexDefinitionError{}};
+  auto const scheduled = DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_label_index, updater, label);
+  if (!scheduled) {
+    return scheduled;
   }
-  // Evicting the entry and publishing the new snapshot happen together, inside the catalogue lock,
-  // and both wait for the commit. The eviction cannot run when the statement does: publishing means
-  // publishing the catalogue, so an entry missing from it is an entry any OTHER publisher hands out
-  // on this transaction's behalf, and registering an unrelated index publishes at statement time
-  // because a creation must. A writer admitted after that captures an index set without this index
-  // and maintains nothing for it, so a drop that then rolls back restores an index short of
-  // whatever that writer wrote.
-  //
-  // So nothing happens here but the check and the record. There is no abort callback because there
-  // is nothing to undo, and the drop is atomic: all that moved is when it happens.
-  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
-      [mem_label_index, label, updater](uint64_t /*commit_ts*/) {
-        return static_cast<bool>(mem_label_index->DropIndex(label, updater));
-      });
-  transaction_.commit_callbacks_.Add(std::move(publisher));
 
   transaction_.md_deltas.emplace_back(MetadataDelta::label_index_drop, label);
   // We don't care if there is a replication error because on main node the change will go through
@@ -2109,12 +2131,15 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
       static_cast<InMemoryLabelPropertyIndex *>(in_memory->indices_.label_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
 
-  // See DropIndex(LabelId) above for why the eviction waits for the commit.
+  // Spelled out rather than going through DropIndexOnCommit, because this is the one kind whose
+  // statement decides more than whether the index is there: it decides which ORDERS it will evict,
+  // and it emits a log record per order. The sequence and its reasons are the same, and
+  // DropIndexOnCommit is where they are written down.
   //
-  // The orders are settled here rather than at commit, because the log records written below have
-  // to describe what the commit will actually evict. Asking again at commit would let an order that
-  // another transaction created in between be evicted without a record, and recovery would then
-  // bring back an index that had been dropped.
+  // The orders are settled here rather than at commit for the reason that function gives about
+  // existence: the log records written below have to describe what the commit will actually evict.
+  // Asking again at commit would let an order that another transaction created in between be
+  // evicted without a record, and recovery would then bring back an index that had been dropped.
   auto const drop_result = mem_label_property_index->OrdersPresent(label, properties, order);
   if (!drop_result) {
     return std::unexpected{IndexDefinitionError{}};
@@ -2153,16 +2178,11 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(in_memory->indices_.edge_type_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  // Done inside the wrapper to ensure plan cache invalidation is safe.
-  if (!mem_edge_type_index->GetActiveIndices()->IndexRegistered(edge_type)) {
-    return std::unexpected{IndexDefinitionError{}};
+  auto const scheduled =
+      DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_edge_type_index, updater, edge_type);
+  if (!scheduled) {
+    return scheduled;
   }
-  // See DropIndex(LabelId) above for why the eviction waits for the commit.
-  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
-      [mem_edge_type_index, edge_type, updater](uint64_t /*commit_ts*/) {
-        return static_cast<bool>(mem_edge_type_index->DropIndex(edge_type, updater));
-      });
-  transaction_.commit_callbacks_.Add(std::move(publisher));
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_index_drop, edge_type);
   return {};
 }
@@ -2180,18 +2200,11 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_type_property_index =
       static_cast<InMemoryEdgeTypePropertyIndex *>(in_memory->indices_.edge_type_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  // Done inside the wrapper to ensure plan cache invalidation is safe.
-  if (!static_cast<InMemoryEdgeTypePropertyIndex::ActiveIndices *>(
-           mem_edge_type_property_index->GetActiveIndices().get())
-           ->IndexRegistered(edge_type, property)) {
-    return std::unexpected{IndexDefinitionError{}};
+  auto const scheduled = DropIndexOnCommit(
+      transaction_, *storage_->invalidator_, mem_edge_type_property_index, updater, edge_type, property);
+  if (!scheduled) {
+    return scheduled;
   }
-  // See DropIndex(LabelId) above for why the eviction waits for the commit.
-  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
-      [mem_edge_type_property_index, edge_type, property, updater](uint64_t /*commit_ts*/) {
-        return static_cast<bool>(mem_edge_type_property_index->DropIndex(edge_type, property, updater));
-      });
-  transaction_.commit_callbacks_.Add(std::move(publisher));
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_property_index_drop, edge_type, property);
   return {};
 }
@@ -2210,15 +2223,11 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_property_index =
       static_cast<InMemoryEdgePropertyIndex *>(in_memory->indices_.edge_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  if (!mem_edge_property_index->GetActiveIndices()->IndexExists(property)) {
-    return std::unexpected{IndexDefinitionError{}};
+  auto const scheduled =
+      DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_edge_property_index, updater, property);
+  if (!scheduled) {
+    return scheduled;
   }
-  // See DropIndex(LabelId) above for why the eviction waits for the commit.
-  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
-      [mem_edge_property_index, property, updater](uint64_t /*commit_ts*/) {
-        return static_cast<bool>(mem_edge_property_index->DropIndex(property, updater));
-      });
-  transaction_.commit_callbacks_.Add(std::move(publisher));
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_edge_property_index_drop, property);
   return {};
@@ -2232,15 +2241,11 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_vertex_property_index =
       static_cast<InMemoryVertexPropertyIndex *>(in_memory->indices_.vertex_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  if (!mem_vertex_property_index->GetActiveIndices()->IndexExists(property)) {
-    return std::unexpected{IndexDefinitionError{}};
+  auto const scheduled =
+      DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_vertex_property_index, updater, property);
+  if (!scheduled) {
+    return scheduled;
   }
-  // See DropIndex(LabelId) above for why the eviction waits for the commit.
-  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
-      [mem_vertex_property_index, property, updater](uint64_t /*commit_ts*/) {
-        return static_cast<bool>(mem_vertex_property_index->DropIndex(property, updater));
-      });
-  transaction_.commit_callbacks_.Add(std::move(publisher));
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_vertex_property_index_drop, property);
   return {};

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1108,9 +1108,8 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   // Replica can log only the write transaction received from main
   // so the wal files are consistent
   auto const durability_commit_timestamp = commit_args.durable_timestamp(*commit_timestamp_);
-  // A main's durable commit timestamp is its local one. Several comparisons elsewhere test the two
-  // for equality, so an edit that separates them must fail here rather than in whichever of those
-  // notices first.
+  // Asserted where the two are derived, so that separating them fails here rather than at whichever
+  // comparison notices first.
   DMG_ASSERT(!commit_args.replication_allowed() || durability_commit_timestamp == *commit_timestamp_,
              "on a main the durable commit timestamp must be the local one");
 
@@ -1292,10 +1291,9 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
   }
 
   // Mark transaction as finished for commit ordering and MVCC visibility.
-  // NOTE: Schema updates may still be queued in pending_schema_updates_ with raw pointers
-  // to vertices. GC protects these by clamping its horizon to the lowest reconstruction boundary
-  // still queued: a queued entry's reconstruction walks version chains down to that boundary, so
-  // nothing at or above it may be unlinked while the entry is waiting.
+  // NOTE: Schema updates may still be queued in pending_schema_updates_ with raw pointers to
+  // vertices. A queued entry walks version chains down to its reconstruction boundary, so it
+  // requires that nothing at or above that boundary is unlinked while it waits.
   mem_storage->commit_log_->MarkFinished(transaction_.start_timestamp);
 
   if (config_.enable_schema_info) {
@@ -2070,24 +2068,19 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 
 namespace {
 
-/// Sequences an index drop, which is the same sequence for every kind of index.
+/// Sequences an index drop. Two things about the order carry the correctness.
 ///
-/// Two things about the order are load-bearing, and both are easy to lose when this is written out
-/// by hand once per index kind.
+/// Existence is settled here and never asked again, because the caller writes its log records
+/// against this answer. Re-asking the catalogue from the commit callback would let an index created
+/// in between be evicted with no record, and recovery would bring back a dropped index.
 ///
-/// The existence of the index is settled HERE, where the caller goes on to write its log records,
-/// and never again. Asking the catalogue a second time from inside the commit callback would let an
-/// index created in between be evicted without a record, and recovery would then bring back an
-/// index that had been dropped.
+/// Evicting and publishing stay in the one call that does both under the catalogue lock, and it
+/// waits for the commit. Evicting earlier leaves the catalogue without an entry that any other
+/// publisher then hands out, and a writer admitted after that maintains nothing for the index, so
+/// an abort restores it short of that writer's rows.
 ///
-/// The eviction and the publication of the new snapshot are left to one call on the index, which
-/// does both under the catalogue lock, and that call waits for the commit. Splitting them, or
-/// publishing a snapshot read earlier, lets another publisher hand out an uncommitted drop and
-/// costs the rollback guarantee: a writer admitted meanwhile would maintain nothing for the index,
-/// so restoring the entry on abort would restore it short of that writer's rows.
-///
-/// Returns the error a statement reports when there is no such index. The caller records its own
-/// metadata deltas, because which and how many of those there are is what differs between kinds.
+/// Returns the error a statement reports when there is no such index. Callers record their own
+/// metadata deltas, which is what differs between kinds.
 template <typename TIndex, typename... TArgs>
 [[nodiscard]] auto DropIndexOnCommit(Transaction &transaction, PlanInvalidator &invalidator, TIndex *index,
                                      ActiveIndicesUpdater const &updater, TArgs... args)
@@ -2131,15 +2124,9 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
       static_cast<InMemoryLabelPropertyIndex *>(in_memory->indices_.label_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
 
-  // Spelled out rather than going through DropIndexOnCommit, because this is the one kind whose
-  // statement decides more than whether the index is there: it decides which ORDERS it will evict,
-  // and it emits a log record per order. The sequence and its reasons are the same, and
-  // DropIndexOnCommit is where they are written down.
-  //
-  // The orders are settled here rather than at commit for the reason that function gives about
-  // existence: the log records written below have to describe what the commit will actually evict.
-  // Asking again at commit would let an order that another transaction created in between be
-  // evicted without a record, and recovery would then bring back an index that had been dropped.
+  // Spelled out rather than going through DropIndexOnCommit, whose comment gives the sequence and
+  // its reasons, because this statement settles which ORDERS it will evict and emits a record per
+  // order. Settling them here is the same requirement that function states about existence.
   auto const drop_result = mem_label_property_index->OrdersPresent(label, properties, order);
   if (!drop_result) {
     return std::unexpected{IndexDefinitionError{}};

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1108,6 +1108,11 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   // Replica can log only the write transaction received from main
   // so the wal files are consistent
   auto const durability_commit_timestamp = commit_args.durable_timestamp(*commit_timestamp_);
+  // A main's durable commit timestamp is its local one. Several comparisons elsewhere test the two
+  // for equality, so an edit that separates them must fail here rather than in whichever of those
+  // notices first.
+  DMG_ASSERT(!commit_args.replication_allowed() || durability_commit_timestamp == *commit_timestamp_,
+             "on a main the durable commit timestamp must be the local one");
 
   // Specific case in which durability mode is != PERIODIC_SNAPSHOT_WITH_WAL
   if (!mem_storage->InitializeWalFile(mem_storage->repl_storage_state_.epoch_.id())) {
@@ -1209,6 +1214,7 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
                          std::move(transaction_.post_process_),
                          transaction_.start_timestamp,
                          durability_commit_timestamp,
+                         *commit_timestamp_,
                          mem_storage->config_.salient.items.properties_on_edges));
   }
 
@@ -1287,8 +1293,9 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
 
   // Mark transaction as finished for commit ordering and MVCC visibility.
   // NOTE: Schema updates may still be queued in pending_schema_updates_ with raw pointers
-  // to vertices. GC protects these by using last_processed_commit_ts_ as a safety horizon
-  // (see CollectGarbage implementation).
+  // to vertices. GC protects these by clamping its horizon to the lowest reconstruction boundary
+  // still queued: a queued entry's reconstruction walks version chains down to that boundary, so
+  // nothing at or above it may be unlinked while the entry is waiting.
   mem_storage->commit_log_->MarkFinished(transaction_.start_timestamp);
 
   if (config_.enable_schema_info) {
@@ -1838,7 +1845,7 @@ void InMemoryStorage::ProcessPendingSchemaUpdates(uint64_t up_to_commit_ts) {
 
   for (auto &update : to_process) {
     schema_info_.ProcessTransaction(
-        update.schema_diff, update.post_process, update.start_ts, update.commit_ts, update.property_on_edges);
+        update.schema_diff, update.post_process, update.start_ts, update.local_commit_ts, update.property_on_edges);
   }
 }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1212,7 +1212,6 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
         SchemaUpdateData(std::move(transaction_.schema_diff_),
                          std::move(transaction_.post_process_),
                          transaction_.start_timestamp,
-                         durability_commit_timestamp,
                          *commit_timestamp_,
                          mem_storage->config_.salient.items.properties_on_edges));
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2078,34 +2078,43 @@ namespace {
 /// publisher then hands out, and a writer admitted after that maintains nothing for the index, so
 /// an abort restores it short of that writer's rows.
 ///
-/// Returns the error a statement reports when there is no such index. Callers record their own
-/// metadata deltas, which is what differs between kinds.
+/// The commit runs the callback after clearing the abort list, so nothing is left to undo an
+/// eviction that got halfway. Every DropIndex implementation therefore allocates everything it
+/// needs before it writes anything, and an allocation that throws leaves the catalogue, the
+/// published indices and the statistics all as they were. Publishing before the catalogue entry
+/// goes is not observable: a transaction reads the published indices only when it begins, and the
+/// committing transaction holds engine_lock_ across the callback, while the catalogue is read
+/// under the lock the callback itself holds.
+///
+/// Answers whether the index was there. That settles whether an eviction is scheduled, and it is
+/// what the caller weighs its AbsentIndex against. Callers record their own metadata deltas, which
+/// is what differs between kinds.
 template <typename TIndex, typename... TArgs>
-[[nodiscard]] auto DropIndexOnCommit(Transaction &transaction, PlanInvalidator &invalidator, TIndex *index,
-                                     ActiveIndicesUpdater const &updater, TArgs... args)
-    -> std::expected<void, StorageIndexDefinitionError> {
+[[nodiscard]] bool DropIndexOnCommit(Transaction &transaction, PlanInvalidator &invalidator, TIndex *index,
+                                     ActiveIndicesUpdater const &updater, TArgs... args) {
   if (!index->GetActiveIndices()->IndexExists(args...)) {
-    return std::unexpected{IndexDefinitionError{}};
+    return false;
   }
   auto publisher = invalidator.invalidate_for_timestamp_wrapper([index, updater, args...](uint64_t /*commit_ts*/) {
     return static_cast<bool>(index->DropIndex(args..., updater));
   });
   transaction.commit_callbacks_.Add(std::move(publisher));
-  return {};
+  return true;
 }
 
 }  // namespace
 
-std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(LabelId label) {
+std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(LabelId label,
+                                                                                              AbsentIndex absent) {
   // UNIQUE access will be done only through schema.assert
   MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
             "Dropping label index requires a unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_label_index = static_cast<InMemoryLabelIndex *>(in_memory->indices_.label_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  auto const scheduled = DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_label_index, updater, label);
-  if (!scheduled) {
-    return scheduled;
+  auto const present = DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_label_index, updater, label);
+  if (!present && absent == AbsentIndex::kFails) {
+    return std::unexpected{IndexDefinitionError{}};
   }
 
   transaction_.md_deltas.emplace_back(MetadataDelta::label_index_drop, label);
@@ -2114,7 +2123,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 }
 
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(
-    LabelId label, std::vector<storage::PropertyPath> &&properties, std::optional<IndexOrder> order) {
+    LabelId label, std::vector<storage::PropertyPath> &&properties, std::optional<IndexOrder> order,
+    AbsentIndex absent) {
   // UNIQUE access will be done only through schema.assert
   MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
             "Dropping label-property index requires a unique, read-only or read access to the storage!");
@@ -2128,18 +2138,19 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   // order. Settling them here is the same requirement that function states about existence.
   auto const drop_result = mem_label_property_index->OrdersPresent(label, properties, order);
   if (!drop_result) {
-    return std::unexpected{IndexDefinitionError{}};
+    if (absent == AbsentIndex::kFails) {
+      return std::unexpected{IndexDefinitionError{}};
+    }
+    // There is nothing to evict, and the record still has to be written. A caller that records an
+    // absent index replays one record at a time, so `order` is the one order this record covers.
+    MG_ASSERT(order, "A recorded drop of an absent index has to name the order it drops");
+    transaction_.md_deltas.emplace_back(MetadataDelta::label_property_index_drop, label, std::move(properties), *order);
+    return {};
   }
   auto const settled_order = [&]() -> std::optional<IndexOrder> {
     if (drop_result.dropped_asc && drop_result.dropped_desc) return std::nullopt;
     return drop_result.dropped_asc ? IndexOrder::ASC : IndexOrder::DESC;
   }();
-  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
-      [mem_label_property_index, label, properties, updater, settled_order](uint64_t /*commit_ts*/) {
-        return static_cast<bool>(mem_label_property_index->DropIndex(label, properties, updater, settled_order).result);
-      });
-  transaction_.commit_callbacks_.Add(std::move(publisher));
-
   if (drop_result.dropped_asc) {
     transaction_.md_deltas.emplace_back(MetadataDelta::label_property_index_drop,
                                         label,
@@ -2152,29 +2163,38 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
                                         std::vector<storage::PropertyPath>(properties),
                                         IndexOrder::DESC);
   }
+
+  auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
+      [mem_label_property_index, label, properties = std::move(properties), updater, settled_order](
+          uint64_t /*commit_ts*/) {
+        return static_cast<bool>(mem_label_property_index->DropIndex(label, properties, updater, settled_order));
+      });
+  transaction_.commit_callbacks_.Add(std::move(publisher));
   // We don't care if there is a replication error because on main node the change will go through
 
   return {};
 }
 
-std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(EdgeTypeId edge_type) {
+std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(EdgeTypeId edge_type,
+                                                                                              AbsentIndex absent) {
   // UNIQUE access will be done only through schema.assert
   MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
             "Dropping edge-type index requires a unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(in_memory->indices_.edge_type_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  auto const scheduled =
+  auto const present =
       DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_edge_type_index, updater, edge_type);
-  if (!scheduled) {
-    return scheduled;
+  if (!present && absent == AbsentIndex::kFails) {
+    return std::unexpected{IndexDefinitionError{}};
   }
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_index_drop, edge_type);
   return {};
 }
 
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropIndex(EdgeTypeId edge_type,
-                                                                                              PropertyId property) {
+                                                                                              PropertyId property,
+                                                                                              AbsentIndex absent) {
   // UNIQUE access will be done only through schema.assert
   MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
             "Dropping edge-type property index requires a unique, read-only or read access to the storage!");
@@ -2186,17 +2206,17 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_type_property_index =
       static_cast<InMemoryEdgeTypePropertyIndex *>(in_memory->indices_.edge_type_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  auto const scheduled = DropIndexOnCommit(
+  auto const present = DropIndexOnCommit(
       transaction_, *storage_->invalidator_, mem_edge_type_property_index, updater, edge_type, property);
-  if (!scheduled) {
-    return scheduled;
+  if (!present && absent == AbsentIndex::kFails) {
+    return std::unexpected{IndexDefinitionError{}};
   }
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_property_index_drop, edge_type, property);
   return {};
 }
 
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropGlobalEdgeIndex(
-    PropertyId property) {
+    PropertyId property, AbsentIndex absent) {
   // UNIQUE access will be done only through schema.assert
   MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
             "Dropping global edge property index requires unique, read-only or read access to the storage!");
@@ -2209,10 +2229,10 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_property_index =
       static_cast<InMemoryEdgePropertyIndex *>(in_memory->indices_.edge_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  auto const scheduled =
+  auto const present =
       DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_edge_property_index, updater, property);
-  if (!scheduled) {
-    return scheduled;
+  if (!present && absent == AbsentIndex::kFails) {
+    return std::unexpected{IndexDefinitionError{}};
   }
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_edge_property_index_drop, property);
@@ -2220,17 +2240,17 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
 }
 
 std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccessor::DropGlobalVertexIndex(
-    PropertyId property) {
+    PropertyId property, AbsentIndex absent) {
   MG_ASSERT(type() == UNIQUE || type() == READ_ONLY || type() == READ,
             "Dropping global vertex property index requires unique, read-only or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_vertex_property_index =
       static_cast<InMemoryVertexPropertyIndex *>(in_memory->indices_.vertex_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  auto const scheduled =
+  auto const present =
       DropIndexOnCommit(transaction_, *storage_->invalidator_, mem_vertex_property_index, updater, property);
-  if (!scheduled) {
-    return scheduled;
+  if (!present && absent == AbsentIndex::kFails) {
+    return std::unexpected{IndexDefinitionError{}};
   }
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_vertex_property_index_drop, property);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -1149,15 +1149,24 @@ class InMemoryStorage final : public Storage {
     LocalSchemaTracking schema_diff;
     SchemaInfoPostProcess post_process;
     uint64_t start_ts;
+    // Orders the queue, and orders it correctly on a replica too, because a replica applies its
+    // main's transactions in the main's order.
     uint64_t commit_ts;
+    // Identifies this transaction's own deltas during the deferred reconstruction, which compares
+    // against Delta::commit_info->timestamp. That holds the local mint, so it is not commit_ts: the
+    // two are equal on a main, while on a replica write commit_ts is the main's desired timestamp
+    // and the delta carries the replica's own. A reconstruction given commit_ts there does not
+    // recognise its own writes.
+    uint64_t local_commit_ts;
     bool property_on_edges;
 
     SchemaUpdateData(LocalSchemaTracking diff, SchemaInfoPostProcess post_proc, uint64_t start, uint64_t commit,
-                     bool prop_on_edges)
+                     uint64_t local_commit, bool prop_on_edges)
         : schema_diff(std::move(diff)),
           post_process(std::move(post_proc)),
           start_ts(start),
           commit_ts(commit),
+          local_commit_ts(local_commit),
           property_on_edges(prop_on_edges) {}
   };
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -1149,14 +1149,11 @@ class InMemoryStorage final : public Storage {
     LocalSchemaTracking schema_diff;
     SchemaInfoPostProcess post_process;
     uint64_t start_ts;
-    // Orders the queue, and orders it correctly on a replica too, because a replica applies its
-    // main's transactions in the main's order.
+    // Orders the queue, on a replica as well, since a replica applies transactions in its main's
+    // order.
     uint64_t commit_ts;
-    // Identifies this transaction's own deltas during the deferred reconstruction, which compares
-    // against Delta::commit_info->timestamp. That holds the local mint, so it is not commit_ts: the
-    // two are equal on a main, while on a replica write commit_ts is the main's desired timestamp
-    // and the delta carries the replica's own. A reconstruction given commit_ts there does not
-    // recognise its own writes.
+    // The local mint, which is what identifies this transaction's own deltas. Not the durable
+    // timestamp, for the reason GetState gives.
     uint64_t local_commit_ts;
     bool property_on_edges;
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -1149,24 +1149,22 @@ class InMemoryStorage final : public Storage {
     LocalSchemaTracking schema_diff;
     SchemaInfoPostProcess post_process;
     uint64_t start_ts;
-    // Orders the queue, on a replica as well, since a replica applies transactions in its main's
-    // order.
-    uint64_t commit_ts;
     // The local mint, which is what identifies this transaction's own deltas. Not the durable
     // timestamp, for the reason GetState gives.
     uint64_t local_commit_ts;
     bool property_on_edges;
 
-    SchemaUpdateData(LocalSchemaTracking diff, SchemaInfoPostProcess post_proc, uint64_t start, uint64_t commit,
-                     uint64_t local_commit, bool prop_on_edges)
+    SchemaUpdateData(LocalSchemaTracking diff, SchemaInfoPostProcess post_proc, uint64_t start, uint64_t local_commit,
+                     bool prop_on_edges)
         : schema_diff(std::move(diff)),
           post_process(std::move(post_proc)),
           start_ts(start),
-          commit_ts(commit),
           local_commit_ts(local_commit),
           property_on_edges(prop_on_edges) {}
   };
 
+  // Keyed on the durable commit timestamp, which orders the queue on a replica as well, since a
+  // replica applies transactions in its main's order.
   std::map<uint64_t, SchemaUpdateData, std::less<uint64_t>,
            memory::DbAwareAllocator<std::pair<const uint64_t, SchemaUpdateData>>>
       pending_schema_updates_;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -545,36 +545,42 @@ class InMemoryStorage final : public Storage {
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
-    /// * `IndexDefinitionError`: the index does not exist.
-    std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label) override;
+    /// * `IndexDefinitionError`: the index does not exist and `absent` is AbsentIndex::kFails.
+    std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
-    /// * `IndexDefinitionError`: the index does not exist.
+    /// * `IndexDefinitionError`: the index does not exist and `absent` is AbsentIndex::kFails.
     std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label,
                                                                std::vector<storage::PropertyPath> &&properties,
-                                                               std::optional<IndexOrder> order = std::nullopt) override;
+                                                               std::optional<IndexOrder> order = std::nullopt,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
-    /// * `IndexDefinitionError`: the index does not exist.
-    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type) override;
+    /// * `IndexDefinitionError`: the index does not exist and `absent` is AbsentIndex::kFails.
+    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
-    /// * `IndexDefinitionError`: the index does not exist.
-    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property) override;
+    /// * `IndexDefinitionError`: the index does not exist and `absent` is AbsentIndex::kFails.
+    std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property,
+                                                               AbsentIndex absent = AbsentIndex::kFails) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
-    /// * `IndexDefinitionError`: the index does not exist.
-    std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(PropertyId property) override;
+    /// * `IndexDefinitionError`: the index does not exist and `absent` is AbsentIndex::kFails.
+    std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(
+        PropertyId property, AbsentIndex absent = AbsentIndex::kFails) override;
 
-    std::expected<void, StorageIndexDefinitionError> DropGlobalVertexIndex(PropertyId property) override;
+    std::expected<void, StorageIndexDefinitionError> DropGlobalVertexIndex(
+        PropertyId property, AbsentIndex absent = AbsentIndex::kFails) override;
 
     std::expected<void, StorageIndexDefinitionError> CreatePointIndex(storage::LabelId label,
                                                                       storage::PropertyId property,

--- a/src/storage/v2/inmemory/vertex_property_index.cpp
+++ b/src/storage/v2/inmemory/vertex_property_index.cpp
@@ -124,35 +124,24 @@ void InMemoryVertexPropertyIndex::IndividualIndex::Publish(uint64_t commit_times
   gauge_ = metrics::ScopedGauge{gauge.gauge};
 }
 
-bool InMemoryVertexPropertyIndex::InstallIndividualIndex_(PropertyId property, std::shared_ptr<IndividualIndex> entry,
-                                                          ActiveIndicesUpdater const &updater,
-                                                          bool register_in_all_indices) {
+bool InMemoryVertexPropertyIndex::RegisterIndex(PropertyId property, ActiveIndicesUpdater const &updater) {
   return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
     if (indices_container->indices_.contains(property)) return false;
     utils::MemoryTracker::OutOfMemoryExceptionEnabler const oom_exception;
     auto new_container = std::make_shared<IndicesContainer>(*indices_container);
-    auto [new_it, _] = new_container->indices_.emplace(property, std::move(entry));
+    auto [new_it, _] = new_container->indices_.emplace(property, std::make_shared<IndividualIndex>());
 
-    if (register_in_all_indices) {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    all_indices_.WithLock([&](auto &all_indices) {
+      auto new_all_indices = *all_indices;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-      all_indices_.WithLock([&](auto &all_indices) {
-        auto new_all_indices = *all_indices;
-        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-        new_all_indices.emplace_back(property, new_it->second);
-        all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
-      });
-    }
+      new_all_indices.emplace_back(property, new_it->second);
+      all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
+    });
     indices_container = std::move(new_container);
     updater(std::make_shared<ActiveIndices>(indices_container));
     return true;
   });
-}
-
-bool InMemoryVertexPropertyIndex::RegisterIndex(PropertyId property, ActiveIndicesUpdater const &updater) {
-  return InstallIndividualIndex_(property,
-                                 std::make_shared<IndividualIndex>(),
-                                 updater,
-                                 /*register_in_all_indices=*/true);
 }
 
 bool InMemoryVertexPropertyIndex::PublishIndex(PropertyId property, uint64_t commit_timestamp) {
@@ -220,18 +209,12 @@ auto InMemoryVertexPropertyIndex::DropIndex(PropertyId property, ActiveIndicesUp
 
         auto new_container = std::make_shared<IndicesContainer>(*indices_container);
         new_container->indices_.erase(property);
-        indices_container = new_container;
-        updater(std::make_shared<ActiveIndices>(indices_container));
+        updater(std::make_shared<ActiveIndices>(new_container));
+        indices_container = std::move(new_container);
         return evicted_entry;
       });
   CleanupAllIndices();
   return evicted;
-}
-
-void InMemoryVertexPropertyIndex::RestoreIndex(PropertyId property, std::shared_ptr<IndividualIndex> evicted,
-                                               ActiveIndicesUpdater const &updater) {
-  if (!evicted) return;
-  (void)InstallIndividualIndex_(property, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
 bool InMemoryVertexPropertyIndex::ActiveIndices::IndexExists(PropertyId property) const {

--- a/src/storage/v2/inmemory/vertex_property_index.hpp
+++ b/src/storage/v2/inmemory/vertex_property_index.hpp
@@ -258,7 +258,6 @@ class InMemoryVertexPropertyIndex : public VertexPropertyIndex {
 
   [[nodiscard]] auto DropIndex(PropertyId property, ActiveIndicesUpdater const &updater)
       -> std::shared_ptr<IndividualIndex>;
-  void RestoreIndex(PropertyId property, std::shared_ptr<IndividualIndex> evicted, ActiveIndicesUpdater const &updater);
 
   /// Sweeps only the indexes whose property `arming` names, and returns how many that was.
   uint64_t RemoveObsoleteEntries(Storage *storage, uint64_t oldest_active_start_timestamp, std::stop_token token,
@@ -273,8 +272,6 @@ class InMemoryVertexPropertyIndex : public VertexPropertyIndex {
  private:
   auto GetIndividualIndex(PropertyId property) const -> std::shared_ptr<IndividualIndex>;
 
-  bool InstallIndividualIndex_(PropertyId property, std::shared_ptr<IndividualIndex> entry,
-                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
   void CleanupAllIndices();
 
   metrics::GaugeHandle gauge_{};

--- a/src/storage/v2/schema_info.cpp
+++ b/src/storage/v2/schema_info.cpp
@@ -89,6 +89,9 @@ inline void ApplyDeltasForRead(const Delta *delta, uint64_t start_timestamp, aut
 
 enum State { NO_CHANGE, THIS_TX, ANOTHER_TX };
 
+// `commit_timestamp` is tested for equality against a delta's own timestamp, so it must come from
+// the same sequence the delta carries: the local commit stamp. A durable timestamp is the main's on
+// a replica, and passing one here leaves a transaction unable to recognise its own writes.
 inline State GetState(const Delta *delta, uint64_t start_timestamp, uint64_t commit_timestamp,
                       bool traverse_chain = false) {
   // This tx is running, so no deltas means there are no changes made after the tx started

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -276,6 +276,16 @@ using PlanInvalidatorPtr = std::unique_ptr<PlanInvalidator>;
 
 class Accessor;
 
+/// What a drop does when the index it names is not there.
+///
+/// A statement reports it, because the user asked to drop something that does not exist. A replica
+/// applies what its main durably decided instead, and the durable order can hold two drops of one
+/// index, so the second one arrives against an index the first already evicted. Recording that drop
+/// anyway keeps the transaction non-empty, and an empty one carries no commit timestamp, so the
+/// replica would stop acknowledging its main. It also leaves the replica's own log holding the same
+/// records its main's does, which is what its recovery and any cascading replica replay.
+enum class AbsentIndex : uint8_t { kFails, kIsRecorded };
+
 class Storage {
   friend class ReplicationServer;
   friend class ReplicationStorageClient;
@@ -890,19 +900,25 @@ class Accessor {
     return CreateGlobalVertexIndex(property, neverCancel);
   }
 
-  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label) = 0;
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label,
+                                                                     AbsentIndex absent = AbsentIndex::kFails) = 0;
 
-  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(
-      LabelId label, std::vector<storage::PropertyPath> &&properties,
-      std::optional<IndexOrder> order = std::nullopt) = 0;
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label,
+                                                                     std::vector<storage::PropertyPath> &&properties,
+                                                                     std::optional<IndexOrder> order = std::nullopt,
+                                                                     AbsentIndex absent = AbsentIndex::kFails) = 0;
 
-  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type) = 0;
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type,
+                                                                     AbsentIndex absent = AbsentIndex::kFails) = 0;
 
-  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property) = 0;
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property,
+                                                                     AbsentIndex absent = AbsentIndex::kFails) = 0;
 
-  virtual std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(PropertyId property) = 0;
+  virtual std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(
+      PropertyId property, AbsentIndex absent = AbsentIndex::kFails) = 0;
 
-  virtual std::expected<void, StorageIndexDefinitionError> DropGlobalVertexIndex(PropertyId property) = 0;
+  virtual std::expected<void, StorageIndexDefinitionError> DropGlobalVertexIndex(
+      PropertyId property, AbsentIndex absent = AbsentIndex::kFails) = 0;
 
   virtual std::expected<void, storage::StorageIndexDefinitionError> CreatePointIndex(
       storage::LabelId label, storage::PropertyId property, ProgressCallback const &on_progress) = 0;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -876,6 +876,11 @@ add_unit_test(storage_v2_indices
     LINK_TARGETS mg::storage mg-utils disk_test_utils ddl_abort_helpers
 )
 
+add_unit_test(storage_v2_index_drop_visibility
+    SOURCES storage_v2_index_drop_visibility.cpp
+    LINK_TARGETS mg::storage mg-utils
+)
+
 add_unit_test(storage_v2_index_entry_lifetime
     SOURCES storage_v2_index_entry_lifetime.cpp
     LINK_TARGETS mg::storage mg-utils

--- a/tests/unit/storage_v2_index_drop_visibility.cpp
+++ b/tests/unit/storage_v2_index_drop_visibility.cpp
@@ -1,0 +1,117 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// An index drop mutates the live catalogue the moment the statement runs. A durability snapshot
+// taken in the window between that and the commit therefore records the index as absent while
+// recording a durable timestamp below the drop's, and the two halves disagree.
+//
+// The test does not depend on timing. Holding the dropping transaction open is enough to place the
+// snapshot inside the window.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <semaphore>
+#include <string>
+#include <thread>
+
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/view.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/file.hpp"
+
+using memgraph::storage::Config;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::View;
+
+namespace {
+
+class IndexDropVisibility : public ::testing::Test {
+ protected:
+  void SetUp() override { Clear(); }
+
+  void TearDown() override { Clear(); }
+
+  std::filesystem::path storage_directory{std::filesystem::temp_directory_path() /
+                                          "MG_test_unit_storage_v2_index_drop_visibility"};
+
+ private:
+  void Clear() {
+    if (std::filesystem::exists(storage_directory)) std::filesystem::remove_all(storage_directory);
+  }
+};
+
+}  // namespace
+
+// A snapshot whose transaction begins after the statement has run and before its transaction commits
+// records the index as absent, while recording a durable timestamp below the drop's. Recovery then
+// replays the drop onto a catalogue that never had the index, and refuses it, so the database does
+// not come up.
+//
+// The snapshot fallback does not save it: the snapshot itself is a valid file and loads fine, and the
+// failure happens later during log replay, which is outside the loop that tries older snapshots.
+TEST_F(IndexDropVisibility, UncommittedDropSnapshotBlocksRecovery) {
+  Config config{};
+  config.durability.storage_directory = storage_directory;
+  config.durability.recover_on_startup = false;
+  config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  config.gc.type = Config::Gc::Type::NONE;
+
+  {
+    auto store = std::make_unique<InMemoryStorage>(config);
+    const auto label = store->NameToLabel("L");
+    {
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_TRUE(acc->CreateIndex(label).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    std::binary_semaphore applied{0};
+    std::binary_semaphore may_commit{0};
+    std::optional<bool> drop_ok;
+
+    // Read-only, which excludes writers but not the snapshot's own read accessor, so the window is
+    // still open to it.
+    std::thread dropper([&] {
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_TRUE(acc->DropIndex(label).has_value());
+      applied.release();
+      may_commit.acquire();
+      drop_ok = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+    });
+
+    applied.acquire();
+    // This snapshot's transaction begins inside the window: after the statement, before the commit.
+    ASSERT_TRUE(store->CreateSnapshot(/*force=*/true).has_value());
+    may_commit.release();
+    dropper.join();
+    ASSERT_TRUE(drop_ok.has_value());
+    ASSERT_TRUE(*drop_ok);
+    store.reset();
+  }
+
+  Config recover_config = config;
+  recover_config.durability.recover_on_startup = true;
+
+  std::string failure;
+  try {
+    auto recovered = std::make_unique<InMemoryStorage>(recover_config);
+    if (recovered->IsBroken()) failure = "storage recovered into the broken state";
+  } catch (std::exception const &e) {
+    failure = e.what();
+  }
+
+  EXPECT_TRUE(failure.empty()) << "a snapshot taken while an index drop was applied but uncommitted produced a "
+                                  "database that cannot be recovered: "
+                               << failure;
+}

--- a/tests/unit/storage_v2_index_drop_visibility.cpp
+++ b/tests/unit/storage_v2_index_drop_visibility.cpp
@@ -9,13 +9,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// An index drop mutates the live catalogue the moment the statement runs and publishes nothing at
-// commit: it registers an abort callback and a log record. Every constraint drop in the same file
-// defers publication to a commit callback instead, and its comment gives this as the reason. These
-// tests cover the two consequences of the difference.
+// An index drop evicts the catalogue entry when it commits, not when its statement runs. These
+// tests pin what that buys: an index stays complete across a rolled-back drop, and a database
+// snapshotted while a drop was pending still starts.
 //
-// Neither test depends on timing. Holding the dropping transaction open is enough to place the
-// other operation inside the window, so both are deterministic.
+// None of them depends on timing. Holding the dropping transaction open places the other operation
+// inside the window.
 
 #include <gtest/gtest.h>
 
@@ -54,17 +53,9 @@ class IndexDropVisibility : public ::testing::Test {
 
 }  // namespace
 
-// A drop evicts the index object and keeps hold of it so that an abort can reinstate the same
-// object. That is only exact if the index was maintained while it was gone, and what decides
-// whether a concurrent writer maintains it is the index set that writer captured when it began.
-//
-// So the drop mutates the container as the statement runs and publishes nothing: the snapshot new
-// transactions capture still holds the index until the drop commits. A writer admitted during the
-// window therefore maintains the very object the abort restores, and the restore is exact without
-// excluding anybody.
-//
-// The drop here takes an accessor that admits writers, and the writer commits inside the window
-// rather than waiting for it, because that is the case the deferral exists to make safe.
+// A rolled-back drop leaves an index that answers for everything committed, including rows written
+// while the drop was pending. The drop takes an accessor that admits writers, and the writer commits
+// inside the window rather than waiting for it.
 TEST_F(IndexDropVisibility, AbortedDropLeavesIndexComplete) {
   Config config{};
   config.gc.type = Config::Gc::Type::NONE;
@@ -77,7 +68,6 @@ TEST_F(IndexDropVisibility, AbortedDropLeavesIndexComplete) {
     ASSERT_TRUE(acc->CreateIndex(label).has_value());
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
-  // One labelled vertex before the window, which the index does contain.
   {
     auto acc = store->Access(memgraph::storage::WRITE);
     auto vertex = acc->CreateVertex();
@@ -99,8 +89,7 @@ TEST_F(IndexDropVisibility, AbortedDropLeavesIndexComplete) {
 
   applied.acquire();
 
-  // Begins and commits entirely inside the window, and is not made to wait for it. Ordering the
-  // abort after this commit is what puts the write inside the window rather than after it.
+  // Ordering the abort after this commit is what puts the write inside the window.
   std::thread writer([&] {
     auto acc = store->Access(memgraph::storage::WRITE);
     auto vertex = acc->CreateVertex();
@@ -114,7 +103,6 @@ TEST_F(IndexDropVisibility, AbortedDropLeavesIndexComplete) {
   dropper.join();
   writer.join();
 
-  // The drop was rolled back, so the index is live again and must answer for both vertices.
   auto acc = store->Access(memgraph::storage::READ);
   int64_t via_index = 0;
   for (auto vertex : acc->Vertices(label, View::OLD)) {
@@ -135,14 +123,9 @@ TEST_F(IndexDropVisibility, AbortedDropLeavesIndexComplete) {
                                     "written while it was gone.";
 }
 
-// The same completeness claim, broken by a publisher that is not the dropper. This is the case
-// that decides where the eviction belongs, and it is why withholding only the dropper's own
-// publication is not enough.
-//
-// Publishing means publishing the catalogue. An eviction that happens when the statement runs is
-// therefore visible to every other publisher, and registering an unrelated index publishes at
-// statement time because a creation must. So the creation below hands out the uncommitted drop on
-// the dropper's behalf, and the writer that begins next maintains nothing for the dropped index.
+// The same claim, against a publisher that is not the dropper. Registering an index publishes the
+// catalogue as it stands, and a creation publishes when its statement runs, so an unrelated
+// creation inside the window is enough to hand out a drop that has not committed.
 TEST_F(IndexDropVisibility, ConcurrentCreateDoesNotPublishAnUncommittedDrop) {
   Config config{};
   config.gc.type = Config::Gc::Type::NONE;
@@ -214,16 +197,9 @@ TEST_F(IndexDropVisibility, ConcurrentCreateDoesNotPublishAnUncommittedDrop) {
                                     "the dropping transaction committed it.";
 }
 
-// A snapshot taken while a drop is pending must leave a database that starts.
-//
-// The snapshot's transaction captures the index set it can see, and the drop has not committed, so
-// the index is recorded as present and replay applies the drop to a catalogue that has it. What
-// makes this worth pinning is the arrangement it rules out: an eviction that happened when the
-// statement ran would have the snapshot record the index as gone while recording a durable
-// timestamp below the drop's, and replay would then apply the drop to a catalogue that never had
-// it. The snapshot fallback would not save that, because the snapshot itself is a valid file that
-// loads, and the refusal comes later during log replay, outside the loop that tries older
-// snapshots.
+// A snapshot taken while a drop is pending leaves a database that starts. The snapshot records the
+// index as present, because the drop has not committed, so replay applies the drop to a catalogue
+// that has it.
 TEST_F(IndexDropVisibility, SnapshotAcrossUncommittedDropStaysRecoverable) {
   Config config{};
   config.durability.storage_directory = storage_directory;
@@ -244,8 +220,6 @@ TEST_F(IndexDropVisibility, SnapshotAcrossUncommittedDropStaysRecoverable) {
     std::binary_semaphore may_commit{0};
     std::optional<bool> drop_ok;
 
-    // Read-only, which excludes writers but not the snapshot's own read accessor, so the window is
-    // still open to it.
     std::thread dropper([&] {
       auto acc = store->ReadOnlyAccess();
       ASSERT_TRUE(acc->DropIndex(label).has_value());
@@ -281,12 +255,8 @@ TEST_F(IndexDropVisibility, SnapshotAcrossUncommittedDropStaysRecoverable) {
 }
 
 // Two transactions can both find the index and both record a drop of it, because a drop settles
-// that the index exists when its statement runs and evicts when it commits. One evicts and the
-// other finds nothing left, and the log holds two drops either way, so replay of the second meets a
-// catalogue that no longer has the index. Recovery has to accept that rather than refuse to start.
-//
-// This is what keeps the tolerant replay honest. Without a case that reaches it, the branch is
-// reachable only from snapshots written by older binaries, which no test here produces.
+// existence when its statement runs and evicts when it commits. The log then holds two drops, and
+// replay of the second meets a catalogue that no longer has the index.
 TEST_F(IndexDropVisibility, ConcurrentDropsOfOneIndexStayRecoverable) {
   Config config{};
   config.durability.storage_directory = storage_directory;

--- a/tests/unit/storage_v2_index_drop_visibility.cpp
+++ b/tests/unit/storage_v2_index_drop_visibility.cpp
@@ -9,12 +9,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// An index drop mutates the live catalogue the moment the statement runs. A durability snapshot
-// taken in the window between that and the commit therefore records the index as absent while
-// recording a durable timestamp below the drop's, and the two halves disagree.
+// An index drop mutates the live catalogue the moment the statement runs and publishes nothing at
+// commit: it registers an abort callback and a log record. Every constraint drop in the same file
+// defers publication to a commit callback instead, and its comment gives this as the reason. These
+// tests cover the two consequences of the difference.
 //
-// The test does not depend on timing. Holding the dropping transaction open is enough to place the
-// snapshot inside the window.
+// Neither test depends on timing. Holding the dropping transaction open is enough to place the
+// other operation inside the window, so both are deterministic.
 
 #include <gtest/gtest.h>
 
@@ -53,14 +54,177 @@ class IndexDropVisibility : public ::testing::Test {
 
 }  // namespace
 
-// A snapshot whose transaction begins after the statement has run and before its transaction commits
-// records the index as absent, while recording a durable timestamp below the drop's. Recovery then
-// replays the drop onto a catalogue that never had the index, and refuses it, so the database does
-// not come up.
+// A drop evicts the index object and keeps hold of it so that an abort can reinstate the same
+// object. That is only exact if the index was maintained while it was gone, and what decides
+// whether a concurrent writer maintains it is the index set that writer captured when it began.
 //
-// The snapshot fallback does not save it: the snapshot itself is a valid file and loads fine, and the
-// failure happens later during log replay, which is outside the loop that tries older snapshots.
-TEST_F(IndexDropVisibility, UncommittedDropSnapshotBlocksRecovery) {
+// So the drop mutates the container as the statement runs and publishes nothing: the snapshot new
+// transactions capture still holds the index until the drop commits. A writer admitted during the
+// window therefore maintains the very object the abort restores, and the restore is exact without
+// excluding anybody.
+//
+// The drop here takes an accessor that admits writers, and the writer commits inside the window
+// rather than waiting for it, because that is the case the deferral exists to make safe.
+TEST_F(IndexDropVisibility, AbortedDropLeavesIndexComplete) {
+  Config config{};
+  config.gc.type = Config::Gc::Type::NONE;
+
+  auto store = std::make_unique<InMemoryStorage>(config);
+  const auto label = store->NameToLabel("L");
+
+  {
+    auto acc = store->ReadOnlyAccess();
+    ASSERT_TRUE(acc->CreateIndex(label).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // One labelled vertex before the window, which the index does contain.
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->CreateVertex();
+    ASSERT_TRUE(vertex.AddLabel(label).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  std::binary_semaphore applied{0};
+  std::binary_semaphore written{0};
+  std::binary_semaphore may_abort{0};
+
+  std::thread dropper([&] {
+    auto acc = store->Access(memgraph::storage::READ);
+    ASSERT_TRUE(acc->DropIndex(label).has_value());
+    applied.release();
+    may_abort.acquire();
+    acc->Abort();
+  });
+
+  applied.acquire();
+
+  // Begins and commits entirely inside the window, and is not made to wait for it. Ordering the
+  // abort after this commit is what puts the write inside the window rather than after it.
+  std::thread writer([&] {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->CreateVertex();
+    ASSERT_TRUE(vertex.AddLabel(label).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    written.release();
+  });
+
+  written.acquire();
+  may_abort.release();
+  dropper.join();
+  writer.join();
+
+  // The drop was rolled back, so the index is live again and must answer for both vertices.
+  auto acc = store->Access(memgraph::storage::READ);
+  int64_t via_index = 0;
+  for (auto vertex : acc->Vertices(label, View::OLD)) {
+    (void)vertex;
+    ++via_index;
+  }
+  int64_t via_scan = 0;
+  for (auto vertex : acc->Vertices(View::OLD)) {
+    auto has = vertex.HasLabel(label, View::OLD);
+    ASSERT_TRUE(has.has_value());
+    if (*has) ++via_scan;
+  }
+
+  ASSERT_EQ(via_scan, 2) << "the two labelled vertices are not both committed, so this test never set up the "
+                            "comparison it exists to make";
+  EXPECT_EQ(via_index, via_scan) << "a scan through the restored index returned " << via_index << " of " << via_scan
+                                 << " labelled vertices, so the rolled-back drop restored it without what was "
+                                    "written while it was gone.";
+}
+
+// The same completeness claim, broken by a publisher that is not the dropper. This is the case
+// that decides where the eviction belongs, and it is why withholding only the dropper's own
+// publication is not enough.
+//
+// Publishing means publishing the catalogue. An eviction that happens when the statement runs is
+// therefore visible to every other publisher, and registering an unrelated index publishes at
+// statement time because a creation must. So the creation below hands out the uncommitted drop on
+// the dropper's behalf, and the writer that begins next maintains nothing for the dropped index.
+TEST_F(IndexDropVisibility, ConcurrentCreateDoesNotPublishAnUncommittedDrop) {
+  Config config{};
+  config.gc.type = Config::Gc::Type::NONE;
+
+  auto store = std::make_unique<InMemoryStorage>(config);
+  const auto dropped = store->NameToLabel("Dropped");
+  const auto other = store->NameToLabel("Other");
+
+  {
+    auto acc = store->ReadOnlyAccess();
+    ASSERT_TRUE(acc->CreateIndex(dropped).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->CreateVertex();
+    ASSERT_TRUE(vertex.AddLabel(dropped).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  std::binary_semaphore applied{0};
+  std::binary_semaphore may_abort{0};
+
+  std::thread dropper([&] {
+    auto acc = store->Access(memgraph::storage::READ);
+    ASSERT_TRUE(acc->DropIndex(dropped).has_value());
+    applied.release();
+    may_abort.acquire();
+    acc->Abort();
+  });
+
+  applied.acquire();
+
+  // An unrelated index, created and committed entirely inside the dropper's window.
+  {
+    auto acc = store->ReadOnlyAccess();
+    ASSERT_TRUE(acc->CreateIndex(other).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Begins after that creation published, so its index set is whatever the creation handed out.
+  {
+    auto acc = store->Access(memgraph::storage::WRITE);
+    auto vertex = acc->CreateVertex();
+    ASSERT_TRUE(vertex.AddLabel(dropped).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  may_abort.release();
+  dropper.join();
+
+  auto acc = store->Access(memgraph::storage::READ);
+  int64_t via_index = 0;
+  for (auto vertex : acc->Vertices(dropped, View::OLD)) {
+    (void)vertex;
+    ++via_index;
+  }
+  int64_t via_scan = 0;
+  for (auto vertex : acc->Vertices(View::OLD)) {
+    auto has = vertex.HasLabel(dropped, View::OLD);
+    ASSERT_TRUE(has.has_value());
+    if (*has) ++via_scan;
+  }
+
+  ASSERT_EQ(via_scan, 2) << "the two labelled vertices are not both committed, so this test never set up the "
+                            "comparison it exists to make";
+  EXPECT_EQ(via_index, via_scan) << "a scan through the restored index returned " << via_index << " of " << via_scan
+                                 << " labelled vertices, so an unrelated index creation published the drop before "
+                                    "the dropping transaction committed it.";
+}
+
+// A snapshot taken while a drop is pending must leave a database that starts.
+//
+// The snapshot's transaction captures the index set it can see, and the drop has not committed, so
+// the index is recorded as present and replay applies the drop to a catalogue that has it. What
+// makes this worth pinning is the arrangement it rules out: an eviction that happened when the
+// statement ran would have the snapshot record the index as gone while recording a durable
+// timestamp below the drop's, and replay would then apply the drop to a catalogue that never had
+// it. The snapshot fallback would not save that, because the snapshot itself is a valid file that
+// loads, and the refusal comes later during log replay, outside the loop that tries older
+// snapshots.
+TEST_F(IndexDropVisibility, SnapshotAcrossUncommittedDropStaysRecoverable) {
   Config config{};
   config.durability.storage_directory = storage_directory;
   config.durability.recover_on_startup = false;
@@ -113,5 +277,55 @@ TEST_F(IndexDropVisibility, UncommittedDropSnapshotBlocksRecovery) {
 
   EXPECT_TRUE(failure.empty()) << "a snapshot taken while an index drop was applied but uncommitted produced a "
                                   "database that cannot be recovered: "
+                               << failure;
+}
+
+// Two transactions can both find the index and both record a drop of it, because a drop settles
+// that the index exists when its statement runs and evicts when it commits. One evicts and the
+// other finds nothing left, and the log holds two drops either way, so replay of the second meets a
+// catalogue that no longer has the index. Recovery has to accept that rather than refuse to start.
+//
+// This is what keeps the tolerant replay honest. Without a case that reaches it, the branch is
+// reachable only from snapshots written by older binaries, which no test here produces.
+TEST_F(IndexDropVisibility, ConcurrentDropsOfOneIndexStayRecoverable) {
+  Config config{};
+  config.durability.storage_directory = storage_directory;
+  config.durability.recover_on_startup = false;
+  config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  config.gc.type = Config::Gc::Type::NONE;
+
+  {
+    auto store = std::make_unique<InMemoryStorage>(config);
+    const auto label = store->NameToLabel("L");
+    {
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_TRUE(acc->CreateIndex(label).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Both statements run before either commits, so both record a drop.
+    auto first = store->Access(memgraph::storage::READ);
+    auto second = store->Access(memgraph::storage::READ);
+    ASSERT_TRUE(first->DropIndex(label).has_value());
+    ASSERT_TRUE(second->DropIndex(label).has_value());
+    ASSERT_TRUE(first->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    ASSERT_TRUE(second->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    first.reset();
+    second.reset();
+    store.reset();
+  }
+
+  Config recover_config = config;
+  recover_config.durability.recover_on_startup = true;
+
+  std::string failure;
+  try {
+    auto recovered = std::make_unique<InMemoryStorage>(recover_config);
+    if (recovered->IsBroken()) failure = "storage recovered into the broken state";
+  } catch (std::exception const &e) {
+    failure = e.what();
+  }
+
+  EXPECT_TRUE(failure.empty()) << "two logged drops of one index produced a database that cannot be recovered: "
                                << failure;
 }

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1959,6 +1959,107 @@ TEST_F(ReplicationTest, SchemaReplication) {
   EXPECT_TRUE(ConfrontJSON(get_schema(*main), get_schema(*replica)));
 }
 
+// Schema info is reconstructed after a transaction commits, and the reconstruction has to tell the
+// transaction's own deltas apart from another transaction's. It does so by comparing the timestamp
+// it queued against the delta's, which holds the local mint. On a main those are the same number.
+// On a replica write they are not: the queued one is the main's desired timestamp and the delta
+// carries the replica's own, so the replica reads its own writes as another transaction's.
+//
+// That switches the four-way edge reconciliation onto the pre-state of both endpoints, so its plus
+// one and minus one land on different shape buckets and the counts drift. It shows up only where
+// the reconciliation actually fires on state the transaction itself wrote, which is why the
+// sequential single-endpoint traffic in SchemaReplication above never sees it: one transaction has
+// to modify BOTH endpoints of an existing edge.
+TEST_F(ReplicationTest, SchemaReplicationBothEndpointsModifiedSameTransaction) {
+  memgraph::storage::Config conf{
+      .durability =
+          {
+              .root_data_directory = storage_directory,
+              .recover_on_startup = false,
+              .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+              .snapshot_retention_count = 1,
+              .restore_replication_state_on_startup = true,
+          },
+      .salient.items =
+          {
+              .properties_on_edges = true,
+              .enable_schema_info = true,
+          },
+      .register_metrics = false,
+  };
+
+  auto repl_conf = conf;
+  UpdatePaths(conf, storage_directory);
+  std::optional<MinMemgraph> main(conf);
+
+  UpdatePaths(repl_conf, repl_storage_directory);
+  std::optional<MinMemgraph> replica(repl_conf);
+
+  replica->repl_handler.TrySetReplicationRoleReplica(
+      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])});
+
+  const auto &reg = main->repl_handler.TryRegisterReplica(ReplicationClientConfig{
+      .name = "REPLICA",
+      .mode = ReplicationMode::SYNC,
+      .repl_server_endpoint = Endpoint(local_host, ports[0]),
+  });
+  ASSERT_TRUE(reg.has_value()) << (int)reg.error();
+
+  auto get_schema = [](auto &instance) {
+    return instance.db.storage()->schema_info_.ToJson(*instance.db.storage()->name_id_mapper_,
+                                                      instance.db.storage()->enum_store_);
+  };
+
+  std::optional<memgraph::memory::DbArenaScope> main_scope{std::in_place, &main->db.Arena()};
+
+  auto l1 = main->db.storage()->NameToLabel("L1");
+  auto l2 = main->db.storage()->NameToLabel("L2");
+  auto e1 = main->db.storage()->NameToEdgeType("E1");
+
+  memgraph::storage::Gid v1_gid;
+  memgraph::storage::Gid v2_gid;
+
+  // Two vertices with an edge between them, all in one transaction.
+  {
+    auto acc = main->db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge = acc->CreateEdge(&v1, &v2, e1);
+    ASSERT_TRUE(edge.has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main->db_acc)).has_value());
+  }
+
+  // Now label BOTH endpoints of that edge in a single transaction. This is the case where the
+  // reconstruction must recognise the deltas as its own.
+  {
+    auto acc = main->db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::NEW);
+    auto v2 = acc->FindVertex(v2_gid, View::NEW);
+    ASSERT_TRUE(v1.has_value() && v2.has_value());
+    ASSERT_TRUE(v1->AddLabel(l1).has_value());
+    ASSERT_TRUE(v2->AddLabel(l2).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main->db_acc)).has_value());
+  }
+
+  const auto main_schema = get_schema(*main);
+  const auto replica_schema = get_schema(*replica);
+
+  // The main's own answer is the reference, and is asserted first so a change that broke both sides
+  // in the same direction could not pass as agreement.
+  const auto expected = nlohmann::json::parse(
+      R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[],"start_node_labels":["L1"],"type":"E1"}],)"
+      R"("nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+  ASSERT_TRUE(ConfrontJSON(main_schema, expected))
+      << "the main's own schema is already wrong, so this test is not measuring replication. Actual: "
+      << main_schema.dump(2);
+
+  EXPECT_TRUE(ConfrontJSON(replica_schema, main_schema))
+      << "the replica's schema diverged from the main's. Main: " << main_schema.dump(2)
+      << " Replica: " << replica_schema.dump(2);
+}
+
 TEST_F(ReplicationTest, ReplicationWithNonSequentialDeltas) {
   MinMemgraph main(main_conf);
   MinMemgraph replica(repl_conf);

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1960,16 +1960,18 @@ TEST_F(ReplicationTest, SchemaReplication) {
 }
 
 // Schema info is reconstructed after a transaction commits, and the reconstruction has to tell the
-// transaction's own deltas apart from another transaction's. It does so by comparing the timestamp
-// it queued against the delta's, which holds the local mint. On a main those are the same number.
-// On a replica write they are not: the queued one is the main's desired timestamp and the delta
-// carries the replica's own, so the replica reads its own writes as another transaction's.
+// transaction's own deltas apart from another transaction's. It compares the timestamp it was
+// queued under against the one each delta carries, which is the local mint. A main mints the
+// timestamp it makes durable, so the two agree there; a replica is handed its main's and mints its
+// own, so they do not, and the replica reads its own writes as another transaction's.
 //
-// That switches the four-way edge reconciliation onto the pre-state of both endpoints, so its plus
-// one and minus one land on different shape buckets and the counts drift. It shows up only where
-// the reconciliation actually fires on state the transaction itself wrote, which is why the
-// sequential single-endpoint traffic in SchemaReplication above never sees it: one transaction has
-// to modify BOTH endpoints of an existing edge.
+// This asserts that a replica reconstructs its main's schema across a transaction that writes both
+// endpoints of one edge, with the replica's counter moved off the main's first so the comparison is
+// made on numbers that differ. It does not fail if the queue is changed back to passing the durable
+// timestamp: the reconstruction then runs the four-way edge reconciliation instead of skipping it,
+// and with both endpoints in the same state that reconciliation adds and subtracts the same two
+// shape buckets and nets to zero. Only endpoints in differing states part the two, and a replica
+// does not reach that, applying transactions one at a time and draining the queue at each commit.
 TEST_F(ReplicationTest, SchemaReplicationBothEndpointsModifiedSameTransaction) {
   memgraph::storage::Config conf{
       .durability =
@@ -2010,6 +2012,17 @@ TEST_F(ReplicationTest, SchemaReplicationBothEndpointsModifiedSameTransaction) {
                                                       instance.db.storage()->enum_store_);
   };
 
+  // Only a transaction begun on the replica advances the replica's own timestamp counter, and a
+  // read is enough. Without this the two counters tick in lockstep, the replica's local mint equals
+  // the main's durable timestamp, and the reconstruction's identity check is never put on the
+  // differing stamps this test is about.
+  {
+    const memgraph::memory::DbArenaScope replica_scope{&replica->db.Arena()};
+    for (int i = 0; i != 3; ++i) {
+      auto read = replica->db.Access(memgraph::storage::READ);
+    }
+  }
+
   std::optional<memgraph::memory::DbArenaScope> main_scope{std::in_place, &main->db.Arena()};
 
   auto l1 = main->db.storage()->NameToLabel("L1");
@@ -2030,6 +2043,10 @@ TEST_F(ReplicationTest, SchemaReplicationBothEndpointsModifiedSameTransaction) {
     ASSERT_TRUE(edge.has_value());
     ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main->db_acc)).has_value());
   }
+
+  ASSERT_NE(main->db.storage()->timestamp_, replica->db.storage()->timestamp_)
+      << "the two counters have to differ for the transaction below to mint a local commit "
+         "timestamp that is not the main's durable one";
 
   // Now label BOTH endpoints of that edge in a single transaction. This is the case where the
   // reconstruction must recognise the deltas as its own.

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -46,6 +46,7 @@
 #include "tests/unit/storage_test_utils.hpp"
 #include "utils/exceptions.hpp"
 
+using testing::IsEmpty;
 using testing::UnorderedElementsAre;
 
 using memgraph::io::network::Endpoint;
@@ -2075,6 +2076,63 @@ TEST_F(ReplicationTest, SchemaReplicationBothEndpointsModifiedSameTransaction) {
   EXPECT_TRUE(ConfrontJSON(replica_schema, main_schema))
       << "the replica's schema diverged from the main's. Main: " << main_schema.dump(2)
       << " Replica: " << replica_schema.dump(2);
+}
+
+// Two transactions can each settle a drop's existence check and commit, because a drop evicts when
+// it commits, so the stream carries two drops of one index. The second reaches a replica that has
+// already evicted it, and applying it has to leave the stream running rather than fail the delta.
+TEST_F(ReplicationTest, ConcurrentDropsOfOneIndexKeepTheStreamRunning) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+
+  replica.repl_handler.TrySetReplicationRoleReplica(
+      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])});
+
+  const auto &reg = main.repl_handler.TryRegisterReplica(ReplicationClientConfig{
+      .name = "REPLICA",
+      .mode = ReplicationMode::SYNC,
+      .repl_server_endpoint = Endpoint(local_host, ports[0]),
+  });
+  ASSERT_TRUE(reg.has_value()) << (int)reg.error();
+
+  std::optional<memgraph::memory::DbArenaScope> main_scope{std::in_place, &main.db.Arena()};
+  auto const label = main.db.storage()->NameToLabel("L");
+
+  {
+    auto unique_acc = main.db.UniqueAccess();
+    ASSERT_TRUE(unique_acc->CreateIndex(label).has_value());
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  {
+    auto first = main.db.Access(memgraph::storage::READ);
+    auto second = main.db.Access(memgraph::storage::READ);
+    ASSERT_TRUE(first->DropIndex(label).has_value());
+    ASSERT_TRUE(second->DropIndex(label).has_value());
+    ASSERT_TRUE(first->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+    ASSERT_TRUE(second->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // A refused delta stops the replica applying anything after it, so this vertex is what says the
+  // second drop was taken rather than merely leaving the index already gone.
+  memgraph::storage::Gid gid;
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    gid = acc->CreateVertex().Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value())
+        << "the main could not commit, which is what a replica that stopped acknowledging looks "
+           "like from here";
+  }
+
+  main_scope.reset();
+
+  {
+    const memgraph::memory::DbArenaScope replica_scope{&replica.db.Arena()};
+    auto racc = replica.db.Access(memgraph::storage::WRITE);
+    EXPECT_TRUE(racc->FindVertex(gid, View::OLD).has_value())
+        << "the replica stopped applying the stream, which is what refusing the second drop does";
+    EXPECT_THAT(racc->ListAllIndices().label, IsEmpty());
+  }
 }
 
 TEST_F(ReplicationTest, ReplicationWithNonSequentialDeltas) {


### PR DESCRIPTION
An index drop now evicts the catalogue entry and publishes the new snapshot
together, under the catalogue lock, when the transaction commits. A writer
maintains the index set it captured when it began, so leaving the entry in place
until the drop commits means a writer running alongside a pending drop keeps
maintaining the index, and the entry an abort puts back is the one that writer
maintained. An abort now has nothing to undo. Evicting when the statement runs
instead leaves the catalogue without an entry that any other publisher then
hands out, an unrelated index creation included, since a creation publishes at
statement time so concurrent writers maintain what it registered.

Recovery accepts a logged drop of an index that is already absent, which is what
two concurrent drops of one index leave for replay. Schema information
identifies a transaction's own deltas by the commit timestamp those deltas
carry rather than the durable timestamp it was queued under; the two hold the
same value on a main and differ on every replica write.
