### PR TITLE
fix(stress): log resume failures and stop skipping tenants silently

### DIFF
--- a/tests/stress/hot_cold_common.py
+++ b/tests/stress/hot_cold_common.py
@@ -102,8 +102,19 @@ def run_query(session, query: str, **params) -> list[dict]:
     return data
 
 
+class ResumeTimeout(RuntimeError):
+    """A tenant did not come HOT within its timeout.
+
+    Carries the last RESUME error for diagnostics. Terminal by construction: the embedded
+    server text holds transitional markers, so classifying it by substring would send the
+    caller back for another full timeout.
+    """
+
+
 def is_transient(exc: Exception) -> bool:
     """Return True if the exception is an expected hot/cold transient error."""
+    if isinstance(exc, ResumeTimeout):
+        return False
     msg = str(exc).lower()
     return any(marker.lower() in msg for marker in TRANSITIONAL_MARKERS)
 
@@ -154,13 +165,17 @@ def resume_tenant_blocking(endpoint: str, username: str, password: str, name: st
     """
     deadline = time.monotonic() + timeout
     drv = make_driver(endpoint, username, password)
+    last_resume_error = None
+    last_probe_error = None
     try:
         while time.monotonic() < deadline:
             try:
                 with drv.session() as sess:
                     run_query(sess, f"RESUME DATABASE {name}")
-            except Exception:
-                pass  # already HOT, or transient failure — detect below
+            except Exception as exc:
+                # Already HOT, or a transient failure; the USE probe below decides which. Kept so
+                # a timeout can report why RESUME was refused.
+                last_resume_error = exc
 
             try:
                 with drv.session() as sess:
@@ -169,10 +184,14 @@ def resume_tenant_blocking(endpoint: str, username: str, password: str, name: st
                 return
             except Exception as exc:
                 if is_transient(exc):
+                    last_probe_error = exc
                     time.sleep(0.2)
                     continue
                 raise
-        raise RuntimeError(f"Tenant {name} did not come HOT within {timeout}s")
+        raise ResumeTimeout(
+            f"Tenant {name} did not come HOT within {timeout}s; "
+            f"last RESUME error: {last_resume_error}; last USE probe error: {last_probe_error}"
+        )
     finally:
         drv.close()
 

--- a/tests/stress/standalone/native/workloads/hot_cold_indexes/workload.py
+++ b/tests/stress/standalone/native/workloads/hot_cold_indexes/workload.py
@@ -644,19 +644,29 @@ def main() -> None:
         try:
             # Resume with bounded retry in case RESUME transiently fails.
             resumed = False
+            reported = False
+            last_exc = None
             for _attempt in range(MAX_RETRIES):
                 try:
                     resume_tenant_blocking(endpoint, username, password, tname, timeout=90.0)
                     resumed = True
                     break
                 except Exception as exc:
+                    last_exc = exc
                     if is_transient(exc):
                         time.sleep(RETRY_SLEEP)
                         continue
                     mismatches.append((tname, "resume", f"resume failed: {exc}"))
+                    reported = True
                     break
 
             if not resumed:
+                # Exhausting the retries leaves this tenant unverified, which the summary has to
+                # report as a failure rather than pass over.
+                if not reported:
+                    mismatches.append(
+                        (tname, "resume", f"resume did not succeed within {MAX_RETRIES} retries: {last_exc}")
+                    )
                 continue
 
             drv_verify = make_driver(endpoint, username, password)

--- a/tests/stress/standalone/native/workloads/hot_cold_oom/workload.py
+++ b/tests/stress/standalone/native/workloads/hot_cold_oom/workload.py
@@ -838,19 +838,29 @@ def main() -> None:
             # were suspended above (and will be re-suspended in the finally block
             # after counting so the next iteration also has the full budget).
             resumed = False
+            reported = False
+            last_exc = None
             for _attempt in range(MAX_RETRIES):
                 try:
                     resume_tenant_blocking(endpoint, username, password, tname, timeout=90.0)
                     resumed = True
                     break
                 except Exception as exc:
+                    last_exc = exc
                     if is_transient(exc):
                         time.sleep(RETRY_SLEEP)
                         continue
                     mismatches.append((tname, -1, expected[tname], f"resume failed: {exc}"))
+                    reported = True
                     break
 
             if not resumed:
+                # Exhausting the retries leaves this tenant unverified, which the summary has to
+                # report as a failure rather than pass over.
+                if not reported:
+                    mismatches.append(
+                        (tname, -1, expected[tname], f"resume did not succeed within {MAX_RETRIES} retries: {last_exc}")
+                    )
                 continue
 
             try:

--- a/tests/stress/standalone/native/workloads/hot_cold_triggers/workload.py
+++ b/tests/stress/standalone/native/workloads/hot_cold_triggers/workload.py
@@ -465,19 +465,29 @@ def main() -> None:
         resumed = False
 
         # Resume with bounded retry (tolerates transient errors).
+        reported = False
+        last_exc = None
         for _attempt in range(MAX_RETRIES):
             try:
                 resume_tenant_blocking(endpoint, username, password, tname, timeout=90.0)
                 resumed = True
                 break
             except Exception as exc:
+                last_exc = exc
                 if is_transient(exc):
                     time.sleep(RETRY_SLEEP)
                     continue
                 mismatches.append((tname, -1, expected[tname], f"resume failed: {exc}"))
+                reported = True
                 break
 
         if not resumed:
+            # Exhausting the retries leaves this tenant unverified, which the summary has to
+            # report as a failure rather than pass over.
+            if not reported:
+                mismatches.append(
+                    (tname, -1, expected[tname], f"resume did not succeed within {MAX_RETRIES} retries: {last_exc}")
+                )
             # Re-suspend best-effort before next iteration.
             suspend_tenant(endpoint, username, password, tname)
             continue

--- a/tests/stress/standalone/native/workloads/hot_cold_ttl/workload.py
+++ b/tests/stress/standalone/native/workloads/hot_cold_ttl/workload.py
@@ -780,19 +780,34 @@ def main() -> None:
         resumed = False
         try:
             # Step A: resume the tenant HOT (bounded retry).
+            reported = False
+            last_exc = None
             for _attempt in range(MAX_RETRIES):
                 try:
                     resume_tenant_blocking(endpoint, username, password, tname, timeout=90.0)
                     resumed = True
                     break
                 except Exception as exc:
+                    last_exc = exc
                     if is_transient(exc):
                         time.sleep(RETRY_SLEEP)
                         continue
                     mismatches.append((tname, -1, expected_perm[tname], f"resume failed: {exc}"))
+                    reported = True
                     break
 
             if not resumed:
+                # Exhausting the retries leaves this tenant unverified: record it so the SKIP
+                # below has a matching entry in the mismatch log.
+                if not reported:
+                    mismatches.append(
+                        (
+                            tname,
+                            -1,
+                            expected_perm[tname],
+                            f"resume did not succeed within {MAX_RETRIES} retries: {last_exc}",
+                        )
+                    )
                 print(f"  SKIP {tname}: could not resume (see mismatch log)", flush=True)
                 continue
 


### PR DESCRIPTION
Two ways the hot/cold stress workloads hid problems. Neither fixes the `hot-cold-oom-stress` flake; they make sure a failure says why, and that a run only passes if it verified something.

### A failed resume did not say why

`resume_tenant_blocking` polls `RESUME DATABASE` until `USE DATABASE` succeeds. It discarded the RESUME error each time, so on timeout it reported only `Tenant t1 did not come HOT within 90.0s`. Finding the real reason meant reading the server log, where every RESUME had been refused with `Memory limit exceeded`.

It now keeps the last RESUME error and includes it in the timeout message.

The timeout is raised as a new `ResumeTimeout`, which `is_transient` always reports as terminal. Embedding the server's text would otherwise make the message classify itself: it contains a tolerated marker, so the retry loops would treat a 90s timeout as transient and try again up to `MAX_RETRIES`. That is 120 attempts of a 90s call against a 12 to 15 minute workload budget, so the run would be killed before it printed the mismatches this PR adds.

### A tenant that never resumed was not verified, and the run still passed

`hot_cold_oom`, `hot_cold_ttl`, `hot_cold_indexes` and `hot_cold_triggers` all reached `if not resumed: continue` without recording anything. The tenant went uncounted and the workload reported success. `hot_cold_ttl` was worst: it printed `SKIP <tenant>: could not resume (see mismatch log)` when no such entry had been written.

All four now record a mismatch naming the tenant and the last error.
