### PR TITLE
fix(storage): fail loud instead of starting empty on unreadable durability (#4742)

### DIFF
--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -128,7 +128,8 @@ bool ValidateDurabilityFile(std::filesystem::directory_entry const &dir_entry) {
 }
 
 std::optional<std::vector<SnapshotDurabilityInfo>> GetSnapshotFiles(const std::filesystem::path &snapshot_directory,
-                                                                    const std::string_view uuid) {
+                                                                    const std::string_view uuid,
+                                                                    std::size_t *unreadable_candidates_out) {
   std::vector<SnapshotDurabilityInfo> snapshot_files;
   if (!utils::DirExists(snapshot_directory)) {
     spdlog::error("Snapshot directory {} doesn't exist", snapshot_directory);
@@ -137,7 +138,10 @@ std::optional<std::vector<SnapshotDurabilityInfo>> GetSnapshotFiles(const std::f
 
   std::error_code error_code;
   for (const auto &item : std::filesystem::directory_iterator(snapshot_directory, error_code)) {
-    if (!ValidateDurabilityFile(item)) continue;
+    if (!ValidateDurabilityFile(item)) {
+      if (unreadable_candidates_out != nullptr && item.is_regular_file()) ++*unreadable_candidates_out;
+      continue;
+    }
 
     try {
       auto info = ReadSnapshotInfo(item.path());
@@ -148,6 +152,7 @@ std::optional<std::vector<SnapshotDurabilityInfo>> GetSnapshotFiles(const std::f
       }
     } catch (const RecoveryFailure &e) {
       spdlog::error("Couldn't read snapshot info in GetSnapshotFiles for file {}: {}", e.what(), item.path());
+      if (unreadable_candidates_out != nullptr) ++*unreadable_candidates_out;
     }
   }
   if (error_code) {
@@ -161,7 +166,8 @@ std::optional<std::vector<SnapshotDurabilityInfo>> GetSnapshotFiles(const std::f
 
 std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem::path &wal_directory,
                                                           const std::string_view uuid,
-                                                          const std::optional<size_t> current_seq_num) {
+                                                          const std::optional<size_t> current_seq_num,
+                                                          std::size_t *unreadable_candidates_out) {
   std::vector<WalDurabilityInfo> wal_files;
   if (!utils::DirExists(wal_directory)) {
     spdlog::error("WAL directory {} doesn't exist", wal_directory);
@@ -175,7 +181,10 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
   std::error_code error_code;
 
   for (const auto &item : std::filesystem::directory_iterator(wal_directory, error_code)) {
-    if (!ValidateDurabilityFile(item)) continue;
+    if (!ValidateDurabilityFile(item)) {
+      if (unreadable_candidates_out != nullptr && item.is_regular_file()) ++*unreadable_candidates_out;
+      continue;
+    }
 
     try {
       auto header = ReadWalHeader(item.path());
@@ -614,7 +623,8 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
 
   auto *const epoch_history = &repl_storage_state.history;
 
-  auto const maybe_snapshot_files = GetSnapshotFiles(snapshot_directory_);
+  std::size_t unusable_candidates = 0;
+  auto const maybe_snapshot_files = GetSnapshotFiles(snapshot_directory_, "", &unusable_candidates);
   if (!maybe_snapshot_files.has_value()) {
     throw RecoveryFailure("Couldn't recover data because of the failure to read snapshot files");
   }
@@ -684,13 +694,23 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
     if (!utils::DirExists(wal_directory_)) return std::nullopt;
 
     // The UUID isn't known yet, so every file in the directory is collected and the unrelated ones dropped below.
-    auto maybe_wal_files = GetWalFiles(wal_directory_);
+    auto maybe_wal_files = GetWalFiles(wal_directory_, "", std::nullopt, &unusable_candidates);
     if (!maybe_wal_files.has_value()) {
       throw RecoveryFailure("Couldn't recover data because of the failure to read wal files");
     }
     wal_files = std::move(*maybe_wal_files);
 
     if (wal_files.empty()) {
+      // #4742: distinguish a genuinely empty durability directory (fresh DB — correct to start empty)
+      // from one whose durability files are present but unreadable/corrupt (an existing DB whose data
+      // cannot be loaded). Starting empty in the second case silently discards data, so fail loud in the
+      // same "broken state" way the recognised-but-unrecoverable snapshot path above already does.
+      if (unusable_candidates > 0) {
+        throw RecoveryFailure(
+            "Durability files are present but none could be read; refusing to start with an empty database "
+            "and discard existing data. The database is now in the broken state. Please inspect the "
+            "snapshot and WAL files and restart.");
+      }
       spdlog::warn(utils::MessageWithLink("No snapshot or WAL file found.", "https://memgr.ph/durability"));
       return std::nullopt;
     }

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -186,18 +186,24 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
       continue;
     }
 
+    WalHeader header{};
     try {
-      auto header = ReadWalHeader(item.path());
-      if ((!uuid.empty() && header.uuid != uuid) || (current_seq_num && header.seq_num >= *current_seq_num)) {
-        spdlog::trace("Wal file {} won't be used. UUID: {}. Header UUID: {}. Current seq num: {}. Header seq num: {}.",
-                      item.path(),
-                      uuid,
-                      header.uuid,
-                      current_seq_num,
-                      header.seq_num);
-        continue;
-      }
-
+      header = ReadWalHeader(item.path());
+    } catch (const RecoveryFailure &e) {
+      if (unreadable_candidates_out != nullptr) ++*unreadable_candidates_out;
+      spdlog::warn("Failed to read WAL header for {}. Error: {}", item.path(), e.what());
+      continue;
+    }
+    if ((!uuid.empty() && header.uuid != uuid) || (current_seq_num && header.seq_num >= *current_seq_num)) {
+      spdlog::trace("Wal file {} won't be used. UUID: {}. Header UUID: {}. Current seq num: {}. Header seq num: {}.",
+                    item.path(),
+                    uuid,
+                    header.uuid,
+                    current_seq_num,
+                    header.seq_num);
+      continue;
+    }
+    try {
       // A file holding no complete transaction has no timestamps to offer, and ReadWalContents throwing for it is
       // how it gets dropped here.
       auto info = ReadWalContents(item.path(), std::move(header));
@@ -691,7 +697,18 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
   } else {
     // UUID couldn't be recovered from the snapshot; recovering it from WALs
     spdlog::info("No snapshot file was found, collecting information from WAL directory {}.", wal_directory_);
-    if (!utils::DirExists(wal_directory_)) return std::nullopt;
+    constexpr const char *kBrokenDurabilityMsg =
+        "Durability files are present but none could be read; refusing to start with an empty database "
+        "and discard existing data. The database is now in the broken state. Please inspect the "
+        "snapshot and WAL files and restart.";
+    // If the snapshot scan found unreadable candidates, a missing WAL directory must not silently
+    // start empty — the corrupt-snapshot signal would be discarded by the early return.
+    if (!utils::DirExists(wal_directory_)) {
+      if (unusable_candidates > 0) {
+        throw RecoveryFailure(kBrokenDurabilityMsg);
+      }
+      return std::nullopt;
+    }
 
     // The UUID isn't known yet, so every file in the directory is collected and the unrelated ones dropped below.
     auto maybe_wal_files = GetWalFiles(wal_directory_, "", std::nullopt, &unusable_candidates);
@@ -701,15 +718,10 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
     wal_files = std::move(*maybe_wal_files);
 
     if (wal_files.empty()) {
-      // #4742: distinguish a genuinely empty durability directory (fresh DB — correct to start empty)
-      // from one whose durability files are present but unreadable/corrupt (an existing DB whose data
-      // cannot be loaded). Starting empty in the second case silently discards data, so fail loud in the
-      // same "broken state" way the recognised-but-unrecoverable snapshot path above already does.
+      // Non-zero unusable_candidates means durability files exist but are unreadable (not a fresh DB):
+      // starting empty would silently discard data, so fail loud instead.
       if (unusable_candidates > 0) {
-        throw RecoveryFailure(
-            "Durability files are present but none could be read; refusing to start with an empty database "
-            "and discard existing data. The database is now in the broken state. Please inspect the "
-            "snapshot and WAL files and restart.");
+        throw RecoveryFailure(kBrokenDurabilityMsg);
       }
       spdlog::warn(utils::MessageWithLink("No snapshot or WAL file found.", "https://memgr.ph/durability"));
       return std::nullopt;

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -58,9 +58,13 @@ struct SnapshotDurabilityInfo {
 /// @param uuid UUID of the Snapshot files. If not empty, fetch only Snapshot
 /// file with the specified UUID. Otherwise, fetch only Snapshot files in the
 /// snapshot_directory.
+/// @param unreadable_candidates_out If non-null, incremented for each regular file that could not be
+/// read/decoded as a valid durability file (used by RecoverData to distinguish an empty directory
+/// from one whose durability files are present but unusable).
 /// @return List of snapshot files defined with its path and UUID.
 std::optional<std::vector<SnapshotDurabilityInfo>> GetSnapshotFiles(const std::filesystem::path &snapshot_directory,
-                                                                    std::string_view uuid = "");
+                                                                    std::string_view uuid = "",
+                                                                    std::size_t *unreadable_candidates_out = nullptr);
 
 /// Used to capture a WAL's data related to durability
 struct WalDurabilityInfo {
@@ -91,11 +95,15 @@ struct WalDurabilityInfo {
 /// @param current_seq_num Sequence number of the WAL file which is currently
 /// being written. If specified, load only finalized WAL files, i.e. WAL files
 /// with seq_num < current_seq_num.
+/// @param unreadable_candidates_out If non-null, incremented for each regular file that could not be
+/// read/decoded as a valid durability file (used by RecoverData to distinguish an empty directory
+/// from one whose durability files are present but unusable).
 /// @return List of WAL files. Each WAL file is defined with its sequence
 /// number, from timestamp, to timestamp and path.
 std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem::path &wal_directory,
                                                           std::string_view uuid = "",
-                                                          std::optional<size_t> current_seq_num = {});
+                                                          std::optional<size_t> current_seq_num = {},
+                                                          std::size_t *unreadable_candidates_out = nullptr);
 
 bool ValidateDurabilityFile(std::filesystem::directory_entry const &dir_entry);
 

--- a/tests/unit/storage_v2_recover_snapshot.cpp
+++ b/tests/unit/storage_v2_recover_snapshot.cpp
@@ -574,3 +574,62 @@ TEST_F(RecoverSnapshotTest, EmptyDurabilityDirectoriesStartFreshWithoutError) {
     EXPECT_EQ(count, 0) << "A fresh database started from empty dirs must have zero vertices";
   });
 }
+
+// Positive regression guard for #4742: the fail-loud predicate must be gated on wal_files.empty(),
+// not on unusable_candidates>0 alone. A corrupt snapshot raises unusable_candidates, but a valid
+// WAL chain must still drive a full recovery — no RecoveryFailure, all committed vertices visible.
+TEST_F(RecoverSnapshotTest, CorruptSnapshotWithValidWalStillRecoversFromWal) {
+  // Phase 1: commit all vertices BEFORE the snapshot so the WAL chain from seq 0 holds every
+  // create delta. WAL-only replay then reconstructs the full dataset even without the snapshot.
+  {
+    memgraph::dbms::Database db{config_};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+    {
+      auto acc = storage->Access(memgraph::storage::WRITE);
+      acc->CreateVertex();
+      acc->CreateVertex();
+      acc->CreateVertex();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    auto snapshot_result = storage->CreateSnapshot();
+    ASSERT_TRUE(snapshot_result.has_value());
+  }
+
+  auto const snapshots_dir = config_.durability.storage_directory / memgraph::storage::durability::kSnapshotDirectory;
+
+  // Corrupt each snapshot: a readable regular file passes ValidateDurabilityFile (no magic/CRC check)
+  // but fails ReadSnapshotInfo, counting it as an unusable candidate — this is the state under test.
+  // WAL files are deliberately left intact so WAL-only recovery can proceed.
+  int corrupted_count = 0;
+  if (std::filesystem::exists(snapshots_dir)) {
+    for (const auto &entry : std::filesystem::directory_iterator(snapshots_dir)) {
+      if (entry.is_regular_file()) {
+        std::ofstream f{entry.path(), std::ios::out | std::ios::trunc};
+        f << "CORRUPTED-NOT-A-VALID-DURABILITY-MAGIC";
+        ++corrupted_count;
+      }
+    }
+  }
+  ASSERT_GT(corrupted_count, 0) << "Expected at least one snapshot file to have been created and corrupted";
+
+  // Phase 3: startup recovery must not throw and must replay all 3 vertices from the WAL chain.
+  auto recover_cfg = config_;
+  recover_cfg.durability.recover_on_startup = true;
+
+  EXPECT_NO_THROW({
+    memgraph::dbms::Database db2{recover_cfg};
+    const memgraph::memory::DbArenaScope arena_scope2{&db2.Arena()};
+    auto *storage2 = static_cast<memgraph::storage::InMemoryStorage *>(db2.storage());
+
+    auto acc = storage2->Access(memgraph::storage::READ);
+    auto vertices = acc->Vertices(memgraph::storage::View::OLD);
+    int count = 0;
+    for ([[maybe_unused]] const auto &v : vertices) {
+      ++count;
+    }
+    EXPECT_EQ(count, 3) << "WAL-only recovery must restore all 3 committed vertices";
+  });
+}

--- a/tests/unit/storage_v2_recover_snapshot.cpp
+++ b/tests/unit/storage_v2_recover_snapshot.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include <filesystem>
+#include <fstream>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -18,6 +19,7 @@
 #include "memory/db_arena.hpp"
 #include "replication/state.hpp"
 #include "storage/v2/config.hpp"
+#include "storage/v2/durability/exceptions.hpp"
 #include "storage/v2/durability/paths.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "tests/test_commit_args_helper.hpp"
@@ -433,4 +435,106 @@ TEST_F(RecoverSnapshotTest, RecoverSnapshotWithWALs) {
     }
     ASSERT_GT(current_wals.size(), 0) << "Should have exactly one WAL file after recovery";
   }
+}
+
+// Regression test for GitHub issue #4742.
+//
+// Before the fix, RecoverData would silently start the database with an empty
+// dataset when all snapshot candidates were corrupt and no WAL files were
+// present.  The fix makes RecoverData throw RecoveryFailure in that case so
+// data is not silently discarded.
+//
+// The corrupted file is a readable regular file filled with garbage text, so
+// it passes ValidateDurabilityFile (readable + is_regular_file) but causes
+// ReadSnapshotInfo to throw RecoveryFailure, which GetSnapshotFiles counts as
+// unusable_candidates.  With no WAL files to fall back on, RecoverData must
+// fail loud instead of returning nullopt.
+TEST_F(RecoverSnapshotTest, CorruptSnapshotWithNoWalFailsRecoveryInsteadOfStartingEmpty) {
+  // Phase 1: create data + a snapshot, then let the database go out of scope
+  // so all WAL and snapshot files are flushed and closed before we tamper.
+  {
+    memgraph::dbms::Database db{config_};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+    {
+      auto acc = storage->Access(memgraph::storage::WRITE);
+      acc->CreateVertex();
+      acc->CreateVertex();
+      acc->CreateVertex();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    auto snapshot_result = storage->CreateSnapshot();
+    ASSERT_TRUE(snapshot_result.has_value());
+  }  // db and arena_scope destroyed here; WAL file is finalized and closed.
+
+  auto const snapshots_dir = config_.durability.storage_directory / memgraph::storage::durability::kSnapshotDirectory;
+  auto const wal_dir = config_.durability.storage_directory / memgraph::storage::durability::kWalDirectory;
+
+  // Phase 2: overwrite every snapshot file with garbage text.  The file
+  // remains a readable regular file (passes ValidateDurabilityFile) but
+  // ReadSnapshotInfo will throw RecoveryFailure on the bogus content, making
+  // GetSnapshotFiles count it as an unusable candidate.
+  int corrupted_count = 0;
+  if (std::filesystem::exists(snapshots_dir)) {
+    for (const auto &entry : std::filesystem::directory_iterator(snapshots_dir)) {
+      if (entry.is_regular_file()) {
+        std::ofstream f{entry.path(), std::ios::out | std::ios::trunc};
+        f << "CORRUPTED-NOT-A-VALID-DURABILITY-MAGIC";
+        ++corrupted_count;
+      }
+    }
+  }
+  ASSERT_GT(corrupted_count, 0) << "Expected at least one snapshot file to have been created and corrupted";
+
+  // Phase 3: remove all WAL regular files so wal_files is empty at recovery
+  // time.  The WAL directory itself is kept; if it did not exist, the else
+  // branch in RecoverData would return nullopt early (line 694) before
+  // reaching the unusable_candidates check.
+  if (std::filesystem::exists(wal_dir)) {
+    for (const auto &entry : std::filesystem::directory_iterator(wal_dir)) {
+      if (entry.is_regular_file()) {
+        std::filesystem::remove(entry.path());
+      }
+    }
+  }
+
+  // Phase 4: attempt recovery.  allow_recovery_failure is false by default,
+  // so the exception propagates unchanged from RecoverData through
+  // InMemoryStorage and Database constructors.
+  auto recover_cfg = config_;
+  recover_cfg.durability.recover_on_startup = true;
+
+  // RecoveryFailure is defined in src/storage/v2/durability/exceptions.hpp and
+  // propagates via InMemoryStorage::ctor (throw; at line ~423 of storage.cpp)
+  // when allow_recovery_failure=false.
+  EXPECT_THROW({ memgraph::dbms::Database db2{recover_cfg}; }, memgraph::storage::durability::RecoveryFailure);
+}
+
+// Control case for issue #4742: a genuinely empty durability directory (no
+// snapshot or WAL files at all) must not trigger the new failure path.
+// RecoverData returns nullopt when neither directory contains any files, and
+// the database starts fresh with zero vertices.
+TEST_F(RecoverSnapshotTest, EmptyDurabilityDirectoriesStartFreshWithoutError) {
+  // No data is created; the storage constructor will create both directories
+  // (EnsureDirOrDie at line ~345 of storage.cpp) before calling RecoverData.
+  // RecoverData finds them empty, unusable_candidates stays 0, and returns
+  // nullopt — fresh start, no exception.
+  auto recover_cfg = config_;
+  recover_cfg.durability.recover_on_startup = true;
+
+  EXPECT_NO_THROW({
+    memgraph::dbms::Database db{recover_cfg};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+    auto acc = storage->Access(memgraph::storage::READ);
+    auto vertices = acc->Vertices(memgraph::storage::View::OLD);
+    int count = 0;
+    for ([[maybe_unused]] const auto &v : vertices) {
+      ++count;
+    }
+    EXPECT_EQ(count, 0) << "A fresh database started from empty dirs must have zero vertices";
+  });
 }

--- a/tests/unit/storage_v2_recover_snapshot.cpp
+++ b/tests/unit/storage_v2_recover_snapshot.cpp
@@ -437,18 +437,8 @@ TEST_F(RecoverSnapshotTest, RecoverSnapshotWithWALs) {
   }
 }
 
-// Regression test for GitHub issue #4742.
-//
-// Before the fix, RecoverData would silently start the database with an empty
-// dataset when all snapshot candidates were corrupt and no WAL files were
-// present.  The fix makes RecoverData throw RecoveryFailure in that case so
-// data is not silently discarded.
-//
-// The corrupted file is a readable regular file filled with garbage text, so
-// it passes ValidateDurabilityFile (readable + is_regular_file) but causes
-// ReadSnapshotInfo to throw RecoveryFailure, which GetSnapshotFiles counts as
-// unusable_candidates.  With no WAL files to fall back on, RecoverData must
-// fail loud instead of returning nullopt.
+// Regression test for #4742 (corrupt-snapshot + no-WAL path): ValidateDurabilityFile passes a garbage
+// file (readable regular file; no magic/CRC check); ReadSnapshotInfo throws → unusable_candidates → RecoveryFailure.
 TEST_F(RecoverSnapshotTest, CorruptSnapshotWithNoWalFailsRecoveryInsteadOfStartingEmpty) {
   // Phase 1: create data + a snapshot, then let the database go out of scope
   // so all WAL and snapshot files are flushed and closed before we tamper.
@@ -467,15 +457,13 @@ TEST_F(RecoverSnapshotTest, CorruptSnapshotWithNoWalFailsRecoveryInsteadOfStarti
 
     auto snapshot_result = storage->CreateSnapshot();
     ASSERT_TRUE(snapshot_result.has_value());
-  }  // db and arena_scope destroyed here; WAL file is finalized and closed.
+  }
 
   auto const snapshots_dir = config_.durability.storage_directory / memgraph::storage::durability::kSnapshotDirectory;
   auto const wal_dir = config_.durability.storage_directory / memgraph::storage::durability::kWalDirectory;
 
-  // Phase 2: overwrite every snapshot file with garbage text.  The file
-  // remains a readable regular file (passes ValidateDurabilityFile) but
-  // ReadSnapshotInfo will throw RecoveryFailure on the bogus content, making
-  // GetSnapshotFiles count it as an unusable candidate.
+  // Corrupt each snapshot: a readable regular file passes ValidateDurabilityFile (no magic/CRC check)
+  // but fails ReadSnapshotInfo, counting it as an unusable candidate in GetSnapshotFiles.
   int corrupted_count = 0;
   if (std::filesystem::exists(snapshots_dir)) {
     for (const auto &entry : std::filesystem::directory_iterator(snapshots_dir)) {
@@ -488,10 +476,8 @@ TEST_F(RecoverSnapshotTest, CorruptSnapshotWithNoWalFailsRecoveryInsteadOfStarti
   }
   ASSERT_GT(corrupted_count, 0) << "Expected at least one snapshot file to have been created and corrupted";
 
-  // Phase 3: remove all WAL regular files so wal_files is empty at recovery
-  // time.  The WAL directory itself is kept; if it did not exist, the else
-  // branch in RecoverData would return nullopt early (line 694) before
-  // reaching the unusable_candidates check.
+  // Delete (not corrupt) WAL files so the WAL scan adds zero to unusable_candidates, keeping the snapshot path as the
+  // sole trigger.
   if (std::filesystem::exists(wal_dir)) {
     for (const auto &entry : std::filesystem::directory_iterator(wal_dir)) {
       if (entry.is_regular_file()) {
@@ -500,27 +486,77 @@ TEST_F(RecoverSnapshotTest, CorruptSnapshotWithNoWalFailsRecoveryInsteadOfStarti
     }
   }
 
-  // Phase 4: attempt recovery.  allow_recovery_failure is false by default,
-  // so the exception propagates unchanged from RecoverData through
-  // InMemoryStorage and Database constructors.
+  // allow_recovery_failure=false (default) propagates the RecoveryFailure through the constructors.
   auto recover_cfg = config_;
   recover_cfg.durability.recover_on_startup = true;
 
-  // RecoveryFailure is defined in src/storage/v2/durability/exceptions.hpp and
-  // propagates via InMemoryStorage::ctor (throw; at line ~423 of storage.cpp)
-  // when allow_recovery_failure=false.
   EXPECT_THROW({ memgraph::dbms::Database db2{recover_cfg}; }, memgraph::storage::durability::RecoveryFailure);
 }
 
-// Control case for issue #4742: a genuinely empty durability directory (no
-// snapshot or WAL files at all) must not trigger the new failure path.
-// RecoverData returns nullopt when neither directory contains any files, and
-// the database starts fresh with zero vertices.
+// Regression test for #4742 — WAL-corruption half. Same ValidateDurabilityFile mechanism as the snapshot
+// test: garbage WAL passes the gate (no magic/CRC check); ReadWalHeader throws → unusable_candidates → RecoveryFailure.
+TEST_F(RecoverSnapshotTest, CorruptWalWithNoSnapshotFailsRecoveryInsteadOfStartingEmpty) {
+  // Phase 1: create data + a snapshot, then let the database go out of scope
+  // so all WAL and snapshot files are flushed and closed before we tamper.
+  {
+    memgraph::dbms::Database db{config_};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+    {
+      auto acc = storage->Access(memgraph::storage::WRITE);
+      acc->CreateVertex();
+      acc->CreateVertex();
+      acc->CreateVertex();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    auto snapshot_result = storage->CreateSnapshot();
+    ASSERT_TRUE(snapshot_result.has_value());
+  }
+
+  auto const snapshots_dir = config_.durability.storage_directory / memgraph::storage::durability::kSnapshotDirectory;
+  auto const wal_dir = config_.durability.storage_directory / memgraph::storage::durability::kWalDirectory;
+
+  // Delete (not corrupt) snapshots so the snapshot scan contributes zero to unusable_candidates, isolating
+  // the WAL path as the sole source of the corrupt-file signal that triggers RecoveryFailure.
+  int deleted_count = 0;
+  if (std::filesystem::exists(snapshots_dir)) {
+    for (const auto &entry : std::filesystem::directory_iterator(snapshots_dir)) {
+      if (entry.is_regular_file()) {
+        std::filesystem::remove(entry.path());
+        ++deleted_count;
+      }
+    }
+  }
+  ASSERT_GT(deleted_count, 0) << "Expected at least one snapshot file to have been created and deleted";
+
+  // Corrupt each WAL: a readable regular file passes ValidateDurabilityFile (no magic/CRC check)
+  // but fails ReadWalHeader, counting it as an unusable candidate in GetWalFiles.
+  int corrupted_count = 0;
+  if (std::filesystem::exists(wal_dir)) {
+    for (const auto &entry : std::filesystem::directory_iterator(wal_dir)) {
+      if (entry.is_regular_file()) {
+        std::ofstream f{entry.path(), std::ios::out | std::ios::trunc};
+        f << "CORRUPTED-NOT-A-VALID-DURABILITY-MAGIC";
+        ++corrupted_count;
+      }
+    }
+  }
+  ASSERT_GT(corrupted_count, 0) << "Expected at least one WAL file to have been created and corrupted";
+
+  // allow_recovery_failure=false (default) propagates the RecoveryFailure through the constructors.
+  auto recover_cfg = config_;
+  recover_cfg.durability.recover_on_startup = true;
+
+  EXPECT_THROW({ memgraph::dbms::Database db2{recover_cfg}; }, memgraph::storage::durability::RecoveryFailure);
+}
+
+// Control case for #4742: genuinely empty durability directories must not trigger the failure path.
+// RecoverData finds no files, unusable_candidates stays 0, and returns nullopt — fresh start, no exception.
 TEST_F(RecoverSnapshotTest, EmptyDurabilityDirectoriesStartFreshWithoutError) {
-  // No data is created; the storage constructor will create both directories
-  // (EnsureDirOrDie at line ~345 of storage.cpp) before calling RecoverData.
-  // RecoverData finds them empty, unusable_candidates stays 0, and returns
-  // nullopt — fresh start, no exception.
+  // The storage constructor creates both directories (EnsureDirOrDie) before calling RecoverData, which finds them
+  // empty.
   auto recover_cfg = config_;
   recover_cfg.durability.recover_on_startup = true;
 


### PR DESCRIPTION
## Problem

Closes #4742.

On recovery, `RecoverData` starts a database **empty** when it finds no usable snapshot and no usable WAL. But `GetSnapshotFiles`/`GetWalFiles` return an empty list for **two indistinguishable cases**:

- the directory was genuinely empty — a fresh DB, correct to start empty; **and**
- durability files were present but **unreadable/corrupt** and got silently dropped — an existing DB whose data cannot be loaded.

`RecoverData` couldn't tell them apart, so a corrupt-durability database came up **empty and served** — silent data loss, with a log line (`No snapshot or WAL file found`) that reads exactly like a fresh install.

## Fix

Make the two cases distinguishable and fail loud on the dangerous one:

- `GetSnapshotFiles` / `GetWalFiles` gain an optional out-param that **counts unreadable/corrupt candidates**.
- `RecoverData`, at the point it would start empty, now **throws `RecoveryFailure`** (broken state) if any such candidate was present — reusing the existing recognised-but-unrecoverable-snapshot mechanism. If the count is 0 (nothing there), it starts fresh, exactly as before.

**Unambiguous data-at-risk signals** that are counted:
- a durability file that cannot be **read** (`ValidateDurabilityFile` fails on a regular file),
- a **snapshot whose contents cannot be decoded** (`ReadSnapshotInfo` throws), and
- a **WAL whose header cannot be decoded** (`ReadWalHeader` throws — bad magic/version). `ValidateDurabilityFile` only checks that a file is a readable regular file — it does **not** validate magic/CRC — so header corruption surfaces here, not there, and must be counted here.

**WAL *content*-parse failures (`ReadWalContents`) are intentionally not counted.** An empty or partially-written first-boot WAL (`num_deltas == 0`) throws the *same* `RecoveryFailure` as genuine corruption, so counting it would falsely fail legitimate fresh boots. The residual gap is therefore narrow and deliberate: a WAL-only DB whose WAL **body** is corrupt behind an otherwise-valid header, with **no** snapshot — indistinguishable from a legitimate first-boot partial WAL, so left out for the same first-boot-safety reason.

A **missing WAL directory** also fails loud now: if the snapshot scan already flagged unreadable candidates, `RecoverData` throws instead of short-circuiting to an empty start (which would silently discard that signal).