### PR TITLE
test(ci): report how often each test failed across the repeats

### DIFF
--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -223,3 +223,25 @@ jobs:
       run_id: "${{ matrix.run_no }}"
       ref: ${{ github.sha }}
     secrets: inherit
+
+  # The repeats above are only useful if someone reads all of them together.
+  # This gathers every run's ctest results into one per-test failure count, so a
+  # flake rate is visible without opening any job log.
+  FlakeSummary:
+    needs: [Community, Coverage, Debug, Release]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+      - name: Download ctest results from every run
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          pattern: ctest_results_*
+          path: ctest-results
+      - name: Summarise failures across the runs
+        run: |
+          python3 tools/ci/summarize_ctest_results.py ctest-results | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -244,4 +244,7 @@ jobs:
           path: ctest-results
       - name: Summarise failures across the runs
         run: |
+          # Without pipefail the step takes tee's status, so the summariser
+          # could fail and still leave the step green.
+          set -euo pipefail
           python3 tools/ci/summarize_ctest_results.py ctest-results | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -128,6 +128,15 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph unit
 
+      - name: Save ctest results
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        if: always()
+        with:
+          name: "ctest_results_Community${{ env.RUN_ID }}"
+          path: build/test-results/
+          if-no-files-found: ignore
+
       - name: Collect core dumps
         if: failure()
         continue-on-error: true

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -45,6 +45,7 @@ env:
   CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
   CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
   CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
+  RUN_ID: ${{ inputs.run_id != '' && format('-{0}', inputs.run_id) || '' }}
 
 
 jobs:

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -172,6 +172,15 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph unit-coverage
 
+      - name: Save ctest results
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        if: always()
+        with:
+          name: "ctest_results_Coverage${{ env.RUN_ID }}"
+          path: build/test-results/
+          if-no-files-found: ignore
+
       - name: Compute code coverage
         run: |
           ./release/package/mgbuild.sh \

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -137,6 +137,15 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph leftover-CTest
 
+      - name: Save ctest results
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        if: always()
+        with:
+          name: "ctest_results_Debug${{ env.RUN_ID }}"
+          path: build/test-results/
+          if-no-files-found: ignore
+
       - name: Run drivers tests
         run: |
           ./release/package/mgbuild.sh \

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -187,6 +187,15 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph unit
 
+      - name: Save ctest results
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        if: always()
+        with:
+          name: "ctest_results_Release${{ env.RUN_ID }}"
+          path: build/test-results/
+          if-no-files-found: ignore
+
       - name: Run query modules unit tests
         run: |
           ./release/package/mgbuild.sh \

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1845,10 +1845,14 @@ test_memgraph() {
   # ctest's per-test results are what say which test failed and how often across
   # repeated runs, and they matter most on the runs that failed. Copy them out of
   # the container whatever the exit status was, then hand that status back.
+  # A failure here is reported rather than hidden: an empty summary otherwise
+  # reads the same as a clean run.
   collect_ctest_results() {
     local status=$1
     mkdir -p "$PROJECT_ROOT/build/test-results"
-    docker cp "$build_container:$BUILD_DIR/test-results/." "$PROJECT_ROOT/build/test-results/" 2>/dev/null || true
+    if ! docker cp "$build_container:$BUILD_DIR/test-results/." "$PROJECT_ROOT/build/test-results/" 2>&1; then
+      echo "Warning: could not copy ctest results out of $build_container; this run will be absent from the flake summary." >&2
+    fi
     return "$status"
   }
 

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1842,23 +1842,39 @@ test_memgraph() {
     fi
   fi
 
+  # ctest's per-test results are what say which test failed and how often across
+  # repeated runs, and they matter most on the runs that failed. Copy them out of
+  # the container whatever the exit status was, then hand that status back.
+  collect_ctest_results() {
+    local status=$1
+    mkdir -p "$PROJECT_ROOT/build/test-results"
+    docker cp "$build_container:$BUILD_DIR/test-results/." "$PROJECT_ROOT/build/test-results/" 2>/dev/null || true
+    return "$status"
+  }
+
   # NOTE: If you need a fresh copy of memgraph files, call copy_project_files funcation on the line below.
   echo "Running $test_name test on $build_container..."
   case "$test_name" in
     unit)
+      local status=0
       if [[ "$threads" == "$DEFAULT_THREADS" ]]; then
-        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN "'&& ctest -R memgraph__unit --output-on-failure -j$(nproc)'
+        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN "'&& mkdir -p test-results && ctest -R memgraph__unit --output-on-failure -j$(nproc) --output-junit test-results/unit.xml' || status=$?
       else
         local EXPORT_THREADS="export THREADS=$threads"
-        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && $EXPORT_THREADS && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN "'&& ctest -R memgraph__unit --output-on-failure -j$THREADS'
+        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && $EXPORT_THREADS && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN "'&& mkdir -p test-results && ctest -R memgraph__unit --output-on-failure -j$THREADS --output-junit test-results/unit.xml' || status=$?
       fi
+      collect_ctest_results "$status"
     ;;
     unit-coverage)
       local setup_lsan_ubsan="export LSAN_OPTIONS=suppressions=$BUILD_DIR/../tools/lsan.supp && export UBSAN_OPTIONS=halt_on_error=1"
