### PR TITLE
refactor(requests): take the CA bundle path instead of reading a flag

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -413,7 +413,7 @@ int main(int argc, char **argv) {
   memgraph::communication::SSLInit sslInit;
 
   // Initialize the requests library.
-  memgraph::requests::Init();
+  memgraph::requests::Init(FLAGS_ca_bundle_file);
 
   // Start memory warning logger.
   memgraph::utils::Scheduler mem_log_scheduler;

--- a/src/requests/CMakeLists.txt
+++ b/src/requests/CMakeLists.txt
@@ -11,4 +11,4 @@ find_package(ctre REQUIRED)
 add_library(mg-requests STATIC ${requests_src_files})
 target_link_libraries(mg-requests
         PUBLIC mg-utils nlohmann_json::nlohmann_json ctre::ctre
-        PRIVATE spdlog::spdlog fmt::fmt gflags CURL::libcurl mg-flags)
+        PRIVATE spdlog::spdlog fmt::fmt gflags CURL::libcurl)

--- a/src/requests/requests.cpp
+++ b/src/requests/requests.cpp
@@ -25,7 +25,6 @@
 #include <sstream>
 #include <utility>
 
-#include "flags/general.hpp"
 #include "spdlog/spdlog.h"
 #include "utils/counter.hpp"
 #include "utils/exceptions.hpp"
@@ -89,13 +88,17 @@ auto PostProgressCallback(void *clientp, curl_off_t /*dltotal*/, curl_off_t /*dl
 }
 
 // libcurl's default CA bundle path is a build-time constant, wrong on distros
-// other than the build host's; use --ca-bundle-file if set, otherwise probe the
-// standard locations. Resolved once and cached for the process lifetime.
-const char *ResolveCaBundle() {
-  static const std::string resolved = []() -> std::string {
+// other than the build host's; use the path given here if there is one,
+// otherwise probe the standard locations.
+//
+// Resolved on the first call and fixed for the process lifetime, which is why
+// Init() must call it before anything issues a request: the path it was given
+// is only read on that first call.
+const char *ResolveCaBundle(std::string_view ca_bundle_file = {}) {
+  static const std::string resolved = [ca_bundle_file]() -> std::string {
     // An explicit path is passed through unvalidated so a bad value fails
     // loudly (CURLE_SSL_CACERT_BADFILE) instead of silently falling back.
-    if (!FLAGS_ca_bundle_file.empty()) return FLAGS_ca_bundle_file;
+    if (!ca_bundle_file.empty()) return std::string{ca_bundle_file};
     constexpr std::array paths = {
         "/etc/ssl/certs/ca-certificates.crt",      // Debian/Ubuntu
         "/etc/pki/tls/certs/ca-bundle.crt",        // RHEL/Fedora/CentOS/Rocky
@@ -123,7 +126,10 @@ void SetCaInfo(CURL *curl) {
 
 }  // namespace
 
-void Init() { curl_global_init(CURL_GLOBAL_ALL); }
+void Init(std::string_view ca_bundle_file) {
+  ResolveCaBundle(ca_bundle_file);
+  curl_global_init(CURL_GLOBAL_ALL);
+}
 
 bool RequestPostJson(const std::string &url, const nlohmann::json &data, int timeout_in_seconds,
                      std::atomic<bool> const *abort_flag) {

--- a/src/requests/requests.hpp
+++ b/src/requests/requests.hpp
@@ -28,9 +28,13 @@ namespace memgraph::requests {
  * Call this function in each `main` file that uses the Requests stack. It is
  * used to initialize all libraries (primarily cURL).
  *
+ * `ca_bundle_file` names the CA bundle to verify https certificates against.
+ * Leave it empty to probe the standard locations. It is passed in rather than
+ * read from a flag here so that this component depends on nothing above it.
+ *
  * NOTE: This function must be called **exactly** once.
  */
-void Init();
+void Init(std::string_view ca_bundle_file = {});
 
 /**
  *


### PR DESCRIPTION
The requests component is given the CA bundle to verify certificates against, and the caller that knows about flags passes it. The component no longer links the flags library.

Flags depends on the license component, which depends on requests, so reading a flag here closed a cycle across three libraries. A cycle cannot be linked as shared objects, and it also meant an HTTP helper reaching up to a global for a value its one caller already had. The two other callers pass nothing and keep the previous behaviour of probing the standard locations.
