### PR TITLE
perf(communication): batch pipelined Bolt responses into one send

### DIFF
--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <spdlog/spdlog.h>
 #include <boost/asio/bind_executor.hpp>
@@ -79,7 +80,21 @@ class OutputStream final {
   OutputStream &operator=(OutputStream &&) = delete;
   ~OutputStream() = default;
 
-  bool Write(const uint8_t *data, size_t len, bool have_more = false) { return write_function_(data, len, have_more); }
+  // Batch small control-plane responses (the Bolt SUCCESS acks are <= ~256 B each) so a pipelined
+  // request burst leaves as one send instead of one blocking send per message. Anything at/above
+  // kFlushThreshold — i.e. a result-record chunk — is pushed straight through the blocking send
+  // (backpressure preserved), after flushing any pending acks first so ordering holds. have_more is
+  // ignored: the batch subsumes MSG_MORE, and a pass-through pushes now (a lingering MSG_MORE tail
+  // would stall until the peer's delayed-ACK). The session flushes the batch when it waits again.
+  bool Write(const uint8_t *data, size_t len, bool /*have_more*/ = false) {
+    if (len >= kFlushThreshold) {
+      if (!buffer_.empty() && !Flush()) return false;
+      return write_function_(data, len, false);
+    }
+    buffer_.insert(buffer_.end(), data, data + len);
+    if (buffer_.size() >= kFlushThreshold) return Flush();
+    return true;
+  }
 
   bool Write(std::span<const uint8_t> data, bool have_more = false) {
     return Write(data.data(), data.size(), have_more);
@@ -89,8 +104,21 @@ class OutputStream final {
     return Write(reinterpret_cast<const uint8_t *>(str.data()), str.size(), have_more);
   }
 
+  // Send whatever is buffered. Moves the bytes out before sending so a re-entrant Flush (a failed
+  // send routes through OnError -> DoShutdown -> Flush) sees an empty buffer and stops.
+  bool Flush() {
+    if (buffer_.empty()) return true;
+    const std::vector<uint8_t> pending = std::move(buffer_);
+    buffer_.clear();
+    return write_function_(pending.data(), pending.size(), false);
+  }
+
  private:
+  // Small: it only batches the control-plane acks (<= ~256 B); result chunks are >= this and take
+  // the blocking send path. Sized to hold a full pipelined burst of acks with room to spare.
+  static constexpr size_t kFlushThreshold = size_t{8} * 1024;
   std::function<bool(const uint8_t *, size_t, bool)> write_function_;
+  std::vector<uint8_t> buffer_;
 };
 
 /**
@@ -136,6 +164,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     return true;
   }
 
+  // Blocking write of a byte range straight to the underlying socket. Response batching lives in
+  // OutputStream (above); this is the socket send it flushes through.
   bool Write(const uint8_t *data, size_t len, bool have_more = false) {
     if (!IsConnected()) {
       return false;
@@ -259,6 +289,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   }
 
   void DoRead() {
+    output_stream_.Flush();  // send the burst's buffered responses before we wait for more input
     if (!IsConnected()) {
       return;
     }
@@ -271,6 +302,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   }
 
   void DoReadAsio() {
+    output_stream_.Flush();  // send the burst's buffered responses before we wait for more input
     if (!IsConnected()) {
       return;
     }
@@ -377,10 +409,10 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     input_buffer_.write_end()->Written(bytes_transferred);
 
     try {
-      // Execute until all data has been read
+      // Execute until all buffered data is processed, then wait for more. DoReadAsio flushes the
+      // burst's buffered responses before it blocks on the socket.
       while (session_.Execute()) {
       }
-      // Handled all data,  async wait for new incoming data
       DoReadAsio();
     } catch (const std::exception & /* unused */) {
       HandleException(std::current_exception());
@@ -395,12 +427,13 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
               if (shared_this->session_.Execute()) {
                 // Check if we can just steal this task (loop through)
                 if (thread_priority > shared_this->session_.ApproximateQueryPriority()) {
-                  // Task priority lower; reschedule
+                  // Task priority lower; reschedule. Buffered responses carry over on the session
+                  // and are flushed when the continuation reaches DoRead.
                   shared_this->DoWork();
                   return;
                 }
               } else {
-                // Handled all data,  async wait for new incoming data
+                // Handled all data, async wait for new incoming data (DoRead flushes first).
                 shared_this->DoRead();
                 return;
               }
@@ -435,6 +468,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     if (!IsConnected()) {
       return;
     }
+    output_stream_.Flush();  // best-effort: get a buffered FAILURE/response out before closing
     execution_active_ = false;
 
     std::visit(utils::Overloaded{[this](WebSocket &ws) {

--- a/tests/concurrent/CMakeLists.txt
+++ b/tests/concurrent/CMakeLists.txt
@@ -26,6 +26,9 @@ target_link_libraries(${test_prefix}network_read_hang mg-communication)
 add_concurrent_test(network_server.cpp)
 target_link_libraries(${test_prefix}network_server mg-communication)
 
+add_concurrent_test(v2_response_batching.cpp)
+target_link_libraries(${test_prefix}v2_response_batching mg-communication mg-flags mg-metrics)
+
 add_concurrent_test(network_session_leak.cpp)
 target_link_libraries(${test_prefix}network_session_leak mg-communication)
 

--- a/tests/concurrent/v2_response_batching.cpp
+++ b/tests/concurrent/v2_response_batching.cpp
@@ -1,0 +1,213 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Response-batching correctness tests: a pipelined burst and a mid-burst threshold flush (64 KiB).
+// Parametrized over both schedulers (asio -> OnReadAsio, priority_queue -> DoWork).
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+
+#include "communication/context.hpp"
+#include "communication/v2/server.hpp"
+#include "communication/v2/session.hpp"
+#include "io/network/endpoint.hpp"
+#include "io/network/socket.hpp"
+#include "utils/on_scope_exit.hpp"
+#include "utils/priorities.hpp"
+
+namespace {
+
+// kReplies separate Write() calls per frame exercise the response-batching path.
+inline constexpr int kReplies = 10;
+
+struct EchoContext {
+  // The priority-queue scheduler routes the burst loop through AddTask; run it inline so that path
+  // is exercised too. Passing the queued priority as the thread priority keeps them equal, so
+  // DoWork drains the burst without taking the reschedule branch.
+  template <typename Task>
+  void AddTask(const Task &task, memgraph::utils::Priority priority) {
+    task(priority);
+  }
+};
+
+class EchoSession {
+ public:
+  EchoSession(EchoContext /*unused*/, memgraph::communication::v2::InputStream *input_stream,
+              memgraph::communication::v2::OutputStream *output_stream)
+      : input_stream_(input_stream), output_stream_(output_stream) {}
+
+  // Returns true if a complete frame was processed; caller loops to drain pipelined frames.
+  bool Execute() {
+    if (input_stream_->size() < 2) return false;
+    const uint8_t *hdr = input_stream_->data();
+    const size_t size = (static_cast<size_t>(hdr[0]) << 8) + hdr[1];
+    input_stream_->Resize(size + 2);
+    if (input_stream_->size() < size + 2) return false;
+    const uint8_t *payload = input_stream_->data() + 2;  // re-read: Resize may have reallocated
+    for (int i = 0; i < kReplies; ++i) {
+      if (!output_stream_->Write(payload, size)) return false;
+    }
+    input_stream_->Shift(size + 2);
+    return true;
+  }
+
+  void HandleError() {}
+
+  memgraph::utils::Priority ApproximateQueryPriority() const { return memgraph::utils::Priority::LOW; }
+
+ private:
+  memgraph::communication::v2::InputStream *input_stream_;
+  memgraph::communication::v2::OutputStream *output_stream_;
+};
+
+using ServerT = memgraph::communication::v2::Server<EchoSession, EchoContext>;
+
+// Build one [len][payload] frame; payload byte j = (tag + j) so frames are distinguishable.
+std::vector<uint8_t> MakeFrame(uint16_t len, uint8_t tag) {
+  std::vector<uint8_t> f;
+  f.reserve(len + 2);
+  f.push_back(static_cast<uint8_t>(len >> 8));
+  f.push_back(static_cast<uint8_t>(len & 0xFF));
+  for (uint16_t j = 0; j < len; ++j) f.push_back(static_cast<uint8_t>(tag + j));
+  return f;
+}
+
+class ResponseBatchingTest : public ::testing::TestWithParam<const char *> {
+ protected:
+  void SetUp() override { gflags::SetCommandLineOption("scheduler", GetParam()); }
+};
+
+// The v2 server does not report its bound port for an ephemeral (:0) bind, so pick a
+// concrete free port first. reuse_address on the server makes re-binding it safe.
+uint16_t GetFreePort() {
+  boost::asio::io_context ioc;
+  boost::asio::ip::tcp::acceptor acceptor(ioc, {boost::asio::ip::make_address("127.0.0.1"), 0});
+  const auto port = acceptor.local_endpoint().port();
+  acceptor.close();
+  return port;
+}
+
+std::vector<uint8_t> ReadExactly(memgraph::io::network::Socket &socket, size_t want) {
+  std::vector<uint8_t> buf(want);
+  size_t have = 0;
+  while (have < want) {
+    auto r = socket.Read(buf.data() + have, want - have);
+    if (r <= 0) break;
+    have += static_cast<size_t>(r);
+  }
+  EXPECT_EQ(have, want);
+  buf.resize(have);
+  return buf;
+}
+
+void ExpectReplies(const std::vector<uint8_t> &echoes, size_t &off, uint16_t len, uint8_t tag) {
+  for (int r = 0; r < kReplies; ++r) {
+    for (uint16_t j = 0; j < len; ++j) {
+      ASSERT_LT(off, echoes.size());
+      ASSERT_EQ(echoes[off], static_cast<uint8_t>(tag + j)) << "reply " << r << " byte " << j;
+      ++off;
+    }
+  }
+}
+
+}  // namespace
+
+// Several pipelined frames in one write: the batch coalesces all replies and delivers them intact.
+TEST_P(ResponseBatchingTest, PipelinedBurstIsByteTransparent) {
+  EchoContext ctx;
+  memgraph::communication::ServerContext ctx_srv;
+  const uint16_t port = GetFreePort();
+  memgraph::communication::v2::ServerEndpoint endpoint{boost::asio::ip::make_address("127.0.0.1"), port};
+  ServerT server(endpoint, &ctx, &ctx_srv, "Test", 2);
+  ASSERT_TRUE(server.Start());
+  memgraph::utils::OnScopeExit cleanup([&] {
+    server.Shutdown();
+    server.AwaitShutdown();
+  });
+
+  const std::vector<std::pair<uint16_t, uint8_t>> frames = {{7, 0x10}, {40, 0x40}, {3, 0xA0}, {200, 0x01}};
+  std::vector<uint8_t> pipelined;
+  for (auto [len, tag] : frames) {
+    auto f = MakeFrame(len, tag);
+    pipelined.insert(pipelined.end(), f.begin(), f.end());
+  }
+
+  memgraph::io::network::Socket socket;
+  ASSERT_TRUE(socket.Connect(memgraph::io::network::Endpoint("127.0.0.1", port)));
+  socket.SetTimeout(5, 0);
+  ASSERT_TRUE(socket.Write(pipelined.data(), pipelined.size()));
+
+  size_t expected = 0;
+  for (auto [len, tag] : frames) expected += static_cast<size_t>(len) * kReplies;
+  auto echoes = ReadExactly(socket, expected);
+  ASSERT_EQ(echoes.size(), expected);
+
+  size_t off = 0;
+  for (auto [len, tag] : frames) ExpectReplies(echoes, off, len, tag);
+  EXPECT_EQ(off, expected);
+
+  socket.Close();
+}
+
+// Exercise both threshold paths in one burst: a frame whose small replies accumulate past the
+// flush threshold (mid-buffer flush), then a frame whose replies each exceed it and are pushed
+// straight through. The pending buffered bytes must flush before the pass-through, in order.
+TEST_P(ResponseBatchingTest, ThresholdCrossingPreservesBytes) {
+  EchoContext ctx;
+  memgraph::communication::ServerContext ctx_srv;
+  const uint16_t port = GetFreePort();
+  memgraph::communication::v2::ServerEndpoint endpoint{boost::asio::ip::make_address("127.0.0.1"), port};
+  ServerT server(endpoint, &ctx, &ctx_srv, "Test", 2);
+  ASSERT_TRUE(server.Start());
+  memgraph::utils::OnScopeExit cleanup([&] {
+    server.Shutdown();
+    server.AwaitShutdown();
+  });
+
+  // frame1: 10 * 1000 B accumulate past the 8 KiB threshold; frame2: 12000 B/reply passes through.
+  const std::vector<std::pair<uint16_t, uint8_t>> frames = {{1000, 0x11}, {12000, 0x55}};
+  std::vector<uint8_t> pipelined;
+  for (auto [len, tag] : frames) {
+    auto f = MakeFrame(len, tag);
+    pipelined.insert(pipelined.end(), f.begin(), f.end());
+  }
+
+  memgraph::io::network::Socket socket;
+  ASSERT_TRUE(socket.Connect(memgraph::io::network::Endpoint("127.0.0.1", port)));
+  socket.SetTimeout(5, 0);
+  ASSERT_TRUE(socket.Write(pipelined.data(), pipelined.size()));
+
+  size_t expected = 0;
+  for (auto [len, tag] : frames) expected += static_cast<size_t>(len) * kReplies;
+  auto echoes = ReadExactly(socket, expected);
+  ASSERT_EQ(echoes.size(), expected);
+
+  size_t off = 0;
+  for (auto [len, tag] : frames) ExpectReplies(echoes, off, len, tag);
+  EXPECT_EQ(off, expected);
+
+  socket.Close();
+}
+
+INSTANTIATE_TEST_SUITE_P(Schedulers, ResponseBatchingTest, ::testing::Values("asio", "priority_queue"));
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Batch a **pipelined** burst of Bolt responses into one `send()` instead of one blocking `send()` per message.

Each request handler flushes its response immediately (`MessageSuccess` → `Flush()` → a blocking `socket.send()` on the worker), so a pipelined transaction costs one send per message. This batches the **small control-plane acks** in `communication::v2::OutputStream`: a Bolt `SUCCESS` (≤ ~256 B) is buffered; a result-record chunk (≥ the 8 KiB threshold) is pushed straight through the blocking send (backpressure preserved); and the session flushes the buffer once when it goes back to waiting for the client (before `DoRead`/`DoReadAsio`) or on teardown.

The bolt encoder — its per-message framing and `Clear`-on-failure — is untouched. That matters: on a mid-burst query failure the client is still connected (`State::Error`, reading in request order), so the earlier acks must survive and go out in order (one response per request, so the client attributes the `FAILURE` correctly). Keeping the acks out of the encoder buffer is what preserves that.

**Server `send()` syscalls per query** (loopback, `strace`):

| mode | before → after |
|---|---|
| auto-commit | 2 → 1 |
| `execute_query` | 4 → 2 |
| explicit | 4 → 3 |

one send per client round-trip instead of per message.

**Scope:** reduces server syscalls/yields, not client round-trips — an efficiency change, not a latency fix. Throughput moves ~1–4% on loopback (a `send()` is cheap there); the win is larger where each send costs more (TLS, high connection counts).

**Test:** `tests/concurrent/v2_response_batching.cpp` drives the real v2 server with an echo session, parametrized over both schedulers (asio + priority_queue), and asserts a pipelined multi-message burst and a threshold-crossing burst (small replies accumulate past the threshold, then a large frame passes through) are byte-transparent.