-      docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN && $setup_lsan_ubsan "'&& ctest -R memgraph__unit --output-on-failure -j2'
+      local status=0
+      docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN && $setup_lsan_ubsan "'&& mkdir -p test-results && ctest -R memgraph__unit --output-on-failure -j2 --output-junit test-results/unit-coverage.xml' || status=$?
+      collect_ctest_results "$status"
     ;;
     leftover-CTest)
-      docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN "'&& ctest -E "(memgraph__unit|memgraph__benchmark)" --output-on-failure'
+      local status=0
+      docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $BUILD_DIR && $ACTIVATE_TOOLCHAIN "'&& mkdir -p test-results && ctest -E "(memgraph__unit|memgraph__benchmark)" --output-on-failure --output-junit test-results/leftover-ctest.xml' || status=$?
+      collect_ctest_results "$status"
     ;;
     drivers)
       docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $MGBUILD_ROOT_DIR && export DISABLE_NODE=$DISABLE_NODE "'&& ./tests/drivers/run.sh'

--- a/tools/ci/summarize_ctest_results.py
+++ b/tools/ci/summarize_ctest_results.py
@@ -16,25 +16,51 @@ import sys
 import xml.etree.ElementTree as ET
 
 
+def build_of(root: pathlib.Path, path: pathlib.Path) -> str:
+    """Name the build a result file came from.
+
+    Each repeat arrives as its own artifact directory, named for the build and
+    the repeat, so the first path component below the download root identifies
+    the build once the repeat suffix is taken off. Counting a test's runs across
+    builds instead would average a break in one build against a pass in
+    another, and report neither.
+    """
+    try:
+        head = path.relative_to(root).parts[0]
+    except (ValueError, IndexError):
+        return "unknown"
+    head = head.removeprefix("ctest_results_")
+    return head.rsplit("-", 1)[0] if "-" in head else head
+
+
 def collect(roots: list[str]):
-    runs: collections.Counter[str] = collections.Counter()
-    failures: collections.Counter[str] = collections.Counter()
+    runs: collections.Counter[tuple[str, str]] = collections.Counter()
+    failures: collections.Counter[tuple[str, str]] = collections.Counter()
     files = 0
-    for root in roots:
-        for path in sorted(pathlib.Path(root).rglob("*.xml")):
+    for raw_root in roots:
+        root = pathlib.Path(raw_root)
+        for path in sorted(root.rglob("*.xml")):
             try:
                 tree = ET.parse(path)
-            except ET.ParseError:
-                print(f"skipped unparseable {path}", file=sys.stderr)
+            except (ET.ParseError, OSError, ValueError):
+                print(f"skipped unreadable {path}", file=sys.stderr)
                 continue
             files += 1
+            build = build_of(root, path)
             for case in tree.iter("testcase"):
-                name = case.get("name") or "<unnamed>"
-                runs[name] += 1
+                # A test ctest never ran tells us nothing about whether it
+                # fails, and counting it would understate the rate of one that
+                # fails whenever it does run. ctest reports an execution as
+                # either run or fail and gives anything it declined to start a
+                # status of its own.
+                if case.find("skipped") is not None or case.get("status") not in ("run", "fail"):
+                    continue
+                key = (build, case.get("name") or "<unnamed>")
+                runs[key] += 1
                 # ctest writes <failure> for a failing test and marks skipped
                 # ones separately; anything with a failure child counts.
                 if case.find("failure") is not None or case.find("error") is not None:
-                    failures[name] += 1
+                    failures[key] += 1
     return runs, failures, files
 
 
