### PR TITLE
fix(CI): reduce various sources of flakiness in workflows

### DIFF
--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ inputs.run_core == 'true' }}
     name: "Core tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -57,7 +57,7 @@ jobs:
     if: ${{ inputs.run_core == 'true' }}
     name: "Core tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 70
+    timeout-minutes: 120
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -62,7 +62,7 @@ jobs:
     if: ${{ inputs.run_core == 'true' }}
     name: "Core tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -228,7 +228,7 @@ jobs:
     if: ${{ inputs.run_integration == 'true' }}
     name: "Integration test"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 80
+    timeout-minutes: 120
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -71,7 +71,7 @@ jobs:
     if: ${{ inputs.run_core == 'true' }}
     name: "Core tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -680,7 +680,7 @@ jobs:
     if: ${{ inputs.run_e2e == 'true' }}
     name: "End to end tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 110
+    timeout-minutes: 120
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -845,7 +845,7 @@ jobs:
     if: ${{ inputs.run_stress == 'true' }}
     name: "Stress tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Set up repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -1076,6 +1076,7 @@ jobs:
           # TODO(matt): add centos-10 when the image is fixed
           distros=(
             centos-9
+            centos-10
           )
           for distro in "${distros[@]}"; do
             ./release/package/mgbuild.sh \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -155,7 +155,7 @@ jobs:
   BuildAndPush:
     name: "Build and Test MAGE"
     runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
+    timeout-minutes: 90
     outputs:
       s3_package_url: ${{ steps.output-url.outputs.s3_url }}
     steps:

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -715,7 +715,7 @@ jobs:
         # framework can exercise the rpm install path. Never pushed. The base
         # memgraph rpm was staged to release/package/mage/memgraph.rpm by the Copy/Download step;
         # the memgraph-mage rpm comes from the Build RPM package step.
-        if: ${{ inputs.run_smoke_tests && !inputs.cugraph && !inputs.cuda && !inputs.malloc }}
+        if: ${{ inputs.run_smoke_tests && !inputs.cugraph && !inputs.cuda && !inputs.malloc && github.event_name != 'merge_group' }}
         run: |
           set -euo pipefail
           # Map the distro to its base image and the python version the modules
@@ -1070,7 +1070,7 @@ jobs:
             --image "${DOCKER_REPOSITORY_NAME}:${DEBUG_IMAGE_TAG}"
 
       - name: "Run Docker smoke tests (rpm)"
