### PR TITLE
refactor(query): give orderability a header of its own

### DIFF
--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -98,6 +98,7 @@ target_sources(mg-query
     procedure/module.cpp
     query_user.cpp
     relations/equality.cpp
+    relations/orderability.cpp
     serialization/property_value.cpp
     stream/common.cpp
     stream/sources.cpp

--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -24,6 +24,7 @@
 #include "query/fmt.hpp"
 #include "query/frontend/ast/ordering.hpp"
 #include "query/frontend/semantic/symbol.hpp"
+#include "query/relations/orderability.hpp"
 #include "query/typed_value.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/property_value.hpp"
@@ -33,108 +34,11 @@
 
 namespace memgraph::query {
 
-namespace {
-std::partial_ordering TypedValueCompare(TypedValue const &a, TypedValue const &b) {
-  // First assume typical same type comparisons
-  if (a.type() == b.type()) {
-    switch (a.type()) {
-      case TypedValue::Type::Bool:
-        return a.UnsafeValueBool() <=> b.UnsafeValueBool();
-      case TypedValue::Type::Int:
-        return a.UnsafeValueInt() <=> b.UnsafeValueInt();
-      case TypedValue::Type::Double:
-        return a.UnsafeValueDouble() <=> b.UnsafeValueDouble();
-      case TypedValue::Type::String:
-        return a.UnsafeValueString() <=> b.UnsafeValueString();
-      case TypedValue::Type::Date:
-        return a.UnsafeValueDate() <=> b.UnsafeValueDate();
-      case TypedValue::Type::LocalTime:
-        return a.UnsafeValueLocalTime() <=> b.UnsafeValueLocalTime();
-      case TypedValue::Type::LocalDateTime:
-        return a.UnsafeValueLocalDateTime() <=> b.UnsafeValueLocalDateTime();
-      case TypedValue::Type::ZonedDateTime:
-        return a.UnsafeValueZonedDateTime() <=> b.UnsafeValueZonedDateTime();
-      case TypedValue::Type::Duration:
-        return a.UnsafeValueDuration() <=> b.UnsafeValueDuration();
-      case TypedValue::Type::Null:
-        return std::partial_ordering::equivalent;
-      case TypedValue::Type::Enum:
-        return a.UnsafeValueEnum() <=> b.UnsafeValueEnum();
-      case TypedValue::Type::Point2d:
-        return a.UnsafeValuePoint2d() <=> b.UnsafeValuePoint2d();
-      case TypedValue::Type::Point3d:
-        return a.UnsafeValuePoint3d() <=> b.UnsafeValuePoint3d();
-        break;
-      case TypedValue::Type::List:
-        return std::lexicographical_compare_three_way(a.UnsafeValueList().begin(),
-                                                      a.UnsafeValueList().end(),
-                                                      b.UnsafeValueList().begin(),
-                                                      b.UnsafeValueList().end(),
-                                                      TypedValueCompare);
-        break;
-      case TypedValue::Type::Map:
-      case TypedValue::Type::Vertex:
-      case TypedValue::Type::Edge:
-      case TypedValue::Type::VirtualEdge:
-      case TypedValue::Type::VirtualNode:
-      case TypedValue::Type::Path:
-      case TypedValue::Type::Graph:
-      case TypedValue::Type::VirtualGraph:
-      case TypedValue::Type::Function:
-        throw QueryRuntimeException("Comparison is not defined for values of type {}.", a.type());
-    }
-  } else {
-    // from this point legal only between values of
-    // int+float combinations or against null
-
-    // in ordering null comes after everything else
-    // at the same time Null is not less that null
-    // first deal with Null < Whatever case
-    if (a.IsNull()) return std::partial_ordering::greater;
-    // now deal with NotNull < Null case
-    if (b.IsNull()) return std::partial_ordering::less;
-
-    if (!(a.IsNumeric() && b.IsNumeric())) [[unlikely]]
-      throw QueryRuntimeException("Can't compare value of type {} to value of type {}.", a.type(), b.type());
-
-    switch (a.type()) {
-      case TypedValue::Type::Int:
-        return a.UnsafeValueInt() <=> b.ValueDouble();
-      case TypedValue::Type::Double:
-        return a.UnsafeValueDouble() <=> b.ValueInt();
-      case TypedValue::Type::Bool:
-      case TypedValue::Type::Null:
-      case TypedValue::Type::String:
-      case TypedValue::Type::List:
-      case TypedValue::Type::Map:
-      case TypedValue::Type::Vertex:
-      case TypedValue::Type::Edge:
-      case TypedValue::Type::VirtualEdge:
-      case TypedValue::Type::VirtualNode:
-      case TypedValue::Type::Path:
-      case TypedValue::Type::Date:
-      case TypedValue::Type::LocalTime:
-      case TypedValue::Type::LocalDateTime:
-      case TypedValue::Type::ZonedDateTime:
-      case TypedValue::Type::Duration:
-      case TypedValue::Type::Enum:
-      case TypedValue::Type::Point2d:
-      case TypedValue::Type::Point3d:
-      case TypedValue::Type::Graph:
-      case TypedValue::Type::VirtualGraph:
-      case TypedValue::Type::Function:
-        LOG_FATAL("Invalid type");
-    }
-  }
-}
-
-}  // namespace
-
 struct OrderedTypedValueCompare {
   OrderedTypedValueCompare(Ordering ordering) : ordering_{ordering}, ascending{ordering == Ordering::ASC} {}
 
   auto operator()(const TypedValue &lhs, const TypedValue &rhs) const -> std::partial_ordering {
-    return ascending ? TypedValueCompare(lhs, rhs) : TypedValueCompare(rhs, lhs);
+    return ascending ? relations::orderability::Compare(lhs, rhs) : relations::orderability::Compare(rhs, lhs);
   }
 
   auto ordering() const { return ordering_; }
@@ -147,7 +51,7 @@ struct OrderedTypedValueCompare {
 /// Custom Comparator type for comparing vectors of TypedValues.
 ///
 /// Does lexicographical ordering of elements based on the above
-/// defined TypedValueCompare, and also accepts a vector of Orderings
+/// defined orderability relation, and also accepts a vector of Orderings
 /// the define how respective elements compare.
 class TypedValueVectorCompare final {
  public:

--- a/src/query/relations/orderability.cpp
+++ b/src/query/relations/orderability.cpp
@@ -1,0 +1,27 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "query/relations/orderability.hpp"
+
+#include <algorithm>
+
+namespace memgraph::query::relations::orderability {
+
+std::partial_ordering CompareOfLists(TypedValue const &a, TypedValue const &b) {
+  auto const &list_a = a.UnsafeValueList();
+  auto const &list_b = b.UnsafeValueList();
+  return std::lexicographical_compare_three_way(
+      list_a.begin(), list_a.end(), list_b.begin(), list_b.end(), [](TypedValue const &x, TypedValue const &y) {
+        return Compare(x, y);
+      });
+}
+
+}  // namespace memgraph::query::relations::orderability

--- a/src/query/relations/orderability.hpp
+++ b/src/query/relations/orderability.hpp
@@ -1,0 +1,128 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/// @file
+/// Orderability: one of the four relations openCypher defines over values, the
+/// one a sort reads.
+///
+/// It answers for pairs comparability refuses, so that `ORDER BY` has somewhere
+/// to put every row: a null sorts after everything, and two values of unlike
+/// type are placed rather than reported as unknown.
+#pragma once
+
+#include <algorithm>
+#include <compare>
+
+#include "query/exceptions.hpp"
+#include "query/fmt.hpp"
+#include "query/typed_value.hpp"
+#include "utils/logging.hpp"
+
+namespace memgraph::query::relations::orderability {
+
+/// Orders two lists element by element, the shorter one first where they agree.
+///
+/// Out of line so that Compare does not call itself. A compiler will not inline
+/// a function that recurses, and every sort reaches Compare through the caller.
+std::partial_ordering CompareOfLists(TypedValue const &a, TypedValue const &b);
+
+/// Where `a` falls relative to `b`.
+///
+/// @throw QueryRuntimeException for a pair this relation does not place.
+inline std::partial_ordering Compare(TypedValue const &a, TypedValue const &b) {
+  // First assume typical same type comparisons
+  if (a.type() == b.type()) {
+    switch (a.type()) {
+      case TypedValue::Type::Bool:
+        return a.UnsafeValueBool() <=> b.UnsafeValueBool();
+      case TypedValue::Type::Int:
+        return a.UnsafeValueInt() <=> b.UnsafeValueInt();
+      case TypedValue::Type::Double:
+        return a.UnsafeValueDouble() <=> b.UnsafeValueDouble();
+      case TypedValue::Type::String:
+        return a.UnsafeValueString() <=> b.UnsafeValueString();
+      case TypedValue::Type::Date:
+        return a.UnsafeValueDate() <=> b.UnsafeValueDate();
+      case TypedValue::Type::LocalTime:
+        return a.UnsafeValueLocalTime() <=> b.UnsafeValueLocalTime();
+      case TypedValue::Type::LocalDateTime:
+        return a.UnsafeValueLocalDateTime() <=> b.UnsafeValueLocalDateTime();
+      case TypedValue::Type::ZonedDateTime:
+        return a.UnsafeValueZonedDateTime() <=> b.UnsafeValueZonedDateTime();
+      case TypedValue::Type::Duration:
+        return a.UnsafeValueDuration() <=> b.UnsafeValueDuration();
+      case TypedValue::Type::Null:
+        return std::partial_ordering::equivalent;
+      case TypedValue::Type::Enum:
+        return a.UnsafeValueEnum() <=> b.UnsafeValueEnum();
+      case TypedValue::Type::Point2d:
+        return a.UnsafeValuePoint2d() <=> b.UnsafeValuePoint2d();
+      case TypedValue::Type::Point3d:
+        return a.UnsafeValuePoint3d() <=> b.UnsafeValuePoint3d();
+      case TypedValue::Type::List:
+        return CompareOfLists(a, b);
+      case TypedValue::Type::Map:
+      case TypedValue::Type::Vertex:
+      case TypedValue::Type::Edge:
+      case TypedValue::Type::VirtualEdge:
+      case TypedValue::Type::VirtualNode:
+      case TypedValue::Type::Path:
+      case TypedValue::Type::Graph:
+      case TypedValue::Type::VirtualGraph:
+      case TypedValue::Type::Function:
+        throw QueryRuntimeException("Comparison is not defined for values of type {}.", a.type());
+    }
+  } else {
+    // from this point legal only between values of
+    // int+float combinations or against null
+
+    // in ordering null comes after everything else
+    // at the same time Null is not less that null
+    // first deal with Null < Whatever case
+    if (a.IsNull()) return std::partial_ordering::greater;
+    // now deal with NotNull < Null case
+    if (b.IsNull()) return std::partial_ordering::less;
+
+    if (!(a.IsNumeric() && b.IsNumeric())) [[unlikely]]
+      throw QueryRuntimeException("Can't compare value of type {} to value of type {}.", a.type(), b.type());
+
+    switch (a.type()) {
+      case TypedValue::Type::Int:
+        return a.UnsafeValueInt() <=> b.ValueDouble();
+      case TypedValue::Type::Double:
+        return a.UnsafeValueDouble() <=> b.ValueInt();
+      case TypedValue::Type::Bool:
+      case TypedValue::Type::Null:
+      case TypedValue::Type::String:
+      case TypedValue::Type::List:
+      case TypedValue::Type::Map:
+      case TypedValue::Type::Vertex:
+      case TypedValue::Type::Edge:
+      case TypedValue::Type::VirtualEdge:
+      case TypedValue::Type::VirtualNode:
+      case TypedValue::Type::Path:
+      case TypedValue::Type::Date:
+      case TypedValue::Type::LocalTime:
+      case TypedValue::Type::LocalDateTime:
+      case TypedValue::Type::ZonedDateTime:
+      case TypedValue::Type::Duration:
+      case TypedValue::Type::Enum:
+      case TypedValue::Type::Point2d:
+      case TypedValue::Type::Point3d:
+      case TypedValue::Type::Graph:
+      case TypedValue::Type::VirtualGraph:
+      case TypedValue::Type::Function:
+        LOG_FATAL("Invalid type");
+    }
+  }
+}
+
+}  // namespace memgraph::query::relations::orderability


### PR DESCRIPTION
Orderability is the relation a sort reads, the one that places a pair
comparability refuses so that ORDER BY has somewhere to put every row. It now
lives in `src/query/relations/orderability.hpp` beside the other three, where a
test can name it and the fix for how a sort treats NaN has one place to go.

The case that walks a list is out of line, so the relation no longer calls
itself. Recursing cost it a callee-saved register across every comparison,
including the ones that never reach a list, and dropping it makes each three
instructions cheaper.
