### PR TITLE
testing: Increase time before registering replicas in Jepsen tests

### DIFF
--- a/tests/jepsen/src/memgraph/replication/nemesis.clj
+++ b/tests/jepsen/src/memgraph/replication/nemesis.clj
@@ -28,7 +28,7 @@
   "Construct nemesis generator."
   []
   (gen/phases
-   (gen/sleep 5)
+   (gen/sleep 15)
    (cycle [(gen/sleep 5)
            {:type :info, :f :kill-node}
            (gen/sleep 5)

--- a/tests/jepsen/src/memgraph/replication/utils.clj
+++ b/tests/jepsen/src/memgraph/replication/utils.clj
@@ -17,7 +17,7 @@
   [ops]
   (gen/each-thread
     (gen/phases
-      (gen/sleep 5)
+      (gen/sleep 10)
       (gen/once register-replicas)
       (gen/sleep 5)
       (gen/delay 3 (gen/mix ops)))))


### PR DESCRIPTION
Increase time before sleeping so that set replication role to replica can run. Needed for slower CI machines.