### PR TITLE
fix(parameters): Stop parameters outliving the database they belong to

### DIFF
--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -489,6 +489,8 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
 
   if (on_uuid_retired_) on_uuid_retired_(uuid);
 
+  if (on_uuid_retired_) on_uuid_retired_(uuid);
+
   // Success
   // Save delta
   if (transaction) {

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -487,6 +487,8 @@ DbmsHandler::DeleteResult DbmsHandler::TryDelete(std::string_view db_name, syste
     spdlog::error(R"(Failed to clean disk while deleting database "{}" stored in {})", db_name, storage_path);
   }
 
+  if (on_uuid_retired_) on_uuid_retired_(uuid);
+
   // Success
   // Save delta
   if (transaction) {
@@ -816,6 +818,7 @@ std::expected<utils::UUID, DeleteError> DbmsHandler::DeleteCold_(std::string_vie
   if (ec) {
     spdlog::error(R"(Failed to clean disk while dropping suspended database "{}" at {})", name_copy, data_dir.string());
   }
+  if (on_uuid_retired_) on_uuid_retired_(uuid);
   UpdateColdGauge_();
   return uuid;
 }
@@ -829,6 +832,7 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
   const auto storage_path = StorageDir_(db_name);
   if (!storage_path) return std::unexpected{DeleteError::NON_EXISTENT};
 
+  utils::UUID retired_uuid;
   {
     auto db = db_handler_.Get(db_name);
     if (!db) {
@@ -845,11 +849,14 @@ DbmsHandler::DeleteResult DbmsHandler::Delete_(std::string_view db_name) {
     //       can occur while we are dropping the database
     db->prepare_for_deletion();
     auto &database = *db->get();
+    retired_uuid = database.uuid();
     database.StopAllBackgroundTasks();
     database.streams()->DropAll();
   }
 
   DetachProfileAndRetireDurabilityKey_(db_name);
+
+  if (on_uuid_retired_) on_uuid_retired_(retired_uuid);
 
   // Check if db exists
   // Low level handlers

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -225,8 +225,10 @@ class DbmsHandler {
       }
       spdlog::debug("Updated default db's UUID");
       // Default db cannot be deleted and remade, have to just update the UUID
+      auto const retired_uuid = storage->config_.salient.uuid;
       storage->config_.salient.uuid = config.uuid;
       metrics::Metrics().RebindDefaultDatabaseUUID(config.uuid);
+      if (on_uuid_retired_) on_uuid_retired_(retired_uuid);
       UpdateDurability(storage->config_, ".");
       return db;
     }
@@ -376,6 +378,14 @@ class DbmsHandler {
    *        running/stopped state. Triggers are NOT restored here (suspend never stops them). Default empty.
    */
   void SetRestoreStreams(std::function<void(DatabaseAccess)> cb) { restore_streams_ = std::move(cb); }
+
+  /**
+   * @brief Set the arm that discards a database's server-side parameters. Those are keyed by database
+   *        uuid in a store this handler does not own, so every event that retires a uuid must announce
+   *        it or the rows outlive the database, unreachable and durable. Fired by DROP DATABASE (HOT and
+   *        COLD) and by the in-place rebind Update performs on the default database. Default empty.
+   */
+  void SetOnUuidRetired(std::function<void(utils::UUID const &)> cb) { on_uuid_retired_ = std::move(cb); }
 
   /**
    * @brief Resume (move COLD -> HOT) the named tenant, recovering its in-memory storage inline.
@@ -1101,7 +1111,8 @@ class DbmsHandler {
   std::function<void(DatabaseAccess)> on_resume_;    //!< pre-publish resume arm (triggers/streams/TTL); empty default
   std::function<void(DatabaseAccess)> on_suspend_;   //!< pre-teardown suspend arm (stop streams); empty default
   std::function<void(DatabaseAccess)>
-      restore_streams_;                      //!< streams-only restore (undo a stopped suspend); empty default
+      restore_streams_;  //!< streams-only restore (undo a stopped suspend); empty default
+  std::function<void(utils::UUID const &)> on_uuid_retired_;  //!< discards a retired uuid's parameters; empty default
   ResumeRetryPolicy resume_retry_policy_{};  //!< Resume_ retry/timeout knobs; test-overridable, production defaults
 #endif
 #ifndef MG_ENTERPRISE

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -381,9 +381,11 @@ class DbmsHandler {
 
   /**
    * @brief Set the arm that discards a database's server-side parameters. Those are keyed by database
-   *        uuid in a store this handler does not own, so every event that retires a uuid must announce
-   *        it or the rows outlive the database, unreachable and durable. Fired by DROP DATABASE (HOT and
-   *        COLD) and by the in-place rebind Update performs on the default database. Default empty.
+   *        uuid in a store this handler does not own, so the invariant is: every path that retires a
+   *        live database's uuid announces the old value here, or the rows outlive the database,
+   *        unreachable and durable. A path that retires a uuid without announcing it also diverges
+   *        main from its replicas, because the replica applies the drop through a path that does
+   *        announce. Default empty.
    */
   void SetOnUuidRetired(std::function<void(utils::UUID const &)> cb) { on_uuid_retired_ = std::move(cb); }
 

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -380,12 +380,9 @@ class DbmsHandler {
   void SetRestoreStreams(std::function<void(DatabaseAccess)> cb) { restore_streams_ = std::move(cb); }
 
   /**
-   * @brief Set the arm that discards a database's server-side parameters. Those are keyed by database
-   *        uuid in a store this handler does not own, so the invariant is: every path that retires a
-   *        live database's uuid announces the old value here, or the rows outlive the database,
-   *        unreachable and durable. A path that retires a uuid without announcing it also diverges
-   *        main from its replicas, because the replica applies the drop through a path that does
-   *        announce. Default empty.
+   * @brief Set the arm that discards a database's server-side parameters, which live in a store this
+   *        handler does not own, keyed by database uuid. Every path that retires a live uuid announces
+   *        the old value here, or the rows outlive the database, unreachable and durable. Default empty.
    */
   void SetOnUuidRetired(std::function<void(utils::UUID const &)> cb) { on_uuid_retired_ = std::move(cb); }
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -865,11 +865,8 @@ int main(int argc, char **argv) {
   }
 
 #ifdef MG_ENTERPRISE
-  // Parameters are keyed by database uuid, so a uuid this handler retires takes its parameters with it.
-  // Wired here, before the replication RPC server and the init file can drop a database: an unwired arm
-  // is an empty std::function, and a drop that finds one leaves the parameters behind for good.
-  // Enterprise-only: dropping a database and the in-place rebind Update performs on the default
-  // database are both enterprise paths.
+  // Wired before the replication RPC server and the init file, either of which can drop a database:
+  // an unwired arm is an empty std::function, so the drop leaves the parameters behind for good.
   if (dbms_handler.has_value()) {
     dbms_handler->SetOnUuidRetired([parameters](memgraph::utils::UUID const &uuid) {
       [[maybe_unused]] auto purged = parameters->DeleteScope(std::string{uuid});

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -864,6 +864,19 @@ int main(int argc, char **argv) {
     dbms_handler.emplace(db_config);
   }
 
+#ifdef MG_ENTERPRISE
+  // Parameters are keyed by database uuid, so a uuid this handler retires takes its parameters with it.
+  // Wired here, before the replication RPC server and the init file can drop a database: an unwired arm
+  // is an empty std::function, and a drop that finds one leaves the parameters behind for good.
+  // Enterprise-only: dropping a database and the in-place rebind Update performs on the default
+  // database are both enterprise paths.
+  if (dbms_handler.has_value()) {
+    dbms_handler->SetOnUuidRetired([parameters](memgraph::utils::UUID const &uuid) {
+      [[maybe_unused]] auto purged = parameters->DeleteScope(std::string{uuid});
+    });
+  }
+#endif
+
   memgraph::metrics::Metrics().SetStorageSnapshotResolver(
       [&dbms_handler](memgraph::utils::UUID const &uuid) -> std::optional<memgraph::metrics::StorageSnapshot> {
         if (!dbms_handler) return std::nullopt;
@@ -1012,17 +1025,6 @@ int main(int argc, char **argv) {
     dbms_handler->RestoreStreams(&interpreter_context_);
     spdlog::trace("Streams restored.");
   }
-
-#ifdef MG_ENTERPRISE
-  // Parameters are keyed by database uuid, so a uuid this handler retires takes its parameters with it.
-  // Enterprise-only: dropping a database and the in-place rebind Update performs on the default
-  // database are both enterprise paths.
-  if (dbms_handler.has_value()) {
-    dbms_handler->SetOnUuidRetired([parameters](memgraph::utils::UUID const &uuid) {
-      [[maybe_unused]] auto purged = parameters->DeleteScope(std::string{uuid});
-    });
-  }
-#endif
 
 #ifdef MG_ENTERPRISE
   // Hot/cold suspend/resume arms (multi-tenant). Wired unconditionally (not gated on recover_on_startup):

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1015,8 +1015,8 @@ int main(int argc, char **argv) {
 
 #ifdef MG_ENTERPRISE
   // Parameters are keyed by database uuid, so a uuid this handler retires takes its parameters with it.
-  // Enterprise-only because both events that retire one are: DROP DATABASE, and the in-place rebind
-  // Update performs on the default database.
+  // Enterprise-only: dropping a database and the in-place rebind Update performs on the default
+  // database are both enterprise paths.
   if (dbms_handler.has_value()) {
     dbms_handler->SetOnUuidRetired([parameters](memgraph::utils::UUID const &uuid) {
       [[maybe_unused]] auto purged = parameters->DeleteScope(std::string{uuid});

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1014,6 +1014,17 @@ int main(int argc, char **argv) {
   }
 
 #ifdef MG_ENTERPRISE
+  // Parameters are keyed by database uuid, so a uuid this handler retires takes its parameters with it.
+  // Enterprise-only because both events that retire one are: DROP DATABASE, and the in-place rebind
+  // Update performs on the default database.
+  if (dbms_handler.has_value()) {
+    dbms_handler->SetOnUuidRetired([parameters](memgraph::utils::UUID const &uuid) {
+      [[maybe_unused]] auto purged = parameters->DeleteScope(std::string{uuid});
+    });
+  }
+#endif
+
+#ifdef MG_ENTERPRISE
   // Hot/cold suspend/resume arms (multi-tenant). Wired unconditionally (not gated on recover_on_startup):
   //  - on_suspend_: before the freeze, stop the per-db stream consumers (each pins the tenant HOT via a
   //    captured DatabaseAccess), preserving their durable metadata so resume rebuilds them;

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -9,11 +9,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#include <fmt/format.h>
-
 #include <map>
 #include <string>
 #include <vector>
+
+#include <fmt/format.h>
 
 #include "parameters/parameters.hpp"
 #include "parameters/rpc.hpp"
@@ -21,6 +21,7 @@
 #include "replication/include/replication/state.hpp"
 #include "system/include/system/action.hpp"
 #include "system/include/system/transaction.hpp"
+#include "utils/logging.hpp"
 
 namespace memgraph::parameters {
 

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -144,6 +144,8 @@ bool Parameters::DeleteAllParameters(system::Transaction *txn) {
   return true;
 }
 
+bool Parameters::DeleteScope(std::string_view scope) { return storage_.DeletePrefix(fmt::format("{}/", scope)); }
+
 bool Parameters::ApplyRecovery(const std::vector<ParameterInfo> &params) {
   std::map<std::string, std::string> items;
   for (const auto &p : params) {

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -10,7 +10,9 @@
 // licenses/APL.txt.
 
 #include <map>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <fmt/format.h>

--- a/src/parameters/parameters.cpp
+++ b/src/parameters/parameters.cpp
@@ -11,6 +11,10 @@
 
 #include <fmt/format.h>
 
+#include <map>
+#include <string>
+#include <vector>
+
 #include "parameters/parameters.hpp"
 #include "parameters/rpc.hpp"
 #include "replication/include/replication/replication_client.hpp"
@@ -144,7 +148,13 @@ bool Parameters::ApplyRecovery(const std::vector<ParameterInfo> &params) {
   for (const auto &p : params) {
     items[MakeKey(p.name, p.scope_context)] = p.value;
   }
-  return storage_.PutMultiple(items);
+  // Recovery replaces local state: a parameter the instance held before joining must not survive,
+  // or a $placeholder here resolves to a value that exists nowhere on main.
+  std::vector<std::string> stale;
+  for (auto it = storage_.begin(); it != storage_.end(); ++it) {
+    if (!items.contains(it->first)) stale.push_back(it->first);
+  }
+  return storage_.PutAndDeleteMultiple(items, stale);
 }
 
 std::vector<ParameterInfo> Parameters::GetSnapshotForRecovery() const {

--- a/src/parameters/parameters.hpp
+++ b/src/parameters/parameters.hpp
@@ -91,6 +91,12 @@ struct Parameters {
   bool DeleteAllParameters(system::Transaction *txn = nullptr);
 
   /**
+   * @brief Delete every parameter in one scope, leaving all other scopes untouched.
+   * @param scope kGlobalScope for global; database UUID for database-scoped.
+   */
+  bool DeleteScope(std::string_view scope);
+
+  /**
    * @brief Apply parameter recovery snapshot from main (used by SystemRecoveryHandler).
    * Replaces local state: parameters absent from the snapshot are dropped. The write is a single
    * batch, so a storage failure leaves the store untouched.

--- a/src/parameters/parameters.hpp
+++ b/src/parameters/parameters.hpp
@@ -92,8 +92,8 @@ struct Parameters {
 
   /**
    * @brief Apply parameter recovery snapshot from main (used by SystemRecoveryHandler).
-   * Replaces local state: parameters absent from the snapshot are dropped. Applied atomically,
-   * so a failure leaves the store untouched.
+   * Replaces local state: parameters absent from the snapshot are dropped. The write is a single
+   * batch, so a storage failure leaves the store untouched.
    * @return true on success, false on storage error.
    */
   bool ApplyRecovery(const std::vector<ParameterInfo> &params);

--- a/src/parameters/parameters.hpp
+++ b/src/parameters/parameters.hpp
@@ -11,6 +11,14 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "kvstore/kvstore.hpp"
 #include "system/state.hpp"
 #include "system/transaction.hpp"

--- a/src/parameters/parameters.hpp
+++ b/src/parameters/parameters.hpp
@@ -84,7 +84,8 @@ struct Parameters {
 
   /**
    * @brief Apply parameter recovery snapshot from main (used by SystemRecoveryHandler).
-   * Applied atomically: either all parameters are written or none.
+   * Replaces local state: parameters absent from the snapshot are dropped. Applied atomically,
+   * so a failure leaves the store untouched.
    * @return true on success, false on storage error.
    */
   bool ApplyRecovery(const std::vector<ParameterInfo> &params);

--- a/tests/e2e/system_replication/replicate_parameters.py
+++ b/tests/e2e/system_replication/replicate_parameters.py
@@ -286,5 +286,43 @@ def test_parameter_replication_after_replica_recovery(connection, test_name, cle
     assert len(main_params) == 2
 
 
+def test_parameters_set_before_registration_do_not_survive_recovery(connection, test_name, clean_dirs):
+    # An instance joining a cluster takes main's state as its own, so a parameter set while it was
+    # standalone must not survive the join. A parameter that did survive would stay reachable: an
+    # unbound $placeholder resolves against the server-side parameters, so a name held only by the
+    # replica would resolve there to a value present nowhere else in the cluster.
+    # 0/ Start all three with no replica setup_queries, so parameters can be set before registration.
+    # 1/ Set parameters on main and different ones on each replica while all are standalone.
+    # 2/ Make the replicas replicas, then register them, which triggers recovery.
+    # 3/ Assert each replica holds exactly main's parameters and the local-only ones are unreachable.
+    instances = _instances_with_recovery(test_name)
+    interactive_mg_runner.start_all(instances, keep_directories=False)
+
+    cursor = connection(BOLT_PORTS["main"], "main").cursor()
+    execute_and_fetch_all(cursor, 'SET GLOBAL PARAMETER on_main="MAIN-only";')
+    execute_and_fetch_all(cursor, 'SET GLOBAL PARAMETER shared="from-MAIN";')
+    execute_and_fetch_all(cursor, 'SET PARAMETER db_on_main="MAIN-db";')
+
+    for name, port in [("replica_1", BOLT_PORTS["replica_1"]), ("replica_2", BOLT_PORTS["replica_2"])]:
+        repl_cursor = connection(port, "replica").cursor()
+        execute_and_fetch_all(repl_cursor, f'SET GLOBAL PARAMETER only_on_{name}="REPLICA-only";')
+        execute_and_fetch_all(repl_cursor, 'SET GLOBAL PARAMETER shared="from-REPLICA";')
+        execute_and_fetch_all(repl_cursor, 'SET PARAMETER db_only_on_replica="REPLICA-db";')
+        execute_and_fetch_all(repl_cursor, f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS[name]};")
+
+    execute_and_fetch_all(cursor, f"REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_1']}';")
+    execute_and_fetch_all(cursor, f"REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_2']}';")
+
+    main_params = sorted(_show_parameters(cursor))
+    assert len(main_params) == 3
+
+    for name, port in [("replica_1", BOLT_PORTS["replica_1"]), ("replica_2", BOLT_PORTS["replica_2"])]:
+        repl_cursor = connection(port, "replica").cursor()
+        mg_sleep_and_assert_collection(main_params, lambda c=repl_cursor: sorted(_show_parameters(c)))
+        # The parameter named only on this replica must not resolve as a query placeholder.
+        with pytest.raises(Exception, match="not provided"):
+            execute_and_fetch_all(repl_cursor, f"RETURN $only_on_{name};")
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/system_replication/replicate_parameters.py
+++ b/tests/e2e/system_replication/replicate_parameters.py
@@ -15,6 +15,7 @@ import sys
 import time
 
 import interactive_mg_runner
+import mgclient
 import pytest
 from common import execute_and_fetch_all, get_data_path, get_logs_path
 from mg_utils import mg_sleep_and_assert_collection
@@ -320,7 +321,7 @@ def test_parameters_set_before_registration_do_not_survive_recovery(connection, 
         repl_cursor = connection(port, "replica").cursor()
         mg_sleep_and_assert_collection(main_params, lambda c=repl_cursor: sorted(_show_parameters(c)))
         # The parameter named only on this replica must not resolve as a query placeholder.
-        with pytest.raises(Exception, match="not provided"):
+        with pytest.raises(mgclient.DatabaseError, match="not provided"):
             execute_and_fetch_all(repl_cursor, f"RETURN $only_on_{name};")
 
 

--- a/tests/e2e/system_replication/replicate_parameters.py
+++ b/tests/e2e/system_replication/replicate_parameters.py
@@ -292,10 +292,6 @@ def test_parameters_set_before_registration_do_not_survive_recovery(connection, 
     # standalone must not survive the join. A parameter that did survive would stay reachable: an
     # unbound $placeholder resolves against the server-side parameters, so a name held only by the
     # replica would resolve there to a value present nowhere else in the cluster.
-    # 0/ Start all three with no replica setup_queries, so parameters can be set before registration.
-    # 1/ Set parameters on main and different ones on each replica while all are standalone.
-    # 2/ Make the replicas replicas, then register them, which triggers recovery.
-    # 3/ Assert each replica holds exactly main's parameters and the local-only ones are unreachable.
     instances = _instances_with_recovery(test_name)
     interactive_mg_runner.start_all(instances, keep_directories=False)
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -414,6 +414,12 @@ add_unit_test(kvstore
     LINK_TARGETS mg-kvstore mg-utils
 )
 
+# Test mg-parameters
+add_unit_test(parameters
+    SOURCES parameters.cpp
+    LINK_TARGETS mg-parameters
+)
+
 if (MG_ENTERPRISE)
 add_unit_test(tenant_profiles
     SOURCES tenant_profiles.cpp ${CMAKE_SOURCE_DIR}/src/dbms/tenant_profiles.cpp

--- a/tests/unit/hot_cold_suspend.cpp
+++ b/tests/unit/hot_cold_suspend.cpp
@@ -27,6 +27,8 @@
 //     --storage-snapshot-on-exit is enabled (the exit-snapshot path exercised here)
 //   SuspendSuccessMakesColdShellInaccessible — happy path: Get() throws, name leaves All()
 //   SuspendMultipleTenants              — two independent suspends both succeed
+//   DropColdTenantRetiresItsUuid        — dropping a COLD tenant announces the retired uuid, so
+//     parameters keyed by it are purged
 
 #ifdef MG_ENTERPRISE
 
@@ -52,6 +54,7 @@
 #include "storage/v2/ttl.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "utils/uuid.hpp"
 
 namespace fs = std::filesystem;
 using memgraph::dbms::DbmsHandler;
@@ -284,6 +287,25 @@ TEST_F(HotColdSuspend, DropColdTenantCleansUp) {
   // The durable cold marker + data dir are gone, so the name is reusable.
   auto recreate = handler_->New(name);
   EXPECT_TRUE(recreate.has_value()) << "name must be reusable after dropping the cold tenant";
+}
+
+// Parameters are keyed by database uuid, so every path that retires one has to announce it or the
+// rows outlive the database. Dropping a COLD tenant is such a path, and it is the only one that does
+// not go through Delete_ or TryDelete.
+TEST_F(HotColdSuspend, DropColdTenantRetiresItsUuid) {
+  auto name = CreateTenant("drop_cold_uuid");
+  memgraph::utils::UUID uuid;
+  {
+    uuid = handler_->Get(name)->config().salient.uuid;
+  }  // release the accessor before suspending -> sole-accessor freeze can proceed
+  ASSERT_TRUE(handler_->Suspend(name).has_value());
+
+  std::vector<memgraph::utils::UUID> retired;
+  handler_->SetOnUuidRetired([&retired](memgraph::utils::UUID const &u) { retired.push_back(u); });
+
+  ASSERT_TRUE(handler_->Delete(name).has_value());
+
+  EXPECT_THAT(retired, ::testing::ElementsAre(uuid));
 }
 
 // RENAME DATABASE on a COLD tenant must be rejected with RenameError::SUSPENDED, NOT abort the

--- a/tests/unit/hot_cold_suspend.cpp
+++ b/tests/unit/hot_cold_suspend.cpp
@@ -289,9 +289,8 @@ TEST_F(HotColdSuspend, DropColdTenantCleansUp) {
   EXPECT_TRUE(recreate.has_value()) << "name must be reusable after dropping the cold tenant";
 }
 
-// Parameters are keyed by database uuid, so every path that retires one has to announce it or the
-// rows outlive the database. Dropping a COLD tenant is such a path, and it is the only one that does
-// not go through Delete_ or TryDelete.
+// Dropping a COLD tenant retires its uuid through DeleteCold_, the one such path that goes through
+// neither Delete_ nor TryDelete. Parameters keyed by that uuid have to go with it.
 TEST_F(HotColdSuspend, DropColdTenantRetiresItsUuid) {
   auto name = CreateTenant("drop_cold_uuid");
   memgraph::utils::UUID uuid;

--- a/tests/unit/multi_tenancy.cpp
+++ b/tests/unit/multi_tenancy.cpp
@@ -339,9 +339,8 @@ TEST_F(MultiTenantTest, DbmsUpdate) {
   ASSERT_THROW(RunQuery(interpreter2, "MATCH(n) RETURN n"), memgraph::query::DatabaseContextRequiredException);
 }
 
-// Parameters are keyed by database uuid. Rebinding the default database's uuid retires the old one,
-// so its parameters have to go with it: nothing reads them afterwards, and they would otherwise sit
-// in the store and be re-exported to every replica by the next recovery snapshot.
+// Rebinding the default database's uuid retires the old one. Rows left under it are unreachable, and
+// the next recovery snapshot re-exports them to every replica.
 TEST_F(MultiTenantTest, UpdateDiscardsRetiredUuidsParameters) {
   auto &dbms = DBMS();
   WireParameterPurge();
@@ -404,8 +403,7 @@ TEST_F(MultiTenantTest, ForcedDeleteDiscardsDroppedDatabasesParameters) {
   EXPECT_EQ(Parameters().GetParameter("global", memgraph::parameters::kGlobalScope), R"("g")");
 }
 
-// DROP DATABASE without FORCE takes TryDelete, a separate path from the forced Delete above, and it
-// retires the uuid just as completely. A HOT tenant dropped this way must lose its parameters too.
+// DROP DATABASE without FORCE takes TryDelete, a different path from the forced Delete above.
 TEST_F(MultiTenantTest, TryDeleteDiscardsDroppedDatabasesParameters) {
   auto &dbms = DBMS();
   WireParameterPurge();

--- a/tests/unit/multi_tenancy.cpp
+++ b/tests/unit/multi_tenancy.cpp
@@ -157,6 +157,15 @@ class MultiTenantTest : public ::testing::Test {
 
   auto &DBMS() { return min_mg->dbms; }
 
+  auto &Parameters() { return min_mg->parameters; }
+
+  // main() wires this arm; a test that exercises a uuid-retiring path has to wire it itself.
+  void WireParameterPurge() {
+    min_mg->dbms.SetOnUuidRetired([this](memgraph::utils::UUID const &uuid) {
+      [[maybe_unused]] auto purged = Parameters().DeleteScope(std::string{uuid});
+    });
+  }
+
   // Helper function to clean up databases before tests
   void CleanupDatabases() {
     auto interpreter = this->NewInterpreter();
@@ -328,6 +337,71 @@ TEST_F(MultiTenantTest, DbmsUpdate) {
   ASSERT_EQ(RunQuery(interpreter2, "MATCH(n) RETURN count(*)")[0][0].ValueInt(), 3);
   RunQuery(interpreter2, "COMMIT");
   ASSERT_THROW(RunQuery(interpreter2, "MATCH(n) RETURN n"), memgraph::query::DatabaseContextRequiredException);
+}
+
+// Parameters are keyed by database uuid. Rebinding the default database's uuid retires the old one,
+// so its parameters have to go with it: nothing reads them afterwards, and they would otherwise sit
+// in the store and be re-exported to every replica by the next recovery snapshot.
+TEST_F(MultiTenantTest, UpdateDiscardsRetiredUuidsParameters) {
+  auto &dbms = DBMS();
+  WireParameterPurge();
+
+  auto default_db = dbms.Get();
+  auto const old_uuid = std::string{default_db->config().salient.uuid};
+  ASSERT_EQ(Parameters().SetParameter("on_default", R"("v")", old_uuid),
+            memgraph::parameters::SetParameterResult::Success);
+  ASSERT_EQ(Parameters().SetParameter("global", R"("g")", memgraph::parameters::kGlobalScope),
+            memgraph::parameters::SetParameterResult::Success);
+
+  memgraph::storage::SalientConfig const config{.name = "memgraph", .uuid = memgraph::utils::UUID{}};
+  ASSERT_TRUE(dbms.Update(config).has_value());
+  ASSERT_NE(std::string{config.uuid}, old_uuid);
+
+  EXPECT_FALSE(Parameters().GetParameter("on_default", old_uuid).has_value());
+  EXPECT_EQ(Parameters().GetParameter("global", memgraph::parameters::kGlobalScope), R"("g")");
+}
+
+// A rebind that fails must not take the parameters with it: the database keeps its uuid, so its
+// parameters are still reachable and still correct.
+TEST_F(MultiTenantTest, FailedUpdateKeepsParameters) {
+  auto &dbms = DBMS();
+  WireParameterPurge();
+  auto interpreter = this->NewInterpreter();
+
+  auto const uuid = std::string{dbms.Get()->config().salient.uuid};
+  ASSERT_EQ(Parameters().SetParameter("on_default", R"("v")", uuid), memgraph::parameters::SetParameterResult::Success);
+
+  // Dirty the default db so the in-place rebind refuses.
+  RunQuery(interpreter, "CREATE (:Node)");
+  memgraph::storage::SalientConfig const config{.name = "memgraph", .uuid = memgraph::utils::UUID{}};
+  ASSERT_FALSE(dbms.Update(config).has_value());
+
+  EXPECT_EQ(Parameters().GetParameter("on_default", uuid), R"("v")");
+}
+
+// Dropping a database retires its uuid, so its parameters go too. Every other scope stays.
+TEST_F(MultiTenantTest, DeleteDiscardsDroppedDatabasesParameters) {
+  auto &dbms = DBMS();
+  WireParameterPurge();
+
+  auto db = dbms.New("params_db");
+  ASSERT_TRUE(db.has_value());
+  auto const db_uuid = std::string{db.value()->config().salient.uuid};
+  auto const default_uuid = std::string{dbms.Get()->config().salient.uuid};
+  db.value().reset();
+
+  ASSERT_EQ(Parameters().SetParameter("on_dropped", R"("gone")", db_uuid),
+            memgraph::parameters::SetParameterResult::Success);
+  ASSERT_EQ(Parameters().SetParameter("on_default", R"("stays")", default_uuid),
+            memgraph::parameters::SetParameterResult::Success);
+  ASSERT_EQ(Parameters().SetParameter("global", R"("g")", memgraph::parameters::kGlobalScope),
+            memgraph::parameters::SetParameterResult::Success);
+
+  ASSERT_TRUE(dbms.Delete("params_db").has_value());
+
+  EXPECT_FALSE(Parameters().GetParameter("on_dropped", db_uuid).has_value());
+  EXPECT_EQ(Parameters().GetParameter("on_default", default_uuid), R"("stays")");
+  EXPECT_EQ(Parameters().GetParameter("global", memgraph::parameters::kGlobalScope), R"("g")");
 }
 
 TEST_F(MultiTenantTest, DbmsNewDelete) {

--- a/tests/unit/multi_tenancy.cpp
+++ b/tests/unit/multi_tenancy.cpp
@@ -379,8 +379,8 @@ TEST_F(MultiTenantTest, FailedUpdateKeepsParameters) {
   EXPECT_EQ(Parameters().GetParameter("on_default", uuid), R"("v")");
 }
 
-// Dropping a database retires its uuid, so its parameters go too. Every other scope stays.
-TEST_F(MultiTenantTest, DeleteDiscardsDroppedDatabasesParameters) {
+// A forced drop retires the uuid, so its parameters go too. Every other scope stays.
+TEST_F(MultiTenantTest, ForcedDeleteDiscardsDroppedDatabasesParameters) {
   auto &dbms = DBMS();
   WireParameterPurge();
 
@@ -398,6 +398,32 @@ TEST_F(MultiTenantTest, DeleteDiscardsDroppedDatabasesParameters) {
             memgraph::parameters::SetParameterResult::Success);
 
   ASSERT_TRUE(dbms.Delete("params_db").has_value());
+
+  EXPECT_FALSE(Parameters().GetParameter("on_dropped", db_uuid).has_value());
+  EXPECT_EQ(Parameters().GetParameter("on_default", default_uuid), R"("stays")");
+  EXPECT_EQ(Parameters().GetParameter("global", memgraph::parameters::kGlobalScope), R"("g")");
+}
+
+// DROP DATABASE without FORCE takes TryDelete, a separate path from the forced Delete above, and it
+// retires the uuid just as completely. A HOT tenant dropped this way must lose its parameters too.
+TEST_F(MultiTenantTest, TryDeleteDiscardsDroppedDatabasesParameters) {
+  auto &dbms = DBMS();
+  WireParameterPurge();
+
+  auto db = dbms.New("try_params_db");
+  ASSERT_TRUE(db.has_value());
+  auto const db_uuid = std::string{db.value()->config().salient.uuid};
+  auto const default_uuid = std::string{dbms.Get()->config().salient.uuid};
+  db.value().reset();
+
+  ASSERT_EQ(Parameters().SetParameter("on_dropped", R"("gone")", db_uuid),
+            memgraph::parameters::SetParameterResult::Success);
+  ASSERT_EQ(Parameters().SetParameter("on_default", R"("stays")", default_uuid),
+            memgraph::parameters::SetParameterResult::Success);
+  ASSERT_EQ(Parameters().SetParameter("global", R"("g")", memgraph::parameters::kGlobalScope),
+            memgraph::parameters::SetParameterResult::Success);
+
+  ASSERT_TRUE(dbms.TryDelete("try_params_db").has_value());
 
   EXPECT_FALSE(Parameters().GetParameter("on_dropped", db_uuid).has_value());
   EXPECT_EQ(Parameters().GetParameter("on_default", default_uuid), R"("stays")");

--- a/tests/unit/parameters.cpp
+++ b/tests/unit/parameters.cpp
@@ -105,9 +105,9 @@ TEST_F(ParametersTest, SnapshotRoundTrips) {
   EXPECT_EQ(target.GetParameter("d", kDbScope), R"("dv")");
 }
 
-// Recovering a snapshot the store already holds must leave every value in place. Deleting the
-// stale keys and writing the incoming ones share one batch, and RocksDB applies a batch in
-// insertion order, so a key in both sets must not end up on the delete side.
+// Recovering a snapshot the store already holds must leave every value in place. Only keys the
+// snapshot does not carry are deleted, so the incoming and stale sets are disjoint and no key is
+// ever both written and dropped.
 TEST_F(ParametersTest, RecoveryOfAnIdenticalSnapshotKeepsEveryValue) {
   auto parameters = MakeParameters("RecoveryOfAnIdenticalSnapshotKeepsEveryValue");
   ASSERT_EQ(parameters.SetParameter("g", R"("gv")", kGlobalScope), SetParameterResult::Success);

--- a/tests/unit/parameters.cpp
+++ b/tests/unit/parameters.cpp
@@ -1,0 +1,142 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "parameters/parameters.hpp"
+#include "utils/file.hpp"
+
+namespace fs = std::filesystem;
+using memgraph::parameters::kGlobalScope;
+using memgraph::parameters::ParameterInfo;
+using memgraph::parameters::Parameters;
+using memgraph::parameters::SetParameterResult;
+
+namespace {
+
+// Database scopes are database uuids; the values only have to be distinct.
+constexpr std::string_view kDbScope = "801d75e3-0beb-4810-9b10-d31223169cba";
+constexpr std::string_view kOtherDbScope = "66dde0d0-2eeb-4209-86c9-43e5a442048f";
+
+auto SortedKeys(std::vector<ParameterInfo> const &params) -> std::vector<std::string> {
+  std::vector<std::string> keys;
+  keys.reserve(params.size());
+  std::ranges::transform(
+      params, std::back_inserter(keys), [](auto const &p) { return p.scope_context + "/" + p.name; });
+  std::ranges::sort(keys);
+  return keys;
+}
+
+}  // namespace
+
+class ParametersTest : public ::testing::Test {
+ protected:
+  void SetUp() override { memgraph::utils::EnsureDir(test_folder_); }
+
+  void TearDown() override { fs::remove_all(test_folder_); }
+
+  auto MakeParameters(std::string_view name) -> Parameters { return Parameters{test_folder_ / name}; }
+
+  fs::path test_folder_{fs::temp_directory_path() /
+                        ("unit_parameters_test_" + std::to_string(static_cast<int>(getpid())))};
+};
+
+TEST_F(ParametersTest, SetGetUnset) {
+  auto parameters = MakeParameters("SetGetUnset");
+
+  ASSERT_EQ(parameters.SetParameter("threshold", "100", kGlobalScope), SetParameterResult::Success);
+  EXPECT_EQ(parameters.GetParameter("threshold", kGlobalScope), "100");
+
+  EXPECT_TRUE(parameters.UnsetParameter("threshold", kGlobalScope));
+  EXPECT_FALSE(parameters.GetParameter("threshold", kGlobalScope).has_value());
+}
+
+TEST_F(ParametersTest, ScopesAreIndependent) {
+  auto parameters = MakeParameters("ScopesAreIndependent");
+
+  ASSERT_EQ(parameters.SetParameter("tier", R"("global")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(parameters.SetParameter("tier", R"("db")", kDbScope), SetParameterResult::Success);
+
+  EXPECT_EQ(parameters.GetParameter("tier", kGlobalScope), R"("global")");
+  EXPECT_EQ(parameters.GetParameter("tier", kDbScope), R"("db")");
+
+  EXPECT_TRUE(parameters.UnsetParameter("tier", kDbScope));
+  EXPECT_EQ(parameters.GetParameter("tier", kGlobalScope), R"("global")");
+}
+
+TEST_F(ParametersTest, GetParametersReturnsGlobalPlusRequestedScope) {
+  auto parameters = MakeParameters("GetParametersReturnsGlobalPlusRequestedScope");
+
+  ASSERT_EQ(parameters.SetParameter("g", "1", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(parameters.SetParameter("mine", "2", kDbScope), SetParameterResult::Success);
+  ASSERT_EQ(parameters.SetParameter("theirs", "3", kOtherDbScope), SetParameterResult::Success);
+
+  EXPECT_EQ(SortedKeys(parameters.GetParameters(kDbScope)),
+            (std::vector<std::string>{std::string{kDbScope} + "/mine", "global/g"}));
+}
+
+TEST_F(ParametersTest, SnapshotRoundTrips) {
+  auto source = MakeParameters("SnapshotRoundTripsSource");
+  ASSERT_EQ(source.SetParameter("g", R"("gv")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(source.SetParameter("d", R"("dv")", kDbScope), SetParameterResult::Success);
+
+  auto target = MakeParameters("SnapshotRoundTripsTarget");
+  ASSERT_TRUE(target.ApplyRecovery(source.GetSnapshotForRecovery()));
+
+  EXPECT_EQ(SortedKeys(target.GetSnapshotForRecovery()), SortedKeys(source.GetSnapshotForRecovery()));
+  EXPECT_EQ(target.GetParameter("d", kDbScope), R"("dv")");
+}
+
+// Recovering a snapshot the store already holds must leave every value in place. Deleting the
+// stale keys and writing the incoming ones share one batch, and RocksDB applies a batch in
+// insertion order, so a key in both sets must not end up on the delete side.
+TEST_F(ParametersTest, RecoveryOfAnIdenticalSnapshotKeepsEveryValue) {
+  auto parameters = MakeParameters("RecoveryOfAnIdenticalSnapshotKeepsEveryValue");
+  ASSERT_EQ(parameters.SetParameter("g", R"("gv")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(parameters.SetParameter("d", R"("dv")", kDbScope), SetParameterResult::Success);
+
+  ASSERT_TRUE(parameters.ApplyRecovery(parameters.GetSnapshotForRecovery()));
+
+  EXPECT_EQ(parameters.CountParameters(), 2);
+  EXPECT_EQ(parameters.GetParameter("g", kGlobalScope), R"("gv")");
+  EXPECT_EQ(parameters.GetParameter("d", kDbScope), R"("dv")");
+}
+
+// A replica joining a cluster must end up with main's parameters and nothing else. Recovery
+// replaces local state for databases and auth (system_replication.cpp), so parameters must too:
+// a parameter set while the instance was standalone has to go, or the replica silently resolves
+// a $placeholder to a value that exists nowhere in the cluster.
+TEST_F(ParametersTest, RecoveryDiscardsPreExistingParameters) {
+  auto main = MakeParameters("RecoveryDiscardsPreExistingParametersMain");
+  ASSERT_EQ(main.SetParameter("on_main", R"("MAIN-only")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(main.SetParameter("shared", R"("from-MAIN")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(main.SetParameter("db_on_main", R"("MAIN-db")", kDbScope), SetParameterResult::Success);
+
+  auto replica = MakeParameters("RecoveryDiscardsPreExistingParametersReplica");
+  ASSERT_EQ(replica.SetParameter("on_replica", R"("REPLICA-only")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(replica.SetParameter("shared", R"("from-REPLICA")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(replica.SetParameter("db_on_replica", R"("REPLICA-db")", kOtherDbScope), SetParameterResult::Success);
+
+  ASSERT_TRUE(replica.ApplyRecovery(main.GetSnapshotForRecovery()));
+
+  EXPECT_EQ(SortedKeys(replica.GetSnapshotForRecovery()), SortedKeys(main.GetSnapshotForRecovery()));
+  EXPECT_EQ(replica.CountParameters(), main.CountParameters());
+  EXPECT_FALSE(replica.GetParameter("on_replica", kGlobalScope).has_value());
+  EXPECT_FALSE(replica.GetParameter("db_on_replica", kOtherDbScope).has_value());
+  EXPECT_EQ(replica.GetParameter("shared", kGlobalScope), R"("from-MAIN")");
+}

--- a/tests/unit/parameters.cpp
+++ b/tests/unit/parameters.cpp
@@ -143,3 +143,42 @@ TEST_F(ParametersTest, RecoveryDiscardsPreExistingParameters) {
   EXPECT_FALSE(replica.GetParameter("db_on_replica", kOtherDbScope).has_value());
   EXPECT_EQ(replica.GetParameter("shared", kGlobalScope), R"("from-MAIN")");
 }
+
+// Dropping a database, or rebinding its uuid, must take that scope's parameters with it. Only the
+// named scope goes: global parameters and every other database's are untouched.
+TEST_F(ParametersTest, DeleteScopeRemovesOnlyThatScope) {
+  auto parameters = MakeParameters("DeleteScopeRemovesOnlyThatScope");
+  ASSERT_EQ(parameters.SetParameter("keep", R"("g")", kGlobalScope), SetParameterResult::Success);
+  ASSERT_EQ(parameters.SetParameter("drop", R"("mine")", kDbScope), SetParameterResult::Success);
+  ASSERT_EQ(parameters.SetParameter("keep", R"("theirs")", kOtherDbScope), SetParameterResult::Success);
+
+  ASSERT_TRUE(parameters.DeleteScope(kDbScope));
+
+  EXPECT_FALSE(parameters.GetParameter("drop", kDbScope).has_value());
+  EXPECT_EQ(parameters.GetParameter("keep", kGlobalScope), R"("g")");
+  EXPECT_EQ(parameters.GetParameter("keep", kOtherDbScope), R"("theirs")");
+  EXPECT_EQ(parameters.CountParameters(), 2);
+}
+
+// A scope whose name is a prefix of another must not take the longer one with it: keys are
+// "<scope>/<name>", so the separator has to be part of the match.
+TEST_F(ParametersTest, DeleteScopeDoesNotMatchOnPrefix) {
+  auto parameters = MakeParameters("DeleteScopeDoesNotMatchOnPrefix");
+  ASSERT_EQ(parameters.SetParameter("p", "1", "db"), SetParameterResult::Success);
+  ASSERT_EQ(parameters.SetParameter("p", "2", "db2"), SetParameterResult::Success);
+
+  ASSERT_TRUE(parameters.DeleteScope("db"));
+
+  EXPECT_FALSE(parameters.GetParameter("p", "db").has_value());
+  EXPECT_EQ(parameters.GetParameter("p", "db2"), "2");
+}
+
+// Purging a scope that holds nothing is a no-op, not an error: the rebind and drop paths call this
+// unconditionally without first checking whether the database had any parameters.
+TEST_F(ParametersTest, DeleteScopeOfEmptyScopeSucceeds) {
+  auto parameters = MakeParameters("DeleteScopeOfEmptyScopeSucceeds");
+  ASSERT_EQ(parameters.SetParameter("g", "1", kGlobalScope), SetParameterResult::Success);
+
+  EXPECT_TRUE(parameters.DeleteScope(kDbScope));
+  EXPECT_EQ(parameters.CountParameters(), 1);
+}

--- a/tests/unit/parameters.cpp
+++ b/tests/unit/parameters.cpp
@@ -11,12 +11,15 @@
 
 #include <unistd.h>
 
-#include <gtest/gtest.h>
-
 #include <algorithm>
 #include <filesystem>
+#include <iterator>
+#include <ranges>
 #include <string>
+#include <string_view>
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include "parameters/parameters.hpp"
 #include "utils/file.hpp"


### PR DESCRIPTION
Database-scoped parameters are keyed by database uuid. Three events broke that key: a replica joining a cluster, dropping a database, and rebinding the default database's uuid. Each left rows on disk that nothing reads, and the next recovery snapshot re-exported them to every replica.

Recovery now replaces local parameters instead of merging into them, and DbmsHandler announces a retired uuid so the store can discard that scope. The announcement goes through an arm main() wires up, so mg-dbms does not need to link mg-parameters.

`DROP DATABASE` has unit coverage only. `SHOW PARAMETERS` reports the current database's uuid plus the globals, and a leak sits under a uuid no live database holds, so an e2e asserting on it passes either way. The unit tests drive `DbmsHandler` directly and do fail without the fix.
