### PR TITLE
test(storage): stop InfoCheck bounding the test process's RSS

### DIFF
--- a/tests/unit/storage_v2_get_info.cpp
+++ b/tests/unit/storage_v2_get_info.cpp
@@ -199,8 +199,10 @@ TYPED_TEST(InfoTest, InfoCheck) {
   ASSERT_EQ(info.vertex_count, 5);
   ASSERT_EQ(info.edge_count, 2);
   ASSERT_EQ(info.average_degree, 0.8);
-  ASSERT_GT(info.memory_res, 10'000'000);  // 256MB < > 10MB
-  ASSERT_LT(info.memory_res, 256'000'000);
+  // memory_res is the whole process's RSS, so its size is set by the test binary, its linked
+  // libraries and the allocator's arenas rather than by the seven graph elements here. Only the
+  // lower bound says anything about the storage: that a resident size was reported at all.
+  ASSERT_GT(info.memory_res, 10'000'000);
   ASSERT_GT(info.disk_usage, 100);  // 1MB < > 100B
   ASSERT_LT(info.disk_usage, 1'000'000);
   ASSERT_EQ(info.label_indices, 1);


### PR DESCRIPTION
### Description

`InfoTest/0.InfoCheck` required `info.memory_res` to stay under 256 MB for a database of five vertices and two edges. That value is the whole process's resident set, so the test binary, its linked libraries, coverage instrumentation, and the allocator's arenas all count toward it; the graph is noise inside it. A coverage build breached the ceiling by 0.27%.

This drops the upper bound. The lower bound still catches a resident size that was never reported, and there is no value for the upper bound both tight enough to test anything and loose enough to absorb changes outside our control.
