### PR TITLE
fix(ci): disclose a fallback binary and tighten the unit-test cap

### DIFF
--- a/cmake/unit_tests.cmake
+++ b/cmake/unit_tests.cmake
@@ -60,22 +60,33 @@ function(add_unit_test exec_name)
 
     # This project calls enable_testing() without including the CTest module, so
     # ctest applies no timeout of its own: a test that hangs runs until whatever
-    # is driving ctest gives up, and the report names no test. Cap it here, well
-    # above the slowest test so that only a hang trips it. A test that needs
-    # longer passes its own TIMEOUT in TEST_PROPERTIES.
+    # is driving ctest gives up, and the report names no test. Cap it here, above
+    # the slowest test so that only a hang trips it, and near enough to it that a
+    # hang is reached well before the job's own limit. A test that needs longer
+    # passes its own TIMEOUT in TEST_PROPERTIES, and still gets the signal
+    # settings below.
     list(FIND test_properties "TIMEOUT" timeout_index)
     if(timeout_index EQUAL -1)
-        list(APPEND test_properties TIMEOUT 1800)
+        list(APPEND test_properties TIMEOUT 1200)
     endif()
 
     # Kill a timed-out test with SIGQUIT, whose default disposition dumps core, so the
     # hang leaves a stack behind for tools/ci/core-dumps to symbolise. SIGKILL, which
     # ctest sends once the grace period is up, leaves nothing to look at. The grace
-    # period covers writing the core, which is far longer than the one second ctest
-    # would otherwise allow for a process this size.
+    # period is there for the core to be written; ctest would otherwise allow one
+    # second, which will not do it for a process this size.
+    #
+    # The two are guarded separately. A caller naming only the signal still wants a
+    # usable window, and one naming only the window would otherwise lose it, since
+    # the later value of a repeated test property is the one that takes effect.
     list(FIND test_properties "TIMEOUT_SIGNAL_NAME" signal_index)
     if(signal_index EQUAL -1)
-        list(APPEND test_properties TIMEOUT_SIGNAL_NAME SIGQUIT TIMEOUT_SIGNAL_GRACE_PERIOD 30)
+        list(APPEND test_properties TIMEOUT_SIGNAL_NAME SIGQUIT)
+    endif()
+
+    list(FIND test_properties "TIMEOUT_SIGNAL_GRACE_PERIOD" grace_index)
+    if(grace_index EQUAL -1)
+        list(APPEND test_properties TIMEOUT_SIGNAL_GRACE_PERIOD 30)
     endif()
 
     # Use gtest_discover_tests if DISCOVER_TESTS is set, otherwise use add_test

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -791,9 +791,14 @@ add_unit_test(storage_v2_decoder_encoder
     LINK_TARGETS mg::storage
 )
 
