### PR TITLE
refactor(storage): let storage raise the request errors it detects

### DIFF
--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -500,9 +500,8 @@ bolt_map_t SessionHL::Discard(std::optional<int> n, std::optional<int> qid) {
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const memgraph::storage::InvalidOperationException &e) {
-    // The engine rejected the query as invalid, so it stays invalid however
-    // many times it is sent. Without this it would fall to the branch below and
-    // be presented as worth retrying.
+    // The engine rejected the request as invalid, so it stays invalid however many times it is
+    // sent. Without this it would fall to the branch below and be presented as worth retrying.
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const utils::BasicException &) {
@@ -527,9 +526,8 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const memgraph::storage::InvalidOperationException &e) {
-    // The engine rejected the query as invalid, so it stays invalid however
-    // many times it is sent. Without this it would fall to the branch below and
-    // be presented as worth retrying.
+    // The engine rejected the request as invalid, so it stays invalid however many times it is
+    // sent. Without this it would fall to the branch below and be presented as worth retrying.
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const utils::BasicException &) {
@@ -656,6 +654,11 @@ void SessionHL::RollbackTransaction() {
     // Count the number of specific exceptions thrown
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
+  } catch (const memgraph::storage::InvalidOperationException &e) {
+    // The engine rejected the request as invalid, so it stays invalid however many times it is
+    // sent. Without this it would fall to the branch below and be presented as worth retrying.
+    metrics::IncrementCounter(GetExceptionName(e));
+    throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const utils::BasicException &) {
     // Exceptions inheriting from BasicException will result in a TransientError
     // i. e. client will be encouraged to retry execution because it
@@ -678,6 +681,11 @@ bolt_map_t SessionHL::CommitTransaction() {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {
     // Count the number of specific exceptions thrown
+    metrics::IncrementCounter(GetExceptionName(e));
+    throw memgraph::communication::bolt::ClientError(e.what());
+  } catch (const memgraph::storage::InvalidOperationException &e) {
+    // The engine rejected the request as invalid, so it stays invalid however many times it is
+    // sent. Without this it would fall to the branch below and be presented as worth retrying.
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const utils::BasicException &) {

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -42,6 +42,7 @@
 #include "query/frontend/semantic/graph_free.hpp"
 #include "query/interpreter_context.hpp"
 #include "query/query_user.hpp"
+#include "storage/v2/exceptions.hpp"
 #include "utils/event_map.hpp"
 #include "utils/logging.hpp"
 #include "utils/priorities.hpp"
@@ -498,6 +499,12 @@ bolt_map_t SessionHL::Discard(std::optional<int> n, std::optional<int> qid) {
   } catch (const memgraph::query::ReplicationException &e) {
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
+  } catch (const memgraph::storage::InvalidOperationException &e) {
+    // The engine rejected the query as invalid, so it stays invalid however
+    // many times it is sent. Without this it would fall to the branch below and
+    // be presented as worth retrying.
+    metrics::IncrementCounter(GetExceptionName(e));
+    throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const utils::BasicException &) {
     // Exceptions inheriting from BasicException will result in a TransientError
     // i. e. client will be encouraged to retry execution because it
@@ -517,6 +524,12 @@ bolt_map_t SessionHL::Pull(std::optional<int> n, std::optional<int> qid) {
   } catch (const memgraph::query::QueryException &e) {
     RewrapQueryException(e);
   } catch (const memgraph::query::ReplicationException &e) {
+    metrics::IncrementCounter(GetExceptionName(e));
+    throw memgraph::communication::bolt::ClientError(e.what());
+  } catch (const memgraph::storage::InvalidOperationException &e) {
+    // The engine rejected the query as invalid, so it stays invalid however
+    // many times it is sent. Without this it would fall to the branch below and
+    // be presented as worth retrying.
     metrics::IncrementCounter(GetExceptionName(e));
     throw memgraph::communication::bolt::ClientError(e.what());
   } catch (const utils::BasicException &) {

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -305,15 +305,6 @@ class ConcurrentSystemQueriesException : public QueryRuntimeException {
   SPECIALIZE_GET_EXCEPTION_NAME(ConcurrentSystemQueriesException)
 };
 
-class WriteVertexOperationInEdgeImportModeException : public QueryException {
- public:
-  WriteVertexOperationInEdgeImportModeException()
-      : QueryException(
-            "Write operations on nodes are forbidden while the edge import mode is active. To disable the edge import "
-            "mode, run the EDGE IMPORT MODE INACTIVE; query.") {}
-  SPECIALIZE_GET_EXCEPTION_NAME(WriteVertexOperationInEdgeImportModeException)
-};
-
 // This one is inherited from BasicException and will be treated as
 // TransientError, i. e. client will be encouraged to retry execution because it
 // could succeed if executed again.
@@ -592,16 +583,6 @@ class DropGraphInMulticommandTxException : public MulticommandTxException {
  public:
   DropGraphInMulticommandTxException() : MulticommandTxException("Dropping the graph") {}
   SPECIALIZE_GET_EXCEPTION_NAME(DropGraphInMulticommandTxException)
-};
-
-class TextSearchException : public QueryException {
-  using QueryException::QueryException;
-  SPECIALIZE_GET_EXCEPTION_NAME(TextSearchException)
-};
-
-class VectorSearchException : public QueryException {
-  using QueryException::QueryException;
-  SPECIALIZE_GET_EXCEPTION_NAME(VectorSearchException)
 };
 
 class EnumModificationInMulticommandTxException : public MulticommandTxException {

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -40,6 +40,7 @@
 #include "query/string_helpers.hpp"
 #include "query/typed_value.hpp"
 #include "storage/v2/edge_accessor.hpp"
+#include "storage/v2/exceptions.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/text_edge_index.hpp"
 #include "storage/v2/indices/text_index.hpp"
@@ -4866,7 +4867,7 @@ mgp_error mgp_graph_search_text_index(mgp_graph *graph, const char *index_name, 
       text_search_results = graph->getImpl()->TextIndexSearch(index_name, search_query, search_mode, config);
     } catch (const AuthorizationException &e) {
       error_msg = e.what();
-    } catch (memgraph::query::QueryException &e) {
+    } catch (memgraph::storage::InvalidOperationException &e) {
       error_msg = e.what();
     }
     WrapTextSearch(graph, memory, result, text_search_results, searched, error_msg);
@@ -4885,7 +4886,7 @@ mgp_error mgp_graph_aggregate_over_text_index(mgp_graph *graph, const char *inde
       search_results = graph->getImpl()->TextIndexAggregate(index_name, search_query, aggregation_query);
     } catch (const AuthorizationException &e) {
       error_msg = e.what();
-    } catch (memgraph::query::QueryException &e) {
+    } catch (memgraph::storage::InvalidOperationException &e) {
       error_msg = e.what();
     }
     WrapTextIndexAggregation(memory, result, search_results, error_msg);
@@ -4905,7 +4906,7 @@ mgp_error mgp_graph_aggregate_over_text_edge_index(mgp_graph *graph, const char 
       search_results = graph->getImpl()->TextEdgeIndexAggregate(index_name, search_query, aggregation_query);
     } catch (const AuthorizationException &e) {
       error_msg = e.what();
-    } catch (memgraph::query::QueryException &e) {
+    } catch (memgraph::storage::InvalidOperationException &e) {
       error_msg = e.what();
     }
     WrapTextIndexAggregation(memory, result, search_results, error_msg);
@@ -4943,7 +4944,7 @@ mgp_error mgp_graph_search_text_edge_index(struct mgp_graph *graph, const char *
       text_edge_search_results = graph->getImpl()->SearchEdgeTextIndex(index_name, search_query, search_mode, config);
     } catch (const AuthorizationException &e) {
       error_msg = e.what();
-    } catch (memgraph::query::QueryException &e) {
+    } catch (memgraph::storage::InvalidOperationException &e) {
       error_msg = e.what();
     }
     WrapTextEdgeSearchResults(graph, memory, result, text_edge_search_results, searched, error_msg);
@@ -4992,7 +4993,7 @@ mgp_error mgp_graph_search_vector_index(mgp_graph *graph, const char *index_name
 #endif
     } catch (const AuthorizationException &e) {
       error_msg = e.what();
-    } catch (memgraph::query::QueryException &e) {
+    } catch (memgraph::storage::InvalidOperationException &e) {
       error_msg = e.what();
     }
     WrapVectorSearchResults(graph, memory, result, found_vertices, error_msg);
@@ -5041,7 +5042,7 @@ mgp_error mgp_graph_search_vector_index_on_edges(mgp_graph *graph, const char *i
 #endif
     } catch (const AuthorizationException &e) {
       error_msg = e.what();
-    } catch (memgraph::query::QueryException &e) {
+    } catch (memgraph::storage::InvalidOperationException &e) {
       error_msg = e.what();
     }
     WrapVectorSearchOnEdgesResults(graph, memory, result, found_edges, error_msg);
@@ -5056,7 +5057,7 @@ mgp_error mgp_graph_show_index_info(mgp_graph *graph, mgp_memory *memory, mgp_ma
     try {
       index_info = graph->getImpl()->ListAllVectorIndices();
       edge_index_info = graph->getImpl()->ListAllVectorEdgeIndices();
-    } catch (memgraph::query::QueryException &e) {
+    } catch (memgraph::storage::InvalidOperationException &e) {
       error_msg = e.what();
     }
     WrapVectorIndexInfoResult(memory, result, index_info, edge_index_info, error_msg, graph->getImpl());

--- a/src/storage/v2/exceptions.hpp
+++ b/src/storage/v2/exceptions.hpp
@@ -1,0 +1,49 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include "utils/exceptions.hpp"
+
+namespace memgraph::storage {
+
+// The operation is not valid for the arguments it was given or the state the
+// engine is in: an index that does not exist, a vector whose dimension does not
+// match the one the index was created with, a write that the active mode
+// forbids. Repeating it unchanged fails the same way, which is what lets a
+// caller distinguish these from a failure worth trying again.
+//
+// Errors the engine detects about itself do not belong here.
+class InvalidOperationException : public utils::BasicException {
+  using utils::BasicException::BasicException;
+  SPECIALIZE_GET_EXCEPTION_NAME(InvalidOperationException)
+};
+
+class VectorSearchException : public InvalidOperationException {
+  using InvalidOperationException::InvalidOperationException;
+  SPECIALIZE_GET_EXCEPTION_NAME(VectorSearchException)
+};
+
+class TextSearchException : public InvalidOperationException {
+  using InvalidOperationException::InvalidOperationException;
+  SPECIALIZE_GET_EXCEPTION_NAME(TextSearchException)
+};
+
+class WriteVertexOperationInEdgeImportModeException : public InvalidOperationException {
+ public:
+  WriteVertexOperationInEdgeImportModeException()
+      : InvalidOperationException(
+            "Write operations on nodes are forbidden while the edge import mode is active. To disable the edge import "
+            "mode, run the EDGE IMPORT MODE INACTIVE; query.") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(WriteVertexOperationInEdgeImportModeException)
+};
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/indices/text_edge_index.cpp
+++ b/src/storage/v2/indices/text_edge_index.cpp
@@ -12,8 +12,8 @@
 #include "storage/v2/indices/text_edge_index.hpp"
 #include <spdlog/spdlog.h>
 #include "mgcxx_text_search.hpp"
-#include "query/exceptions.hpp"
 #include "storage/v2/edge_accessor.hpp"
+#include "storage/v2/exceptions.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/text_index_utils.hpp"
@@ -48,8 +48,7 @@ void TextEdgeIndex::CreateTantivyIndex(const std::string &index_path, const Text
     mappings["properties"][kToVertexGidField] = {{"type", "u64"}, {"fast", true}, {"stored", true}, {"indexed", true}};
 
     if (index_->contains(index_info.index_name)) {
-      throw query::TextSearchException(
-          "Text edge index {} already exists at path: {}.", index_info.index_name, index_path);
+      throw TextSearchException("Text edge index {} already exists at path: {}.", index_info.index_name, index_path);
     }
 
     // If index already exists on disk, it will be loaded and reused.
@@ -65,7 +64,7 @@ void TextEdgeIndex::CreateTantivyIndex(const std::string &index_path, const Text
   } catch (const std::exception &e) {
     spdlog::error(
         "Failed to create text edge index {} at path: {}. Error: {}", index_info.index_name, index_path, e.what());
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
 }
 
@@ -87,7 +86,7 @@ void TextEdgeIndex::AddEdgeToTextIndex(std::int64_t edge_gid, std::int64_t from_
                                               document.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace)},
         kDoSkipCommit);
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
 }
 
@@ -121,7 +120,7 @@ void TextEdgeIndex::CreateIndex(const TextEdgeIndexSpec &index_info, VerticesIte
   try {
     mgcxx::text_search::commit(index_data.context);
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Text index commit error: {}", e.what());
+    throw TextSearchException("Text index commit error: {}", e.what());
   }
 }
 
@@ -132,7 +131,7 @@ void TextEdgeIndex::RecoverIndex(const TextEdgeIndexSpec &index_info, utils::Ski
   auto needs_rebuild = !std::filesystem::exists(index_path);
   try {
     CreateTantivyIndex(index_path, index_info);
-  } catch (const query::TextSearchException &) {
+  } catch (const TextSearchException &) {
     if (needs_rebuild) throw;
     // It's possible that index on disk has incompatible schema if, for example, new required properties were added to
     // the index spec in new versions
@@ -140,8 +139,7 @@ void TextEdgeIndex::RecoverIndex(const TextEdgeIndexSpec &index_info, utils::Ski
     std::error_code ec;
     std::filesystem::remove_all(index_path, ec);
     if (ec)
-      throw query::TextSearchException(
-          "Failed to remove stale text edge index {}: {}", index_info.index_name, ec.message());
+      throw TextSearchException("Failed to remove stale text edge index {}: {}", index_info.index_name, ec.message());
     needs_rebuild = true;
     CreateTantivyIndex(index_path, index_info);
   }
@@ -170,7 +168,7 @@ void TextEdgeIndex::RecoverIndex(const TextEdgeIndexSpec &index_info, utils::Ski
     try {
       mgcxx::text_search::commit(context);
     } catch (const std::exception &e) {
-      throw query::TextSearchException("Text index commit error: {}", e.what());
+      throw TextSearchException("Text index commit error: {}", e.what());
     }
   }
 
@@ -182,7 +180,7 @@ void TextEdgeIndex::RecoverIndex(const TextEdgeIndexSpec &index_info, utils::Ski
 std::shared_ptr<TextEdgeIndexData> TextEdgeIndex::DropIndex(const std::string &index_name) {
   auto it = index_->find(index_name);
   if (it == index_->end()) {
-    throw query::TextSearchException("Text index {} doesn't exist.", index_name);
+    throw TextSearchException("Text index {} doesn't exist.", index_name);
   }
   auto evicted = it->second;  // Keep alive until the caller's commit callback.
 
@@ -289,7 +287,7 @@ std::vector<TextEdgeSearchResult> TextEdgeIndex::ActiveIndices::Search(const std
                                                                        const Transaction &tx) {
   auto it = index_container_->find(index_name);
   if (it == index_container_->end()) {
-    throw query::TextSearchException("Text index {} doesn't exist.", index_name);
+    throw TextSearchException("Text index {} doesn't exist.", index_name);
   }
   auto &index_data = *it->second;
   auto &context = index_data.context;
@@ -345,12 +343,12 @@ std::vector<TextEdgeSearchResult> TextEdgeIndex::ActiveIndices::Search(const std
                                             .fuzzy_field = kDataField});
         break;
       default:
-        throw query::TextSearchException(
+        throw TextSearchException(
             "Unsupported search mode: please use one of text_search.search_edges, text_search.search_all_edges, "
             "text_search.fuzzy_phrase_search_edges, or text_search.regex_search_edges.");
     }
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
 
   return search_results.docs | rv::transform([](const auto &doc) -> TextEdgeSearchResult {
@@ -368,7 +366,7 @@ std::string TextEdgeIndex::ActiveIndices::Aggregate(const std::string &index_nam
     if (const auto it = index_container_->find(index_name); it != index_container_->end()) {
       return it->second->context;
     }
-    throw query::TextSearchException("Text index {} doesn't exist.", index_name);
+    throw TextSearchException("Text index {} doesn't exist.", index_name);
   });
   mgcxx::text_search::DocumentOutput aggregation_result;
   try {
@@ -378,7 +376,7 @@ std::string TextEdgeIndex::ActiveIndices::Aggregate(const std::string &index_nam
             .search_fields = {kDataField}, .search_query = search_query, .aggregation_query = aggregation_query});
 
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
   // The CXX .data() method (https://cxx.rs/binding/string.html) may overestimate string length, causing JSON parsing
   // errors downstream. We prevent this by resizing the converted string with the correctly-working .length() method.
@@ -453,7 +451,7 @@ void TextEdgeIndex::ActiveIndices::ApplyTrackedChanges(Transaction &tx, NameIdMa
       }
       mgcxx::text_search::commit(index_data_ptr->context);
     } catch (const std::exception &e) {
-      throw query::TextSearchException("Text search error: {}", e.what());
+      throw TextSearchException("Text search error: {}", e.what());
     }
   }
 }

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -19,6 +19,7 @@
 #include "storage/v2/transaction.hpp"
 #include "storage/v2/view.hpp"
 
+#include "storage/v2/exceptions.hpp"
 namespace r = ranges;
 namespace rv = r::views;
 
@@ -45,7 +46,7 @@ void TextIndex::CreateTantivyIndex(const std::string &index_path, const TextInde
     mappings["properties"][kGidField] = {{"type", "u64"}, {"fast", true}, {"stored", true}, {"indexed", true}};
 
     if (index_->contains(index_info.index_name)) {
-      throw query::TextSearchException("Text index {} already exists at path: {}.", index_info.index_name, index_path);
+      throw TextSearchException("Text index {} already exists at path: {}.", index_info.index_name, index_path);
     }
 
     // If index already exists on disk, it will be loaded and reused.
@@ -60,7 +61,7 @@ void TextIndex::CreateTantivyIndex(const std::string &index_path, const TextInde
     index_ = std::move(new_map);
   } catch (const std::exception &e) {
     spdlog::error("Failed to create text index {} at path: {}. Error: {}", index_info.index_name, index_path, e.what());
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
 }
 
@@ -79,7 +80,7 @@ void TextIndex::AddNodeToTextIndex(std::int64_t gid, nlohmann::json properties, 
                                               document.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace)},
         kDoSkipCommit);
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
 }
 
@@ -112,7 +113,7 @@ void TextIndex::CreateIndex(const TextIndexSpec &index_info, storage::VerticesIt
   try {
     mgcxx::text_search::commit(index_data.context);
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Text index commit error: {}", e.what());
+    throw TextSearchException("Text index commit error: {}", e.what());
   }
 }
 
@@ -123,15 +124,14 @@ void TextIndex::RecoverIndex(const TextIndexSpec &index_info, utils::SkipListDb<
   auto needs_rebuild = !std::filesystem::exists(index_path);
   try {
     CreateTantivyIndex(index_path, index_info);
-  } catch (const query::TextSearchException &) {
+  } catch (const TextSearchException &) {
     if (needs_rebuild) throw;
     // It's possible that index on disk has incompatible schema if, for example, new required properties were added to
     // the index spec in new versions
     spdlog::warn("Text index {} has incompatible schema on disk, rebuilding.", index_info.index_name);
     std::error_code ec;
     std::filesystem::remove_all(index_path, ec);
-    if (ec)
-      throw query::TextSearchException("Failed to remove stale text index {}: {}", index_info.index_name, ec.message());
+    if (ec) throw TextSearchException("Failed to remove stale text index {}: {}", index_info.index_name, ec.message());
     needs_rebuild = true;
     CreateTantivyIndex(index_path, index_info);
   }
@@ -154,7 +154,7 @@ void TextIndex::RecoverIndex(const TextIndexSpec &index_info, utils::SkipListDb<
     try {
       mgcxx::text_search::commit(context);
     } catch (const std::exception &e) {
-      throw query::TextSearchException("Text index commit error: {}", e.what());
+      throw TextSearchException("Text index commit error: {}", e.what());
     }
   }
 
@@ -166,7 +166,7 @@ void TextIndex::RecoverIndex(const TextIndexSpec &index_info, utils::SkipListDb<
 std::shared_ptr<TextIndexData> TextIndex::DropIndex(const std::string &index_name) {
   auto it = index_->find(index_name);
   if (it == index_->end()) {
-    throw query::TextSearchException("Text index {} doesn't exist.", index_name);
+    throw TextSearchException("Text index {} doesn't exist.", index_name);
   }
   auto evicted = it->second;  // Keep alive until the caller's commit callback.
 
@@ -289,7 +289,7 @@ std::vector<TextSearchResult> TextIndex::ActiveIndices::Search(const std::string
                                                                const TextSearchConfig &config, const Transaction &tx) {
   auto it = index_container_->find(index_name);
   if (it == index_container_->end()) {
-    throw query::TextSearchException("Text index {} doesn't exist.", index_name);
+    throw TextSearchException("Text index {} doesn't exist.", index_name);
   }
   auto &index_data = *it->second;
   auto &context = index_data.context;
@@ -345,12 +345,12 @@ std::vector<TextSearchResult> TextIndex::ActiveIndices::Search(const std::string
                                             .fuzzy_field = kDataField});
         break;
       default:
-        throw query::TextSearchException(
+        throw TextSearchException(
             "Unsupported search mode: please use one of text_search.search, text_search.search_all, "
             "text_search.fuzzy_phrase_search, or text_search.regex_search.");
     }
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
 
   return search_results.docs | rv::transform([](const auto &doc) -> TextSearchResult {
@@ -365,7 +365,7 @@ std::string TextIndex::ActiveIndices::Aggregate(const std::string &index_name, c
     if (const auto it = index_container_->find(index_name); it != index_container_->end()) {
       return it->second->context;
     }
-    throw query::TextSearchException("Text index {} doesn't exist.", index_name);
+    throw TextSearchException("Text index {} doesn't exist.", index_name);
   });
   mgcxx::text_search::DocumentOutput aggregation_result;
   try {
@@ -375,7 +375,7 @@ std::string TextIndex::ActiveIndices::Aggregate(const std::string &index_name, c
             .search_fields = {kDataField}, .search_query = search_query, .aggregation_query = aggregation_query});
 
   } catch (const std::exception &e) {
-    throw query::TextSearchException("Tantivy error: {}", e.what());
+    throw TextSearchException("Tantivy error: {}", e.what());
   }
   // The CXX .data() method (https://cxx.rs/binding/string.html) may overestimate string length, causing JSON parsing
   // errors downstream. We prevent this by resizing the converted string with the correctly-working .length() method.
@@ -441,7 +441,7 @@ void TextIndex::ActiveIndices::ApplyTrackedChanges(Transaction &tx, NameIdMapper
       }
       mgcxx::text_search::commit(index_data_ptr->context);
     } catch (const std::exception &e) {
-      throw query::TextSearchException("Text search error: {}", e.what());
+      throw TextSearchException("Text search error: {}", e.what());
     }
   }
 }

--- a/src/storage/v2/indices/vector_edge_index.cpp
+++ b/src/storage/v2/indices/vector_edge_index.cpp
@@ -16,8 +16,8 @@
 #include <unordered_set>
 
 #include "flags/general.hpp"
-#include "query/exceptions.hpp"
 #include "storage/v2/edge.hpp"
+#include "storage/v2/exceptions.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/tracked_vector_allocator.hpp"
@@ -62,12 +62,12 @@ std::optional<uint64_t> VectorEdgeIndex::SetupIndex(const VectorEdgeIndexSpec &s
   auto mg_edge_index =
       mg_vector_edge_index_t::make(metric, {}, {}, std::move(tape_allocator), std::move(vectors_tape_allocator));
   if (!mg_edge_index) {
-    throw query::VectorSearchException(fmt::format(
+    throw VectorSearchException(fmt::format(
         "Failed to create vector edge index {}, error message: {}", spec.index_name, mg_edge_index.error.what()));
   }
 
   if (!mg_edge_index.index.try_reserve(limits)) {
-    throw query::VectorSearchException(
+    throw VectorSearchException(
         fmt::format("Failed to create vector edge index {}. Failed to reserve memory for the index", spec.index_name));
   }
 
@@ -85,7 +85,7 @@ void VectorEdgeIndex::AddEdgeToIndex(uint64_t index_id, Edge *edge, EdgeTypeId e
                                      std::optional<std::size_t> thread_id) {
   auto it = index_->find(index_id);
   if (it == index_->end()) {
-    throw query::VectorSearchException(fmt::format("Vector edge index {} does not exist.", index_id));
+    throw VectorSearchException(fmt::format("Vector edge index {} does not exist.", index_id));
   }
   auto &item_ptr = it->second;
   auto &spec = item_ptr->spec;
@@ -144,8 +144,7 @@ void VectorEdgeIndex::RecoverIndex(VectorEdgeIndexRecoveryInfo &recovery_info,
     auto &recovery_entries = recovery_info.index_entries;
     const auto index_id = SetupIndex(spec, name_id_mapper);
     if (!index_id.has_value()) {
-      throw query::VectorSearchException(
-          "Given vector edge index already exists. Corrupted or invalid index recovery files.");
+      throw VectorSearchException("Given vector edge index already exists. Corrupted or invalid index recovery files.");
     }
     auto &item_ptr = index_->at(*index_id);
     auto &mg_index = item_ptr->mg_index;
@@ -331,7 +330,7 @@ void VectorEdgeIndex::EraseEndpointsIfUnreferenced(Edge *edge) {
 void VectorEdgeIndex::RemoveEdgeFromIndex(Edge *edge, uint64_t index_id) {
   auto it = index_->find(index_id);
   if (it == index_->end()) {
-    throw query::VectorSearchException(
+    throw VectorSearchException(
         fmt::format("Error in removing edge from index: index id {} does not exist.", index_id));
   }
   auto &item_ptr = it->second;
@@ -384,7 +383,7 @@ VectorEdgeIndex::VectorSearchEdgeResults VectorEdgeIndex::SearchEdges(std::strin
     return std::nullopt;
   });
   if (!maybe_id.has_value()) {
-    throw query::VectorSearchException("Vector edge index {} does not exist.", index_name);
+    throw VectorSearchException("Vector edge index {} does not exist.", index_name);
   }
   auto &item_ptr = index_->at(*maybe_id);
   auto &mg_index = item_ptr->mg_index;
@@ -502,11 +501,11 @@ utils::small_vector<float> VectorEdgeIndex::GetVectorPropertyFromEdgeIndex(Edge 
                                                                            NameIdMapper *name_id_mapper) const {
   auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
   if (!maybe_id.has_value()) {
-    throw query::VectorSearchException("Vector edge index {} does not exist.", index_name);
+    throw VectorSearchException("Vector edge index {} does not exist.", index_name);
   }
   auto it = index_->find(*maybe_id);
   if (it == index_->end()) {
-    throw query::VectorSearchException("Vector edge index {} does not exist.", index_name);
+    throw VectorSearchException("Vector edge index {} does not exist.", index_name);
   }
   auto &item_ptr = it->second;
   auto guard = utils::SharedResourceLockGuard(item_ptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -12,7 +12,7 @@
 #include "storage/v2/indices/vector_index.hpp"
 
 #include <range/v3/all.hpp>
-#include "query/exceptions.hpp"
+#include "storage/v2/exceptions.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indexed_property_decoder.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
@@ -77,12 +77,12 @@ std::optional<uint64_t> VectorIndex::SetupIndex(const VectorIndexSpec &spec, Nam
   auto mg_vector_index =
       mg_vector_index_t::make(metric, {}, {}, std::move(tape_allocator), std::move(vectors_tape_allocator));
   if (!mg_vector_index) {
-    throw query::VectorSearchException(fmt::format(
+    throw VectorSearchException(fmt::format(
         "Failed to create vector index {}, error message: {}", spec.index_name, mg_vector_index.error.what()));
   }
 
   if (!mg_vector_index.index.try_reserve(limits)) {
-    throw query::VectorSearchException(
+    throw VectorSearchException(
         fmt::format("Failed to create vector index {}. Failed to reserve memory for the index", spec.index_name));
   }
 
@@ -103,8 +103,7 @@ void VectorIndex::RecoverIndex(VectorIndexRecoveryInfo &recovery_info, utils::Sk
     auto &recovery_entries = recovery_info.index_entries;
     const auto index_id = SetupIndex(spec, name_id_mapper);
     if (!index_id.has_value()) {
-      throw query::VectorSearchException(
-          "Given vector index already exists. Corrupted or invalid index recovery files.");
+      throw VectorSearchException("Given vector index already exists. Corrupted or invalid index recovery files.");
     }
     auto &item_ptr = index_->at(*index_id);
     auto &mg_index = item_ptr->mg_index;
@@ -143,7 +142,7 @@ void VectorIndex::AddVertexToIndex(uint64_t index_id, Vertex &vertex, const Inde
                                    std::optional<std::size_t> thread_id) {
   auto it = index_->find(index_id);
   if (it == index_->end()) {
-    throw query::VectorSearchException(fmt::format("Vector index {} does not exist.", index_id));
+    throw VectorSearchException(fmt::format("Vector index {} does not exist.", index_id));
   }
   auto &item_ptr = it->second;
   auto &spec = item_ptr->spec;
@@ -315,7 +314,7 @@ void VectorIndex::UpdateOnSetProperty(PropertyId property, const PropertyValue &
 void VectorIndex::RemoveVertexFromIndex(Vertex *vertex, uint64_t index_id) {
   auto it = index_->find(index_id);
   if (it == index_->end()) {
-    throw query::VectorSearchException(
+    throw VectorSearchException(
         fmt::format("Error in removing vertex from index: index id {} does not exist.", index_id));
   }
   auto &item_ptr = it->second;
@@ -326,11 +325,11 @@ utils::small_vector<float> VectorIndex::GetVectorPropertyFromIndex(Vertex *verte
                                                                    NameIdMapper *name_id_mapper) const {
   auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
   if (!maybe_id.has_value()) {
-    throw query::VectorSearchException("Vector index {} does not exist.", index_name);
+    throw VectorSearchException("Vector index {} does not exist.", index_name);
   }
   auto it = index_->find(*maybe_id);
   if (it == index_->end()) {
-    throw query::VectorSearchException("Vector index {} does not exist.", index_name);
+    throw VectorSearchException("Vector index {} does not exist.", index_name);
   }
   auto &item_ptr = it->second;
   auto guard = utils::SharedResourceLockGuard(item_ptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
@@ -432,11 +431,11 @@ VectorIndex::VectorSearchNodeResults VectorIndex::SearchNodes(std::string_view i
                                                               NameIdMapper *name_id_mapper) const {
   auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
   if (!maybe_id.has_value()) {
-    throw query::VectorSearchException(fmt::format("Vector index {} does not exist.", index_name));
+    throw VectorSearchException(fmt::format("Vector index {} does not exist.", index_name));
   }
   auto it = index_->find(*maybe_id);
   if (it == index_->end()) {
-    throw query::VectorSearchException(fmt::format("Vector index {} does not exist.", index_name));
+    throw VectorSearchException(fmt::format("Vector index {} does not exist.", index_name));
   }
   auto &item_ptr = it->second;
 
@@ -624,7 +623,7 @@ utils::small_vector<float> VectorIndexRecovery::ExtractVectorForRecovery(
 
   const auto &ids = value.ValueVectorIndexIds();
   if (ids.empty()) {
-    throw query::VectorSearchException("Vector index ID list is empty.");
+    throw VectorSearchException("Vector index ID list is empty.");
   }
 
   const auto &index_name = name_id_mapper->IdToName(ids[0]);
@@ -636,7 +635,7 @@ utils::small_vector<float> VectorIndexRecovery::ExtractVectorForRecovery(
       break;
     }
   }
-  throw query::VectorSearchException(fmt::format("Vector index {} not found in recovery info.", index_name));
+  throw VectorSearchException(fmt::format("Vector index {} not found in recovery info.", index_name));
 }
 
 void VectorIndexRecovery::UpdateOnIndexDrop(std::string_view index_name, NameIdMapper *name_id_mapper,
@@ -723,7 +722,7 @@ void VectorIndexRecovery::UpdateOnLabelRemoval(LabelId label, Vertex *vertex, Na
           vertex->properties.SetProperty(recovery_info->spec.property,
                                          PropertyValue(std::vector<double>(it->second.begin(), it->second.end())));
         } else {
-          throw query::VectorSearchException(
+          throw VectorSearchException(
               fmt::format("Vector index {} not found in recovery info.", recovery_info->spec.index_name));
         }
       } else {

--- a/src/storage/v2/indices/vector_index_utils.hpp
+++ b/src/storage/v2/indices/vector_index_utils.hpp
@@ -16,8 +16,8 @@
 #include "flags/bolt.hpp"
 #include "flags/general.hpp"
 #include "memory/db_arena_fwd.hpp"
-#include "query/exceptions.hpp"
 #include "range/v3/algorithm/remove.hpp"
+#include "storage/v2/exceptions.hpp"
 #include "storage/v2/indices/tracked_vector_allocator.hpp"
 #include "storage/v2/property_store.hpp"
 #include "storage/v2/property_value.hpp"
@@ -91,7 +91,7 @@ struct VectorIndexConfigMap {
 /// @brief Converts a metric kind to its string representation.
 /// @param metric The metric kind to convert.
 /// @return A string representation of the metric kind.
-/// @throws query::VectorSearchException if the metric kind is unsupported.
+/// @throws VectorSearchException if the metric kind is unsupported.
 inline const char *NameFromMetric(unum::usearch::metric_kind_t metric) {
   switch (metric) {
     case unum::usearch::metric_kind_t::l2sq_k:
@@ -113,7 +113,7 @@ inline const char *NameFromMetric(unum::usearch::metric_kind_t metric) {
     case unum::usearch::metric_kind_t::sorensen_k:
       return "sorensen";
     default:
-      throw query::VectorSearchException(
+      throw VectorSearchException(
           "Unsupported metric kind. Supported metrics are l2sq, ip, cos, haversine, divergence, pearson, hamming, "
           "tanimoto, and sorensen.");
   }
@@ -122,7 +122,7 @@ inline const char *NameFromMetric(unum::usearch::metric_kind_t metric) {
 /// @brief Converts a metric name to its corresponding metric kind.
 /// @param name The name of the metric.
 /// @return The corresponding metric kind.
-/// @throws query::VectorSearchException if the metric name is unsupported.
+/// @throws VectorSearchException if the metric name is unsupported.
 inline unum::usearch::metric_kind_t MetricFromName(std::string_view name) {
   if (name == "l2sq" || name == "euclidean_sq") {
     return unum::usearch::metric_kind_t::l2sq_k;
@@ -151,7 +151,7 @@ inline unum::usearch::metric_kind_t MetricFromName(std::string_view name) {
   if (name == "sorensen") {
     return unum::usearch::metric_kind_t::sorensen_k;
   }
-  throw query::VectorSearchException(
+  throw VectorSearchException(
       "Unsupported metric name: {}. Supported metrics are l2sq, ip, cos, haversine, divergence, pearson, "
       "hamming, tanimoto, and sorensen.",
       name);
@@ -160,7 +160,7 @@ inline unum::usearch::metric_kind_t MetricFromName(std::string_view name) {
 /// @brief Converts a scalar kind to its string representation.
 /// @param scalar The scalar kind to convert.
 /// @return A string representation of the scalar kind.
-/// @throws query::VectorSearchException if the scalar kind is unsupported.
+/// @throws VectorSearchException if the scalar kind is unsupported.
 inline const char *NameFromScalar(unum::usearch::scalar_kind_t scalar) {
   switch (scalar) {
     case unum::usearch::scalar_kind_t::b1x8_k:
@@ -196,7 +196,7 @@ inline const char *NameFromScalar(unum::usearch::scalar_kind_t scalar) {
     case unum::usearch::scalar_kind_t::i8_k:
       return "i8";
     default:
-      throw query::VectorSearchException(
+      throw VectorSearchException(
           "Unsupported scalar kind. Supported scalars are b1x8, u40, uuid, bf16, f64, f32, f16, f8, "
           "u64, u32, u16, u8, i64, i32, i16, and i8.");
   }
@@ -205,7 +205,7 @@ inline const char *NameFromScalar(unum::usearch::scalar_kind_t scalar) {
 /// @brief Converts a scalar name to its corresponding scalar kind.
 /// @param name The name of the scalar.
 /// @return The corresponding scalar kind.
-/// @throws query::VectorSearchException if the scalar name is unsupported.
+/// @throws VectorSearchException if the scalar name is unsupported.
 inline unum::usearch::scalar_kind_t ScalarFromName(std::string_view name) {
   if (name == "b1x8" || name == "binary") {
     return unum::usearch::scalar_kind_t::b1x8_k;
@@ -256,7 +256,7 @@ inline unum::usearch::scalar_kind_t ScalarFromName(std::string_view name) {
     return unum::usearch::scalar_kind_t::i8_k;
   }
 
-  throw query::VectorSearchException(
+  throw VectorSearchException(
       "Unsupported scalar name: {}. Supported scalars are b1x8, u40, uuid, bf16, f64, f32, f16, f8, "
       "u64, u32, u16, u8, i64, i32, i16, and i8.",
       name);
@@ -266,7 +266,7 @@ inline unum::usearch::scalar_kind_t ScalarFromName(std::string_view name) {
 /// @param metric The metric kind used for the distance.
 /// @param distance The distance value to convert.
 /// @return The similarity score corresponding to the distance.
-/// @throws query::VectorSearchException if the metric kind is unsupported.
+/// @throws VectorSearchException if the metric kind is unsupported.
 inline double SimilarityFromDistance(unum::usearch::metric_kind_t metric, double distance) {
   switch (metric) {
     case unum::usearch::metric_kind_t::ip_k:
@@ -284,8 +284,7 @@ inline double SimilarityFromDistance(unum::usearch::metric_kind_t metric, double
       return 1.0 / (1.0 + distance);
 
     default:
-      throw query::VectorSearchException("Unsupported metric kind for similarity calculation: {}",
-                                         NameFromMetric(metric));
+      throw VectorSearchException("Unsupported metric kind for similarity calculation: {}", NameFromMetric(metric));
   }
 }
 
@@ -307,11 +306,11 @@ inline std::optional<utils::small_vector<float>> TryListToVector(const PropertyV
 }
 
 /// @brief Converts a PropertyValue list to a vector of floats.
-/// @throws query::VectorSearchException if the value is not a list or contains non-numeric values.
+/// @throws VectorSearchException if the value is not a list or contains non-numeric values.
 inline utils::small_vector<float> ListToVector(const PropertyValue &value) {
   auto result = TryListToVector(value);
   if (!result) {
-    throw query::VectorSearchException("Vector index property must be a list of floats or integers.");
+    throw VectorSearchException("Vector index property must be a list of floats or integers.");
   }
   return *std::move(result);
 }
@@ -404,7 +403,7 @@ inline std::size_t GetVectorIndexThreadCount() {
 /// @param key The key to add/update in the index.
 /// @param vector The vector to insert into the index.
 /// @param thread_id Optional thread ID hint for usearch's internal thread-local optimizations.
-/// @throws query::VectorSearchException if dimension mismatch or add fails for reasons other than capacity.
+/// @throws VectorSearchException if dimension mismatch or add fails for reasons other than capacity.
 template <typename SyncIndex, typename Key, typename Spec>
 void UpdateVectorIndex(SyncIndex &mg_index, Spec &spec, const Key &key, const utils::small_vector<float> &vector,
                        std::optional<std::size_t> thread_id = std::nullopt) {
@@ -418,7 +417,7 @@ void UpdateVectorIndex(SyncIndex &mg_index, Spec &spec, const Key &key, const ut
   }
 
   if (vector.size() != spec.dimension) {
-    throw query::VectorSearchException(
+    throw VectorSearchException(
         "Vector index property must have the same number of dimensions as specified in the index.");
   }
 
@@ -456,7 +455,7 @@ void UpdateVectorIndex(SyncIndex &mg_index, Spec &spec, const Key &key, const ut
   const auto new_size = static_cast<std::size_t>(spec.resize_coefficient * mg_index.index.capacity());
   const unum::usearch::index_limits_t new_limits(new_size, GetVectorIndexThreadCount());
   if (!mg_index.index.try_reserve(new_limits)) {
-    throw query::VectorSearchException("Failed to resize vector index.");
+    throw VectorSearchException("Failed to resize vector index.");
   }
   spec.capacity = mg_index.index.capacity();
 
@@ -465,7 +464,7 @@ void UpdateVectorIndex(SyncIndex &mg_index, Spec &spec, const Key &key, const ut
     return;
   }
   result.error.release();
-  throw query::VectorSearchException("Failed to add entry to vector index.");
+  throw VectorSearchException("Failed to add entry to vector index.");
 }
 
 /// @brief Populates a vector index by iterating over vertices on a single thread.

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -36,6 +36,8 @@
 #include "utils/small_vector.hpp"
 #include "utils/variant_helpers.hpp"
 
+#include "storage/v2/exceptions.hpp"
+
 namespace memgraph::storage {
 class InMemoryStorage;
 
@@ -687,7 +689,7 @@ std::expected<void, storage::StorageIndexDefinitionError> Storage::Accessor::Cre
   try {
     storage_->indices_.text_index_.CreateIndex(
         text_index_info, Vertices(View::NEW), storage_->name_id_mapper_.get(), on_progress);
-  } catch (const query::TextSearchException &e) {
+  } catch (const TextSearchException &e) {
     return std::unexpected{storage::StorageIndexDefinitionError{IndexDefinitionError{}}};
   }
 
@@ -724,7 +726,7 @@ std::expected<void, storage::StorageIndexDefinitionError> Storage::Accessor::Cre
   try {
     storage_->indices_.text_edge_index_.CreateIndex(
         text_edge_index_info, Vertices(View::NEW), storage_->name_id_mapper_.get(), on_progress);
-  } catch (const query::TextSearchException &e) {
+  } catch (const TextSearchException &e) {
     return std::unexpected{storage::StorageIndexDefinitionError{IndexDefinitionError{}}};
   }
 

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -18,6 +18,7 @@
 #include "storage/v2/edge.hpp"
 #include "storage/v2/edge_accessor.hpp"
 #include "storage/v2/edge_direction.hpp"
+#include "storage/v2/exceptions.hpp"
 #include "storage/v2/hops_limit.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indexed_property_decoder.hpp"
@@ -174,7 +175,7 @@ bool VertexAccessor::IsVisible(View view) const {
 
 Result<bool> VertexAccessor::AddLabel(LabelId label) {
   if (transaction_->edge_import_mode_active) {
-    throw query::WriteVertexOperationInEdgeImportModeException();
+    throw WriteVertexOperationInEdgeImportModeException();
   }
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   // This has to be called before any object gets locked
@@ -249,7 +250,7 @@ Result<bool> VertexAccessor::AddLabel(LabelId label) {
 // TODO: move to after update and change naming to vertex after update
 Result<bool> VertexAccessor::RemoveLabel(LabelId label) {
   if (transaction_->edge_import_mode_active) {
-    throw query::WriteVertexOperationInEdgeImportModeException();
+    throw WriteVertexOperationInEdgeImportModeException();
   }
   // This has to be called before any object gets locked
   // 1. do an optimistic shared lock
@@ -406,7 +407,7 @@ Result<VertexKey> VertexAccessor::Labels(View view) const {
 
 Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const PropertyValue &value) const {
   if (transaction_->edge_import_mode_active) {
-    throw query::WriteVertexOperationInEdgeImportModeException();
+    throw WriteVertexOperationInEdgeImportModeException();
   }
 
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
@@ -491,7 +492,7 @@ Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const Pro
 
 Result<bool> VertexAccessor::InitProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) const {
   if (transaction_->edge_import_mode_active) {
-    throw query::WriteVertexOperationInEdgeImportModeException();
+    throw WriteVertexOperationInEdgeImportModeException();
   }
 
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
@@ -559,7 +560,7 @@ Result<bool> VertexAccessor::InitProperties(std::map<storage::PropertyId, storag
 Result<std::vector<std::tuple<PropertyId, PropertyValue, PropertyValue>>> VertexAccessor::UpdateProperties(
     std::map<storage::PropertyId, storage::PropertyValue> &properties) const {
   if (transaction_->edge_import_mode_active) {
-    throw query::WriteVertexOperationInEdgeImportModeException();
+    throw WriteVertexOperationInEdgeImportModeException();
   }
 
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
@@ -630,7 +631,7 @@ Result<std::vector<std::tuple<PropertyId, PropertyValue, PropertyValue>>> Vertex
 
 Result<std::map<PropertyId, PropertyValue>> VertexAccessor::ClearProperties() {
   if (transaction_->edge_import_mode_active) {
-    throw query::WriteVertexOperationInEdgeImportModeException();
+    throw WriteVertexOperationInEdgeImportModeException();
   }
   // This has to be called before any object gets locked
   auto schema_acc = SchemaInfoAccessor(storage_, transaction_);

--- a/tests/unit/text_index.cpp
+++ b/tests/unit/text_index.cpp
@@ -23,6 +23,7 @@
 #include "tests/test_commit_args_helper.hpp"
 #include "tests/unit/ddl_abort_helpers.hpp"
 
+#include "storage/v2/exceptions.hpp"
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
 
@@ -396,6 +397,6 @@ TEST_F(TextIndexTest, FuzzyDistanceAboveTwoThrows) {
     constexpr TextSearchConfig bad_config{.limit = 10, .fuzzy_distance = 3};
     EXPECT_THROW(acc->TextIndexSearch(
                      test_index.data(), "data.title:memgraph", text_search_mode::SPECIFIED_PROPERTIES, bad_config),
-                 memgraph::query::TextSearchException);
+                 memgraph::storage::TextSearchException);
   }
 }

--- a/tests/unit/vector_edge_index.cpp
+++ b/tests/unit/vector_edge_index.cpp
@@ -40,6 +40,7 @@
 #include "utils/on_scope_exit.hpp"
 #include "utils/settings.hpp"
 
+#include "storage/v2/exceptions.hpp"
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
 
@@ -202,7 +203,7 @@ TEST_F(VectorEdgeIndexTest, InvalidDimensionTest) {
   std::vector<PropertyValue> properties(3, PropertyValue(1.0));
   PropertyValue property_value(properties);
   EXPECT_THROW(this->CreateEdge(acc.get(), test_property, property_value, test_edge_type),
-               memgraph::query::VectorSearchException);
+               memgraph::storage::VectorSearchException);
 }
 
 TEST_F(VectorEdgeIndexTest, SearchWithMultipleEdges) {
@@ -529,7 +530,7 @@ TEST_F(VectorEdgeIndexTest, CreateIndexWithWrongDimensionRollsBack) {
     [[maybe_unused]] auto [fv2, tv2, e2] = this->CreateEdge(acc.get(), test_property, bad_vec, test_edge_type);
     ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
   }
-  EXPECT_THROW(this->CreateEdgeIndex(2, 10), memgraph::query::VectorSearchException);
+  EXPECT_THROW(this->CreateEdgeIndex(2, 10), memgraph::storage::VectorSearchException);
   {
     auto acc = this->storage->Access(memgraph::storage::READ);
     EXPECT_EQ(acc->ListAllVectorEdgeIndices().size(), 0);


### PR DESCRIPTION
The graph engine raises its own exceptions for the conditions it detects: an index that does not exist, a vector whose dimension does not match the index it is being added to, a write the active mode forbids, a type constraint a property violates. It no longer names the query layer's exception types in its own sources, and its index headers no longer pull the query layer's exception header into every translation unit that uses them.

They share a base saying the operation is not valid for the arguments it was given or the state the engine is in, so repeating it unchanged fails the same way. That is a fact the engine can assert without knowing who asked. What follows from it belongs to the caller: a session presents one of these as permanent, meaning do not retry, where anything deriving from the plain base is presented as transient. Deriving from the query layer's exception used to decide that from a distance.