@@ -50,19 +76,20 @@ def main() -> int:
     total_runs = sum(runs.values())
     flaky = sorted(failures.items(), key=lambda kv: (-kv[1], kv[0]))
 
-    print(f"Read {files} result file(s): {len(runs)} distinct tests, {total_runs} executions.\n")
+    print(f"Read {files} result file(s): {len(runs)} build/test pairs, {total_runs} executions.\n")
     if not flaky:
         print("No failures across any repeat.")
         return 0
 
-    print("| test | failed | of runs | rate |")
-    print("| --- | ---: | ---: | ---: |")
-    for name, failed in flaky:
-        n = runs[name]
-        print(f"| `{name}` | {failed} | {n} | {failed / n:.0%} |")
+    print("| build | test | failed | of runs | rate |")
+    print("| --- | --- | ---: | ---: | ---: |")
+    for key, failed in flaky:
+        build, name = key
+        n = runs[key]
+        print(f"| {build} | `{name}` | {failed} | {n} | {failed / n:.0%} |")
 
-    always = [n for n, f in flaky if f == runs[n]]
-    sometimes = [n for n, f in flaky if f != runs[n]]
+    always = [k for k, f in flaky if f == runs[k]]
+    sometimes = [k for k, f in flaky if f != runs[k]]
     print()
     print(f"{len(sometimes)} test(s) failed on some runs but not all, which is the flaky set.")
     if always:

--- a/tools/ci/summarize_ctest_results.py
+++ b/tools/ci/summarize_ctest_results.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Summarise repeated ctest runs into a per-test flake rate.
+
+The flakiness workflow runs every job several times and each run uploads its
+JUnit output. Reading those together says how often each test failed across the
+repeats, which is the number that decides whether a test is flaky and whether a
+fix worked. Reading it out of the job logs instead means reading every log.
+
+Usage: summarize_ctest_results.py DIR [DIR ...]
+"""
+from __future__ import annotations
+
+import collections
+import pathlib
+import sys
+import xml.etree.ElementTree as ET
+
+
+def collect(roots: list[str]):
+    runs: collections.Counter[str] = collections.Counter()
+    failures: collections.Counter[str] = collections.Counter()
+    files = 0
+    for root in roots:
+        for path in sorted(pathlib.Path(root).rglob("*.xml")):
+            try:
+                tree = ET.parse(path)
+            except ET.ParseError:
+                print(f"skipped unparseable {path}", file=sys.stderr)
+                continue
+            files += 1
+            for case in tree.iter("testcase"):
+                name = case.get("name") or "<unnamed>"
+                runs[name] += 1
+                # ctest writes <failure> for a failing test and marks skipped
+                # ones separately; anything with a failure child counts.
+                if case.find("failure") is not None or case.find("error") is not None:
+                    failures[name] += 1
+    return runs, failures, files
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    runs, failures, files = collect(sys.argv[1:])
+    if not files:
+        print("No ctest result files found.")
+        return 0
+
+    total_runs = sum(runs.values())
+    flaky = sorted(failures.items(), key=lambda kv: (-kv[1], kv[0]))
+
+    print(f"Read {files} result file(s): {len(runs)} distinct tests, {total_runs} executions.\n")
+    if not flaky:
+        print("No failures across any repeat.")
+        return 0
+
+    print("| test | failed | of runs | rate |")
+    print("| --- | ---: | ---: | ---: |")
+    for name, failed in flaky:
+        n = runs[name]
+        print(f"| `{name}` | {failed} | {n} | {failed / n:.0%} |")
+
+    always = [n for n, f in flaky if f == runs[n]]
+    sometimes = [n for n, f in flaky if f != runs[n]]
+    print()
+    print(f"{len(sometimes)} test(s) failed on some runs but not all, which is the flaky set.")
+    if always:
+        print(f"{len(always)} test(s) failed on every run, which is a break rather than a flake.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every ctest invocation in the build script now writes JUnit output, each test job uploads it, and the flakiness workflow reads all of a night's repeats together into a count, for each build and test, of how often that test failed. A test that fails on some repeats and not others is separated from one that fails on every repeat, because the two need different responses. Reaching the same numbers without this means opening each job's log and reading it by hand.

The results are copied out of the container whatever the exit status was and the status is then handed back, so a failing run still fails its job and still leaves its results behind: the runs worth reading are the ones that failed. Uploading and downloading the results are allowed to fail without failing the job, since a missing summary is worth less than the run it would otherwise take down, but a summary that cannot be produced fails the step that produces it. Test suites other than ctest are untouched.