+# Much the slowest test in the suite: it writes and recovers snapshots and WAL
+# across every durability mode, and in a sanitized build it runs long enough that
+# the general cap would leave it far less headroom than it leaves every other
+# test. It keeps the signal settings, so a hang in it still dumps core.
 add_unit_test(storage_v2_durability_inmemory
     SOURCES storage_v2_durability_inmemory.cpp
     LINK_TARGETS mg::storage mg-dbms storage_test_utils
+    TEST_PROPERTIES TIMEOUT 1800
 )
 
 add_unit_test(storage_v2_create_snapshot

--- a/tools/ci/core-dumps/analyze_core_dumps.sh
+++ b/tools/ci/core-dumps/analyze_core_dumps.sh
@@ -73,23 +73,43 @@ if [[ ! -f "$BINARY" ]]; then
   echo "Warning: fallback binary '$BINARY' not found; any core that does not name its own executable will have NO SYMBOLS (addresses only)." >&2
 fi
 
-# A core records the path of every file mapped into the process, and the
-# executable is the first of them, so a core from a test binary symbolises as
-# well as one from memgraph, without the caller having to say which binary to
-# expect. The command line the core also records is truncated to a fixed width
-# by the kernel, so a binary sitting deep enough in the tree is unrecoverable
-# from it. Falls back to the binary passed in when the core maps no file, or
-# names one that is not present here.
+# A core records the path of every file mapped into the process, and in the
+# layouts these cores come from the executable is the lowest-mapped of them, so
+# a core from a test binary symbolises as well as one from memgraph without the
+# caller having to say which binary to expect. The command line the core also
+# records is truncated to a fixed width by the kernel, so a binary sitting deep
+# enough in the tree is unrecoverable from it.
+#
+# Sets core_binary to the binary to analyse against, and
+# core_binary_fallback_reason to why the mapped executable could not be used, if
+# it could not. A caller must not run this in a command substitution: the
+# reason is returned in a variable, which a subshell would discard.
+core_binary=""
+core_binary_fallback_reason=""
 resolve_binary_for_core() {
-  local core="$1" exe
+  local core="$1" log exe
+  core_binary=""
+  core_binary_fallback_reason=""
+  log="$(mktemp)"
   # gdb exits non-zero on a core it cannot read, which would otherwise take the
-  # whole run down and lose the cores not yet analysed.
-  exe="$(gdb -batch -nx -ex "info proc mappings" --core="$core" 2>/dev/null |
-    awk '$1 ~ /^0x/ { i = index($0, " /"); if (i > 0) { print substr($0, i + 1); exit } }' || true)"
-  if [[ -n "$exe" && -f "$exe" ]]; then
-    printf '%s' "$exe"
+  # whole run down and lose the cores not yet analysed. Its output is kept so
+  # that a core it refused says why.
+  gdb -batch -nx -ex "info proc mappings" --core="$core" >"$log" 2>&1 || true
+  exe="$(awk '$1 ~ /^0x/ { i = index($0, " /"); if (i > 0) { print substr($0, i + 1); exit } }' "$log")"
+
+  if [[ -z "$exe" ]]; then
+    core_binary_fallback_reason="core maps no executable ($(grep -iEm1 'error|warning|not a core|no such' "$log" || echo 'no detail from gdb'))"
+  elif [[ ! -f "$exe" ]]; then
+    core_binary_fallback_reason="the executable this core names, '$exe', is not present here"
+  elif [[ ! -x "$exe" ]]; then
+    core_binary_fallback_reason="the executable this core names, '$exe', is not executable here"
+  fi
+  rm -f "$log"
+
+  if [[ -z "$core_binary_fallback_reason" ]]; then
+    core_binary="$exe"
   else
-    printf '%s' "$BINARY"
+    core_binary="$BINARY"
   fi
 }
 
@@ -121,14 +141,24 @@ for core in "${cores[@]}"; do
     out="$OUT_DIR/${trace_name}_${dup}.txt"
     dup=$((dup + 1))
   done
-  core_binary="$(resolve_binary_for_core "$core")"
-  echo "Analyzing $core ($(basename "$core_binary")) -> $out"
+  resolve_binary_for_core "$core"
+  if [[ -n "$core_binary_fallback_reason" ]]; then
+    echo "Analyzing $core ($(basename "$core_binary"), fallback) -> $out"
+  else
+    echo "Analyzing $core ($(basename "$core_binary")) -> $out"
+  fi
   {
     echo "=== Memgraph CI core dump stack trace ==="
     echo "core:      $core"
     [[ -n "$sig" ]] && echo "signal:    $sig"
     [[ -n "$epoch" ]] && echo "crashed:   $(date -u -d "@${epoch}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "epoch ${epoch}")"
     echo "binary:    $core_binary"
+    # A fallback binary that exists still produces a backtrace, and gdb reports
+    # success, so without this line the reader has no way to tell that the
+    # symbols belong to a different program than the one that dumped.
+    if [[ -n "$core_binary_fallback_reason" ]]; then
+      echo "symbols:   FALLBACK — ${core_binary_fallback_reason}; frames may name the wrong program, treat as unreliable"
+    fi
     [[ -f "$core_binary" ]] || echo "symbols:   MISSING — binary not found; backtrace shows addresses only, treat as unreliable"
     echo "generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "gdb:       $(gdb --version | head -n1)"


### PR DESCRIPTION
A core whose own executable cannot be used is still analysed against the binary passed in, and the trace now says so and names the executable the core asked for. gdb reports success either way and produces a backtrace from whatever binary it was handed, so a fallback was indistinguishable from a correctly resolved core. A core gdb refuses to read reports what gdb said about it.

The general timeout on a unit test comes down, so a hang is reached further ahead of the limit the job itself imposes, and the one test that runs long enough to need more headroom than that leaves declares its own. The signal name and the write window are defaulted under separate guards: a test naming only the window had it replaced, since the later value of a repeated test property is the one that takes effect, and a test naming only the signal was left with whatever window ctest defaults to.
