### PR TITLE
perf(query,storage,bolt): park BEGIN & COMMIT off main_lock/commit_mutex (lock-free-read-snapshot)

### DIFF
--- a/U3-main-lock-park-spec.md
+++ b/U3-main-lock-park-spec.md
@@ -1,0 +1,584 @@
+# U3 — main_lock BEGIN park (design spec)
+
+Branch `feat/adaptive-commit-lock-scheduling` off #4685. Gated on flag `lockfree-read-snapshot`
+(same flag as commit-park; when OFF every path below is byte-identical to base).
+
+## Goal
+Today BEGIN blocks-with-timeout on `main_lock_` inside `CurrentDB::SetupDatabaseTransaction`
+(interpreter.cpp:196) via `db_acc->Access/UniqueAccess/ReadOnlyAccess(..., timeout)`. A blocked pool
+worker occupies a thread while a DDL/UNIQUE/READ_ONLY holder drains. U3 replaces the block with a
+bounded-try + PARK-the-pool-worker driver, mirroring the commit-park (U4) exactly but for the
+BEGIN/main_lock path. This ports the S2e "main lock wins" onto the #4685 base.
+
+Difference vs engine_lock (which we deliberately do NOT park): main_lock is the COLD path
+(DDL/schema/UNIQUE/READ_ONLY), not the read hot path, so parking here cannot reproduce the
+RW-fast/UNIQ_RO/UNIQ_UQ pure-contention regressions that killed engine-lock parking.
+
+## The four modes and what U3 does per mode
+| BEGIN mode | main_lock hold | gates anyone? | park style |
+|---|---|---|---|
+| READ  | shared READ  | no | STATELESS retry (no PendingScope) |
+| WRITE | shared WRITE | no | STATELESS retry (no PendingScope) |
+| READ_ONLY | shared READ_ONLY | yes (ro_pending gates WRITE) | HOLD `ReadOnlyPendingScope` across park |
+| UNIQUE | exclusive | yes (unique_pending gates all shared) | HOLD `UniquePendingScope` across park |
+
+READ/WRITE register no pending state (they gate nobody), so their park is a plain re-probe
+(`try_acquire`) on wake — identical shape to commit-park. UNIQUE/READ_ONLY must register-pending
+ONCE up front and hold it for the whole park so writer-preference priority is preserved while the
+worker is off-thread; each wake calls `scope.try_acquire()`.
+
+## VERIFIER-MANDATED FIXES (logic-verifier 2026-09-03, folded — MUST implement)
+- **Q1c (HIGH) — no PendingScope leak on abandonment.** The scope variant lives in the session's
+  pending-begin state. The session is NOT destroyed on a timeout/error transition (client can RESET
+  and continue), so a scope left live keeps `unique_pending_count`/`ro_pending_count` elevated →
+  process-wide admission block on that ResourceLock until disconnect. FIX: in `FinishPendingBegin_`,
+  place an `utils::OnScopeExit` at entry that resets the scope to `std::monostate`
+  (`pending_begin_scope_.emplace<std::monostate>()`), and CANCEL it only on the Reschedule return
+  (the one path that must keep the scope alive for the next wake). Timeout, ClientError, and Done all
+  fall through to the reset. Do NOT rely on the outer session destructor.
+- **Q4b (RISK) — finite MainLock deadline.** `ParkAdmission` for `WaitResource::MainLock` MUST pass
+  the stashed finite deadline (`now + GetStorageAccessTimeoutSec()` captured at the throw site), NOT
+  the commit-park's `time_point::max()`. Copy-pasting the commit-park call silently drops the BEGIN
+  timeout contract. Add `DMG_ASSERT(deadline != std::chrono::steady_clock::time_point::max())` on the
+  MainLock park path.
+
+## Novel correctness surface (verify this)
+A `PendingScope` that is registered but never deregistered blocks its mode process-wide (see
+resource_lock.hpp:91-93, 625-643). So the PendingScope MUST be destroyed on every exit path of the
+park: success (ownership transfers out via `try_acquire()` → guard), timeout (throw), client
+disconnect / session teardown, and pool drain/shutdown. It lives inside the bolt session's
+pending-begin state; the state object's destructor must run on all those paths.
+
+## Components
+
+### U3a — ResourceLock notify callback + non-blocking BEGIN probe
+1. `src/utils/resource_lock.hpp`: add a single optional hook
+   `std::move_only_function<void()> on_notify_all_;` (needs `<functional>`), with a setter
+   `void SetNotifyHook(std::move_only_function<void()>)`. Fire it inside `maybe_notify` AFTER
+   `lock.unlock()`, ONLY when `kind == NotifyKind::All`:
+   ```cpp
+   void maybe_notify(std::unique_lock<std::mutex> &lock, NotifyKind kind) {
+     lock.unlock();
+     if (kind == NotifyKind::All) {
+       cv.notify_all();
+       if (on_notify_all_) on_notify_all_();   // fired off-mtx: covers ALL six NotifyKind::All points
+     }
+   }
+   ```
+   Rationale (finalized design decision #1): the six NotifyKind::All points (4 release +
+   downgrade_to_read + 2 pending-gate clears in unregister_pending) all funnel through maybe_notify,
+   so one hook covers them with no call-site enumeration. Fires off the internal mtx → the hook may
+   take the pool's parked_mtx_ without inverting lock order (decision #5). Other ResourceLock
+   instances leave the hook empty → one null-check of overhead, no behavior change.
+
+2. Storage side: a non-blocking BEGIN accessor acquisition. `AcquireGuardOrThrow` (storage.hpp:565)
+   currently blocks-with-timeout. Add a non-blocking sibling that the query layer can call to decide
+   whether to park, WITHOUT throwing on miss:
+   - For READ/WRITE: `main_lock_.try_lock_shared<mode>()` → on success adopt into a guard; on miss
+     return "would block".
+   - For UNIQUE/READ_ONLY: this is the PendingScope path; the probe is `scope.try_acquire()`, so the
+     scope (not the storage helper) owns the retry. The storage helper only needs to expose enough
+     to build the Accessor from an already-acquired guard (the Accessor ctor already takes a
+     `ResourceLockGuard`), plus access to `main_lock_` so the driver can construct the right
+     PendingScope. Prefer: expose `main_lock_` acquisition through a small storage method rather than
+     leaking the lock — e.g. `Database::TryBeginAccess(acc_type, iso)` returning
+     `std::optional<unique_ptr<Accessor>>` for READ/WRITE, and a
+     `Database::MakePendingBeginScope(acc_type)` returning a type-erased pending scope for
+     UNIQUE/READ_ONLY. FINAL API SHAPE TBD in implementation — keep OFF-path byte-identical.
+
+3. Wire the hook: when flag ON, storage sets `main_lock_.SetNotifyHook([pool]{ pool->WakeMatching({WaitResource::MainLock}); })`
+   once at storage construction (or when the pool becomes known). Must be torn down before the pool
+   dies (RC-3 shutdown order): clear the hook in storage teardown / before pool destruction so a late
+   notify never calls into a dead pool.
+
+4. `src/query/exceptions.hpp`: `class BeginWouldBlockException final : public std::exception`
+   (NOT BasicException — must not be caught by the interpreter's generic catch(BasicException),
+   exactly like CommitWouldBlockException at :626).
+
+5. `CurrentDB::SetupDatabaseTransaction` (interpreter.cpp:196): when flag ON, replace the
+   blocking-with-timeout acquire with: bounded try; on miss throw `BeginWouldBlockException`
+   carrying (acc_type, remaining deadline). The finite BEGIN timeout is preserved
+   (`GetStorageAccessTimeoutSec` — user: "the begin timeout is safe, keep it"): the driver parks
+   only until that deadline, then throws the SAME timeout exception the blocking path throws today.
+
+### U3b — bolt PendingBegin park/resume driver (mirror PendingCommit U4b/U4c)
+- `state.hpp`: add `State::PendingBegin` + reuse/extend the outcome enum.
+- `session.hpp`: `HasPendingBegin`, `StashPendingBegin(...)`, `FinishPendingBegin_`, members holding
+  the pending-begin state INCLUDING the `std::variant<monostate, UniquePendingScope,
+  ReadOnlyPendingScope>` scope + acc_type + deadline + the stashed message/qid needed to re-drive
+  the query after the accessor is acquired.
+- `handlers.hpp`: catch `BeginWouldBlockException` where a BEGIN/first-query is prepared, BEFORE the
+  generic catch; stash + return `State::PendingBegin`.
+- `v2/session.hpp`: `DoWork` HasPendingBegin branch → park via
+  `ParkAdmission(cont, id, deadline, {WaitResource::MainLock, mode})` (FINITE deadline, unlike
+  commit). On wake: `scope.try_acquire()` (UNIQUE/READ_ONLY) or re-probe (READ/WRITE); success →
+  build accessor, resume query; miss → re-park; deadline passed → throw timeout exception → Error.
+
+### U3c — glue wiring
+- `SessionContext.hpp`/`SessionHL.hpp`: any pool wrappers PendingBegin needs (mirror the
+  PendingCommit wrappers already added in U4b).
+
+## U3a-3s — storage worker concrete shapes (grounded)
+Facts: `ThrowAccessTimeout(StorageAccessType)` is `[[noreturn]]` in an ANON namespace at storage.cpp:43
+(throws UniqueAccessTimeout/ReadOnlyAccessTimeout/SharedAccessTimeout) → must be exposed. `TryAccess`
+(inmemory/storage.hpp:819, .cpp:5091) builds `new InMemoryAccessor{this, iso, std::move(guard)}`.
+`main_lock_` is a Storage member (storage.hpp:455). PendingScope is NON-movable/non-copyable →
+construct in-place in a variant. `storage_access_timeout_sec` default 1s.
+
+1. `storage.hpp`, inside `class Storage` near the Access virtuals (:362-378): nested
+   ```cpp
+   struct PendingAccess {                      // one in-flight non-blocking BEGIN attempt
+     virtual ~PendingAccess() = default;
+     virtual std::unique_ptr<Accessor> TryAcquire(std::optional<IsolationLevel> override_isolation_level) = 0;
+   };
+   virtual std::unique_ptr<PendingAccess> MakePendingAccess(StorageAccessType /*rw_type*/) { return nullptr; }
+   ```
+2. Expose the timeout throw: move `ThrowAccessTimeout` OUT of the anon namespace in storage.cpp (make it
+   `memgraph::storage::ThrowAccessTimeout`), and declare it in storage.hpp near AcquireGuardOrThrow
+   (:565): `[[noreturn]] void ThrowAccessTimeout(StorageAccessType rw_type);`. AcquireGuardOrThrow's
+   existing call keeps working.
+3. `inmemory/storage.hpp`: declare the override
+   `std::unique_ptr<PendingAccess> MakePendingAccess(StorageAccessType rw_type) override;` and a PUBLIC
+   helper `std::unique_ptr<Accessor> AccessorFromGuard(utils::ResourceLockGuard guard, std::optional<IsolationLevel> iso);`
+   (symmetric to TryAccess). Refactor TryAccess to build via AccessorFromGuard (DRY; behavior identical).
+4. `inmemory/storage.cpp`: `#include <variant>`. File-local concrete class:
+   ```cpp
+   namespace {
+   class InMemoryPendingAccess final : public Storage::PendingAccess {
+    public:
+     InMemoryPendingAccess(InMemoryStorage *storage, utils::ResourceLock &main_lock, StorageAccessType rw_type)
+         : storage_{storage}, rw_type_{rw_type} {
+       switch (rw_type) {                       // register pending up front for the gating modes only
+         case StorageAccessType::UNIQUE:    scope_.emplace<utils::UniquePendingScope>(main_lock);   break;
+         case StorageAccessType::READ_ONLY: scope_.emplace<utils::ReadOnlyPendingScope>(main_lock); break;
+         default: break;                        // READ / WRITE gate nobody → no scope
+       }
+     }
+     std::unique_ptr<Storage::Accessor> TryAcquire(std::optional<IsolationLevel> iso) override {
+       switch (rw_type_) {
+         case StorageAccessType::UNIQUE: {
+           auto g = std::get<utils::UniquePendingScope>(scope_).try_acquire();
+           return g ? storage_->AccessorFromGuard(std::move(*g), iso) : nullptr;
+         }
+         case StorageAccessType::READ_ONLY: {
+           auto g = std::get<utils::ReadOnlyPendingScope>(scope_).try_acquire();
+           return g ? storage_->AccessorFromGuard(std::move(*g), iso) : nullptr;
+         }
+         default: return storage_->TryAccess(rw_type_, iso);   // READ/WRITE: plain one-probe
+       }
+     }
+    private:
+     InMemoryStorage *storage_;
+     StorageAccessType rw_type_;
+     std::variant<std::monostate, utils::UniquePendingScope, utils::ReadOnlyPendingScope> scope_;
+   };
+   }  // namespace
+   std::unique_ptr<Storage::PendingAccess> InMemoryStorage::MakePendingAccess(StorageAccessType rw_type) {
+     return std::make_unique<InMemoryPendingAccess>(this, main_lock_, rw_type);
+   }
+   ```
+   NOTE: DiskStorage does NOT override → inherits the base `return nullptr` (query layer falls back to
+   blocking on disk). Do NOT touch disk/storage.*.
+
+## U3a-3q — query worker (depends on U3a-3s + addendum being green)
+Two files. Ground truth: `CurrentDB` struct interpreter.hpp:255-293 (ResetDB :275); SetupDatabaseTransaction
+interpreter.cpp:196-231; CleanupDBTransaction interpreter.cpp:233-242. `db_acc->storage()` → `Storage*`
+(base); `IsCommitSerialised()` is storage.hpp:408. `BeginWouldBlockException` is in query/exceptions.hpp
+(already included by interpreter.cpp). `storage::ThrowAccessTimeout` decl comes from storage.hpp (U3a-3s).
+
+### interpreter.hpp — CurrentDB members (after `metrics::ScopedGauge transaction_gauge_;`, ~:292)
+```cpp
+  // U3 main_lock BEGIN park (experimental_lockfree_read_snapshot ON). A non-blocking BEGIN attempt that
+  // missed once and is now parked/retried by the bolt driver; carries its PendingScope (writer-preference)
+  // for its whole life. unique_ptr so teardown here (CleanupDBTransaction/ResetDB/~CurrentDB) deregisters
+  // the pending scope on any abandonment — a leaked registration would block a main_lock mode process-wide.
+  std::unique_ptr<storage::Storage::PendingAccess> pending_access_;
+  std::optional<std::chrono::steady_clock::time_point> pending_begin_deadline_;
+```
+Add `pending_access_.reset(); pending_begin_deadline_.reset();` to `ResetDB()` (:275-280).
+
+### interpreter.cpp — SetupDatabaseTransaction (:196) rewrite to the Option A″ pseudocode above.
+- Keep the existing `if (!db_acc_) throw`, the `db_arena_scope`, and `const auto timeout = GetStorageAccessTimeoutSec();`.
+- Insert the flag-gated non-blocking block (fast-path TryAccess → MakePendingAccess → TryAcquire →
+  success/timeout/park), then guard the existing `switch(acc_type){Access/UniqueAccess/ReadOnlyAccess}`
+  with `if (!db_transactional_accessor_)` so it runs only for flag-OFF / Disk. The post-setup
+  (execution_db_accessor_.emplace(:224), transaction_gauge_(:226), triggers(:228)) is UNCHANGED and runs
+  after an accessor exists.
+- CleanupDBTransaction (:233): also `pending_access_.reset(); pending_begin_deadline_.reset();`
+  (belt-and-suspenders for a mid-park abort; the normal success/timeout paths already reset in Setup).
+- Needs `#include <chrono>` if not present.
+
+FLAG-OFF / Disk MUST be byte-identical: when `IsCommitSerialised()` is false the whole new block is
+skipped and control falls straight into the original switch.
+
+## Timeout semantics (user-locked)
+- Commit park: NO timeout (bounded by holder's replication resolution). [done in U4]
+- BEGIN park: FINITE timeout = `GetStorageAccessTimeoutSec` — same deadline the blocking path uses
+  today. On expiry the driver throws the mode's existing timeout exception. This is the "bring the
+  timeout onto BEGIN/main_lock" the user asked for.
+
+## KEY DIVERGENCE FROM U4 (commit-park) — PendingScope must persist across re-drives
+U4's retry is STATELESS: on wake the bolt driver re-Pulls → Commit() → TryLockCommit fresh. Nothing
+is carried in the session but "retry me".
+
+U3's UNIQUE/READ_ONLY retry is STATEFUL and this is REQUIRED for liveness, not an optimization:
+without a held pending registration, a bare try_lock loop registers nothing, so sustained shared
+(READ/WRITE) holders keep main_lock SHARED forever and the UNIQUE/READ_ONLY probe starves. The
+`unique_pending_count`/`ro_pending_count` from a live PendingScope is what gates NEW shared
+acquisitions (can_acquire<READ|WRITE|READ_ONLY> all demand the relevant pending count == 0), draining
+the holders so a probe wins. So the PendingScope MUST outlive each re-drive.
+
+=> **Plumbing: Option A″ (FINAL — SUPERSEDES A′ and A; grounded on the base's own design intent).**
+The base already ships `InMemoryStorage::TryAccess` (inmemory/storage.hpp:805, one-probe non-blocking,
+nullptr on miss, InMemory-only — DiskStorage deliberately has none so a poller learns to block) and
+its doc (:812-815) states the intended scheduler-yield pattern verbatim: "A caller that needs to be
+preferred while it retries holds a UniquePendingScope or ReadOnlyPendingScope across the whole loop."
+So U3 is the caller the base anticipated. We encapsulate the scope + polymorphic accessor construction
+behind ONE small storage handle so the query layer never touches main_lock_ and never sees InMemory
+types:
+
+```cpp
+// base storage.hpp:
+struct PendingAccess {                       // one in-flight non-blocking BEGIN attempt
+  virtual ~PendingAccess() = default;
+  // One non-blocking probe. Returns the built accessor if main_lock_ now admits the requested mode,
+  // else nullptr (still registered pending — call again on the next wake). Never blocks, never throws.
+  virtual std::unique_ptr<Accessor> TryAcquire(std::optional<IsolationLevel> override_isolation_level) = 0;
+};
+// base Storage: default = "no non-blocking path, caller must block" (DiskStorage keeps this default).
+virtual std::unique_ptr<PendingAccess> MakePendingAccess(StorageAccessType /*rw_type*/) { return nullptr; }
+```
+InMemoryStorage overrides `MakePendingAccess` to return a concrete PendingAccess holding, for
+UNIQUE/READ_ONLY, the matching PendingScope (registers pending immediately, held for the attempt's
+whole life); for READ/WRITE, no scope (they gate nobody) — its TryAcquire just calls TryAccess. Either
+way TryAcquire builds the InMemoryAccessor from the adopted guard (factor the post-guard construction
+out of TryAccess so both share it).
+
+`CurrentDB` gains two members: `std::unique_ptr<storage::PendingAccess> pending_access_;` and
+`std::optional<std::chrono::steady_clock::time_point> pending_begin_deadline_;`.
+
+HOT-PATH RULE: BEGIN (incl. uncontended read BEGIN) is the hot path #4685 protects. Do NOT allocate a
+PendingAccess handle or register pending on the uncontended path. Probe once with the alloc-free
+`TryAccess` first; only on a MISS allocate MakePendingAccess (which registers pending for
+UNIQUE/READ_ONLY) and park. => `TryAccess` must be a BASE Storage virtual (default nullptr = "no probe,
+block"; DiskStorage inherits it — this is exactly the semantics inmemory/storage.hpp:817 documents).
+See "U3a-3s ADDENDUM" below.
+
+`SetupDatabaseTransaction` (interpreter.cpp:196), flag ON (`db_acc->storage()->IsCommitSerialised()`):
+```
+if (db_acc->storage()->IsCommitSerialised()) {
+  if (!pending_access_) {                                      // first drive of this transaction
+    if (auto acc = db_acc->storage()->TryAccess(acc_type, override_isolation_level)) {  // uncontended: NO alloc
+      db_transactional_accessor_ = std::move(acc);
+    } else {                                                   // contended: begin a pending+parked attempt
+      pending_access_ = db_acc->storage()->MakePendingAccess(acc_type);   // nullptr on Disk
+    }
+  }
+  if (pending_access_) {                                       // a parked attempt is in flight (this or prior drive)
+    if (!pending_begin_deadline_) pending_begin_deadline_ = steady_clock::now() + GetStorageAccessTimeoutSec();
+    if (auto acc = pending_access_->TryAcquire(override_isolation_level)) {
+      db_transactional_accessor_ = std::move(acc);
+      pending_access_.reset(); pending_begin_deadline_.reset();
+    } else if (steady_clock::now() >= *pending_begin_deadline_) {
+      pending_access_.reset(); pending_begin_deadline_.reset();
+      storage::ThrowAccessTimeout(acc_type);                   // same client-visible timeout as today
+    } else {
+      throw BeginWouldBlockException{*pending_begin_deadline_};// park until deadline
+    }
+  }
+}
+if (!db_transactional_accessor_) {                             // flag OFF, or Disk (TryAccess & MakePendingAccess null)
+  // the existing blocking switch: db_acc->Access/UniqueAccess/ReadOnlyAccess(..., timeout)
+}
+// then the existing post-setup (execution_db_accessor_.emplace, transaction_gauge_, triggers) runs
+// only once an accessor was actually acquired (every would-block/timeout path throws before here).
+```
+Uncontended cost when flag ON: one `TryAccess` (a single try_lock_shared) and NO heap alloc / NO pending
+registration — same order as today's `try_lock_for`. Alloc + pending registration happen ONLY under
+contention (the cold DDL/UNIQUE/READ_ONLY-vs-txn path).
+
+## U3a-3s ADDENDUM — promote TryAccess to a base Storage virtual
+`TryAccess` is currently an InMemoryStorage-only concrete method. Promote it to
+`virtual std::unique_ptr<Accessor> TryAccess(StorageAccessType rw_type, std::optional<IsolationLevel> = {}) { return nullptr; }`
+on base Storage (default nullptr — the documented "Disk has no probe, so the caller learns to block"),
+and mark InMemoryStorage's as `override`. DiskStorage does NOT override. This lets the query layer call
+`db_acc->storage()->TryAccess(...)` polymorphically without a dynamic_cast.
+
+Q1c is STRUCTURAL: `pending_access_` is a `unique_ptr` CurrentDB member. It is reset on the success and
+timeout paths, and destroyed by CurrentDB teardown (CleanupDBTransaction/ResetDB/ResetInterpreter/
+~CurrentDB) on disconnect/RESET — the concrete PendingAccess dtor destroys its PendingScope →
+unregister_pending. No bolt-layer reset discipline; no scope in the session or the exception.
+ALSO reset `pending_access_` + `pending_begin_deadline_` in `CleanupDBTransaction` and `ResetDB`
+(belt-and-suspenders for a mid-park abort).
+Q4b: the finite deadline lives in CurrentDB and is carried in BeginWouldBlockException → the bolt park
+uses it; the query-layer `now >= deadline` check is the authoritative timeout regardless.
+main_lock_ never leaks to the query layer; Disk & flag-OFF stay byte-identical.
+
+Verifier mapping (all preserved/strengthened): Q1a/b unchanged (TryAcquire wraps scope.try_acquire);
+Q2 unchanged (PendingAccess created on one worker, TryAcquire'd on the next — sequential, scope ops
+take mtx fresh); Q3/Q5 unaffected.
+
+--- superseded ---
+Option A′ (do NOT implement): scope+deadline in CurrentDB directly (query layer touches main_lock_).
+Option A (do NOT implement): The bolt session's pending-begin state OWNS the scope
+The scope + deadline live in `CurrentDB` (the query layer where SetupDatabaseTransaction already is),
+NOT in the bolt session. `CurrentDB` persists across the park (the txn is mid-BEGIN, not torn down),
+so it can own `std::variant<std::monostate, UniquePendingScope, ReadOnlyPendingScope>
+pending_begin_scope_` + `std::optional<steady_clock::time_point> pending_begin_deadline_`.
+
+`SetupDatabaseTransaction` (interpreter.cpp:196), flag ON, becomes a re-entrant probe:
+  - Fresh (deadline nullopt): set `deadline = now + GetStorageAccessTimeoutSec()`; for UNIQUE/READ_ONLY
+    construct the matching PendingScope into the member; for READ/WRITE leave monostate.
+  - Probe: UNIQUE/READ_ONLY → `scope.try_acquire()`; READ/WRITE → `ResourceLockGuard(main_lock_, type,
+    std::try_to_lock)`.
+    - success → build Accessor from the adopted guard; reset scope=monostate, deadline=nullopt; return.
+    - miss & now >= deadline → reset scope+deadline; `ThrowAccessTimeout(rw_type)` (the SAME exception
+      today's blocking timeout throws — identical client-visible behavior). [handles Q4b at query layer]
+    - miss & now < deadline → throw `BeginWouldBlockException{deadline}` (park until deadline).
+  - OFF path: unchanged — the existing AcquireGuardOrThrow(blocking-with-timeout) call.
+
+Q1c is now STRUCTURAL: the scope is a CurrentDB member, so its destructor runs `PendingScope::
+~PendingScope` (→ unregister_pending) whenever CurrentDB dies (session disconnect / RESET /
+ResetInterpreter), and the success + timeout paths reset it explicitly in SetupDatabaseTransaction.
+No bolt-layer OnScopeExit reset discipline is required (the verifier's Q1c fix was for Option A).
+main_lock_ outlives the scope because CurrentDB holds db_acc_ (keeps the database alive) for the
+scope's whole lifetime.
+
+The bolt driver (U3b) is then as thin as commit-park: catch BeginWouldBlockException → park with the
+FINITE stashed deadline → on wake re-drive the query (which re-enters SetupDatabaseTransaction). No
+scope in the session, no scope in the exception.
+
+--- superseded ---
+Option A (do NOT implement): The bolt session's pending-begin state OWNS the scope
+(`std::variant<std::monostate, UniquePendingScope, ReadOnlyPendingScope>`; monostate for READ/WRITE).
+On the first miss SetupDatabaseTransaction (or a storage helper it calls) constructs the scope, probes
+once, and on miss the scope is MOVED OUT into the session state (via the stash), not destroyed. On
+each re-drive the session passes the held scope back down; the probe is `scope.try_acquire()`. On
+success the returned guard is adopted into the Accessor ctor (Accessor already takes a
+ResourceLockGuard); the scope goes inert. Storage stays OFF-path byte-identical: the non-blocking
+probe + scope construction is a NEW flag-gated branch, the existing AcquireGuardOrThrow path
+(storage.cpp:62) is untouched when the flag is OFF.
+
+Storage-side choke point: `AcquireGuardOrThrow(storage, rw_type, timeout)` (storage.cpp:62) is the
+single main_lock acquisition site behind Storage::Access/UniqueAccess/ReadOnlyAccess. The new
+non-blocking sibling lives beside it. READ/WRITE probe = `ResourceLockGuard(main_lock_, type,
+std::try_to_lock)`; UNIQUE/READ_ONLY probe = `scope.try_acquire()`. The Accessor is built from the
+adopted guard exactly as the blocking path builds it.
+
+Flag gate: `config_.experimental_lockfree_read_snapshot` (== `Storage::IsCommitSerialised()`,
+storage.hpp:408) — the same gate commit-park uses.
+
+## U3b — bolt PendingBegin park/resume driver (EXACT MIRROR of PendingCommit; grounded)
+The in-tree PendingCommit driver (U4b/U4c) is the template — read it and mirror it. Two throw origins,
+mapping 1:1 to PendingCommit's two:
+- **RUN origin** ↔ U4 PULL origin: `BeginWouldBlockException` throws from `session.InterpretPrepare()`
+  inside `HandlePrepare` (handlers.hpp:225). Retry = re-run `HandlePrepare(impl)` (re-Prepares, sends header).
+- **BEGIN-message origin** ↔ U4 COMMIT-message origin: throws from `session.BeginTransaction(extra)` inside
+  `HandleBegin` (handlers.hpp:448). Retry = re-run `impl.BeginTransaction(extra)` + `MessageSuccess({})`.
+
+### state.hpp
+- Add `State::PendingBegin` (mirror `State::PendingCommit` at :71 + its doc).
+- Add `enum class PendingBeginOutcome : uint8_t { Reschedule, Done, ClientError };` next to PendingCommitOutcome
+  (must live here so v2/session.hpp can name it).
+
+### bolt/v1/session.hpp — mirror the PendingCommit surface (lines 163-276, 323-328)
+- Execute_ dechunk loop: after the `if (state_ == State::PendingCommit) return true;` block (:163-168) add
+  `if (state_ == State::PendingBegin) { return true; }` (stop the loop so a pipelined msg can't run first).
+- `bool HasPendingBegin() const { return pending_begin_; }`
+- `void StashPendingBeginPrepare(std::chrono::steady_clock::time_point deadline) { pending_begin_ = true;
+   pending_begin_from_message_ = false; pending_begin_deadline_ = deadline; }`
+- `void StashPendingBeginMessage(<extra-map-type> extra, std::chrono::steady_clock::time_point deadline)
+   { pending_begin_ = true; pending_begin_from_message_ = true; pending_begin_extra_ = std::move(extra);
+     pending_begin_deadline_ = deadline; }`  (extra-map-type = the type of `extra.ValueMap()` that HandleBegin
+     passes to BeginTransaction — determine by reading; it is the bolt Value map, e.g. `map_t`.)
+- `std::chrono::steady_clock::time_point PendingBeginDeadline() const { return pending_begin_deadline_; }`
+- `template <typename TImpl> PendingBeginOutcome FinishPendingBegin_(TImpl &impl)` mirroring
+  FinishPendingCommit_ (:227-276):
+  ```
+  MG_ASSERT(pending_begin_, ...);  ScopedSessionLog log_guard(impl.GetLogContext());
+  if (pending_begin_from_message_) {
+    try {
+      impl.BeginTransaction(pending_begin_extra_);
+      if (!encoder_.MessageSuccess({})) { state_ = State::Close; pending_begin_ = false; return ClientError; }
+      state_ = State::Idle; pending_begin_ = false; return Done;
+    } catch (const memgraph::query::BeginWouldBlockException &) {
+      return PendingBeginOutcome::Reschedule;         // pending_begin_ stays true; extra + deadline retained
+    } catch (const std::exception &e) {
+      state_ = HandleFailure(impl, e); pending_begin_ = false; return ClientError;  // e.g. access timeout
+    }
+  }
+  state_ = details::HandlePrepare(impl);              // RUN origin: re-Prepare (sends header on success)
+  switch (state_) {
+    case State::PendingBegin: return PendingBeginOutcome::Reschedule;  // BeginWouldBlock again; HandlePrepare re-stashed
+    case State::Result:       pending_begin_ = false; return PendingBeginOutcome::Done;
+    default:                  pending_begin_ = false; return PendingBeginOutcome::ClientError;  // Error/Close: HandleFailure sent it
+  }
+  ```
+  NOTE vs U4c: the message reschedule does NOT re-call Stash (unlike U4c:244) — pending_begin_ is already
+  true and pending_begin_extra_ must be retained (re-stashing would self-move the map). Just return Reschedule.
+- Members (mirror :323-328):
+  `bool pending_begin_{false}; bool pending_begin_from_message_{false}; <extra-map-type> pending_begin_extra_{};
+   std::chrono::steady_clock::time_point pending_begin_deadline_{};`
+
+### bolt/v1/states/handlers.hpp — two catches, each BEFORE the generic `catch (const std::exception &e)`
+- `HandlePrepare` (:244): `} catch (const memgraph::query::BeginWouldBlockException &e) {
+     session.StashPendingBeginPrepare(e.deadline()); return State::PendingBegin; }`
+- `HandleBegin` (:454): `} catch (const memgraph::query::BeginWouldBlockException &e) {
+     session.StashPendingBeginMessage(extra.ValueMap(), e.deadline()); return State::PendingBegin; }`
+  (query/exceptions.hpp is already included here — CommitWouldBlockException is caught in this file.)
+
+### communication/v2/session.hpp — mirror PostFinishPendingCommit (442-483), DoWork branch (398-413),
+###   drain loop (~387), and the task-id member (607)
+- DoWork: after the HasPendingCommit branch, add
+  `if (shared_this->session_.HasPendingBegin()) { shared_this->PostFinishPendingBegin(); return; }`.
+- Teardown drain loop (the `while (session_.HasPendingCommit()) session_.FinishPendingCommit();` at ~:387):
+  add an analogous `while (session_.HasPendingBegin()) session_.FinishPendingBegin();` beside it.
+- `PostFinishPendingBegin()` mirrors PostFinishPendingCommit but: calls `session_.FinishPendingBegin()`;
+  switches on PendingBeginOutcome; on Reschedule re-park; uses `pending_begin_task_id_`; and the
+  **ParkAdmission deadline is FINITE**: `session_.PendingBeginDeadline()` (NOT time_point::max — Q4b),
+  tag `utils::WaitTag{utils::WaitResource::MainLock, {}}`.
+- `std::atomic<utils::PriorityThreadPool::TaskID> pending_begin_task_id_{0};`
+
+### glue/SessionHL.hpp — mirror FinishPendingCommit() (:147)
+- `memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return this->FinishPendingBegin_(*this); }`
+  (BeginTransaction is already exposed at SessionHL.hpp:72; ParkAdmission/IsDrainingAdmissions already in
+  SessionContext.hpp from U1.)
+
+### KEY CORRECTNESS PROPERTY to verify post-implementation (like U4's re-Pull safety)
+Re-running `HandlePrepare`/`InterpretPrepare` after a BeginWouldBlock throw from SetupDatabaseTransaction
+must be idempotent: no non-idempotent side effect may occur in Interpreter::Prepare BEFORE the accessor is
+acquired in SetupDatabaseTransaction. (Accessor acquisition is where the throw happens, so nothing storage-
+mutating has run.) Flag for the concurrency/logic review of concrete U3.
+
+## U3c — wire main_lock notify hook → WakeMatching({MainLock}) (NEEDED, not optional)
+Why needed: the perf kit's UNIQ_RO/UNIQ_UQ scenarios exercise main_lock directly. Base #4685 blocks on
+main_lock but wakes INSTANTLY (ResourceLock's own cv.notify_all). If U3's parked tasks wake only via the
+100ms monitor backstop, U3 would be a large regression in exactly those scenarios. So the on_notify_all_
+hook must fire WakeMatching so parked tasks wake as promptly as the cv did. (U3's real value is
+long-DDL-under-load: frees the pool threads that would otherwise all block through a long CREATE INDEX;
+the hook makes their post-DDL resume prompt.)
+
+DATA-RACE FIX (found during U3c grounding): lazy install writes the hook while concurrent maybe_notify
+calls READ it off-mtx → a move_only_function assign-vs-call race (UB). So the U3a hook (plain
+move_only_function read directly in maybe_notify) must be revised to ATOMIC-POINTER PUBLICATION in
+resource_lock.hpp:
+```cpp
+ private:
+  std::move_only_function<void()> on_notify_all_storage_;               // owns the callable; set once
+  std::atomic<std::move_only_function<void()>*> on_notify_all_{nullptr};// published pointer (nullptr = unarmed)
+ public:
+  void SetNotifyHook(std::move_only_function<void()> hook) {            // install once, before or during concurrent use
+    on_notify_all_storage_ = std::move(hook);
+    on_notify_all_.store(on_notify_all_storage_ ? &on_notify_all_storage_ : nullptr, std::memory_order_release);
+  }
+  void ClearNotifyHook() { on_notify_all_.store(nullptr, std::memory_order_release); }  // storage_ left valid until ~ResourceLock
+```
+maybe_notify:
+```cpp
+  if (kind == NotifyKind::All) {
+    cv.notify_all();
+    if (auto *h = on_notify_all_.load(std::memory_order_acquire)) (*h)();  // release/acquire: storage write is visible
+  }
+```
+Race-free because: install is done AT MOST ONCE (Storage-level exchange guards it) and publishes the
+callable via release/acquire; ClearNotifyHook publishes nullptr but never destroys storage_ (so an
+in-flight reader that loaded the old pointer still derefs valid storage_); ~ResourceLock runs only after
+all main_lock activity has ceased (DB torn down), so no notify is in flight at destruction.
+
+Design (lazy install — avoids startup-order + new/resumed-DB seam + is uniform across all DBs):
+1. base Storage (storage.hpp, near main_lock_ :455): add
+   ```cpp
+   std::atomic<bool> main_lock_hook_installed_{false};
+   bool MainLockHookInstalled() const noexcept { return main_lock_hook_installed_.load(std::memory_order_acquire); }
+   // Install once; a second call is a no-op (returns false). The exchange makes concurrent first-callers safe.
+   bool TrySetMainLockNotifyHook(std::move_only_function<void()> hook) {
+     if (main_lock_hook_installed_.exchange(true, std::memory_order_acq_rel)) return false;
+     main_lock_.SetNotifyHook(std::move(hook));
+     return true;
+   }
+   void ClearMainLockNotifyHook() { main_lock_.ClearNotifyHook(); main_lock_hook_installed_.store(false, std::memory_order_release); }
+   ```
+2. Interpreter layer — `Interpreter::SetupDatabaseTransaction` (interpreter.cpp:11270 wrapper; has
+   `interpreter_context_` and `current_db_`). Both BEGIN-message and RUN paths route through it. Before the
+   `current_db_.SetupDatabaseTransaction(...)` call, flag-gated, install once per storage (cheap load-guard
+   avoids constructing the lambda every BEGIN; the exchange inside Try* closes the load→install race):
+   ```cpp
+   if (current_db_.db_acc_) {
+     auto *storage = (*current_db_.db_acc_)->storage();
+     if (storage->IsCommitSerialised() && interpreter_context_->worker_pool && !storage->MainLockHookInstalled()) {
+       storage->TrySetMainLockNotifyHook([pool = interpreter_context_->worker_pool] {
+         pool->WakeMatching(utils::WaitTag{utils::WaitResource::MainLock, {}});
+       });
+     }
+   }
+   ```
+   (utils::WaitTag/WaitResource already used in this TU by U4's WakeMatching({CommitLock}).) Covers default,
+   newly-created, and resumed tenants uniformly, at the first txn that touches each.
+3. SHUTDOWN UAF (worker_pool_ declared memgraph.cpp:869 AFTER dbms_handler :810 → destroyed BEFORE the
+   databases; a main_lock release during DB teardown would fire the hook on a dead pool). FIX: clear all
+   hooks before pool destruction, at the existing shutdown `dbms_handler->ForEach` (memgraph.cpp:1147, runs
+   after worker_pool_->ShutDown() :1123 and before end-of-main pool destruction). Add inside that lambda:
+   `acc->storage()->ClearMainLockNotifyHook();`. Between :1123 and the clear, a notify may still fire on the
+   shut-down-but-ALIVE pool → WakeMatching sees draining_ → safe no-op; after the clear, no hook fires.
+   VERIFY in the concurrency review that :1147 runs on the normal shutdown path before pool destruction.
+
+## Wake correctness
+`WakeMatching({MainLock})` wakes ALL MainLock-parked tasks on ANY main_lock NotifyKind::All (decision
+#2: per-resource conservative wake, correct-by-construction, mirrors the lock's own notify_all). Mode
+is carried in the tag for a future per-mode narrowing only. `has_parked_` relaxed pre-filter;
+100ms monitor sweep is the accepted lost-wakeup backstop.
+
+## Storage access modes in BEGIN — VERIFIED (2026-09-04)
+Full record: `~/workspace/opencode-work/commit-lock-scheduling/2026-09-04--storage-access-modes-in-begin.html`.
+Verdict: **all four modes correct, no fix required.** The park is transparent to `main_lock_`'s admission
+and writer-preference semantics for every access type that reaches BEGIN.
+
+- `StorageAccessType` has FIVE values (access_type.hpp:18): UNIQUE, WRITE, READ, READ_ONLY, NO_ACCESS.
+  `NO_ACCESS` is structurally excluded from the park: `CurrentDB::accessor_type_` (a `std::optional`) is
+  NEVER assigned NO_ACCESS, meta queries leave it nullopt, and Prepare only calls SetupDatabaseTransaction
+  when it is engaged (interpreter.cpp:10839). So `ToGuardType(NO_ACCESS)`'s `LOG_FATAL` (storage.hpp:75-76)
+  is unreachable on the flag-ON TryAccess path — same as the base Access. Flag-OFF-identical preserved.
+- The four reachable modes and their sources: UNIQUE = DDL (point/text/vector index, DROP ALL, DROP GRAPH,
+  enum, disk-constraint, RECOVER SNAPSHOT — interpreter.cpp:10437,10480-10508,10593); READ_ONLY =
+  CREATE INDEX / CREATE CONSTRAINT (in-memory) / edge-index create (interpreter.cpp:10554,10560,10577,10593);
+  WRITE = general Cypher writes (RWType W/RW, :3888-3895) + explicit BEGIN write (:3974); READ = read queries
+  (EXPLAIN/DUMP/ANALYZE/DESCRIBE-get, index-drop) + explicit BEGIN read.
+- **Correctness invariant:** U3's per-mode scope split mirrors the base ResourceLock's per-mode pending
+  registration EXACTLY — only UNIQUE (`unique_pending`) and READ_ONLY (`ro_pending`) register when blocking
+  (resource_lock.hpp:80-81); READ/WRITE register nothing (:77). So the park holds `UniquePendingScope` /
+  `ReadOnlyPendingScope` for those two, and NO scope for READ/WRITE. A parked task therefore carries the
+  same admission priority a blocking acquirer of that mode would have. Wake (`WakeMatching({MainLock})`) +
+  finite BEGIN deadline cover all four uniformly.
+- **Nuance 1 (judgment call, NOT a bug):** the alloc-free fast-path probe does not register pending for
+  UNIQUE/READ_ONLY — only the on-miss `MakePendingAccess` does. vs the base (register-then-wait), this is a
+  one-probe window of softened writer-preference on the cold DDL path; once parked, the scope persists and
+  gating is full (no starvation). Kept for the uniform fast path; tightening = route UNIQUE/READ_ONLY
+  straight to MakePendingAccess (adds an alloc to every uncontended DDL BEGIN). OPEN DECISION.
+- **Nuance 2 (covered):** a `SET STORAGE MODE` mid-park can flip a constraint's mode (READ_ONLY↔UNIQUE).
+  The pre-existing `StorageModeChangedDuringSetupException` retry (interpreter.cpp:10845-10853) handles it —
+  SetupDatabaseTransaction resets `pending_access_` on the successful-acquire path (:218) BEFORE the pinned-
+  mode check throws, so the retry re-derives the correct mode with a fresh `pending_access_`. Park doesn't
+  break it.
+
+## Liveness + task-closure audits (2026-09-04) — outcomes + L1 fix
+Two adversarial concurrency-debugger passes over the whole park machinery (pool + commit-park + main-lock-
+park + notify hook + monitor + shutdown), folded into commit `1a5acf74c`.
+
+- **Liveness (lost-task / missed-wake / block-forever):**
+  - L2 (no missed wake) PASS — monitor's unconditional kick-oldest (every 100ms, ignores tag+deadline)
+    backstops the deadline-less commit parks; `has_parked_` relaxed-load race ≤100ms.
+  - L3 (no block forever) PASS — lock order acyclic (`parked_mtx_`→`Worker::mtx_` only; ResourceLock mtx
+    released before the hook fires; commit_mutex_/engine_lock_ released before WakeMatching); no park-induced
+    starvation beyond std::mutex; PendingScope released by the finite BEGIN deadline; shutdown can't strand.
+  - **L1 (no lost task) — REAL bug FOUND + FIXED (`1a5acf74c`).** Shutdown-only race: `WakeMatching` pulls a
+    parked continuation out of the deque, `ShutDown` then swaps + `request_stop()`s, and
+    `ScheduledReAddTask`'s stop-guard silently DROPPED it (client got a TCP close, not a Bolt error). No hang/
+    corruption, but a genuine lost task. Closed at both ends by running the woken continuation INLINE
+    (mirrors ShutDown's own drain; the v2 drivers short-circuit via `IsDrainingAdmissions()` at
+    v2/session.hpp:464,510): `WakeMatching` runs inline if draining; `ScheduledReAddTask` runs inline on
+    `stop_requested` instead of dropping. Flag-OFF unaffected. Pool 27/27, bolt_session 35/35, binary links.
+- **Task-closure audit (the pool-scheduled lambdas):** T1 capture-lifetime, T2 exactly-once, T3 execution-
+  context, T4 session-state concurrency — ALL PASS. Every lambda captures `shared_from_this()` (no UAF across
+  a seconds-long park); ≤1 in-flight task per session (no double-commit/response/state race). One physically-
+  unrealizable + 100ms-self-recovering NOTE on the `pending_*_task_id_` relaxed store — left relaxed, comment
+  corrected in `1a5acf74c`.

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -121,6 +121,12 @@ class Session {
       if (state_ == State::Close) [[unlikely]] {
         ClientFailureInvalidData();
       }
+      // RUN-first-query parked on main_lock_: return before the dechunk loop below. Otherwise its first
+      // GetChunk() consumes a pipelined PULL out of input_stream_ into the decoder (the in-loop
+      // PendingBegin guard is one GetChunk() too late — it stops dispatch, not consumption), leaving
+      // input_stream_ empty so the park-resolution's HasBufferedData() picks DoRead() and the PULL is
+      // stranded. Leaving it in input_stream_ lets resolution (HasBufferedData -> DoWork) dispatch it.
+      if (state_ == State::PendingBegin) return true;  // more data to process
       // We are here, so the query will have the correct priority; just fall down to execute any other requests
     }
 

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -190,12 +190,20 @@ class Session {
   // decide DoWork vs DoRead after the commit completes.
   bool HasBufferedData() const { return input_stream_.size() > 0; }
 
-  // Record the PULL arguments so FinishPendingCommit_ can retry without re-decoding.
-  // Called from HandlePullDiscard on a CommitWouldBlockException catch.
+  // Record the PULL arguments so FinishPendingCommit_ can retry via the PULL path without re-decoding.
+  // Called from HandlePullDiscard on a CommitWouldBlockException catch (autocommit / COMMIT-as-query).
   void StashPendingCommit(std::optional<int> n, std::optional<int> qid) {
     pending_commit_ = true;
+    pending_commit_from_message_ = false;
     pending_commit_n_ = n;
     pending_commit_qid_ = qid;
+  }
+
+  // Record that an explicit-transaction COMMIT *message* would-blocked, so FinishPendingCommit_ retries
+  // via CommitTransaction() (not the PULL path). Called from HandleCommit on a CommitWouldBlockException.
+  void StashPendingCommitMessage() {
+    pending_commit_ = true;
+    pending_commit_from_message_ = true;
   }
 
   // Pool-side retry of a Commit() that threw CommitWouldBlockException.
@@ -219,6 +227,28 @@ class Session {
   PendingCommitOutcome FinishPendingCommit_(TImpl &impl) {
     MG_ASSERT(pending_commit_, "FinishPendingCommit_ called without a stashed pending commit");
     memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+
+    if (pending_commit_from_message_) {
+      // Explicit-transaction COMMIT message retry — mirrors HandleCommit's body. The staged txn is
+      // intact (Commit throws before mutating), so re-running CommitTransaction() is safe.
+      try {
+        if (!encoder_.MessageSuccess(impl.CommitTransaction())) {
+          state_ = State::Close;
+          pending_commit_ = false;
+          return PendingCommitOutcome::ClientError;
+        }
+        state_ = State::Idle;
+        pending_commit_ = false;
+        return PendingCommitOutcome::Done;
+      } catch (const memgraph::query::CommitWouldBlockException &) {
+        StashPendingCommitMessage();  // still contended → park again
+        return PendingCommitOutcome::Reschedule;
+      } catch (const std::exception &e) {
+        state_ = HandleFailure(impl, e);
+        pending_commit_ = false;
+        return PendingCommitOutcome::ClientError;
+      }
+    }
 
     const auto n = pending_commit_n_;
     const auto qid = pending_commit_qid_;
@@ -291,6 +321,7 @@ class Session {
   // Set when HandlePullDiscard catches CommitWouldBlockException; cleared when the pool-side
   // retry completes (Done) or fails unrecoverably (ClientError).
   bool pending_commit_{false};
+  bool pending_commit_from_message_{false};  // true = retry via CommitTransaction(); false = via PULL path
 
   // Arguments from the original PULL stashed so FinishPendingCommit_ can retry without re-decoding.
   std::optional<int> pending_commit_n_{};

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -32,6 +32,9 @@
 #include "utils/uuid.hpp"
 
 namespace memgraph::communication::bolt {
+
+// PendingCommitOutcome lives in state.hpp (so the v2 session driver can name it).
+
 /**
  * Bolt Session Exception
  *
@@ -157,6 +160,13 @@ class Session {
         return true;  // more data to process
       }
 
+      if (state_ == State::PendingCommit) {
+        // PULL/DISCARD's Commit() step would block on commit_mutex_; the pool driver
+        // (PostFinishPendingCommit) parks this worker under CommitLock and retries on wake.
+        // Stop the dechunk loop so a pipelined message can't run before the commit finishes.
+        return true;  // more data to process
+      }
+
       if (state_ == State::Close) [[unlikely]] {
         // State::Close is handled here because we always want to check for
         // it after the above select. If any of the states above return a
@@ -170,6 +180,68 @@ class Session {
   void HandleError() {
     if (!at_least_one_run_) {
       spdlog::info("Sudden connection loss. Make sure the client supports Memgraph.");
+    }
+  }
+
+  // True while a PULL/DISCARD commit is parked waiting for commit_mutex_.
+  bool HasPendingCommit() const { return pending_commit_; }
+
+  // Whether the input buffer still has unprocessed bytes; used by PostFinishPendingCommit to
+  // decide DoWork vs DoRead after the commit completes.
+  bool HasBufferedData() const { return input_stream_.size() > 0; }
+
+  // Record the PULL arguments so FinishPendingCommit_ can retry without re-decoding.
+  // Called from HandlePullDiscard on a CommitWouldBlockException catch.
+  void StashPendingCommit(std::optional<int> n, std::optional<int> qid) {
+    pending_commit_ = true;
+    pending_commit_n_ = n;
+    pending_commit_qid_ = qid;
+  }
+
+  // Pool-side retry of a Commit() that threw CommitWouldBlockException.
+  // Re-runs the exhausted HandlePullDiscard<PULL> path: the cursor is already drained so
+  // Pull() streams 0 rows and only retries Commit().  On another TryLock miss, the specific
+  // CommitWouldBlockException catch in HandlePullDiscard re-stashes and returns PendingCommit
+  // — the pool driver re-parks.  On success, HandlePullDiscard sends the SUCCESS response and
+  // sets state_ = Idle.  Any other exception becomes ClientError (the bolt error was already
+  // sent by HandleFailure inside HandlePullDiscard).
+  //
+  // FLAG (re-Pull safety): commit_mutex_ is try-locked as the FIRST action in Interpreter::Commit()
+  // (interpreter.cpp:11518), before any state mutation.  The cursor has already returned its last
+  // result row and set maybe_res = COMMIT before the first CommitWouldBlockException; a second
+  // Pull() on an exhausted PullPlan/PullPlanVector cursor returns immediately (0 rows, returns
+  // the done signal) so Commit() is the only meaningful work.  The plan_execution_time in the
+  // re-generated summary accumulates a near-zero second elapsed — negligible measurement noise.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  PendingCommitOutcome FinishPendingCommit_(TImpl &impl) {
+    MG_ASSERT(pending_commit_, "FinishPendingCommit_ called without a stashed pending commit");
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+
+    const auto n = pending_commit_n_;
+    const auto qid = pending_commit_qid_;
+
+    // Re-invoke the Pull path.  HandlePullDiscard's specific CommitWouldBlockException catch
+    // re-stashes n/qid and returns PendingCommit on another TryLock miss; any other exception
+    // triggers HandleFailure (bolt Error → ClientError here).  state_ is written by either the
+    // success return (Idle) or by HandleFailure (Error/Close) inside HandlePullDiscard.
+    state_ = details::HandlePullDiscard</*is_pull=*/true>(impl, n, qid);
+
+    switch (state_) {
+      case State::PendingCommit:
+        // CommitWouldBlockException thrown again; StashPendingCommit already re-set pending_commit_.
+        return PendingCommitOutcome::Reschedule;
+      case State::Idle:
+      case State::Result:
+        // Commit succeeded; HandlePullDiscard already sent SUCCESS to the client.
+        pending_commit_ = false;
+        return PendingCommitOutcome::Done;
+      default:
+        // State::Error or State::Close: HandleFailure sent the bolt error response.
+        pending_commit_ = false;
+        return PendingCommitOutcome::ClientError;
     }
   }
 
@@ -216,6 +288,14 @@ class Session {
   }
 
  private:
+  // Set when HandlePullDiscard catches CommitWouldBlockException; cleared when the pool-side
+  // retry completes (Done) or fails unrecoverably (ClientError).
+  bool pending_commit_{false};
+
+  // Arguments from the original PULL stashed so FinishPendingCommit_ can retry without re-decoding.
+  std::optional<int> pending_commit_n_{};
+  std::optional<int> pending_commit_qid_{};
+
   const std::string kTimestampFormat = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}";
   const std::string session_uuid_;  //!< unique identifier of the session (auto generated)
   const std::string login_timestamp_;

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -215,19 +215,8 @@ class Session {
   }
 
   // Pool-side retry of a Commit() that threw CommitWouldBlockException.
-  // Re-runs the exhausted HandlePullDiscard<PULL> path: the cursor is already drained so
-  // Pull() streams 0 rows and only retries Commit().  On another TryLock miss, the specific
-  // CommitWouldBlockException catch in HandlePullDiscard re-stashes and returns PendingCommit
-  // — the pool driver re-parks.  On success, HandlePullDiscard sends the SUCCESS response and
-  // sets state_ = Idle.  Any other exception becomes ClientError (the bolt error was already
-  // sent by HandleFailure inside HandlePullDiscard).
-  //
-  // FLAG (re-Pull safety): commit_mutex_ is try-locked as the FIRST action in Interpreter::Commit()
-  // (interpreter.cpp:11518), before any state mutation.  The cursor has already returned its last
-  // result row and set maybe_res = COMMIT before the first CommitWouldBlockException; a second
-  // Pull() on an exhausted PullPlan/PullPlanVector cursor returns immediately (0 rows, returns
-  // the done signal) so Commit() is the only meaningful work.  The plan_execution_time in the
-  // re-generated summary accumulates a near-zero second elapsed — negligible measurement noise.
+  // FLAG (re-Pull safety): try-lock is Commit()'s first action before any mutation; an
+  // exhausted cursor's second Pull() streams 0 rows so only Commit() re-runs.
   template <typename TImpl>
     requires requires(TImpl &impl) {
       { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
@@ -261,10 +250,8 @@ class Session {
     const auto n = pending_commit_n_;
     const auto qid = pending_commit_qid_;
 
-    // Re-invoke the Pull path.  HandlePullDiscard's specific CommitWouldBlockException catch
-    // re-stashes n/qid and returns PendingCommit on another TryLock miss; any other exception
-    // triggers HandleFailure (bolt Error → ClientError here).  state_ is written by either the
-    // success return (Idle) or by HandleFailure (Error/Close) inside HandlePullDiscard.
+    // Re-invoke the Pull path; HandlePullDiscard's CommitWouldBlockException catch re-stashes
+    // n/qid so State::PendingCommit below means pending_commit_ is already re-set.
     state_ = details::HandlePullDiscard</*is_pull=*/true>(impl, n, qid);
 
     switch (state_) {
@@ -294,9 +281,8 @@ class Session {
     pending_begin_deadline_ = deadline;
   }
 
-  // Record that HandleBegin (explicit BEGIN message) threw BeginWouldBlockException; the pool
-  // driver retries by calling BeginTransaction(pending_begin_extra_) + MessageSuccess({}) on wake.
-  // Configure() has already run so only the BeginTransaction call is repeated.
+  // Record that HandleBegin threw BeginWouldBlockException; Configure() already ran, so the pool
+  // driver retries only BeginTransaction(pending_begin_extra_) + MessageSuccess({}) on wake.
   void StashPendingBeginMessage(map_t extra, std::chrono::steady_clock::time_point deadline) {
     pending_begin_ = true;
     pending_begin_from_message_ = true;
@@ -309,19 +295,8 @@ class Session {
   std::chrono::steady_clock::time_point PendingBeginDeadline() const { return pending_begin_deadline_; }
 
   // Pool-side retry of a BEGIN / RUN-as-first-query that threw BeginWouldBlockException.
-  //
-  // RUN origin: re-runs HandlePrepare (InterpretPrepare + header send). On another
-  // BeginWouldBlockException, HandlePrepare's catch re-stashes and returns PendingBegin →
-  // Reschedule returned here. On success → Result state → Done.
-  //
-  // BEGIN-message origin: re-runs BeginTransaction(pending_begin_extra_) + MessageSuccess({}).
-  // On another BeginWouldBlockException, returns Reschedule without re-stashing (pending_begin_
-  // stays true and pending_begin_extra_ is retained — re-stashing would self-move the map).
-  // On success → Idle state → Done.
-  //
-  // FLAG (re-Prepare safety): InterpretPrepare enters SetupDatabaseTransaction BEFORE any
-  // storage-mutating work; the BeginWouldBlockException is thrown there so nothing non-idempotent
-  // has occurred. Re-running HandlePrepare is therefore safe.
+  // FLAG (re-Prepare safety): BeginWouldBlockException is thrown in SetupDatabaseTransaction
+  // before any storage txn opens, so nothing non-idempotent has run; retry is safe.
   template <typename TImpl>
     requires requires(TImpl &impl) {
       { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <concepts>
 #include <optional>
 
@@ -167,6 +168,13 @@ class Session {
         return true;  // more data to process
       }
 
+      if (state_ == State::PendingBegin) {
+        // BEGIN (or RUN-as-first-query) would block on main_lock_; the pool driver
+        // (PostFinishPendingBegin) parks this worker under MainLock and retries on wake.
+        // Stop the dechunk loop so a pipelined message can't run before the accessor is acquired.
+        return true;  // more data to process
+      }
+
       if (state_ == State::Close) [[unlikely]] {
         // State::Close is handled here because we always want to check for
         // it after the above select. If any of the states above return a
@@ -275,6 +283,96 @@ class Session {
     }
   }
 
+  // True while a BEGIN / RUN-as-first-query is parked waiting for main_lock_.
+  bool HasPendingBegin() const { return pending_begin_; }
+
+  // Record that HandlePrepare (RUN-first-query) threw BeginWouldBlockException; the pool driver
+  // retries via HandlePrepare on wake (which re-runs InterpretPrepare and sends the header).
+  void StashPendingBeginPrepare(std::chrono::steady_clock::time_point deadline) {
+    pending_begin_ = true;
+    pending_begin_from_message_ = false;
+    pending_begin_deadline_ = deadline;
+  }
+
+  // Record that HandleBegin (explicit BEGIN message) threw BeginWouldBlockException; the pool
+  // driver retries by calling BeginTransaction(pending_begin_extra_) + MessageSuccess({}) on wake.
+  // Configure() has already run so only the BeginTransaction call is repeated.
+  void StashPendingBeginMessage(map_t extra, std::chrono::steady_clock::time_point deadline) {
+    pending_begin_ = true;
+    pending_begin_from_message_ = true;
+    pending_begin_extra_ = std::move(extra);
+    pending_begin_deadline_ = deadline;
+  }
+
+  // Finite deadline carried from BeginWouldBlockException; used by PostFinishPendingBegin to
+  // pass to ParkAdmission (MUST NOT be time_point::max — that would bypass the BEGIN timeout).
+  std::chrono::steady_clock::time_point PendingBeginDeadline() const { return pending_begin_deadline_; }
+
+  // Pool-side retry of a BEGIN / RUN-as-first-query that threw BeginWouldBlockException.
+  //
+  // RUN origin: re-runs HandlePrepare (InterpretPrepare + header send). On another
+  // BeginWouldBlockException, HandlePrepare's catch re-stashes and returns PendingBegin →
+  // Reschedule returned here. On success → Result state → Done.
+  //
+  // BEGIN-message origin: re-runs BeginTransaction(pending_begin_extra_) + MessageSuccess({}).
+  // On another BeginWouldBlockException, returns Reschedule without re-stashing (pending_begin_
+  // stays true and pending_begin_extra_ is retained — re-stashing would self-move the map).
+  // On success → Idle state → Done.
+  //
+  // FLAG (re-Prepare safety): InterpretPrepare enters SetupDatabaseTransaction BEFORE any
+  // storage-mutating work; the BeginWouldBlockException is thrown there so nothing non-idempotent
+  // has occurred. Re-running HandlePrepare is therefore safe.
+  template <typename TImpl>
+    requires requires(TImpl &impl) {
+      { impl.GetLogContext() } -> std::same_as<memgraph::logging::SessionLogContext *>;
+    }
+  PendingBeginOutcome FinishPendingBegin_(TImpl &impl) {
+    MG_ASSERT(pending_begin_, "FinishPendingBegin_ called without a stashed pending begin");
+    memgraph::logging::ScopedSessionLog log_guard(impl.GetLogContext());
+
+    if (pending_begin_from_message_) {
+      // Explicit-transaction BEGIN message retry: Configure already ran, only BeginTransaction is
+      // repeated. On success send MessageSuccess({}) and transition to Idle (no cursor needed).
+      try {
+        impl.BeginTransaction(pending_begin_extra_);
+        if (!encoder_.MessageSuccess({})) {
+          state_ = State::Close;
+          pending_begin_ = false;
+          return PendingBeginOutcome::ClientError;
+        }
+        state_ = State::Idle;
+        pending_begin_ = false;
+        return PendingBeginOutcome::Done;
+      } catch (const memgraph::query::BeginWouldBlockException &) {
+        // main_lock_ still contended; deadline is retained in pending_begin_deadline_.
+        // Do NOT re-stash: pending_begin_ is already true and pending_begin_extra_ must be kept.
+        return PendingBeginOutcome::Reschedule;
+      } catch (const std::exception &e) {
+        // Deadline expired (access-timeout) or other unrecoverable error; send bolt FAILURE.
+        state_ = HandleFailure(impl, e);
+        pending_begin_ = false;
+        return PendingBeginOutcome::ClientError;
+      }
+    }
+
+    // RUN origin: re-run HandlePrepare. On BeginWouldBlockException, HandlePrepare's catch
+    // calls StashPendingBeginPrepare and returns State::PendingBegin → Reschedule here.
+    state_ = HandlePrepare(impl);
+    switch (state_) {
+      case State::PendingBegin:
+        // BeginWouldBlockException thrown again; HandlePrepare re-stashed pending_begin_.
+        return PendingBeginOutcome::Reschedule;
+      case State::Result:
+        // InterpretPrepare succeeded; header sent by HandlePrepare.
+        pending_begin_ = false;
+        return PendingBeginOutcome::Done;
+      default:
+        // State::Error or State::Close: HandleFailure sent the bolt error response.
+        pending_begin_ = false;
+        return PendingBeginOutcome::ClientError;
+    }
+  }
+
   // TODO: Rethink if there is a way to hide some members. At the momement all of them are public.
   TInputStream &input_stream_;
   TOutputStream &output_stream_;
@@ -326,6 +424,19 @@ class Session {
   // Arguments from the original PULL stashed so FinishPendingCommit_ can retry without re-decoding.
   std::optional<int> pending_commit_n_{};
   std::optional<int> pending_commit_qid_{};
+
+  // Set when HandlePrepare or HandleBegin catches BeginWouldBlockException; cleared when the
+  // pool-side retry completes (Done) or fails unrecoverably (ClientError / deadline expired).
+  bool pending_begin_{false};
+  bool pending_begin_from_message_{false};  // true = retry via BeginTransaction(); false = via HandlePrepare
+
+  // Extra map from the original BEGIN message (needed to re-run BeginTransaction on wake).
+  // Only meaningful when pending_begin_from_message_ == true.
+  map_t pending_begin_extra_{};
+
+  // Finite deadline carried from BeginWouldBlockException; passed to ParkAdmission so the park
+  // respects the user-configured storage-access timeout.
+  std::chrono::steady_clock::time_point pending_begin_deadline_{};
 
   const std::string kTimestampFormat = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}";
   const std::string session_uuid_;  //!< unique identifier of the session (auto generated)

--- a/src/communication/bolt/v1/state.hpp
+++ b/src/communication/bolt/v1/state.hpp
@@ -62,35 +62,21 @@ enum class State : uint8_t {
   Close,
 
   /**
-   * A PULL (or DISCARD) whose autocommit Commit() step returned
-   * CommitWouldBlockException — commit_mutex_ is held by another writer.
-   * The bolt driver parks this pool worker under WaitResource::CommitLock and
-   * retries Commit() on wake. Nothing is sent to the client until the commit
-   * completes or fails permanently.
+   * PULL/DISCARD autocommit whose Commit() threw CommitWouldBlockException (commit_mutex_ contended);
+   * parks under WaitResource::CommitLock and retries on wake — nothing sent to client until commit settles.
    */
   PendingCommit,
 
   /**
-   * A BEGIN message (or RUN-as-first-query) whose SetupDatabaseTransaction()
-   * returned BeginWouldBlockException — main_lock_ is held by a DDL/UNIQUE/
-   * READ_ONLY holder. The bolt driver parks this pool worker under
-   * WaitResource::MainLock until the finite storage-access deadline and retries
-   * on wake. Nothing is sent to the client until the accessor is acquired or
-   * the deadline expires (whereupon the ordinary access-timeout exception is
-   * thrown by the query layer).
+   * BEGIN/RUN-as-first-query whose SetupDatabaseTransaction() threw BeginWouldBlockException (main_lock_ contended);
+   * parks under WaitResource::MainLock and retries on wake — deadline expiry calls storage::ThrowAccessTimeout.
    */
   PendingBegin,
 };
 
-// Outcome of a single FinishPendingCommit_ attempt: the commit acquired commit_mutex_ and the SUCCESS
-// response was sent (Done), must be re-tried (Reschedule), or the connection should be torn down
-// (ClientError — encoder write failure or unrecoverable exception). Lives here (not session.hpp) so the
-// v2 session driver can name it without pulling in the whole bolt Session header.
+// Lives here (not session.hpp) so the v2 driver can name it without pulling in the bolt Session header.
 enum class PendingCommitOutcome : uint8_t { Reschedule, Done, ClientError };
 
-// Outcome of a single FinishPendingBegin_ attempt: main_lock_ was acquired and the query resumed
-// (Done), must be re-tried (Reschedule), or the connection should be torn down (ClientError —
-// deadline expired / encoder write failure / unrecoverable exception). Lives here so the v2 session
-// driver can name it without pulling in the whole bolt Session header.
+// Lives here (not session.hpp) so the v2 driver can name it without pulling in the bolt Session header.
 enum class PendingBeginOutcome : uint8_t { Reschedule, Done, ClientError };
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/state.hpp
+++ b/src/communication/bolt/v1/state.hpp
@@ -69,6 +69,17 @@ enum class State : uint8_t {
    * completes or fails permanently.
    */
   PendingCommit,
+
+  /**
+   * A BEGIN message (or RUN-as-first-query) whose SetupDatabaseTransaction()
+   * returned BeginWouldBlockException — main_lock_ is held by a DDL/UNIQUE/
+   * READ_ONLY holder. The bolt driver parks this pool worker under
+   * WaitResource::MainLock until the finite storage-access deadline and retries
+   * on wake. Nothing is sent to the client until the accessor is acquired or
+   * the deadline expires (whereupon the ordinary access-timeout exception is
+   * thrown by the query layer).
+   */
+  PendingBegin,
 };
 
 // Outcome of a single FinishPendingCommit_ attempt: the commit acquired commit_mutex_ and the SUCCESS
@@ -76,4 +87,10 @@ enum class State : uint8_t {
 // (ClientError — encoder write failure or unrecoverable exception). Lives here (not session.hpp) so the
 // v2 session driver can name it without pulling in the whole bolt Session header.
 enum class PendingCommitOutcome : uint8_t { Reschedule, Done, ClientError };
+
+// Outcome of a single FinishPendingBegin_ attempt: main_lock_ was acquired and the query resumed
+// (Done), must be re-tried (Reschedule), or the connection should be torn down (ClientError —
+// deadline expired / encoder write failure / unrecoverable exception). Lives here so the v2 session
+// driver can name it without pulling in the whole bolt Session header.
+enum class PendingBeginOutcome : uint8_t { Reschedule, Done, ClientError };
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/state.hpp
+++ b/src/communication/bolt/v1/state.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -60,5 +60,20 @@ enum class State : uint8_t {
    * session should be closed.
    */
   Close,
+
+  /**
+   * A PULL (or DISCARD) whose autocommit Commit() step returned
+   * CommitWouldBlockException — commit_mutex_ is held by another writer.
+   * The bolt driver parks this pool worker under WaitResource::CommitLock and
+   * retries Commit() on wake. Nothing is sent to the client until the commit
+   * completes or fails permanently.
+   */
+  PendingCommit,
 };
+
+// Outcome of a single FinishPendingCommit_ attempt: the commit acquired commit_mutex_ and the SUCCESS
+// response was sent (Done), must be re-tried (Reschedule), or the connection should be torn down
+// (ClientError — encoder write failure or unrecoverable exception). Lives here (not session.hpp) so the
+// v2 session driver can name it without pulling in the whole bolt Session header.
+enum class PendingCommitOutcome : uint8_t { Reschedule, Done, ClientError };
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -241,6 +241,12 @@ State HandlePrepare(TSession &session) {
       return State::Close;
     }
     return State::Result;
+  } catch (const memgraph::query::BeginWouldBlockException &e) {
+    // main_lock_ is contended; park this worker until the accessor becomes available.
+    // Nothing non-idempotent has occurred (throw is the first action in SetupDatabaseTransaction
+    // before any storage mutation), so re-running InterpretPrepare on wake is safe.
+    session.StashPendingBeginPrepare(e.deadline());
+    return State::PendingBegin;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }
@@ -451,6 +457,11 @@ State HandleBegin(TSession &session, const State state, const Marker marker) {
       return State::Close;
     }
     return State::Idle;
+  } catch (const memgraph::query::BeginWouldBlockException &e) {
+    // main_lock_ is contended; Configure() has already run. Stash the extra map so the pool
+    // driver can retry BeginTransaction(extra) + MessageSuccess({}) on wake without re-decoding.
+    session.StashPendingBeginMessage(extra.ValueMap(), e.deadline());
+    return State::PendingBegin;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -477,6 +477,11 @@ State HandleCommit(TSession &session, const State state, const Marker marker) {
       return State::Close;
     }
     return State::Idle;
+  } catch (const memgraph::query::CommitWouldBlockException &) {
+    // commit_mutex_ contended: park this write and retry the COMMIT message on wake (U4c), instead of
+    // failing the client. The explicit txn stays staged (Commit throws before mutating).
+    session.StashPendingCommitMessage();
+    return State::PendingCommit;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -127,11 +127,8 @@ State HandlePullDiscard(TSession &session, std::optional<int> n, std::optional<i
 
     return State::Idle;
   } catch (const memgraph::query::CommitWouldBlockException &) {
-    // Interpreter::Commit() could not acquire commit_mutex_ without blocking.  Nothing has been
-    // mutated — the throw is the very first action in Commit(), before any state change.  Stash
-    // n/qid so the pool driver (PostFinishPendingCommit in v2/session.hpp) can retry Commit()
-    // on wake without re-decoding.  Both the PULL and DISCARD branches reach Commit(), so the
-    // catch is outside the if-constexpr.
+    // Commit() throws before any state change — stash n/qid so PostFinishPendingCommit can retry on wake.
+    // Both PULL and DISCARD call Commit(), so this catch is outside the if-constexpr.
     session.StashPendingCommit(n, qid);
     return State::PendingCommit;
   } catch (const std::exception &e) {
@@ -242,9 +239,8 @@ State HandlePrepare(TSession &session) {
     }
     return State::Result;
   } catch (const memgraph::query::BeginWouldBlockException &e) {
-    // main_lock_ is contended; park this worker until the accessor becomes available.
-    // Nothing non-idempotent has occurred (throw is the first action in SetupDatabaseTransaction
-    // before any storage mutation), so re-running InterpretPrepare on wake is safe.
+    // main_lock_ is contended; SetupDatabaseTransaction throws before any storage mutation,
+    // so re-running InterpretPrepare on wake is safe.
     session.StashPendingBeginPrepare(e.deadline());
     return State::PendingBegin;
   } catch (const std::exception &e) {
@@ -489,7 +485,7 @@ State HandleCommit(TSession &session, const State state, const Marker marker) {
     }
     return State::Idle;
   } catch (const memgraph::query::CommitWouldBlockException &) {
-    // commit_mutex_ contended: park this write and retry the COMMIT message on wake (U4c), instead of
+    // commit_mutex_ contended: park this write and retry the COMMIT message on wake, instead of
     // failing the client. The explicit txn stays staged (Commit throws before mutating).
     session.StashPendingCommitMessage();
     return State::PendingCommit;

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -27,6 +27,7 @@
 #include "communication/exceptions.hpp"
 #include "license/license_sender.hpp"
 #include "metrics/prometheus_metrics.hpp"
+#include "query/exceptions.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/logging.hpp"
 #include "utils/memory_tracker.hpp"
@@ -125,6 +126,14 @@ State HandlePullDiscard(TSession &session, std::optional<int> n, std::optional<i
     }
 
     return State::Idle;
+  } catch (const memgraph::query::CommitWouldBlockException &) {
+    // Interpreter::Commit() could not acquire commit_mutex_ without blocking.  Nothing has been
+    // mutated — the throw is the very first action in Commit(), before any state change.  Stash
+    // n/qid so the pool driver (PostFinishPendingCommit in v2/session.hpp) can retry Commit()
+    // on wake without re-decoding.  Both the PULL and DISCARD branches reach Commit(), so the
+    // catch is outside the if-constexpr.
+    session.StashPendingCommit(n, qid);
+    return State::PendingCommit;
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -387,6 +387,10 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
         while (session_.HasPendingCommit()) {
           session_.FinishPendingCommit();
         }
+        // Websocket busy-wait for the rare main_lock_ contention case (mirrors PendingCommit above).
+        while (session_.HasPendingBegin()) {
+          session_.FinishPendingBegin();
+        }
       }
       // Handled all data,  async wait for new incoming data
       DoReadAsio();
@@ -405,6 +409,12 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                   // PULL/DISCARD's Commit() would block; park this worker until commit_mutex_ frees.
                   // Return now so a pipelined message can't run before the commit finishes.
                   shared_this->PostFinishPendingCommit();
+                  return;
+                }
+                if (shared_this->session_.HasPendingBegin()) {
+                  // BEGIN/RUN-first-query would block on main_lock_; park until it frees (bounded
+                  // by the finite storage-access deadline).
+                  shared_this->PostFinishPendingBegin();
                   return;
                 }
                 // Check if we can just steal this task (loop through)
@@ -481,6 +491,60 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
                                       id,
                                       std::chrono::steady_clock::time_point::max(),
                                       utils::WaitTag{utils::WaitResource::CommitLock, {}});
+    }
+  }
+
+  // Completes a would-block BEGIN / RUN-as-first-query on the pool.
+  //
+  // Mirrors PostFinishPendingCommit but uses a FINITE deadline (session_.PendingBeginDeadline())
+  // rather than time_point::max, and parks under WaitResource::MainLock (not CommitLock).  The
+  // finite deadline is mandatory: main_lock_ is the BEGIN/DDL-contention path and a max-deadline
+  // park could outlast the monitor backstop, violating the storage-access timeout contract.
+  //
+  // On Reschedule (main_lock_ still contended): re-park under MainLock until woken by the
+  // ResourceLock notify hook (U3a) or the monitor sweep.
+  // On Done / ClientError: reset task id and resume the session (DoWork or DoRead).
+  void PostFinishPendingBegin() {
+    auto lambda = [shared_this = shared_from_this()](const auto /*thread_priority*/) {
+      try {
+        switch (shared_this->session_.FinishPendingBegin()) {
+          case memgraph::communication::bolt::PendingBeginOutcome::Reschedule:
+            // main_lock_ still held; re-park and wait for the next WakeMatching({MainLock}).
+            shared_this->PostFinishPendingBegin();
+            return;
+          case memgraph::communication::bolt::PendingBeginOutcome::Done:
+          case memgraph::communication::bolt::PendingBeginOutcome::ClientError:
+            shared_this->pending_begin_task_id_.store(0, std::memory_order_relaxed);
+            if (shared_this->session_.HasBufferedData()) {
+              shared_this->DoWork();
+            } else {
+              shared_this->DoRead();
+            }
+            return;
+        }
+      } catch (const std::exception & /* unused */) {
+        boost::asio::post(shared_this->strand_,
+                          [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
+      }
+    };
+
+    // Pool shutting down: drop the continuation; teardown will error the client.
+    if (session_context_->IsDrainingAdmissions()) return;
+
+    const auto id = pending_begin_task_id_.load(std::memory_order_relaxed);
+    if (id == 0) {
+      // First post: add to queue to get a place-keeping id; one spin-try before parking.
+      pending_begin_task_id_.store(
+          session_context_->AddTask(std::move(lambda), utils::Priority::LOW, /*productive=*/false),
+          std::memory_order_relaxed);
+    } else {
+      // Reschedule: park under MainLock with the FINITE storage-access deadline so the pool
+      // worker sleeps until WakeMatching({MainLock}) fires from the ResourceLock notify hook.
+      const auto deadline = session_.PendingBeginDeadline();
+      DMG_ASSERT(deadline != std::chrono::steady_clock::time_point::max(),
+                 "PendingBegin park deadline must be finite (storage-access timeout)");
+      session_context_->ParkAdmission(
+          std::move(lambda), id, deadline, utils::WaitTag{utils::WaitResource::MainLock, {}});
     }
   }
 
@@ -605,5 +669,10 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   // Relaxed accesses are safe: a single session has at most one pending commit at a time
   // and the pool sees it via the task-queue / parked-admissions mechanisms.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_commit_task_id_{0};
+
+  // TaskID of the in-flight begin-park continuation; 0 = not yet issued.
+  // Same relaxed-access reasoning as pending_commit_task_id_ above: one pending-begin per
+  // session at a time, visible to the pool via the task-queue / parked-admissions mechanisms.
+  std::atomic<utils::PriorityThreadPool::TaskID> pending_begin_task_id_{0};
 };
 }  // namespace memgraph::communication::v2

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -643,8 +643,11 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   std::string_view service_name_;
   std::atomic_bool execution_active_{false};
 
-  // TaskID of the in-flight commit-park continuation; 0 = not yet issued.
-  // Relaxed is safe: one pending commit per session; enqueue/dequeue order provides visibility.
+  // TaskID of the in-flight commit-park continuation; 0 = not yet issued. Only one commit-park is ever
+  // in flight per session (the sequential post-and-return chain). Relaxed is safe because the sole
+  // hazard — the first-post store landing after AddTask returns — is self-correcting: a stale-0 read
+  // costs at most one extra (harmless, sequential) AddTask, and a stale-nonzero read is recovered by
+  // the pool's 100ms monitor backstop. Not a load-bearing ordering; do not read into it.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_commit_task_id_{0};
 
   // TaskID of the in-flight begin-park continuation; 0 = not yet issued; same relaxed reasoning as above.

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -43,7 +43,7 @@
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/system/detail/error_code.hpp>
 
-#include "communication/bolt/v1/state.hpp"  // PendingCommitOutcome (commit-park driver)
+#include "communication/bolt/v1/state.hpp"  // PendingCommitOutcome, PendingBeginOutcome
 #include "communication/buffer.hpp"
 #include "communication/context.hpp"
 #include "communication/exceptions.hpp"
@@ -380,14 +380,11 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     try {
       // Execute until all data has been read
       while (session_.Execute()) {
-        // Websocket runs the bolt state machine inline on the strand; drive any pending commit to
-        // completion here — the pool resume path (DoWork/DoRead) would remove this connection from
-        // the websocket read loop.  This is a busy-wait for the rare case where commit_mutex_ is
-        // contended; websocket is not the performance-critical transport.
+        // WebSocket runs Bolt inline on the strand; the pool-path (DoWork/DoRead) would exit the
+        // WS read loop, so busy-wait here instead — acceptable: WebSocket is not the hot transport.
         while (session_.HasPendingCommit()) {
           session_.FinishPendingCommit();
         }
-        // Websocket busy-wait for the rare main_lock_ contention case (mirrors PendingCommit above).
         while (session_.HasPendingBegin()) {
           session_.FinishPendingBegin();
         }
@@ -437,18 +434,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
         session_.ApproximateQueryPriority());
   }
 
-  // Completes a would-block PULL/DISCARD commit on the pool.
-  //
-  // First attempt (pending_commit_task_id_ == 0): adds to the pool queue and records the id; the
-  // task runs immediately and tries FinishPendingCommit_.  If commit_mutex_ is now free, Done is
-  // returned and we resume DoWork/DoRead.
-  //
-  // On Reschedule (TryLockCommit missed again): re-park under CommitLock so this worker sleeps
-  // until WakeMatching({CommitLock}) fires from inside Interpreter::Commit().  No deadline: a
-  // commit must never be abandoned by timeout — the monitor-sweep backstop in the pool provides
-  // liveness.
-  //
-  // On terminal (Done / ClientError): reset the task id and resume the session.
+  // Parks a would-block PULL/DISCARD commit on the pool under CommitLock, no deadline:
+  // a commit must not be abandoned by timeout; the pool's monitor-sweep provides liveness.
   void PostFinishPendingCommit() {
     auto lambda = [shared_this = shared_from_this()](const auto /*thread_priority*/) {
       try {
@@ -478,9 +465,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
 
     const auto id = pending_commit_task_id_.load(std::memory_order_relaxed);
     if (id == 0) {
-      // First post: add to queue to get a place-keeping id; one spin-try before parking.
-      // A pool thread that races to Reschedule before the store lands will re-mint its own id —
-      // at most one reschedule misses place-keeping; no correctness impact.
+      // First post: add to queue for a place-keeping id; one spin-try before parking.
+      // A racing Reschedule before the store lands re-mints its own id — no correctness impact.
       pending_commit_task_id_.store(
           session_context_->AddTask(std::move(lambda), utils::Priority::LOW, /*productive=*/false),
           std::memory_order_relaxed);
@@ -494,16 +480,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     }
   }
 
-  // Completes a would-block BEGIN / RUN-as-first-query on the pool.
-  //
-  // Mirrors PostFinishPendingCommit but uses a FINITE deadline (session_.PendingBeginDeadline())
-  // rather than time_point::max, and parks under WaitResource::MainLock (not CommitLock).  The
-  // finite deadline is mandatory: main_lock_ is the BEGIN/DDL-contention path and a max-deadline
-  // park could outlast the monitor backstop, violating the storage-access timeout contract.
-  //
-  // On Reschedule (main_lock_ still contended): re-park under MainLock until woken by the
-  // ResourceLock notify hook (U3a) or the monitor sweep.
-  // On Done / ClientError: reset task id and resume the session (DoWork or DoRead).
+  // Parks a would-block BEGIN on the pool under MainLock with the FINITE storage-access deadline:
+  // unlike commit, main_lock_ contention must time out to honour the storage-access timeout contract.
   void PostFinishPendingBegin() {
     auto lambda = [shared_this = shared_from_this()](const auto /*thread_priority*/) {
       try {
@@ -666,13 +644,10 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   std::atomic_bool execution_active_{false};
 
   // TaskID of the in-flight commit-park continuation; 0 = not yet issued.
-  // Relaxed accesses are safe: a single session has at most one pending commit at a time
-  // and the pool sees it via the task-queue / parked-admissions mechanisms.
+  // Relaxed is safe: one pending commit per session; enqueue/dequeue order provides visibility.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_commit_task_id_{0};
 
-  // TaskID of the in-flight begin-park continuation; 0 = not yet issued.
-  // Same relaxed-access reasoning as pending_commit_task_id_ above: one pending-begin per
-  // session at a time, visible to the pool via the task-queue / parked-admissions mechanisms.
+  // TaskID of the in-flight begin-park continuation; 0 = not yet issued; same relaxed reasoning as above.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_begin_task_id_{0};
 };
 }  // namespace memgraph::communication::v2

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -43,6 +43,7 @@
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/system/detail/error_code.hpp>
 
+#include "communication/bolt/v1/state.hpp"  // PendingCommitOutcome (commit-park driver)
 #include "communication/buffer.hpp"
 #include "communication/context.hpp"
 #include "communication/exceptions.hpp"
@@ -379,6 +380,13 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     try {
       // Execute until all data has been read
       while (session_.Execute()) {
+        // Websocket runs the bolt state machine inline on the strand; drive any pending commit to
+        // completion here — the pool resume path (DoWork/DoRead) would remove this connection from
+        // the websocket read loop.  This is a busy-wait for the rare case where commit_mutex_ is
+        // contended; websocket is not the performance-critical transport.
+        while (session_.HasPendingCommit()) {
+          session_.FinishPendingCommit();
+        }
       }
       // Handled all data,  async wait for new incoming data
       DoReadAsio();
@@ -393,6 +401,12 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           try {
             while (true) {
               if (shared_this->session_.Execute()) {
+                if (shared_this->session_.HasPendingCommit()) {
+                  // PULL/DISCARD's Commit() would block; park this worker until commit_mutex_ frees.
+                  // Return now so a pipelined message can't run before the commit finishes.
+                  shared_this->PostFinishPendingCommit();
+                  return;
+                }
                 // Check if we can just steal this task (loop through)
                 if (thread_priority > shared_this->session_.ApproximateQueryPriority()) {
                   // Task priority lower; reschedule
@@ -411,6 +425,63 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           }
         },
         session_.ApproximateQueryPriority());
+  }
+
+  // Completes a would-block PULL/DISCARD commit on the pool.
+  //
+  // First attempt (pending_commit_task_id_ == 0): adds to the pool queue and records the id; the
+  // task runs immediately and tries FinishPendingCommit_.  If commit_mutex_ is now free, Done is
+  // returned and we resume DoWork/DoRead.
+  //
+  // On Reschedule (TryLockCommit missed again): re-park under CommitLock so this worker sleeps
+  // until WakeMatching({CommitLock}) fires from inside Interpreter::Commit().  No deadline: a
+  // commit must never be abandoned by timeout — the monitor-sweep backstop in the pool provides
+  // liveness.
+  //
+  // On terminal (Done / ClientError): reset the task id and resume the session.
+  void PostFinishPendingCommit() {
+    auto lambda = [shared_this = shared_from_this()](const auto /*thread_priority*/) {
+      try {
+        switch (shared_this->session_.FinishPendingCommit()) {
+          case memgraph::communication::bolt::PendingCommitOutcome::Reschedule:
+            // commit_mutex_ still held; re-park and wait for the next WakeMatching({CommitLock}).
+            shared_this->PostFinishPendingCommit();
+            return;
+          case memgraph::communication::bolt::PendingCommitOutcome::Done:
+          case memgraph::communication::bolt::PendingCommitOutcome::ClientError:
+            shared_this->pending_commit_task_id_.store(0, std::memory_order_relaxed);
+            if (shared_this->session_.HasBufferedData()) {
+              shared_this->DoWork();
+            } else {
+              shared_this->DoRead();
+            }
+            return;
+        }
+      } catch (const std::exception & /* unused */) {
+        boost::asio::post(shared_this->strand_,
+                          [shared_this, eptr = std::current_exception()]() { shared_this->HandleException(eptr); });
+      }
+    };
+
+    // Pool shutting down: drop the continuation; teardown will error the client.
+    if (session_context_->IsDrainingAdmissions()) return;
+
+    const auto id = pending_commit_task_id_.load(std::memory_order_relaxed);
+    if (id == 0) {
+      // First post: add to queue to get a place-keeping id; one spin-try before parking.
+      // A pool thread that races to Reschedule before the store lands will re-mint its own id —
+      // at most one reschedule misses place-keeping; no correctness impact.
+      pending_commit_task_id_.store(
+          session_context_->AddTask(std::move(lambda), utils::Priority::LOW, /*productive=*/false),
+          std::memory_order_relaxed);
+    } else {
+      // Reschedule: park (not re-post) so this worker yields the core until commit_mutex_ frees.
+      // commit_mutex_ can be held for O(replication_latency) so spinning wastes CPU.
+      session_context_->ParkAdmission(std::move(lambda),
+                                      id,
+                                      std::chrono::steady_clock::time_point::max(),
+                                      utils::WaitTag{utils::WaitResource::CommitLock, {}});
+    }
   }
 
   void OnError(const boost::system::error_code &ec) {
@@ -529,5 +600,10 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   std::optional<tcp::endpoint> remote_endpoint_;
   std::string_view service_name_;
   std::atomic_bool execution_active_{false};
+
+  // TaskID of the in-flight commit-park continuation; 0 = not yet issued.
+  // Relaxed accesses are safe: a single session has at most one pending commit at a time
+  // and the pool sees it via the task-queue / parked-admissions mechanisms.
+  std::atomic<utils::PriorityThreadPool::TaskID> pending_commit_task_id_{0};
 };
 }  // namespace memgraph::communication::v2

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -381,12 +381,15 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
       // Execute until all data has been read
       while (session_.Execute()) {
         // WebSocket runs Bolt inline on the strand; the pool-path (DoWork/DoRead) would exit the
-        // WS read loop, so busy-wait here instead — acceptable: WebSocket is not the hot transport.
+        // WS read loop, so poll here instead — acceptable: WebSocket is not the hot transport. Sleep
+        // between attempts so a contended commit_mutex_/main_lock_ does not spin a core (NB5).
         while (session_.HasPendingCommit()) {
           session_.FinishPendingCommit();
+          if (session_.HasPendingCommit()) std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
         while (session_.HasPendingBegin()) {
           session_.FinishPendingBegin();
+          if (session_.HasPendingBegin()) std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
       }
       // Handled all data,  async wait for new incoming data

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -447,6 +447,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           case memgraph::communication::bolt::PendingCommitOutcome::Done:
           case memgraph::communication::bolt::PendingCommitOutcome::ClientError:
             shared_this->pending_commit_task_id_.store(0, std::memory_order_relaxed);
+            shared_this->pending_commit_retries_ = 0;
             if (shared_this->session_.HasBufferedData()) {
               shared_this->DoWork();
             } else {
@@ -464,15 +465,20 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     if (session_context_->IsDrainingAdmissions()) return;
 
     const auto id = pending_commit_task_id_.load(std::memory_order_relaxed);
-    if (id == 0) {
-      // First post: add to queue for a place-keeping id; one spin-try before parking.
-      // A racing Reschedule before the store lands re-mints its own id — no correctness impact.
+    // Layer-2: re-post up to N(P) times before parking.  On the very first would-block (id==0) we
+    // always re-post to mint a place-keeping id.  On subsequent would-blocks we re-post while the
+    // retry count is below the pressure-scaled cap; once exhausted we park (CV sleep) to yield the
+    // core.  commit_mutex_ can be held for O(replication_latency) so under high pressure we park
+    // sooner; under light pressure a cheap re-post avoids the CV round-trip cost.
+    const uint32_t cap = session_context_->RescheduleCap();
+    if (id == 0 || pending_commit_retries_ < cap) {
+      ++pending_commit_retries_;
       pending_commit_task_id_.store(
           session_context_->AddTask(std::move(lambda), utils::Priority::LOW, /*productive=*/false),
           std::memory_order_relaxed);
     } else {
-      // Reschedule: park (not re-post) so this worker yields the core until commit_mutex_ frees.
-      // commit_mutex_ can be held for O(replication_latency) so spinning wastes CPU.
+      // Cap exhausted: park until WakeMatching({CommitLock}) fires.
+      // No deadline: a commit must not be abandoned by timeout; the monitor-sweep provides liveness.
       session_context_->ParkAdmission(std::move(lambda),
                                       id,
                                       std::chrono::steady_clock::time_point::max(),
@@ -493,6 +499,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           case memgraph::communication::bolt::PendingBeginOutcome::Done:
           case memgraph::communication::bolt::PendingBeginOutcome::ClientError:
             shared_this->pending_begin_task_id_.store(0, std::memory_order_relaxed);
+            shared_this->pending_begin_retries_ = 0;
             if (shared_this->session_.HasBufferedData()) {
               shared_this->DoWork();
             } else {
@@ -510,13 +517,17 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     if (session_context_->IsDrainingAdmissions()) return;
 
     const auto id = pending_begin_task_id_.load(std::memory_order_relaxed);
-    if (id == 0) {
-      // First post: add to queue to get a place-keeping id; one spin-try before parking.
+    // Layer-2: re-post up to N(P) times before parking.  Same pressure-scaling as commit; see
+    // PostFinishPendingCommit for the rationale.  Unlike commit, the park deadline is FINITE
+    // (storage-access timeout) so the begin path must not be parked indefinitely.
+    const uint32_t cap = session_context_->RescheduleCap();
+    if (id == 0 || pending_begin_retries_ < cap) {
+      ++pending_begin_retries_;
       pending_begin_task_id_.store(
           session_context_->AddTask(std::move(lambda), utils::Priority::LOW, /*productive=*/false),
           std::memory_order_relaxed);
     } else {
-      // Reschedule: park under MainLock with the FINITE storage-access deadline so the pool
+      // Cap exhausted: park under MainLock with the FINITE storage-access deadline so the pool
       // worker sleeps until WakeMatching({MainLock}) fires from the ResourceLock notify hook.
       const auto deadline = session_.PendingBeginDeadline();
       DMG_ASSERT(deadline != std::chrono::steady_clock::time_point::max(),
@@ -650,7 +661,16 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   // the pool's 100ms monitor backstop. Not a load-bearing ordering; do not read into it.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_commit_task_id_{0};
 
+  // How many times the current commit admission has been re-posted (Layer-2 reschedule count).
+  // Strand-serialized: all PostFinishPendingCommit calls are dispatched on strand_, so plain uint32_t
+  // is safe.  Reset to 0 when the commit finishes (Done/ClientError).
+  uint32_t pending_commit_retries_{0};
+
   // TaskID of the in-flight begin-park continuation; 0 = not yet issued; same relaxed reasoning as above.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_begin_task_id_{0};
+
+  // How many times the current begin admission has been re-posted (Layer-2 reschedule count).
+  // Strand-serialized: same reasoning as pending_commit_retries_.  Reset to 0 on Done/ClientError.
+  uint32_t pending_begin_retries_{0};
 };
 }  // namespace memgraph::communication::v2

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -465,11 +465,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     if (session_context_->IsDrainingAdmissions()) return;
 
     const auto id = pending_commit_task_id_.load(std::memory_order_relaxed);
-    // Layer-2: re-post up to N(P) times before parking.  On the very first would-block (id==0) we
-    // always re-post to mint a place-keeping id.  On subsequent would-blocks we re-post while the
-    // retry count is below the pressure-scaled cap; once exhausted we park (CV sleep) to yield the
-    // core.  commit_mutex_ can be held for O(replication_latency) so under high pressure we park
-    // sooner; under light pressure a cheap re-post avoids the CV round-trip cost.
+    // Layer-2: id==0 always re-posts (mints a place-keeping id).  Otherwise re-post until the
+    // pressure-scaled cap; light load avoids CV round-trip cost, high load parks sooner.
     const uint32_t cap = session_context_->RescheduleCap();
     if (id == 0 || pending_commit_retries_ < cap) {
       ++pending_commit_retries_;
@@ -477,8 +474,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           session_context_->AddTask(std::move(lambda), utils::Priority::LOW, /*productive=*/false),
           std::memory_order_relaxed);
     } else {
-      // Cap exhausted: park until WakeMatching({CommitLock}) fires.
-      // No deadline: a commit must not be abandoned by timeout; the monitor-sweep provides liveness.
+      // No deadline: a commit must not be abandoned mid-flight; monitor-sweep provides liveness.
       session_context_->ParkAdmission(std::move(lambda),
                                       id,
                                       std::chrono::steady_clock::time_point::max(),
@@ -517,9 +513,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
     if (session_context_->IsDrainingAdmissions()) return;
 
     const auto id = pending_begin_task_id_.load(std::memory_order_relaxed);
-    // Layer-2: re-post up to N(P) times before parking.  Same pressure-scaling as commit; see
-    // PostFinishPendingCommit for the rationale.  Unlike commit, the park deadline is FINITE
-    // (storage-access timeout) so the begin path must not be parked indefinitely.
+    // Layer-2: same pressure-scaling as commit (see PostFinishPendingCommit).  Unlike commit,
+    // the park deadline is FINITE (storage-access timeout) — begin must not park indefinitely.
     const uint32_t cap = session_context_->RescheduleCap();
     if (id == 0 || pending_begin_retries_ < cap) {
       ++pending_begin_retries_;
@@ -527,8 +522,7 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
           session_context_->AddTask(std::move(lambda), utils::Priority::LOW, /*productive=*/false),
           std::memory_order_relaxed);
     } else {
-      // Cap exhausted: park under MainLock with the FINITE storage-access deadline so the pool
-      // worker sleeps until WakeMatching({MainLock}) fires from the ResourceLock notify hook.
+      // Finite deadline (storage-access timeout); woken by ResourceLock::maybe_notify → WakeMatching({MainLock}).
       const auto deadline = session_.PendingBeginDeadline();
       DMG_ASSERT(deadline != std::chrono::steady_clock::time_point::max(),
                  "PendingBegin park deadline must be finite (storage-access timeout)");
@@ -661,16 +655,15 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
   // the pool's 100ms monitor backstop. Not a load-bearing ordering; do not read into it.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_commit_task_id_{0};
 
-  // How many times the current commit admission has been re-posted (Layer-2 reschedule count).
-  // Strand-serialized: all PostFinishPendingCommit calls are dispatched on strand_, so plain uint32_t
-  // is safe.  Reset to 0 when the commit finishes (Done/ClientError).
+  // Layer-2 reschedule counter for the in-flight commit.  Safe as plain uint32_t: post-and-return
+  // discipline ensures only one commit task is active at a time.  Reset on Done/ClientError.
   uint32_t pending_commit_retries_{0};
 
   // TaskID of the in-flight begin-park continuation; 0 = not yet issued; same relaxed reasoning as above.
   std::atomic<utils::PriorityThreadPool::TaskID> pending_begin_task_id_{0};
 
-  // How many times the current begin admission has been re-posted (Layer-2 reschedule count).
-  // Strand-serialized: same reasoning as pending_commit_retries_.  Reset to 0 on Done/ClientError.
+  // Layer-2 reschedule counter for the in-flight begin.  One-in-flight serialized; same reasoning
+  // as pending_commit_retries_.  Reset on Done/ClientError.
   uint32_t pending_begin_retries_{0};
 };
 }  // namespace memgraph::communication::v2

--- a/src/glue/SessionContext.hpp
+++ b/src/glue/SessionContext.hpp
@@ -45,9 +45,27 @@ struct Context {
 #endif
   utils::PriorityThreadPool *worker_pool_;
 
-  auto AddTask(auto &&task, utils::Priority priority) {
+  using TaskID = utils::PriorityThreadPool::TaskID;
+
+  // Add a new task; productive=false for admission-retry work that must not open the real-work gate.
+  auto AddTask(auto &&task, utils::Priority priority, bool productive = true) {
     MG_ASSERT(worker_pool_, "Trying to add task to a non-existent worker pool");
-    return worker_pool_->ScheduledAddTask(std::forward<decltype(task)>(task), priority);
+    return worker_pool_->ScheduledAddTask(std::forward<decltype(task)>(task), priority, productive);
   }
+
+  // Re-add a previously issued task by its id for place-keeping in the priority order.
+  auto AddReTask(auto &&task, TaskID id, utils::Priority priority, bool productive = false) {
+    MG_ASSERT(worker_pool_, "Trying to re-add task to a non-existent worker pool");
+    return worker_pool_->ScheduledReAddTask(std::forward<decltype(task)>(task), id, priority, productive);
+  }
+
+  // Park a task until a matching WakeMatching({resource}) fires.  deadline is advisory (monitor backstop).
+  void ParkAdmission(auto &&task, TaskID id, std::chrono::steady_clock::time_point deadline, utils::WaitTag tag) {
+    MG_ASSERT(worker_pool_, "Trying to park admission on a non-existent worker pool");
+    worker_pool_->ParkAdmission(std::forward<decltype(task)>(task), id, deadline, tag);
+  }
+
+  // True when the pool is shutting down; pending tasks should be dropped (teardown errors the client).
+  bool IsDrainingAdmissions() const noexcept { return worker_pool_ && worker_pool_->IsDrainingAdmissions(); }
 };
 }  // namespace memgraph::glue

--- a/src/glue/SessionContext.hpp
+++ b/src/glue/SessionContext.hpp
@@ -67,5 +67,9 @@ struct Context {
 
   // True when the pool is shutting down; pending tasks should be dropped (teardown errors the client).
   bool IsDrainingAdmissions() const noexcept { return worker_pool_ && worker_pool_->IsDrainingAdmissions(); }
+
+  // Pressure-scaled reschedule cap: how many times to re-post before parking.
+  // Returns 1 when no pool is configured (conservative: park on first contention).
+  uint32_t RescheduleCap() const noexcept { return worker_pool_ ? worker_pool_->AdmissionRescheduleCap() : 1u; }
 };
 }  // namespace memgraph::glue

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -568,15 +568,24 @@ void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, cons
 }
 
 std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrepare() {
-  if (!parsed_res_) {
+  // A parked autocommit (RUN-first-query) BEGIN consumed parsed_res_ on its first pass; on the pool
+  // wake, re-drive the stashed Prepare rather than failing "not parsed". Explicit BEGIN is already
+  // re-runnable via BeginTransaction(); this makes the implicit path symmetric.
+  const bool resume = !parsed_res_ && interpreter_.HasParkedPrepare();
+  if (!parsed_res_ && !resume) {
     throw memgraph::communication::bolt::ClientError("Trying to prepare a query that was not parsed.");
   }
 
   try {
-    auto parsed_res = *std::move(parsed_res_);
-    parsed_res_.reset();
-    auto result =
-        interpreter_.Prepare(std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
+    // BeginWouldBlockException propagates out (it is not a QueryException) so the Bolt pool driver
+    // parks/reschedules the BEGIN; a re-block inside ResumeParkedPrepare re-stashes and re-parks.
+    auto result = [&] {
+      if (resume) return interpreter_.ResumeParkedPrepare();
+      auto parsed_res = *std::move(parsed_res_);
+      parsed_res_.reset();
+      return interpreter_.Prepare(
+          std::move(parsed_res.parsed_query), std::move(parsed_res.get_params_pv), parsed_res.extra);
+    }();
     interpreter_.CheckAuthorized(result.privileges, result.db);
 
     return {std::move(result.headers), result.qid};

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -142,15 +142,13 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
   inline bool Execute() { return Execute_(*this); }
 
   // Pool-side commit retry; forwards *this so FinishPendingCommit_ can call impl.Pull() and
-  // impl.GetLogContext().  HasPendingCommit() and HasBufferedData() are inherited from bolt::Session
-  // and do not need to be re-declared here.
+  // impl.GetLogContext().
   memgraph::communication::bolt::PendingCommitOutcome FinishPendingCommit() {
     return this->FinishPendingCommit_(*this);
   }
 
   // Pool-side BEGIN retry; forwards *this so FinishPendingBegin_ can call impl.BeginTransaction()
-  // and impl.GetLogContext().  HasPendingBegin(), PendingBeginDeadline(), and HasBufferedData()
-  // are inherited from bolt::Session and do not need to be re-declared here.
+  // and impl.GetLogContext().
   memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return this->FinishPendingBegin_(*this); }
 
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -148,6 +148,11 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
     return this->FinishPendingCommit_(*this);
   }
 
+  // Pool-side BEGIN retry; forwards *this so FinishPendingBegin_ can call impl.BeginTransaction()
+  // and impl.GetLogContext().  HasPendingBegin(), PendingBeginDeadline(), and HasBufferedData()
+  // are inherited from bolt::Session and do not need to be re-declared here.
+  memgraph::communication::bolt::PendingBeginOutcome FinishPendingBegin() { return this->FinishPendingBegin_(*this); }
+
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }
 
   metrics::DatabaseMetricHandles *GetMetricHandles() {

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -141,6 +141,13 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   inline bool Execute() { return Execute_(*this); }
 
+  // Pool-side commit retry; forwards *this so FinishPendingCommit_ can call impl.Pull() and
+  // impl.GetLogContext().  HasPendingCommit() and HasBufferedData() are inherited from bolt::Session
+  // and do not need to be re-declared here.
+  memgraph::communication::bolt::PendingCommitOutcome FinishPendingCommit() {
+    return this->FinishPendingCommit_(*this);
+  }
+
   memgraph::logging::SessionLogContext *GetLogContext() noexcept { return interpreter_.GetLogContext(); }
 
   metrics::DatabaseMetricHandles *GetMetricHandles() {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1149,6 +1149,10 @@ int main(int argc, char **argv) {
         spdlog::trace("Closing background tasks and deleting repl clients for db: {}", acc->name());
         // Stop all triggers, streams and ttl
         acc->StopAllBackgroundTasks();
+        // U3c: disarm the main_lock notify hook before the pool is destroyed. worker_pool_->ShutDown()
+        // has already run, so WakeMatching on a still-alive but draining pool is a safe no-op; after
+        // this clear no further hook call can reach the pool.
+        acc->storage()->ClearMainLockNotifyHook();
         acc->storage()->repl_storage_state_.replication_storage_clients_.WithLock(
             [](auto &clients) { clients.clear(); });
       });

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1149,9 +1149,8 @@ int main(int argc, char **argv) {
         spdlog::trace("Closing background tasks and deleting repl clients for db: {}", acc->name());
         // Stop all triggers, streams and ttl
         acc->StopAllBackgroundTasks();
-        // U3c: disarm the main_lock notify hook before the pool is destroyed. worker_pool_->ShutDown()
-        // has already run, so WakeMatching on a still-alive but draining pool is a safe no-op; after
-        // this clear no further hook call can reach the pool.
+        // Disarm the main_lock notify hook before the pool is destroyed; after this clear
+        // no hook call can reach the pool (worker_pool_->ShutDown() has already run).
         acc->storage()->ClearMainLockNotifyHook();
         acc->storage()->repl_storage_state_.replication_storage_clients_.WithLock(
             [](auto &clients) { clients.clear(); });

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -617,13 +617,9 @@ class ShowSchemaInfoInMulticommandTxException : public MulticommandTxException {
   SPECIALIZE_GET_EXCEPTION_NAME(ShowSchemaInfoInMulticommandTxException)
 };
 
-/// Thrown inside Interpreter::Commit() when commit_mutex_ cannot be acquired without
-/// blocking (experimental_lockfree_read_snapshot ON, another committer holds the mutex).
-///
-/// This is a PURE INTERNAL PARKING SIGNAL — it never becomes a client-visible Bolt error.
-/// The Bolt session driver (U4b) catches it, parks the worker with WaitResource::CommitLock,
-/// and calls Commit() again when woken.  Because the throw happens as the very first action
-/// in Commit(), no non-idempotent side-effect has occurred and re-entry is safe.
+/// Thrown inside Interpreter::Commit() (first action, pre-mutation) when commit_mutex_ is
+/// contended (experimental_lockfree_read_snapshot ON). Never a client Bolt error; the Bolt
+/// driver (U4b) catches, parks under WaitResource::CommitLock, and retries — re-entry is safe.
 class CommitWouldBlockException final : public std::exception {
  public:
   CommitWouldBlockException() = default;
@@ -631,14 +627,9 @@ class CommitWouldBlockException final : public std::exception {
   const char *what() const noexcept override { return "commit_mutex_ held by another committer; park and retry"; }
 };
 
-/// Thrown inside CurrentDB::SetupDatabaseTransaction() when main_lock_ cannot be acquired without
-/// blocking (experimental_lockfree_read_snapshot ON, a DDL/UNIQUE/READ_ONLY holder contends) and the
-/// finite storage-access deadline has NOT yet passed.
-///
-/// PURE INTERNAL PARKING SIGNAL — never a client-visible Bolt error. The Bolt session driver (U3b)
-/// catches it, parks the pool worker under WaitResource::MainLock until `deadline()`, and re-drives
-/// the query when woken. Once the deadline passes, SetupDatabaseTransaction throws the ordinary
-/// access-timeout exception instead of this one.
+/// Thrown inside CurrentDB::SetupDatabaseTransaction() when main_lock_ is contended and the
+/// storage-access deadline has NOT yet passed (experimental_lockfree_read_snapshot ON). Never a
+/// client Bolt error; Bolt driver (U3b) catches, parks under WaitResource::MainLock, then retries.
 class BeginWouldBlockException final : public std::exception {
  public:
   explicit BeginWouldBlockException(std::chrono::steady_clock::time_point deadline) : deadline_{deadline} {}

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -616,4 +616,18 @@ class ShowSchemaInfoInMulticommandTxException : public MulticommandTxException {
   SPECIALIZE_GET_EXCEPTION_NAME(ShowSchemaInfoInMulticommandTxException)
 };
 
+/// Thrown inside Interpreter::Commit() when commit_mutex_ cannot be acquired without
+/// blocking (experimental_lockfree_read_snapshot ON, another committer holds the mutex).
+///
+/// This is a PURE INTERNAL PARKING SIGNAL — it never becomes a client-visible Bolt error.
+/// The Bolt session driver (U4b) catches it, parks the worker with WaitResource::CommitLock,
+/// and calls Commit() again when woken.  Because the throw happens as the very first action
+/// in Commit(), no non-idempotent side-effect has occurred and re-entry is safe.
+class CommitWouldBlockException final : public std::exception {
+ public:
+  CommitWouldBlockException() = default;
+
+  const char *what() const noexcept override { return "commit_mutex_ held by another committer; park and retry"; }
+};
+
 }  // namespace memgraph::query

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -14,6 +14,7 @@
 #include "utils/exceptions.hpp"
 
 #include <fmt/format.h>
+#include <chrono>
 
 namespace memgraph::query {
 
@@ -628,6 +629,26 @@ class CommitWouldBlockException final : public std::exception {
   CommitWouldBlockException() = default;
 
   const char *what() const noexcept override { return "commit_mutex_ held by another committer; park and retry"; }
+};
+
+/// Thrown inside CurrentDB::SetupDatabaseTransaction() when main_lock_ cannot be acquired without
+/// blocking (experimental_lockfree_read_snapshot ON, a DDL/UNIQUE/READ_ONLY holder contends) and the
+/// finite storage-access deadline has NOT yet passed.
+///
+/// PURE INTERNAL PARKING SIGNAL — never a client-visible Bolt error. The Bolt session driver (U3b)
+/// catches it, parks the pool worker under WaitResource::MainLock until `deadline()`, and re-drives
+/// the query when woken. Once the deadline passes, SetupDatabaseTransaction throws the ordinary
+/// access-timeout exception instead of this one.
+class BeginWouldBlockException final : public std::exception {
+ public:
+  explicit BeginWouldBlockException(std::chrono::steady_clock::time_point deadline) : deadline_{deadline} {}
+
+  const char *what() const noexcept override { return "main_lock_ contended; park and retry BEGIN"; }
+
+  std::chrono::steady_clock::time_point deadline() const noexcept { return deadline_; }
+
+ private:
+  std::chrono::steady_clock::time_point deadline_;
 };
 
 }  // namespace memgraph::query

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -267,7 +267,7 @@ void memgraph::query::CurrentDB::CleanupDBTransaction(bool abort) {
   trigger_context_collector_.reset();
   // Clear ScopedGauge, which decrements the gauge backing this metric.
   transaction_gauge_ = {};
-  // Belt-and-suspenders: destroy any in-flight pending access (deregisters PendingScope) on mid-park abort.
+  // Deregister any in-flight PendingScope if aborted while parked waiting for the commit serializer.
   pending_access_.reset();
   pending_begin_deadline_.reset();
 }
@@ -3691,10 +3691,8 @@ struct PullPlan {
   // we have to keep track of any unsent results from previous `PullPlan::Pull`
   // manually by using this flag.
   bool has_unsent_results_ = false;
-  // Shutdown the cursor at most once. A commit-lock park (lockfree-read-snapshot) makes the bolt driver
-  // re-invoke Pull on an already-exhausted plan to retry only the commit; without this guard the second
-  // Pull would call cursor_->Shutdown() again. Inert for today's cursors, but the interface carries no
-  // idempotency contract (a coroutine cursor could destroy() its frame on Shutdown) — so guard it.
+  // Guard against double-Shutdown: a commit-lock park re-invokes Pull on an already-exhausted plan,
+  // and a coroutine cursor's Shutdown() may not be idempotent (could destroy its frame on second call).
   bool shutdown_done_ = false;
   metrics::DatabaseMetricHandles *metric_handles_;
   utils::QueryMemoryTracker *fallback_memory_tracker_;
@@ -10244,11 +10242,8 @@ void Interpreter::BeginTransaction(QueryExtras const &extras) {
   try {
     prepared_query.query_handler(nullptr, {});
   } catch (const BeginWouldBlockException &) {
-    // The BEGIN handler set in_explicit_transaction_ = true before SetupDatabaseTransaction threw to
-    // park on main_lock_ (flag ON). ResetInterpreter does not clear that flag, so the bolt driver's
-    // park-retry BeginTransaction would otherwise re-enter the handler and hit the nested-transaction
-    // guard. Reset it here so the retry begins cleanly. Only reachable when the parking exception is
-    // thrown (flag ON) — the permanent BEGIN-failure paths keep their existing state.
+    // PrepareTransactionQuery(BEGIN) sets in_explicit_transaction_ = true before calling
+    // SetupDatabaseTransaction (which throws here). Reset it so the Bolt retry doesn't hit the nested-txn guard.
     in_explicit_transaction_ = false;
     throw;
   }
@@ -11278,10 +11273,8 @@ void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privi
 }
 
 void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type) {
-  // U3c: lazy install of the main_lock notify hook. Fires once per DB (exchange-guarded inside
-  // TrySetMainLockNotifyHook). Inert when the flag is OFF (IsCommitSerialised() false) or on Disk
-  // storage (no parked MainLock tasks). The load-guard avoids constructing the lambda every BEGIN;
-  // TrySetMainLockNotifyHook's exchange closes the residual load→install TOCTOU race.
+  // Lazily install the main_lock wake hook once per DB; TrySetMainLockNotifyHook's internal exchange
+  // closes the load→install TOCTOU race. No-op when flag is OFF or on Disk storage.
   if (current_db_.db_acc_) {
     auto *storage = (*current_db_.db_acc_)->storage();
     if (storage->IsCommitSerialised() && interpreter_context_->worker_pool && !storage->MainLockHookInstalled()) {
@@ -11548,28 +11541,9 @@ void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *int
 }  // namespace
 
 void Interpreter::Commit() {
-  // U4a — parkable commit acquire.
-  //
-  // When the lock-free read-snapshot experiment is ON, every write commit serialises on
-  // commit_mutex_.  We try to take it here — as the absolute first action in Commit() — so
-  // that if another committer is currently in the WAL+replication phase (which can stall for
-  // hundreds of milliseconds on SYNC replication), we throw CommitWouldBlockException BEFORE
-  // any non-idempotent work runs.  The Bolt session driver (U4b) catches that exception,
-  // parks this worker with WaitResource::CommitLock, and calls Commit() again from the top
-  // when woken; because nothing else has been modified yet the retry is safe.
-  //
-  // Off-path (flag OFF, no db_transactional_accessor_, read-only txn with no deltas): the
-  // TryLockCommit call is never made, preheld_commit_lock stays non-owning, and it is passed
-  // as a default-constructed lock to PrepareForCommitPhase — which ignores it and behaves
-  // exactly as before this change.
-  //
-  // FLAG (non-idempotent work before this point): There is none — this IS the first action.
-  // Every line of Commit() below this block is non-idempotent (MG_ENTERPRISE memory decrement,
-  // status CAS, trigger execution, …), so if the try fails and throws, nothing has been
-  // mutated.
-  // Only a WRITE commit takes commit_mutex_ (PrepareForCommitPhase short-circuits an empty txn before
-  // the serializer). Reads must NOT touch commit_mutex_ — that is the whole point of #4685 (the stall
-  // is writers-only) — so gate the try on the txn actually having (meta)deltas.
+  // Try commit_mutex_ as the first action so that if another write is in WAL+replication, we throw
+  // CommitWouldBlockException before any non-idempotent work runs, making park-and-retry safe.
+  // Gate on write deltas: reads bypass the serializer entirely (the stall is writers-only, not readers).
   std::unique_lock<std::mutex> preheld_commit_lock;  // non-owning by default
   if (current_db_.db_transactional_accessor_ && current_db_.db_transactional_accessor_->IsCommitSerialised()) {
     auto const *commit_txn = current_db_.db_transactional_accessor_->GetTransaction();
@@ -11757,25 +11731,15 @@ void Interpreter::Commit() {
   if (!is_main && !curr_txn->deltas.empty()) {
     throw QueryException("Cannot commit because instance is not main anymore.");
   }
-  // did_take_commit_lock is captured before the move so we can wake parked writers
-  // after commit_mutex_ is released inside PrepareForCommitPhase (the lock goes out of scope
-  // at the end of that function).  preheld_commit_lock is moved-from and unusable afterwards.
+  // Snapshot before move: preheld_commit_lock is unusable after PrepareForCommitPhase takes ownership.
   const bool did_take_commit_lock = preheld_commit_lock.owns_lock();
   auto maybe_commit_error = current_db_.db_transactional_accessor_->PrepareForCommitPhase(
       make_commit_arg(is_main, *current_db_.db_acc_), std::move(preheld_commit_lock));
   // Proactively unlock repl_state
   locked_repl_state.reset();
 
-  // U4a — wake parked writers.
-  // commit_mutex_ was released when commit_serializer was destroyed inside
-  // PrepareForCommitPhase.  Any writer parked by U4b with WaitResource::CommitLock
-  // can now re-try.  worker_pool is null in embedded/unit-test contexts — skip safely.
-  //
-  // FLAG (PrepareForNewEpoch wake): PrepareForNewEpoch also acquires commit_mutex_ but
-  // lives inside InMemoryStorage (no pool handle available there).  Epoch rotation is
-  // rare (leader election / HA reconfiguration only) and the 100 ms monitor sweep in
-  // PriorityThreadPool acts as a backstop, so the missed immediate wake is acceptable.
-  // A storage→pool callback hook can be added in U4b when wiring the full Bolt driver.
+  // Wake parked write commits now that commit_mutex_ has been released inside PrepareForCommitPhase.
+  // PrepareForNewEpoch also holds commit_mutex_ but has no pool handle; the 100 ms sweep is the backstop.
   if (did_take_commit_lock && interpreter_context_->worker_pool != nullptr) {
     interpreter_context_->worker_pool->WakeMatching(
         {.resource = utils::WaitResource::CommitLock, .freed = utils::AccessMode::WRITE});

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -11232,6 +11232,14 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
             .privileges = query_execution->prepared_query->privileges,
             .qid = qid,
             .db = query_execution->prepared_query->db};
+  } catch (const BeginWouldBlockException &) {
+    // Autocommit (RUN-first-query) BEGIN parked on main_lock_: stash the still-intact parse. Prepare
+    // throws at the storage-access acquire, before parsed_query/params_getter are consumed, so the
+    // pool wake can re-drive via ResumeParkedPrepare instead of hitting "query was not parsed". Do NOT
+    // AbortCommand here: pending_access_ (on CurrentDB) must survive to keep writer-preference across
+    // the park; ResetInterpreter on the re-drive clears the transient query_execution.
+    parked_prepare_.emplace(ParkedPrepare{std::move(parse_res), std::move(params_getter), extras});
+    throw;
   } catch (const utils::BasicException &e) {
     memgraph::logging::EmitSessionTraceEvent("Failed query: {}", e.what());
     // query_execution holds the query string copy that survives Prepare* moving it out.
@@ -11249,6 +11257,15 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     AbortCommand(query_execution_ptr);
     throw;
   }
+}
+
+Interpreter::PrepareResult Interpreter::ResumeParkedPrepare() {
+  MG_ASSERT(parked_prepare_, "ResumeParkedPrepare called without a stashed parked prepare");
+  // Move the stash out first: a further would-block re-stashes a fresh copy inside Prepare, and a
+  // terminal outcome (acquired or access-timeout) leaves it cleared.
+  auto parked = std::move(*parked_prepare_);
+  parked_prepare_.reset();
+  return Prepare(std::move(parked.parse_res), std::move(parked.params_getter), parked.extras);
 }
 
 void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privileges, std::optional<std::string> db) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -202,25 +202,53 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
   auto &db_acc = *db_acc_;
   const memory::DbArenaScope db_arena_scope{db_acc.get()};
   const auto timeout = memgraph::flags::run_time::GetStorageAccessTimeoutSec();
-  switch (acc_type) {
-    case storage::StorageAccessType::READ:
-      [[fallthrough]];
-    case storage::StorageAccessType::WRITE:
-      db_transactional_accessor_ = db_acc->Access(acc_type,
-                                                  override_isolation_level,
-                                                  /*allow timeout*/ timeout);
-      break;
-    case storage::StorageAccessType::UNIQUE:
-      db_transactional_accessor_ = db_acc->UniqueAccess(override_isolation_level, /*allow timeout*/ timeout);
-      break;
-    case storage::StorageAccessType::READ_ONLY:
-      db_transactional_accessor_ = db_acc->ReadOnlyAccess(override_isolation_level, /*allow timeout*/ timeout);
-      break;
-    default:
-      // TODO: no access case
-      spdlog::error("Unknown accessor type: {}", static_cast<int>(acc_type));
-      throw QueryRuntimeException("Failed to gain storage access! Unknown accessor type.");
+
+  if (db_acc->storage()->IsCommitSerialised()) {
+    if (!pending_access_) {
+      if (auto acc = db_acc->storage()->TryAccess(acc_type, override_isolation_level)) {  // uncontended: no alloc
+        db_transactional_accessor_ = std::move(acc);
+      } else {
+        pending_access_ = db_acc->storage()->MakePendingAccess(acc_type);  // nullptr on Disk
+      }
+    }
+    if (pending_access_) {
+      if (!pending_begin_deadline_) pending_begin_deadline_ = std::chrono::steady_clock::now() + timeout;
+      if (auto acc = pending_access_->TryAcquire(override_isolation_level)) {
+        db_transactional_accessor_ = std::move(acc);
+        pending_access_.reset();
+        pending_begin_deadline_.reset();
+      } else if (std::chrono::steady_clock::now() >= *pending_begin_deadline_) {
+        pending_access_.reset();
+        pending_begin_deadline_.reset();
+        storage::ThrowAccessTimeout(acc_type);
+      } else {
+        throw BeginWouldBlockException{*pending_begin_deadline_};
+      }
+    }
   }
+
+  if (!db_transactional_accessor_) {
+    switch (acc_type) {
+      case storage::StorageAccessType::READ:
+        [[fallthrough]];
+      case storage::StorageAccessType::WRITE:
+        db_transactional_accessor_ = db_acc->Access(acc_type,
+                                                    override_isolation_level,
+                                                    /*allow timeout*/ timeout);
+        break;
+      case storage::StorageAccessType::UNIQUE:
+        db_transactional_accessor_ = db_acc->UniqueAccess(override_isolation_level, /*allow timeout*/ timeout);
+        break;
+      case storage::StorageAccessType::READ_ONLY:
+        db_transactional_accessor_ = db_acc->ReadOnlyAccess(override_isolation_level, /*allow timeout*/ timeout);
+        break;
+      default:
+        // TODO: no access case
+        spdlog::error("Unknown accessor type: {}", static_cast<int>(acc_type));
+        throw QueryRuntimeException("Failed to gain storage access! Unknown accessor type.");
+    }
+  }
+
   execution_db_accessor_.emplace(db_transactional_accessor_.get());
 
   transaction_gauge_ = metrics::ScopedGauge{db_acc->metric_handles()->active_transactions.gauge};
@@ -239,6 +267,9 @@ void memgraph::query::CurrentDB::CleanupDBTransaction(bool abort) {
   trigger_context_collector_.reset();
   // Clear ScopedGauge, which decrements the gauge backing this metric.
   transaction_gauge_ = {};
+  // Belt-and-suspenders: destroy any in-flight pending access (deregisters PendingScope) on mid-park abort.
+  pending_access_.reset();
+  pending_begin_deadline_.reset();
 }
 
 struct QueryLogWrapper {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -10241,7 +10241,17 @@ bool Interpreter::IsCurrentTransactionEmpty() const {
 void Interpreter::BeginTransaction(QueryExtras const &extras) {
   ResetInterpreter();
   auto prepared_query = PrepareTransactionQuery(TransactionQuery::BEGIN, extras);
-  prepared_query.query_handler(nullptr, {});
+  try {
+    prepared_query.query_handler(nullptr, {});
+  } catch (const BeginWouldBlockException &) {
+    // The BEGIN handler set in_explicit_transaction_ = true before SetupDatabaseTransaction threw to
+    // park on main_lock_ (flag ON). ResetInterpreter does not clear that flag, so the bolt driver's
+    // park-retry BeginTransaction would otherwise re-enter the handler and hit the nested-transaction
+    // guard. Reset it here so the retry begins cleanly. Only reachable when the parking exception is
+    // thrown (flag ON) — the permanent BEGIN-failure paths keep their existing state.
+    in_explicit_transaction_ = false;
+    throw;
+  }
 }
 
 std::optional<Notification> Interpreter::CommitTransaction() {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -11486,6 +11486,40 @@ void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *int
 }  // namespace
 
 void Interpreter::Commit() {
+  // U4a — parkable commit acquire.
+  //
+  // When the lock-free read-snapshot experiment is ON, every write commit serialises on
+  // commit_mutex_.  We try to take it here — as the absolute first action in Commit() — so
+  // that if another committer is currently in the WAL+replication phase (which can stall for
+  // hundreds of milliseconds on SYNC replication), we throw CommitWouldBlockException BEFORE
+  // any non-idempotent work runs.  The Bolt session driver (U4b) catches that exception,
+  // parks this worker with WaitResource::CommitLock, and calls Commit() again from the top
+  // when woken; because nothing else has been modified yet the retry is safe.
+  //
+  // Off-path (flag OFF, no db_transactional_accessor_, read-only txn with no deltas): the
+  // TryLockCommit call is never made, preheld_commit_lock stays non-owning, and it is passed
+  // as a default-constructed lock to PrepareForCommitPhase — which ignores it and behaves
+  // exactly as before this change.
+  //
+  // FLAG (non-idempotent work before this point): There is none — this IS the first action.
+  // Every line of Commit() below this block is non-idempotent (MG_ENTERPRISE memory decrement,
+  // status CAS, trigger execution, …), so if the try fails and throws, nothing has been
+  // mutated.
+  // Only a WRITE commit takes commit_mutex_ (PrepareForCommitPhase short-circuits an empty txn before
+  // the serializer). Reads must NOT touch commit_mutex_ — that is the whole point of #4685 (the stall
+  // is writers-only) — so gate the try on the txn actually having (meta)deltas.
+  std::unique_lock<std::mutex> preheld_commit_lock;  // non-owning by default
+  if (current_db_.db_transactional_accessor_ && current_db_.db_transactional_accessor_->IsCommitSerialised()) {
+    auto const *commit_txn = current_db_.db_transactional_accessor_->GetTransaction();
+    bool const is_write = commit_txn && (!commit_txn->deltas.empty() || !commit_txn->md_deltas.empty());
+    if (is_write) {
+      preheld_commit_lock = current_db_.db_transactional_accessor_->TryLockCommit();
+      if (!preheld_commit_lock.owns_lock()) {
+        throw CommitWouldBlockException{};
+      }
+    }
+  }
+
 #ifdef MG_ENTERPRISE
   if (user_resource_ && current_db_.db_transactional_accessor_) {
     const auto leftover = current_db_.db_transactional_accessor_->GetTransactionMemoryTracker().Amount();
@@ -11661,10 +11695,29 @@ void Interpreter::Commit() {
   if (!is_main && !curr_txn->deltas.empty()) {
     throw QueryException("Cannot commit because instance is not main anymore.");
   }
-  auto maybe_commit_error =
-      current_db_.db_transactional_accessor_->PrepareForCommitPhase(make_commit_arg(is_main, *current_db_.db_acc_));
+  // did_take_commit_lock is captured before the move so we can wake parked writers
+  // after commit_mutex_ is released inside PrepareForCommitPhase (the lock goes out of scope
+  // at the end of that function).  preheld_commit_lock is moved-from and unusable afterwards.
+  const bool did_take_commit_lock = preheld_commit_lock.owns_lock();
+  auto maybe_commit_error = current_db_.db_transactional_accessor_->PrepareForCommitPhase(
+      make_commit_arg(is_main, *current_db_.db_acc_), std::move(preheld_commit_lock));
   // Proactively unlock repl_state
   locked_repl_state.reset();
+
+  // U4a — wake parked writers.
+  // commit_mutex_ was released when commit_serializer was destroyed inside
+  // PrepareForCommitPhase.  Any writer parked by U4b with WaitResource::CommitLock
+  // can now re-try.  worker_pool is null in embedded/unit-test contexts — skip safely.
+  //
+  // FLAG (PrepareForNewEpoch wake): PrepareForNewEpoch also acquires commit_mutex_ but
+  // lives inside InMemoryStorage (no pool handle available there).  Epoch rotation is
+  // rare (leader election / HA reconfiguration only) and the 100 ms monitor sweep in
+  // PriorityThreadPool acts as a backstop, so the missed immediate wake is acceptable.
+  // A storage→pool callback hook can be added in U4b when wiring the full Bolt driver.
+  if (did_take_commit_lock && interpreter_context_->worker_pool != nullptr) {
+    interpreter_context_->worker_pool->WakeMatching(
+        {.resource = utils::WaitResource::CommitLock, .freed = utils::AccessMode::WRITE});
+  }
 
   std::optional<std::string> replication_error_msg;
   bool replication_error_committed = false;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -11268,6 +11268,19 @@ void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privi
 }
 
 void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAccessType acc_type) {
+  // U3c: lazy install of the main_lock notify hook. Fires once per DB (exchange-guarded inside
+  // TrySetMainLockNotifyHook). Inert when the flag is OFF (IsCommitSerialised() false) or on Disk
+  // storage (no parked MainLock tasks). The load-guard avoids constructing the lambda every BEGIN;
+  // TrySetMainLockNotifyHook's exchange closes the residual load→install TOCTOU race.
+  if (current_db_.db_acc_) {
+    auto *storage = (*current_db_.db_acc_)->storage();
+    if (storage->IsCommitSerialised() && interpreter_context_->worker_pool && !storage->MainLockHookInstalled()) {
+      storage->TrySetMainLockNotifyHook([pool = interpreter_context_->worker_pool] {
+        pool->WakeMatching(
+            utils::FreedTag{.resource = utils::WaitResource::MainLock, .freed = utils::AccessMode::WRITE});
+      });
+    }
+  }
   current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type);
 }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3660,6 +3660,11 @@ struct PullPlan {
   // we have to keep track of any unsent results from previous `PullPlan::Pull`
   // manually by using this flag.
   bool has_unsent_results_ = false;
+  // Shutdown the cursor at most once. A commit-lock park (lockfree-read-snapshot) makes the bolt driver
+  // re-invoke Pull on an already-exhausted plan to retry only the commit; without this guard the second
+  // Pull would call cursor_->Shutdown() again. Inert for today's cursors, but the interface carries no
+  // idempotency contract (a coroutine cursor could destroy() its frame on Shutdown) — so guard it.
+  bool shutdown_done_ = false;
   metrics::DatabaseMetricHandles *metric_handles_;
   utils::QueryMemoryTracker *fallback_memory_tracker_;
 };
@@ -3829,7 +3834,10 @@ std::optional<plan::ProfilingStatsWithTotalTime> PullPlan::Pull(AnyStream *strea
     }
     summary->insert_or_assign("stats", std::move(stats));
   }
-  cursor_->Shutdown();
+  if (!shutdown_done_) {
+    cursor_->Shutdown();
+    shutdown_done_ = true;
+  }
   // NOTE: += because each thread adds its own execution time to the total execution time
   ctx_.profile_execution_time += execution_time_;
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -204,8 +204,7 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
   const auto timeout = memgraph::flags::run_time::GetStorageAccessTimeoutSec();
 
   if (db_acc->storage()->IsCommitSerialised()) {
-    // Layer-1: pressure-scaled timed wait. AdmissionTryBudget() returns a duration proportional
-    // to pool idle capacity — longer when workers are free, shorter under pressure.
+    // Layer-1 budget: AdmissionTryBudget() shrinks under backlog and scarce idle workers.
     const auto budget =
         pool ? pool->AdmissionTryBudget() : std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
     if (!pending_access_) {
@@ -226,11 +225,9 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
         pending_begin_deadline_.reset();
         storage::ThrowAccessTimeout(acc_type);
       } else if (pool != nullptr && pool->ShouldParkAdmission()) {
-        // Productive workers are available to absorb this BEGIN after rescheduling.
         throw BeginWouldBlockException{*pending_begin_deadline_};
       } else {
-        // P==0 or no pool: do not park — fall through to the blocking Access() switch so
-        // this thread does not stall forever on an idle strand with no one to reschedule it.
+        // !ShouldParkAdmission: P==0 (no waker) or idle spinners present (blocking is immediate) — skip park.
         pending_access_.reset();
         pending_begin_deadline_.reset();
       }
@@ -11572,23 +11569,21 @@ void Interpreter::Commit() {
   // Try commit_mutex_ as the first action so that if another write is in WAL+replication, we throw
   // CommitWouldBlockException before any non-idempotent work runs, making park-and-retry safe.
   // Gate on write deltas: reads bypass the serializer entirely (the stall is writers-only, not readers).
-  memgraph::storage::CommitLock preheld_commit_lock;  // non-owning by default
+  memgraph::storage::CommitLock preheld_commit_lock;
   if (current_db_.db_transactional_accessor_ && current_db_.db_transactional_accessor_->IsCommitSerialised()) {
     auto const *commit_txn = current_db_.db_transactional_accessor_->GetTransaction();
     bool const is_write = commit_txn && (!commit_txn->deltas.empty() || !commit_txn->md_deltas.empty());
     if (is_write) {
-      // Layer-1: pressure-scaled timed wait. AdmissionTryBudget() returns a duration proportional
-      // to pool idle capacity — longer when workers are free, shorter under pressure.
+      // Layer-1 budget: AdmissionTryBudget() shrinks under backlog and scarce idle workers.
       auto *pool = interpreter_context_->worker_pool;
       auto const budget =
           pool ? pool->AdmissionTryBudget() : std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
       preheld_commit_lock = current_db_.db_transactional_accessor_->TryLockCommitFor(budget);
       if (!preheld_commit_lock.owns_lock()) {
         if (pool != nullptr && pool->ShouldParkAdmission()) {
-          // Productive workers are available to absorb this commit after rescheduling.
           throw CommitWouldBlockException{};
         }
-        // No idle workers (P==0) or no pool: fall back to blocking sleep so we do not stall forever.
+        // !ShouldParkAdmission: P==0 (no waker) or idle spinners present (blocking is immediate) — block instead.
         preheld_commit_lock = current_db_.db_transactional_accessor_->LockCommitBlocking();
       }
     }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -11259,7 +11259,8 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     // pool wake can re-drive via ResumeParkedPrepare instead of hitting "query was not parsed". Do NOT
     // AbortCommand here: pending_access_ (on CurrentDB) must survive to keep writer-preference across
     // the park; ResetInterpreter on the re-drive clears the transient query_execution.
-    parked_prepare_.emplace(ParkedPrepare{std::move(parse_res), std::move(params_getter), extras});
+    parked_prepare_.emplace(
+        ParkedPrepare{.parse_res = std::move(parse_res), .params_getter = std::move(params_getter), .extras = extras});
     throw;
   } catch (const utils::BasicException &e) {
     memgraph::logging::EmitSessionTraceEvent("Failed query: {}", e.what());

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -195,7 +195,7 @@ TypedValue EvaluateConfigMapToTypedValue(std::unordered_map<Expression *, Expres
 // access
 void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-    storage::StorageAccessType acc_type) {
+    storage::StorageAccessType acc_type, utils::PriorityThreadPool *pool) {
   if (!db_acc_) {
     throw DatabaseContextRequiredException("Database required for the transaction setup.");
   }
@@ -204,8 +204,12 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
   const auto timeout = memgraph::flags::run_time::GetStorageAccessTimeoutSec();
 
   if (db_acc->storage()->IsCommitSerialised()) {
+    // Layer-1: pressure-scaled timed wait. AdmissionTryBudget() returns a duration proportional
+    // to pool idle capacity — longer when workers are free, shorter under pressure.
+    const auto budget =
+        pool ? pool->AdmissionTryBudget() : std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
     if (!pending_access_) {
-      if (auto acc = db_acc->storage()->TryAccess(acc_type, override_isolation_level)) {  // uncontended: no alloc
+      if (auto acc = db_acc->storage()->TryAccessFor(acc_type, override_isolation_level, budget)) {
         db_transactional_accessor_ = std::move(acc);
       } else {
         pending_access_ = db_acc->storage()->MakePendingAccess(acc_type);  // nullptr on Disk
@@ -213,7 +217,7 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
     }
     if (pending_access_) {
       if (!pending_begin_deadline_) pending_begin_deadline_ = std::chrono::steady_clock::now() + timeout;
-      if (auto acc = pending_access_->TryAcquire(override_isolation_level)) {
+      if (auto acc = pending_access_->TryAcquireFor(override_isolation_level, budget)) {
         db_transactional_accessor_ = std::move(acc);
         pending_access_.reset();
         pending_begin_deadline_.reset();
@@ -221,8 +225,14 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
         pending_access_.reset();
         pending_begin_deadline_.reset();
         storage::ThrowAccessTimeout(acc_type);
-      } else {
+      } else if (pool != nullptr && pool->ShouldParkAdmission()) {
+        // Productive workers are available to absorb this BEGIN after rescheduling.
         throw BeginWouldBlockException{*pending_begin_deadline_};
+      } else {
+        // P==0 or no pool: do not park — fall through to the blocking Access() switch so
+        // this thread does not stall forever on an idle strand with no one to reschedule it.
+        pending_access_.reset();
+        pending_begin_deadline_.reset();
       }
     }
   }
@@ -11301,7 +11311,8 @@ void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::StorageAcc
       });
     }
   }
-  current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type);
+  current_db_.SetupDatabaseTransaction(
+      GetIsolationLevelOverride(), couldCommit, acc_type, interpreter_context_->worker_pool);
 }
 
 void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -204,32 +204,46 @@ void memgraph::query::CurrentDB::SetupDatabaseTransaction(
   const auto timeout = memgraph::flags::run_time::GetStorageAccessTimeoutSec();
 
   if (db_acc->storage()->IsCommitSerialised()) {
-    // Layer-1 budget: AdmissionTryBudget() shrinks under backlog and scarce idle workers.
-    const auto budget =
-        pool ? pool->AdmissionTryBudget() : std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
+    // Arm the storage-access deadline before the first probe so every timed wait is charged against it
+    // and no probe can push the total wait past it (NB2). Persists across park-retries.
+    if (!pending_begin_deadline_) pending_begin_deadline_ = std::chrono::steady_clock::now() + timeout;
     if (!pending_access_) {
-      if (auto acc = db_acc->storage()->TryAccessFor(acc_type, override_isolation_level, budget)) {
+      // Alloc-free one-probe TryAccess on the hot path; allocate a PendingAccess only on a miss (NB7).
+      if (auto acc = db_acc->storage()->TryAccess(acc_type, override_isolation_level)) {
         db_transactional_accessor_ = std::move(acc);
+        pending_begin_deadline_.reset();
       } else {
         pending_access_ = db_acc->storage()->MakePendingAccess(acc_type);  // nullptr on Disk
       }
     }
     if (pending_access_) {
-      if (!pending_begin_deadline_) pending_begin_deadline_ = std::chrono::steady_clock::now() + timeout;
-      if (auto acc = pending_access_->TryAcquireFor(override_isolation_level, budget)) {
-        db_transactional_accessor_ = std::move(acc);
-        pending_access_.reset();
-        pending_begin_deadline_.reset();
-      } else if (std::chrono::steady_clock::now() >= *pending_begin_deadline_) {
+      auto const now = std::chrono::steady_clock::now();
+      if (now >= *pending_begin_deadline_) {
         pending_access_.reset();
         pending_begin_deadline_.reset();
         storage::ThrowAccessTimeout(acc_type);
-      } else if (pool != nullptr && pool->ShouldParkAdmission()) {
-        throw BeginWouldBlockException{*pending_begin_deadline_};
       } else {
-        // !ShouldParkAdmission: P==0 (no waker) or idle spinners present (blocking is immediate) — skip park.
-        pending_access_.reset();
-        pending_begin_deadline_.reset();
+        // Per-attempt budget clamped to the time left so a timed probe can't overshoot the deadline (NB2).
+        // Null pool: a finite cap, never microseconds{int64 max} (µs->ns overflow wraps negative — NB3).
+        auto const base = pool ? pool->AdmissionTryBudget()
+                               : std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::hours{24});
+        auto const budget =
+            std::min(base, std::chrono::duration_cast<std::chrono::microseconds>(*pending_begin_deadline_ - now));
+        if (auto acc = pending_access_->TryAcquireFor(override_isolation_level, budget)) {
+          db_transactional_accessor_ = std::move(acc);
+          pending_access_.reset();
+          pending_begin_deadline_.reset();
+        } else if (std::chrono::steady_clock::now() >= *pending_begin_deadline_) {
+          pending_access_.reset();
+          pending_begin_deadline_.reset();
+          storage::ThrowAccessTimeout(acc_type);
+        } else if (pool != nullptr && pool->ShouldParkAdmission()) {
+          throw BeginWouldBlockException{*pending_begin_deadline_};
+        } else {
+          // !ShouldParkAdmission: P==0 (no waker) or idle spinners present (blocking is immediate) — skip park.
+          pending_access_.reset();
+          pending_begin_deadline_.reset();
+        }
       }
     }
   }
@@ -11569,15 +11583,24 @@ void Interpreter::Commit() {
   // Try commit_mutex_ as the first action so that if another write is in WAL+replication, we throw
   // CommitWouldBlockException before any non-idempotent work runs, making park-and-retry safe.
   // Gate on write deltas: reads bypass the serializer entirely (the stall is writers-only, not readers).
+  // Acquire repl_state_ ReadLock BEFORE commit_mutex_ so this thread's order (repl_state_ -> commit_mutex_)
+  // matches DoToMainPromotion's (repl_state_ WRITE -> commit_mutex_ in PrepareForNewEpoch); the two orders
+  // would otherwise form an ABBA deadlock under the flag (B2). Held only for write txns here (the sole path
+  // that pre-takes commit_mutex_); other commits fill it at the is_main site below, reads never take it.
+  decltype(std::optional{interpreter_context_->repl_state->ReadLock()}) locked_repl_state{std::nullopt};
   memgraph::storage::CommitLock preheld_commit_lock;
   if (current_db_.db_transactional_accessor_ && current_db_.db_transactional_accessor_->IsCommitSerialised()) {
     auto const *commit_txn = current_db_.db_transactional_accessor_->GetTransaction();
     bool const is_write = commit_txn && (!commit_txn->deltas.empty() || !commit_txn->md_deltas.empty());
     if (is_write) {
+      locked_repl_state.emplace(interpreter_context_->repl_state->ReadLock());
       // Layer-1 budget: AdmissionTryBudget() shrinks under backlog and scarce idle workers.
       auto *pool = interpreter_context_->worker_pool;
-      auto const budget =
-          pool ? pool->AdmissionTryBudget() : std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
+      // Null pool: no pressure signal, so an effectively-infinite budget — but a finite cap, never
+      // microseconds{int64 max}, whose µs→ns conversion overflows steady_clock and wraps negative (NB3).
+      // The blocking fallback below governs in the null-pool case regardless.
+      auto const budget = pool ? pool->AdmissionTryBudget()
+                               : std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::hours{24});
       preheld_commit_lock = current_db_.db_transactional_accessor_->TryLockCommitFor(budget);
       if (!preheld_commit_lock.owns_lock()) {
         if (pool != nullptr && pool->ShouldParkAdmission()) {
@@ -11730,7 +11753,11 @@ void Interpreter::Commit() {
       QueryAllocator execution_memory{db->DbQueryMemoryTracker()};
       AdvanceCommand();
       try {
-        auto is_main = interpreter_context_->repl_state->ReadLock()->IsMain();
+        // Reuse the commit's held ReadLock (write txns) so this is NOT a nested read — a nested read would
+        // deadlock against a concurrent system-transaction's blocking repl_state_ WRITE under the writer-
+        // preferring RWSpinLock (B2). Non-write commits hold nothing here and take a standalone read.
+        bool const is_main =
+            locked_repl_state ? (*locked_repl_state)->IsMain() : interpreter_context_->repl_state->ReadLock()->IsMain();
         trigger.Execute(&*current_db_.execution_db_accessor_,
                         *current_db_.db_acc_,
                         execution_memory.resource(),
@@ -11757,7 +11784,10 @@ void Interpreter::Commit() {
   };
   utils::OnScopeExit const reset_members(reset_necessary_members);
 
-  auto locked_repl_state = std::optional{interpreter_context_->repl_state->ReadLock()};
+  // Reuse the ReadLock hoisted above commit_mutex_ (write txns); otherwise acquire it now (B2).
+  if (!locked_repl_state) {
+    locked_repl_state = interpreter_context_->repl_state->ReadLock();
+  }
   bool const is_main = (*locked_repl_state)->IsMain();
   auto *curr_txn = current_db_.db_transactional_accessor_->GetTransaction();
   // if I was main with write txn which became replica, abort.

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -11561,14 +11561,24 @@ void Interpreter::Commit() {
   // Try commit_mutex_ as the first action so that if another write is in WAL+replication, we throw
   // CommitWouldBlockException before any non-idempotent work runs, making park-and-retry safe.
   // Gate on write deltas: reads bypass the serializer entirely (the stall is writers-only, not readers).
-  std::unique_lock<std::mutex> preheld_commit_lock;  // non-owning by default
+  memgraph::storage::CommitLock preheld_commit_lock;  // non-owning by default
   if (current_db_.db_transactional_accessor_ && current_db_.db_transactional_accessor_->IsCommitSerialised()) {
     auto const *commit_txn = current_db_.db_transactional_accessor_->GetTransaction();
     bool const is_write = commit_txn && (!commit_txn->deltas.empty() || !commit_txn->md_deltas.empty());
     if (is_write) {
-      preheld_commit_lock = current_db_.db_transactional_accessor_->TryLockCommit();
+      // Layer-1: pressure-scaled timed wait. AdmissionTryBudget() returns a duration proportional
+      // to pool idle capacity — longer when workers are free, shorter under pressure.
+      auto *pool = interpreter_context_->worker_pool;
+      auto const budget =
+          pool ? pool->AdmissionTryBudget() : std::chrono::microseconds{std::numeric_limits<int64_t>::max()};
+      preheld_commit_lock = current_db_.db_transactional_accessor_->TryLockCommitFor(budget);
       if (!preheld_commit_lock.owns_lock()) {
-        throw CommitWouldBlockException{};
+        if (pool != nullptr && pool->ShouldParkAdmission()) {
+          // Productive workers are available to absorb this commit after rescheduling.
+          throw CommitWouldBlockException{};
+        }
+        // No idle workers (P==0) or no pool: fall back to blocking sleep so we do not stall forever.
+        preheld_commit_lock = current_db_.db_transactional_accessor_->LockCommitBlocking();
       }
     }
   }

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -292,10 +292,8 @@ struct CurrentDB {
   std::optional<TriggerContextCollector> trigger_context_collector_;
   bool in_explicit_db_{false};
   metrics::ScopedGauge transaction_gauge_;
-  // U3 main_lock BEGIN park (experimental_lockfree_read_snapshot ON). A non-blocking BEGIN attempt that
-  // missed once and is now parked/retried by the bolt driver; carries its PendingScope (writer-preference)
-  // for its whole life. unique_ptr so teardown here (CleanupDBTransaction/ResetDB/~CurrentDB) deregisters
-  // the pending scope on any abandonment — a leaked registration would block a main_lock mode process-wide.
+  // unique_ptr: teardown (CleanupDBTransaction/ResetDB/~CurrentDB) deregisters the PendingScope on
+  // abandonment — a leaked scope blocks all new main_lock acquisitions on this storage.
   std::unique_ptr<storage::Storage::PendingAccess> pending_access_;
   std::optional<std::chrono::steady_clock::time_point> pending_begin_deadline_;
 };

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -277,6 +277,8 @@ struct CurrentDB {
     db_transactional_accessor_.reset();
     execution_db_accessor_.reset();
     trigger_context_collector_.reset();
+    pending_access_.reset();
+    pending_begin_deadline_.reset();
   }
 
   std::string name() const { return db_acc_ ? db_acc_->get()->name() : ""; }
@@ -290,6 +292,12 @@ struct CurrentDB {
   std::optional<TriggerContextCollector> trigger_context_collector_;
   bool in_explicit_db_{false};
   metrics::ScopedGauge transaction_gauge_;
+  // U3 main_lock BEGIN park (experimental_lockfree_read_snapshot ON). A non-blocking BEGIN attempt that
+  // missed once and is now parked/retried by the bolt driver; carries its PendingScope (writer-preference)
+  // for its whole life. unique_ptr so teardown here (CleanupDBTransaction/ResetDB/~CurrentDB) deregisters
+  // the pending scope on any abandonment — a leaked registration would block a main_lock mode process-wide.
+  std::unique_ptr<storage::Storage::PendingAccess> pending_access_;
+  std::optional<std::chrono::steady_clock::time_point> pending_begin_deadline_;
 };
 
 using UserParameters_fn = std::function<UserParameters(storage::Storage const *)>;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -399,6 +399,14 @@ class Interpreter final {
 
   Interpreter::PrepareResult Prepare(ParseRes parse_res, UserParameters_fn params_getter, QueryExtras const &extras);
 
+  // True while an autocommit (RUN-first-query) BEGIN is parked on main_lock_ with its parse stashed.
+  bool HasParkedPrepare() const { return parked_prepare_.has_value(); }
+
+  // Re-drive a parked autocommit Prepare from the stashed parse (pool wake). Re-attempts only the
+  // storage-access acquire; on a further would-block it re-stashes and rethrows (park again). This is
+  // the implicit-transaction analogue of retrying an explicit BEGIN via BeginTransaction().
+  Interpreter::PrepareResult ResumeParkedPrepare();
+
   /**
    * Prepare a query for execution.
    *
@@ -677,6 +685,19 @@ class Interpreter final {
   // TODO Figure out how this would work for multi-database
   // SubqueryExpression only during a single transaction (for now should be okay as is)
   std::vector<std::unique_ptr<QueryExecution>> query_executions_;
+
+  // Stash for a parked autocommit BEGIN. When Prepare's storage-access acquire would block, the
+  // still-intact parse inputs are moved here (Prepare throws before consuming them) so the pool wake
+  // can re-drive via ResumeParkedPrepare instead of failing "not parsed". pending_access_ lives on
+  // CurrentDB and survives ResetInterpreter, so the retained scope keeps writer-preference across the
+  // park. Cleared on the first successful/failed re-drive.
+  struct ParkedPrepare {
+    ParseRes parse_res;
+    UserParameters_fn params_getter;
+    QueryExtras extras;
+  };
+
+  std::optional<ParkedPrepare> parked_prepare_;
 
   // all queries that are run as part of the current transaction
   utils::Synchronized<std::vector<std::string>, utils::SpinLock> transaction_queries_;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -41,6 +41,10 @@
 #include "utils/resource_monitoring.hpp"
 #endif
 
+namespace memgraph::utils {
+class PriorityThreadPool;
+}  // namespace memgraph::utils
+
 namespace memgraph::query {
 
 class FineGrainedAuthChecker;
@@ -263,7 +267,8 @@ struct CurrentDB {
   CurrentDB &operator=(CurrentDB const &) = delete;
 
   void SetupDatabaseTransaction(std::optional<storage::IsolationLevel> override_isolation_level, bool could_commit,
-                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE);
+                                storage::StorageAccessType acc_type = storage::StorageAccessType::WRITE,
+                                utils::PriorityThreadPool *pool = nullptr);
   void CleanupDBTransaction(bool abort);
 
   void SetCurrentDB(memgraph::dbms::DatabaseAccess new_db, bool in_explicit_db) {

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -1791,7 +1791,7 @@ DiskStorage::CheckExistingVerticesBeforeCreatingUniqueConstraint(LabelId label,
 
 // NOLINTNEXTLINE(google-default-arguments)
 std::expected<void, StorageManipulationError> DiskStorage::DiskAccessor::PrepareForCommitPhase(
-    CommitArgs /*commit_args*/) {
+    CommitArgs /*commit_args*/, std::unique_lock<std::mutex> /*preheld_commit_lock*/) {
   MG_ASSERT(is_transaction_active_, "The transaction is already terminated!");
   MG_ASSERT(!transaction_.has_serialization_error, "Unable to commit due to serialization error.");
 

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -1791,7 +1791,7 @@ DiskStorage::CheckExistingVerticesBeforeCreatingUniqueConstraint(LabelId label,
 
 // NOLINTNEXTLINE(google-default-arguments)
 std::expected<void, StorageManipulationError> DiskStorage::DiskAccessor::PrepareForCommitPhase(
-    CommitArgs /*commit_args*/, std::unique_lock<std::mutex> /*preheld_commit_lock*/) {
+    CommitArgs /*commit_args*/, CommitLock /*preheld_commit_lock*/) {
   MG_ASSERT(is_transaction_active_, "The transaction is already terminated!");
   MG_ASSERT(!transaction_.has_serialization_error, "Unable to commit due to serialization error.");
 

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -328,7 +328,8 @@ class DiskStorage final : public Storage {
     void DropAllConstraints() override;
 
     // NOLINTNEXTLINE(google-default-arguments)
-    std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args) override;
+    std::expected<void, StorageManipulationError> PrepareForCommitPhase(
+        CommitArgs commit_args, std::unique_lock<std::mutex> preheld_commit_lock = {}) override;
 
     // NOLINTNEXTLINE(google-default-arguments)
     std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) override;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -328,8 +328,8 @@ class DiskStorage final : public Storage {
     void DropAllConstraints() override;
 
     // NOLINTNEXTLINE(google-default-arguments)
-    std::expected<void, StorageManipulationError> PrepareForCommitPhase(
-        CommitArgs commit_args, std::unique_lock<std::mutex> preheld_commit_lock = {}) override;
+    std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args,
+                                                                        CommitLock preheld_commit_lock = {}) override;
 
     // NOLINTNEXTLINE(google-default-arguments)
     std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) override;

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -89,7 +89,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   // EXPERIMENTAL (lock-free-read-snapshot): under the flag the committer holds commit_mutex_ (not engine_lock_)
   // across its WAL-append window, so take commit_mutex_ here — in the committer's lock order, before engine_lock_ —
   // to keep the current WAL stable while its seq/timestamps are read. Released together with transaction_guard.
-  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  std::optional<CommitLock> commit_serializer;
   if (main_storage->config_.experimental_lockfree_read_snapshot) {
     commit_serializer.emplace(main_storage->commit_mutex_);
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -24,6 +24,7 @@
 #include <system_error>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 
 #include "ctre.hpp"
 #include "dbms/constants.hpp"
@@ -5097,11 +5098,59 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
       this, override_isolation_level, AcquireGuardOrThrow(this, StorageAccessType::READ_ONLY, timeout)});
 }
 
+std::unique_ptr<Storage::Accessor> InMemoryStorage::AccessorFromGuard(
+    utils::ResourceLockGuard guard, std::optional<IsolationLevel> override_isolation_level) {
+  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{this, override_isolation_level, std::move(guard)});
+}
+
 std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccess(StorageAccessType rw_type,
                                                               std::optional<IsolationLevel> override_isolation_level) {
   utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::try_to_lock};
   if (!guard.owns_lock()) return nullptr;
-  return std::unique_ptr<InMemoryAccessor>(new InMemoryAccessor{this, override_isolation_level, std::move(guard)});
+  return AccessorFromGuard(std::move(guard), override_isolation_level);
+}
+
+namespace {
+class InMemoryPendingAccess final : public Storage::PendingAccess {
+ public:
+  InMemoryPendingAccess(InMemoryStorage *storage, utils::ResourceLock &main_lock, StorageAccessType rw_type)
+      : storage_{storage}, rw_type_{rw_type} {
+    switch (rw_type) {  // register pending up front for the gating modes only
+      case StorageAccessType::UNIQUE:
+        scope_.emplace<utils::UniquePendingScope>(main_lock);
+        break;
+      case StorageAccessType::READ_ONLY:
+        scope_.emplace<utils::ReadOnlyPendingScope>(main_lock);
+        break;
+      default:
+        break;  // READ / WRITE gate nobody → no scope
+    }
+  }
+
+  std::unique_ptr<Storage::Accessor> TryAcquire(std::optional<IsolationLevel> iso) override {
+    switch (rw_type_) {
+      case StorageAccessType::UNIQUE: {
+        auto g = std::get<utils::UniquePendingScope>(scope_).try_acquire();
+        return g ? storage_->AccessorFromGuard(std::move(*g), iso) : nullptr;
+      }
+      case StorageAccessType::READ_ONLY: {
+        auto g = std::get<utils::ReadOnlyPendingScope>(scope_).try_acquire();
+        return g ? storage_->AccessorFromGuard(std::move(*g), iso) : nullptr;
+      }
+      default:
+        return storage_->TryAccess(rw_type_, iso);  // READ/WRITE: plain one-probe
+    }
+  }
+
+ private:
+  InMemoryStorage *storage_;
+  StorageAccessType rw_type_;
+  std::variant<std::monostate, utils::UniquePendingScope, utils::ReadOnlyPendingScope> scope_;
+};
+}  // namespace
+
+std::unique_ptr<Storage::PendingAccess> InMemoryStorage::MakePendingAccess(StorageAccessType rw_type) {
+  return std::make_unique<InMemoryPendingAccess>(this, main_lock_, rw_type);
 }
 
 void InMemoryStorage::CreateSnapshotHandler(

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1131,13 +1131,11 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   std::optional<std::unique_lock<std::mutex>> commit_serializer;
   if (lockfree) {
     if (preheld_commit_lock.owns_lock()) {
-      // Caller (Interpreter::Commit, U4a) already acquired commit_mutex_ via try_lock.
+      // Caller (Interpreter::Commit) already acquired commit_mutex_ via try_lock.
       // Adopt the existing hold so we do not re-acquire (which would deadlock).
       commit_serializer.emplace(std::move(preheld_commit_lock));
     } else {
-      // No pre-held guard (PeriodicCommit, replica paths, or OFF-path callers that
-      // passed the default-constructed lock): acquire blocking — OFF-path behavior
-      // is byte-identical to before this change.
+      // No pre-held guard (PeriodicCommit, replica paths): acquire blocking.
       commit_serializer.emplace(mem_storage->commit_mutex_);
     }
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1079,7 +1079,7 @@ void InMemoryStorage::InMemoryAccessor::PublishIndexArming() {
 }
 
 std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor::PrepareForCommitPhase(
-    CommitArgs const commit_args) {
+    CommitArgs const commit_args, std::unique_lock<std::mutex> preheld_commit_lock) {
   MG_ASSERT(is_transaction_active_, "The transaction is already terminated!");
   MG_ASSERT(!transaction_.has_serialization_error, "Unable to commit due to serialization error.");
 
@@ -1128,7 +1128,18 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   //    the WAL append) would break unique-constraint validation even if watermark ordering were
   //    re-established through another mechanism.
   std::optional<std::unique_lock<std::mutex>> commit_serializer;
-  if (lockfree) commit_serializer.emplace(mem_storage->commit_mutex_);
+  if (lockfree) {
+    if (preheld_commit_lock.owns_lock()) {
+      // Caller (Interpreter::Commit, U4a) already acquired commit_mutex_ via try_lock.
+      // Adopt the existing hold so we do not re-acquire (which would deadlock).
+      commit_serializer.emplace(std::move(preheld_commit_lock));
+    } else {
+      // No pre-held guard (PeriodicCommit, replica paths, or OFF-path callers that
+      // passed the default-constructed lock): acquire blocking — OFF-path behavior
+      // is byte-identical to before this change.
+      commit_serializer.emplace(mem_storage->commit_mutex_);
+    }
+  }
 
   auto engine_guard = std::unique_lock{storage_->engine_lock_};
   commit_timestamp_.emplace(mem_storage->GetCommitTimestamp());

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -5108,6 +5108,14 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccess(StorageAccessType 
   return AccessorFromGuard(std::move(guard), override_isolation_level);
 }
 
+std::unique_ptr<Storage::Accessor> InMemoryStorage::TryAccessFor(StorageAccessType rw_type,
+                                                                 std::optional<IsolationLevel> override_isolation_level,
+                                                                 std::chrono::microseconds budget) {
+  utils::ResourceLockGuard guard{main_lock_, ToGuardType(rw_type), std::defer_lock};
+  if (!guard.try_lock_for(budget)) return nullptr;
+  return AccessorFromGuard(std::move(guard), override_isolation_level);
+}
+
 namespace {
 class InMemoryPendingAccess final : public Storage::PendingAccess {
  public:
@@ -5137,6 +5145,22 @@ class InMemoryPendingAccess final : public Storage::PendingAccess {
       }
       default:
         return storage_->TryAccess(rw_type_, iso);  // READ/WRITE: plain one-probe
+    }
+  }
+
+  std::unique_ptr<Storage::Accessor> TryAcquireFor(std::optional<IsolationLevel> iso,
+                                                   std::chrono::microseconds budget) override {
+    switch (rw_type_) {
+      case StorageAccessType::UNIQUE: {
+        auto g = std::get<utils::UniquePendingScope>(scope_).try_acquire_for(budget);
+        return g ? storage_->AccessorFromGuard(std::move(*g), iso) : nullptr;
+      }
+      case StorageAccessType::READ_ONLY: {
+        auto g = std::get<utils::ReadOnlyPendingScope>(scope_).try_acquire_for(budget);
+        return g ? storage_->AccessorFromGuard(std::move(*g), iso) : nullptr;
+      }
+      default:
+        return storage_->TryAccessFor(rw_type_, iso, budget);  // READ/WRITE: timed probe
     }
   }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1080,7 +1080,7 @@ void InMemoryStorage::InMemoryAccessor::PublishIndexArming() {
 }
 
 std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor::PrepareForCommitPhase(
-    CommitArgs const commit_args, std::unique_lock<std::mutex> preheld_commit_lock) {
+    CommitArgs const commit_args, CommitLock preheld_commit_lock) {
   MG_ASSERT(is_transaction_active_, "The transaction is already terminated!");
   MG_ASSERT(!transaction_.has_serialization_error, "Unable to commit due to serialization error.");
 
@@ -1128,7 +1128,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   //    commit_mutex_ provides exactly this guarantee.  Releasing commit_mutex_ earlier (e.g. after
   //    the WAL append) would break unique-constraint validation even if watermark ordering were
   //    re-established through another mechanism.
-  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  std::optional<CommitLock> commit_serializer;
   if (lockfree) {
     if (preheld_commit_lock.owns_lock()) {
       // Caller (Interpreter::Commit) already acquired commit_mutex_ via try_lock.
@@ -5039,7 +5039,7 @@ uint64_t InMemoryStorage::GetCommitTimestamp() { return timestamp_++; }
 void InMemoryStorage::PrepareForNewEpoch() {
   // EXPERIMENTAL (lock-free-read-snapshot): take commit_mutex_ before engine_lock_ (committer order) so this
   // WAL reset cannot race a committer's WAL append under the flag.
-  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  std::optional<CommitLock> commit_serializer;
   if (config_.experimental_lockfree_read_snapshot) {
     commit_serializer.emplace(commit_mutex_);
   }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -817,7 +817,14 @@ class InMemoryStorage final : public Storage {
   /// InMemoryStorage's alone: DiskStorage has no probe rather than one that always fails, so a
   /// caller polling it would spin instead of learning that it should just block.
   std::unique_ptr<Accessor> TryAccess(StorageAccessType rw_type,
-                                      std::optional<IsolationLevel> override_isolation_level = {});
+                                      std::optional<IsolationLevel> override_isolation_level = {}) override;
+
+  /// Builds an InMemoryAccessor from an already-held main_lock_ guard (the shared post-guard tail of
+  /// Access and TryAccess). Symmetric to TryAccess: ownership of the guard transfers into the accessor.
+  std::unique_ptr<Accessor> AccessorFromGuard(utils::ResourceLockGuard guard,
+                                              std::optional<IsolationLevel> override_isolation_level);
+
+  std::unique_ptr<PendingAccess> MakePendingAccess(StorageAccessType rw_type) override;
 
   void FreeMemory(utils::ResourceLockGuard main_guard, bool periodic) override;
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -465,7 +465,8 @@ class InMemoryStorage final : public Storage {
     // finalize commit method which will bump ldt, update commit ts etc.
     // @throw std::bad_alloc
     // NOLINTNEXTLINE(google-default-arguments)
-    std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args) override;
+    std::expected<void, StorageManipulationError> PrepareForCommitPhase(
+        CommitArgs commit_args, std::unique_lock<std::mutex> preheld_commit_lock = {}) override;
 
     std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) override;
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <concepts>
 #include <cstdint>
 #include <limits>
@@ -818,6 +819,11 @@ class InMemoryStorage final : public Storage {
   /// caller polling it would spin instead of learning that it should just block.
   std::unique_ptr<Accessor> TryAccess(StorageAccessType rw_type,
                                       std::optional<IsolationLevel> override_isolation_level = {}) override;
+
+  /// Timed variant of TryAccess: waits up to `budget` for main_lock_ to admit the mode.
+  std::unique_ptr<Accessor> TryAccessFor(StorageAccessType rw_type,
+                                         std::optional<IsolationLevel> override_isolation_level,
+                                         std::chrono::microseconds budget) override;
 
   /// Builds an InMemoryAccessor from an already-held main_lock_ guard (the shared post-guard tail of
   /// Access and TryAccess). Symmetric to TryAccess: ownership of the guard transfers into the accessor.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -465,8 +465,8 @@ class InMemoryStorage final : public Storage {
     // finalize commit method which will bump ldt, update commit ts etc.
     // @throw std::bad_alloc
     // NOLINTNEXTLINE(google-default-arguments)
-    std::expected<void, StorageManipulationError> PrepareForCommitPhase(
-        CommitArgs commit_args, std::unique_lock<std::mutex> preheld_commit_lock = {}) override;
+    std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args,
+                                                                        CommitLock preheld_commit_lock = {}) override;
 
     std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) override;
 

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -244,7 +244,7 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
   // EXPERIMENTAL (lock-free-read-snapshot): engine_lock_ alone is stale for the ldt read at ~line 287;
   // under the flag, ldt advances at publish outside the post-mint engine_lock_ hold, so hold commit_mutex_
   // first (committer's order: commit_mutex_ then engine_lock_) to exclude any in-flight committer.
-  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  std::optional<CommitLock> commit_serializer;
   if (static_cast<InMemoryStorage *>(main_storage)->config_.experimental_lockfree_read_snapshot) {
     commit_serializer.emplace(static_cast<InMemoryStorage *>(main_storage)->commit_mutex_);
   }
@@ -894,7 +894,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                 // EXPERIMENTAL (lock-free-read-snapshot): serialize against the committer (which holds commit_mutex_,
                 // not engine_lock_, across its WAL window) before reading/flush-toggling the current WAL. Released
                 // with transaction_guard; the subsequent Path()/transfer is covered by DisableFlushing()'s flush_lock_.
-                std::optional<std::unique_lock<std::mutex>> commit_serializer;
+                std::optional<CommitLock> commit_serializer;
                 if (main_mem_storage->config_.experimental_lockfree_read_snapshot) {
                   commit_serializer.emplace(main_mem_storage->commit_mutex_);
                 }
@@ -991,7 +991,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
   // so a reader holding only engine_lock_ can see a stale ldt and mark the replica READY across a commit
   // it will miss. Hold commit_mutex_ first (committer's order: commit_mutex_ then engine_lock_) to exclude
   // any in-flight committer so the READY decision reflects it.
-  std::optional<std::unique_lock<std::mutex>> commit_serializer;
+  std::optional<CommitLock> commit_serializer;
   if (main_mem_storage->config_.experimental_lockfree_read_snapshot) {
     commit_serializer.emplace(main_mem_storage->commit_mutex_);
   }

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -39,7 +39,6 @@
 namespace memgraph::storage {
 class InMemoryStorage;
 
-namespace {
 [[noreturn]] void ThrowAccessTimeout(StorageAccessType rw_type) {
   switch (rw_type) {
     using enum StorageAccessType;
@@ -56,8 +55,6 @@ namespace {
       LOG_FATAL("NO_ACCESS names the absence of a hold; there is nothing to time out acquiring");
   }
 }
-
-}  // namespace
 
 utils::ResourceLockGuard AcquireGuardOrThrow(Storage *storage, StorageAccessType rw_type,
                                              std::optional<std::chrono::milliseconds> timeout) {

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -160,6 +160,20 @@ std::vector<LabelId> Storage::ListAllPossiblyPresentVertexLabels() const { retur
 
 StorageMode Storage::Accessor::GetPinnedStorageMode() const noexcept { return transaction_.storage_mode; }
 
+// Out-of-line default: defined here (not in the header) because Accessor is only forward-declared at the
+// header declaration point, so instantiating unique_ptr<Accessor>'s destructor there is ill-formed.
+// Default (DiskStorage / no timed-wait backend): fall back to the one-probe variant.
+std::unique_ptr<Storage::Accessor> Storage::PendingAccess::TryAcquireFor(
+    std::optional<IsolationLevel> override_isolation_level, std::chrono::microseconds /*budget*/) {
+  return TryAcquire(override_isolation_level);
+}
+
+std::unique_ptr<Storage::Accessor> Storage::TryAccessFor(StorageAccessType rw_type,
+                                                         std::optional<IsolationLevel> override_isolation_level,
+                                                         std::chrono::microseconds /*budget*/) {
+  return TryAccess(rw_type, override_isolation_level);
+}
+
 std::optional<uint64_t> Storage::Accessor::GetStartTimestamp() const {
   if (is_transaction_active_) {
     return transaction_.original_start_timestamp;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -382,9 +382,8 @@ class Storage {
   /// registration (for UNIQUE / READ_ONLY) so the query layer never touches main_lock_ directly.
   struct PendingAccess {
     virtual ~PendingAccess() = default;
-    /// One non-blocking probe.  Returns the built accessor if main_lock_ now admits the requested
-    /// mode, else nullptr (still registered pending — call again on the next wake).
-    /// Never blocks, never throws.
+    /// Returns the built accessor if main_lock_ now admits the requested mode, else nullptr
+    /// (still registered pending — call again on the next wake). Never blocks, never throws.
     virtual std::unique_ptr<Accessor> TryAcquire(std::optional<IsolationLevel> override_isolation_level) = 0;
   };
 
@@ -419,10 +418,8 @@ class Storage {
 
   virtual void PrepareForNewEpoch() = 0;
 
-  // EXPERIMENTAL (lock-free-read-snapshot).
-  // Attempt to acquire commit_mutex_ without blocking.  Returns an owning unique_lock on success,
-  // a non-owning (default-constructed) unique_lock when another committer already holds it.
-  // Only meaningful when experimental_lockfree_read_snapshot is ON.
+  // EXPERIMENTAL (lock-free-read-snapshot). Only meaningful when the experiment is ON.
+  // Returns an owning lock on success, a non-owning (empty) lock when another committer holds it.
   [[nodiscard]] std::unique_lock<std::mutex> TryCommitLock() noexcept {
     return std::unique_lock<std::mutex>{commit_mutex_, std::try_to_lock};
   }
@@ -477,10 +474,8 @@ class Storage {
   // creation.
   mutable utils::ResourceLock main_lock_;
 
-  // U3c: install-once hook that fires WakeMatching({MainLock}) from ResourceLock::maybe_notify.
-  // The boolean exchange makes concurrent first-BEGIN callers on this DB safe. The hook is
-  // cleared before pool destruction (memgraph.cpp shutdown ForEach) so no notify can call
-  // into a dead pool.
+  // Install-once hook; fires WakeMatching({MainLock}) from ResourceLock::maybe_notify.
+  // Cleared before pool destruction (memgraph.cpp ForEach) so no notify reaches a dead pool.
   std::atomic<bool> main_lock_hook_installed_{false};
 
   bool MainLockHookInstalled() const noexcept { return main_lock_hook_installed_.load(std::memory_order_acquire); }
@@ -493,10 +488,8 @@ class Storage {
     return true;
   }
 
-  // Disarm the hook for the rest of this storage's life (shutdown). Deliberately does NOT reset
-  // main_lock_hook_installed_ to false: the hook is installed at most once per lifetime, and re-arming
-  // the guard would open a window for a second SetNotifyHook to overwrite on_notify_all_storage_ while
-  // an in-flight maybe_notify reader still holds the old pointer to it (a data race).
+  // Disarm for shutdown. Does NOT reset main_lock_hook_installed_: re-arming would open a window
+  // for a second SetNotifyHook to overwrite on_notify_all_storage_ under an in-flight reader.
   void ClearMainLockNotifyHook() { main_lock_.ClearNotifyHook(); }
 
   // Even though the edge count is already kept in the `edges_` SkipList, the
@@ -605,8 +598,7 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
   return os;
 }
 
-/// Throws the timeout exception for the given access mode (UniqueAccessTimeout, ReadOnlyAccessTimeout,
-/// or SharedAccessTimeout). Used by AcquireGuardOrThrow and the non-blocking BEGIN park driver.
+/// Throws UniqueAccessTimeout, ReadOnlyAccessTimeout, or SharedAccessTimeout for the given mode.
 [[noreturn]] void ThrowAccessTimeout(StorageAccessType rw_type);
 
 /// Acquires `main_lock_` in the mode `rw_type` names. Blocks indefinitely without a timeout; with
@@ -879,10 +871,8 @@ class Accessor {
   virtual void DropAllConstraints() = 0;
 
   // NOLINTNEXTLINE(google-default-arguments)
-  // preheld_commit_lock: when the caller (Interpreter::Commit, U4a) has already acquired
-  // commit_mutex_ via TryLockCommit(), it passes the owning lock here so PrepareForCommitPhase
-  // can adopt it instead of re-acquiring.  A default-constructed (non-owning) lock signals
-  // "no pre-held guard"; the implementation then acquires blocking, preserving OFF-path behaviour.
+  // preheld_commit_lock: owning lock pre-acquired by the caller via TryLockCommit(); adopted here.
+  // Default-constructed (non-owning) = no pre-held guard; implementation acquires blocking.
   virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(
       CommitArgs commit_args, std::unique_lock<std::mutex> preheld_commit_lock = {}) = 0;
 
@@ -893,14 +883,11 @@ class Accessor {
 
   virtual void FinalizeTransaction() = 0;
 
-  // EXPERIMENTAL (lock-free-read-snapshot) helpers for the parkable-commit path (U4a).
-  // True iff the experiment is ON for this accessor's storage.
+  // EXPERIMENTAL (lock-free-read-snapshot) helpers for the parkable-commit path.
   bool IsCommitSerialised() const noexcept { return storage_->IsCommitSerialised(); }
 
-  // Attempt commit_mutex_ without blocking. Returns an owning lock on success,
-  // a non-owning lock when another committer holds it.  Must not be called on the OFF path
-  // (storage_->commit_mutex_ is never taken there, so the try always succeeds — harmless but
-  // wasteful; gate the call with IsCommitSerialised()).
+  // Must not be called on the OFF path: commit_mutex_ is never taken there, so the try always
+  // succeeds (harmless but wasteful); gate the call with IsCommitSerialised().
   [[nodiscard]] std::unique_lock<std::mutex> TryLockCommit() noexcept { return storage_->TryCommitLock(); }
 
   // Stable per-query id; preserved across PERIODIC COMMIT.

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -377,6 +377,28 @@ class Storage {
   std::unique_ptr<Accessor> ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level);
   std::unique_ptr<Accessor> ReadOnlyAccess();
 
+  /// Handle for a single in-flight non-blocking BEGIN attempt.  Encapsulates the pending-scope
+  /// registration (for UNIQUE / READ_ONLY) so the query layer never touches main_lock_ directly.
+  struct PendingAccess {
+    virtual ~PendingAccess() = default;
+    /// One non-blocking probe.  Returns the built accessor if main_lock_ now admits the requested
+    /// mode, else nullptr (still registered pending — call again on the next wake).
+    /// Never blocks, never throws.
+    virtual std::unique_ptr<Accessor> TryAcquire(std::optional<IsolationLevel> override_isolation_level) = 0;
+  };
+
+  /// Returns a PendingAccess for non-blocking BEGIN retry, or nullptr when the storage backend does
+  /// not support non-blocking acquisition (DiskStorage keeps this default → caller must block).
+  virtual std::unique_ptr<PendingAccess> MakePendingAccess(StorageAccessType /*rw_type*/) { return nullptr; }
+
+  /// Non-blocking single-probe accessor acquisition: returns the accessor if main_lock_ admits the
+  /// mode right now, else nullptr. Grants no priority (one probe). DiskStorage keeps this default
+  /// (no probe → a poller learns to block instead of spinning); InMemoryStorage overrides it.
+  virtual std::unique_ptr<Accessor> TryAccess(StorageAccessType /*rw_type*/,
+                                              std::optional<IsolationLevel> /*override_isolation_level*/ = {}) {
+    return nullptr;
+  }
+
   enum class SetIsolationLevelError : uint8_t { DisabledForAnalyticalMode };
 
   std::expected<void, SetIsolationLevelError> SetIsolationLevel(IsolationLevel isolation_level);
@@ -559,6 +581,10 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
   }
   return os;
 }
+
+/// Throws the timeout exception for the given access mode (UniqueAccessTimeout, ReadOnlyAccessTimeout,
+/// or SharedAccessTimeout). Used by AcquireGuardOrThrow and the non-blocking BEGIN park driver.
+[[noreturn]] void ThrowAccessTimeout(StorageAccessType rw_type);
 
 /// Acquires `main_lock_` in the mode `rw_type` names. Blocks indefinitely without a timeout; with
 /// one, throws the timeout exception belonging to that mode.

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -493,10 +493,11 @@ class Storage {
     return true;
   }
 
-  void ClearMainLockNotifyHook() {
-    main_lock_.ClearNotifyHook();
-    main_lock_hook_installed_.store(false, std::memory_order_release);
-  }
+  // Disarm the hook for the rest of this storage's life (shutdown). Deliberately does NOT reset
+  // main_lock_hook_installed_ to false: the hook is installed at most once per lifetime, and re-arming
+  // the guard would open a window for a second SetNotifyHook to overwrite on_notify_all_storage_ while
+  // an in-flight maybe_notify reader still holds the old pointer to it (a data race).
+  void ClearMainLockNotifyHook() { main_lock_.ClearNotifyHook(); }
 
   // Even though the edge count is already kept in the `edges_` SkipList, the
   // list is used only when properties are enabled for edges. Because of that we

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -396,6 +396,17 @@ class Storage {
 
   virtual void PrepareForNewEpoch() = 0;
 
+  // EXPERIMENTAL (lock-free-read-snapshot).
+  // Attempt to acquire commit_mutex_ without blocking.  Returns an owning unique_lock on success,
+  // a non-owning (default-constructed) unique_lock when another committer already holds it.
+  // Only meaningful when experimental_lockfree_read_snapshot is ON.
+  [[nodiscard]] std::unique_lock<std::mutex> TryCommitLock() noexcept {
+    return std::unique_lock<std::mutex>{commit_mutex_, std::try_to_lock};
+  }
+
+  // True iff the lock-free read-snapshot experiment is ON for this storage instance.
+  bool IsCommitSerialised() const noexcept { return config_.experimental_lockfree_read_snapshot; }
+
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState> {
     return repl_storage_state_.GetReplicaState(name);
   }
@@ -819,7 +830,12 @@ class Accessor {
   virtual void DropAllConstraints() = 0;
 
   // NOLINTNEXTLINE(google-default-arguments)
-  virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args) = 0;
+  // preheld_commit_lock: when the caller (Interpreter::Commit, U4a) has already acquired
+  // commit_mutex_ via TryLockCommit(), it passes the owning lock here so PrepareForCommitPhase
+  // can adopt it instead of re-acquiring.  A default-constructed (non-owning) lock signals
+  // "no pre-held guard"; the implementation then acquires blocking, preserving OFF-path behaviour.
+  virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(
+      CommitArgs commit_args, std::unique_lock<std::mutex> preheld_commit_lock = {}) = 0;
 
   // NOLINTNEXTLINE(google-default-arguments)
   virtual std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) = 0;
@@ -827,6 +843,16 @@ class Accessor {
   virtual void Abort() = 0;
 
   virtual void FinalizeTransaction() = 0;
+
+  // EXPERIMENTAL (lock-free-read-snapshot) helpers for the parkable-commit path (U4a).
+  // True iff the experiment is ON for this accessor's storage.
+  bool IsCommitSerialised() const noexcept { return storage_->IsCommitSerialised(); }
+
+  // Attempt commit_mutex_ without blocking. Returns an owning lock on success,
+  // a non-owning lock when another committer holds it.  Must not be called on the OFF path
+  // (storage_->commit_mutex_ is never taken there, so the try always succeeds — harmless but
+  // wasteful; gate the call with IsCommitSerialised()).
+  [[nodiscard]] std::unique_lock<std::mutex> TryLockCommit() noexcept { return storage_->TryCommitLock(); }
 
   // Stable per-query id; preserved across PERIODIC COMMIT.
   std::optional<uint64_t> GetStartTimestamp() const;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <set>
@@ -475,6 +476,27 @@ class Storage {
   // operations on storage that affect the global state, for example index
   // creation.
   mutable utils::ResourceLock main_lock_;
+
+  // U3c: install-once hook that fires WakeMatching({MainLock}) from ResourceLock::maybe_notify.
+  // The boolean exchange makes concurrent first-BEGIN callers on this DB safe. The hook is
+  // cleared before pool destruction (memgraph.cpp shutdown ForEach) so no notify can call
+  // into a dead pool.
+  std::atomic<bool> main_lock_hook_installed_{false};
+
+  bool MainLockHookInstalled() const noexcept { return main_lock_hook_installed_.load(std::memory_order_acquire); }
+
+  // Install once; a second call is a no-op (returns false). The exchange closes the
+  // load→install race between concurrent first-BEGINs on the same DB.
+  bool TrySetMainLockNotifyHook(std::move_only_function<void()> hook) {
+    if (main_lock_hook_installed_.exchange(true, std::memory_order_acq_rel)) return false;
+    main_lock_.SetNotifyHook(std::move(hook));
+    return true;
+  }
+
+  void ClearMainLockNotifyHook() {
+    main_lock_.ClearNotifyHook();
+    main_lock_hook_installed_.store(false, std::memory_order_release);
+  }
 
   // Even though the edge count is already kept in the `edges_` SkipList, the
   // list is used only when properties are enabled for edges. Because of that we

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -446,7 +446,11 @@ class Storage {
   [[nodiscard]] CommitLock LockCommitBlocking() { return CommitLock{commit_mutex_}; }
 
   // True iff the lock-free read-snapshot experiment is ON for this storage instance.
-  bool IsCommitSerialised() const noexcept { return config_.experimental_lockfree_read_snapshot; }
+  // The lock-free read-snapshot commit path is IN_MEMORY_TRANSACTIONAL-only; the spec says the flag is
+  // inert for on-disk and analytical storage, so gate on the mode as well as the flag (NB6).
+  bool IsCommitSerialised() const noexcept {
+    return config_.experimental_lockfree_read_snapshot && GetStorageMode() == StorageMode::IN_MEMORY_TRANSACTIONAL;
+  }
 
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState> {
     return repl_storage_state_.GetReplicaState(name);

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -391,6 +392,11 @@ class Storage {
     /// Returns the built accessor if main_lock_ now admits the requested mode, else nullptr
     /// (still registered pending — call again on the next wake). Never blocks, never throws.
     virtual std::unique_ptr<Accessor> TryAcquire(std::optional<IsolationLevel> override_isolation_level) = 0;
+    /// Timed variant: waits up to `budget` for main_lock_ to admit the mode. Returns the accessor
+    /// on success, nullptr on timeout (pending registration stays for the next probe).
+    /// Default falls back to the one-probe TryAcquire for backends without timed-wait support.
+    virtual std::unique_ptr<Accessor> TryAcquireFor(std::optional<IsolationLevel> override_isolation_level,
+                                                    std::chrono::microseconds budget);
   };
 
   /// Returns a PendingAccess for non-blocking BEGIN retry, or nullptr when the storage backend does
@@ -404,6 +410,13 @@ class Storage {
                                               std::optional<IsolationLevel> /*override_isolation_level*/ = {}) {
     return nullptr;
   }
+
+  /// Timed variant of TryAccess: waits up to `budget` for main_lock_ to admit the requested mode.
+  /// Returns the accessor on success, nullptr on timeout. Default falls back to one-probe TryAccess
+  /// for backends (DiskStorage) that have no timed-probe path.
+  virtual std::unique_ptr<Accessor> TryAccessFor(StorageAccessType rw_type,
+                                                 std::optional<IsolationLevel> override_isolation_level,
+                                                 std::chrono::microseconds budget);
 
   enum class SetIsolationLevelError : uint8_t { DisabledForAnalyticalMode };
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -278,9 +278,7 @@ struct PlanInvalidatorDefault : public PlanInvalidator {
 
 using PlanInvalidatorPtr = std::unique_ptr<PlanInvalidator>;
 
-// Type aliases for the commit serializer mutex and its owning lock.
 // Using timed_mutex so callers can use try_lock_for() without a type change.
-// CommitMutex supports the same lock()/try_lock()/unlock() interface as std::mutex.
 using CommitMutex = std::timed_mutex;
 using CommitLock = std::unique_lock<CommitMutex>;
 
@@ -438,19 +436,13 @@ class Storage {
   virtual void PrepareForNewEpoch() = 0;
 
   // EXPERIMENTAL (lock-free-read-snapshot). Only meaningful when the experiment is ON.
-  // Returns an owning lock on success, a non-owning (empty) lock when another committer holds it.
-  [[nodiscard]] CommitLock TryCommitLock() noexcept { return CommitLock{commit_mutex_, std::try_to_lock}; }
-
-  // EXPERIMENTAL (lock-free-read-snapshot). Only meaningful when the experiment is ON.
-  // Pressure-scaled timed wait: sleeps up to `budget` for commit_mutex_; returns a non-owning lock
-  // on timeout. Caller must check owns_lock() before proceeding.
+  // Returns non-owning lock on timeout — caller must check owns_lock() before proceeding.
   [[nodiscard]] CommitLock TryCommitLockFor(std::chrono::microseconds budget) noexcept {
     return CommitLock{commit_mutex_, budget};
   }
 
   // EXPERIMENTAL (lock-free-read-snapshot). Only meaningful when the experiment is ON.
-  // Blocking (indefinite sleep) acquire of commit_mutex_. Used when no idle workers are available
-  // and parking would stall the pool entirely (P==0 case).
+  // Blocking acquire of commit_mutex_; always returns owning lock.
   [[nodiscard]] CommitLock LockCommitBlocking() { return CommitLock{commit_mutex_}; }
 
   // True iff the lock-free read-snapshot experiment is ON for this storage instance.
@@ -900,7 +892,7 @@ class Accessor {
   virtual void DropAllConstraints() = 0;
 
   // NOLINTNEXTLINE(google-default-arguments)
-  // preheld_commit_lock: owning lock pre-acquired by the caller via TryLockCommit(); adopted here.
+  // preheld_commit_lock: owning lock pre-acquired by the caller via TryLockCommitFor(); adopted here.
   // Default-constructed (non-owning) = no pre-held guard; implementation acquires blocking.
   virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args,
                                                                               CommitLock preheld_commit_lock = {}) = 0;
@@ -915,16 +907,14 @@ class Accessor {
   // EXPERIMENTAL (lock-free-read-snapshot) helpers for the parkable-commit path.
   bool IsCommitSerialised() const noexcept { return storage_->IsCommitSerialised(); }
 
-  // Must not be called on the OFF path: commit_mutex_ is never taken there, so the try always
-  // succeeds (harmless but wasteful); gate the call with IsCommitSerialised().
-  [[nodiscard]] CommitLock TryLockCommit() noexcept { return storage_->TryCommitLock(); }
-
-  // Pressure-scaled timed wait. Must not be called on the OFF path (see TryLockCommit above).
+  // Pressure-scaled timed wait. Must not be called on the OFF path — commit_mutex_ is only
+  // meaningful when IsCommitSerialised().
   [[nodiscard]] CommitLock TryLockCommitFor(std::chrono::microseconds budget) noexcept {
     return storage_->TryCommitLockFor(budget);
   }
 
-  // Blocking acquire. Must not be called on the OFF path (see TryLockCommit above).
+  // Blocking acquire. Must not be called on the OFF path — commit_mutex_ is only meaningful
+  // when IsCommitSerialised().
   [[nodiscard]] CommitLock LockCommitBlocking() { return storage_->LockCommitBlocking(); }
 
   // Stable per-query id; preserved across PERIODIC COMMIT.

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -277,6 +277,12 @@ struct PlanInvalidatorDefault : public PlanInvalidator {
 
 using PlanInvalidatorPtr = std::unique_ptr<PlanInvalidator>;
 
+// Type aliases for the commit serializer mutex and its owning lock.
+// Using timed_mutex so callers can use try_lock_for() without a type change.
+// CommitMutex supports the same lock()/try_lock()/unlock() interface as std::mutex.
+using CommitMutex = std::timed_mutex;
+using CommitLock = std::unique_lock<CommitMutex>;
+
 class Accessor;
 
 class Storage {
@@ -420,9 +426,19 @@ class Storage {
 
   // EXPERIMENTAL (lock-free-read-snapshot). Only meaningful when the experiment is ON.
   // Returns an owning lock on success, a non-owning (empty) lock when another committer holds it.
-  [[nodiscard]] std::unique_lock<std::mutex> TryCommitLock() noexcept {
-    return std::unique_lock<std::mutex>{commit_mutex_, std::try_to_lock};
+  [[nodiscard]] CommitLock TryCommitLock() noexcept { return CommitLock{commit_mutex_, std::try_to_lock}; }
+
+  // EXPERIMENTAL (lock-free-read-snapshot). Only meaningful when the experiment is ON.
+  // Pressure-scaled timed wait: sleeps up to `budget` for commit_mutex_; returns a non-owning lock
+  // on timeout. Caller must check owns_lock() before proceeding.
+  [[nodiscard]] CommitLock TryCommitLockFor(std::chrono::microseconds budget) noexcept {
+    return CommitLock{commit_mutex_, budget};
   }
+
+  // EXPERIMENTAL (lock-free-read-snapshot). Only meaningful when the experiment is ON.
+  // Blocking (indefinite sleep) acquire of commit_mutex_. Used when no idle workers are available
+  // and parking would stall the pool entirely (P==0 case).
+  [[nodiscard]] CommitLock LockCommitBlocking() { return CommitLock{commit_mutex_}; }
 
   // True iff the lock-free read-snapshot experiment is ON for this storage instance.
   bool IsCommitSerialised() const noexcept { return config_.experimental_lockfree_read_snapshot; }
@@ -512,7 +528,7 @@ class Storage {
   // EXPERIMENTAL (lock-free-read-snapshot). All three are inert when the experiment is OFF.
   // Serializes committers across mint->durability->publish and (in that mode) guards the WAL group;
   // acquired only on the experiment's ON path, so the OFF path is byte-for-byte unchanged.
-  mutable std::mutex commit_mutex_;
+  mutable CommitMutex commit_mutex_;
   // Runtime-only watermark: the last fully-published commit timestamp. Advanced at publish on the ON
   // path, seeded from recovered max commit ts on startup. NEVER persisted (durable data is flag-independent).
   std::atomic<uint64_t> last_committed_mvcc_ts_{kTimestampInitialId};
@@ -873,8 +889,8 @@ class Accessor {
   // NOLINTNEXTLINE(google-default-arguments)
   // preheld_commit_lock: owning lock pre-acquired by the caller via TryLockCommit(); adopted here.
   // Default-constructed (non-owning) = no pre-held guard; implementation acquires blocking.
-  virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(
-      CommitArgs commit_args, std::unique_lock<std::mutex> preheld_commit_lock = {}) = 0;
+  virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args,
+                                                                              CommitLock preheld_commit_lock = {}) = 0;
 
   // NOLINTNEXTLINE(google-default-arguments)
   virtual std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) = 0;
@@ -888,7 +904,15 @@ class Accessor {
 
   // Must not be called on the OFF path: commit_mutex_ is never taken there, so the try always
   // succeeds (harmless but wasteful); gate the call with IsCommitSerialised().
-  [[nodiscard]] std::unique_lock<std::mutex> TryLockCommit() noexcept { return storage_->TryCommitLock(); }
+  [[nodiscard]] CommitLock TryLockCommit() noexcept { return storage_->TryCommitLock(); }
+
+  // Pressure-scaled timed wait. Must not be called on the OFF path (see TryLockCommit above).
+  [[nodiscard]] CommitLock TryLockCommitFor(std::chrono::microseconds budget) noexcept {
+    return storage_->TryCommitLockFor(budget);
+  }
+
+  // Blocking acquire. Must not be called on the OFF path (see TryLockCommit above).
+  [[nodiscard]] CommitLock LockCommitBlocking() { return storage_->LockCommitBlocking(); }
 
   // Stable per-query id; preserved across PERIODIC COMMIT.
   std::optional<uint64_t> GetStartTimestamp() const;

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -70,6 +70,13 @@ std::optional<uint16_t> HotMask::GetHotElement() {
   return {};
 }
 
+bool HotMask::AnySet() const noexcept {
+  for (size_t g = 0; g < n_groups_; ++g) {
+    if (hot_masks_[g].load(std::memory_order_acquire) != 0) return true;
+  }
+  return false;
+}
+
 PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16_t high_priority_threads_count,
                                        ThreadInitCallback thread_init_callback)
     : hot_threads_{mixed_work_threads_count}, task_id_{kMaxLowPriorityId}, last_wid_{0} {
@@ -89,6 +96,7 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
     pool_.emplace_back([this, i, &barrier, thread_init_callback]() {
       // Divide work by each thread
       workers_[i] = std::make_unique<Worker>();
+      workers_[i]->productive_pending_ = &productive_pending_;
       barrier.arrive_and_wait();
       // Call user-defined thread initialization callback (e.g., to register with Python interpreter)
       if (thread_init_callback) {
@@ -101,6 +109,7 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
   for (size_t i = 0; i < high_priority_threads_count; ++i) {
     pool_.emplace_back([this, i, &barrier, thread_init_callback]() {
       hp_workers_[i] = std::make_unique<Worker>();
+      hp_workers_[i]->productive_pending_ = &productive_pending_;
       barrier.arrive_and_wait();
       // Call user-defined thread initialization callback (e.g., to register with Python interpreter)
       if (thread_init_callback) {
@@ -114,46 +123,82 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
 
   // Under heavy load a task can get stuck, monitor and move to different thread
   monitoring_.SetInterval(std::chrono::milliseconds(100));
-  monitoring_.Run("sched_mon",
-                  [this,
-                   workers_num = workers_.size(),
-                   hp_workers_num = hp_workers_.size(),
-                   last_task = std::array<TaskID, kMaxWorkers>{}]() mutable {
-                    size_t i = 0;
-                    for (auto &worker : workers_) {
-                      const auto worker_id = i++;
-                      auto &worker_last_task = last_task[worker_id];
-                      auto update = utils::OnScopeExit{[&]() mutable { worker_last_task = worker->last_task_; }};
-                      if (worker_last_task == worker->last_task_ && worker->working_ && worker->has_pending_work_) {
-                        // worker stuck on a task; move task to a different queue
-                        auto l = std::unique_lock{worker->mtx_, std::defer_lock};
-                        if (!l.try_lock()) continue;  // Thread is busy...
-                        // Recheck under lock
-                        if (worker->work_.empty() || worker_last_task != worker->last_task_) continue;
-                        // Update flag as soon as possible
-                        worker->has_pending_work_.store(worker->work_.size() > 1, std::memory_order_release);
-                        Worker::Work work{.id = worker->work_.top().id, .work = std::move(worker->work_.top().work)};
-                        worker->work_.pop();
-                        l.unlock();
+  monitoring_.Run(
+      "sched_mon",
+      [this,
+       workers_num = workers_.size(),
+       hp_workers_num = hp_workers_.size(),
+       last_task = std::array<TaskID, kMaxWorkers>{}]() mutable {
+        size_t i = 0;
+        for (auto &worker : workers_) {
+          const auto worker_id = i++;
+          auto &worker_last_task = last_task[worker_id];
+          auto update = utils::OnScopeExit{[&]() mutable { worker_last_task = worker->last_task_; }};
+          if (worker_last_task == worker->last_task_ && worker->working_ && worker->has_pending_work_) {
+            // worker stuck on a task; move task to a different queue
+            auto l = std::unique_lock{worker->mtx_, std::defer_lock};
+            if (!l.try_lock()) continue;  // Thread is busy...
+            // Recheck under lock
+            if (worker->work_.empty() || worker_last_task != worker->last_task_) continue;
+            // Update flag as soon as possible
+            worker->has_pending_work_.store(worker->work_.size() > 1, std::memory_order_release);
+            const bool prod = worker->work_.top().productive;
+            Worker::Work work{
+                .id = worker->work_.top().id, .work = std::move(worker->work_.top().work), .productive = prod};
+            if (prod) productive_pending_.fetch_sub(1, std::memory_order_relaxed);
+            worker->work_.pop();
+            l.unlock();
 
-                        auto tid = hot_threads_.GetHotElement();
-                        if (!tid) {
-                          // No hot LP threads available; schedule HP work to HP thread
-                          if (work.id > kMinHighPriorityId) {
-                            static size_t last_hp_thread = 0;
-                            auto &hp_worker = hp_workers_[hp_workers_num > 1 ? last_hp_thread++ % hp_workers_num : 0];
-                            if (!hp_worker->has_pending_work_) {
-                              hp_worker->push(std::move(work.work), work.id);
-                              continue;
-                            }
-                          }
-                          // No hot thread and low priority work, schedule to the next lp worker
-                          tid = (worker_id + 1) % workers_num;
-                        }
-                        workers_[*tid]->push(std::move(work.work), work.id);
-                      }
-                    }
-                  });
+            auto tid = hot_threads_.GetHotElement();
+            if (!tid) {
+              // No hot LP threads available; schedule HP work to HP thread
+              if (work.id > kMinHighPriorityId) {
+                static size_t last_hp_thread = 0;
+                auto &hp_worker = hp_workers_[hp_workers_num > 1 ? last_hp_thread++ % hp_workers_num : 0];
+                if (!hp_worker->has_pending_work_) {
+                  hp_worker->push(std::move(work.work), work.id, work.productive);
+                  continue;
+                }
+              }
+              // No hot thread and low priority work, schedule to the next lp worker
+              tid = (worker_id + 1) % workers_num;
+            }
+            workers_[*tid]->push(std::move(work.work), work.id, work.productive);
+          }
+        }
+
+        // Admission park sweep: re-inject timed-out entries and kick the oldest to
+        // prevent starvation.  parked_mtx_ is never held across ScheduledReAddTask
+        // (which acquires Worker::mtx_).
+        {
+          const auto now = std::chrono::steady_clock::now();
+          using WakeEntry = std::pair<TaskID, TaskSignature>;
+          std::vector<WakeEntry> wakeups;
+          {
+            std::unique_lock lk{parked_mtx_};
+            if (!parked_admissions_.empty()) {
+              wakeups.reserve(parked_admissions_.size());
+              for (auto it = parked_admissions_.begin(); it != parked_admissions_.end();) {
+                if (it->deadline <= now) {
+                  wakeups.emplace_back(it->id, std::move(it->task));
+                  it = parked_admissions_.erase(it);
+                } else {
+                  ++it;
+                }
+              }
+              // Backstop: kick the oldest remaining entry to prevent starvation.
+              if (!parked_admissions_.empty()) {
+                wakeups.emplace_back(parked_admissions_.front().id, std::move(parked_admissions_.front().task));
+                parked_admissions_.pop_front();
+              }
+              has_parked_.store(!parked_admissions_.empty(), std::memory_order_release);
+            }
+          }
+          for (auto &[id, task] : wakeups) {
+            ScheduledReAddTask(std::move(task), id, utils::Priority::LOW, /*productive=*/false);
+          }
+        }
+      });
 }
 
 PriorityThreadPool::~PriorityThreadPool() {
@@ -165,24 +210,38 @@ PriorityThreadPool::~PriorityThreadPool() {
 void PriorityThreadPool::AwaitShutdown() { pool_.clear(); }
 
 void PriorityThreadPool::ShutDown() {
+  // (RC-3) Stop monitor FIRST so no sweep tick can race the drain below.
+  monitoring_.Stop();
+  // (RC-1/RC-2) Mark drain: ParkAdmission now drops new arrivals under parked_mtx_.
+  draining_admissions_.store(true, std::memory_order_release);
   {
-    pool_stop_source_.request_stop();
-    // Stop monitoring thread before workers
-    monitoring_.Stop();
-    // Mixed work workers
-    for (auto &worker : workers_) {
-      worker->stop();
+    std::deque<ParkedAdmission> drain;
+    {
+      std::unique_lock lk{parked_mtx_};
+      drain.swap(parked_admissions_);
+      has_parked_.store(false, std::memory_order_release);
     }
-    // High priority workers
-    for (auto &worker : hp_workers_) {
-      worker->stop();
-    }
+    // Running each continuation directly lets the session driver observe IsDrainingAdmissions()
+    // and fail the client cleanly (no re-park — the driver terminates); stragglers that park after
+    // the swap are dropped and the client is errored by connection teardown.
+    for (auto &e : drain) e.task(utils::Priority::LOW);
+  }
+  // AFTER the drain: ScheduledReAddTask's stop-guard now trips for external callers.
+  pool_stop_source_.request_stop();
+  // Mixed work workers
+  for (auto &worker : workers_) {
+    worker->stop();
+  }
+  // High priority workers
+  for (auto &worker : hp_workers_) {
+    worker->stop();
   }
 }
 
-void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, const Priority priority) {
+PriorityThreadPool::TaskID PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, Priority priority,
+                                                                bool productive) {
   if (pool_stop_source_.stop_requested()) [[unlikely]] {
-    return;
+    return 0;
   }
   const auto id = (TaskID(priority == Priority::HIGH) * kMinHighPriorityId) +
                   --task_id_;  // Way to priorities hp tasks and older tasks
@@ -195,15 +254,78 @@ void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, const Priority
     // If no hot thread found, give it to the next thread
     tid = last_wid_++ % max_wakeup_thread;
   }
-  workers_[*tid]->push(std::move(new_task), id);
+  workers_[*tid]->push(std::move(new_task), id, productive);
   // High priority tasks are marked and given to mixed priority threads (at front of the queue)
   // HP threads are going to steal this work if not executed in time
+  return id;
 }
 
-void PriorityThreadPool::Worker::push(TaskSignature new_task, TaskID id) {
+PriorityThreadPool::TaskID PriorityThreadPool::ScheduledReAddTask(TaskSignature task, TaskID id, Priority priority,
+                                                                  bool productive) {
+  (void)priority;  // Not used for id computation here; kept for API symmetry with ScheduledAddTask
+  if (pool_stop_source_.stop_requested()) [[unlikely]] {
+    return 0;
+  }
+  auto tid = hot_threads_.GetHotElement();
+  if (!tid) {
+    static const auto max_wakeup_thread =
+        std::max(1UL, std::min(static_cast<TaskID>(GetSafeHardwareConcurrency()), workers_.size()));
+    tid = last_wid_++ % max_wakeup_thread;
+  }
+  workers_[*tid]->push(std::move(task), id, productive);
+  return id;
+}
+
+bool PriorityThreadPool::HasPendingWork() const noexcept {
+  // Productive (non-admission) queued work only: admission re-posts carry productive=false and never
+  // touch productive_pending_, so a reschedule storm cannot keep this gate open.
+  return productive_pending_.load(std::memory_order_relaxed) > 0;
+}
+
+void PriorityThreadPool::ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline,
+                                       WaitTag tag) {
+  std::unique_lock lk{parked_mtx_};
+  if (draining_admissions_.load(std::memory_order_acquire)) return;  // shutting down: drop; teardown errors the client
+  parked_admissions_.push_back({id, std::move(task), deadline, tag});
+  has_parked_.store(true, std::memory_order_release);
+}
+
+bool PriorityThreadPool::ShouldParkAdmission() const noexcept {
+  // Park only when there is other productive work AND no idle worker to take it — yielding this
+  // core actually lets real work run; otherwise the caller keeps bounded-spinning.
+  return productive_pending_.load(std::memory_order_acquire) > 0 && !hot_threads_.AnySet();
+}
+
+void PriorityThreadPool::WakeMatching(FreedTag freed) {
+  // Fast-path: if has_parked_ is false, there is nothing to wake.
+  // A false-negative (stale true → we proceed under the lock unnecessarily) is safe.
+  // A false-positive (stale false → we skip a real entry) is covered by the monitor sweep backstop.
+  if (!has_parked_.load(std::memory_order_relaxed)) return;
+
+  using WakeEntry = std::pair<TaskID, TaskSignature>;
+  std::vector<WakeEntry> wakeups;
+  {
+    std::unique_lock lk{parked_mtx_};
+    for (auto it = parked_admissions_.begin(); it != parked_admissions_.end();) {
+      if (it->tag.resource == freed.resource) {
+        wakeups.emplace_back(it->id, std::move(it->task));
+        it = parked_admissions_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    has_parked_.store(!parked_admissions_.empty(), std::memory_order_release);
+  }  // release parked_mtx_ BEFORE ScheduledReAddTask (which acquires Worker::mtx_)
+  for (auto &[id, task] : wakeups) {
+    ScheduledReAddTask(std::move(task), id, utils::Priority::LOW, /*productive=*/false);
+  }
+}
+
+void PriorityThreadPool::Worker::push(TaskSignature new_task, TaskID id, bool productive) {
   {
     auto l = std::unique_lock{mtx_};
-    work_.emplace(id, std::move(new_task));
+    if (productive && productive_pending_) productive_pending_->fetch_add(1, std::memory_order_relaxed);
+    work_.emplace(id, std::move(new_task), productive);
   }
   has_pending_work_ = true;
   cv_.notify_one();
@@ -249,6 +371,7 @@ void PriorityThreadPool::Worker::operator()(const uint16_t worker_id,
   auto pop_task = [&] {
     has_pending_work_.store(work_.size() > 1, std::memory_order::release);
     last_task_.store(work_.top().id, std::memory_order_release);
+    if (work_.top().productive && productive_pending_) productive_pending_->fetch_sub(1, std::memory_order_relaxed);
     task = std::move(work_.top().work);
     work_.pop();
   };
@@ -300,6 +423,8 @@ void PriorityThreadPool::Worker::operator()(const uint16_t worker_id,
 
         // Move work to current thread
         last_task_.store(worker->work_.top().id, std::memory_order_release);
+        if (worker->work_.top().productive && productive_pending_)
+          productive_pending_->fetch_sub(1, std::memory_order_relaxed);
         task = std::move(worker->work_.top().work);
 
         worker->work_.pop();

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -167,9 +167,8 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
           }
         }
 
-        // Admission park sweep: re-inject timed-out entries and kick the oldest to
-        // prevent starvation.  parked_mtx_ is never held across ScheduledReAddTask
-        // (which acquires Worker::mtx_).
+        // Sweep parked admissions: re-inject expired entries; kick oldest to prevent starvation.
+        // parked_mtx_ is released before the wakeup loop so ScheduledReAddTask can acquire Worker::mtx_.
         {
           const auto now = std::chrono::steady_clock::now();
           using WakeEntry = std::pair<TaskID, TaskSignature>;
@@ -210,9 +209,8 @@ PriorityThreadPool::~PriorityThreadPool() {
 void PriorityThreadPool::AwaitShutdown() { pool_.clear(); }
 
 void PriorityThreadPool::ShutDown() {
-  // (RC-3) Stop monitor FIRST so no sweep tick can race the drain below.
+  // Stop monitor before the drain so no sweep tick can race the swap below.
   monitoring_.Stop();
-  // (RC-1/RC-2) Mark drain: ParkAdmission now drops new arrivals under parked_mtx_.
   draining_admissions_.store(true, std::memory_order_release);
   {
     std::deque<ParkedAdmission> drain;
@@ -221,18 +219,15 @@ void PriorityThreadPool::ShutDown() {
       drain.swap(parked_admissions_);
       has_parked_.store(false, std::memory_order_release);
     }
-    // Running each continuation directly lets the session driver observe IsDrainingAdmissions()
-    // and fail the client cleanly (no re-park — the driver terminates); stragglers that park after
-    // the swap are dropped and the client is errored by connection teardown.
+    // Running continuations directly lets the session driver observe IsDrainingAdmissions() and
+    // fail cleanly; stragglers that slip in after the swap are dropped by connection teardown.
     for (auto &e : drain) e.task(utils::Priority::LOW);
   }
-  // AFTER the drain: ScheduledReAddTask's stop-guard now trips for external callers.
+  // After drain: pool_stop_source_ stop trips ScheduledReAddTask's stop-guard.
   pool_stop_source_.request_stop();
-  // Mixed work workers
   for (auto &worker : workers_) {
     worker->stop();
   }
-  // High priority workers
   for (auto &worker : hp_workers_) {
     worker->stop();
   }
@@ -277,8 +272,6 @@ PriorityThreadPool::TaskID PriorityThreadPool::ScheduledReAddTask(TaskSignature 
 }
 
 bool PriorityThreadPool::HasPendingWork() const noexcept {
-  // Productive (non-admission) queued work only: admission re-posts carry productive=false and never
-  // touch productive_pending_, so a reschedule storm cannot keep this gate open.
   return productive_pending_.load(std::memory_order_relaxed) > 0;
 }
 
@@ -291,15 +284,12 @@ void PriorityThreadPool::ParkAdmission(TaskSignature task, TaskID id, std::chron
 }
 
 bool PriorityThreadPool::ShouldParkAdmission() const noexcept {
-  // Park only when there is other productive work AND no idle worker to take it — yielding this
-  // core actually lets real work run; otherwise the caller keeps bounded-spinning.
   return productive_pending_.load(std::memory_order_acquire) > 0 && !hot_threads_.AnySet();
 }
 
 void PriorityThreadPool::WakeMatching(FreedTag freed) {
-  // Fast-path: if has_parked_ is false, there is nothing to wake.
-  // A false-negative (stale true → we proceed under the lock unnecessarily) is safe.
-  // A false-positive (stale false → we skip a real entry) is covered by the monitor sweep backstop.
+  // Relaxed fast-path: stale-true (false positive) wastes one lock acquisition; stale-false
+  // (false negative — real entry missed) is covered by the monitor sweep backstop.
   if (!has_parked_.load(std::memory_order_relaxed)) return;
 
   using WakeEntry = std::pair<TaskID, TaskSignature>;

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -259,6 +259,11 @@ PriorityThreadPool::TaskID PriorityThreadPool::ScheduledReAddTask(TaskSignature 
                                                                   bool productive) {
   (void)priority;  // Not used for id computation here; kept for API symmetry with ScheduledAddTask
   if (pool_stop_source_.stop_requested()) [[unlikely]] {
+    // Shutting down (past the parked-set drain): run the woken continuation inline rather than
+    // dropping it. It observes IsDrainingAdmissions() and fails the client cleanly, exactly as
+    // ShutDown's drain does. Dropping here would lose a task that WakeMatching pulled from the deque
+    // in the window where ShutDown swapped the parked set and then requested stop.
+    task(utils::Priority::LOW);
     return 0;
   }
   auto tid = hot_threads_.GetHotElement();
@@ -306,8 +311,17 @@ void PriorityThreadPool::WakeMatching(FreedTag freed) {
     }
     has_parked_.store(!parked_admissions_.empty(), std::memory_order_release);
   }  // release parked_mtx_ BEFORE ScheduledReAddTask (which acquires Worker::mtx_)
+  // If the pool is draining, run the woken continuations inline (each fails the client cleanly via
+  // IsDrainingAdmissions()) instead of rescheduling onto workers that ShutDown is about to stop.
+  // ScheduledReAddTask's own stop-guard covers the narrower window where stop is requested after this
+  // check; between them a task pulled out of the deque here is never lost.
+  const bool draining = draining_admissions_.load(std::memory_order_acquire);
   for (auto &[id, task] : wakeups) {
-    ScheduledReAddTask(std::move(task), id, utils::Priority::LOW, /*productive=*/false);
+    if (draining) [[unlikely]] {
+      task(utils::Priority::LOW);
+    } else {
+      ScheduledReAddTask(std::move(task), id, utils::Priority::LOW, /*productive=*/false);
+    }
   }
 }
 

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -304,7 +304,7 @@ std::chrono::microseconds PriorityThreadPool::AdmissionTryBudget() const noexcep
   // perf-tunable.
   const uint64_t safe_pool = pool > 0 ? pool : 1;
   const uint64_t clamped_backlog = backlog < safe_pool ? backlog : safe_pool;
-  const uint64_t range = static_cast<uint64_t>(kTryBudgetMax.count() - kTryBudgetMin.count());
+  const auto range = static_cast<uint64_t>(kTryBudgetMax.count() - kTryBudgetMin.count());
   const int64_t budget_us =
       static_cast<int64_t>(kTryBudgetMax.count()) - static_cast<int64_t>((clamped_backlog * range) / safe_pool);
 
@@ -348,7 +348,7 @@ void PriorityThreadPool::ParkAdmission(TaskSignature task, TaskID id, std::chron
                                        WaitTag tag) {
   std::unique_lock lk{parked_mtx_};
   if (draining_admissions_.load(std::memory_order_acquire)) return;  // shutting down: drop; teardown errors the client
-  parked_admissions_.push_back({id, std::move(task), deadline, tag});
+  parked_admissions_.push_back({.id = id, .task = std::move(task), .deadline = deadline, .tag = tag});
   has_parked_.store(true, std::memory_order_release);
 }
 

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -322,6 +322,34 @@ std::chrono::microseconds PriorityThreadPool::AdmissionTryBudget() const noexcep
   return std::chrono::microseconds{clamped};
 }
 
+uint32_t PriorityThreadPool::AdmissionRescheduleCap() const noexcept {
+  // All reads are relaxed: this is a heuristic pressure signal, not a synchronisation barrier.
+  const uint64_t pool = GetNumWorkers();
+  const uint64_t free = FreeWorkers();
+  const uint64_t backlog = QueuedProductiveTasks();
+
+  // Scarce-worker fast path: fewer than 10% workers idle → park immediately (core is precious).
+  if (free * 10 < pool) return kRescheduleCapMin;
+
+  // No-pressure fast path: ≥10% workers idle and backlog empty → maximum reschedule budget.
+  if (backlog == 0) return kRescheduleCapMax;
+
+  // Linear interpolation from kRescheduleCapMax down toward kRescheduleCapMin as backlog fills the pool.
+  // fraction = min(backlog, pool) / pool  — clamped to [0, 1] using integer arithmetic only.
+  // safe_pool guards the division; pool >= 1 is guaranteed by the constructor MG_ASSERT.
+  // PROVISIONAL: the exact slope and threshold constants are perf-tunable.
+  const uint64_t safe_pool = pool > 0 ? pool : 1;
+  const uint64_t clamped_backlog = backlog < safe_pool ? backlog : safe_pool;
+  const uint32_t range = kRescheduleCapMax - kRescheduleCapMin;
+  const uint32_t reduction = static_cast<uint32_t>((clamped_backlog * range) / safe_pool);
+  const uint32_t cap = kRescheduleCapMax > reduction ? kRescheduleCapMax - reduction : kRescheduleCapMin;
+
+  // Final clamp: protect against any arithmetic edge case.
+  if (cap < kRescheduleCapMin) return kRescheduleCapMin;
+  if (cap > kRescheduleCapMax) return kRescheduleCapMax;
+  return cap;
+}
+
 void PriorityThreadPool::ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline,
                                        WaitTag tag) {
   std::unique_lock lk{parked_mtx_};

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -12,6 +12,7 @@
 #include "utils/priority_thread_pool.hpp"
 
 #include <atomic>
+#include <bit>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -75,6 +76,18 @@ bool HotMask::AnySet() const noexcept {
     if (hot_masks_[g].load(std::memory_order_acquire) != 0) return true;
   }
   return false;
+}
+
+uint16_t HotMask::Count() const noexcept {
+  // Relaxed loads are intentional: Count() is a soft pressure signal, not a synchronisation point.
+  // Stale bits (worker just transitioned hot→cold or vice versa) are tolerable; callers treat the
+  // result as an approximate snapshot.
+  uint32_t total = 0;
+  for (size_t g = 0; g < n_groups_; ++g) {
+    total += std::popcount(hot_masks_[g].load(std::memory_order_relaxed));
+  }
+  // total ≤ n_groups_ * 64 ≤ 1024, safe to narrow to uint16_t.
+  return static_cast<uint16_t>(total);
 }
 
 PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16_t high_priority_threads_count,
@@ -278,6 +291,35 @@ PriorityThreadPool::TaskID PriorityThreadPool::ScheduledReAddTask(TaskSignature 
 
 bool PriorityThreadPool::HasPendingWork() const noexcept {
   return productive_pending_.load(std::memory_order_relaxed) > 0;
+}
+
+std::chrono::microseconds PriorityThreadPool::AdmissionTryBudget() const noexcept {
+  // All reads are relaxed: this is a heuristic pressure signal, not a synchronisation barrier.
+  const uint64_t pool = GetNumWorkers();
+  const uint64_t free = FreeWorkers();
+  const uint64_t backlog = QueuedProductiveTasks();
+
+  // No-pressure fast path: ≥10% workers idle and backlog empty → caller can afford to sleep long.
+  if (free * 10 >= pool && backlog == 0) return kTryBudgetMax;
+
+  // Linear interpolation from kTryBudgetMax toward kTryBudgetMin as backlog fills the pool.
+  // fraction = min(backlog, pool) / pool  — clamped to [0, 1] using integer arithmetic only.
+  // safe_pool guards the division; pool >= 1 is guaranteed by the constructor MG_ASSERT.
+  // PROVISIONAL: the exact slope and threshold constants below are perf-tunable.
+  const uint64_t safe_pool = pool > 0 ? pool : 1;
+  const uint64_t clamped_backlog = backlog < safe_pool ? backlog : safe_pool;
+  const uint64_t range = static_cast<uint64_t>(kTryBudgetMax.count() - kTryBudgetMin.count());
+  const int64_t budget_us =
+      static_cast<int64_t>(kTryBudgetMax.count()) - static_cast<int64_t>((clamped_backlog * range) / safe_pool);
+
+  // Scarce-worker clamp: fewer than 10% free → collapse immediately to minimum regardless of backlog.
+  if (free * 10 < pool) return kTryBudgetMin;
+
+  // Final bounds: protect against any arithmetic edge case.
+  const int64_t clamped = budget_us < kTryBudgetMin.count()   ? kTryBudgetMin.count()
+                          : budget_us > kTryBudgetMax.count() ? kTryBudgetMax.count()
+                                                              : budget_us;
+  return std::chrono::microseconds{clamped};
 }
 
 void PriorityThreadPool::ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline,

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -79,9 +79,7 @@ bool HotMask::AnySet() const noexcept {
 }
 
 uint16_t HotMask::Count() const noexcept {
-  // Relaxed loads are intentional: Count() is a soft pressure signal, not a synchronisation point.
-  // Stale bits (worker just transitioned hot→cold or vice versa) are tolerable; callers treat the
-  // result as an approximate snapshot.
+  // Relaxed: Count() is a soft pressure signal; stale bits from an in-flight hot→cold transition are tolerable.
   uint32_t total = 0;
   for (size_t g = 0; g < n_groups_; ++g) {
     total += std::popcount(hot_masks_[g].load(std::memory_order_relaxed));
@@ -302,10 +300,8 @@ std::chrono::microseconds PriorityThreadPool::AdmissionTryBudget() const noexcep
   // No-pressure fast path: ≥10% workers idle and backlog empty → caller can afford to sleep long.
   if (free * 10 >= pool && backlog == 0) return kTryBudgetMax;
 
-  // Linear interpolation from kTryBudgetMax toward kTryBudgetMin as backlog fills the pool.
-  // fraction = min(backlog, pool) / pool  — clamped to [0, 1] using integer arithmetic only.
-  // safe_pool guards the division; pool >= 1 is guaranteed by the constructor MG_ASSERT.
-  // PROVISIONAL: the exact slope and threshold constants below are perf-tunable.
+  // T(P) = kTryBudgetMax − (clamped_backlog/pool)×range; pool ≥ 2 by MG_ASSERT. PROVISIONAL: constants are
+  // perf-tunable.
   const uint64_t safe_pool = pool > 0 ? pool : 1;
   const uint64_t clamped_backlog = backlog < safe_pool ? backlog : safe_pool;
   const uint64_t range = static_cast<uint64_t>(kTryBudgetMax.count() - kTryBudgetMin.count());
@@ -315,10 +311,11 @@ std::chrono::microseconds PriorityThreadPool::AdmissionTryBudget() const noexcep
   // Scarce-worker clamp: fewer than 10% free → collapse immediately to minimum regardless of backlog.
   if (free * 10 < pool) return kTryBudgetMin;
 
-  // Final bounds: protect against any arithmetic edge case.
-  const int64_t clamped = budget_us < kTryBudgetMin.count()   ? kTryBudgetMin.count()
-                          : budget_us > kTryBudgetMax.count() ? kTryBudgetMax.count()
-                                                              : budget_us;
+  int64_t clamped = budget_us;
+  if (budget_us < kTryBudgetMin.count())
+    clamped = kTryBudgetMin.count();
+  else if (budget_us > kTryBudgetMax.count())
+    clamped = kTryBudgetMax.count();
   return std::chrono::microseconds{clamped};
 }
 
@@ -334,17 +331,14 @@ uint32_t PriorityThreadPool::AdmissionRescheduleCap() const noexcept {
   // No-pressure fast path: ≥10% workers idle and backlog empty → maximum reschedule budget.
   if (backlog == 0) return kRescheduleCapMax;
 
-  // Linear interpolation from kRescheduleCapMax down toward kRescheduleCapMin as backlog fills the pool.
-  // fraction = min(backlog, pool) / pool  — clamped to [0, 1] using integer arithmetic only.
-  // safe_pool guards the division; pool >= 1 is guaranteed by the constructor MG_ASSERT.
-  // PROVISIONAL: the exact slope and threshold constants are perf-tunable.
+  // N(P) = kRescheduleCapMax − (clamped_backlog/pool)×range; pool ≥ 2 by MG_ASSERT. PROVISIONAL: constants are
+  // perf-tunable.
   const uint64_t safe_pool = pool > 0 ? pool : 1;
   const uint64_t clamped_backlog = backlog < safe_pool ? backlog : safe_pool;
   const uint32_t range = kRescheduleCapMax - kRescheduleCapMin;
-  const uint32_t reduction = static_cast<uint32_t>((clamped_backlog * range) / safe_pool);
+  const auto reduction = static_cast<uint32_t>((clamped_backlog * range) / safe_pool);
   const uint32_t cap = kRescheduleCapMax > reduction ? kRescheduleCapMax - reduction : kRescheduleCapMin;
 
-  // Final clamp: protect against any arithmetic edge case.
   if (cap < kRescheduleCapMin) return kRescheduleCapMin;
   if (cap > kRescheduleCapMax) return kRescheduleCapMax;
   return cap;

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -185,7 +185,7 @@ PriorityThreadPool::PriorityThreadPool(uint16_t mixed_work_threads_count, uint16
           using WakeEntry = std::pair<TaskID, TaskSignature>;
           std::vector<WakeEntry> wakeups;
           {
-            std::unique_lock lk{parked_mtx_};
+            const std::unique_lock lk{parked_mtx_};
             if (!parked_admissions_.empty()) {
               wakeups.reserve(parked_admissions_.size());
               for (auto it = parked_admissions_.begin(); it != parked_admissions_.end();) {
@@ -226,7 +226,7 @@ void PriorityThreadPool::ShutDown() {
   {
     std::deque<ParkedAdmission> drain;
     {
-      std::unique_lock lk{parked_mtx_};
+      const std::unique_lock lk{parked_mtx_};
       drain.swap(parked_admissions_);
       has_parked_.store(false, std::memory_order_release);
     }
@@ -346,7 +346,7 @@ uint32_t PriorityThreadPool::AdmissionRescheduleCap() const noexcept {
 
 void PriorityThreadPool::ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline,
                                        WaitTag tag) {
-  std::unique_lock lk{parked_mtx_};
+  const std::unique_lock lk{parked_mtx_};
   if (draining_admissions_.load(std::memory_order_acquire)) return;  // shutting down: drop; teardown errors the client
   parked_admissions_.push_back({.id = id, .task = std::move(task), .deadline = deadline, .tag = tag});
   has_parked_.store(true, std::memory_order_release);
@@ -364,7 +364,7 @@ void PriorityThreadPool::WakeMatching(FreedTag freed) {
   using WakeEntry = std::pair<TaskID, TaskSignature>;
   std::vector<WakeEntry> wakeups;
   {
-    std::unique_lock lk{parked_mtx_};
+    const std::unique_lock lk{parked_mtx_};
     for (auto it = parked_admissions_.begin(); it != parked_admissions_.end();) {
       if (it->tag.resource == freed.resource) {
         wakeups.emplace_back(it->id, std::move(it->task));

--- a/src/utils/priority_thread_pool.hpp
+++ b/src/utils/priority_thread_pool.hpp
@@ -54,9 +54,8 @@ class HotMask {
   // Returns the position of the first set bit and resets it
   std::optional<uint16_t> GetHotElement();
 
-  // Non-destructive: true iff any group mask is set (at least one idle worker).
-  // Used by ShouldParkAdmission to avoid the destructive GetHotElement when only a
-  // park-vs-continue decision is needed.
+  // Non-destructive: true iff any worker is idle. Used by ShouldParkAdmission instead of
+  // GetHotElement to avoid consuming a hot slot for a park-vs-continue decision.
   bool AnySet() const noexcept;
 
  private:
@@ -79,19 +78,16 @@ class HotMask {
   const uint16_t n_groups_;
 };
 
-// Resource discriminant for parked admission wait tags.
 enum class WaitResource : uint8_t { MainLock, CommitLock };
 
 // Access mode carried with a park tag for future per-mode narrowing; not consulted by wake yet.
 enum class AccessMode : uint8_t { READ, WRITE, READ_ONLY, UNIQUE };
 
-// Tag attached to a parked admission identifying which resource it is blocked on.
 struct WaitTag {
   WaitResource resource;
   AccessMode mode;
 };
 
-// Passed to WakeMatching to identify which resource was just freed.
 struct FreedTag {
   WaitResource resource;
   AccessMode freed;
@@ -165,9 +161,8 @@ class PriorityThreadPool {
 
   TaskID ScheduledAddTask(TaskSignature new_task, Priority priority, bool productive = true);
 
-  // Place-keeping re-post: reuses the original id so a rescheduled admission keeps its FIFO
-  // position instead of going behind newer arrivals. productive=false so it does not feed the
-  // reschedule gate.
+  // Place-keeping re-post: reuses the original id to preserve FIFO order.
+  // productive=false so admission retries do not feed the reschedule gate.
   TaskID ScheduledReAddTask(TaskSignature task, TaskID id, Priority priority, bool productive = false);
 
   void ScheduledCollection(TaskCollection &collection) {
@@ -182,28 +177,24 @@ class PriorityThreadPool {
 
   uint64_t GetNumWorkers() const { return workers_.size() + hp_workers_.size(); }
 
-  // True iff the pool has queued productive (non-admission) tasks. Reads productive_pending_ via
-  // relaxed atomic; used to gate admission reschedule — admission re-posts are non-productive and
-  // do not increment the counter, so a pure-admission storm cannot hold the gate open.
+  // True iff queued productive (non-admission) tasks exist. Reads productive_pending_ relaxed;
+  // admission re-posts carry productive=false so an admission storm cannot hold this gate open.
   bool HasPendingWork() const noexcept;
 
-  // Park a blocked admission continuation aside (0 CPU) until a wake re-injects it.
-  // PRECONDITION (not asserted): must NOT be called while holding any Worker::mtx_ —
-  // the session continuation that calls this runs outside any worker lock.
+  // PRECONDITION: must not be called while holding any Worker::mtx_.
+  // The session continuation that calls this runs outside any worker lock.
   void ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline, WaitTag tag);
 
   // True iff parking the calling admission would let real work run. Yields the core only when
   // there is productive work queued AND no idle worker to take it.
   bool ShouldParkAdmission() const noexcept;
 
-  // Re-inject every parked admission whose tag.resource matches freed.resource. Conservative
-  // per-resource wake: mode is not consulted yet. A woken-but-still-blocked task re-parks —
-  // bounded by kMaxReparks in test harness; place-kept ids maintain FIFO order.
-  // Lock order: parked_mtx_ released BEFORE calling ScheduledReAddTask (which takes Worker::mtx_).
+  // Conservative per-resource wake: mode is not consulted (extension point for future narrowing).
+  // Lock order: parked_mtx_ released BEFORE ScheduledReAddTask (which takes Worker::mtx_).
   void WakeMatching(FreedTag freed);
 
-  // True while ShutDown is draining parked admissions. The session driver reads this to terminate
-  // a woken admission with a shutdown error instead of re-parking it (wired in a later unit).
+  // True while ShutDown drains parks; session driver reads this to terminate woken admissions with a shutdown error
+  // instead of re-parking.
   bool IsDrainingAdmissions() const noexcept { return draining_admissions_.load(std::memory_order_acquire); }
 
   // Single worker implementation
@@ -261,8 +252,8 @@ class PriorityThreadPool {
   std::mutex parked_mtx_;
   std::deque<ParkedAdmission> parked_admissions_;  // FIFO: push_back to park, front = oldest
   std::atomic_bool draining_admissions_{false};    // true while ShutDown drains → drop new parks
-  // Maintained under parked_mtx_: true while deque is non-empty.
-  // WakeMatching fast-path reads relaxed; a false-negative is fine (monitor sweep backstop covers it).
+  // Written under parked_mtx_ (release); true iff deque is non-empty.
+  // WakeMatching reads relaxed: a false-negative is safe — the monitor sweep backstop covers it.
   std::atomic<bool> has_parked_{false};
 
   std::stop_source pool_stop_source_;
@@ -278,8 +269,8 @@ class PriorityThreadPool {
   std::atomic<TaskID> task_id_;     // Generates a unique tasks id | MSB signals high priority
   std::atomic<uint16_t> last_wid_;  // Used to pick next worker
 
-  // Counts queued productive tasks (excludes admission retries). Increment in push, decrement at
-  // every pop that does not re-push. May be positive at shutdown for unrun tasks — irrelevant to the gate.
+  // Counts queued productive tasks (excludes admission retries). Incremented in push, decremented
+  // at every pop. May be positive at shutdown for unrun tasks — irrelevant to the gate.
   alignas(64) std::atomic<int64_t> productive_pending_{0};
 };
 

--- a/src/utils/priority_thread_pool.hpp
+++ b/src/utils/priority_thread_pool.hpp
@@ -12,8 +12,10 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -25,6 +27,7 @@
 #include "utils/scheduler.hpp"
 
 namespace memgraph::utils {
+
 // Thread-safe mask that returns the position of first set bit
 class HotMask {
  public:
@@ -51,6 +54,11 @@ class HotMask {
   // Returns the position of the first set bit and resets it
   std::optional<uint16_t> GetHotElement();
 
+  // Non-destructive: true iff any group mask is set (at least one idle worker).
+  // Used by ShouldParkAdmission to avoid the destructive GetHotElement when only a
+  // park-vs-continue decision is needed.
+  bool AnySet() const noexcept;
+
  private:
   static constexpr auto kGroupSize = sizeof(uint64_t) * 8;  // bits
   static constexpr auto kGroupMask = kGroupSize - 1;
@@ -69,6 +77,24 @@ class HotMask {
   const uint16_t n_elements_;
 #endif
   const uint16_t n_groups_;
+};
+
+// Resource discriminant for parked admission wait tags.
+enum class WaitResource : uint8_t { MainLock, CommitLock };
+
+// Access mode carried with a park tag for future per-mode narrowing; not consulted by wake yet.
+enum class AccessMode : uint8_t { READ, WRITE, READ_ONLY, UNIQUE };
+
+// Tag attached to a parked admission identifying which resource it is blocked on.
+struct WaitTag {
+  WaitResource resource;
+  AccessMode mode;
+};
+
+// Passed to WakeMatching to identify which resource was just freed.
+struct FreedTag {
+  WaitResource resource;
+  AccessMode freed;
 };
 
 using TaskSignature = std::move_only_function<void(utils::Priority)>;
@@ -137,7 +163,12 @@ class PriorityThreadPool {
 
   void ShutDown();
 
-  void ScheduledAddTask(TaskSignature new_task, Priority priority);
+  TaskID ScheduledAddTask(TaskSignature new_task, Priority priority, bool productive = true);
+
+  // Place-keeping re-post: reuses the original id so a rescheduled admission keeps its FIFO
+  // position instead of going behind newer arrivals. productive=false so it does not feed the
+  // reschedule gate.
+  TaskID ScheduledReAddTask(TaskSignature task, TaskID id, Priority priority, bool productive = false);
 
   void ScheduledCollection(TaskCollection &collection) {
     for (size_t i = 0; i < collection.Size(); ++i) {
@@ -150,6 +181,30 @@ class PriorityThreadPool {
   uint64_t GetNumHighPriorityWorkers() const { return hp_workers_.size(); }
 
   uint64_t GetNumWorkers() const { return workers_.size() + hp_workers_.size(); }
+
+  // True iff the pool has queued productive (non-admission) tasks. Reads productive_pending_ via
+  // relaxed atomic; used to gate admission reschedule — admission re-posts are non-productive and
+  // do not increment the counter, so a pure-admission storm cannot hold the gate open.
+  bool HasPendingWork() const noexcept;
+
+  // Park a blocked admission continuation aside (0 CPU) until a wake re-injects it.
+  // PRECONDITION (not asserted): must NOT be called while holding any Worker::mtx_ —
+  // the session continuation that calls this runs outside any worker lock.
+  void ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline, WaitTag tag);
+
+  // True iff parking the calling admission would let real work run. Yields the core only when
+  // there is productive work queued AND no idle worker to take it.
+  bool ShouldParkAdmission() const noexcept;
+
+  // Re-inject every parked admission whose tag.resource matches freed.resource. Conservative
+  // per-resource wake: mode is not consulted yet. A woken-but-still-blocked task re-parks —
+  // bounded by kMaxReparks in test harness; place-kept ids maintain FIFO order.
+  // Lock order: parked_mtx_ released BEFORE calling ScheduledReAddTask (which takes Worker::mtx_).
+  void WakeMatching(FreedTag freed);
+
+  // True while ShutDown is draining parked admissions. The session driver reads this to terminate
+  // a woken admission with a shutdown error instead of re-parking it (wired in a later unit).
+  bool IsDrainingAdmissions() const noexcept { return draining_admissions_.load(std::memory_order_acquire); }
 
   // Single worker implementation
   class Worker {
@@ -165,11 +220,12 @@ class PriorityThreadPool {
     struct Work {
       TaskID id;                   // ID used to order (issued by the pool)
       mutable TaskSignature work;  // mutable so it can be moved from the queue
+      bool productive{true};       // false for admission retries; excluded from productive_pending_
 
       bool operator<(const Work &other) const { return id < other.id; }
     };
 
-    void push(TaskSignature new_task, TaskID id);
+    void push(TaskSignature new_task, TaskID id, bool productive = true);
 
     void stop();
 
@@ -188,10 +244,27 @@ class PriorityThreadPool {
     // Used by monitor to decide if worker is blocked
     std::atomic<TaskID> last_task_{0};
 
+    // Pool-owned counter; set once after construction, never null at task time.
+    std::atomic<int64_t> *productive_pending_{nullptr};
+
     friend class PriorityThreadPool;
   };
 
  private:
+  struct ParkedAdmission {
+    TaskID id;
+    mutable TaskSignature task;  // mutable: moved out of the deque even via const ref
+    std::chrono::steady_clock::time_point deadline;
+    WaitTag tag;
+  };
+
+  std::mutex parked_mtx_;
+  std::deque<ParkedAdmission> parked_admissions_;  // FIFO: push_back to park, front = oldest
+  std::atomic_bool draining_admissions_{false};    // true while ShutDown drains → drop new parks
+  // Maintained under parked_mtx_: true while deque is non-empty.
+  // WakeMatching fast-path reads relaxed; a false-negative is fine (monitor sweep backstop covers it).
+  std::atomic<bool> has_parked_{false};
+
   std::stop_source pool_stop_source_;
 
   std::vector<std::unique_ptr<Worker>> workers_;  // Mixed work threads
@@ -204,6 +277,10 @@ class PriorityThreadPool {
 
   std::atomic<TaskID> task_id_;     // Generates a unique tasks id | MSB signals high priority
   std::atomic<uint16_t> last_wid_;  // Used to pick next worker
+
+  // Counts queued productive tasks (excludes admission retries). Increment in push, decrement at
+  // every pop that does not re-push. May be positive at shutdown for unrun tasks — irrelevant to the gate.
+  alignas(64) std::atomic<int64_t> productive_pending_{0};
 };
 
 class CollectionScheduler {

--- a/src/utils/priority_thread_pool.hpp
+++ b/src/utils/priority_thread_pool.hpp
@@ -58,6 +58,10 @@ class HotMask {
   // GetHotElement to avoid consuming a hot slot for a park-vs-continue decision.
   bool AnySet() const noexcept;
 
+  // Non-destructive count of idle workers (set bits across all group atomics).
+  // Uses relaxed loads — caller treats result as a soft pressure signal, not an exact snapshot.
+  uint16_t Count() const noexcept;
+
  private:
   static constexpr auto kGroupSize = sizeof(uint64_t) * 8;  // bits
   static constexpr auto kGroupMask = kGroupSize - 1;
@@ -181,6 +185,22 @@ class PriorityThreadPool {
   // admission re-posts carry productive=false so an admission storm cannot hold this gate open.
   bool HasPendingWork() const noexcept;
 
+  // Number of queued productive (non-admission-retry) tasks. Clamped to 0 for negative transients
+  // caused by the relaxed-decrement / relaxed-increment ordering gap during a fast pop.
+  uint64_t QueuedProductiveTasks() const noexcept {
+    const auto v = productive_pending_.load(std::memory_order_relaxed);
+    return v > 0 ? static_cast<uint64_t>(v) : 0;
+  }
+
+  // Number of currently idle workers (hot-mask set bits). Soft signal: caller must tolerate races.
+  uint16_t FreeWorkers() const noexcept { return hot_threads_.Count(); }
+
+  // Returns a pressure-scaled timed-wait budget for an admission that would otherwise block.
+  // No-pressure (free workers available, empty backlog) → kTryBudgetMax (long sleep is fine).
+  // High-pressure (backlog growing or workers scarce) → down to kTryBudgetMin.
+  // Call sites: would-block lock acquire paths (commit_mutex_, main_lock_). See AdmissionTryBudget().
+  std::chrono::microseconds AdmissionTryBudget() const noexcept;
+
   // PRECONDITION: must not be called while holding any Worker::mtx_.
   // The session continuation that calls this runs outside any worker lock.
   void ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline, WaitTag tag);
@@ -242,6 +262,11 @@ class PriorityThreadPool {
   };
 
  private:
+  // Pressure-to-budget range for AdmissionTryBudget(). Both values are provisional and must be
+  // re-validated against real workload profiles before hardening (perf-tunable).
+  static constexpr std::chrono::microseconds kTryBudgetMin{2};        // tightest budget under max pressure
+  static constexpr std::chrono::microseconds kTryBudgetMax{100'000};  // 100 ms: no-pressure long wait
+
   struct ParkedAdmission {
     TaskID id;
     mutable TaskSignature task;  // mutable: moved out of the deque even via const ref

--- a/src/utils/priority_thread_pool.hpp
+++ b/src/utils/priority_thread_pool.hpp
@@ -201,6 +201,14 @@ class PriorityThreadPool {
   // Call sites: would-block lock acquire paths (commit_mutex_, main_lock_). See AdmissionTryBudget().
   std::chrono::microseconds AdmissionTryBudget() const noexcept;
 
+  // Returns a pressure-scaled reschedule cap N(P): the number of times an admission re-posts
+  // (via AddTask) before parking (via ParkAdmission).  Scales inversely with pressure:
+  //   - high pressure (scarce workers or large backlog) → small N → park sooner (core is precious).
+  //   - light/moderate pressure → larger N → a cheap re-post is preferred over a park CV round-trip
+  //     when the held lock is expected to free quickly.
+  // PROVISIONAL: kRescheduleCapMin/Max are perf-tunable — re-validate against real workload profiles.
+  uint32_t AdmissionRescheduleCap() const noexcept;
+
   // PRECONDITION: must not be called while holding any Worker::mtx_.
   // The session continuation that calls this runs outside any worker lock.
   void ParkAdmission(TaskSignature task, TaskID id, std::chrono::steady_clock::time_point deadline, WaitTag tag);
@@ -266,6 +274,10 @@ class PriorityThreadPool {
   // re-validated against real workload profiles before hardening (perf-tunable).
   static constexpr std::chrono::microseconds kTryBudgetMin{2};        // tightest budget under max pressure
   static constexpr std::chrono::microseconds kTryBudgetMax{100'000};  // 100 ms: no-pressure long wait
+
+  // Reschedule-cap range for AdmissionRescheduleCap(). Provisional/perf-tunable.
+  static constexpr uint32_t kRescheduleCapMin{1};  // park after 1 reschedule under high pressure
+  static constexpr uint32_t kRescheduleCapMax{4};  // park after 4 reschedules under light pressure
 
   struct ParkedAdmission {
     TaskID id;

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
@@ -135,7 +136,8 @@ struct ResourceLock {
       cv.notify_all();
       // Fired off `mtx` (already unlocked above) so the hook may take an unrelated lock without a
       // lock-order inversion. Covers all six NotifyKind::All points, since they all route here.
-      if (on_notify_all_) on_notify_all_();
+      // acquire pairs with the release in SetNotifyHook: the storage_ write is visible to this load.
+      if (auto *h = on_notify_all_.load(std::memory_order_acquire)) (*h)();
     }
   }
 
@@ -246,11 +248,19 @@ struct ResourceLock {
   void unlock() { release<LockReq::UNIQUE>(); }
 
   /// Installs a callback fired inside maybe_notify (after the internal mtx is released) on every
-  /// NotifyKind::All. Intended to wake parked schedulers waiting on this lock. Set ONCE at owner
-  /// construction, before the lock is shared with other threads: the callback is read off-mtx in
-  /// maybe_notify, so a concurrent SetNotifyHook would race. An empty hook (the default) is a single
-  /// null-check of overhead and no behavior change, so every other ResourceLock is unaffected.
-  void SetNotifyHook(std::move_only_function<void()> hook) { on_notify_all_ = std::move(hook); }
+  /// NotifyKind::All. Intended to wake parked schedulers waiting on this lock. Install at most once
+  /// per ResourceLock lifetime (the Storage-level exchange guard enforces this); cleared at owner
+  /// shutdown before pool destruction. release/acquire makes the callable visible to concurrent
+  /// maybe_notify readers without a mutex. An unarmed hook (the default nullptr) is a single atomic
+  /// load of overhead and no behavior change, so every other ResourceLock is unaffected.
+  void SetNotifyHook(std::move_only_function<void()> hook) {
+    on_notify_all_storage_ = std::move(hook);
+    on_notify_all_.store(on_notify_all_storage_ ? &on_notify_all_storage_ : nullptr, std::memory_order_release);
+  }
+
+  /// Disarms the hook: in-flight maybe_notify readers that loaded the old pointer still dereference
+  /// valid storage_ (never freed until ~ResourceLock, which runs after all lock activity has ceased).
+  void ClearNotifyHook() { on_notify_all_.store(nullptr, std::memory_order_release); }
 
   template <LockReq Req = LockReq::WRITE>
     requires(Req != LockReq::UNIQUE)
@@ -307,9 +317,12 @@ struct ResourceLock {
   // Callers waiting to acquire UNIQUE (blocking lock()/try_lock_for(), or a UniquePendingScope
   // campaign). Gates new shared acquisitions for writer-preference; see can_acquire.
   uint32_t unique_pending_count = 0;
-  // Optional wake hook; see SetNotifyHook. Empty on every ResourceLock except where an owner installs
-  // one. Read off-mtx in maybe_notify, so it is set once before concurrent use and never mutated after.
-  std::move_only_function<void()> on_notify_all_;
+  // Optional wake hook; see SetNotifyHook/ClearNotifyHook. on_notify_all_ is an atomic pointer to
+  // on_notify_all_storage_ (or nullptr when unarmed). Installed at most once per lifetime via
+  // release/acquire so maybe_notify can read it off-mtx without a data race. storage_ is left
+  // intact after ClearNotifyHook so in-flight readers that loaded the old pointer remain safe.
+  std::move_only_function<void()> on_notify_all_storage_;
+  std::atomic<std::move_only_function<void()> *> on_notify_all_{nullptr};
 };
 
 struct SharedResourceLockGuard {

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -12,6 +12,7 @@
 
 #include <condition_variable>
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <utility>
@@ -130,7 +131,12 @@ struct ResourceLock {
 
   void maybe_notify(std::unique_lock<std::mutex> &lock, NotifyKind kind) {
     lock.unlock();
-    if (kind == NotifyKind::All) cv.notify_all();
+    if (kind == NotifyKind::All) {
+      cv.notify_all();
+      // Fired off `mtx` (already unlocked above) so the hook may take an unrelated lock without a
+      // lock-order inversion. Covers all six NotifyKind::All points, since they all route here.
+      if (on_notify_all_) on_notify_all_();
+    }
   }
 
   /// Acquires in mode `Req`, `wait` supplying the wait strategy. Requires `lock` to own mtx; leaves
@@ -239,6 +245,13 @@ struct ResourceLock {
 
   void unlock() { release<LockReq::UNIQUE>(); }
 
+  /// Installs a callback fired inside maybe_notify (after the internal mtx is released) on every
+  /// NotifyKind::All. Intended to wake parked schedulers waiting on this lock. Set ONCE at owner
+  /// construction, before the lock is shared with other threads: the callback is read off-mtx in
+  /// maybe_notify, so a concurrent SetNotifyHook would race. An empty hook (the default) is a single
+  /// null-check of overhead and no behavior change, so every other ResourceLock is unaffected.
+  void SetNotifyHook(std::move_only_function<void()> hook) { on_notify_all_ = std::move(hook); }
+
   template <LockReq Req = LockReq::WRITE>
     requires(Req != LockReq::UNIQUE)
   void lock_shared() {
@@ -294,6 +307,9 @@ struct ResourceLock {
   // Callers waiting to acquire UNIQUE (blocking lock()/try_lock_for(), or a UniquePendingScope
   // campaign). Gates new shared acquisitions for writer-preference; see can_acquire.
   uint32_t unique_pending_count = 0;
+  // Optional wake hook; see SetNotifyHook. Empty on every ResourceLock except where an owner installs
+  // one. Read off-mtx in maybe_notify, so it is set once before concurrent use and never mutated after.
+  std::move_only_function<void()> on_notify_all_;
 };
 
 struct SharedResourceLockGuard {

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -135,8 +135,7 @@ struct ResourceLock {
     if (kind == NotifyKind::All) {
       cv.notify_all();
       // Fired off `mtx` (already unlocked above) so the hook may take an unrelated lock without a
-      // lock-order inversion. Covers all six NotifyKind::All points, since they all route here.
-      // acquire pairs with the release in SetNotifyHook: the storage_ write is visible to this load.
+      // lock-order inversion. acquire pairs with the release in SetNotifyHook: storage_ is visible.
       if (auto *h = on_notify_all_.load(std::memory_order_acquire)) (*h)();
     }
   }
@@ -247,12 +246,9 @@ struct ResourceLock {
 
   void unlock() { release<LockReq::UNIQUE>(); }
 
-  /// Installs a callback fired inside maybe_notify (after the internal mtx is released) on every
-  /// NotifyKind::All. Intended to wake parked schedulers waiting on this lock. Install at most once
-  /// per ResourceLock lifetime (the Storage-level exchange guard enforces this); cleared at owner
-  /// shutdown before pool destruction. release/acquire makes the callable visible to concurrent
-  /// maybe_notify readers without a mutex. An unarmed hook (the default nullptr) is a single atomic
-  /// load of overhead and no behavior change, so every other ResourceLock is unaffected.
+  /// Installs a callback fired after the internal mtx is released on every NotifyKind::All, intended
+  /// to wake parked schedulers. Install at most once per lifetime (exchange-guarded at the Storage
+  /// level); clear before pool destruction. release/acquire makes the callable visible off-mtx.
   void SetNotifyHook(std::move_only_function<void()> hook) {
     on_notify_all_storage_ = std::move(hook);
     on_notify_all_.store(on_notify_all_storage_ ? &on_notify_all_storage_ : nullptr, std::memory_order_release);
@@ -317,10 +313,8 @@ struct ResourceLock {
   // Callers waiting to acquire UNIQUE (blocking lock()/try_lock_for(), or a UniquePendingScope
   // campaign). Gates new shared acquisitions for writer-preference; see can_acquire.
   uint32_t unique_pending_count = 0;
-  // Optional wake hook; see SetNotifyHook/ClearNotifyHook. on_notify_all_ is an atomic pointer to
-  // on_notify_all_storage_ (or nullptr when unarmed). Installed at most once per lifetime via
-  // release/acquire so maybe_notify can read it off-mtx without a data race. storage_ is left
-  // intact after ClearNotifyHook so in-flight readers that loaded the old pointer remain safe.
+  // release/acquire so maybe_notify can load the pointer off-mtx without a data race; storage_
+  // survives ClearNotifyHook so in-flight readers that hold the old pointer stay safe.
   std::move_only_function<void()> on_notify_all_storage_;
   std::atomic<std::move_only_function<void()> *> on_notify_all_{nullptr};
 };

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -228,11 +228,8 @@ struct ResourceLock {
     return true;
   }
 
-  /// Timed variant of try_acquire_pending: waits up to `time` for can_acquire<Req>(), then
-  /// transitions from pending to held on success (deregisters the pending count). On timeout
-  /// returns false and leaves the pending registration intact so the caller can retry. Never
-  /// calls maybe_notify on failure — the caller's PendingScope destructor handles that via
-  /// unregister_pending when the campaign is finally abandoned.
+  /// Timeout: returns false, pending count stays intact for retry. On failure, no maybe_notify —
+  /// ~PendingScope calls unregister_pending which fires the wake when the campaign ends.
   template <LockReq Req, typename Rep, typename Period>
   bool try_acquire_pending_for(std::chrono::duration<Rep, Period> const &time) {
     auto guard = std::unique_lock{mtx};
@@ -704,8 +701,8 @@ class PendingScope {
     return ResourceLockGuard{*acquired_lock, ToGuardType(Req), std::adopt_lock};
   }
 
-  /// Timed variant of try_acquire: waits up to `time` for the lock to admit `Req`, then returns
-  /// the guard on success. On timeout returns nullopt and leaves the pending registration intact.
+  /// Timed variant of try_acquire: waits up to `time` for the lock to admit `Req`. On timeout
+  /// returns nullopt and leaves the pending registration intact.
   template <typename Rep, typename Period>
   std::optional<ResourceLockGuard> try_acquire_for(std::chrono::duration<Rep, Period> const &time) {
     if (lock_ == nullptr) return std::nullopt;

--- a/src/utils/resource_lock.hpp
+++ b/src/utils/resource_lock.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
@@ -223,6 +224,20 @@ struct ResourceLock {
   bool try_acquire_pending() {
     auto guard = std::unique_lock{mtx};
     if (!try_acquire<Req>()) return false;
+    pending_sub<Req>();
+    return true;
+  }
+
+  /// Timed variant of try_acquire_pending: waits up to `time` for can_acquire<Req>(), then
+  /// transitions from pending to held on success (deregisters the pending count). On timeout
+  /// returns false and leaves the pending registration intact so the caller can retry. Never
+  /// calls maybe_notify on failure — the caller's PendingScope destructor handles that via
+  /// unregister_pending when the campaign is finally abandoned.
+  template <LockReq Req, typename Rep, typename Period>
+  bool try_acquire_pending_for(std::chrono::duration<Rep, Period> const &time) {
+    auto guard = std::unique_lock{mtx};
+    if (!cv.wait_for(guard, time, [this] { return can_acquire<Req>(); })) return false;
+    commit_state<Req>();
     pending_sub<Req>();
     return true;
   }
@@ -685,6 +700,16 @@ class PendingScope {
   std::optional<ResourceLockGuard> try_acquire() {
     if (lock_ == nullptr) return std::nullopt;  // already consumed by a prior successful call
     if (!lock_->template try_acquire_pending<Req>()) return std::nullopt;
+    Lock *acquired_lock = std::exchange(lock_, nullptr);
+    return ResourceLockGuard{*acquired_lock, ToGuardType(Req), std::adopt_lock};
+  }
+
+  /// Timed variant of try_acquire: waits up to `time` for the lock to admit `Req`, then returns
+  /// the guard on success. On timeout returns nullopt and leaves the pending registration intact.
+  template <typename Rep, typename Period>
+  std::optional<ResourceLockGuard> try_acquire_for(std::chrono::duration<Rep, Period> const &time) {
+    if (lock_ == nullptr) return std::nullopt;
+    if (!lock_->template try_acquire_pending_for<Req>(time)) return std::nullopt;
     Lock *acquired_lock = std::exchange(lock_, nullptr);
     return ResourceLockGuard{*acquired_lock, ToGuardType(Req), std::adopt_lock};
   }

--- a/tests/unit/utils_priority_thread_pool.cpp
+++ b/tests/unit/utils_priority_thread_pool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -469,6 +469,441 @@ TEST(TaskCollection, LargeTaskSet) {
   // Wait for all tasks to complete
   collection.Wait();
   ASSERT_EQ(counter.load(), num_tasks);
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// ==================================================================================
+// NB-3 productive_pending_ gate test
+// ==================================================================================
+
+// Verifies the NB-3 admission-gate contract for HasPendingWork():
+//   - productive=false tasks (admission re-posts) never increment productive_pending_,
+//     so they cannot hold the gate open even when queued.
+//   - productive=true tasks (real queries) immediately open the gate on submission.
+TEST(PriorityThreadPool, HasPendingWorkCountsProductiveNotAdmissionReposts) {
+  using namespace memgraph;
+
+  // 4 mixed workers, 1 HP worker.
+  constexpr int kN = 4;
+  utils::PriorityThreadPool pool{kN, 1};
+
+  std::atomic<int> occupied{0};
+  std::atomic<bool> release{false};
+
+  // Occupy all kN mixed workers with non-productive tasks (productive=false) so that
+  // productive_pending_ stays at zero throughout the occupancy phase.
+  for (int k = 1; k <= kN; ++k) {
+    pool.ScheduledAddTask(
+        [&](utils::Priority) {
+          occupied.fetch_add(1, std::memory_order_acq_rel);
+          while (!release.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          }
+        },
+        utils::Priority::LOW,
+        /*productive=*/false);
+    for (int waited = 0; occupied.load(std::memory_order_acquire) < k && waited < 5000; ++waited) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(occupied.load(std::memory_order_acquire), k) << "worker " << k << " did not start in time";
+  }
+
+  // All kN workers are now spinning on `release`.  No productive task has ever been
+  // submitted, so productive_pending_ must be zero and the gate must be closed.
+  ASSERT_FALSE(pool.HasPendingWork());
+
+  // Submit an admission re-post (productive=false).  It queues behind a busy worker
+  // but must NOT open the gate.
+  pool.ScheduledAddTask([](utils::Priority) {}, utils::Priority::LOW, /*productive=*/false);
+  ASSERT_FALSE(pool.HasPendingWork());
+
+  // Submit a real productive task (productive=true).  push() increments productive_pending_
+  // before returning, so HasPendingWork() must be true immediately after this call.
+  std::atomic<bool> productive_ran{false};
+  pool.ScheduledAddTask([&](utils::Priority) { productive_ran.store(true, std::memory_order_release); },
+                        utils::Priority::LOW,
+                        /*productive=*/true);
+  ASSERT_TRUE(pool.HasPendingWork());
+
+  // Release all occupiers so the pool can drain.
+  release.store(true, std::memory_order_release);
+
+  // Wait (bounded) for the productive task to complete.
+  constexpr int kMaxPollIter = 100'000;
+  for (int i = 0; i < kMaxPollIter && !productive_ran.load(std::memory_order_acquire); ++i) {
+    std::this_thread::yield();
+  }
+  ASSERT_TRUE(productive_ran.load(std::memory_order_acquire)) << "productive task never ran within poll bound";
+  ASSERT_FALSE(pool.HasPendingWork());
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// ==================================================================================
+// Park subsystem tests
+// ==================================================================================
+
+// Convenience tag values used across park tests.
+namespace {
+constexpr memgraph::utils::WaitTag kMainTag{memgraph::utils::WaitResource::MainLock, memgraph::utils::AccessMode::READ};
+constexpr memgraph::utils::WaitTag kCommitTag{memgraph::utils::WaitResource::CommitLock,
+                                              memgraph::utils::AccessMode::READ};
+constexpr memgraph::utils::FreedTag kFreeMain{memgraph::utils::WaitResource::MainLock,
+                                              memgraph::utils::AccessMode::READ};
+constexpr memgraph::utils::FreedTag kFreeCommit{memgraph::utils::WaitResource::CommitLock,
+                                                memgraph::utils::AccessMode::READ};
+}  // namespace
+
+// Test 1: ParkAdmission then WakeMatching (MainLock) re-injects the task and it runs on a worker.
+TEST(PriorityThreadPool, ParkAdmission_WakeMatching_Single) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  std::atomic<bool> ran{false};
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::hours(1);
+
+  pool.ParkAdmission([&](utils::Priority) { ran.store(true, std::memory_order_release); }, 1000, deadline, kMainTag);
+
+  pool.WakeMatching(kFreeMain);
+
+  for (int w = 0; !ran.load(std::memory_order_acquire) && w < 5000; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_TRUE(ran.load(std::memory_order_acquire));
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Test 2: Monitor sweep re-injects a parked entry whose deadline is already in the past
+// within approximately one monitor tick (~100 ms).
+TEST(PriorityThreadPool, MonitorSweep_PastDeadlineReinjected) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  std::atomic<bool> ran{false};
+  // Deadline already expired — the next monitor tick must pick this up.
+  auto past_deadline = std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+
+  pool.ParkAdmission(
+      [&](utils::Priority) { ran.store(true, std::memory_order_release); }, 1000, past_deadline, kMainTag);
+
+  // Monitor fires every 100 ms; wait up to 400 ms (4 ticks).
+  for (int w = 0; !ran.load(std::memory_order_acquire) && w < 40; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  ASSERT_TRUE(ran.load(std::memory_order_acquire));
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Test 3: ShouldParkAdmission returns false when productive_pending_ == 0.
+TEST(PriorityThreadPool, ShouldParkAdmission_FalseWithNoProductiveWork) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  // No productive tasks submitted yet.
+  ASSERT_FALSE(pool.ShouldParkAdmission());
+
+  // Non-productive task does not increment productive_pending_ — gate must stay closed.
+  pool.ScheduledAddTask([](utils::Priority) {}, utils::Priority::LOW, /*productive=*/false);
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  ASSERT_FALSE(pool.ShouldParkAdmission());
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Test 4: ShutDown drain — every parked continuation runs exactly once.
+TEST(PriorityThreadPool, ShutDown_DrainsParkedAdmissions) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  constexpr int kN = 5;
+  std::atomic<int> ran{0};
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::hours(1);
+
+  for (int i = 0; i < kN; ++i) {
+    pool.ParkAdmission([&](utils::Priority) { ran.fetch_add(1, std::memory_order_acq_rel); },
+                       static_cast<utils::PriorityThreadPool::TaskID>(1000 - i),
+                       deadline,
+                       kMainTag);
+  }
+
+  // ShutDown runs the drain synchronously in the caller thread before stopping workers;
+  // every parked continuation must have run by the time ShutDown returns.
+  pool.ShutDown();
+
+  ASSERT_EQ(ran.load(std::memory_order_acquire), kN);
+
+  pool.AwaitShutdown();
+}
+
+// ==================================================================================
+// WakeMatching tests
+// ==================================================================================
+
+// Test 5: WakeMatching drains every parked entry with the matching resource in a single call.
+TEST(PriorityThreadPool, WakeMatching_ReinjectsAllMatchingResource) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  constexpr int kN = 5;
+  std::atomic<int> ran{0};
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::hours(1);
+
+  for (int i = 0; i < kN; ++i) {
+    pool.ParkAdmission([&](utils::Priority) { ran.fetch_add(1, std::memory_order_acq_rel); },
+                       static_cast<utils::PriorityThreadPool::TaskID>(1000 - i),
+                       deadline,
+                       kMainTag);
+  }
+
+  pool.WakeMatching(kFreeMain);
+
+  // Bounded wait: all kN tasks must run within 5 s.
+  for (int w = 0; ran.load(std::memory_order_acquire) < kN && w < 5000; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(ran.load(std::memory_order_acquire), kN);
+
+  // Parked deque must now be empty: additional wakes must be silent no-ops.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  pool.WakeMatching(kFreeMain);
+  pool.WakeMatching(kFreeCommit);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  ASSERT_EQ(ran.load(std::memory_order_acquire), kN);
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Test 6: WakeMatching on an empty parked deque must be a safe no-op.
+TEST(PriorityThreadPool, WakeMatching_EmptyIsNoOp) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  // Consecutive wakes on an empty pool must not crash, deadlock, or assert.
+  pool.WakeMatching(kFreeMain);
+  pool.WakeMatching(kFreeCommit);
+  pool.WakeMatching(kFreeMain);
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Helper for Test 7 (re-park cycle simulation).
+// Each instance represents one parked admission slot that re-parks itself while
+// `still_contended` is true, simulating a stalled acquisition gate. `repark_count`
+// guards against an infinite re-park loop: if kMaxReparks is reached the task
+// completes regardless of the flag, so a stuck-flag bug cannot hang the suite.
+namespace {
+struct ParkReparker : std::enable_shared_from_this<ParkReparker> {
+  std::atomic<bool> *still_contended{nullptr};
+  std::atomic<int> *parked_back{nullptr};
+  std::atomic<int> *completed{nullptr};
+  memgraph::utils::PriorityThreadPool *pool{nullptr};
+  memgraph::utils::PriorityThreadPool::TaskID task_id{0};
+  std::chrono::steady_clock::time_point deadline{};
+  memgraph::utils::WaitTag tag{memgraph::utils::WaitResource::MainLock, memgraph::utils::AccessMode::READ};
+
+  static constexpr int kMaxReparks = 5;
+  int repark_count{0};  // single-writer: only the task executing this slot modifies it
+
+  memgraph::utils::TaskSignature MakeTask() {
+    return [self = shared_from_this()](memgraph::utils::Priority) {
+      const bool contended = self->still_contended->load(std::memory_order_acquire);
+      if (contended && self->repark_count < kMaxReparks) {
+        ++self->repark_count;
+        // Re-park first; signal only after the entry is in the deque so the
+        // main thread's parked_back wait is a true happens-before for the
+        // subsequent WakeMatching call.
+        self->pool->ParkAdmission(self->MakeTask(), self->task_id, self->deadline, self->tag);
+        self->parked_back->fetch_add(1, std::memory_order_release);
+      } else {
+        self->completed->fetch_add(1, std::memory_order_acq_rel);
+      }
+    };
+  }
+};
+}  // namespace
+
+// Test 7: Re-park cycle — each task re-parks itself while `still_contended` is true
+// (simulating a stalled engine_lock_ acquisition), then drains when the flag clears.
+TEST(PriorityThreadPool, WakeMatching_StillContendedReparkPattern) {
+  using namespace memgraph;
+  constexpr int kN = 3;
+  constexpr int kPollMs = 3000;  // 3 s per phase
+
+  utils::PriorityThreadPool pool{2, 1};
+  std::atomic<bool> still_contended{true};
+  std::atomic<int> parked_back{0};
+  std::atomic<int> completed{0};
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::hours(1);
+
+  for (int i = 0; i < kN; ++i) {
+    auto r = std::make_shared<ParkReparker>();
+    r->still_contended = &still_contended;
+    r->parked_back = &parked_back;
+    r->completed = &completed;
+    r->pool = &pool;
+    r->task_id = static_cast<utils::PriorityThreadPool::TaskID>(1000 - i);
+    r->deadline = deadline;
+    pool.ParkAdmission(r->MakeTask(), r->task_id, deadline, kMainTag);
+  }
+
+  // Phase A: wake all MainLock; still_contended=true → tasks re-park.
+  pool.WakeMatching(kFreeMain);
+  for (int w = 0; parked_back.load(std::memory_order_acquire) < kN && w < kPollMs; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(parked_back.load(std::memory_order_acquire), kN) << "tasks did not re-park within timeout";
+  ASSERT_EQ(completed.load(std::memory_order_acquire), 0) << "tasks must not complete while contended";
+
+  // Phase B: clear flag → tasks complete on next wake.
+  still_contended.store(false, std::memory_order_release);
+  pool.WakeMatching(kFreeMain);
+  for (int w = 0; completed.load(std::memory_order_acquire) < kN && w < kPollMs; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(completed.load(std::memory_order_acquire), kN);
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Test 8: ParkAdmission called after ShutDown drops the task without running it.
+TEST(PriorityThreadPool, ParkDropsWhenDraining) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  std::atomic<bool> task_ran{false};
+
+  pool.ShutDown();
+
+  pool.ParkAdmission([&](utils::Priority) { task_ran.store(true, std::memory_order_release); },
+                     static_cast<utils::PriorityThreadPool::TaskID>(1000),
+                     std::chrono::steady_clock::now() + std::chrono::hours(1),
+                     kMainTag);
+
+  ASSERT_FALSE(task_ran.load(std::memory_order_acquire));
+
+  pool.AwaitShutdown();
+}
+
+// ==================================================================================
+// Tagging extension tests (new in this port)
+// ==================================================================================
+
+// Test 9: WakeMatching with a MainLock FreedTag re-injects ONLY MainLock-tagged parked;
+// CommitLock-tagged parked entries remain in the deque and are woken only by a CommitLock wake.
+TEST(PriorityThreadPool, WakeMatching_ResourceSelective) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  constexpr int kMain = 3;
+  constexpr int kCommit = 3;
+  std::atomic<int> main_ran{0};
+  std::atomic<int> commit_ran{0};
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::hours(1);
+
+  for (int i = 0; i < kMain; ++i) {
+    pool.ParkAdmission([&](utils::Priority) { main_ran.fetch_add(1, std::memory_order_acq_rel); },
+                       static_cast<utils::PriorityThreadPool::TaskID>(2000 - i),
+                       deadline,
+                       kMainTag);
+  }
+  for (int i = 0; i < kCommit; ++i) {
+    pool.ParkAdmission([&](utils::Priority) { commit_ran.fetch_add(1, std::memory_order_acq_rel); },
+                       static_cast<utils::PriorityThreadPool::TaskID>(1000 - i),
+                       deadline,
+                       kCommitTag);
+  }
+
+  // Wake only MainLock: MainLock tasks should run; CommitLock tasks stay parked.
+  pool.WakeMatching(kFreeMain);
+
+  // Wait for all MainLock tasks to run (bounded 3 s).
+  for (int w = 0; main_ran.load(std::memory_order_acquire) < kMain && w < 3000; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(main_ran.load(std::memory_order_acquire), kMain);
+
+  // CommitLock tasks must still be parked — give a small grace period for any spurious run to appear.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  ASSERT_EQ(commit_ran.load(std::memory_order_acquire), 0) << "CommitLock tasks must not run after MainLock wake";
+
+  // Now free CommitLock: CommitLock tasks must run.
+  pool.WakeMatching(kFreeCommit);
+  for (int w = 0; commit_ran.load(std::memory_order_acquire) < kCommit && w < 3000; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(commit_ran.load(std::memory_order_acquire), kCommit);
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Test 10: has_parked_ is correctly false after all parked entries are drained; a subsequent
+// WakeMatching fast-returns without re-injecting any task (behavioral verification of the flag).
+TEST(PriorityThreadPool, HasParked_FalseAfterAllDrained) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  constexpr int kN = 4;
+  std::atomic<int> ran{0};
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::hours(1);
+
+  for (int i = 0; i < kN; ++i) {
+    pool.ParkAdmission([&](utils::Priority) { ran.fetch_add(1, std::memory_order_acq_rel); },
+                       static_cast<utils::PriorityThreadPool::TaskID>(1000 - i),
+                       deadline,
+                       kMainTag);
+  }
+
+  // Drain all by waking MainLock.
+  pool.WakeMatching(kFreeMain);
+  for (int w = 0; ran.load(std::memory_order_acquire) < kN && w < 3000; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(ran.load(std::memory_order_acquire), kN);
+
+  // At this point has_parked_ must be false. A WakeMatching call must be a no-op:
+  // it fast-returns on the relaxed false load and does NOT re-inject any task.
+  // Verify by checking the counter stays at kN after the extra wake.
+  pool.WakeMatching(kFreeMain);
+  pool.WakeMatching(kFreeCommit);
+  std::this_thread::sleep_for(std::chrono::milliseconds(30));
+  ASSERT_EQ(ran.load(std::memory_order_acquire), kN) << "extra WakeMatching must not trigger more runs";
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// Test 11: Monitor sweep re-injects a deadline-expired parked entry regardless of its tag.
+// Verify that the monitor handles entries of both MainLock and CommitLock tags correctly.
+TEST(PriorityThreadPool, MonitorSweep_DeadlineExpiredAnyTag) {
+  using namespace memgraph;
+  utils::PriorityThreadPool pool{2, 1};
+
+  std::atomic<int> ran{0};
+  auto past_deadline = std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+
+  // Park one entry of each resource type with a past deadline.
+  pool.ParkAdmission(
+      [&](utils::Priority) { ran.fetch_add(1, std::memory_order_acq_rel); }, 2000, past_deadline, kMainTag);
+  pool.ParkAdmission(
+      [&](utils::Priority) { ran.fetch_add(1, std::memory_order_acq_rel); }, 1000, past_deadline, kCommitTag);
+
+  // Monitor fires every 100 ms; wait up to 600 ms (6 ticks) for both to be re-injected.
+  for (int w = 0; ran.load(std::memory_order_acquire) < 2 && w < 60; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  ASSERT_EQ(ran.load(std::memory_order_acquire), 2);
 
   pool.ShutDown();
   pool.AwaitShutdown();

--- a/tests/unit/utils_resource_lock.cpp
+++ b/tests/unit/utils_resource_lock.cpp
@@ -1359,6 +1359,209 @@ TEST_F(ResourceLockTest, ConcurrentMutualExclusionInvariantsFuzzWithPendingScope
   ASSERT_FALSE(invariant_violated.load()) << violation_message;
 }
 
+// --- Notify hook: single-threaded, deterministic fire-count tests ---
+//
+// SetNotifyHook installs a callable fired inside maybe_notify after the internal mutex is
+// unlocked and cv.notify_all() has returned, on every NotifyKind::All transition.  The hook
+// is armed via an atomic pointer, so an unarmed lock (no hook) is a single null-load of overhead.
+//
+// There are exactly six NotifyKind::All producers:
+//  (1) unlock_shared<WRITE>  when w_count reaches 0
+//  (2) unlock_shared<READ>   when r==w==ro==0 (fully unlocked)
+//  (3) unlock_shared<READ_ONLY> when ro_count reaches 0
+//  (4) unlock()              (UNIQUE always fully frees the lock)
+//  (5) downgrade_to_read<WRITE|READ_ONLY> when the source count reaches 0
+//  (6) ~UniquePendingScope / ~ReadOnlyPendingScope (unregister_pending) when their pending
+//      counter reaches 0
+//
+// Every test below uses a plain `int fire_count` captured by reference — safe in single-threaded
+// context without std::atomic.
+
+TEST_F(ResourceLockTest, NotifyHookFiresOnWriteRelease) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  lock.lock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 0);  // hook fires on release, not on acquisition
+
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 1);  // w_count reached 0 → NotifyKind::All
+}
+
+TEST_F(ResourceLockTest, NotifyHookFiresOnReadRelease) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  lock.lock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 0);
+
+  // unlock_should_notify<READ> fires only when r==w==ro==0 (fully unlocked).
+  lock.unlock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 1);
+}
+
+TEST_F(ResourceLockTest, NotifyHookFiresOnReadOnlyRelease) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  lock.lock_shared<ResourceLock::LockReq::READ_ONLY>();
+  EXPECT_EQ(fire_count, 0);
+
+  lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+  EXPECT_EQ(fire_count, 1);  // ro_count reached 0 → NotifyKind::All
+}
+
+TEST_F(ResourceLockTest, NotifyHookFiresOnUniqueRelease) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  lock.lock();
+  EXPECT_EQ(fire_count, 0);
+
+  lock.unlock();
+  EXPECT_EQ(fire_count, 1);  // UNIQUE release always fires
+}
+
+// downgrade_to_read<WRITE> decrements w_count (0 reached → first fire); the resulting READ hold
+// is then released, freeing the lock (r==w==ro==0 → second fire).
+TEST_F(ResourceLockTest, NotifyHookFiresOnWriteDowngradeThenReadRelease) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  lock.lock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 0);
+
+  ASSERT_TRUE(lock.downgrade_to_read<ResourceLock::LockReq::WRITE>());
+  EXPECT_EQ(fire_count, 1);  // w_count hit 0 during downgrade
+
+  lock.unlock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 2);  // READ release: r==w==ro==0 → fully unlocked → second fire
+}
+
+// A UniquePendingScope constructed while UNIQUE cannot acquire (READ is held, state == SHARED)
+// and then destroyed WITHOUT calling try_acquire fires the hook once via unregister_pending<UNIQUE>
+// when unique_pending_count reaches 0.
+TEST_F(ResourceLockTest, NotifyHookFiresOnUniquePendingScopeDestroyedUnacquired) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  // Hold READ: state == SHARED, so can_acquire<UNIQUE> (needs UNLOCKED) will fail.
+  lock.lock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 0);
+
+  {
+    UniquePendingScope scope(lock);
+    // Confirm try_acquire fails while READ is held.
+    EXPECT_FALSE(scope.try_acquire().has_value());
+    EXPECT_EQ(fire_count, 0);
+    // Destructor: unregister_pending<UNIQUE> → unique_pending_count reaches 0 → fires.
+  }
+  EXPECT_EQ(fire_count, 1);
+
+  // Release the READ hold: r==w==ro==0 → fires again.
+  lock.unlock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 2);
+}
+
+// A ReadOnlyPendingScope constructed while READ_ONLY cannot acquire (WRITE is held, w_count != 0)
+// and destroyed WITHOUT acquiring fires once via unregister_pending<READ_ONLY> when
+// ro_pending_count reaches 0.
+TEST_F(ResourceLockTest, NotifyHookFiresOnReadOnlyPendingScopeDestroyedUnacquired) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  // Hold WRITE: can_acquire<READ_ONLY> requires w_count == 0, so the scope cannot acquire.
+  lock.lock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 0);
+
+  {
+    ReadOnlyPendingScope scope(lock);
+    EXPECT_FALSE(scope.try_acquire().has_value());
+    EXPECT_EQ(fire_count, 0);
+    // Destructor: unregister_pending<READ_ONLY> → ro_pending_count reaches 0 → fires.
+  }
+  EXPECT_EQ(fire_count, 1);
+
+  // Release WRITE: w_count reaches 0 → fires again.
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 2);
+}
+
+// Two concurrent WRITE holds: releasing the first drops w_count to 1 (not 0), which is a
+// NotifyKind::None transition.  The hook must NOT fire at the intermediate step.
+TEST_F(ResourceLockTest, NotifyHookDoesNotFireOnPartialWriteRelease) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  lock.lock_shared<ResourceLock::LockReq::WRITE>();  // w_count = 1
+  lock.lock_shared<ResourceLock::LockReq::WRITE>();  // w_count = 2
+  EXPECT_EQ(fire_count, 0);
+
+  // First release: w_count drops to 1, still non-zero → NotifyKind::None.
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 0);  // intermediate: no fire
+
+  // Second release: w_count drops to 0 → NotifyKind::All.
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 1);
+}
+
+// After ClearNotifyHook() the hook pointer is set to nullptr; the same acquire/release cycle
+// that fired before must not call the hook again.
+TEST_F(ResourceLockTest, NotifyHookSilentAfterClearNotifyHook) {
+  int fire_count = 0;
+  lock.SetNotifyHook([&] { ++fire_count; });
+
+  lock.lock_shared<ResourceLock::LockReq::WRITE>();
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 1);  // hook was armed and fired
+
+  lock.ClearNotifyHook();
+
+  lock.lock_shared<ResourceLock::LockReq::WRITE>();
+  lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 1);  // hook disarmed: count unchanged
+}
+
+// A lock with no hook installed must operate correctly across all six NotifyKind::All producers
+// without crashing, and must never increment an external counter that was never installed as a hook.
+TEST_F(ResourceLockTest, UnarmedLockIsSafeAndSilentWithoutHook) {
+  ResourceLock unarmed_lock;
+  int fire_count = 0;
+  // Intentionally no SetNotifyHook on unarmed_lock.
+
+  unarmed_lock.lock_shared<ResourceLock::LockReq::WRITE>();
+  unarmed_lock.unlock_shared<ResourceLock::LockReq::WRITE>();
+  EXPECT_EQ(fire_count, 0);
+
+  unarmed_lock.lock_shared<ResourceLock::LockReq::READ>();
+  unarmed_lock.unlock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 0);
+
+  unarmed_lock.lock_shared<ResourceLock::LockReq::READ_ONLY>();
+  unarmed_lock.unlock_shared<ResourceLock::LockReq::READ_ONLY>();
+  EXPECT_EQ(fire_count, 0);
+
+  unarmed_lock.lock();
+  unarmed_lock.unlock();
+  EXPECT_EQ(fire_count, 0);
+
+  // downgrade (producer 5) with no hook
+  unarmed_lock.lock_shared<ResourceLock::LockReq::WRITE>();
+  ASSERT_TRUE(unarmed_lock.downgrade_to_read<ResourceLock::LockReq::WRITE>());
+  unarmed_lock.unlock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 0);
+
+  // unregister_pending (producer 6) with no hook
+  unarmed_lock.lock_shared<ResourceLock::LockReq::READ>();
+  {
+    UniquePendingScope scope(unarmed_lock);
+    EXPECT_FALSE(scope.try_acquire().has_value());
+  }
+  unarmed_lock.unlock_shared<ResourceLock::LockReq::READ>();
+  EXPECT_EQ(fire_count, 0);
+}
+
 // A pending UNIQUE waiter must not miss its wake-up to a waiter that cannot use it.
 //
 // Every waiter parks on the same condition variable but each has its own predicate, so a


### PR DESCRIPTION
## What

When a write transaction holds `commit_mutex_` across the durability/replication wait, any Bolt worker that needs `main_lock_` (BEGIN) or `commit_mutex_` (COMMIT) blocks on it, tying up a pool thread and stalling unrelated fast queries.

This PR makes those acquisitions **park** the worker instead of blocking it, through a pressure-adaptive funnel: a bounded timed `try_lock` first, then a bounded number of re-posts, and only under real pool pressure does the continuation park (thread released back to the pool, resumed on wake). An uncontended acquire still takes the lock on the first try, so the fast path is unchanged.

- **BEGIN** — timed `main_lock_` acquire; on timeout under pressure the (implicit or explicit) BEGIN parks and is re-driven on wake, otherwise it blocks like master.
- **COMMIT** — timed `commit_mutex_` acquire; on timeout under pressure the PULL-path COMMIT parks and retries on wake, otherwise it blocks like master.
- **Pool** — park/resume support in `priority_thread_pool` (place-keeping + wait-tagging), plus pressure signals that scale the try budget `T(P)` and the reschedule cap `N(P)` off backlog and free-worker fraction, so a parked continuation resumes in order without losing its slot.

## Why

Frees pool threads that would otherwise sit blocked behind an in-flight commit, so short reads and BEGINs keep making progress while a slow write drains. Under readers contended by slow writers this recovers double-digit throughput.

The funnel keeps the uncontended fast-write path at master parity: with no pool pressure a worker acquires on the first try and never touches the reschedule/park machinery. (A naive always-park form of this cost roughly −5% on `single_vertex_write`; the pressure gating removes that.)

## Flag

Gated behind `experimental_lockfree_read_snapshot`. With the flag off, behavior is identical to master.

## Notes

Stacked on #4685; draft until that lands. The `T(P)` and `N(P)` constants are provisional, pending perf-box tuning.
