### PR TITLE
test(ci): bound a hanging unit test and keep its stack

### DIFF
--- a/cmake/unit_tests.cmake
+++ b/cmake/unit_tests.cmake
@@ -68,6 +68,16 @@ function(add_unit_test exec_name)
         list(APPEND test_properties TIMEOUT 1800)
     endif()
 
+    # Kill a timed-out test with SIGQUIT, whose default disposition dumps core, so the
+    # hang leaves a stack behind for tools/ci/core-dumps to symbolise. SIGKILL, which
+    # ctest sends once the grace period is up, leaves nothing to look at. The grace
+    # period covers writing the core, which is far longer than the one second ctest
+    # would otherwise allow for a process this size.
+    list(FIND test_properties "TIMEOUT_SIGNAL_NAME" signal_index)
+    if(signal_index EQUAL -1)
+        list(APPEND test_properties TIMEOUT_SIGNAL_NAME SIGQUIT TIMEOUT_SIGNAL_GRACE_PERIOD 30)
+    endif()
+
     # Use gtest_discover_tests if DISCOVER_TESTS is set, otherwise use add_test
     if(ARG_DISCOVER_TESTS)
         # Prepare test properties for gtest_discover_tests

--- a/cmake/unit_tests.cmake
+++ b/cmake/unit_tests.cmake
@@ -58,6 +58,16 @@ function(add_unit_test exec_name)
         set(test_properties ${ARG_TEST_PROPERTIES})
     endif()
 
+    # This project calls enable_testing() without including the CTest module, so
+    # ctest applies no timeout of its own: a test that hangs runs until whatever
+    # is driving ctest gives up, and the report names no test. Cap it here, well
+    # above the slowest test so that only a hang trips it. A test that needs
+    # longer passes its own TIMEOUT in TEST_PROPERTIES.
+    list(FIND test_properties "TIMEOUT" timeout_index)
+    if(timeout_index EQUAL -1)
+        list(APPEND test_properties TIMEOUT 1800)
+    endif()
+
     # Use gtest_discover_tests if DISCOVER_TESTS is set, otherwise use add_test
     if(ARG_DISCOVER_TESTS)
         # Prepare test properties for gtest_discover_tests

--- a/tools/ci/core-dumps/analyze_core_dumps.sh
+++ b/tools/ci/core-dumps/analyze_core_dumps.sh
@@ -69,11 +69,29 @@ if [[ ${#cores[@]} -eq 0 ]]; then
   exit 0
 fi
 
-binary_missing=false
 if [[ ! -f "$BINARY" ]]; then
-  echo "Warning: Memgraph binary '$BINARY' not found; stack traces will have NO SYMBOLS (addresses only)." >&2
-  binary_missing=true
+  echo "Warning: fallback binary '$BINARY' not found; any core that does not name its own executable will have NO SYMBOLS (addresses only)." >&2
 fi
+
+# A core records the path of every file mapped into the process, and the
+# executable is the first of them, so a core from a test binary symbolises as
+# well as one from memgraph, without the caller having to say which binary to
+# expect. The command line the core also records is truncated to a fixed width
+# by the kernel, so a binary sitting deep enough in the tree is unrecoverable
+# from it. Falls back to the binary passed in when the core maps no file, or
+# names one that is not present here.
+resolve_binary_for_core() {
+  local core="$1" exe
+  # gdb exits non-zero on a core it cannot read, which would otherwise take the
+  # whole run down and lose the cores not yet analysed.
+  exe="$(gdb -batch -nx -ex "info proc mappings" --core="$core" 2>/dev/null |
+    awk '$1 ~ /^0x/ { i = index($0, " /"); if (i > 0) { print substr($0, i + 1); exit } }' || true)"
+  if [[ -n "$exe" && -f "$exe" ]]; then
+    printf '%s' "$exe"
+  else
+    printf '%s' "$BINARY"
+  fi
+}
 
 mkdir -p "$OUT_DIR"
 
@@ -103,14 +121,15 @@ for core in "${cores[@]}"; do
     out="$OUT_DIR/${trace_name}_${dup}.txt"
     dup=$((dup + 1))
   done
-  echo "Analyzing $core -> $out"
+  core_binary="$(resolve_binary_for_core "$core")"
+  echo "Analyzing $core ($(basename "$core_binary")) -> $out"
   {
     echo "=== Memgraph CI core dump stack trace ==="
     echo "core:      $core"
     [[ -n "$sig" ]] && echo "signal:    $sig"
     [[ -n "$epoch" ]] && echo "crashed:   $(date -u -d "@${epoch}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "epoch ${epoch}")"
-    echo "binary:    $BINARY"
-    [[ "$binary_missing" == true ]] && echo "symbols:   MISSING — binary not found; backtrace shows addresses only, treat as unreliable"
+    echo "binary:    $core_binary"
+    [[ -f "$core_binary" ]] || echo "symbols:   MISSING — binary not found; backtrace shows addresses only, treat as unreliable"
     echo "generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "gdb:       $(gdb --version | head -n1)"
     echo "=========================================="
@@ -124,7 +143,7 @@ for core in "${cores[@]}"; do
       -ex "thread apply all bt" \
       -ex "info sharedlibrary" \
       -ex "quit" \
-      "$BINARY" "$core" 2>&1 || echo "(gdb exited non-zero while analyzing $core)"
+      "$core_binary" "$core" 2>&1 || echo "(gdb exited non-zero while analyzing $core)"
   } > "$out"
   count=$((count + 1))
 done


### PR DESCRIPTION
Every unit test runs under a time limit. A test that stops making progress is killed at that limit and named in the report, and one that legitimately needs longer declares its own limit where it is registered.

The kill uses a signal whose default action dumps core, with enough grace for the core to be written, so a hang leaves a stack to read. Core analysis resolves each core against the executable that core maps, so a core from a test binary symbolises to source lines. The binary passed on the command line stays the fallback for a core that maps nothing present.
