### PR TITLE
fix(utils): wait for the accessor count to drain in try_exclusively

### DIFF
--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -258,13 +258,17 @@ struct Gatekeeper {
       return std::addressof(*owner_->value_);
     }
 
+    // Invokes func with this accessor as the sole one, waiting up to timeout for the other accessors
+    // to drop. Most accessors are short-lived, so sampling the count once refuses work that was about
+    // to become legal. The wait does not keep new accessors out: access() takes the same mutex that
+    // wait_for releases, so a steady stream of them starves the wait until the timeout.
     template <typename Func>
-    [[nodiscard]] auto try_exclusively(Func &&func) -> EvalResult<std::invoke_result_t<Func, T &>> {
+    [[nodiscard]] auto try_exclusively(Func &&func, std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
+        -> EvalResult<std::invoke_result_t<Func, T &>> {
       if (!owner_) return {not_run_t{}};
-      // Prevent new access
       auto guard = std::unique_lock{owner_->mutex_};
-      // Only invoke if we have exclusive access
-      if (owner_->count_ != 1) {
+      if (!owner_->cv_.wait_for(guard, timeout, [this] { return owner_->count_ == 1; })) {
+        spdlog::trace("Exclusive access denied after {}ms, {} accessors still live.", timeout.count(), owner_->count_);
         return {not_run_t{}};
       }
       // Invoke and hold result in wrapper type

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -444,6 +444,11 @@ add_unit_test(utils_algorithm
     LINK_TARGETS mg-utils
 )
 
+add_unit_test(utils_gatekeeper
+    SOURCES utils_gatekeeper.cpp
+    LINK_TARGETS mg-utils
+)
+
 # Hot/cold tenants: gatekeeper 4-state lifecycle machine
 add_unit_test(hot_cold_gatekeeper
     SOURCES hot_cold_gatekeeper.cpp

--- a/tests/unit/utils_gatekeeper.cpp
+++ b/tests/unit/utils_gatekeeper.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "utils/gatekeeper.hpp"
+
+using namespace memgraph::utils;
+using namespace std::chrono_literals;
+
+namespace {
+
+struct Widget {
+  int v;
+};
+
+}  // namespace
+
+// An accessor that is on its way out must not deny exclusive access: the caller
+// asked for sole access, and it gets it as soon as the other holder lets go.
+TEST(UtilsGatekeeper, TryExclusivelyWaitsForAnotherAccessorToDrop) {
+  auto gk = Gatekeeper<Widget>{42};
+
+  auto sole = gk.access();
+  ASSERT_TRUE(sole.has_value());
+
+  auto other = gk.access();
+  ASSERT_TRUE(other.has_value());
+
+  auto releaser = std::jthread{[acc = std::move(*other)]() mutable {
+    std::this_thread::sleep_for(50ms);
+    acc.reset();
+  }};
+
+  auto observed = 0;
+  EXPECT_TRUE(static_cast<bool>(sole->try_exclusively([&](Widget &w) { observed = w.v; }, 5s)));
+  EXPECT_EQ(observed, 42);
+}
+
+// A holder that stays put is a genuine denial, reported within the timeout.
+TEST(UtilsGatekeeper, TryExclusivelyGivesUpWhenAnotherAccessorStays) {
+  auto gk = Gatekeeper<Widget>{42};
+
+  auto sole = gk.access();
+  ASSERT_TRUE(sole.has_value());
+  auto other = gk.access();
+  ASSERT_TRUE(other.has_value());
+
+  auto ran = false;
+  EXPECT_FALSE(static_cast<bool>(sole->try_exclusively([&](Widget & /*unused*/) { ran = true; }, 20ms)));
+  EXPECT_FALSE(ran);
+}
+
+// Zero timeout keeps the one-shot check available for callers that must not block.
+TEST(UtilsGatekeeper, TryExclusivelyWithZeroTimeoutSamplesOnce) {
+  auto gk = Gatekeeper<Widget>{42};
+
+  auto sole = gk.access();
+  ASSERT_TRUE(sole.has_value());
+
+  {
+    auto other = gk.access();
+    ASSERT_TRUE(other.has_value());
+    EXPECT_FALSE(static_cast<bool>(sole->try_exclusively([](Widget & /*unused*/) {}, 0ms)));
+  }
+
+  EXPECT_TRUE(static_cast<bool>(sole->try_exclusively([](Widget & /*unused*/) {}, 0ms)));
+}
+
+TEST(UtilsGatekeeper, TryExclusivelyReturnsTheFunctionsResult) {
+  auto gk = Gatekeeper<Widget>{42};
+
+  auto sole = gk.access();
+  ASSERT_TRUE(sole.has_value());
+
+  auto result = sole->try_exclusively([](Widget &w) { return w.v + 1; }, 0ms);
+  ASSERT_TRUE(static_cast<bool>(result));
+  EXPECT_EQ(result.value(), 43);
+}
+
+// The wait must not swallow the exception the function throws: the storage-mode
+// switch reports its refusals that way.
+TEST(UtilsGatekeeper, TryExclusivelyPropagatesExceptions) {
+  auto gk = Gatekeeper<Widget>{42};
+
+  auto sole = gk.access();
+  ASSERT_TRUE(sole.has_value());
+
+  EXPECT_THROW((void)sole->try_exclusively([](Widget & /*unused*/) { throw std::runtime_error{"nope"}; }, 0ms),
+               std::runtime_error);
+}


### PR DESCRIPTION
try_exclusively waits up to a timeout for the other accessors to drop before it
invokes its function, matching try_delete and try_begin_suspend. A caller that
must not block passes zero. Sampling the count once refuses work that is about
to become legal, because most accessors are short-lived.

The one caller is the switch to on-disk storage, which tells the operator to
close their other sessions. Any second accessor anywhere in the process reaches
that message, whether or not a session holds it, so a switch that becomes legal
a moment later would otherwise be reported as a conflict. New accessors are not
kept out while it waits, so a holder that stays is still reported, and a denial
that outlasts the timeout logs the count still live at trace level.
