### PR TITLE
fix: global Python dependency install for MAGE images

### DIFF
--- a/release/package/mage/Dockerfile.cugraph
+++ b/release/package/mage/Dockerfile.cugraph
@@ -36,14 +36,12 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
 COPY requirements-gpu.txt /tmp/requirements-gpu.txt
 COPY auth-module-requirements.txt /tmp/auth_module-requirements.txt
 
-USER memgraph
-COPY --chown=memgraph:memgraph install_python_requirements.sh /home/memgraph/install_python_requirements.sh
-COPY --chown=memgraph:memgraph ./wheels /tmp/wheels
-RUN cd $HOME && \
-    pip install --no-cache-dir --find-links=/tmp/wheels --only-binary=gssapi gssapi==1.11.1 --break-system-packages && \
-    chmod +x /home/memgraph/install_python_requirements.sh && \
-    ./install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda true --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \
-    rm /home/memgraph/install_python_requirements.sh && \
+COPY install_python_requirements.sh /tmp/install_python_requirements.sh
+COPY ./wheels /tmp/wheels
+RUN pip install --no-cache-dir --find-links=/tmp/wheels --only-binary=gssapi gssapi==1.11.1 --break-system-packages && \
+    chmod +x /tmp/install_python_requirements.sh && \
+    /tmp/install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda true --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \
+    rm /tmp/install_python_requirements.sh && \
     rm -rf /tmp/wheels
 
 FROM rapidsai/base:${RAPIDS_VERSION}-cuda${CUDA_VERSION}-py${PY_VERSION_DEFAULT} AS cugraph-dev
@@ -135,8 +133,9 @@ RUN --mount=type=bind,source="./memgraph-mage.deb",target=/memgraph-mage.deb,ro 
 # copy script to convert to dev container
 COPY make-dev-container.sh /make-dev-container.sh
 
+COPY --from=python-base /usr/local/lib/python${PY_VERSION}/dist-packages /usr/local/lib/python${PY_VERSION}/dist-packages
+
 USER memgraph
-COPY --from=python-base --chown=memgraph:memgraph /home/memgraph/.local /home/memgraph/.local
 
 # Stable telemetry ID for containers — see release/docker/v7_deb.dockerfile
 # for the why. Resolved at runtime by GetMachineId() in

--- a/release/package/mage/Dockerfile.cugraph
+++ b/release/package/mage/Dockerfile.cugraph
@@ -40,7 +40,10 @@ COPY install_python_requirements.sh /tmp/install_python_requirements.sh
 COPY ./wheels /tmp/wheels
 RUN pip install --no-cache-dir --find-links=/tmp/wheels --only-binary=gssapi gssapi==1.11.1 --break-system-packages && \
     chmod +x /tmp/install_python_requirements.sh && \
-    /tmp/install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda true --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \
+    /tmp/install_python_requirements.sh \
+      --arch "${TARGETARCH}" --ci --cuda true \
+      --cache-present "${CACHE_PRESENT}" \
+      --wheel-cache-dir /tmp/wheels && \
     rm /tmp/install_python_requirements.sh && \
     rm -rf /tmp/wheels
 

--- a/release/package/mage/Dockerfile.release
+++ b/release/package/mage/Dockerfile.release
@@ -32,14 +32,12 @@ COPY requirements.txt /tmp/requirements.txt
 COPY requirements-gpu.txt /tmp/requirements-gpu.txt
 COPY auth-module-requirements.txt /tmp/auth_module-requirements.txt
 
-USER memgraph
-COPY --chown=memgraph:memgraph install_python_requirements.sh /home/memgraph/install_python_requirements.sh
-COPY --chown=memgraph:memgraph ./wheels /tmp/wheels
-RUN cd $HOME && \
-    pip install --no-cache-dir --find-links=/tmp/wheels --only-binary=gssapi gssapi==1.11.1 --break-system-packages && \
-    chmod +x /home/memgraph/install_python_requirements.sh && \
-    ./install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda ${CUDA} --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \
-    rm /home/memgraph/install_python_requirements.sh && \
+COPY install_python_requirements.sh /tmp/install_python_requirements.sh
+COPY ./wheels /tmp/wheels
+RUN pip install --no-cache-dir --find-links=/tmp/wheels --only-binary=gssapi gssapi==1.11.1 --break-system-packages && \
+    chmod +x /tmp/install_python_requirements.sh && \
+    /tmp/install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda ${CUDA} --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \
+    rm /tmp/install_python_requirements.sh && \
     rm -rf /tmp/wheels
 
 FROM ubuntu:24.04 AS base
@@ -118,7 +116,7 @@ ENV PY_VERSION=${PY_VERSION_DEFAULT}
 ENV MEMGRAPH_REF=${MEMGRAPH_REF}
 ARG CUSTOM_MIRROR
 
-COPY --from=python-base --chown=memgraph:memgraph /home/memgraph/.local /home/memgraph/.local
+COPY --from=python-base /usr/local/lib/python${PY_VERSION}/dist-packages /usr/local/lib/python${PY_VERSION}/dist-packages
 
 # Stable telemetry ID for containers — see release/docker/v7_deb.dockerfile
 # for the why. Resolved at runtime by GetMachineId() in
@@ -145,7 +143,7 @@ ENV PY_VERSION=${PY_VERSION_DEFAULT}
 ENV MEMGRAPH_REF=${MEMGRAPH_REF}
 ARG CUSTOM_MIRROR
 
-COPY --from=python-base --chown=memgraph:memgraph /home/memgraph/.local /home/memgraph/.local
+COPY --from=python-base /usr/local/lib/python${PY_VERSION}/dist-packages /usr/local/lib/python${PY_VERSION}/dist-packages
 
 # copy script to convert to dev container
 COPY make-dev-container.sh /make-dev-container.sh

--- a/release/package/mage/Dockerfile.release
+++ b/release/package/mage/Dockerfile.release
@@ -36,7 +36,10 @@ COPY install_python_requirements.sh /tmp/install_python_requirements.sh
 COPY ./wheels /tmp/wheels
 RUN pip install --no-cache-dir --find-links=/tmp/wheels --only-binary=gssapi gssapi==1.11.1 --break-system-packages && \
     chmod +x /tmp/install_python_requirements.sh && \
-    /tmp/install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda ${CUDA} --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \
+    /tmp/install_python_requirements.sh \
+      --arch "${TARGETARCH}" --ci --cuda "${CUDA}" \
+      --cache-present "${CACHE_PRESENT}" \
+      --wheel-cache-dir /tmp/wheels && \
     rm /tmp/install_python_requirements.sh && \
     rm -rf /tmp/wheels
 

--- a/release/package/mage/install_python_requirements.sh
+++ b/release/package/mage/install_python_requirements.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-# run me as `memgraph` user
+# Run me as `memgraph` for a per-user install (~/.local, what the deb/rpm
+# postinst does) or as root for a global install (/usr/local/lib/python3.*/
+# dist-packages, what the docker images do so any UID can import the deps).
 
 CI=false
 CACHE_PRESENT=false


### PR DESCRIPTION
Move installation of Python packages from the `memgraph` user's home directory to a global installation in the MAGE Docker images so that Memgraph's Python interpreter can use them when `/usr/lib/memgraph/memgraph` runs as another user. This does not affect the default behaviour of the MAGE DEB/RPM packages (these will still install to `memgraph`'s `$HOME` to avoid causing problems on a  user's system.

