### PR TITLE
refactor(includes): include what these files name and drop the rest

### DIFF
--- a/src/csv/include/csv/parsing.cppm
+++ b/src/csv/include/csv/parsing.cppm
@@ -19,6 +19,7 @@
 module;
 
 #include <cstdint>
+#include <expected>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -90,6 +91,7 @@ static_assert(Streamable<StreamCsvSource>);
 class CsvSource {
  public:
   static auto Create(std::string csv_location, std::optional<utils::S3Config> s3_cfg) -> CsvSource;
+
   template <Streamable T>
   explicit CsvSource(T source) : source_{std::move(source)} {}
 
@@ -103,6 +105,7 @@ class Reader {
  public:
   struct Config {
     Config() = default;
+
     Config(const bool with_header, const bool ignore_bad, std::optional<utils::pmr::string> delim,
            std::optional<utils::pmr::string> qt)
         : with_header(with_header), ignore_bad(ignore_bad), delimiter(std::move(delim)), quote(std::move(qt)) {
@@ -132,6 +135,7 @@ class Reader {
 
   struct ParseError {
     enum class ErrorCode : uint8_t { BAD_HEADER, NO_CLOSING_QUOTE, UNEXPECTED_TOKEN, BAD_NUM_OF_COLUMNS, NULL_BYTE };
+
     ParseError(ErrorCode code, std::string message) : code(code), message(std::move(message)) {}
 
     ErrorCode code;

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -18,7 +18,8 @@
 #include <string>
 
 #include "memory/db_arena_fwd.hpp"
-#include "query/cypher_query_interpreter.hpp"
+#include "metrics/prometheus_metrics.hpp"
+#include "query/plan_cache.hpp"
 #include "storage/v2/access_type.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/database_protector.hpp"
@@ -170,11 +171,6 @@ class Database {
    */
   void AddTask(utils::ThreadPool::TaskSignature new_task) { after_commit_trigger_pool_.AddTask(std::move(new_task)); }
 
-  /**
-   * @brief Returns the PlanCache vector raw pointer
-   *
-   * @return utils::Synchronized<utils::LRUCache<uint64_t, std::shared_ptr<PlanWrapper>>, utils::RWSpinLock>
-   */
   query::PlanCacheLRU *plan_cache() { return &plan_cache_; }
 
   storage::ttl::TTL &ttl();

--- a/src/flags/coord_flag_env_handler.cpp
+++ b/src/flags/coord_flag_env_handler.cpp
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
-#include <format>
 #include <functional>
 #include <meta/meta.hpp>
 #include <optional>

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include "general.hpp"
+#include "flags/query_modules_directory.hpp"
 
 #include <gflags/gflags.h>
 #include <algorithm>

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -11,8 +11,7 @@
 
 #pragma once
 
-#include <filesystem>
-#include <vector>
+#include <optional>
 
 #include "gflags/gflags.h"
 
@@ -141,10 +140,6 @@ DECLARE_string(pulsar_service_url);
 DECLARE_string(query_modules_directory);
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_string(query_callable_mappings_path);
-
-namespace memgraph::flags {
-auto ParseQueryModulesDirectory() -> std::vector<std::filesystem::path>;
-}  // namespace memgraph::flags
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_string(license_key);

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <filesystem>
-#include <format>
 #include <vector>
 
 #include "gflags/gflags.h"

--- a/src/flags/query_modules_directory.hpp
+++ b/src/flags/query_modules_directory.hpp
@@ -1,0 +1,25 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+// Kept apart from the other flag declarations because it is the only one whose
+// type needs <filesystem>, and that header reaches <format> through <ostream>,
+// which is expensive enough to be worth keeping out of a header this widely
+// included.
+
+#include <filesystem>
+#include <vector>
+
+namespace memgraph::flags {
+// The --query-modules-directory flag split into its individual paths.
+auto ParseQueryModulesDirectory() -> std::vector<std::filesystem::path>;
+}  // namespace memgraph::flags

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -39,6 +39,7 @@
 #include "flags/experimental.hpp"
 #include "flags/general.hpp"
 #include "flags/logging.hpp"
+#include "flags/query_modules_directory.hpp"
 #include "glue/MonitoringServerT.hpp"
 #include "glue/PrometheusServerT.hpp"
 #include "glue/ServerT.hpp"

--- a/src/query/interpret/awesome_memgraph_functions.hpp
+++ b/src/query/interpret/awesome_memgraph_functions.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 #include "query/procedure/module_fwd.hpp"

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -21,6 +21,7 @@
 #include "flags/run_time_configurable.hpp"
 #include "memory/db_arena_fwd.hpp"
 #include "query/context.hpp"
+#include "query/cypher_query_interpreter.hpp"
 #include "query/db_accessor.hpp"
 #include "query/plan_v2/frontend/query_planner_context.hpp"
 #include "query/stream.hpp"

--- a/src/query/plan_cache.hpp
+++ b/src/query/plan_cache.hpp
@@ -1,0 +1,39 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+// The plan cache's type, apart from the plan it holds. Naming the cache costs a
+// caller the key type and the containers; naming the plan costs it the planner,
+// the syntax tree and the symbol table as well. Whoever holds a cache needs the
+// first and not the second.
+
+#include <memory>
+
+#include "query/frontend/stripped.hpp"
+#include "utils/lru_cache.hpp"
+#include "utils/rw_spin_lock.hpp"
+#include "utils/synchronized.hpp"
+
+namespace memgraph::query {
+
+// Defined where plans are built. A holder of the cache only ever moves these
+// around by pointer, so it does not need the definition.
+class PlanWrapper;
+
+// Declared identically where plans are built, so that a file needing the plan
+// as well does not have to include this too. Naming the same type twice is
+// allowed; the two must be changed together.
+
+using PlanCache_t = utils::LRUCache<frontend::HashedString, std::shared_ptr<PlanWrapper>>;
+using PlanCacheLRU = utils::Synchronized<PlanCache_t, utils::RWSpinLock>;
+
+}  // namespace memgraph::query

--- a/src/query/query_user.hpp
+++ b/src/query/query_user.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <format>
 #include <memory>
 #include <optional>
 #include <string>

--- a/src/storage/v2/enum_store.hpp
+++ b/src/storage/v2/enum_store.hpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <expected>
 #include <map>
 #include <ranges>
 #include <string>

--- a/src/utils/shared_quota.hpp
+++ b/src/utils/shared_quota.hpp
@@ -15,7 +15,6 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
-#include <format>
 #include <functional>
 #include <memory>
 #include <optional>

--- a/src/utils/system_info.hpp
+++ b/src/utils/system_info.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <cstdint>
-#include <format>
 #include <nlohmann/json_fwd.hpp>
 #include <string>
 #include <unordered_set>

--- a/src/utils/temporal.hpp
+++ b/src/utils/temporal.hpp
@@ -16,6 +16,7 @@
 #include <ctime>
 #include <iosfwd>
 #include <limits>
+#include <variant>
 
 #include "utils/exceptions.hpp"
 import memgraph.utils.fnv;

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -29,6 +29,7 @@
 #include "tests/test_commit_args_helper.hpp"
 #include "tests/unit/ddl_abort_helpers.hpp"
 
+#include "query/exceptions.hpp"
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
 


### PR DESCRIPTION
Four files name a standard type without including the header that declares it, and compile only because a logging header brings that header along. Each now includes what it names. Five files include `<format>` without naming anything from it, and no longer do.

Two widely included headers no longer carry a dependency their users do not need. The one flag accessor whose type needs `<filesystem>` moves to a header of its own, included by its two users, so the general flag declarations no longer reach that header from every file that reads a flag. The plan cache's type is declared apart from the plans it holds, so a file that holds a cache pays for the key type and the containers, and not for the planner, the syntax tree or the symbol table.
