### PR TITLE
refactor(communication): narrow what the websocket asks of auth

### DIFF
--- a/src/communication/CMakeLists.txt
+++ b/src/communication/CMakeLists.txt
@@ -8,7 +8,6 @@ target_link_libraries(mg-communication-metrics PRIVATE nlohmann_json::nlohmann_j
 add_library(mg-communication STATIC)
 target_sources(mg-communication
     PRIVATE
-    websocket/auth.cpp
     websocket/server.cpp
     websocket/listener.cpp
     websocket/session.cpp
@@ -29,5 +28,5 @@ target_sources(mg-communication
 )
 target_link_libraries(mg-communication
     PUBLIC Boost::headers mg-io mg-utils gflags
-    PRIVATE Threads::Threads mg-auth fmt::fmt mg-communication-metrics mg-metrics openssl::openssl
+    PRIVATE Threads::Threads fmt::fmt mg-communication-metrics mg-metrics openssl::openssl
 )

--- a/src/communication/websocket/auth.hpp
+++ b/src/communication/websocket/auth.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,34 +13,21 @@
 
 #include <string>
 
-#include "auth/auth.hpp"
-
 namespace memgraph::communication::websocket {
 
+// What a websocket session needs of whoever holds the users, stated so that the session does not
+// have to name the permission vocabulary it is asking about.
 class AuthenticationInterface {
  public:
   virtual bool Authenticate(const std::string &username, const std::string &password) const = 0;
 
-  virtual bool HasPermission(auth::Permission permission) const = 0;
+  // Whether the authenticated party may use the websocket at all, which is the only question a
+  // session asks.
+  virtual bool HasWebsocketPermission() const = 0;
 
   virtual bool AccessControlled() const = 0;
 
   virtual ~AuthenticationInterface() = default;
 };
 
-class SafeAuth : public AuthenticationInterface {
- public:
-  explicit SafeAuth(auth::SynchedAuth *auth) : auth_{auth} {}
-
-  bool Authenticate(const std::string &username, const std::string &password) const override;
-
-  bool HasPermission(auth::Permission permission) const override;
-
-  bool AccessControlled() const override;
-
- private:
-  auth::SynchedAuth *auth_;
-  mutable std::optional<auth::UserOrRole> user_or_role_;
-  mutable auth::Auth::Epoch auth_epoch_{};
-};
 }  // namespace memgraph::communication::websocket

--- a/src/communication/websocket/session.cpp
+++ b/src/communication/websocket/session.cpp
@@ -164,7 +164,7 @@ std::expected<void, std::string> Session::Authorize(const nlohmann::json &creds)
     return std::unexpected{"Authentication failed!"};
   }
 #ifdef MG_ENTERPRISE
-  if (!auth_.HasPermission(auth::Permission::WEBSOCKET)) {
+  if (!auth_.HasWebsocketPermission()) {
     return std::unexpected{"Authorization failed!"};
   }
 #endif

--- a/src/glue/CMakeLists.txt
+++ b/src/glue/CMakeLists.txt
@@ -9,5 +9,6 @@ target_sources(mg-glue PRIVATE auth.cpp
                                MonitoringServerT.cpp
                                PrometheusServerT.cpp
                                run_id.cpp
-                               query_user.cpp)
-target_link_libraries(mg-glue PRIVATE mg-query mg-auth mg-audit mg-flags mg-metrics prometheus-cpp::pull)
+                               query_user.cpp
+                               websocket_auth.cpp)
+target_link_libraries(mg-glue PRIVATE mg-query mg-auth mg-audit mg-flags mg-metrics mg-communication prometheus-cpp::pull)

--- a/src/glue/websocket_auth.cpp
+++ b/src/glue/websocket_auth.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -9,19 +9,21 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#include "communication/websocket/auth.hpp"
+#include "glue/websocket_auth.hpp"
 
 #include <string>
+
+#include "dbms/constants.hpp"
 #include "utils/variant_helpers.hpp"
 
-namespace memgraph::communication::websocket {
+namespace memgraph::glue {
 
 bool SafeAuth::Authenticate(const std::string &username, const std::string &password) const {
   user_or_role_ = auth_->Lock()->Authenticate(username, password);
   return user_or_role_.has_value();
 }
 
-bool SafeAuth::HasPermission(const auth::Permission permission) const {
+bool SafeAuth::HasWebsocketPermission() const {
   auto locked_auth = auth_->ReadLock();
   // Update if cache invalidated
   if (!locked_auth->UpToDate(auth_epoch_) && user_or_role_) {
@@ -62,7 +64,8 @@ bool SafeAuth::HasPermission(const auth::Permission permission) const {
 #else
                             dbms::kDefaultDB;
 #endif
-                        return user_or_role.GetPermissions(db_name).Has(permission) == auth::PermissionLevel::GRANT;
+                        return user_or_role.GetPermissions(db_name).Has(auth::Permission::WEBSOCKET) ==
+                               auth::PermissionLevel::GRANT;
                       }},
                       *user_or_role_);
   }
@@ -71,4 +74,5 @@ bool SafeAuth::HasPermission(const auth::Permission permission) const {
 }
 
 bool SafeAuth::AccessControlled() const { return auth_->ReadLock()->AccessControlled(); }
-}  // namespace memgraph::communication::websocket
+
+}  // namespace memgraph::glue

--- a/src/glue/websocket_auth.hpp
+++ b/src/glue/websocket_auth.hpp
@@ -1,0 +1,40 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "auth/auth.hpp"
+#include "communication/websocket/auth.hpp"
+
+namespace memgraph::glue {
+
+// Answers a websocket session's questions out of the user store, caching the authenticated party
+// and refreshing it when the store's epoch moves on.
+class SafeAuth : public communication::websocket::AuthenticationInterface {
+ public:
+  explicit SafeAuth(auth::SynchedAuth *auth) : auth_{auth} {}
+
+  bool Authenticate(const std::string &username, const std::string &password) const override;
+
+  bool HasWebsocketPermission() const override;
+
+  bool AccessControlled() const override;
+
+ private:
+  auth::SynchedAuth *auth_;
+  mutable std::optional<auth::UserOrRole> user_or_role_;
+  mutable auth::Auth::Epoch auth_epoch_{};
+};
+
+}  // namespace memgraph::glue

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -28,7 +28,6 @@
 #include "communication/cluster_tls.hpp"
 #include "communication/init.hpp"
 #include "communication/v2/server.hpp"
-#include "communication/websocket/auth.hpp"
 #include "communication/websocket/server.hpp"
 #include "coordination/coordinator_state.hpp"
 #include "coordination/data_instance_management_server_handlers.hpp"
@@ -48,6 +47,7 @@
 #include "glue/auth_checker.hpp"
 #include "glue/auth_handler.hpp"
 #include "glue/run_id.hpp"
+#include "glue/websocket_auth.hpp"
 #include "helpers.hpp"
 #include "license/license.hpp"
 #include "license/license_sender.hpp"
@@ -1113,7 +1113,7 @@ int main(int argc, char **argv) {
                                                            memory_limit,
                                                            memgraph::license::global_license_checker.GetLicenseInfo());
 
-  memgraph::communication::websocket::SafeAuth websocket_auth{auth_.get()};
+  memgraph::glue::SafeAuth websocket_auth{auth_.get()};
   memgraph::communication::websocket::Server websocket_server{
       {FLAGS_monitoring_address, static_cast<uint16_t>(FLAGS_monitoring_port)}, &bolt_server_context, websocket_auth};
 

--- a/tests/unit/monitoring.cpp
+++ b/tests/unit/monitoring.cpp
@@ -49,7 +49,7 @@ struct MockAuth : public memgraph::communication::websocket::AuthenticationInter
     return authentication;
   }
 
-  bool HasPermission(memgraph::auth::Permission /*permission*/) const override { return authorization; }
+  bool HasWebsocketPermission() const override { return authorization; }
 
   bool AccessControlled() const override { return has_any_users; }
 


### PR DESCRIPTION
The websocket asks auth only for what it needs to authenticate and authorise a connection, expressed as an interface it owns, and the implementation that knows about users and roles moves to the glue layer that already binds the two together. The communication library no longer links auth.

That link made the websocket's session depend on the whole user model to answer one question about one connection.