-        if: ${{ inputs.run_smoke_tests && !inputs.cugraph && !inputs.cuda  && !inputs.malloc }}
+        if: ${{ inputs.run_smoke_tests && !inputs.cugraph && !inputs.cuda  && !inputs.malloc && github.event_name != 'merge_group' }}
         run: |
           # TODO(matt): add centos-10 when the image is fixed
           distros=(

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -729,6 +729,7 @@ jobs:
           fi
           mage_rpm="$(ls -t output/memgraph-mage-[0-9]*.rpm | head -n 1)"
           cp -v "$mage_rpm" release/package/mage/memgraph-mage.rpm
+          ./tools/ci/mirrors/stage.sh release/package/mage
           distros=(
             centos-9
             centos-10

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -729,9 +729,9 @@ jobs:
           fi
           mage_rpm="$(ls -t output/memgraph-mage-[0-9]*.rpm | head -n 1)"
           cp -v "$mage_rpm" release/package/mage/memgraph-mage.rpm
-          # TODO(matt): add centos-10 when the image is fixed
           distros=(
             centos-9
+            centos-10
           )
           for distro in "${distros[@]}"; do
             case "$distro" in

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -57,7 +57,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Community build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - name: Set up repository
@@ -162,7 +162,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Coverage build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       BUILD_TYPE: Debug
 
@@ -288,7 +288,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Debug build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 80
+    timeout-minutes: 120
     env:
       BUILD_TYPE: Debug
 
@@ -443,7 +443,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Debug integration tests"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 70
+    timeout-minutes: 120
     env:
       BUILD_TYPE: Debug
 
@@ -555,7 +555,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Malloc build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - name: Set up repository
@@ -696,7 +696,7 @@ jobs:
   release_build:
     name: "Release build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: ${{ inputs.run_release_tests == 'true' }}
     steps:
       - name: Set up repository
@@ -997,7 +997,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release End-to-end Test"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 80
+    timeout-minutes: 120
 
     steps:
       - name: Set up repository
@@ -1135,7 +1135,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release durability and stress tests"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - name: Set up repository

--- a/release/docker/.gitignore
+++ b/release/docker/.gitignore
@@ -1,0 +1,2 @@
+# Transient artifacts staged into this docker build context by package_docker.
+mirrors/

--- a/release/docker/package_docker
+++ b/release/docker/package_docker
@@ -182,6 +182,9 @@ if [[ "$custom_mirror" == true ]]; then
   cp -v ../../tools/ci/ubuntu-mirrors/${arch}/ci.sources "${working_dir}/ci.sources"
 fi
 
+# copy scripts to be bind mounted for setting/unsetting mirrors
+../../tools/ci/mirrors/stage.sh "${working_dir}"
+
 # Assemble the optional --build-arg for DEBUGINFO_BINARY_NAME so it only
 # appears when the relwithdebinfo target needs it.
 debuginfo_build_arg=()

--- a/release/docker/v8_deb.dockerfile
+++ b/release/docker/v8_deb.dockerfile
@@ -69,7 +69,8 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   else \
     /mirrors/pin_mirrors.sh apply; \
   fi && \
-  /mirrors/retry.sh -- apt-get update && apt-get install -y \
+  /mirrors/retry.sh -- apt-get update && \
+  /mirrors/retry.sh -- apt-get install -y \
     /openssl/openssl*.deb \
     /openssl/libssl3t64*.deb \
     --no-install-recommends && \

--- a/release/docker/v8_deb.dockerfile
+++ b/release/docker/v8_deb.dockerfile
@@ -22,16 +22,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 USER root
 COPY auth-module-requirements.txt /tmp/auth-module-requirements.txt
 RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && apt-get install -y \
+  /mirrors/retry.sh -- apt-get update && /mirrors/retry.sh -- apt-get install -y \
   python3 libpython3.12 python3-pip adduser curl binutils \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi && \
   groupadd -g 103 memgraph && \
   useradd -u 101 -g memgraph -m -d /home/memgraph -s /bin/bash memgraph
@@ -57,18 +62,21 @@ ARG CUSTOM_MIRROR
 RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false \
   --mount=type=bind,source="./${BINARY_NAME}${TARGETARCH}.${EXTENSION}",target=/${BINARY_NAME}${TARGETARCH}.${EXTENSION},ro \
   --mount=type=bind,source="./openssl",target=/openssl,ro \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && apt-get install -y \
+  /mirrors/retry.sh -- apt-get update && apt-get install -y \
     /openssl/openssl*.deb \
     /openssl/libssl3t64*.deb \
     --no-install-recommends && \
-  apt-get install -y \
+  /mirrors/retry.sh -- apt-get install -y \
     libcurl4 libseccomp2 python3 python3-pip libpython3.12 libatomic1 adduser ca-certificates \
     --no-install-recommends && \
-  apt install -y libxmlsec1 && \
+  /mirrors/retry.sh -- apt install -y libxmlsec1 && \
   groupadd -g 103 memgraph && \
   useradd -u 101 -g memgraph -m -d /home/memgraph -s /bin/bash memgraph && \
   # Ubuntu Docker images exclude /usr/share/doc/* but only include copyright and changelog files
@@ -87,6 +95,8 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi
 
 # Memgraph listens for Bolt Protocol on this port by default.
@@ -133,11 +143,14 @@ ARG CUSTOM_MIRROR
 USER root
 RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false \
   --mount=type=bind,source="./${DEBUGINFO_BINARY_NAME}${TARGETARCH}.${EXTENSION}",target=/${DEBUGINFO_BINARY_NAME}${TARGETARCH}.${EXTENSION},ro \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && apt-get install -y \
+  /mirrors/retry.sh -- apt-get update && /mirrors/retry.sh -- apt-get install -y \
     python3-pip python3.12-venv \
     gdb procps linux-tools-common linux-tools-generic libc6-dbg \
     --no-install-recommends && \
@@ -145,6 +158,8 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi
 
 COPY "${SOURCE_CODE}" /home/mg/memgraph/src

--- a/release/package/mage/.gitignore
+++ b/release/package/mage/.gitignore
@@ -6,6 +6,7 @@ openssl/
 wheels/
 heaptrack/
 ci.sources
+mirrors/
 requirements.txt
 requirements-gpu.txt
 auth-module-requirements.txt

--- a/release/package/mage/Dockerfile.cugraph
+++ b/release/package/mage/Dockerfile.cugraph
@@ -14,16 +14,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 USER root
 
 RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && apt-get install -y \
+  /mirrors/retry.sh -- apt-get update && /mirrors/retry.sh -- apt-get install -y \
   python3 libpython3.12 python3-pip adduser curl \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi && \
   groupadd -g 103 memgraph && \
   useradd -u 101 -g memgraph -m -d /home/memgraph -s /bin/bash memgraph
@@ -61,9 +66,12 @@ ENV PY_VERSION=${PY_VERSION_DEFAULT}
 ENV MEMGRAPH_REF=${MEMGRAPH_REF}
 ARG CUSTOM_MIRROR=false
 
-RUN apt-get update && \
+RUN --mount=type=bind,source=./mirrors,target=/mirrors,ro \
+    /mirrors/pin_mirrors.sh apply && \
+    /mirrors/retry.sh -- apt-get update && \
     apt-get remove -y 'cuda-compat-*' && \
     apt-get autoremove -y && \
+    /mirrors/pin_mirrors.sh restore && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=cugraph-dev /opt/conda/lib/libcugraph.so /opt/conda/lib/libcugraph.so
@@ -81,11 +89,14 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   --mount=type=bind,source="./memgraph.deb",target=/memgraph.deb,ro \
   --mount=type=bind,source="./openssl",target=/openssl,ro \
   --mount=type=bind,source="./install_runtime_requirements.sh",target=/install_runtime_requirements.sh,ro \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && \
+  /mirrors/retry.sh -- apt-get update && \
   if test -n "$(find /openssl -maxdepth 1 -name '*.deb' -print -quit 2>/dev/null)"; then \
     apt-get install -y \
     /openssl/*.deb \
@@ -94,7 +105,7 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   if [ "$BUILD_TYPE" = "RelWithDebInfo" ]; then \
     apt-get install -y gdb libc6-dbg --no-install-recommends; \
   fi && \
-  apt-get install adduser libxmlsec1 python3 libpython3.12 python3-pip -y --no-install-recommends && \
+  /mirrors/retry.sh -- apt-get install adduser libxmlsec1 python3 libpython3.12 python3-pip -y --no-install-recommends && \
   /install_runtime_requirements.sh --ci --target-arch ${TARGETARCH} \
     --py-version ${PY_VERSION} --cuda true && \
   groupadd -g 103 memgraph && \
@@ -112,6 +123,8 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi
 
 # Copy modules: extract the memgraph-mage package payload

--- a/release/package/mage/Dockerfile.cugraph
+++ b/release/package/mage/Dockerfile.cugraph
@@ -98,12 +98,12 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   fi && \
   /mirrors/retry.sh -- apt-get update && \
   if test -n "$(find /openssl -maxdepth 1 -name '*.deb' -print -quit 2>/dev/null)"; then \
-    apt-get install -y \
+    /mirrors/retry.sh -- apt-get install -y \
     /openssl/*.deb \
     --no-install-recommends; \
   fi && \
   if [ "$BUILD_TYPE" = "RelWithDebInfo" ]; then \
-    apt-get install -y gdb libc6-dbg --no-install-recommends; \
+    /mirrors/retry.sh -- apt-get install -y gdb libc6-dbg --no-install-recommends; \
   fi && \
   /mirrors/retry.sh -- apt-get install adduser libxmlsec1 python3 libpython3.12 python3-pip -y --no-install-recommends && \
   /install_runtime_requirements.sh --ci --target-arch ${TARGETARCH} \

--- a/release/package/mage/Dockerfile.release
+++ b/release/package/mage/Dockerfile.release
@@ -9,16 +9,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 USER root
 
 RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && apt-get install -y \
+  /mirrors/retry.sh -- apt-get update && /mirrors/retry.sh -- apt-get install -y \
   python3 libpython3.12 python3-pip adduser curl \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi && \
   groupadd -g 103 memgraph && \
   useradd -u 101 -g memgraph -m -d /home/memgraph -s /bin/bash memgraph
@@ -58,17 +63,20 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   --mount=type=bind,source="./memgraph.deb",target=/memgraph.deb,ro \
   --mount=type=bind,source="./openssl",target=/openssl,ro \
   --mount=type=bind,source="./install_runtime_requirements.sh",target=/install_runtime_requirements.sh,ro \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && \
+  /mirrors/retry.sh -- apt-get update && \
   if test -n "$(find /openssl -maxdepth 1 -name '*.deb' -print -quit 2>/dev/null)"; then \
     apt-get install -y \
     /openssl/*.deb \
     --no-install-recommends; \
   fi && \
-  apt-get install adduser libxmlsec1 python3 libpython3.12 python3-pip -y --no-install-recommends && \
+  /mirrors/retry.sh -- apt-get install adduser libxmlsec1 python3 libpython3.12 python3-pip -y --no-install-recommends && \
   /install_runtime_requirements.sh --ci --target-arch ${TARGETARCH} \
     --py-version ${PY_VERSION} --cuda ${CUDA} && \
   groupadd -g 103 memgraph && \
@@ -86,6 +94,8 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi
 
 ENV LD_LIBRARY_PATH=/usr/lib/memgraph/query_modules
@@ -142,16 +152,21 @@ COPY make-dev-container.sh /make-dev-container.sh
 
 # Add gdb
 RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false \
+  --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /ubuntu.sources ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh apply; \
   fi && \
-  apt-get update && apt-get install -y \
+  /mirrors/retry.sh -- apt-get update && /mirrors/retry.sh -- apt-get install -y \
   gdb libc6-dbg \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \
+  else \
+    /mirrors/pin_mirrors.sh restore; \
   fi
 
 RUN --mount=type=bind,source="./memgraph-debuginfo.deb",target=/memgraph-debuginfo.deb,ro \

--- a/release/package/mage/Dockerfile.release
+++ b/release/package/mage/Dockerfile.release
@@ -72,7 +72,7 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
   fi && \
   /mirrors/retry.sh -- apt-get update && \
   if test -n "$(find /openssl -maxdepth 1 -name '*.deb' -print -quit 2>/dev/null)"; then \
-    apt-get install -y \
+    /mirrors/retry.sh -- apt-get install -y \
     /openssl/*.deb \
     --no-install-recommends; \
   fi && \

--- a/release/package/mage/Dockerfile.rpm
+++ b/release/package/mage/Dockerfile.rpm
@@ -16,6 +16,7 @@
 # Dockerfile.release does with ./memgraph.deb):
 #   ./memgraph.rpm        - the base memgraph package
 #   ./memgraph-mage.rpm   - the MAGE query-modules package built by package.sh
+# plus ./mirrors/, staged by tools/ci/mirrors/stage.sh.
 ARG BASE_IMAGE=quay.io/centos/centos:stream9
 FROM ${BASE_IMAGE} AS base
 
@@ -36,32 +37,17 @@ USER root
 ARG PY_VERSION=""
 RUN --mount=type=bind,source=./memgraph.rpm,target=/packages/memgraph.rpm,ro \
     --mount=type=bind,source=./memgraph-mage.rpm,target=/packages/memgraph-mage.rpm,ro \
+    --mount=type=bind,source=./mirrors,target=/mirrors,ro \
   export PIP_BREAK_SYSTEM_PACKAGES=1 && \
   if [ -n "$PY_VERSION" ]; then \
     py_pkgs="python${PY_VERSION} python${PY_VERSION}-pip python${PY_VERSION}-devel"; \
   else \
     py_pkgs="python3 python3-pip python3-devel"; \
   fi && \
-  # CentOS Stream metalinks often hand dnf a mirror that is mid-sync (repomd
-  # checksum mismatch); pin the same mirror list package_smoke_image uses
-  # (mgbuild.sh — keep in sync), upstream master last. Rocky etc. untouched.
-  mirror_opts="" && \
-  if [ "$(. /etc/os-release; echo "$ID")" = "centos" ]; then \
-    stream="$(. /etc/os-release; echo "$VERSION_ID")-stream"; \
-    basearch="$(uname -m)"; \
-    baseos_urls=""; appstream_urls=""; \
-    for m in https://ftp.plusline.net/centos-stream \
-             https://ftp.gwdg.de/pub/linux/centos-stream \
-             https://centos.anexia.at/centos-stream \
-             https://mirror.stream.centos.org; do \
-      baseos_urls="${baseos_urls:+$baseos_urls,}$m/$stream/BaseOS/$basearch/os/"; \
-      appstream_urls="${appstream_urls:+$appstream_urls,}$m/$stream/AppStream/$basearch/os/"; \
-    done; \
-    mirror_opts="--setopt=baseos.metalink= --setopt=baseos.baseurl=$baseos_urls --setopt=appstream.metalink= --setopt=appstream.baseurl=$appstream_urls"; \
-  fi && \
-  dnf install -y --setopt=tsflags='' $mirror_opts \
+  /mirrors/pin_mirrors.sh apply && \
+  /mirrors/retry.sh -- dnf install -y --setopt=tsflags='' \
     $py_pkgs gcc gcc-c++ krb5-devel unixODBC && \
-  dnf install -y --setopt=tsflags='' $mirror_opts \
+  /mirrors/retry.sh -- dnf install -y --setopt=tsflags='' \
     /packages/memgraph.rpm /packages/memgraph-mage.rpm && \
   auth_py="$(sed -n '1s|^#!||p' /usr/lib/memgraph/auth_module/kerberos.py)" && \
   echo "auth modules run on $auth_py ($($auth_py --version 2>&1))" && \

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -143,7 +143,7 @@ print_help () {
   echo -e "\nbuild options:"
   echo -e "  --git-ref string              Specify git ref from which the environment deps will be installed (default \"master\")"
   echo -e "  --rust-version number         Specify rustc and cargo version which be installed (default \"$DEFAULT_RUST_VERSION\")"
-  echo -e "  --node-version number         Specify nodejs version which be installed (default \"20\")"
+  echo -e "  --node-version number         Specify nodejs version which be installed (default \"24.19.0\")"
 
   echo -e "\nbuild-memgraph options:"
   echo -e "  --asan                        Build with ASAN"
@@ -3395,7 +3395,7 @@ case $command in
       # Default values for --git-ref, --rust-version and --node-version
       git_ref_flag="--build-arg GIT_REF=master"
       rust_version_flag="--build-arg RUST_VERSION=$DEFAULT_RUST_VERSION"
-      node_version_flag="--build-arg NODE_VERSION=20"
+      node_version_flag="--build-arg NODE_VERSION=24.19.0"
       rapids_version_flag="--build-arg RAPIDS_VERSION=25.12"
       cuda_version_minor="13.1.0"
       python_build_version_flag="--build-arg PY_VERSION=3.12"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2793,17 +2793,16 @@ test_mage() {
           ;;
         esac
       done
+
       cleanup_container() {
-        docker stop $neo4j_container || true
-        docker rm $neo4j_container || true
-        # This trap replaces the outer stop_monitoring trap, so chain it here
-        # to ensure the monitoring stack restarts fresh for the next test (and
-        # picks up the new service_name/labels from the regenerated configs).
-        if [[ "$enable_monitoring" == "true" ]]; then
+        local container="$1"
+        docker stop "$container" || true
+        docker rm "$container" || true
+        if [[ "${enable_monitoring:-false}" == "true" ]]; then
           stop_monitoring || true
         fi
       }
-      trap cleanup_container EXIT INT TERM
+      trap "cleanup_container '$neo4j_container'" EXIT INT TERM
       create_e2e_test_env
       cd $PROJECT_ROOT/tests/mage
       source env/bin/activate
@@ -2813,7 +2812,7 @@ test_mage() {
         $neo4j_container \
         $mage_container \
         $memgraph_network
-      cleanup_container
+      cleanup_container "$neo4j_container"
       if [[ "$clean_env" = true ]]; then
         rm -rf $PROJECT_ROOT/tests/mage/env
       fi
@@ -2850,23 +2849,19 @@ test_mage() {
           ;;
         esac
       done
-      # Define cleanup function for this case branch
+
       cleanup_containers() {
-        docker stop $mage_container || true
-        docker rm $mage_container || true
-        docker stop $mysql_container || true
-        docker rm $mysql_container || true
-        docker stop $postgresql_container || true
-        docker rm $postgresql_container || true
-        # This trap replaces the outer stop_monitoring trap, so chain it here
-        # to ensure the monitoring stack restarts fresh for the next test (and
-        # picks up the new service_name/labels from the regenerated configs).
-        if [[ "$enable_monitoring" == "true" ]]; then
+        local container
+        for container in "$@"; do
+          docker stop "$container" || true
+          docker rm "$container" || true
+        done
+        if [[ "${enable_monitoring:-false}" == "true" ]]; then
           stop_monitoring || true
         fi
       }
       # Set trap to cleanup on exit/interrupt (scoped to this case branch)
-      trap cleanup_containers EXIT INT TERM
+      trap "cleanup_containers '$mage_container' '$mysql_container' '$postgresql_container'" EXIT INT TERM
       create_e2e_test_env
       cd $PROJECT_ROOT/tests/mage
       source env/bin/activate
@@ -2875,7 +2870,7 @@ test_mage() {
         --mysql-container $mysql_container \
         --postgresql-container $postgresql_container
       # Normal cleanup
-      cleanup_containers
+      cleanup_containers "$mage_container" "$mysql_container" "$postgresql_container"
       if [[ "$clean_env" = true ]]; then
         rm -rf $PROJECT_ROOT/tests/mage/env
       fi

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1360,15 +1360,14 @@ package_smoke_image() {
 
   local base_image=""
   local pkg_format=""
-  local centos_stream=""
   case "$os" in
     ubuntu-26.04*) base_image="ubuntu:26.04"; pkg_format="deb" ;;
     ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb" ;;
     ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb" ;;
     debian-12*)    base_image="debian:12";    pkg_format="deb" ;;
     debian-13*)    base_image="debian:13";    pkg_format="deb" ;;
-    centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm"; centos_stream="9-stream" ;;
-    centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm"; centos_stream="10-stream" ;;
+    centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm" ;;
+    centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
     rocky-10*)     base_image="rockylinux/rockylinux:10";  pkg_format="rpm" ;;
     fedora-43*)    base_image="fedora:43"; pkg_format="rpm" ;;
     fedora-44*)    base_image="fedora:44"; pkg_format="rpm" ;;
@@ -1403,6 +1402,7 @@ package_smoke_image() {
   # if $build_dir's scope has unwound by the time the trap fires.
   trap "rm -rf '$build_dir'" EXIT
   cp "$package_dir/$package_name" "$build_dir/"
+  "$PROJECT_ROOT/tools/ci/mirrors/stage.sh" "$build_dir"
 
   local pip_find_links=""
   local copy_wheels_line=""
@@ -1445,54 +1445,37 @@ package_smoke_image() {
     # Add a path-include exception before installing the package, matching
     # the workaround in release/docker/v8_deb.dockerfile.
     install_cmd="export DEBIAN_FRONTEND=noninteractive && \
-      apt-get update && \
-      apt-get install -y --no-install-recommends libcurl4 libseccomp2 && \
+      /mirrors/pin_mirrors.sh apply && \
+      /mirrors/retry.sh -- apt-get install -y --no-install-recommends libcurl4 libseccomp2 && \
       if [ -f /etc/dpkg/dpkg.cfg.d/excludes ]; then \
         echo '' >> /etc/dpkg/dpkg.cfg.d/excludes && \
         echo '# Include all memgraph documentation files (licenses, etc.)' >> /etc/dpkg/dpkg.cfg.d/excludes && \
         echo 'path-include=/usr/share/doc/memgraph/*' >> /etc/dpkg/dpkg.cfg.d/excludes; \
       fi && \
-      apt-get install -y --no-install-recommends /pkg/$package_name && \
+      /mirrors/retry.sh -- apt-get install -y --no-install-recommends /pkg/$package_name && \
       ($gssapi_cmd) && \
       rm -rf /var/lib/apt/lists/*"
   else
-    # CentOS Stream metalinks often hand dnf a mirror that is mid-sync
-    # (repomd.xml fails its metalink checksum), so pin baseos/appstream to a
-    # list of nearby mirrors that dnf tries in order, with the upstream
-    # master as the final fallback.
-    local mirror_opts=""
-    if [[ -n "$centos_stream" ]]; then
-      local rpm_arch="x86_64"
-      [[ "$arch" == "arm" ]] && rpm_arch="aarch64"
-      local mirror baseos_urls="" appstream_urls=""
-      for mirror in \
-        "https://ftp.plusline.net/centos-stream" \
-        "https://ftp.gwdg.de/pub/linux/centos-stream" \
-        "https://centos.anexia.at/centos-stream" \
-        "https://mirror.stream.centos.org"; do
-        baseos_urls+="${baseos_urls:+,}$mirror/$centos_stream/BaseOS/$rpm_arch/os/"
-        appstream_urls+="${appstream_urls:+,}$mirror/$centos_stream/AppStream/$rpm_arch/os/"
-      done
-      mirror_opts="--setopt=baseos.metalink= --setopt=baseos.baseurl=$baseos_urls \
-      --setopt=appstream.metalink= --setopt=appstream.baseurl=$appstream_urls"
-    fi
     # Fedora/CentOS/Rocky minimal docker images set tsflags=nodocs in
     # /etc/dnf/dnf.conf, which strips memgraph's license files in
     # /usr/share/doc/memgraph/. Override on the dnf install line so the
     # smoke license check passes.
     # rpm demotes %post scriptlet failures to warnings, so a failed pip
     # install would still produce an image; assert the deps actually landed.
-    install_cmd="dnf install -y --setopt=tsflags='' $mirror_opts libseccomp /pkg/$package_name && \
+    install_cmd="/mirrors/pin_mirrors.sh apply && \
+      /mirrors/retry.sh -- dnf install -y --setopt=tsflags='' libseccomp /pkg/$package_name && \
       ls /var/lib/memgraph/.local/lib/python3.*/site-packages/networkx >/dev/null && \
       ($gssapi_cmd) && \
       dnf clean all"
   fi
 
+  # The mirror scripts come in on a bind mount rather than a COPY so they
+  # leave no trace in the image the smoke tests then run.
   cat > "$build_dir/Dockerfile" <<EOF
 FROM $base_image
 COPY $package_name /pkg/$package_name
 ${copy_wheels_line}
-RUN $install_cmd
+RUN --mount=type=bind,source=./mirrors,target=/mirrors,ro $install_cmd
 USER memgraph
 WORKDIR /usr/lib/memgraph
 EXPOSE 7687
@@ -1504,9 +1487,6 @@ EOF
   cat "$build_dir/Dockerfile"
   echo "------------------"
 
-  # Transient repo-mirror failures (e.g. a CentOS Stream mirror mid-sync whose
-  # repomd.xml fails its metalink checksum) dominate here; growing waits give
-  # the sync window time to close, and each attempt refetches the metadata.
   local attempt
   local built=false
   for attempt in 1 2 3 4 5; do
@@ -2569,6 +2549,10 @@ package_mage_docker() {
     cp $PROJECT_ROOT/tools/ci/ubuntu-mirrors/${arch}/ci.sources $PROJECT_ROOT/release/package/mage/ci.sources
     build_args+=(--secret id=ubuntu_sources,src=ci.sources)
   fi
+
+  # The Dockerfile falls back to the vetted public mirror list whenever the
+  # in-network custom mirror isn't in play, so the scripts are always needed.
+  $PROJECT_ROOT/tools/ci/mirrors/stage.sh $PROJECT_ROOT/release/package/mage
 
   # build the docker image
   docker buildx build \

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2552,7 +2552,7 @@ package_mage_docker() {
 
   # The Dockerfile falls back to the vetted public mirror list whenever the
   # in-network custom mirror isn't in play, so the scripts are always needed.
-  $PROJECT_ROOT/tools/ci/mirrors/stage.sh $PROJECT_ROOT/release/package/mage
+  "$PROJECT_ROOT/tools/ci/mirrors/stage.sh" "$PROJECT_ROOT/release/package/mage"
 
   # build the docker image
   docker buildx build \

--- a/tests/mage/run_e2e_correctness_tests.sh
+++ b/tests/mage/run_e2e_correctness_tests.sh
@@ -6,12 +6,30 @@ NEO4J_CONTAINER=$3
 MAGE_CONTAINER=$4
 MEMGRAPH_NETWORK=$5
 
+
+NEO4J_START_TIMEOUT="${NEO4J_START_TIMEOUT:-180}"
+
+remove_neo4j() {
+  docker stop "$NEO4J_CONTAINER" >/dev/null 2>&1 || true
+  docker rm -f "$NEO4J_CONTAINER" >/dev/null 2>&1 || true
+}
+
+# Report why neo4j never came up, then take the container away.
+neo4j_start_failed() {
+  echo "$1"
+  echo "--- last 50 lines of '$NEO4J_CONTAINER' logs ---"
+  docker logs --tail 50 "$NEO4J_CONTAINER" 2>&1 || echo "(no logs available)"
+  exit 1
+}
+
+remove_neo4j
+
 echo "Start Neo4j..."
-docker run --rm \
+docker run \
     --name "$NEO4J_CONTAINER"  \
     --network "$MEMGRAPH_NETWORK" \
     -p 7474:7474 \
-    -p $NEO4J_PORT:7687 \
+    -p "$NEO4J_PORT":7687 \
     -d \
     -v "$HOME/neo4j/plugins:/plugins" \
     --env NEO4J_AUTH=none  \
@@ -19,22 +37,25 @@ docker run --rm \
     -e NEO4J_apoc_import_file_enabled=true \
     -e NEO4J_apoc_import_file_use__neo4j__config=true  \
     -e NEO4J_PLUGINS='["apoc"]' neo4j:5.10.0
+trap remove_neo4j EXIT INT TERM
 
-echo "Waiting for Neo4j to start..."
+echo "Waiting up to ${NEO4J_START_TIMEOUT}s for Neo4j Bolt to accept queries..."
 counter=0
-timeout=30
-while ! curl --silent --fail http://localhost:7474; do
+while ! docker exec "$NEO4J_CONTAINER" \
+        cypher-shell -a bolt://localhost:7687 "RETURN 1" >/dev/null 2>&1; do
+  if [ "$(docker inspect -f '{{.State.Running}}' "$NEO4J_CONTAINER" 2>/dev/null)" != "true" ]; then
+    neo4j_start_failed "Neo4j container '$NEO4J_CONTAINER' stopped running after ${counter}s."
+  fi
   sleep 1
   counter=$((counter+1))
-  if [ $counter -gt $timeout ]; then
-    echo "Neo4j failed to start in $timeout seconds"
-    exit 1
+  if [ $counter -gt "$NEO4J_START_TIMEOUT" ]; then
+    neo4j_start_failed "Neo4j did not accept Bolt queries within ${NEO4J_START_TIMEOUT}s."
   fi
 done
-echo "Neo4j is up and running."
+echo "Neo4j is up and running (Bolt ready after ${counter}s)."
 
 echo "Running e2e correctness tests..."
 python3 test_e2e_correctness.py --memgraph-port $MEMGRAPH_PORT --neo4j-port $NEO4J_PORT --neo4j-container $NEO4J_CONTAINER
 
 echo "Stopping Neo4j..."
-docker stop "$NEO4J_CONTAINER"
+remove_neo4j

--- a/tests/smoke/features/kerberos_auth.bash
+++ b/tests/smoke/features/kerberos_auth.bash
@@ -108,7 +108,7 @@ test_kerberos_auth_setup() {
   echo "SUBFEATURE: bringing up a throwaway KDC for realm $KERBEROS_REALM"
   # The KDC image pins the distro mirrors rather than trusting the redirector;
   # the scripts have to be inside the build context.
-  "$SCRIPT_DIR/../../../tools/ci/mirrors/stage.sh" "$KERBEROS_DIR"
+  "$SMOKE_DIR/../../tools/ci/mirrors/stage.sh" "$KERBEROS_DIR"
   # BuildKit required: the Dockerfile uses RUN --mount=type=bind.
   DOCKER_BUILDKIT=1 docker build -t "$KERBEROS_KDC_IMAGE" "$KERBEROS_DIR"
   docker run -d --name "$KERBEROS_KDC_CONTAINER" \

--- a/tests/smoke/features/kerberos_auth.bash
+++ b/tests/smoke/features/kerberos_auth.bash
@@ -106,7 +106,11 @@ test_kerberos_auth_setup() {
   docker network create "$KERBEROS_NETWORK" >/dev/null
 
   echo "SUBFEATURE: bringing up a throwaway KDC for realm $KERBEROS_REALM"
-  docker build -t "$KERBEROS_KDC_IMAGE" "$KERBEROS_DIR"
+  # The KDC image pins the distro mirrors rather than trusting the redirector;
+  # the scripts have to be inside the build context.
+  "$SCRIPT_DIR/../../../tools/ci/mirrors/stage.sh" "$KERBEROS_DIR"
+  # BuildKit required: the Dockerfile uses RUN --mount=type=bind.
+  DOCKER_BUILDKIT=1 docker build -t "$KERBEROS_KDC_IMAGE" "$KERBEROS_DIR"
   docker run -d --name "$KERBEROS_KDC_CONTAINER" \
     --network "$KERBEROS_NETWORK" --network-alias "$KERBEROS_KDC_HOST" \
     -v "$KERBEROS_SHARED_DIR:/krb5" \

--- a/tests/smoke/features/kerberos_auth.bash
+++ b/tests/smoke/features/kerberos_auth.bash
@@ -109,8 +109,7 @@ test_kerberos_auth_setup() {
   # The KDC image pins the distro mirrors rather than trusting the redirector;
   # the scripts have to be inside the build context.
   "$SMOKE_DIR/../../tools/ci/mirrors/stage.sh" "$KERBEROS_DIR"
-  # BuildKit required: the Dockerfile uses RUN --mount=type=bind.
-  DOCKER_BUILDKIT=1 docker build -t "$KERBEROS_KDC_IMAGE" "$KERBEROS_DIR"
+  docker build -t "$KERBEROS_KDC_IMAGE" "$KERBEROS_DIR"
   docker run -d --name "$KERBEROS_KDC_CONTAINER" \
     --network "$KERBEROS_NETWORK" --network-alias "$KERBEROS_KDC_HOST" \
     -v "$KERBEROS_SHARED_DIR:/krb5" \

--- a/tests/smoke/kerberos/.gitignore
+++ b/tests/smoke/kerberos/.gitignore
@@ -1,0 +1,3 @@
+# Staged into this docker build context by tools/ci/mirrors/stage.sh, which
+# features/kerberos_auth.bash runs before building the KDC image.
+mirrors/

--- a/tests/smoke/kerberos/Dockerfile
+++ b/tests/smoke/kerberos/Dockerfile
@@ -4,8 +4,12 @@
 # created per run by setup-kdc.sh.
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
-# Retry the network steps: a flaky mirror says nothing about memgraph.
-RUN for attempt in 1 2 3 4 5; do \
+# Don't take whichever mirror the redirector offers -- pin the vetted list
+# first (./mirrors is staged by tools/ci/mirrors/stage.sh), then retry what
+# still trips: a flaky mirror says nothing about memgraph.
+RUN --mount=type=bind,source=./mirrors,target=/mirrors,ro \
+    /mirrors/pin_mirrors.sh apply && \
+    for attempt in 1 2 3 4 5; do \
       [ "$attempt" -eq 1 ] || sleep $((attempt * 5)); \
       apt-get update -qq && \
       apt-get install -y -qq --no-install-recommends \

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -2,20 +2,41 @@
 
 DISABLE_NODE=${DISABLE_NODE:-false}
 
-NODE_VERSION="20"
+# TODO(matt): rebuild mgbuild images with node 24 installed in mg user's directory
+NODE_MIN_VERSION="${NODE_MIN_VERSION:-20}"
+NODE_INSTALL_VERSION="${NODE_INSTALL_VERSION:-24.19.0}"
+
+# True when a node on PATH is at least $1 major.
+node_major_at_least() {
+  local want="$1" have
+  command -v node >/dev/null 2>&1 || return 1
+  have="$(node --version 2>/dev/null)" || return 1
+  have="${have##v}"
+  have="${have%%.*}"
+  [ -n "$have" ] || return 1
+  [ "$have" -ge "$want" ] 2>/dev/null
+}
+
 setup_node() {
   if [ "$DISABLE_NODE" = "true" ]; then
     echo "Skipping node setup because DISABLE_NODE is set to true"
     return 0
   fi
+
   if [ -f "$HOME/.nvm/nvm.sh" ]; then
     . "$HOME/.nvm/nvm.sh"
-    nvm install $NODE_VERSION
-    nvm use $NODE_VERSION
+    if ! node_major_at_least "$NODE_MIN_VERSION"; then
+      nvm use default >/dev/null 2>&1 || true
+    fi
+    if ! node_major_at_least "$NODE_MIN_VERSION"; then
+      echo "No node >= $NODE_MIN_VERSION installed under nvm; installing $NODE_INSTALL_VERSION"
+      nvm install "$NODE_INSTALL_VERSION"
+      nvm use "$NODE_INSTALL_VERSION"
+    fi
   fi
 
   if ! command -v node >/dev/null; then
-    echo "Could NOT node. Make sure node is installed."
+    echo "Could NOT find node. Make sure node is installed."
     exit 1
   fi
 
@@ -27,14 +48,10 @@ setup_node() {
     echo "Could NOT find pnpm. Make sure pnpm is installed."
     exit 1
   fi
-  node_version=$(node --version)
-  pnpm_version=$(pnpm --version)
-  echo "NODE VERSION: $node_version"
-  echo "PNPM VERSION: $pnpm_version"
-  node_major_version=${node_version##v}
-  node_major_version=${node_major_version%%.*}
-  if [ ! "$node_major_version" -ge $NODE_VERSION ]; then
-    echo "ERROR: It's required to have node >= $NODE_VERSION."
+  echo "NODE VERSION: $(node --version)"
+  echo "PNPM VERSION: $(pnpm --version)"
+  if ! node_major_at_least "$NODE_MIN_VERSION"; then
+    echo "ERROR: It's required to have node >= $NODE_MIN_VERSION, found $(node --version)."
     exit 1
   fi
 }

--- a/tools/ci/mirrors/check_mirrors.sh
+++ b/tools/ci/mirrors/check_mirrors.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Probe every mirror in pin_mirrors.sh against every repo it is expected to
+# serve, for both arches, and report which combinations answer.
+#
+# Mirrors do drop distros -- ftp.fau.de answers 410 for centos-stream now, and
+# a root that has quietly stopped carrying a repo would silently push every
+# build onto the next entry in the list. Run this when adding a distro, when
+# bumping to a new release, or when a mirror looks suspect:
+#
+#   tools/ci/mirrors/check_mirrors.sh                 # everything
+#   tools/ci/mirrors/check_mirrors.sh --os fedora-44  # one distro
+#
+# Exits non-zero if any mirror fails to serve a repo it is listed for, so it
+# can be run on a schedule. Nothing here touches the machine it runs on.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./pin_mirrors.sh
+source "$SCRIPT_DIR/pin_mirrors.sh"
+# pin_mirrors.sh sets -e for its own run; here a failing probe is a result to
+# report, not a reason to stop.
+set +e
+
+CONNECT_TIMEOUT=5
+MAX_TIME=20
+
+# The distros CI builds on -- keep in step with the case list in
+# package_smoke_image() (release/package/mgbuild.sh).
+ALL_TARGETS=(
+  "ubuntu 22.04 jammy"
+  "ubuntu 24.04 noble"
+  "ubuntu 26.04 resolute"
+  "debian 12 bookworm"
+  "debian 13 trixie"
+  "centos 9 -"
+  "centos 10 -"
+  "rocky 10 -"
+  "fedora 43 -"
+  "fedora 44 -"
+  "fedora 45 -"
+)
+
+only_os=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --os)
+      [[ $# -ge 2 ]] || { echo "Error: --os requires a value" >&2; exit 2; }
+      only_os="$2"; shift 2
+    ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    *) echo "Error: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+failures=0
+checked=0
+
+probe() {
+  curl --head --location --fail --silent \
+       --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+       --output /dev/null "$1"
+}
+
+report() {
+  local verdict="$1" root="$2" what="$3" detail="$4"
+  checked=$(( checked + 1 ))
+  if [[ "$verdict" == "OK" ]]; then
+    printf '  ok    %-24s %s\n' "$what" "$root"
+  else
+    printf '  FAIL  %-24s %s\n      tried: %s\n' "$what" "$root" "$detail"
+    failures=$(( failures + 1 ))
+  fi
+}
+
+# One repo is satisfied by a root if any of the paths listed for it answers --
+# Fedora legitimately has a release under development/ rather than releases/.
+check_paths() {
+  local root="$1" what="$2"
+  shift 2
+  local url tried=""
+  for url in "$@"; do
+    tried+="${tried:+ }$url"
+    if probe "$url"; then
+      report OK "$root" "$what" ""
+      return
+    fi
+  done
+  report FAIL "$root" "$what" "$tried"
+}
+
+check_apt_target() {
+  local id="$1" ver="$2" codename="$3" arch="$4"
+  # Read by the apt_roots/dnf_roots/dnf_repo_paths functions sourced above.
+  # shellcheck disable=SC2034
+  DISTRO_ID="$id"; DISTRO_VER="$ver"; DISTRO_MAJOR="${ver%%.*}"
+  export MG_MIRROR_ARCH="$arch"
+
+  echo "== $id $ver ($codename, $arch)"
+  local kind root suite suites
+  for kind in archive security; do
+    if [[ "$id" == "ubuntu" && "$kind" == "security" ]]; then
+      continue  # served from the archive roots, already covered
+    fi
+    if [[ "$kind" == "security" ]]; then
+      suites="$codename-security"
+    elif [[ "$id" == "ubuntu" ]]; then
+      suites="$codename $codename-updates $codename-backports $codename-security"
+    else
+      suites="$codename $codename-updates"
+    fi
+    while read -r root; do
+      [[ -n "$root" ]] || continue
+      for suite in $suites; do
+        check_paths "$root" "$suite" "$root/dists/$suite/Release"
+      done
+    done < <(apt_roots "$kind")
+  done
+}
+
+check_dnf_target() {
+  local id="$1" ver="$2" arch="$3"
+  # Read by the apt_roots/dnf_roots/dnf_repo_paths functions sourced above.
+  # shellcheck disable=SC2034
+  DISTRO_ID="$id"; DISTRO_VER="$ver"; DISTRO_MAJOR="${ver%%.*}"
+  export MG_MIRROR_ARCH="$arch"
+
+  echo "== $id $ver ($arch)"
+  local root line repo_id paths path
+  while read -r root; do
+    [[ -n "$root" ]] || continue
+    while read -r line; do
+      [[ -n "$line" ]] || continue
+      repo_id="${line%% *}"
+      paths="${line#* }"
+      local -a urls=()
+      for path in $paths; do
+        urls+=("$root/${path%/}/repodata/repomd.xml")
+      done
+      check_paths "$root" "$repo_id" "${urls[@]}"
+    done < <(dnf_repo_paths)
+  done < <(dnf_roots)
+}
+
+for target in "${ALL_TARGETS[@]}"; do
+  read -r id ver codename <<<"$target"
+  if [[ -n "$only_os" && "$only_os" != "$id-$ver" && "$only_os" != "$id" ]]; then
+    continue
+  fi
+  for arch in amd arm; do
+    case "$id" in
+      ubuntu|debian) check_apt_target "$id" "$ver" "$codename" "$arch" ;;
+      *)             check_dnf_target "$id" "$ver" "$arch" ;;
+    esac
+  done
+done
+
+echo
+if [[ "$checked" -eq 0 ]]; then
+  echo "No targets matched${only_os:+ --os $only_os}." >&2
+  exit 2
+fi
+echo "$checked checks, $failures failed"
+[[ "$failures" -eq 0 ]]

--- a/tools/ci/mirrors/pin_mirrors.sh
+++ b/tools/ci/mirrors/pin_mirrors.sh
@@ -1,0 +1,553 @@
+#!/usr/bin/env bash
+# Point a container's distro package repos at a vetted, ordered mirror list.
+#
+# Every distro we build on resolves its repos through a metalink/mirrorlist
+# redirector that hands out whichever mirror it likes at that moment. In CI
+# that regularly lands on a mirror that is mid-sync -- dnf fails the repomd
+# checksum, apt fails a hash sum mismatch -- and the build dies for reasons
+# that have nothing to do with memgraph. This replaces that lottery with an
+# explicit, ordered list of mirrors, keeping the distro's own default last so
+# the worst case is the behaviour we had before.
+#
+# The two package managers need that done differently. dnf takes a
+# comma-separated baseurl and fails over through it itself, so the list goes
+# straight into the repo config. apt has no equivalent: its mirror+file method
+# disregards the order and spends minutes retrying mirrors it has already
+# ignored, so here we pick one mirror, prove it with the `apt-get update` the
+# caller needs anyway, and only move to the next candidate if that fails.
+#
+# Runs INSIDE the image being built: the distro and arch come from
+# /etc/os-release and uname, so callers never have to say which one it is,
+# and an unrecognised distro is a no-op rather than an error.
+#
+#   apply    rewrite the repo config (default). Verifies the result with a
+#            metadata refresh and, if that fails, restores the original config
+#            and still exits 0 -- pinning must never itself break a build.
+#   restore  put the original repo config back. Shipping images call this
+#            after installing so the delivered image carries stock sources.
+#   print    print the mirror roots for the detected distro and exit.
+#
+# Maintaining the lists: every root must serve the layouts in apt_roots() /
+# dnf_repo_paths() for both arches we build (x86_64 and aarch64), and the
+# distro's own default belongs last. tools/ci/mirrors/check_mirrors.sh probes
+# every URL these tables can produce -- run it when adding a distro or when a
+# mirror starts 404ing (mirrors do drop distros: ftp.fau.de now answers 410
+# for centos-stream, which is why it is not in that list).
+
+set -euo pipefail
+
+BACKUP_SUFFIX=".mg-orig"
+APT_CONF="/etc/apt/apt.conf.d/99-mg-ci-mirrors"
+DNF_CONF="/etc/dnf/dnf.conf"
+
+log() { echo "pin_mirrors: $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+DISTRO_ID=""
+DISTRO_VER=""
+DISTRO_MAJOR=""
+
+detect_distro() {
+  if [[ ! -r /etc/os-release ]]; then
+    log "no /etc/os-release, nothing to pin"
+    exit 0
+  fi
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  DISTRO_ID="${ID:-}"
+  DISTRO_VER="${VERSION_ID:-}"
+  DISTRO_MAJOR="${DISTRO_VER%%.*}"
+}
+
+# dnf's $basearch / apt's dpkg architecture, from the running container -- under
+# qemu emulation uname already reports the target arch, which is what we want.
+# MG_MIRROR_ARCH (amd|arm) overrides it, which is how check_mirrors.sh probes
+# the arm lists from an amd host.
+mirror_arch() {
+  case "${MG_MIRROR_ARCH:-$(uname -m)}" in
+    arm|aarch64|arm64) echo arm ;;
+    *)                 echo amd ;;
+  esac
+}
+
+rpm_arch() {
+  [[ "$(mirror_arch)" == "arm" ]] && echo aarch64 || echo x86_64
+}
+
+dpkg_arch() {
+  [[ "$(mirror_arch)" == "arm" ]] && echo arm64 || echo amd64
+}
+
+# ---------------------------------------------------------------------------
+# Mirror tables
+# ---------------------------------------------------------------------------
+
+# Roots for an apt source kind: "archive" or "security", most preferred first
+# and the distro's own host last. Ubuntu's mirrors carry <suite>-security under
+# the same root, so both kinds share one list there; Debian keeps security on a
+# separate archive.
+#
+# These are http, not https, and deliberately so: the ubuntu/debian base images
+# ship no CA store, so apt cannot verify any TLS certificate in them ("No
+# system certificates available") and every https source fails the handshake.
+# That is why the distros' own sources are http too -- apt authenticates the
+# repo by its GPG signature, which is what actually protects the packages.
+apt_roots() {
+  local kind="$1"
+  case "$DISTRO_ID" in
+    ubuntu)
+      if [[ "$(dpkg_arch)" == "arm64" ]]; then
+        # arm64 is not in the main Ubuntu archive; it lives in ubuntu-ports,
+        # which far fewer mirrors carry.
+        printf '%s\n' \
+          "http://ftp.fau.de/ubuntu-ports" \
+          "http://mirror.dogado.de/ubuntu-ports" \
+          "http://ftp.tu-chemnitz.de/pub/linux/ubuntu-ports" \
+          "http://ports.ubuntu.com/ubuntu-ports"
+      else
+        printf '%s\n' \
+          "http://ftp.halifax.rwth-aachen.de/ubuntu" \
+          "http://ftp.fau.de/ubuntu" \
+          "http://mirror.init7.net/ubuntu" \
+          "http://archive.ubuntu.com/ubuntu"
+      fi
+    ;;
+    debian)
+      if [[ "$kind" == "security" ]]; then
+        printf '%s\n' \
+          "http://mirror.init7.net/debian-security" \
+          "http://mirror.dogado.de/debian-security" \
+          "http://security.debian.org/debian-security"
+      else
+        printf '%s\n' \
+          "http://ftp.halifax.rwth-aachen.de/debian" \
+          "http://ftp.fau.de/debian" \
+          "http://mirror.init7.net/debian" \
+          "http://deb.debian.org/debian"
+      fi
+    ;;
+  esac
+}
+
+dnf_roots() {
+  case "$DISTRO_ID" in
+    centos)
+      printf '%s\n' \
+        "https://ftp.plusline.net/centos-stream" \
+        "https://ftp.gwdg.de/pub/linux/centos-stream" \
+        "https://centos.anexia.at/centos-stream" \
+        "https://mirror.stream.centos.org"
+    ;;
+    rocky)
+      printf '%s\n' \
+        "https://ftp.gwdg.de/pub/linux/rocky" \
+        "https://mirror.23m.com/rocky" \
+        "https://mirror1.hs-esslingen.de/pub/Mirrors/rocky" \
+        "https://mirror.dogado.de/rockylinux" \
+        "https://dl.rockylinux.org/pub/rocky"
+    ;;
+    fedora)
+      printf '%s\n' \
+        "https://ftp.halifax.rwth-aachen.de/fedora/linux" \
+        "https://ftp.gwdg.de/pub/linux/fedora/linux" \
+        "https://ftp.fau.de/fedora/linux" \
+        "https://dl.fedoraproject.org/pub/fedora/linux"
+    ;;
+  esac
+}
+
+# "<repo-id> <path>[ <path>...]" per line: the path(s) under each root that
+# serve that repo. A repo with several paths gets them all, tried in order --
+# Fedora needs that because a release is under development/ until it ships and
+# releases/ afterwards, and we should not have to track which it is today.
+dnf_repo_paths() {
+  local arch
+  arch="$(rpm_arch)"
+  case "$DISTRO_ID" in
+    centos)
+      local stream="${DISTRO_MAJOR}-stream"
+      printf '%s\n' \
+        "baseos $stream/BaseOS/$arch/os/" \
+        "appstream $stream/AppStream/$arch/os/" \
+        "crb $stream/CRB/$arch/os/" \
+        "extras-common SIGs/$stream/extras/$arch/extras-common/"
+    ;;
+    rocky)
+      printf '%s\n' \
+        "baseos $DISTRO_MAJOR/BaseOS/$arch/os/" \
+        "appstream $DISTRO_MAJOR/AppStream/$arch/os/" \
+        "crb $DISTRO_MAJOR/CRB/$arch/os/" \
+        "extras $DISTRO_MAJOR/extras/$arch/os/"
+    ;;
+    fedora)
+      printf '%s\n' \
+        "fedora releases/$DISTRO_VER/Everything/$arch/os/ development/$DISTRO_VER/Everything/$arch/os/" \
+        "updates updates/$DISTRO_VER/Everything/$arch/"
+    ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Backup / restore
+# ---------------------------------------------------------------------------
+
+backup_file() {
+  local f="$1"
+  # First apply wins, so a second apply doesn't overwrite the pristine copy
+  # with an already-pinned one.
+  [[ -e "$f$BACKUP_SUFFIX" ]] || cp -a "$f" "$f$BACKUP_SUFFIX"
+}
+
+restore_globs() {
+  local backup f quiet=false
+  if [[ "${1:-}" == "--quiet" ]]; then
+    quiet=true
+    shift
+  fi
+  shopt -s nullglob
+  for backup in "$@"; do
+    # nullglob drops the patterns that matched nothing, but the fixed paths in
+    # the argument list survive whether or not they exist -- and most of them
+    # won't, since a given image is either apt- or dnf-based.
+    [[ -e "$backup" ]] || continue
+    f="${backup%"$BACKUP_SUFFIX"}"
+    mv -f "$backup" "$f"
+    [[ "$quiet" == "true" ]] || log "restored $f"
+  done
+  shopt -u nullglob
+}
+
+# Just the apt sources, keeping the backups' contents available again: the
+# probe loop below rewrites from pristine sources on every attempt, because a
+# second rewrite of an already-pinned file would find no distro host to match.
+restore_apt_sources() {
+  restore_globs --quiet \
+    /etc/apt/sources.list"$BACKUP_SUFFIX" \
+    /etc/apt/sources.list.d/*"$BACKUP_SUFFIX"
+}
+
+restore_all() {
+  restore_globs \
+    /etc/apt/sources.list"$BACKUP_SUFFIX" \
+    /etc/apt/sources.list.d/*"$BACKUP_SUFFIX" \
+    /etc/yum.repos.d/*"$BACKUP_SUFFIX" \
+    "$DNF_CONF$BACKUP_SUFFIX"
+  rm -f "$APT_CONF"
+}
+
+# ---------------------------------------------------------------------------
+# apt
+# ---------------------------------------------------------------------------
+
+# Rewrite the archive URIs in one sources file to point at the given roots.
+# Only the distro's own hosts are touched: a third-party repo (nodesource,
+# say) is left exactly as it was, and everything but the URI -- suites,
+# components, signing keys -- stays as the distro shipped it.
+rewrite_apt_file() {
+  local file="$1" archive="$2" security="$3" tmp
+  tmp="$(mktemp)"
+  awk -v distro="$DISTRO_ID" -v archive="$archive" -v security="$security" '
+    function is_distro_host(uri) {
+      if (distro == "ubuntu") return uri ~ /^[a-z+.-]+:\/\/([A-Za-z0-9._-]+\.)?ubuntu\.com(\/|$)/
+      if (distro == "debian") return uri ~ /^[a-z+.-]+:\/\/([A-Za-z0-9._-]+\.)?debian\.org(\/|$)/
+      return 0
+    }
+    # Ubuntu serves <suite>-security from its archive roots, so only Debian
+    # sends anything to a separate security root.
+    function replacement(uri) {
+      if (security != "" && (uri ~ /debian-security/ || uri ~ /:\/\/security\.debian\.org/)) return security
+      return archive
+    }
+    # deb822 (.sources): a URIs: line may carry several URIs.
+    /^[[:space:]]*URIs:/ {
+      out = ""
+      for (i = 2; i <= NF; i++) {
+        tok = is_distro_host($i) ? replacement($i) : $i
+        if (out != tok) out = (out == "" ? tok : out " " tok)
+      }
+      print "URIs: " out
+      next
+    }
+    # one-line (.list): deb [options] URI suite components...
+    /^[[:space:]]*deb(-src)?[[:space:]]/ {
+      for (i = 1; i <= NF; i++)
+        if ($i ~ /:\/\// && is_distro_host($i)) $i = replacement($i)
+      print
+      next
+    }
+    { print }
+  ' "$file" > "$tmp"
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
+apt_sources_files() {
+  shopt -s nullglob
+  local f
+  for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+    if [[ -f "$f" ]]; then
+      printf '%s\n' "$f"
+    fi
+  done
+  shopt -u nullglob
+}
+
+# apt has no usable per-source failover -- its mirror+file method ignores the
+# preference order and burns minutes retrying -- so do the failover here
+# instead: pin one mirror, prove it with the update we have to run anyway, and
+# move to the next one only if that fails. The last candidate is the distro's
+# own host, so the final attempt is exactly the unpinned behaviour.
+apt_apply() {
+  local -a archive_roots security_roots sources
+  mapfile -t archive_roots < <(apt_roots archive)
+  mapfile -t security_roots < <(apt_roots security)
+  mapfile -t sources < <(apt_sources_files)
+
+  if [[ ${#archive_roots[@]} -eq 0 ]]; then
+    log "no mirror list for $DISTRO_ID $DISTRO_VER"
+    return 1
+  fi
+  if [[ ${#sources[@]} -eq 0 ]]; then
+    log "no apt sources files found"
+    return 1
+  fi
+
+  cat > "$APT_CONF" <<'EOF'
+// Generated by tools/ci/mirrors/pin_mirrors.sh. One retry rides out a blip;
+// past that we would rather fall through to the next mirror than sit on a
+// stalled one, so the timeouts are deliberately short.
+Acquire::Retries "1";
+Acquire::http::Timeout "15";
+Acquire::https::Timeout "15";
+EOF
+  chmod 0644 "$APT_CONF"
+
+  local f i archive security
+  for (( i = 0; i < ${#archive_roots[@]}; i++ )); do
+    archive="${archive_roots[i]}"
+    security=""
+    if [[ ${#security_roots[@]} -gt 0 ]]; then
+      # Zip the two lists; the shorter one holds on its last entry.
+      if (( i < ${#security_roots[@]} )); then
+        security="${security_roots[i]}"
+      else
+        security="${security_roots[${#security_roots[@]} - 1]}"
+      fi
+      [[ "$security" == "$archive" ]] && security=""
+    fi
+
+    restore_apt_sources
+    for f in "${sources[@]}"; do
+      backup_file "$f"
+      rewrite_apt_file "$f" "$archive" "$security"
+    done
+
+    log "trying $archive for $DISTRO_ID $DISTRO_VER ($(dpkg_arch))"
+    # Error-Mode=any is what makes this a real test: by default apt-get update
+    # reports a source it could not fetch as a warning and still exits 0, so
+    # without this a mirror that served nothing would look like a success.
+    if apt-get update -o APT::Update::Error-Mode=any; then
+      log "pinned apt to $archive${security:+ (security: $security)}"
+      return 0
+    fi
+    log "$archive did not serve a usable index, moving on"
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# dnf
+# ---------------------------------------------------------------------------
+
+PINNED_REPO_IDS=""
+
+# Comment out the metalink/mirrorlist/baseurl of the named sections and give
+# them an explicit ordered baseurl list instead. Sections we have no path for
+# keep their original config.
+rewrite_repo_file() {
+  local file="$1" spec="$2" tmp
+  tmp="$(mktemp)"
+  awk -v spec="$spec" '
+    BEGIN {
+      n = split(spec, entries, "\n")
+      for (i = 1; i <= n; i++) {
+        if (entries[i] == "") continue
+        eq = index(entries[i], "=")
+        urls[substr(entries[i], 1, eq - 1)] = substr(entries[i], eq + 1)
+      }
+    }
+    /^[[:space:]]*\[/ {
+      section = $0
+      sub(/^[[:space:]]*\[/, "", section)
+      sub(/\].*$/, "", section)
+      pinned = (section in urls)
+      print
+      if (pinned) print "baseurl=" urls[section]
+      next
+    }
+    pinned && /^[[:space:]]*(metalink|mirrorlist|baseurl)[[:space:]]*=/ {
+      print "#" $0 "  # pin_mirrors.sh"
+      next
+    }
+    { print }
+  ' "$file" > "$tmp"
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
+dnf_apply() {
+  local -a roots
+  mapfile -t roots < <(dnf_roots)
+  if [[ ${#roots[@]} -eq 0 ]]; then
+    log "no mirror list for $DISTRO_ID $DISTRO_VER, leaving dnf alone"
+    return 0
+  fi
+
+  # Build "<repo-id>=<url>,<url>,..." lines. Mirror order is the outer loop, so
+  # our preferred mirror gets tried for every path it might serve the repo from
+  # before we move on to the next mirror.
+  local spec="" line repo_id paths root path urls
+  while read -r line; do
+    [[ -n "$line" ]] || continue
+    repo_id="${line%% *}"
+    paths="${line#* }"
+    # Only claim repos this image actually defines -- the table covers a
+    # family, and a given base image may not ship every one of its repos.
+    # Naming an absent repo would also make the verify below fail on
+    # --enablerepo and throw away good pinning.
+    if ! grep -qs "^[[:space:]]*\[$repo_id\]" /etc/yum.repos.d/*.repo; then
+      continue
+    fi
+    urls=""
+    for root in "${roots[@]}"; do
+      for path in $paths; do
+        urls+="${urls:+,}$root/$path"
+      done
+    done
+    spec+="${repo_id}=${urls}"$'\n'
+    PINNED_REPO_IDS+="${PINNED_REPO_IDS:+,}$repo_id"
+  done < <(dnf_repo_paths)
+
+  if [[ -z "$spec" ]]; then
+    log "no repo paths for $DISTRO_ID $DISTRO_VER, leaving dnf alone"
+    return 0
+  fi
+
+  local f found=0
+  shopt -s nullglob
+  for f in /etc/yum.repos.d/*.repo; do
+    [[ -f "$f" ]] || continue
+    backup_file "$f"
+    rewrite_repo_file "$f" "$spec"
+    found=1
+  done
+  shopt -u nullglob
+  if [[ "$found" -eq 0 ]]; then
+    log "no .repo files found"
+    return 0
+  fi
+
+  if [[ -f "$DNF_CONF" ]]; then
+    backup_file "$DNF_CONF"
+    # fastestmirror reorders our deliberate ordering; the rest just makes dnf
+    # persist against a slow or stalling mirror instead of giving up.
+    {
+      echo "retries=5"
+      echo "timeout=60"
+      echo "minrate=1k"
+      echo "fastestmirror=0"
+    } >> "$DNF_CONF"
+  fi
+  log "pinned dnf repos [$PINNED_REPO_IDS] to ${#roots[@]} mirrors for $DISTRO_ID $DISTRO_VER ($(rpm_arch))"
+}
+
+# Refresh only what we repointed: an unrelated repo failing (Fedora's openh264
+# repo lives on its own host) must not make us throw away good pinning.
+dnf_verify() {
+  [[ -n "$PINNED_REPO_IDS" ]] || return 0
+  dnf -q --disablerepo='*' --enablerepo="$PINNED_REPO_IDS" makecache --refresh
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+package_family() {
+  case "$DISTRO_ID" in
+    ubuntu|debian)        echo apt ;;
+    centos|rocky|fedora)  echo dnf ;;
+    *)                    echo none ;;
+  esac
+}
+
+do_apply() {
+  local family
+  family="$(package_family)"
+  case "$family" in
+    apt)
+      if ! apt_apply; then
+        log "no candidate mirror served a usable index, reverting to the distro default"
+        restore_all
+        # Leave the caller's install to be the thing that reports a genuinely
+        # unreachable archive; pinning must never be the failure.
+        apt-get update || true
+      fi
+    ;;
+    dnf)
+      dnf_apply
+      if ! dnf_verify; then
+        log "dnf makecache failed against the pinned mirrors, reverting to the distro default"
+        restore_all
+      fi
+    ;;
+    *)
+      log "$DISTRO_ID is not a distro we pin mirrors for, nothing to do"
+    ;;
+  esac
+}
+
+do_print() {
+  case "$(package_family)" in
+    apt)
+      echo "# $DISTRO_ID $DISTRO_VER ($(dpkg_arch)) archive"
+      apt_roots archive
+      if [[ "$DISTRO_ID" == "debian" ]]; then
+        echo "# $DISTRO_ID $DISTRO_VER security"
+        apt_roots security
+      fi
+    ;;
+    dnf)
+      echo "# $DISTRO_ID $DISTRO_VER ($(rpm_arch)) roots"
+      dnf_roots
+      echo "# repo paths"
+      dnf_repo_paths
+    ;;
+    *) echo "# $DISTRO_ID: not pinned" ;;
+  esac
+}
+
+main() {
+  local action="${1:-apply}"
+  detect_distro
+  case "$action" in
+    apply)   do_apply ;;
+    restore) restore_all ;;
+    print)   do_print ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+    ;;
+    *)
+      echo "Error: unknown action '$action' (expected apply, restore or print)" >&2
+      exit 2
+    ;;
+  esac
+}
+
+# Sourceable so check_mirrors.sh can walk the tables above without applying
+# anything.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tools/ci/mirrors/retry.sh
+++ b/tools/ci/mirrors/retry.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run a command, retrying it with a growing wait between attempts.
+#
+# Written for package-manager and docker-build commands, where the failure we
+# actually see in CI is a mirror mid-sync: the window closes on its own within
+# a minute or two, so waiting and refetching the metadata is the whole fix.
+# Pairs with pin_mirrors.sh -- pinning picks better mirrors, this rides out the
+# ones that go bad anyway.
+#
+#   retry.sh -- apt-get install -y foo
+#   retry.sh --attempts 5 --delay 30 -- docker build .
+#
+# The wait before attempt N is (N-1) * delay seconds, so the default of 5
+# attempts at 10s spends at most 60s waiting.
+
+set -euo pipefail
+
+attempts=5
+delay=10
+
+print_help() {
+  sed -n '2,17p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --attempts)
+      [[ $# -ge 2 ]] || { echo "Error: --attempts requires a value" >&2; exit 2; }
+      attempts="$2"; shift 2
+    ;;
+    --delay)
+      [[ $# -ge 2 ]] || { echo "Error: --delay requires a value" >&2; exit 2; }
+      delay="$2"; shift 2
+    ;;
+    -h|--help) print_help; exit 0 ;;
+    --) shift; break ;;
+    *)
+      echo "Error: unknown argument '$1' (did you forget the -- before the command?)" >&2
+      exit 2
+    ;;
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "Error: no command given" >&2
+  print_help >&2
+  exit 2
+fi
+
+attempt=1
+while true; do
+  # Capture the status with `|| status=$?`, not from an `if`: a failed `if`
+  # condition leaves $? at 0, which would make this exit 0 after every attempt
+  # had failed and hide the failure from the caller.
+  status=0
+  "$@" || status=$?
+  if (( status == 0 )); then
+    exit 0
+  fi
+  if (( attempt >= attempts )); then
+    echo "retry: '$*' failed after $attempts attempts" >&2
+    exit "$status"
+  fi
+  wait_for=$(( attempt * delay ))
+  echo "retry: '$*' failed (attempt $attempt/$attempts), retrying in ${wait_for}s..." >&2
+  sleep "$wait_for"
+  attempt=$(( attempt + 1 ))
+done

--- a/tools/ci/mirrors/retry.sh
+++ b/tools/ci/mirrors/retry.sh
@@ -11,7 +11,7 @@
 #   retry.sh --attempts 5 --delay 30 -- docker build .
 #
 # The wait before attempt N is (N-1) * delay seconds, so the default of 5
-# attempts at 10s spends at most 60s waiting.
+# attempts at 10s spends at most 100s waiting.
 
 set -euo pipefail
 

--- a/tools/ci/mirrors/stage.sh
+++ b/tools/ci/mirrors/stage.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copy the in-container mirror scripts into a docker build context.
+#
+#   tools/ci/mirrors/stage.sh <context-dir>
+#
+# leaves <context-dir>/mirrors/{pin_mirrors.sh,retry.sh}, which the Dockerfile
+# picks up with a bind mount:
+#
+#   RUN --mount=type=bind,source=./mirrors,target=/mirrors,ro \
+#     /mirrors/pin_mirrors.sh apply && \
+#     /mirrors/retry.sh -- apt-get install -y ... && \
+#     /mirrors/pin_mirrors.sh restore
+#
+# A build context is only ever the repo root or a directory the caller already
+# stages packages into, so the staged copy is a transient artifact -- the
+# contexts that live in the tree gitignore mirrors/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: stage.sh <context-dir>" >&2
+  exit 2
+fi
+
+context="$1"
+if [[ ! -d "$context" ]]; then
+  echo "Error: '$context' is not a directory" >&2
+  exit 2
+fi
+
+mkdir -p "$context/mirrors"
+cp "$SCRIPT_DIR/pin_mirrors.sh" "$SCRIPT_DIR/retry.sh" "$context/mirrors/"
+chmod 0755 "$context/mirrors/pin_mirrors.sh" "$context/mirrors/retry.sh"
+echo "Staged mirror scripts into $context/mirrors"

--- a/tools/ci/smoke_test_docker_image.sh
+++ b/tools/ci/smoke_test_docker_image.sh
@@ -7,17 +7,18 @@
 # (for example, a Dockerfile with `CMD [""]` that passes an empty argument
 # to the memgraph entrypoint).
 #
-# Usage: smoke_test_docker_image.sh <image_tag>
+# Usage: smoke_test_docker_image.sh <image_tag> [max_ready_attempts]
 #   e.g. smoke_test_docker_image.sh memgraph/memgraph-mage:1.30.0
 
 set -euo pipefail
 
 if [[ $# -lt 1 || -z "${1:-}" ]]; then
-  echo "Usage: $0 <image_tag>" >&2
+  echo "Usage: $0 <image_tag> [max_ready_attempts]" >&2
   exit 1
 fi
 
 IMAGE="$1"
+MAX_READY_ATTEMPTS="${2:-${BOLT_MAX_RETRIES:-180}}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WAIT_SCRIPT="$SCRIPT_DIR/wait_for_memgraph_bolt.sh"
 
@@ -33,7 +34,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-echo "Starting container $CONTAINER_NAME from $IMAGE (no arguments)..."
+echo "Starting container $CONTAINER_NAME from $IMAGE (no arguments), allowing up to ${MAX_READY_ATTEMPTS} attempts ~1s apart for Bolt..."
 docker run -d --name "$CONTAINER_NAME" "$IMAGE" >/dev/null
 
 # Give the entrypoint a moment to fail fast (e.g. bad args) before we exec.
@@ -51,7 +52,7 @@ fi
 # mgconsole binary instead of requiring one on the runner host.
 docker cp "$WAIT_SCRIPT" "$CONTAINER_NAME:/tmp/wait_for_memgraph_bolt.sh"
 
-if ! docker exec "$CONTAINER_NAME" bash /tmp/wait_for_memgraph_bolt.sh 127.0.0.1 7687 30 1; then
+if ! docker exec "$CONTAINER_NAME" bash /tmp/wait_for_memgraph_bolt.sh 127.0.0.1 7687 "$MAX_READY_ATTEMPTS" 1; then
   echo "Smoke test FAILED for $IMAGE: container did not accept Bolt connections." >&2
   echo "--- container logs ---" >&2
   docker logs "$CONTAINER_NAME" 2>&1 || true

--- a/tools/ci/smoke_test_offline_installer.sh
+++ b/tools/ci/smoke_test_offline_installer.sh
@@ -39,8 +39,8 @@ BASE_IMAGE="${BASE_IMAGE:-ubuntu:24.04}"
 MEMGRAPH_HOST=127.0.0.1
 MEMGRAPH_PORT=7687
 MEMGRAPH_LOG=/tmp/memgraph.log
-BOLT_MAX_RETRIES=60
-BOLT_RETRY_DELAY=1
+BOLT_MAX_RETRIES="${BOLT_MAX_RETRIES:-180}"
+BOLT_RETRY_DELAY="${BOLT_RETRY_DELAY:-1}"
 
 # --------------------------------------------------------------------------
 # In-container half.

--- a/tools/ci/smoke_test_shutdown.sh
+++ b/tools/ci/smoke_test_shutdown.sh
@@ -100,7 +100,7 @@ fi
 # Wait for connectivity using the in-container mgconsole (same helper as the
 # bolt smoke test), so we time the shutdown of a fully-started instance.
 docker cp "$WAIT_SCRIPT" "$CONTAINER_NAME:/tmp/wait_for_memgraph_bolt.sh"
-if ! docker exec "$CONTAINER_NAME" bash /tmp/wait_for_memgraph_bolt.sh 127.0.0.1 7687 30 1; then
+if ! docker exec "$CONTAINER_NAME" bash /tmp/wait_for_memgraph_bolt.sh 127.0.0.1 7687; then
   echo "Shutdown smoke test FAILED for $IMAGE: container did not accept Bolt connections." >&2
   echo "--- container logs ---" >&2
   docker logs "$CONTAINER_NAME" 2>&1 || true

--- a/tools/ci/wait_for_memgraph_bolt.sh
+++ b/tools/ci/wait_for_memgraph_bolt.sh
@@ -2,23 +2,35 @@
 
 # Wait until Memgraph accepts Bolt connections via mgconsole.
 # Usage: wait_for_memgraph_bolt <host> <port> [max_retries] [retry_delay_seconds]
+
 wait_for_memgraph_bolt() {
   local host="${1:-127.0.0.1}"
   local port="${2:-7687}"
-  local max_retries="${3:-20}"
-  local retry_delay_seconds="${4:-1}"
+  local max_retries="${3:-${BOLT_MAX_RETRIES:-180}}"
+  local retry_delay_seconds="${4:-${BOLT_RETRY_DELAY:-1}}"
   local attempt=1
+  local started=$SECONDS
+  local last_error=""
 
   while (( attempt <= max_retries )); do
-    if echo "RETURN 1;" | mgconsole --host "${host}" --port "${port}" >/dev/null 2>&1; then
-      echo "Memgraph became ready at ${host}:${port}"
+    if last_error="$(echo "RETURN 1;" | mgconsole --host "${host}" --port "${port}" 2>&1)"; then
+      echo "Memgraph became ready at ${host}:${port} after $(( SECONDS - started ))s (attempt ${attempt}/${max_retries})"
       return 0
+    fi
+    # A long silent wait tells whoever reads the log nothing, so mark progress.
+    if (( attempt % 15 == 0 )); then
+      echo "  still waiting for ${host}:${port} ($(( SECONDS - started ))s elapsed, attempt ${attempt}/${max_retries})"
     fi
     sleep "${retry_delay_seconds}"
     ((attempt++))
   done
 
-  echo "Memgraph did not become ready at ${host}:${port} after ${max_retries} attempts."
+  # Report the elapsed time, not just the attempt count: attempts say nothing
+  # about how long we actually gave it once mgconsole itself is slow to fail.
+  echo "Memgraph did not become ready at ${host}:${port} after ${max_retries} attempts ($(( SECONDS - started ))s)."
+  if [[ -n "$last_error" ]]; then
+    echo "Last mgconsole error: ${last_error}"
+  fi
   return 1
 }
 


### PR DESCRIPTION
- Increased timeouts for slow workers.
- Removed a smoke image build for RPM packages from MAGE in the merge queue (saves ~7 minutes).
- Added fallback mirrors for supported Linux distributions + retry mechanism during Docker builds.
- Increased Neo4j startup timeout on slow machines + added log dump.
- Increased MAGE failing to start within timeout on slow runners .
- Reintroduced CentOS 10 image for smoke testing now that the rootfs has returned :joy: 



