### PR TITLE
AI-license: bound vector-index embeddings in queries (lazy VectorRef)

### DIFF
--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -267,6 +267,13 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
       return storage::Result<Value>{std::in_place, ToBoltVertex(value.ValueVirtualNode(), *db)};
     }
 
+    case query::TypedValue::Type::VectorRef: {
+      // Materialize the lazy embedding into a transient List of Doubles, then
+      // encode using the same path as a regular TypedValue::List.
+      const query::TypedValue materialized = value.MaterializeVectorRef(value.get_allocator());
+      return ToBoltValue(materialized, db, view, auth_checker);
+    }
+
     // Unsupported conversions
     case query::TypedValue::Type::Function: {
       throw communication::bolt::ValueException("Unsupported conversion from TypedValue::Function to Value");

--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -136,9 +136,12 @@ LicenseChecker global_license_checker;
 
 LicenseChecker::~LicenseChecker() { Finalize(); }
 
-void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
-  spdlog::trace("License revalidation started");
-
+namespace {
+// Routes a license memory limit to the correct tracker(s), de-duped against the last applied state.
+// AI_PLATFORM caps graph memory only (embeddings/total fall back to --memory-limit); every other
+// tier caps total memory and clears the graph limit. Shared by RevalidateLicense and EnableTesting
+// so tests exercise the real routing without a signed key.
+void ApplyLicenseMemoryLimit(int64_t memory_limit, std::optional<LicenseType> license_type) {
   // Passing 0 to SetHardLimit restores the limit to maximum_hard_limit_ (the --memory-limit flag value)
   // if --memory-limit was configured. If it was not (maximum_hard_limit_ == 0), this is a no-op.
   constexpr int64_t kUseDefaultMemoryLimit = 0;
@@ -149,28 +152,34 @@ void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
     bool operator==(const PreviousMemoryState &) const = default;
   };
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static utils::Synchronized<std::optional<PreviousMemoryState>, utils::SpinLock> previous_memory_limit;
-  const auto set_memory_limit = [](int64_t memory_limit, std::optional<LicenseType> license_type = std::nullopt) {
-    auto locked = previous_memory_limit.Lock();
-    const PreviousMemoryState current{.limit = memory_limit, .type = license_type};
-    if (*locked && **locked == current) return;
+  auto locked = previous_memory_limit.Lock();
+  const PreviousMemoryState current{.limit = memory_limit, .type = license_type};
+  if (*locked && **locked == current) {
+    return;
+  }
 
-    if (license_type == LicenseType::AI_PLATFORM && memory_limit > 0) {
-      // AI_PLATFORM: limit graph memory only; total falls back to --memory-limit
-      utils::total_memory_tracker.SetHardLimit(kUseDefaultMemoryLimit);
-      utils::graph_memory_tracker.SetHardLimit(memory_limit);
-    } else {
-      // ENTERPRISE / no license: limit total memory, clear graph limit
-      utils::graph_memory_tracker.ResetLimit();
-      utils::total_memory_tracker.SetHardLimit(memory_limit);
-    }
+  if (license_type == LicenseType::AI_PLATFORM && memory_limit > 0) {
+    // AI_PLATFORM: limit graph memory only; total falls back to --memory-limit
+    utils::total_memory_tracker.SetHardLimit(kUseDefaultMemoryLimit);
+    utils::graph_memory_tracker.SetHardLimit(memory_limit);
+  } else {
+    // ENTERPRISE / no license: limit total memory, clear graph limit
+    utils::graph_memory_tracker.ResetLimit();
+    utils::total_memory_tracker.SetHardLimit(memory_limit);
+  }
 
-    *locked = current;
-  };
+  *locked = current;
+}
+}  // namespace
+
+void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
+  spdlog::trace("License revalidation started");
 
   if (enterprise_enabled_) [[unlikely]] {
     is_valid_.store(true, std::memory_order_release);
-    set_memory_limit(0, license_type_);
+    ApplyLicenseMemoryLimit(0, license_type_);
     return;
   }
 
@@ -219,7 +228,7 @@ void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
       locked->reset();
     }
     is_valid_.store(false, std::memory_order_relaxed);
-    set_memory_limit(0);
+    ApplyLicenseMemoryLimit(0, std::nullopt);
     return;
   }
 
@@ -246,7 +255,7 @@ void LicenseChecker::RevalidateLicense(utils::Settings &settings) {
       locked->emplace(winner.key, winner.org);
       (*locked)->is_valid = true;
       (*locked)->license = winner.license;
-      set_memory_limit(winner.license.memory_limit, winner.license.type);
+      ApplyLicenseMemoryLimit(winner.license.memory_limit, winner.license.type);
     }
   }
 
@@ -269,12 +278,21 @@ void LicenseChecker::EnableTesting(const LicenseType license_type) {
   spdlog::info("The license type {} is set for testing.", LicenseTypeToString(license_type));
 }
 
+void LicenseChecker::EnableTesting(const LicenseType license_type, const int64_t memory_limit) {
+  EnableTesting(license_type);
+  // EnableTesting does not run RevalidateLicense, so route the limit through the same logic the
+  // real license path uses. Lets a test define e.g. AI_PLATFORM + graph limit without a signed key.
+  ApplyLicenseMemoryLimit(memory_limit, license_type);
+}
+
 void LicenseChecker::DisableTesting() {
   enterprise_enabled_ = false;
   {
     auto locked = previous_license_info_.Lock();
     locked->reset();
   }
+  // Clear any test-applied memory limit so tests do not contaminate one another.
+  ApplyLicenseMemoryLimit(0, std::nullopt);
   is_valid_.store(false, std::memory_order_relaxed);
   spdlog::info("The license is disabled for testing.");
 }

--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -137,10 +137,8 @@ LicenseChecker global_license_checker;
 LicenseChecker::~LicenseChecker() { Finalize(); }
 
 namespace {
-// Routes a license memory limit to the correct tracker(s), de-duped against the last applied state.
-// AI_PLATFORM caps graph memory only (embeddings/total fall back to --memory-limit); every other
-// tier caps total memory and clears the graph limit. Shared by RevalidateLicense and EnableTesting
-// so tests exercise the real routing without a signed key.
+// Routes memory_limit to graph_memory_tracker (AI_PLATFORM) or total_memory_tracker (all other tiers).
+// Shared with EnableTesting so tests exercise the real routing without a signed key.
 void ApplyLicenseMemoryLimit(int64_t memory_limit, std::optional<LicenseType> license_type) {
   // Passing 0 to SetHardLimit restores the limit to maximum_hard_limit_ (the --memory-limit flag value)
   // if --memory-limit was configured. If it was not (maximum_hard_limit_ == 0), this is a no-op.
@@ -280,8 +278,7 @@ void LicenseChecker::EnableTesting(const LicenseType license_type) {
 
 void LicenseChecker::EnableTesting(const LicenseType license_type, const int64_t memory_limit) {
   EnableTesting(license_type);
-  // EnableTesting does not run RevalidateLicense, so route the limit through the same logic the
-  // real license path uses. Lets a test define e.g. AI_PLATFORM + graph limit without a signed key.
+  // EnableTesting skips RevalidateLicense; call here so tests can install e.g. an AI graph cap without a signed key.
   ApplyLicenseMemoryLimit(memory_limit, license_type);
 }
 

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -109,6 +109,9 @@ struct LicenseChecker {
   void CheckEnvLicense(utils::Settings &settings);
   void SetCliLicense(std::string license_key, std::string organization_name, utils::Settings &settings);
   void EnableTesting(LicenseType license_type = LicenseType::ENTERPRISE);
+  // Test-only: additionally applies a license memory limit through the real routing
+  // (AI_PLATFORM -> graph_memory_tracker, others -> total_memory_tracker).
+  void EnableTesting(LicenseType license_type, int64_t memory_limit);
   void DisableTesting();
   // Checks if license is valid and if enterprise is enabled
   LicenseCheckResult IsEnterpriseValid(std::string_view license_key, std::string_view organization_name) const;

--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -12,10 +12,12 @@
 /// @file
 #pragma once
 
+#include <algorithm>
 #include <concepts>
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <range/v3/view/zip.hpp>
 

--- a/src/query/edge_accessor.hpp
+++ b/src/query/edge_accessor.hpp
@@ -33,8 +33,9 @@ class EdgeAccessor final {
     return impl_.Properties(view, with_vector_reconstruction);
   }
 
-  storage::Result<storage::PropertyValue> GetProperty(storage::View view, storage::PropertyId key) const {
-    return impl_.GetProperty(key, view);
+  storage::Result<storage::PropertyValue> GetProperty(storage::View view, storage::PropertyId key,
+                                                      bool with_vector_reconstruction = true) const {
+    return impl_.GetProperty(key, view, with_vector_reconstruction);
   }
 
   storage::Result<uint64_t> GetPropertySize(storage::PropertyId key, storage::View view) const {

--- a/src/query/edge_accessor.hpp
+++ b/src/query/edge_accessor.hpp
@@ -29,7 +29,9 @@ class EdgeAccessor final {
 
   storage::EdgeTypeId EdgeType() const { return impl_.EdgeType(); }
 
-  auto Properties(storage::View view) const { return impl_.Properties(view); }
+  auto Properties(storage::View view, bool with_vector_reconstruction = true) const {
+    return impl_.Properties(view, with_vector_reconstruction);
+  }
 
   storage::Result<storage::PropertyValue> GetProperty(storage::View view, storage::PropertyId key) const {
     return impl_.GetProperty(key, view);

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -460,7 +460,9 @@ TypedValue Properties(const TypedValue *args, int64_t nargs, const FunctionConte
   auto *dba = ctx.db_accessor;
   auto get_properties = [&](const auto &record_accessor, auto const &is_allowed) {
     TypedValue::TMap properties(ctx.memory);
-    auto maybe_props = record_accessor.Properties(ctx.view);
+    // Read without reconstructing embeddings; wrap each as a lazy VectorRef so a retained properties()
+    // map costs O(references), not O(N*dim) floats.
+    auto maybe_props = record_accessor.Properties(ctx.view, /*with_vector_reconstruction=*/false);
     if (!maybe_props) {
       switch (maybe_props.error()) {
         case storage::Error::DELETED_OBJECT:
@@ -476,9 +478,14 @@ TypedValue Properties(const TypedValue *args, int64_t nargs, const FunctionConte
     for (const auto &property : *maybe_props) {
       auto key = TypedValue::TString(dba->PropertyToName(property.first), ctx.memory);
       if (is_allowed(property.first)) {
-        auto typed_value =
-            TypedValue(property.second, ctx.db_accessor->GetStorageAccessor()->GetNameIdMapper(), ctx.memory);
-        properties.emplace(std::move(key), std::move(typed_value));
+        if (property.second.IsVectorIndexId()) {
+          properties.emplace(std::move(key),
+                             TypedValue(LazyVectorRef{record_accessor.impl_, property.first}, ctx.memory));
+        } else {
+          auto typed_value =
+              TypedValue(property.second, ctx.db_accessor->GetStorageAccessor()->GetNameIdMapper(), ctx.memory);
+          properties.emplace(std::move(key), std::move(typed_value));
+        }
       } else {
         properties.emplace(std::move(key), TypedValue(ctx.memory));
       }

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -871,6 +871,7 @@ TypedValue ValueType(const TypedValue *args, int64_t nargs, const FunctionContex
     case TypedValue::Type::String:
       return TypedValue("STRING", ctx.memory);
     case TypedValue::Type::List:
+    case TypedValue::Type::VectorRef:  // a lazy embedding is semantically a list of floats
       return TypedValue("LIST", ctx.memory);
     case TypedValue::Type::Map:
       return TypedValue("MAP", ctx.memory);
@@ -1421,6 +1422,7 @@ std::optional<TypedValue> TryToString(const TypedValue &arg, const FunctionConte
     }
 
     case List:
+    case VectorRef:
     case Map:
     case Vertex:
     case Edge:

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -460,8 +460,7 @@ TypedValue Properties(const TypedValue *args, int64_t nargs, const FunctionConte
   auto *dba = ctx.db_accessor;
   auto get_properties = [&](const auto &record_accessor, auto const &is_allowed) {
     TypedValue::TMap properties(ctx.memory);
-    // Read without reconstructing embeddings; wrap each as a lazy VectorRef so a retained properties()
-    // map costs O(references), not O(N*dim) floats.
+    // Wrap each embedding property as a lazy VectorRef — a retained map costs O(references), not O(N*dim) floats.
     auto maybe_props = record_accessor.Properties(ctx.view, /*with_vector_reconstruction=*/false);
     if (!maybe_props) {
       switch (maybe_props.error()) {

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -153,12 +153,7 @@ TypedValue ExpressionEvaluator::Visit(AllPropertiesLookup &all_properties_lookup
         auto key = TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory);
         // Keep embeddings lazy in the projected map: a map retained by collect / ORDER BY then holds
         // O(refs), not O(N*dim) floats. Materialization happens only at compare/hash/serialize.
-        if (value.IsVectorIndexId()) {
-          result.emplace(std::move(key),
-                         TypedValue(LazyVectorRef{.entity = vertex.impl_, .prop = property_id}, ctx_->memory));
-        } else {
-          result.emplace(std::move(key), TypedValue(value, GetNameIdMapper(), ctx_->memory));
-        }
+        result.emplace(std::move(key), MakePropertyValue(vertex, property_id, value));
       }
       return {result, ctx_->memory};
     }
@@ -166,12 +161,7 @@ TypedValue ExpressionEvaluator::Visit(AllPropertiesLookup &all_properties_lookup
       const auto &edge = expression_result.ValueEdge();
       for (const auto &[property_id, value] : GetAllProperties(edge)) {
         auto key = TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory);
-        if (value.IsVectorIndexId()) {
-          result.emplace(std::move(key),
-                         TypedValue(LazyVectorRef{.entity = edge.impl_, .prop = property_id}, ctx_->memory));
-        } else {
-          result.emplace(std::move(key), TypedValue(value, GetNameIdMapper(), ctx_->memory));
-        }
+        result.emplace(std::move(key), MakePropertyValue(edge, property_id, value));
       }
       return {result, ctx_->memory};
     }
@@ -456,25 +446,16 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
 
         auto property_id = ctx_->properties[property_lookup.property_.ix];
         if (property_lookup_cache_[symbol_pos].contains(property_id)) {
-          const auto &cached = property_lookup_cache_[symbol_pos][property_id];
-          // GetAllProperties left embeddings as references; hand back a lazy VectorRef, not an
-          // (empty) reconstructed list.
-          if (cached.IsVectorIndexId()) {
-            return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueVertex().impl_, .prop = property_id},
-                              ctx_->memory);
-          }
-          return {cached, GetNameIdMapper(), ctx_->memory};
+          // GetAllProperties left embeddings as references; MakePropertyValue hands back a lazy
+          // VectorRef, not an (empty) reconstructed list.
+          return MakePropertyValue(
+              expression_result_ptr->ValueVertex(), property_id, property_lookup_cache_[symbol_pos][property_id]);
         }
         return TypedValue(ctx_->memory);
       } else {
-        auto raw_prop = GetProperty(expression_result_ptr->ValueVertex(), property_lookup.property_);
-        if (raw_prop.IsVectorIndexId()) {
-          // Materialization happens only on compare, hash, or serialize.
-          const auto prop_id = ctx_->properties[property_lookup.property_.ix];
-          return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueVertex().impl_, .prop = prop_id},
-                            ctx_->memory);
-        }
-        return {std::move(raw_prop), GetNameIdMapper(), ctx_->memory};
+        return MakePropertyValue(expression_result_ptr->ValueVertex(),
+                                 ctx_->properties[property_lookup.property_.ix],
+                                 GetProperty(expression_result_ptr->ValueVertex(), property_lookup.property_));
       }
     case TypedValue::Type::Edge:
       if (property_lookup.evaluation_mode_ == PropertyLookup::EvaluationMode::GET_ALL_PROPERTIES) {
@@ -485,22 +466,14 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
 
         auto property_id = ctx_->properties[property_lookup.property_.ix];
         if (property_lookup_cache_[symbol_pos].contains(property_id)) {
-          const auto &cached = property_lookup_cache_[symbol_pos][property_id];
-          if (cached.IsVectorIndexId()) {
-            return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueEdge().impl_, .prop = property_id},
-                              ctx_->memory);
-          }
-          return {cached, GetNameIdMapper(), ctx_->memory};
+          return MakePropertyValue(
+              expression_result_ptr->ValueEdge(), property_id, property_lookup_cache_[symbol_pos][property_id]);
         }
         return TypedValue(ctx_->memory);
       } else {
-        auto raw_prop = GetProperty(expression_result_ptr->ValueEdge(), property_lookup.property_);
-        if (raw_prop.IsVectorIndexId()) {
-          const auto prop_id = ctx_->properties[property_lookup.property_.ix];
-          return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueEdge().impl_, .prop = prop_id},
-                            ctx_->memory);
-        }
-        return {std::move(raw_prop), GetNameIdMapper(), ctx_->memory};
+        return MakePropertyValue(expression_result_ptr->ValueEdge(),
+                                 ctx_->properties[property_lookup.property_.ix],
+                                 GetProperty(expression_result_ptr->ValueEdge(), property_lookup.property_));
       }
     case TypedValue::Type::VirtualEdge: {
       auto prop_id = dba_->NameToProperty(property_lookup.property_.name);

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -154,7 +154,8 @@ TypedValue ExpressionEvaluator::Visit(AllPropertiesLookup &all_properties_lookup
         // Keep embeddings lazy in the projected map: a map retained by collect / ORDER BY then holds
         // O(refs), not O(N*dim) floats. Materialization happens only at compare/hash/serialize.
         if (value.IsVectorIndexId()) {
-          result.emplace(std::move(key), TypedValue(LazyVectorRef{vertex.impl_, property_id}, ctx_->memory));
+          result.emplace(std::move(key),
+                         TypedValue(LazyVectorRef{.entity = vertex.impl_, .prop = property_id}, ctx_->memory));
         } else {
           result.emplace(std::move(key), TypedValue(value, GetNameIdMapper(), ctx_->memory));
         }
@@ -166,7 +167,8 @@ TypedValue ExpressionEvaluator::Visit(AllPropertiesLookup &all_properties_lookup
       for (const auto &[property_id, value] : GetAllProperties(edge)) {
         auto key = TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory);
         if (value.IsVectorIndexId()) {
-          result.emplace(std::move(key), TypedValue(LazyVectorRef{edge.impl_, property_id}, ctx_->memory));
+          result.emplace(std::move(key),
+                         TypedValue(LazyVectorRef{.entity = edge.impl_, .prop = property_id}, ctx_->memory));
         } else {
           result.emplace(std::move(key), TypedValue(value, GetNameIdMapper(), ctx_->memory));
         }
@@ -458,7 +460,8 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
           // GetAllProperties left embeddings as references; hand back a lazy VectorRef, not an
           // (empty) reconstructed list.
           if (cached.IsVectorIndexId()) {
-            return TypedValue(LazyVectorRef{expression_result_ptr->ValueVertex().impl_, property_id}, ctx_->memory);
+            return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueVertex().impl_, .prop = property_id},
+                              ctx_->memory);
           }
           return {cached, GetNameIdMapper(), ctx_->memory};
         }
@@ -468,9 +471,10 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
         if (raw_prop.IsVectorIndexId()) {
           // Materialization happens only on compare, hash, or serialize.
           const auto prop_id = ctx_->properties[property_lookup.property_.ix];
-          return TypedValue(LazyVectorRef{expression_result_ptr->ValueVertex().impl_, prop_id}, ctx_->memory);
+          return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueVertex().impl_, .prop = prop_id},
+                            ctx_->memory);
         }
-        return TypedValue(std::move(raw_prop), GetNameIdMapper(), ctx_->memory);
+        return {std::move(raw_prop), GetNameIdMapper(), ctx_->memory};
       }
     case TypedValue::Type::Edge:
       if (property_lookup.evaluation_mode_ == PropertyLookup::EvaluationMode::GET_ALL_PROPERTIES) {
@@ -483,7 +487,8 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
         if (property_lookup_cache_[symbol_pos].contains(property_id)) {
           const auto &cached = property_lookup_cache_[symbol_pos][property_id];
           if (cached.IsVectorIndexId()) {
-            return TypedValue(LazyVectorRef{expression_result_ptr->ValueEdge().impl_, property_id}, ctx_->memory);
+            return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueEdge().impl_, .prop = property_id},
+                              ctx_->memory);
           }
           return {cached, GetNameIdMapper(), ctx_->memory};
         }
@@ -492,9 +497,10 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
         auto raw_prop = GetProperty(expression_result_ptr->ValueEdge(), property_lookup.property_);
         if (raw_prop.IsVectorIndexId()) {
           const auto prop_id = ctx_->properties[property_lookup.property_.ix];
-          return TypedValue(LazyVectorRef{expression_result_ptr->ValueEdge().impl_, prop_id}, ctx_->memory);
+          return TypedValue(LazyVectorRef{.entity = expression_result_ptr->ValueEdge().impl_, .prop = prop_id},
+                            ctx_->memory);
         }
-        return TypedValue(std::move(raw_prop), GetNameIdMapper(), ctx_->memory);
+        return {std::move(raw_prop), GetNameIdMapper(), ctx_->memory};
       }
     case TypedValue::Type::VirtualEdge: {
       auto prop_id = dba_->NameToProperty(property_lookup.property_.name);

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -453,9 +453,10 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
         }
         return TypedValue(ctx_->memory);
       } else {
-        return MakePropertyValue(expression_result_ptr->ValueVertex(),
-                                 ctx_->properties[property_lookup.property_.ix],
-                                 GetProperty(expression_result_ptr->ValueVertex(), property_lookup.property_));
+        // GetProperty checks the accessor (and throws without one) before we index ctx_->properties below.
+        auto value = GetProperty(expression_result_ptr->ValueVertex(), property_lookup.property_);
+        return MakePropertyValue(
+            expression_result_ptr->ValueVertex(), ctx_->properties[property_lookup.property_.ix], std::move(value));
       }
     case TypedValue::Type::Edge:
       if (property_lookup.evaluation_mode_ == PropertyLookup::EvaluationMode::GET_ALL_PROPERTIES) {
@@ -471,9 +472,10 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
         }
         return TypedValue(ctx_->memory);
       } else {
-        return MakePropertyValue(expression_result_ptr->ValueEdge(),
-                                 ctx_->properties[property_lookup.property_.ix],
-                                 GetProperty(expression_result_ptr->ValueEdge(), property_lookup.property_));
+        // GetProperty checks the accessor (and throws without one) before we index ctx_->properties below.
+        auto value = GetProperty(expression_result_ptr->ValueEdge(), property_lookup.property_);
+        return MakePropertyValue(
+            expression_result_ptr->ValueEdge(), ctx_->properties[property_lookup.property_.ix], std::move(value));
       }
     case TypedValue::Type::VirtualEdge: {
       auto prop_id = dba_->NameToProperty(property_lookup.property_.name);

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -446,9 +446,14 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
         }
         return TypedValue(ctx_->memory);
       } else {
-        return {GetProperty(expression_result_ptr->ValueVertex(), property_lookup.property_),
-                GetNameIdMapper(),
-                ctx_->memory};
+        auto raw_prop = GetProperty(expression_result_ptr->ValueVertex(), property_lookup.property_);
+        if (raw_prop.IsVectorIndexId()) {
+          // Return a lazy handle: floats are not reconstructed here.
+          // Materialization happens only on compare, hash, or Bolt serialize.
+          const auto prop_id = ctx_->properties[property_lookup.property_.ix];
+          return TypedValue(LazyVectorRef{expression_result_ptr->ValueVertex().impl_, prop_id}, ctx_->memory);
+        }
+        return TypedValue(std::move(raw_prop), GetNameIdMapper(), ctx_->memory);
       }
     case TypedValue::Type::Edge:
       if (property_lookup.evaluation_mode_ == PropertyLookup::EvaluationMode::GET_ALL_PROPERTIES) {

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -148,16 +148,28 @@ TypedValue ExpressionEvaluator::Visit(AllPropertiesLookup &all_properties_lookup
     case TypedValue::Type::Null:
       return TypedValue(ctx_->memory);
     case TypedValue::Type::Vertex: {
-      for (const auto &[property_id, value] : GetAllProperties(expression_result.ValueVertex())) {
-        auto typed_value = TypedValue(value, GetNameIdMapper(), ctx_->memory);
-        result.emplace(TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory), typed_value);
+      const auto &vertex = expression_result.ValueVertex();
+      for (const auto &[property_id, value] : GetAllProperties(vertex)) {
+        auto key = TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory);
+        // Keep embeddings lazy in the projected map: a map retained by collect / ORDER BY then holds
+        // O(refs), not O(N*dim) floats. Materialization happens only at compare/hash/serialize.
+        if (value.IsVectorIndexId()) {
+          result.emplace(std::move(key), TypedValue(LazyVectorRef{vertex.impl_, property_id}, ctx_->memory));
+        } else {
+          result.emplace(std::move(key), TypedValue(value, GetNameIdMapper(), ctx_->memory));
+        }
       }
       return {result, ctx_->memory};
     }
     case TypedValue::Type::Edge: {
-      for (const auto &[property_id, value] : GetAllProperties(expression_result.ValueEdge())) {
-        auto typed_value = TypedValue(value, GetNameIdMapper(), ctx_->memory);
-        result.emplace(TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory), typed_value);
+      const auto &edge = expression_result.ValueEdge();
+      for (const auto &[property_id, value] : GetAllProperties(edge)) {
+        auto key = TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory);
+        if (value.IsVectorIndexId()) {
+          result.emplace(std::move(key), TypedValue(LazyVectorRef{edge.impl_, property_id}, ctx_->memory));
+        } else {
+          result.emplace(std::move(key), TypedValue(value, GetNameIdMapper(), ctx_->memory));
+        }
       }
       return {result, ctx_->memory};
     }
@@ -442,7 +454,13 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
 
         auto property_id = ctx_->properties[property_lookup.property_.ix];
         if (property_lookup_cache_[symbol_pos].contains(property_id)) {
-          return {property_lookup_cache_[symbol_pos][property_id], GetNameIdMapper(), ctx_->memory};
+          const auto &cached = property_lookup_cache_[symbol_pos][property_id];
+          // GetAllProperties left embeddings as references; hand back a lazy VectorRef, not an
+          // (empty) reconstructed list.
+          if (cached.IsVectorIndexId()) {
+            return TypedValue(LazyVectorRef{expression_result_ptr->ValueVertex().impl_, property_id}, ctx_->memory);
+          }
+          return {cached, GetNameIdMapper(), ctx_->memory};
         }
         return TypedValue(ctx_->memory);
       } else {
@@ -464,13 +482,20 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
 
         auto property_id = ctx_->properties[property_lookup.property_.ix];
         if (property_lookup_cache_[symbol_pos].contains(property_id)) {
-          return {property_lookup_cache_[symbol_pos][property_id], GetNameIdMapper(), ctx_->memory};
+          const auto &cached = property_lookup_cache_[symbol_pos][property_id];
+          if (cached.IsVectorIndexId()) {
+            return TypedValue(LazyVectorRef{expression_result_ptr->ValueEdge().impl_, property_id}, ctx_->memory);
+          }
+          return {cached, GetNameIdMapper(), ctx_->memory};
         }
         return TypedValue(ctx_->memory);
       } else {
-        return {GetProperty(expression_result_ptr->ValueEdge(), property_lookup.property_),
-                GetNameIdMapper(),
-                ctx_->memory};
+        auto raw_prop = GetProperty(expression_result_ptr->ValueEdge(), property_lookup.property_);
+        if (raw_prop.IsVectorIndexId()) {
+          const auto prop_id = ctx_->properties[property_lookup.property_.ix];
+          return TypedValue(LazyVectorRef{expression_result_ptr->ValueEdge().impl_, prop_id}, ctx_->memory);
+        }
+        return TypedValue(std::move(raw_prop), GetNameIdMapper(), ctx_->memory);
       }
     case TypedValue::Type::VirtualEdge: {
       auto prop_id = dba_->NameToProperty(property_lookup.property_.name);

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -466,8 +466,7 @@ TypedValue ExpressionEvaluator::Visit(PropertyLookup &property_lookup) {
       } else {
         auto raw_prop = GetProperty(expression_result_ptr->ValueVertex(), property_lookup.property_);
         if (raw_prop.IsVectorIndexId()) {
-          // Return a lazy handle: floats are not reconstructed here.
-          // Materialization happens only on compare, hash, or Bolt serialize.
+          // Materialization happens only on compare, hash, or serialize.
           const auto prop_id = ctx_->properties[property_lookup.property_.ix];
           return TypedValue(LazyVectorRef{expression_result_ptr->ValueVertex().impl_, prop_id}, ctx_->memory);
         }

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -553,12 +553,15 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 
     if (lhs_ptr->IsVertex()) {
       if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
-      return {GetProperty(lhs_ptr->ValueVertex(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
+      const auto &vertex = lhs_ptr->ValueVertex();
+      return MakePropertyValue(
+          vertex, dba_->NameToProperty(index.ValueString()), GetProperty(vertex, index.ValueString()));
     }
 
     if (lhs_ptr->IsEdge()) {
       if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
-      return {GetProperty(lhs_ptr->ValueEdge(), index.ValueString()), GetNameIdMapper(), ctx_->memory};
+      const auto &edge = lhs_ptr->ValueEdge();
+      return MakePropertyValue(edge, dba_->NameToProperty(index.ValueString()), GetProperty(edge, index.ValueString()));
     };
 
     // lhs is Null
@@ -1166,6 +1169,17 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   }
 #endif
 
+  // Turns a raw property into its TypedValue, keeping a vector-index embedding as a lazy VectorRef
+  // bound to (accessor, prop). Every property-read site routes through this, so none can accidentally
+  // materialize an embedding — the reference is only forced on compare, hash, or serialize.
+  template <class TRecordAccessor>
+  TypedValue MakePropertyValue(const TRecordAccessor &record_accessor, storage::PropertyId prop_id,
+                               storage::PropertyValue raw) {
+    if (raw.IsVectorIndexId())
+      return TypedValue(LazyVectorRef{.entity = record_accessor.impl_, .prop = prop_id}, ctx_->memory);
+    return {std::move(raw), GetNameIdMapper(), ctx_->memory};
+  }
+
   template <class TRecordAccessor>
   storage::PropertyValue GetProperty(const TRecordAccessor &record_accessor, const PropertyIx &prop) {
     RequireAccessor("Reading a property");
@@ -1204,7 +1218,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     RequireAccessor("Reading a property");
     auto prop_id = dba_->NameToProperty(name);
     if (!IsPropertyAllowed(record_accessor, prop_id)) return storage::PropertyValue{};
-    auto maybe_prop = record_accessor.GetProperty(view_, prop_id);
+    auto maybe_prop = record_accessor.GetProperty(view_, prop_id, /*with_vector_reconstruction=*/false);
     if (maybe_prop == std::unexpected{storage::Error::NONEXISTENT_OBJECT}) {
       // This is a very nasty and temporary hack in order to make MERGE work.
       // The old storage had the following logic when returning an `OLD` view:
@@ -1212,7 +1226,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       // exist, it returned the NEW view. With this hack we simulate that
       // behavior.
       // TODO (mferencevic, teon.banek): Remove once MERGE is reimplemented.
-      maybe_prop = record_accessor.GetProperty(view_, prop_id);
+      maybe_prop = record_accessor.GetProperty(view_, prop_id, /*with_vector_reconstruction=*/false);
     }
     if (!maybe_prop) {
       switch (maybe_prop.error()) {

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -554,14 +554,17 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (lhs_ptr->IsVertex()) {
       if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
       const auto &vertex = lhs_ptr->ValueVertex();
-      return MakePropertyValue(
-          vertex, dba_->NameToProperty(index.ValueString()), GetProperty(vertex, index.ValueString()));
+      // GetProperty resolves the name (and throws without an accessor) before we deref dba_ below.
+      auto value = GetProperty(vertex, index.ValueString());
+      return MakePropertyValue(vertex, dba_->NameToProperty(index.ValueString()), std::move(value));
     }
 
     if (lhs_ptr->IsEdge()) {
       if (!index.IsString()) throw QueryRuntimeException("Expected a string as a property name, got {}.", index.type());
       const auto &edge = lhs_ptr->ValueEdge();
-      return MakePropertyValue(edge, dba_->NameToProperty(index.ValueString()), GetProperty(edge, index.ValueString()));
+      // GetProperty resolves the name (and throws without an accessor) before we deref dba_ below.
+      auto value = GetProperty(edge, index.ValueString());
+      return MakePropertyValue(edge, dba_->NameToProperty(index.ValueString()), std::move(value));
     };
 
     // lhs is Null

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1228,7 +1228,10 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
  private:
   template <class TRecordAccessor>
   std::map<storage::PropertyId, storage::PropertyValue> GetAllProperties(const TRecordAccessor &record_accessor) {
-    auto maybe_props = record_accessor.Properties(view_);
+    // Read WITHOUT reconstructing vector embeddings: they come back as compact VectorIndexId
+    // references and the caller (AllPropertiesLookup) wraps each as a lazy VectorRef, so a projected
+    // map never materialises O(dim) floats per property. Non-embedding properties are unaffected.
+    auto maybe_props = record_accessor.Properties(view_, /*with_vector_reconstruction=*/false);
     if (maybe_props == std::unexpected{storage::Error::NONEXISTENT_OBJECT}) {
       // This is a very nasty and temporary hack in order to make MERGE work.
       // The old storage had the following logic when returning an `OLD` view:

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1170,7 +1170,10 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   storage::PropertyValue GetProperty(const TRecordAccessor &record_accessor, const PropertyIx &prop) {
     RequireAccessor("Reading a property");
     if (!IsPropertyAllowed(record_accessor, ctx_->properties[prop.ix])) return storage::PropertyValue{};
-    auto maybe_prop = record_accessor.GetProperty(view_, ctx_->properties[prop.ix]);
+    // Keep a vector-index embedding as its compact reference; PropertyLookup wraps it as a lazy
+    // VectorRef, so reconstructing the floats here would only be discarded.
+    auto maybe_prop =
+        record_accessor.GetProperty(view_, ctx_->properties[prop.ix], /*with_vector_reconstruction=*/false);
     if (maybe_prop == std::unexpected{storage::Error::NONEXISTENT_OBJECT}) {
       // This is a very nasty and temporary hack in order to make MERGE work.
       // The old storage had the following logic when returning an `OLD` view:
@@ -1178,7 +1181,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       // exist, it returned the NEW view. With this hack we simulate that
       // behavior.
       // TODO (mferencevic, teon.banek): Remove once MERGE is reimplemented.
-      maybe_prop = record_accessor.GetProperty(storage::View::NEW, ctx_->properties[prop.ix]);
+      maybe_prop = record_accessor.GetProperty(
+          storage::View::NEW, ctx_->properties[prop.ix], /*with_vector_reconstruction=*/false);
     }
     if (!maybe_prop) {
       switch (maybe_prop.error()) {

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -446,7 +446,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       }
       // Exceptions have higher priority than returning nulls when list expression
       // is not null.
-      if (list.type() != TypedValue::Type::List) {
+      if (!list.IsList()) {
         throw QueryRuntimeException("IN expected a list, got {}.", list.type());
       }
       const auto &list_value = list.ValueList();
@@ -587,7 +587,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     auto _list = op.list_->Accept(*this);
     if (_list.type() == TypedValue::Type::Null) {
       is_null = true;
-    } else if (_list.type() != TypedValue::Type::List) {
+    } else if (!_list.IsList()) {
       throw QueryRuntimeException("Expected a list to slice, got {}.", _list.type());
     }
 
@@ -848,7 +848,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (list_value.IsNull()) {
       return TypedValue(ctx_->memory);
     }
-    if (list_value.type() != TypedValue::Type::List) {
+    if (!list_value.IsList()) {
       throw QueryRuntimeException("REDUCE expected a list, got {}.", list_value.type());
     }
     auto &list = list_value.ValueList();
@@ -868,7 +868,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (list_value.IsNull()) {
       return TypedValue(ctx_->memory);
     }
-    if (list_value.type() != TypedValue::Type::List) {
+    if (!list_value.IsList()) {
       throw QueryRuntimeException("EXTRACT expected a list, got {}.", list_value.type());
     }
     auto &list = list_value.ValueList();
@@ -892,7 +892,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       return TypedValue(ctx_->memory);
     }
 
-    if (list_value.type() != TypedValue::Type::List) {
+    if (!list_value.IsList()) {
       throw QueryRuntimeException("List comprehension expected a list, got {}.", list_value.type());
     }
 
@@ -968,7 +968,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (list_value.IsNull()) {
       return TypedValue(ctx_->memory);
     }
-    if (list_value.type() != TypedValue::Type::List) {
+    if (!list_value.IsList()) {
       throw QueryRuntimeException("ALL expected a list, got {}.", list_value.type());
     }
     auto &list = list_value.ValueList();
@@ -1005,7 +1005,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (list_value.IsNull()) {
       return TypedValue(ctx_->memory);
     }
-    if (list_value.type() != TypedValue::Type::List) {
+    if (!list_value.IsList()) {
       throw QueryRuntimeException("SINGLE expected a list, got {}.", list_value.type());
     }
     auto &list = list_value.ValueList();
@@ -1053,7 +1053,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (list_value.IsNull()) {
       return TypedValue(ctx_->memory);
     }
-    if (list_value.type() != TypedValue::Type::List) {
+    if (!list_value.IsList()) {
       throw QueryRuntimeException("ANY expected a list, got {}.", list_value.type());
     }
     auto &list = list_value.ValueList();
@@ -1091,7 +1091,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (list_value.IsNull()) {
       return TypedValue(ctx_->memory);
     }
-    if (list_value.type() != TypedValue::Type::List) {
+    if (!list_value.IsList()) {
       throw QueryRuntimeException("NONE expected a list, got {}.", list_value.type());
     }
     auto &list = list_value.ValueList();

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -6724,8 +6724,8 @@ bool ContainsSameEdge(const TypedValue &a, const TypedValue &b) {
     return false;
   };
 
-  if (a.type() == TypedValue::Type::List) return compare_to_list(a, b);
-  if (b.type() == TypedValue::Type::List) return compare_to_list(b, a);
+  if (a.IsList()) return compare_to_list(a, b);
+  if (b.IsList()) return compare_to_list(b, a);
 
   return a.ValueEdge() == b.ValueEdge();
 }
@@ -7477,13 +7477,13 @@ class AggregateCursor : public Cursor {
   /** Project a subgraph from lists of nodes and lists of edges. Any nulls in these lists are ignored.
    */
   static void ProjectList(TypedValue const &arg1, TypedValue const &arg2, Graph &projectedGraph) {
-    if (arg1.type() != TypedValue::Type::List || !std::ranges::all_of(arg1.ValueList(), [](TypedValue const &each) {
+    if (!arg1.IsList() || !std::ranges::all_of(arg1.ValueList(), [](TypedValue const &each) {
           return each.type() == TypedValue::Type::Vertex || each.type() == TypedValue::Type::Null;
         })) {
       throw QueryRuntimeException("project() argument 1 must be a list of nodes or nulls.");
     }
 
-    if (arg2.type() != TypedValue::Type::List || !std::ranges::all_of(arg2.ValueList(), [](TypedValue const &each) {
+    if (!arg2.IsList() || !std::ranges::all_of(arg2.ValueList(), [](TypedValue const &each) {
           return each.type() == TypedValue::Type::Edge || each.type() == TypedValue::Type::Null;
         })) {
       throw QueryRuntimeException("project() argument 2 must be a list of relationships or nulls.");
@@ -7511,7 +7511,7 @@ class AggregateCursor : public Cursor {
                                VirtualNode::allocator_type alloc) const {
     VirtualNode::label_list labels{alloc};
     if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
-      if (labels_it->second.type() != TypedValue::Type::List) {
+      if (!labels_it->second.IsList()) {
         throw QueryRuntimeException("derive() option '{}' must be a list of label strings.", labels_key);
       }
       for (const auto &label : labels_it->second.ValueList()) {
@@ -7588,7 +7588,7 @@ class AggregateCursor : public Cursor {
     const bool type_is_undirected = [&] {
       const auto it = options.find(kUndirectedEdgeTypes);
       if (it == options.end()) return false;
-      if (it->second.type() != TypedValue::Type::List) {
+      if (!it->second.IsList()) {
         throw QueryRuntimeException("derive() option '{}' must be a list of edge-type strings.", kUndirectedEdgeTypes);
       }
       const auto &list = it->second.ValueList();
@@ -8112,7 +8112,7 @@ class UnwindCursor : public Cursor {
         ExpressionEvaluator evaluator = ExpressionEvaluator{&frame, context, storage::View::OLD};
 
         TypedValue input_value = self_.input_expression_->Accept(evaluator);
-        if (input_value.type() != TypedValue::Type::List)
+        if (!input_value.IsList())
           throw QueryRuntimeException("Argument of UNWIND must be a list, but '{}' was provided.", input_value.type());
         // Move the evaluted input_value_list to our vector.
         input_value_ = std::move(input_value.ValueList());

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -652,9 +652,13 @@ mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, al
       // value. This handles the case when filling the container throws
       // something and our destructor doesn't get called so member value isn't
       // released.
+      // A lazy vector-index embedding maps to LIST but has no ValueList(); materialize it first.
+      const memgraph::query::TypedValue materialized =
+          tv.IsVectorRef() ? tv.MaterializeVectorRef(tv.get_allocator()) : memgraph::query::TypedValue{};
+      const memgraph::query::TypedValue &list_tv = tv.IsVectorRef() ? materialized : tv;
       memgraph::utils::pmr::vector<mgp_value> elems(alloc);
-      elems.reserve(tv.ValueList().size());
-      for (const auto &elem : tv.ValueList()) {
+      elems.reserve(list_tv.ValueList().size());
+      for (const auto &elem : list_tv.ValueList()) {
         elems.emplace_back(elem, graph);
       }
       memgraph::utils::Allocator<mgp_list> allocator(alloc);

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -364,6 +364,7 @@ mgp_value_type FromTypedValueType(memgraph::query::TypedValue::Type type) {
     case memgraph::query::TypedValue::Type::String:
       return MGP_VALUE_TYPE_STRING;
     case memgraph::query::TypedValue::Type::List:
+    case memgraph::query::TypedValue::Type::VectorRef:  // materializes to a list of floats
       return MGP_VALUE_TYPE_LIST;
     case memgraph::query::TypedValue::Type::Map:
       return MGP_VALUE_TYPE_MAP;
@@ -5550,6 +5551,8 @@ std::ostream &PrintValue(const TypedValue &value, std::ostream *stream) {
       memgraph::utils::PrintIterable(
           *stream, value.ValueList(), ", ", [](auto &stream, const auto &elem) { PrintValue(elem, &stream); });
       return (*stream) << "]";
+    case TypedValue::Type::VectorRef:  // lazy embedding: materialize transiently and print as a list
+      return PrintValue(value.MaterializeVectorRef(value.get_allocator()), stream);
     case TypedValue::Type::Map:
       (*stream) << "{";
       memgraph::utils::PrintIterable(*stream, value.ValueMap(), ", ", [](auto &stream, const auto &item) {

--- a/src/query/relations/comparability.hpp
+++ b/src/query/relations/comparability.hpp
@@ -18,6 +18,9 @@
 /// must place every pair because a sort is undefined without that.
 #pragma once
 
+#include <algorithm>
+#include <vector>
+
 #include "query/typed_value.hpp"
 
 namespace memgraph::query::relations::comparability {
@@ -53,6 +56,7 @@ constexpr bool Admits(TypedValue::Type type) {
     case TypedValue::Type::Enum:
     case TypedValue::Type::Point2d:
     case TypedValue::Type::Point3d:
+    case TypedValue::Type::VectorRef:
       return false;
   }
 }
@@ -78,6 +82,19 @@ constexpr bool IsTemporal(TypedValue::Type type) {
 ///
 /// @throw TypedValueException for a pair of types this relation does not admit.
 inline TypedValue Less(const TypedValue &a, const TypedValue &b) {
+  // Lazy embedding refs: reconstruct both operands into reused thread-local float buffers (never the
+  // query's monotonic arena) and compare the floats directly. Mixed operands fall back to a transient
+  // List materialization, which Admits rejects like any other list.
+  if (a.IsVectorRef() && b.IsVectorRef()) {
+    thread_local std::vector<float> fa;
+    thread_local std::vector<float> fb;
+    a.MaterializeVectorRefInto(fa);
+    b.MaterializeVectorRefInto(fb);
+    return TypedValue(std::lexicographical_compare(fa.begin(), fa.end(), fb.begin(), fb.end()), a.get_allocator());
+  }
+  if (a.IsVectorRef()) return a.MaterializeVectorRef(a.get_allocator()) < b;
+  if (b.IsVectorRef()) return a < b.MaterializeVectorRef(b.get_allocator());
+
   if (!Admits(a.type()) || !Admits(b.type())) {
     if ((is_canonical(a.type()) || is_canonical(b.type())) && (a.type() != b.type())) return {};
     throw TypedValueException("Invalid 'less' operand types({} + {})", a.type(), b.type());

--- a/src/query/relations/equality.hpp
+++ b/src/query/relations/equality.hpp
@@ -42,6 +42,18 @@ TypedValue EqualOfContainers(const TypedValue &a, const TypedValue &b);
 inline TypedValue Equal(const TypedValue &a, const TypedValue &b) {
   if (a.IsNull() || b.IsNull()) return TypedValue(a.get_allocator());
 
+  // Lazy embedding refs: compare two embeddings via reused thread-local float buffers (never the query
+  // arena). Mixed operands fall back to a transient List materialization.
+  if (a.IsVectorRef() && b.IsVectorRef()) {
+    thread_local std::vector<float> fa;
+    thread_local std::vector<float> fb;
+    a.MaterializeVectorRefInto(fa);
+    b.MaterializeVectorRefInto(fb);
+    return TypedValue(fa == fb, a.get_allocator());
+  }
+  if (a.IsVectorRef()) return a.MaterializeVectorRef(a.get_allocator()) == b;
+  if (b.IsVectorRef()) return a == b.MaterializeVectorRef(b.get_allocator());
+
   // check we have values that can be compared
   // this means that either they're the same type, or (int, double) combo
   if ((a.type() != b.type() && !(a.IsNumeric() && b.IsNumeric()))) return TypedValue(false, a.get_allocator());
@@ -96,6 +108,9 @@ inline TypedValue Equal(const TypedValue &a, const TypedValue &b) {
     case TypedValue::Type::Function:
     case TypedValue::Type::Null:
       LOG_FATAL("Unhandled comparison for types");
+    case TypedValue::Type::VectorRef:
+      // Materialized above before reaching this switch; unreachable in practice.
+      LOG_FATAL("Unhandled VectorRef in equality::Equal");
   }
 }
 

--- a/src/query/relations/orderability.hpp
+++ b/src/query/relations/orderability.hpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <compare>
+#include <vector>
 
 #include "query/exceptions.hpp"
 #include "query/fmt.hpp"
@@ -69,6 +70,15 @@ inline std::partial_ordering Compare(TypedValue const &a, TypedValue const &b) {
         return a.UnsafeValuePoint3d() <=> b.UnsafeValuePoint3d();
       case TypedValue::Type::List:
         return CompareOfLists(a, b);
+      case TypedValue::Type::VectorRef: {
+        // Lazy embedding: reconstruct both operands into reused thread-local float buffers (never the
+        // query's monotonic arena) and compare the floats, so a full ORDER BY holds only references.
+        thread_local std::vector<float> la;
+        thread_local std::vector<float> lb;
+        a.MaterializeVectorRefInto(la);
+        b.MaterializeVectorRefInto(lb);
+        return std::lexicographical_compare_three_way(la.begin(), la.end(), lb.begin(), lb.end());
+      }
       case TypedValue::Type::Map:
       case TypedValue::Type::Vertex:
       case TypedValue::Type::Edge:
@@ -120,6 +130,7 @@ inline std::partial_ordering Compare(TypedValue const &a, TypedValue const &b) {
       case TypedValue::Type::Graph:
       case TypedValue::Type::VirtualGraph:
       case TypedValue::Type::Function:
+      case TypedValue::Type::VectorRef:  // unreachable: not numeric, rejected by the IsNumeric guard above
         LOG_FATAL("Invalid type");
     }
   }

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -1031,7 +1031,44 @@ DEFINE_VALUE_AND_TYPE_GETTERS_PRIMITIVE(bool, Bool, bool_v)
 DEFINE_VALUE_AND_TYPE_GETTERS_PRIMITIVE(int64_t, Int, int_v)
 DEFINE_VALUE_AND_TYPE_GETTERS_PRIMITIVE(double, Double, double_v)
 DEFINE_VALUE_AND_TYPE_GETTERS(TypedValue::TString, String, string_v)
-DEFINE_VALUE_AND_TYPE_GETTERS(TypedValue::TVector, List, list_v)
+
+// List is hand-written (not macro-generated) so a lazy VectorRef materializes into an owned List on
+// first access. The ordering/equality/hash fast-paths dispatch on type() and never reach here, so a
+// value used only as a sort/dedup key stays compact.
+void TypedValue::EnsureListMaterialized() const {
+  if (type_ != Type::VectorRef) return;
+  std::vector<float> tmp;
+  MaterializeVectorRefInto(tmp);
+  auto *self = const_cast<TypedValue *>(this);
+  TVector list(alloc_);
+  list.reserve(tmp.size());
+  for (const float f : tmp) list.emplace_back(static_cast<double>(f));
+  std::destroy_at(&self->vector_ref_v);
+  std::construct_at(&self->list_v, std::move(list));
+  self->type_ = Type::List;
+}
+
+TypedValue::TVector &TypedValue::ValueList() {
+  EnsureListMaterialized();
+  if (type_ != Type::List) [[unlikely]]
+    throw TypedValueException("TypedValue is of type '{}', not '{}'", type_, Type::List);
+  return list_v;
+}
+
+const TypedValue::TVector &TypedValue::ValueList() const {
+  EnsureListMaterialized();
+  if (type_ != Type::List) [[unlikely]]
+    throw TypedValueException("TypedValue is of type '{}', not '{}'", type_, Type::List);
+  return list_v;
+}
+
+bool TypedValue::IsList() const { return type_ == Type::List || type_ == Type::VectorRef; }
+
+const TypedValue::TVector &TypedValue::UnsafeValueList() const {
+  EnsureListMaterialized();
+  return list_v;
+}
+
 DEFINE_VALUE_AND_TYPE_GETTERS(TypedValue::TMap, Map, map_v)
 DEFINE_VALUE_AND_TYPE_GETTERS(VertexAccessor, Vertex, vertex_v)
 DEFINE_VALUE_AND_TYPE_GETTERS(EdgeAccessor, Edge, edge_v)
@@ -2126,6 +2163,7 @@ void to_json(nlohmann::json &j, TypedValue const &value) {
       j = value.ValueString();
       break;
     case TypedValue::Type::List:
+    case TypedValue::Type::VectorRef:  // a lazy embedding materializes to its list of doubles
       j = value.ValueList();
       break;
     case TypedValue::Type::Map:

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -701,7 +701,7 @@ TypedValue::operator storage::ExternalPropertyValue() const {
       MaterializeVectorRefInto(tmp);
       std::vector<storage::ExternalPropertyValue> list;
       list.reserve(tmp.size());
-      for (float f : tmp) list.emplace_back(static_cast<double>(f));
+      for (const float f : tmp) list.emplace_back(static_cast<double>(f));
       return storage::ExternalPropertyValue(std::move(list));
     }
     case Type::Vertex:
@@ -985,7 +985,7 @@ storage::PropertyValue TypedValue::ToPropertyValue(storage::NameIdMapper *name_i
       MaterializeVectorRefInto(tmp);
       storage::PropertyValue::list_t list;
       list.reserve(tmp.size());
-      for (float f : tmp) list.emplace_back(static_cast<double>(f));
+      for (const float f : tmp) list.emplace_back(static_cast<double>(f));
       return storage::PropertyValue(storage::DoubleListTag{}, std::move(list));
     }
     case Type::Vertex:
@@ -1060,11 +1060,11 @@ TypedValue TypedValue::MaterializeVectorRef(allocator_type alloc) const {
   std::visit([&](auto const &acc) { acc.GetVectorInto(vector_ref_v.prop, tmp); }, vector_ref_v.entity);
   TVector list(alloc);
   list.reserve(tmp.size());
-  for (float f : tmp) {
+  for (const float f : tmp) {
     // The pmr vector injects its own allocator (uses_allocator); do not pass it explicitly.
     list.emplace_back(static_cast<double>(f));
   }
-  return TypedValue(std::move(list), alloc);
+  return {std::move(list), alloc};
 }
 
 void TypedValue::MaterializeVectorRefInto(std::vector<float> &out) const {

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -695,6 +695,15 @@ TypedValue::operator storage::ExternalPropertyValue() const {
       return storage::ExternalPropertyValue(point_2d_v);
     case TypedValue::Type::Point3d:
       return storage::ExternalPropertyValue(point_3d_v);
+    case Type::VectorRef: {
+      // Materialize the lazy embedding ref into a plain list of doubles, matching the List case above.
+      std::vector<float> tmp;
+      MaterializeVectorRefInto(tmp);
+      std::vector<storage::ExternalPropertyValue> list;
+      list.reserve(tmp.size());
+      for (float f : tmp) list.emplace_back(static_cast<double>(f));
+      return storage::ExternalPropertyValue(std::move(list));
+    }
     case Type::Vertex:
     case Type::Edge:
     case Type::VirtualEdge:
@@ -703,7 +712,6 @@ TypedValue::operator storage::ExternalPropertyValue() const {
     case Type::Graph:
     case Type::VirtualGraph:
     case Type::Function:
-    case Type::VectorRef:
       throw TypedValueException("Unsupported conversion from TypedValue to PropertyValue");
   }
 }
@@ -970,6 +978,16 @@ storage::PropertyValue TypedValue::ToPropertyValue(storage::NameIdMapper *name_i
       return storage::PropertyValue(point_2d_v);
     case TypedValue::Type::Point3d:
       return storage::PropertyValue(point_3d_v);
+    case Type::VectorRef: {
+      // A lazy embedding ref materializes to the same DoubleList a literal `SET n.emb = [...]` stores,
+      // so a persisted copy is re-indexed by the vector index exactly like any other double list.
+      std::vector<float> tmp;
+      MaterializeVectorRefInto(tmp);
+      storage::PropertyValue::list_t list;
+      list.reserve(tmp.size());
+      for (float f : tmp) list.emplace_back(static_cast<double>(f));
+      return storage::PropertyValue(storage::DoubleListTag{}, std::move(list));
+    }
     case Type::Vertex:
     case Type::Edge:
     case Type::VirtualEdge:
@@ -978,7 +996,6 @@ storage::PropertyValue TypedValue::ToPropertyValue(storage::NameIdMapper *name_i
     case Type::Graph:
     case Type::VirtualGraph:
     case Type::Function:
-    case Type::VectorRef:
       throw TypedValueException("Unsupported conversion from TypedValue to PropertyValue");
   }
 }
@@ -1052,7 +1069,11 @@ TypedValue TypedValue::MaterializeVectorRef(allocator_type alloc) const {
 
 void TypedValue::MaterializeVectorRefInto(std::vector<float> &out) const {
   MG_ASSERT(type_ == Type::VectorRef, "MaterializeVectorRefInto called on non-VectorRef TypedValue");
-  std::visit([&](auto const &acc) { acc.GetVectorInto(vector_ref_v.prop, out); }, vector_ref_v.entity);
+  const bool ok =
+      std::visit([&](auto const &acc) { return acc.GetVectorInto(vector_ref_v.prop, out); }, vector_ref_v.entity);
+  // On any miss GetVectorInto leaves `out` untouched (or resized but unfilled); clear the reused
+  // thread-local scratch so a failed lookup never compares/hashes against a prior entity's floats.
+  if (!ok) out.clear();
 }
 
 bool TypedValue::ContainsDeleted() const {
@@ -2035,14 +2056,18 @@ size_t Hash(const TypedValue &value) {
     case TypedValue::Type::VirtualGraph:
       throw TypedValueException("Unsupported hash function for VirtualGraph");
     case TypedValue::Type::VectorRef: {
-      // Thread-local float buffer avoids pmr arena growth on DISTINCT/GROUP BY; must stay consistent with operator== (same float sequence).
+      // A VectorRef is equal to the List<Double> that MaterializeVectorRef produces, so it must hash
+      // identically or DISTINCT/GROUP BY would keep duplicates. Fold the same FnvCollection hash over
+      // a reused thread-local float buffer (no List allocated in the monotonic query arena), hashing
+      // each float exactly as its materialized Double element would be.
       thread_local std::vector<float> tmp;
       value.MaterializeVectorRefInto(tmp);
-      size_t h = 0;
-      for (float f : tmp) {
-        h ^= std::hash<float>{}(f) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-      }
-      return h;
+
+      struct FloatAsDoubleHash {
+        size_t operator()(float f) const { return Hash(TypedValue(static_cast<double>(f))); }
+      };
+
+      return utils::FnvCollection<std::vector<float>, float, FloatAsDoubleHash>{}(tmp);
     }
   }
   LOG_FATAL("Unhandled TypedValue.type() in hash function");

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -19,6 +19,7 @@
 #include <nlohmann/json.hpp>
 #include <string_view>
 #include <utility>
+#include <variant>
 
 #include "query/fmt.hpp"
 #include "query/graph.hpp"
@@ -1039,7 +1040,7 @@ DEFINE_VALUE_AND_TYPE_GETTERS(LazyVectorRef, VectorRef, vector_ref_v)
 TypedValue TypedValue::MaterializeVectorRef(allocator_type alloc) const {
   MG_ASSERT(type_ == Type::VectorRef, "MaterializeVectorRef called on non-VectorRef TypedValue");
   std::vector<float> tmp;
-  vector_ref_v.vertex.GetVectorInto(vector_ref_v.prop, tmp);
+  std::visit([&](auto const &acc) { acc.GetVectorInto(vector_ref_v.prop, tmp); }, vector_ref_v.entity);
   TVector list(alloc);
   list.reserve(tmp.size());
   for (float f : tmp) {
@@ -1051,7 +1052,7 @@ TypedValue TypedValue::MaterializeVectorRef(allocator_type alloc) const {
 
 void TypedValue::MaterializeVectorRefInto(std::vector<float> &out) const {
   MG_ASSERT(type_ == Type::VectorRef, "MaterializeVectorRefInto called on non-VectorRef TypedValue");
-  vector_ref_v.vertex.GetVectorInto(vector_ref_v.prop, out);
+  std::visit([&](auto const &acc) { acc.GetVectorInto(vector_ref_v.prop, out); }, vector_ref_v.entity);
 }
 
 bool TypedValue::ContainsDeleted() const {

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -2035,10 +2035,7 @@ size_t Hash(const TypedValue &value) {
     case TypedValue::Type::VirtualGraph:
       throw TypedValueException("Unsupported hash function for VirtualGraph");
     case TypedValue::Type::VectorRef: {
-      // Hash the reconstructed embedding from a REUSED thread-local float buffer rather than a
-      // materialized pmr List, so DISTINCT / GROUP BY over embeddings never grows the query arena and
-      // allocates the scratch buffer once per thread. Consistent with operator==, which compares the
-      // same float sequence.
+      // Thread-local float buffer avoids pmr arena growth on DISTINCT/GROUP BY; must stay consistent with operator== (same float sequence).
       thread_local std::vector<float> tmp;
       value.MaterializeVectorRefInto(tmp);
       size_t h = 0;

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -702,6 +702,7 @@ TypedValue::operator storage::ExternalPropertyValue() const {
     case Type::Graph:
     case Type::VirtualGraph:
     case Type::Function:
+    case Type::VectorRef:
       throw TypedValueException("Unsupported conversion from TypedValue to PropertyValue");
   }
 }
@@ -787,6 +788,9 @@ TypedValue::TypedValue(const TypedValue &other, allocator_type alloc) : alloc_{a
       alloc_trait::construct(alloc_, &virtual_graph_v, graph_ptr);
       return;
     }
+    case Type::VectorRef:
+      vector_ref_v = other.vector_ref_v;
+      return;
   }
   LOG_FATAL("Unsupported TypedValue::Type");
 }
@@ -891,6 +895,9 @@ TypedValue::TypedValue(TypedValue &&other, allocator_type alloc) : alloc_{alloc}
         alloc_trait::construct(alloc_, &virtual_graph_v, graph_ptr);
       }
       break;
+    case Type::VectorRef:
+      vector_ref_v = other.vector_ref_v;
+      break;
   }
 }
 
@@ -970,6 +977,7 @@ storage::PropertyValue TypedValue::ToPropertyValue(storage::NameIdMapper *name_i
     case Type::Graph:
     case Type::VirtualGraph:
     case Type::Function:
+    case Type::VectorRef:
       throw TypedValueException("Unsupported conversion from TypedValue to PropertyValue");
   }
 }
@@ -1023,9 +1031,28 @@ DEFINE_VALUE_AND_TYPE_GETTERS(storage::Point3d, Point3d, point_3d_v)
 DEFINE_VALUE_AND_TYPE_GETTERS(std::function<void(TypedValue *)>, Function, function_v)
 DEFINE_VALUE_AND_TYPE_GETTERS(Graph, Graph, *graph_v)
 DEFINE_VALUE_AND_TYPE_GETTERS(VirtualGraph, VirtualGraph, *virtual_graph_v)
+DEFINE_VALUE_AND_TYPE_GETTERS(LazyVectorRef, VectorRef, vector_ref_v)
 
 #undef DEFINE_VALUE_AND_TYPE_GETTERS
 #undef DEFINE_VALUE_AND_TYPE_GETTERS_PRIMITIVE
+
+TypedValue TypedValue::MaterializeVectorRef(allocator_type alloc) const {
+  MG_ASSERT(type_ == Type::VectorRef, "MaterializeVectorRef called on non-VectorRef TypedValue");
+  std::vector<float> tmp;
+  vector_ref_v.vertex.GetVectorInto(vector_ref_v.prop, tmp);
+  TVector list(alloc);
+  list.reserve(tmp.size());
+  for (float f : tmp) {
+    // The pmr vector injects its own allocator (uses_allocator); do not pass it explicitly.
+    list.emplace_back(static_cast<double>(f));
+  }
+  return TypedValue(std::move(list), alloc);
+}
+
+void TypedValue::MaterializeVectorRefInto(std::vector<float> &out) const {
+  MG_ASSERT(type_ == Type::VectorRef, "MaterializeVectorRefInto called on non-VectorRef TypedValue");
+  vector_ref_v.vertex.GetVectorInto(vector_ref_v.prop, out);
+}
 
 bool TypedValue::ContainsDeleted() const {
   switch (type_) {
@@ -1064,6 +1091,8 @@ bool TypedValue::ContainsDeleted() const {
     case Type::VirtualGraph:
     case Type::Function:
       throw TypedValueException("Value of unknown type");
+    case Type::VectorRef:
+      return false;
   }
   return false;
 }
@@ -1096,6 +1125,7 @@ bool TypedValue::IsPropertyValue() const {
     case Type::Graph:
     case Type::VirtualGraph:
     case Type::Function:
+    case Type::VectorRef:
       return false;
   }
 }
@@ -1147,6 +1177,8 @@ std::ostream &operator<<(std::ostream &os, const TypedValue::Type &type) {
       return os << "virtual_graph";
     case TypedValue::Type::Function:
       return os << "function";
+    case TypedValue::Type::VectorRef:
+      return os << "vector";
   }
   LOG_FATAL("Unsupported TypedValue::Type");
 }
@@ -1406,6 +1438,9 @@ TypedValue &TypedValue::operator=(const TypedValue &other) {
         case Type::Point3d:
           point_3d_v = other.point_3d_v;
           break;
+        case Type::VectorRef:
+          vector_ref_v = other.vector_ref_v;
+          break;
       }
       return *this;
     }
@@ -1520,6 +1555,9 @@ TypedValue &TypedValue::operator=(TypedValue &&other) noexcept(false) {
         case Type::Point3d:
           point_3d_v = other.point_3d_v;
           break;
+        case Type::VectorRef:
+          vector_ref_v = other.vector_ref_v;
+          break;
       }
 
       return *this;
@@ -1592,7 +1630,8 @@ TypedValue::~TypedValue() {
     case Type::Point2d:
     case Type::Point3d:
     case Type::ZonedDateTime:
-      // Do nothing: std::chrono::time_zone* pointers reference immutable values from the external tz DB
+    case Type::VectorRef:
+      // Trivially destructible: no heap ownership.
       break;
     case Type::Function:
       std::destroy_at(&function_v);
@@ -1994,6 +2033,19 @@ size_t Hash(const TypedValue &value) {
       throw TypedValueException("Unsupported hash function for Graph");
     case TypedValue::Type::VirtualGraph:
       throw TypedValueException("Unsupported hash function for VirtualGraph");
+    case TypedValue::Type::VectorRef: {
+      // Hash the reconstructed embedding from a REUSED thread-local float buffer rather than a
+      // materialized pmr List, so DISTINCT / GROUP BY over embeddings never grows the query arena and
+      // allocates the scratch buffer once per thread. Consistent with operator==, which compares the
+      // same float sequence.
+      thread_local std::vector<float> tmp;
+      value.MaterializeVectorRefInto(tmp);
+      size_t h = 0;
+      for (float f : tmp) {
+        h ^= std::hash<float>{}(f) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+      }
+      return h;
+    }
   }
   LOG_FATAL("Unhandled TypedValue.type() in hash function");
 }

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -37,6 +37,14 @@ class VirtualGraph;  // fwd declare
 class VirtualEdge;   // fwd declare
 class VirtualNode;   // fwd declare
 
+/// Lazy handle for a vector-index embedding stored as a VectorIndexId reference.
+/// Holds a copy of the storage accessor (trivially copyable) and the property id.
+/// No floats are reconstructed until MaterializeVectorRef() is called.
+struct LazyVectorRef {
+  storage::VertexAccessor vertex;
+  storage::PropertyId prop;
+};
+
 namespace {
 template <typename T>
 concept TypedValueValidPrimativeType =
@@ -111,7 +119,8 @@ class TypedValue {
     Point2d,
     Point3d,
     VirtualEdge,
-    VirtualNode
+    VirtualNode,
+    VectorRef
   };
 
   // TypedValue at this exact moment of compilation is an incomplete type, and
@@ -211,6 +220,10 @@ class TypedValue {
 
   explicit TypedValue(const storage::Point3d &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Point3d) {
     point_3d_v = value;
+  }
+
+  explicit TypedValue(LazyVectorRef ref, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::VectorRef) {
+    vector_ref_v = ref;
   }
 
   // conversion function to storage::ExternalPropertyValue
@@ -536,9 +549,21 @@ class TypedValue {
   DECLARE_VALUE_AND_TYPE_GETTERS(Graph, Graph, *graph_v)
   DECLARE_VALUE_AND_TYPE_GETTERS(VirtualGraph, VirtualGraph, *virtual_graph_v)
   DECLARE_VALUE_AND_TYPE_GETTERS(std::function<void(TypedValue *)>, Function, function_v)
+  DECLARE_VALUE_AND_TYPE_GETTERS(LazyVectorRef, VectorRef, vector_ref_v)
 
 #undef DECLARE_VALUE_AND_TYPE_GETTERS
 #undef DECLARE_VALUE_AND_TYPE_GETTERS_PRIMITIVE
+
+  /// Reconstruct the referenced embedding into a TypedValue::List of Doubles.
+  /// Transient: the returned list is freed when the TypedValue goes out of scope.
+  /// Must only be called when type() == Type::VectorRef.
+  TypedValue MaterializeVectorRef(allocator_type alloc) const;
+
+  /// Reconstruct the referenced embedding into a caller-owned float buffer (std::allocator).
+  /// This is the allocation-free path for the hot compare / hash / equality routines: the buffer
+  /// frees at the caller's scope, so it never accumulates in the query's monotonic arena the way a
+  /// materialized pmr List would. Must only be called when type() == Type::VectorRef.
+  void MaterializeVectorRefInto(std::vector<float> &out) const;
 
   bool ContainsDeleted() const;
 
@@ -794,6 +819,8 @@ class TypedValue {
     std::function<void(TypedValue *)> function_v;
     std::unique_ptr<VirtualEdge> virtual_edge_v;
     std::unique_ptr<VirtualNode> virtual_node_v;
+    // Trivially copyable: storage accessor + property id, no heap allocation.
+    LazyVectorRef vector_ref_v;
   };
 
   /**

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -531,7 +531,16 @@ class TypedValue {
   DECLARE_VALUE_AND_TYPE_GETTERS_PRIMITIVE(double, Double, double_v)
   DECLARE_VALUE_AND_TYPE_GETTERS(TString, String, string_v)
 
-  DECLARE_VALUE_AND_TYPE_GETTERS(TVector, List, list_v)
+  // A VectorRef is a lazy list of the embedding's floats. IsList() reports it as a list and the
+  // ValueList() accessors force it (materialize-on-access, cached in place); the distinct type() lets
+  // the ordering/equality/hash fast-paths keep it compact (they read type(), never call ValueList()).
+  // So every list operation — subscript, slicing, UNWIND, IN, list functions — works without special
+  // casing a VectorRef.
+  TVector &ValueList();
+  const TVector &ValueList() const;
+  bool IsList() const;
+  const TVector &UnsafeValueList() const;
+
   DECLARE_VALUE_AND_TYPE_GETTERS(TMap, Map, map_v)
   DECLARE_VALUE_AND_TYPE_GETTERS(VertexAccessor, Vertex, vertex_v)
   DECLARE_VALUE_AND_TYPE_GETTERS(EdgeAccessor, Edge, edge_v)
@@ -788,6 +797,11 @@ class TypedValue {
   friend auto GetCRS(TypedValue const &tv) -> std::optional<storage::CoordinateReferenceSystem>;
 
  private:
+  // If this is a VectorRef, reconstruct the embedding into an owned List (in this value's allocator)
+  // and become a List. Const because it is a lazy load of a value already logically present; callers
+  // observe no change other than the list materializing. No-op for any other type.
+  void EnsureListMaterialized() const;
+
   [[no_unique_address]] allocator_type alloc_{};
 
   // storage for the value of the property

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "query/path.hpp"
@@ -37,11 +38,11 @@ class VirtualGraph;  // fwd declare
 class VirtualEdge;   // fwd declare
 class VirtualNode;   // fwd declare
 
-/// Lazy handle for a vector-index embedding stored as a VectorIndexId reference.
-/// Holds a copy of the storage accessor (trivially copyable) and the property id.
-/// No floats are reconstructed until MaterializeVectorRef() is called.
+/// Lazy handle for a vector-index embedding stored as a VectorIndexId reference. Holds a copy of the
+/// storage accessor (vertex or edge; both trivially copyable) and the property id. No floats are
+/// reconstructed until MaterializeVectorRef() / MaterializeVectorRefInto() is called.
 struct LazyVectorRef {
-  storage::VertexAccessor vertex;
+  std::variant<storage::VertexAccessor, storage::EdgeAccessor> entity;
   storage::PropertyId prop;
 };
 

--- a/src/query/vertex_accessor.hpp
+++ b/src/query/vertex_accessor.hpp
@@ -48,8 +48,9 @@ class VertexAccessor final {
     return impl_.Properties(view, with_vector_reconstruction);
   }
 
-  storage::Result<storage::PropertyValue> GetProperty(storage::View view, storage::PropertyId key) const {
-    return impl_.GetProperty(key, view);
+  storage::Result<storage::PropertyValue> GetProperty(storage::View view, storage::PropertyId key,
+                                                      bool with_vector_reconstruction = true) const {
+    return impl_.GetProperty(key, view, with_vector_reconstruction);
   }
 
   storage::Result<uint64_t> GetPropertySize(storage::PropertyId key, storage::View view) const {

--- a/src/query/vertex_accessor.hpp
+++ b/src/query/vertex_accessor.hpp
@@ -44,7 +44,9 @@ class VertexAccessor final {
     return impl_.HasLabel(label, view);
   }
 
-  auto Properties(storage::View view) const { return impl_.Properties(view); }
+  auto Properties(storage::View view, bool with_vector_reconstruction = true) const {
+    return impl_.Properties(view, with_vector_reconstruction);
+  }
 
   storage::Result<storage::PropertyValue> GetProperty(storage::View view, storage::PropertyId key) const {
     return impl_.GetProperty(key, view);

--- a/src/storage/v2/edge_accessor.cpp
+++ b/src/storage/v2/edge_accessor.cpp
@@ -464,7 +464,7 @@ Result<uint64_t> EdgeAccessor::GetPropertySize(PropertyId property, View view) c
   return property_store.PropertySize(property);
 };
 
-Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::Properties(View view) const {
+Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::Properties(View view, bool with_vector_reconstruction) const {
   if (!storage_->config_.salient.items.properties_on_edges) return std::map<PropertyId, PropertyValue>{};
   bool exists = true;
   bool deleted = false;
@@ -473,8 +473,14 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::Properties(View view) 
   {
     auto guard = std::shared_lock{edge_.ptr->lock};
     deleted = edge_.ptr->deleted();
-    properties = edge_.ptr->properties.Properties(IndexedPropertyDecoder<Edge>{
-        .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = edge_.ptr});
+    // Without reconstruction, embeddings come back as compact VectorIndexId references (empty float
+    // list) — the caller keeps them lazy instead of paying an O(dim) reconstruction per property.
+    properties = with_vector_reconstruction
+                     ? edge_.ptr->properties.Properties(IndexedPropertyDecoder<Edge>{
+                           .indices = &storage_->indices_,
+                           .name_id_mapper = storage_->name_id_mapper_.get(),
+                           .entity = edge_.ptr})
+                     : edge_.ptr->properties.Properties();
     delta = edge_.ptr->delta();
   }
   ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &properties](const Delta &delta) {
@@ -515,6 +521,23 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::Properties(View view) 
   if (!exists) return std::unexpected{Error::NONEXISTENT_OBJECT};
   if (!for_deleted_ && deleted) return std::unexpected{Error::DELETED_OBJECT};
   return std::move(properties);
+}
+
+bool EdgeAccessor::GetVectorInto(PropertyId property, std::vector<float> &out) const {
+  if (!storage_->config_.salient.items.properties_on_edges) return false;
+  // Read the stored reference form (VectorIndexId) WITHOUT the decoder, so nothing is reconstructed
+  // into an owning PropertyValue; stream the floats straight into the caller's buffer.
+  PropertyValue ref;
+  {
+    auto guard = std::shared_lock{edge_.ptr->lock};
+    ref = edge_.ptr->properties.GetProperty(property);
+  }
+  if (!ref.IsVectorIndexId()) return false;
+  const auto &ids = ref.ValueVectorIndexIds();
+  if (ids.empty()) return false;
+  const auto index_name = storage_->name_id_mapper_->IdToName(ids[0]);
+  return storage_->indices_.vector_edge_index_.GetVectorInto(edge_.ptr, index_name, storage_->name_id_mapper_.get(),
+                                                             out);
 }
 
 std::vector<PropertyId> EdgeAccessor::VectorIndexedProperties() const {

--- a/src/storage/v2/edge_accessor.cpp
+++ b/src/storage/v2/edge_accessor.cpp
@@ -397,7 +397,7 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::ClearProperties() {
   return std::move(properties).value_or(ReturnType{});
 }
 
-Result<PropertyValue> EdgeAccessor::GetProperty(PropertyId property, View view) const {
+Result<PropertyValue> EdgeAccessor::GetProperty(PropertyId property, View view, bool with_vector_reconstruction) const {
   if (!storage_->config_.salient.items.properties_on_edges) return PropertyValue();
   bool exists = true;
   bool deleted = false;
@@ -406,10 +406,14 @@ Result<PropertyValue> EdgeAccessor::GetProperty(PropertyId property, View view) 
   {
     auto guard = std::shared_lock{edge_.ptr->lock};
     deleted = edge_.ptr->deleted();
-    value.emplace(edge_.ptr->properties.GetProperty(
-        property,
-        IndexedPropertyDecoder<Edge>{
-            .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = edge_.ptr}));
+    // Without reconstruction, an embedding stays a compact VectorIndexId reference (see VertexAccessor).
+    value.emplace(with_vector_reconstruction
+                      ? edge_.ptr->properties.GetProperty(
+                            property,
+                            IndexedPropertyDecoder<Edge>{.indices = &storage_->indices_,
+                                                         .name_id_mapper = storage_->name_id_mapper_.get(),
+                                                         .entity = edge_.ptr})
+                      : edge_.ptr->properties.GetProperty(property));
     delta = edge_.ptr->delta();
   }
   ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &value, property](const Delta &delta) {
@@ -475,12 +479,11 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::Properties(View view, 
     deleted = edge_.ptr->deleted();
     // Without reconstruction, embeddings come back as compact VectorIndexId references (empty float
     // list) — the caller keeps them lazy instead of paying an O(dim) reconstruction per property.
-    properties = with_vector_reconstruction
-                     ? edge_.ptr->properties.Properties(IndexedPropertyDecoder<Edge>{
-                           .indices = &storage_->indices_,
-                           .name_id_mapper = storage_->name_id_mapper_.get(),
-                           .entity = edge_.ptr})
-                     : edge_.ptr->properties.Properties();
+    properties = with_vector_reconstruction ? edge_.ptr->properties.Properties(IndexedPropertyDecoder<Edge>{
+                                                  .indices = &storage_->indices_,
+                                                  .name_id_mapper = storage_->name_id_mapper_.get(),
+                                                  .entity = edge_.ptr})
+                                            : edge_.ptr->properties.Properties();
     delta = edge_.ptr->delta();
   }
   ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &properties](const Delta &delta) {
@@ -536,8 +539,8 @@ bool EdgeAccessor::GetVectorInto(PropertyId property, std::vector<float> &out) c
   const auto &ids = ref.ValueVectorIndexIds();
   if (ids.empty()) return false;
   const auto index_name = storage_->name_id_mapper_->IdToName(ids[0]);
-  return storage_->indices_.vector_edge_index_.GetVectorInto(edge_.ptr, index_name, storage_->name_id_mapper_.get(),
-                                                             out);
+  return storage_->indices_.vector_edge_index_.GetVectorInto(
+      edge_.ptr, index_name, storage_->name_id_mapper_.get(), out);
 }
 
 std::vector<PropertyId> EdgeAccessor::VectorIndexedProperties() const {

--- a/src/storage/v2/edge_accessor.hpp
+++ b/src/storage/v2/edge_accessor.hpp
@@ -86,7 +86,9 @@ class EdgeAccessor final {
   Result<uint64_t> GetPropertySize(PropertyId property, View view) const;
 
   /// @throw std::bad_alloc
-  Result<std::map<PropertyId, PropertyValue>> Properties(View view) const;
+  /// When `with_vector_reconstruction` is false, vector-index embeddings are returned as their compact
+  /// VectorIndexId reference (empty float list) instead of being reconstructed — the lazy read path.
+  Result<std::map<PropertyId, PropertyValue>> Properties(View view, bool with_vector_reconstruction = true) const;
 
   /// @throw std::bad_alloc
   Result<std::map<PropertyId, PropertyValue>> PropertiesByPropertyIds(std::span<PropertyId const> properties,
@@ -94,6 +96,10 @@ class EdgeAccessor final {
 
   /// Properties of this edge that are backed by a vector index.
   std::vector<PropertyId> VectorIndexedProperties() const;
+
+  /// Streams the edge's embedding for `property` into a caller-owned buffer without allocating an
+  /// owning PropertyValue. Returns false if the property is not a vector-index embedding.
+  bool GetVectorInto(PropertyId property, std::vector<float> &out) const;
 
   auto GidPropertiesOnEdges() const -> Gid { return edge_.ptr->gid; }
 

--- a/src/storage/v2/edge_accessor.hpp
+++ b/src/storage/v2/edge_accessor.hpp
@@ -79,8 +79,10 @@ class EdgeAccessor final {
   /// @throw std::bad_alloc
   Result<std::map<PropertyId, PropertyValue>> ClearProperties();
 
+  /// When `with_vector_reconstruction` is false, a vector-index embedding is returned as its compact
+  /// VectorIndexId reference (empty float list) instead of being reconstructed — the lazy read path.
   /// @throw std::bad_alloc
-  Result<PropertyValue> GetProperty(PropertyId property, View view) const;
+  Result<PropertyValue> GetProperty(PropertyId property, View view, bool with_vector_reconstruction = true) const;
 
   /// Returns the size of the encoded edge property in bytes.
   Result<uint64_t> GetPropertySize(PropertyId property, View view) const;

--- a/src/storage/v2/indices/vector_edge_index.cpp
+++ b/src/storage/v2/indices/vector_edge_index.cpp
@@ -515,6 +515,18 @@ utils::small_vector<float> VectorEdgeIndex::GetVectorPropertyFromEdgeIndex(Edge 
   return vector;
 }
 
+bool VectorEdgeIndex::GetVectorInto(Edge *edge, std::string_view index_name, NameIdMapper *name_id_mapper,
+                                    std::vector<float> &out) const {
+  auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
+  if (!maybe_id.has_value()) return false;
+  auto it = index_->find(*maybe_id);
+  if (it == index_->end()) return false;
+  auto &item_ptr = it->second;
+  auto guard = utils::SharedResourceLockGuard(item_ptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
+  out.resize(item_ptr->mg_index.index.dimensions());
+  return item_ptr->mg_index.index.get(edge, out.data());
+}
+
 utils::small_vector<uint64_t> VectorEdgeIndex::GetIndexIdsForEdgeTypeProperty(EdgeTypeId edge_type,
                                                                               PropertyId property) const {
   utils::small_vector<uint64_t> result;

--- a/src/storage/v2/indices/vector_edge_index.hpp
+++ b/src/storage/v2/indices/vector_edge_index.hpp
@@ -272,6 +272,12 @@ class VectorEdgeIndex {
   utils::small_vector<float> GetVectorPropertyFromEdgeIndex(Edge *edge, std::string_view index_name,
                                                             NameIdMapper *name_id_mapper) const;
 
+  /// @brief Streams the edge's embedding into a caller-owned buffer without allocating an owning
+  /// PropertyValue. Mirrors VectorIndex::GetVectorInto for the lazy read path. Returns false if the
+  /// index or entry is missing.
+  bool GetVectorInto(Edge *edge, std::string_view index_name, NameIdMapper *name_id_mapper,
+                     std::vector<float> &out) const;
+
   /// @brief Returns all index ids whose filter matches `edge_type` and which index `property`.
   /// Multiple indices may overlap (e.g. wildcard '(p)' plus specific ':REL(p)'); all are returned.
   utils::small_vector<uint64_t> GetIndexIdsForEdgeTypeProperty(EdgeTypeId edge_type, PropertyId property) const;

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -339,6 +339,18 @@ utils::small_vector<float> VectorIndex::GetVectorPropertyFromIndex(Vertex *verte
   return vector;
 }
 
+bool VectorIndex::GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
+                                std::span<float> out) const {
+  auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
+  if (!maybe_id.has_value()) return false;
+  auto it = index_->find(*maybe_id);
+  if (it == index_->end()) return false;
+  auto &item_ptr = it->second;
+  auto guard = utils::SharedResourceLockGuard(item_ptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
+  if (out.size() < item_ptr->mg_index.index.dimensions()) return false;
+  return item_ptr->mg_index.index.get(vertex, out.data());
+}
+
 std::vector<VectorIndexInfo> VectorIndex::ListVectorIndicesInfo() const {
   std::vector<VectorIndexInfo> result;
   result.reserve(index_->size());

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -340,18 +340,6 @@ utils::small_vector<float> VectorIndex::GetVectorPropertyFromIndex(Vertex *verte
 }
 
 bool VectorIndex::GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
-                                std::span<float> out) const {
-  auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
-  if (!maybe_id.has_value()) return false;
-  auto it = index_->find(*maybe_id);
-  if (it == index_->end()) return false;
-  auto &item_ptr = it->second;
-  auto guard = utils::SharedResourceLockGuard(item_ptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
-  if (out.size() < item_ptr->mg_index.index.dimensions()) return false;
-  return item_ptr->mg_index.index.get(vertex, out.data());
-}
-
-bool VectorIndex::GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
                                 std::vector<float> &out) const {
   auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
   if (!maybe_id.has_value()) return false;

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -351,6 +351,18 @@ bool VectorIndex::GetVectorInto(Vertex *vertex, std::string_view index_name, Nam
   return item_ptr->mg_index.index.get(vertex, out.data());
 }
 
+bool VectorIndex::GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
+                                std::vector<float> &out) const {
+  auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
+  if (!maybe_id.has_value()) return false;
+  auto it = index_->find(*maybe_id);
+  if (it == index_->end()) return false;
+  auto &item_ptr = it->second;
+  auto guard = utils::SharedResourceLockGuard(item_ptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
+  out.resize(item_ptr->mg_index.index.dimensions());
+  return item_ptr->mg_index.index.get(vertex, out.data());
+}
+
 std::vector<VectorIndexInfo> VectorIndex::ListVectorIndicesInfo() const {
   std::vector<VectorIndexInfo> result;
   result.reserve(index_->size());

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -357,6 +357,13 @@ class VectorIndex {
   utils::small_vector<float> GetVectorPropertyFromIndex(Vertex *vertex, std::string_view index_name,
                                                         NameIdMapper *name_id_mapper) const;
 
+  /// PROTOTYPE (Variant 1): reconstruct a vertex's indexed vector into a caller-provided buffer with
+  /// ZERO allocation, so callers can materialize an embedding transiently — inside a comparator/hash
+  /// or at the serialization boundary — without ever owning a PropertyValue. Returns false if the
+  /// vertex is not in the index or the buffer is smaller than the index dimension.
+  bool GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
+                     std::span<float> out) const;
+
   /// @brief Lists the info of all existing indexes.
   /// @return A vector of VectorIndexInfo objects representing the indexes.
   std::vector<VectorIndexInfo> ListVectorIndicesInfo() const;

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -357,14 +357,7 @@ class VectorIndex {
   utils::small_vector<float> GetVectorPropertyFromIndex(Vertex *vertex, std::string_view index_name,
                                                         NameIdMapper *name_id_mapper) const;
 
-  /// PROTOTYPE (Variant 1): reconstruct a vertex's indexed vector into a caller-provided buffer with
-  /// ZERO allocation, so callers can materialize an embedding transiently — inside a comparator/hash
-  /// or at the serialization boundary — without ever owning a PropertyValue. Returns false if the
-  /// vertex is not in the index or the buffer is smaller than the index dimension.
-  bool GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
-                     std::span<float> out) const;
-
-  /// Resizable variant of GetVectorInto: resizes `out` to the index dimension and fills it.
+  /// Reconstruct a vertex's indexed vector into `out` (resized to the index dimension); false if absent. Zero owning PropertyValue — used to materialize an embedding transiently.
   bool GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
                      std::vector<float> &out) const;
 

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -364,6 +364,10 @@ class VectorIndex {
   bool GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
                      std::span<float> out) const;
 
+  /// Resizable variant of GetVectorInto: resizes `out` to the index dimension and fills it.
+  bool GetVectorInto(Vertex *vertex, std::string_view index_name, NameIdMapper *name_id_mapper,
+                     std::vector<float> &out) const;
+
   /// @brief Lists the info of all existing indexes.
   /// @return A vector of VectorIndexInfo objects representing the indexes.
   std::vector<VectorIndexInfo> ListVectorIndicesInfo() const;

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -723,6 +723,21 @@ Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view
   return std::move(value);
 }
 
+bool VertexAccessor::GetVectorInto(PropertyId property, std::span<float> out) const {
+  // Read the stored reference form (VectorIndexId) WITHOUT the decoder, so nothing is reconstructed
+  // into an owning PropertyValue. Committed base state only (prototype).
+  const auto ref = std::invoke([&] {
+    VertexReadLock read_lock{vertex_};
+    auto const guard = read_lock.AcquireLock();
+    return vertex_->properties.GetProperty(property);
+  });
+  if (!ref.IsVectorIndexId()) return false;
+  const auto &ids = ref.ValueVectorIndexIds();
+  if (ids.empty()) return false;
+  const auto index_name = storage_->name_id_mapper_->IdToName(ids[0]);
+  return storage_->indices_.vector_index_.GetVectorInto(vertex_, index_name, storage_->name_id_mapper_.get(), out);
+}
+
 Result<uint64_t> VertexAccessor::GetPropertySize(PropertyId property, View view) const {
   {
     auto guard = std::shared_lock{vertex_->lock};

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -738,6 +738,19 @@ bool VertexAccessor::GetVectorInto(PropertyId property, std::span<float> out) co
   return storage_->indices_.vector_index_.GetVectorInto(vertex_, index_name, storage_->name_id_mapper_.get(), out);
 }
 
+bool VertexAccessor::GetVectorInto(PropertyId property, std::vector<float> &out) const {
+  const auto ref = std::invoke([&] {
+    VertexReadLock read_lock{vertex_};
+    auto const guard = read_lock.AcquireLock();
+    return vertex_->properties.GetProperty(property);
+  });
+  if (!ref.IsVectorIndexId()) return false;
+  const auto &ids = ref.ValueVectorIndexIds();
+  if (ids.empty()) return false;
+  const auto index_name = storage_->name_id_mapper_->IdToName(ids[0]);
+  return storage_->indices_.vector_index_.GetVectorInto(vertex_, index_name, storage_->name_id_mapper_.get(), out);
+}
+
 Result<uint64_t> VertexAccessor::GetPropertySize(PropertyId property, View view) const {
   {
     auto guard = std::shared_lock{vertex_->lock};

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -715,7 +715,7 @@ Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view
       cache.StoreExists(view, vertex_, exists);
       cache.StoreDeleted(view, vertex_, deleted);
       // Don't cache a reconstructed embedding: it would pin O(dim) floats per vertex on the graph
-      // tracker for the whole transaction. A later read re-applies the (short) delta chain instead.
+      // tracker for the whole transaction. A later read re-applies the delta chain instead.
       if (!value.IsVectorIndexId()) cache.StoreProperty(view, vertex_, property, value);
     }
   }
@@ -723,21 +723,6 @@ Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view
   if (!exists) return std::unexpected{Error::NONEXISTENT_OBJECT};
   if (!for_deleted_ && deleted) return std::unexpected{Error::DELETED_OBJECT};
   return std::move(value);
-}
-
-bool VertexAccessor::GetVectorInto(PropertyId property, std::span<float> out) const {
-  // Read the stored reference form (VectorIndexId) WITHOUT the decoder, so nothing is reconstructed
-  // into an owning PropertyValue. Committed base state only (prototype).
-  const auto ref = std::invoke([&] {
-    VertexReadLock read_lock{vertex_};
-    auto const guard = read_lock.AcquireLock();
-    return vertex_->properties.GetProperty(property);
-  });
-  if (!ref.IsVectorIndexId()) return false;
-  const auto &ids = ref.ValueVectorIndexIds();
-  if (ids.empty()) return false;
-  const auto index_name = storage_->name_id_mapper_->IdToName(ids[0]);
-  return storage_->indices_.vector_index_.GetVectorInto(vertex_, index_name, storage_->name_id_mapper_.get(), out);
 }
 
 bool VertexAccessor::GetVectorInto(PropertyId property, std::vector<float> &out) const {
@@ -820,9 +805,7 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
       auto &cache = transaction_->manyDeltasCache;
       cache.StoreExists(view, vertex_, exists);
       cache.StoreDeleted(view, vertex_, deleted);
-      // Skip caching the whole map if it holds a reconstructed embedding: caching only the non-embedding
-      // subset would serve an incomplete map on a later cache hit, and caching the floats would pin
-      // O(dim) per vertex for the transaction. A later read re-applies the delta chain instead.
+      // VectorIndexId in map: skip cache — pins O(dim) floats under reconstruction; mode-mismatch without.
       bool has_embedding = false;
       for (auto const &kv : properties) {
         if (kv.second.IsVectorIndexId()) {

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -671,7 +671,8 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::ClearProperties() {
   return std::move(properties).value_or(ReturnType{});
 }
 
-Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view) const {
+Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view,
+                                                  bool with_vector_reconstruction) const {
   bool exists = true;
   bool deleted = false;
   Delta *delta = nullptr;
@@ -680,11 +681,15 @@ Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view
     auto const guard = read_lock.AcquireLock();
     deleted = vertex_->deleted();
     delta = vertex_->delta();
-    auto prop_value = vertex_->properties.GetProperty(
-        property,
-        IndexedPropertyDecoder<Vertex>{
-            .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_});
-    return prop_value;
+    // Without reconstruction, an embedding stays a compact VectorIndexId reference; the caller keeps
+    // it lazy instead of paying an O(dim) reconstruction it would immediately discard.
+    return with_vector_reconstruction
+               ? vertex_->properties.GetProperty(
+                     property,
+                     IndexedPropertyDecoder<Vertex>{.indices = &storage_->indices_,
+                                                    .name_id_mapper = storage_->name_id_mapper_.get(),
+                                                    .entity = vertex_})
+               : vertex_->properties.GetProperty(property);
   });
 
   // Checking cache has a cost, only do it if we have any deltas
@@ -758,7 +763,8 @@ Result<uint64_t> VertexAccessor::GetPropertySize(PropertyId property, View view)
   return property_store.PropertySize(property);
 };
 
-Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view, bool with_vector_reconstruction) const {
+Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view,
+                                                                       bool with_vector_reconstruction) const {
   bool exists = true;
   bool deleted = false;
   std::map<PropertyId, PropertyValue> properties;
@@ -769,12 +775,11 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
     deleted = vertex_->deleted();
     // Without reconstruction, embeddings come back as compact VectorIndexId references (empty float
     // list) — the caller keeps them lazy instead of paying an O(dim) reconstruction per property.
-    properties = with_vector_reconstruction
-                     ? vertex_->properties.Properties(IndexedPropertyDecoder<Vertex>{
-                           .indices = &storage_->indices_,
-                           .name_id_mapper = storage_->name_id_mapper_.get(),
-                           .entity = vertex_})
-                     : vertex_->properties.Properties();
+    properties =
+        with_vector_reconstruction
+            ? vertex_->properties.Properties(IndexedPropertyDecoder<Vertex>{
+                  .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_})
+            : vertex_->properties.Properties();
     delta = vertex_->delta();
   }
 

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -714,7 +714,9 @@ Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view
       auto &cache = transaction_->manyDeltasCache;
       cache.StoreExists(view, vertex_, exists);
       cache.StoreDeleted(view, vertex_, deleted);
-      cache.StoreProperty(view, vertex_, property, value);
+      // Don't cache a reconstructed embedding: it would pin O(dim) floats per vertex on the graph
+      // tracker for the whole transaction. A later read re-applies the (short) delta chain instead.
+      if (!value.IsVectorIndexId()) cache.StoreProperty(view, vertex_, property, value);
     }
   }
 
@@ -771,7 +773,7 @@ Result<uint64_t> VertexAccessor::GetPropertySize(PropertyId property, View view)
   return property_store.PropertySize(property);
 };
 
-Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view) const {
+Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view, bool with_vector_reconstruction) const {
   bool exists = true;
   bool deleted = false;
   std::map<PropertyId, PropertyValue> properties;
@@ -780,8 +782,14 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
   {
     auto const guard = read_lock.AcquireLock();
     deleted = vertex_->deleted();
-    properties = vertex_->properties.Properties(IndexedPropertyDecoder<Vertex>{
-        .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_});
+    // Without reconstruction, embeddings come back as compact VectorIndexId references (empty float
+    // list) — the caller keeps them lazy instead of paying an O(dim) reconstruction per property.
+    properties = with_vector_reconstruction
+                     ? vertex_->properties.Properties(IndexedPropertyDecoder<Vertex>{
+                           .indices = &storage_->indices_,
+                           .name_id_mapper = storage_->name_id_mapper_.get(),
+                           .entity = vertex_})
+                     : vertex_->properties.Properties();
     delta = vertex_->delta();
   }
 
@@ -812,7 +820,17 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
       auto &cache = transaction_->manyDeltasCache;
       cache.StoreExists(view, vertex_, exists);
       cache.StoreDeleted(view, vertex_, deleted);
-      cache.StoreProperties(view, vertex_, properties);
+      // Skip caching the whole map if it holds a reconstructed embedding: caching only the non-embedding
+      // subset would serve an incomplete map on a later cache hit, and caching the floats would pin
+      // O(dim) per vertex for the transaction. A later read re-applies the delta chain instead.
+      bool has_embedding = false;
+      for (auto const &kv : properties) {
+        if (kv.second.IsVectorIndexId()) {
+          has_embedding = true;
+          break;
+        }
+      }
+      if (!has_embedding) cache.StoreProperties(view, vertex_, properties);
     }
   }
 

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -91,15 +91,8 @@ class VertexAccessor final {
   /// @throw std::bad_alloc
   Result<PropertyValue> GetProperty(PropertyId property, View view) const;
 
-  /// PROTOTYPE (Variant 1): if `property` is a vector-index-backed embedding, reconstruct it into
-  /// the caller buffer `out` with zero allocation and return true; otherwise return false (the caller
-  /// falls back to GetProperty). Lets operators/serialization materialize the embedding transiently
-  /// without ever holding an owning PropertyValue. Reads committed base state (no delta resolution).
-  bool GetVectorInto(PropertyId property, std::span<float> out) const;
-
-  /// Resizable variant: reconstructs the indexed embedding into `out`, resizing it to the index
-  /// dimension. Returns false if `property` is not a vector-index embedding. Used by the lazy
-  /// TypedValue to materialize into a reused buffer (compare/hash/serialize) or a result list.
+  /// Reconstruct a vertex's indexed vector into `out` (resized to the index dimension); false if absent.
+  /// Zero owning PropertyValue — used to materialize an embedding transiently.
   bool GetVectorInto(PropertyId property, std::vector<float> &out) const;
 
   /// Returns the size of the encoded vertex property in bytes.

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -106,7 +106,9 @@ class VertexAccessor final {
   Result<uint64_t> GetPropertySize(PropertyId property, View view) const;
 
   /// @throw std::bad_alloc
-  Result<std::map<PropertyId, PropertyValue>> Properties(View view) const;
+  /// When `with_vector_reconstruction` is false, vector-index embeddings are returned as their compact
+  /// VectorIndexId reference (empty float list) instead of being reconstructed — the lazy read path.
+  Result<std::map<PropertyId, PropertyValue>> Properties(View view, bool with_vector_reconstruction = true) const;
 
   /// @throw std::bad_alloc
   Result<std::map<PropertyId, PropertyValue>> PropertiesByPropertyIds(std::span<PropertyId const> properties,

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -91,6 +91,12 @@ class VertexAccessor final {
   /// @throw std::bad_alloc
   Result<PropertyValue> GetProperty(PropertyId property, View view) const;
 
+  /// PROTOTYPE (Variant 1): if `property` is a vector-index-backed embedding, reconstruct it into
+  /// the caller buffer `out` with zero allocation and return true; otherwise return false (the caller
+  /// falls back to GetProperty). Lets operators/serialization materialize the embedding transiently
+  /// without ever holding an owning PropertyValue. Reads committed base state (no delta resolution).
+  bool GetVectorInto(PropertyId property, std::span<float> out) const;
+
   /// Returns the size of the encoded vertex property in bytes.
   Result<uint64_t> GetPropertySize(PropertyId property, View view) const;
 

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -97,6 +97,11 @@ class VertexAccessor final {
   /// without ever holding an owning PropertyValue. Reads committed base state (no delta resolution).
   bool GetVectorInto(PropertyId property, std::span<float> out) const;
 
+  /// Resizable variant: reconstructs the indexed embedding into `out`, resizing it to the index
+  /// dimension. Returns false if `property` is not a vector-index embedding. Used by the lazy
+  /// TypedValue to materialize into a reused buffer (compare/hash/serialize) or a result list.
+  bool GetVectorInto(PropertyId property, std::vector<float> &out) const;
+
   /// Returns the size of the encoded vertex property in bytes.
   Result<uint64_t> GetPropertySize(PropertyId property, View view) const;
 

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -88,8 +88,10 @@ class VertexAccessor final {
   /// @throw std::bad_alloc
   Result<std::map<PropertyId, PropertyValue>> ClearProperties();
 
+  /// When `with_vector_reconstruction` is false, a vector-index embedding is returned as its compact
+  /// VectorIndexId reference (empty float list) instead of being reconstructed — the lazy read path.
   /// @throw std::bad_alloc
-  Result<PropertyValue> GetProperty(PropertyId property, View view) const;
+  Result<PropertyValue> GetProperty(PropertyId property, View view, bool with_vector_reconstruction = true) const;
 
   /// Reconstruct a vertex's indexed vector into `out` (resized to the index dimension); false if absent.
   /// Zero owning PropertyValue — used to materialize an embedding transiently.

--- a/tests/gql_behave/tests/memgraph_V1/features/vector_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/vector_search.feature
@@ -1049,3 +1049,81 @@ Feature: Vector search related features
             | 'label+property_vector'     | ':Person'         | 'embedding' | 0     |
             | 'label+property_vector'     | ':Person&Star'    | 'embedding' | 0     |
             | 'label+property_vector'     | ':Person\|Movie'  | 'embedding' | 0     |
+
+    Scenario: Indexing into a vector-index property returns its elements
+        Given an empty graph
+        And with new vector index test_index on :L1(prop1) with dimension 2 and capacity 10
+        And having executed
+            """
+            CREATE (:L1 {prop1: [1.0, 2.0]});
+            """
+        When executing query:
+            """
+            MATCH (n) RETURN n.prop1[0] AS first, n.prop1[1] AS second;
+            """
+        Then the result should be:
+            | first | second |
+            | 1.0   | 2.0    |
+        When executing query:
+            """
+            MATCH (n) RETURN n["prop1"] AS p, n["prop1"][0] AS first;
+            """
+        Then the result should be:
+            | p          | first |
+            | [1.0, 2.0] | 1.0   |
+        When executing query:
+            """
+            MATCH (n) RETURN size(n.prop1) AS s, 2.0 IN n.prop1 AS has_two;
+            """
+        Then the result should be:
+            | s | has_two |
+            | 2 | true    |
+
+    Scenario: UNWIND and list functions over a vector-index property
+        Given an empty graph
+        And with new vector index test_index on :L1(prop1) with dimension 2 and capacity 10
+        And having executed
+            """
+            CREATE (:L1 {prop1: [1.0, 2.0]});
+            """
+        When executing query:
+            """
+            MATCH (n) UNWIND n.prop1 AS e RETURN e ORDER BY e;
+            """
+        Then the result should be, in order:
+            | e   |
+            | 1.0 |
+            | 2.0 |
+        When executing query:
+            """
+            MATCH (n) RETURN head(n.prop1) AS h, last(n.prop1) AS l, n.prop1[0..1] AS sliced;
+            """
+        Then the result should be:
+            | h   | l   | sliced |
+            | 1.0 | 2.0 | [1.0]  |
+        When executing query:
+            """
+            MATCH (n) RETURN reduce(s = 0.0, x IN n.prop1 | s + x) AS total;
+            """
+        Then the result should be:
+            | total |
+            | 3.0   |
+
+    Scenario: Ordering by a vector-index property element
+        Given an empty graph
+        And with new vector index test_index on :L1(prop1) with dimension 2 and capacity 10
+        And having executed
+            """
+            CREATE (:L1 {prop1: [3.0, 1.0]})
+            CREATE (:L1 {prop1: [1.0, 2.0]})
+            CREATE (:L1 {prop1: [2.0, 5.0]});
+            """
+        When executing query:
+            """
+            MATCH (n) RETURN n.prop1 AS p ORDER BY n.prop1[0];
+            """
+        Then the result should be, in order:
+            | p          |
+            | [1.0, 2.0] |
+            | [2.0, 5.0] |
+            | [3.0, 1.0] |

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -96,6 +96,11 @@ add_unit_test(interpreter
     LINK_TARGETS mg-communication mg-query mg-glue disk_test_utils
 )
 
+add_unit_test(ai_license_embedding_memory
+    SOURCES ai_license_embedding_memory.cpp
+    LINK_TARGETS mg-communication mg-query mg-glue mg-dbms
+)
+
 add_unit_test(query_plan_pruning_bfs
     SOURCES query_plan_pruning_bfs.cpp
     LINK_TARGETS mg-query

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -491,4 +491,81 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1_LazySortBoundedVsEagerSort) {
   EXPECT_EQ(lazy_sorted, eager_sorted) << "lazy comparator must produce the same order as an eager sort";
 }
 
+// ---------------------------------------------------------------------------
+// 7. Variant 1 end-to-end through the real interpreter. With the lazy embedding TypedValue (VectorRef)
+//    flowing out of PropertyLookup, an accumulating operator that would blow the AI_PLATFORM graph cap
+//    if it materialised every embedding stays bounded: it buffers only cheap references and materialises
+//    O(dim) transiently inside its comparator / hasher. Under a graph limit far below the total
+//    embedding footprint, driven through the real query engine:
+//      (a) ORDER BY n.emb  -> lazy sort keys + transient compare  -> SUCCEEDS (bounded).
+//      (b) DISTINCT n.emb  -> lazy set keys + transient hash/==    -> SUCCEEDS (bounded).
+//      (c) RETURN n.emb    -> result stream retains every materialised embedding -> ABORTS.
+//    (c) is the customer symptom, and it anchors that the cap is genuinely below O(N*dim), so (a)/(b)
+//    passing under the same cap is a real boundedness result, not a slack cap.
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_OrderByAndDistinctBoundedThroughInterpreter) {
+  auto gk = MakeDb("t7");
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(MakeConfig(data_dir_ / "t7"))};
+  memgraph::dbms::DatabaseAccess db = [&]() {
+    auto a = gk->access();
+    MG_ASSERT(a, "db access");
+    return *a;
+  }();
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVerticesBig, kDimBig);
+  CreateIndex(db.get(), label, prop, kDimBig, kNumVerticesBig);
+
+  memgraph::system::System system_state;
+  memgraph::query::InterpreterContext interpreter_context{{},
+                                                          nullptr,
+                                                          nullptr,
+                                                          kNoHandler,
+                                                          &repl_state,
+                                                          system_state,
+                                                          nullptr
+#ifdef MG_ENTERPRISE
+                                                          ,
+                                                          nullptr,
+                                                          nullptr
+#endif
+  };
+  InterpreterFaker faker{&interpreter_context, db};
+
+  const int64_t retained_bytes = static_cast<int64_t>(kNumVerticesBig) * kDimBig * sizeof(float);
+  // Headroom sits ABOVE the O(N) reference caches an ORDER BY / DISTINCT over kNumVerticesBig rows
+  // holds (~a few MiB of cheap VectorRef / vertex handles) but well BELOW the O(N*dim) cost of
+  // materialising every embedding (retained_bytes). That gap is exactly the lazy-value win.
+  const int64_t headroom = 8 * kOneMiB;
+  Stabilize(db.get());
+  const int64_t limit = Graph() + headroom;
+  ASSERT_GT(retained_bytes, headroom + 2 * kOneMiB)
+      << "materialising every embedding must exceed the cap, so (c) is a real abort";
+
+  // AI_PLATFORM: only graph memory is capped; the (larger) embedding index is exempt.
+  memgraph::license::global_license_checker.EnableTesting(memgraph::license::LicenseType::AI_PLATFORM, limit);
+  memgraph::utils::MemoryTracker::OutOfMemoryExceptionEnabler enabler;
+
+  // (a) ORDER BY buffers cheap VectorRef sort keys and materialises O(dim) transiently in the
+  //     comparator. LIMIT keeps the ordering from being optimised away; count proves every row sorted.
+  {
+    auto stream = faker.Interpret("MATCH (n) WITH n ORDER BY n.emb LIMIT 1000000 RETURN count(n) AS c");
+    ASSERT_EQ(stream.GetResults().size(), 1u);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), kNumVerticesBig)
+        << "every row was sorted by its embedding without exceeding the AI graph cap";
+  }
+
+  // (b) DISTINCT dedups via a lazy hash set: VectorRef keys, transient hash/equality. The populated
+  //     data has 7 distinct vectors (value == i%7), so a bounded run yields exactly 7 rows.
+  {
+    auto stream = faker.Interpret("MATCH (n) RETURN DISTINCT n.emb AS e");
+    EXPECT_EQ(stream.GetResults().size(), 7u)
+        << "DISTINCT over embeddings deduped via lazy hash/equality without exceeding the AI graph cap";
+  }
+
+  // (c) RETURN n.emb retains a materialised embedding per row in the result stream -> blows the cap.
+  EXPECT_THROW(faker.Interpret("MATCH (n) RETURN n.emb"), memgraph::utils::OutOfMemoryException);
+}
+
 #endif  // USE_JEMALLOC

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -558,6 +558,9 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_OrderByAndDistinctBoundedThrou
 
   // (b) DISTINCT dedups via a lazy hash set: VectorRef keys, transient hash/equality. The populated
   //     data has 7 distinct vectors (value == i%7), so a bounded run yields exactly 7 rows.
+  // Purge jemalloc's dirty-page slack left by the prior query so each sub-query runs with fresh
+  // headroom under the fixed cap (the tracker is extent-commit granular; freed memory lingers as slack).
+  memgraph::memory::PurgeUnusedMemory();
   {
     auto stream = faker.Interpret("MATCH (n) RETURN DISTINCT n.emb AS e");
     EXPECT_EQ(stream.GetResults().size(), 7u)
@@ -565,7 +568,57 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_OrderByAndDistinctBoundedThrou
   }
 
   // (c) RETURN n.emb retains a materialised embedding per row in the result stream -> blows the cap.
+  memgraph::memory::PurgeUnusedMemory();
   EXPECT_THROW(faker.Interpret("MATCH (n) RETURN n.emb"), memgraph::utils::OutOfMemoryException);
+}
+
+// ---------------------------------------------------------------------------
+// 8. Variant 1 map-projection round-trip: `n{.*}` reads properties WITHOUT reconstructing embeddings
+//    (they stay compact VectorIndexId references) and wraps each as a lazy VectorRef inside the map.
+//    Serialising the map must still yield the full embedding — this proves the no-decoder read + the
+//    VectorRef wrap + Bolt materialisation are correct end-to-end (a broken lazy path would surface an
+//    empty list here). Small/fast dataset; correctness only, no memory cap.
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_MapProjectionMaterialisesFullEmbedding) {
+  auto gk = MakeDb("t8");
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(MakeConfig(data_dir_ / "t8"))};
+  memgraph::dbms::DatabaseAccess db = [&]() {
+    auto a = gk->access();
+    MG_ASSERT(a, "db access");
+    return *a;
+  }();
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVertices, kDim);
+  CreateIndex(db.get(), label, prop, kDim, kNumVertices);
+
+  memgraph::system::System system_state;
+  memgraph::query::InterpreterContext interpreter_context{{},
+                                                          nullptr,
+                                                          nullptr,
+                                                          kNoHandler,
+                                                          &repl_state,
+                                                          system_state,
+                                                          nullptr
+#ifdef MG_ENTERPRISE
+                                                          ,
+                                                          nullptr,
+                                                          nullptr
+#endif
+  };
+  InterpreterFaker faker{&interpreter_context, db};
+
+  auto stream = faker.Interpret("MATCH (n) RETURN n{.*} AS m");
+  ASSERT_EQ(stream.GetResults().size(), static_cast<size_t>(kNumVertices));
+  for (const auto &row : stream.GetResults()) {
+    const auto &m = row[0].ValueMap();
+    auto it = m.find("emb");
+    ASSERT_NE(it, m.end()) << "n{.*} must include the embedding property";
+    const auto &emb = it->second.ValueList();
+    // A broken lazy path would hand back an empty (un-reconstructed) list; the full vector must survive.
+    EXPECT_EQ(emb.size(), static_cast<size_t>(kDim)) << "lazy map embedding must materialise to full dimension";
+  }
 }
 
 #endif  // USE_JEMALLOC

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -28,14 +28,17 @@
 #include "memory/db_arena.hpp"
 #include "memory/global_memory_control.hpp"
 #include "query/interpreter_context.hpp"
+#include "query/typed_value.hpp"
 #include "replication/state.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/indices/vector_index.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/property_value.hpp"
+#include "storage/v2/vertex_accessor.hpp"
 #include "storage/v2/view.hpp"
 #include "system/system.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "utils/memory.hpp"
 #include "utils/memory_tracker.hpp"
 
 using memgraph::storage::PropertyValue;
@@ -564,6 +567,88 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_MapProjectionMaterialisesFullE
     // A broken lazy path would hand back an empty (un-reconstructed) list; the full vector must survive.
     EXPECT_EQ(emb.size(), static_cast<size_t>(kDim)) << "lazy map embedding must materialise to full dimension";
   }
+}
+
+// A lazy VectorRef must behave exactly like the List<Double> it materialises to. Two consequences the
+// value-level code must guarantee: (1) equal values hash identically, or a DISTINCT/GROUP BY hash set
+// keeps a lazy ref and its materialised twin as separate rows; (2) the write-path conversion produces
+// that same list instead of throwing, so SET/CREATE can copy an embedding.
+TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_HashConsistentAndWritePathMaterialises) {
+  auto gk = MakeDb("t9");
+  memgraph::dbms::DatabaseAccess db = [&]() {
+    auto a = gk->access();
+    MG_ASSERT(a, "db access");
+    return *a;
+  }();
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVertices, kDim);
+  CreateIndex(db.get(), label, prop, kDim, kNumVertices);
+
+  auto acc = db->Access();
+  auto vertices = acc->Vertices(View::NEW);
+  auto it = vertices.begin();
+  ASSERT_NE(it, vertices.end());
+  const memgraph::storage::VertexAccessor sva = *it;
+
+  auto *mem = memgraph::utils::NewDeleteResource();
+  const memgraph::query::TypedValue vref{memgraph::query::LazyVectorRef{sva, prop}, mem};
+  ASSERT_TRUE(vref.IsVectorRef());
+
+  const memgraph::query::TypedValue materialised = vref.MaterializeVectorRef(mem);
+  ASSERT_TRUE(materialised.IsList());
+  ASSERT_EQ(materialised.ValueList().size(), static_cast<size_t>(kDim));
+
+  // (1) equal => same hash. A float-vs-double hash mismatch would silently keep both under DISTINCT.
+  EXPECT_TRUE((vref == materialised).ValueBool());
+  EXPECT_EQ(memgraph::query::TypedValue::Hash{}(vref), memgraph::query::TypedValue::Hash{}(materialised));
+
+  // (2) the ref converts to the same double list a literal assignment would store, not a throw.
+  memgraph::storage::PropertyValue pv;
+  EXPECT_NO_THROW(pv = vref.ToPropertyValue(nullptr));
+  // Storage keeps typed double-lists distinct from generic lists; assert on the query-layer list the
+  // stored value round-trips to (the shape a reader actually sees).
+  const memgraph::query::TypedValue back{pv, nullptr, mem};
+  ASSERT_TRUE(back.IsList());
+  EXPECT_EQ(back.ValueList().size(), static_cast<size_t>(kDim));
+}
+
+// The user-facing write path: SET copying an embedding to another property runs the ref through
+// ToPropertyValue and must store the full vector rather than throwing "Unsupported conversion".
+TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_SetCopiesEmbeddingProperty) {
+  auto gk = MakeDb("t10");
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(MakeConfig(data_dir_ / "t10"))};
+  memgraph::dbms::DatabaseAccess db = [&]() {
+    auto a = gk->access();
+    MG_ASSERT(a, "db access");
+    return *a;
+  }();
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVertices, kDim);
+  CreateIndex(db.get(), label, prop, kDim, kNumVertices);
+
+  memgraph::system::System system_state;
+  memgraph::query::InterpreterContext interpreter_context{{},
+                                                          nullptr,
+                                                          nullptr,
+                                                          kNoHandler,
+                                                          &repl_state,
+                                                          system_state,
+                                                          nullptr
+#ifdef MG_ENTERPRISE
+                                                          ,
+                                                          nullptr,
+                                                          nullptr
+#endif
+  };
+  InterpreterFaker faker{&interpreter_context, db};
+
+  auto stream = faker.Interpret("MATCH (n) WITH n LIMIT 1 SET n.copy = n.emb RETURN size(n.copy) AS s");
+  ASSERT_EQ(stream.GetResults().size(), 1u);
+  EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), static_cast<int64_t>(kDim))
+      << "SET n.copy = n.emb must persist the full embedding as a list";
 }
 
 #endif  // USE_JEMALLOC

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -23,8 +23,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <filesystem>
+#include <span>
+#include <utility>
 #include <vector>
 
 #include "dbms/database.hpp"
@@ -420,6 +423,72 @@ TEST_F(AiLicenseEmbeddingMemoryTest, DoubleCharge_IndexCopyPlusMaterializedCopyB
   EXPECT_LT(storage_delta, retained_bytes / 8) << "reconstruction does not touch the per-DB storage arena";
 
   held.clear();
+}
+
+// ---------------------------------------------------------------------------
+// 6. Variant 1 (lazy value): an accumulating operator (sort / ORDER BY) can stay bounded if it holds
+//    cheap references and materializes the embedding transiently inside the comparator. Here we sort
+//    N vertices by their embedding using VertexAccessor::GetVectorInto — which reconstructs into a
+//    REUSED scratch buffer with zero per-comparison allocation — and show the sort's peak graph
+//    footprint is O(dim), not O(N*dim), while producing the same order as an eager sort.
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, Variant1_LazySortBoundedVsEagerSort) {
+  auto gk = MakeDb("t6");
+  auto acc_opt = gk->access();
+  ASSERT_TRUE(acc_opt);
+  auto &db = *acc_opt;
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVerticesBig, kDimBig);
+  CreateIndex(db.get(), label, prop, kDimBig, kNumVerticesBig);
+
+  const int64_t retained_bytes = static_cast<int64_t>(kNumVerticesBig) * kDimBig * sizeof(float);
+
+  auto acc = db->Access();
+  std::vector<memgraph::storage::VertexAccessor> verts;
+  verts.reserve(kNumVerticesBig);
+  for (auto v : acc->Vertices(View::OLD)) verts.push_back(v);
+  ASSERT_EQ(verts.size(), static_cast<size_t>(kNumVerticesBig));
+
+  // Eager reference: reconstruct + RETAIN every embedding, sort them; record the sorted value sequence.
+  std::vector<std::vector<float>> eager_sorted;
+  {
+    std::vector<std::vector<float>> eager;
+    eager.reserve(kNumVerticesBig);
+    for (auto &va : verts) {
+      auto pv = va.GetProperty(prop, View::OLD);
+      const auto &lst = pv->ValueVectorIndexList();
+      eager.emplace_back(lst.begin(), lst.end());
+    }
+    std::ranges::sort(eager, [](const auto &a, const auto &b) { return std::ranges::lexicographical_compare(a, b); });
+    eager_sorted = std::move(eager);
+  }
+
+  // Lazy sort: sort the vertex references; the comparator materializes both operands transiently into
+  // two REUSED pre-allocated scratch buffers — zero per-comparison allocation.
+  std::vector<float> buf_a(kDimBig);
+  std::vector<float> buf_b(kDimBig);
+  Stabilize(db.get());
+  const int64_t graph_before = Graph();
+  std::ranges::sort(verts, [&](const memgraph::storage::VertexAccessor &x, const memgraph::storage::VertexAccessor &y) {
+    const bool ok_x = x.GetVectorInto(prop, buf_a);
+    const bool ok_y = y.GetVectorInto(prop, buf_b);
+    EXPECT_TRUE(ok_x && ok_y);
+    return std::ranges::lexicographical_compare(buf_a, buf_b);
+  });
+  const int64_t lazy_peak = Graph() - graph_before;
+
+  EXPECT_LT(lazy_peak, retained_bytes / 8)
+      << "lazy sort must stay O(dim), not O(N*dim): lazy_peak=" << lazy_peak << " retained=" << retained_bytes;
+
+  // Correctness: the lazily-sorted embedding sequence equals the eager one (robust to ties).
+  std::vector<std::vector<float>> lazy_sorted;
+  lazy_sorted.reserve(verts.size());
+  for (auto &va : verts) {
+    ASSERT_TRUE(va.GetVectorInto(prop, buf_a));
+    lazy_sorted.emplace_back(buf_a.begin(), buf_a.end());
+  }
+  EXPECT_EQ(lazy_sorted, eager_sorted) << "lazy comparator must produce the same order as an eager sort";
 }
 
 #endif  // USE_JEMALLOC

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -651,4 +651,60 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_SetCopiesEmbeddingProperty) {
       << "SET n.copy = n.emb must persist the full embedding as a list";
 }
 
+// A lazy embedding is a list; every list operation must treat it as one instead of throwing
+// "got vector". Regression for the e2e durability failure, where `ORDER BY n.emb[0]` (a subscript on
+// the embedding) threw and aborted the query.
+TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_ListOperationsOnEmbedding) {
+  auto gk = MakeDb("t11");
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(MakeConfig(data_dir_ / "t11"))};
+  memgraph::dbms::DatabaseAccess db = [&]() {
+    auto a = gk->access();
+    MG_ASSERT(a, "db access");
+    return *a;
+  }();
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVertices, kDim);
+  CreateIndex(db.get(), label, prop, kDim, kNumVertices);
+
+  memgraph::system::System system_state;
+  memgraph::query::InterpreterContext interpreter_context{{},
+                                                          nullptr,
+                                                          nullptr,
+                                                          kNoHandler,
+                                                          &repl_state,
+                                                          system_state,
+                                                          nullptr
+#ifdef MG_ENTERPRISE
+                                                          ,
+                                                          nullptr,
+                                                          nullptr
+#endif
+  };
+  InterpreterFaker faker{&interpreter_context, db};
+
+  // Subscript, in an ORDER BY key — the exact operation that threw on a VectorRef in the e2e test.
+  {
+    auto stream = faker.Interpret("MATCH (n) RETURN n.emb ORDER BY n.emb[0] LIMIT 1");
+    ASSERT_EQ(stream.GetResults().size(), 1u);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueList().size(), static_cast<size_t>(kDim));
+  }
+  // Bare subscript yields the element (embeddings are Populate()'d as (i%7)+0.5, so emb[0] is a double).
+  {
+    auto stream = faker.Interpret("MATCH (n) WITH n LIMIT 1 RETURN n.emb[0] AS x");
+    ASSERT_EQ(stream.GetResults().size(), 1u);
+    EXPECT_TRUE(stream.GetResults()[0][0].IsDouble());
+  }
+  // size() and UNWIND treat the embedding as a list of kDim elements.
+  {
+    auto stream = faker.Interpret("MATCH (n) WITH n LIMIT 1 RETURN size(n.emb) AS s");
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), static_cast<int64_t>(kDim));
+  }
+  {
+    auto stream = faker.Interpret("MATCH (n) WITH n LIMIT 1 UNWIND n.emb AS e RETURN count(e) AS c");
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), static_cast<int64_t>(kDim));
+  }
+}
+
 #endif  // USE_JEMALLOC

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -10,16 +10,8 @@
 // licenses/APL.txt.
 
 // Grounds the AI_PLATFORM license memory accounting for vector embeddings.
-//
-// Facts under test:
-//   1. Embeddings live ONLY in the usearch index; the vertex property is replaced by a compact
-//      VectorIndexId reference. Reading it reconstructs the full vector from the index.
-//   2. That reconstruction is a plain operator-new allocation -> default arena -> graph_memory_tracker
-//      (the AI_PLATFORM license limit), NOT the exempt vector_index_memory_tracker, and NOT the
-//      per-DB query PMR tracker.
-//   3. Under an AI_PLATFORM graph limit, retaining a whole result set of embeddings (RETURN n)
-//      aborts, while reconstructing-and-discarding one at a time (count(n.emb)) stays under the cap,
-//      even though the embedding index itself is far larger than the cap (it is exempt).
+// Indexing replaces the vertex property with a compact VectorIndexId reference; reads reconstruct
+// via operator-new -> graph_memory_tracker (AI limit), NOT the exempt vector_index domain.
 
 #include <gtest/gtest.h>
 
@@ -54,9 +46,8 @@ namespace {
 // Small scale for the storage-model / query-semantics tests (fast).
 constexpr int kDim = 256;
 constexpr int kNumVertices = 1024;
-// graph_memory_tracker is fed by jemalloc EXTENT-COMMIT hooks, so it moves only when committed arena
-// memory grows past jemalloc's retained (dirty-page) slack. The accounting tests therefore use a
-// working set large enough to force new extent commits after a purge.
+// graph_memory_tracker moves only when jemalloc commits new arena extents past its dirty-page slack.
+// The accounting tests need a working set large enough to force fresh commits after a purge.
 constexpr int kDimBig = 512;
 constexpr int kNumVerticesBig = 6000;
 constexpr int64_t kOneMiB = 1 << 20;
@@ -109,9 +100,8 @@ class AiLicenseEmbeddingMemoryTest : public ::testing::Test {
 
   void SetUp() override {
     std::filesystem::create_directories(data_dir_);
-    // Install the global graph arena hooks so plain operator-new allocations (the reconstructed
-    // embedding small_vector, the retained result set) are attributed to graph_memory_tracker,
-    // exactly as they are in a running server.
+    // Install the global graph arena hooks so operator-new allocations (reconstructed embeddings,
+    // retained result sets) are attributed to graph_memory_tracker, as in a running server.
     memgraph::memory::SetHooks();
   }
 
@@ -148,10 +138,8 @@ class AiLicenseEmbeddingMemoryTest : public ::testing::Test {
   }
 };
 
-// ---------------------------------------------------------------------------
-// 1. Storage model: after indexing, the embedding is gone from the property store (replaced by a
-//    compact reference) and lives in the vector index. Reading reconstructs the full vector.
-// ---------------------------------------------------------------------------
+// Storage model: after indexing, the vertex property is a compact VectorIndexId reference; the
+// embedding lives in the vector index. Reading it reconstructs the full vector.
 TEST_F(AiLicenseEmbeddingMemoryTest, StorageModel_EmbeddingLivesOnlyInIndex) {
   auto gk = MakeDb("t1");
   auto acc_opt = gk->access();
@@ -171,10 +159,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, StorageModel_EmbeddingLivesOnlyInIndex) {
   EXPECT_GT(emb_after - emb_before, static_cast<int64_t>(kNumVertices) * kDim * 2)
       << "Vector index must now hold the embeddings (db_embedding_memory_tracker -> vector_index domain)";
 
-  // After indexing, the property is no longer a raw list: it is a compact VectorIndexId reference,
-  // and reading it reconstructs the full vector out of the index. (The property-store shrink is real
-  // but not observable via DbStorageMemoryUsage, which tracks committed arena extents, not logical
-  // property bytes.)
+  // After indexing, the property is a compact VectorIndexId reference, not a raw list; reading it
+  // reconstructs the full vector from the index.
   auto racc = db->Access();
   int seen = 0;
   for (auto v : racc->Vertices(View::OLD)) {
@@ -188,11 +174,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, StorageModel_EmbeddingLivesOnlyInIndex) {
   EXPECT_EQ(seen, 4);
 }
 
-// ---------------------------------------------------------------------------
-// 2. Materialization accounting: reconstructing embeddings on read charges graph_memory_tracker
-//    (the AI limit), leaves the exempt vector_index_memory_tracker untouched, and does NOT touch
-//    the per-DB query PMR tracker. (Answers: is it missed? no. which tracker? graph.)
-// ---------------------------------------------------------------------------
+// Materialization accounting: reconstructing embeddings charges graph_memory_tracker (the AI limit),
+// leaves the exempt vector_index domain untouched, and does not touch the per-DB query PMR tracker.
 TEST_F(AiLicenseEmbeddingMemoryTest, Materialization_ChargesGraphNotVectorIndexNotQuery) {
   auto gk = MakeDb("t2");
   auto acc_opt = gk->access();
@@ -229,9 +212,6 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Materialization_ChargesGraphNotVectorIndexN
   // graph must grow by a large fraction of the retained embedding bytes (extent-commit granular).
   EXPECT_GT(graph_delta, retained_bytes / 2)
       << "Reconstructed embeddings are charged to graph_memory_tracker (the AI_PLATFORM limit)";
-  // The exempt vector_index domain is not re-charged by reading, and the per-DB query PMR tracker
-  // sees nothing: the reconstruction is a plain operator-new, not a PMR allocation. So "removing
-  // query-runtime tracking from the AI limit" (the db_query PMR path) would NOT exempt it.
   EXPECT_LT(vidx_delta, retained_bytes / 8) << "The exempt vector_index domain is not re-charged by reading";
   EXPECT_LT(dbq_delta, retained_bytes / 8) << "Reconstruction is not query PMR memory";
   EXPECT_GT(graph_delta, vidx_delta * 4);
@@ -240,11 +220,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Materialization_ChargesGraphNotVectorIndexN
   held.clear();
 }
 
-// ---------------------------------------------------------------------------
-// 3. AI limit behaviour: with a graph limit far below the embedding index size, the index/embeddings
-//    are fine (exempt), reconstruct-and-discard (count(n.emb)) survives, but retaining the whole set
-//    (RETURN n) throws OutOfMemory. This is the customer symptom, reproduced.
-// ---------------------------------------------------------------------------
+// AI limit: with the graph cap below the embedding index size (exempt), count(n.emb) survives
+// (reconstruct-and-discard stays bounded), but RETURN n throws OutOfMemory (customer symptom).
 TEST_F(AiLicenseEmbeddingMemoryTest, AiGraphLimit_RetainAbortsDiscardSurvives) {
   auto gk = MakeDb("t3");
   auto acc_opt = gk->access();
@@ -264,7 +241,6 @@ TEST_F(AiLicenseEmbeddingMemoryTest, AiGraphLimit_RetainAbortsDiscardSurvives) {
   const int64_t limit = Graph() + headroom;
   ASSERT_GT(retained_bytes, 2 * headroom) << "test must retain far more than the headroom";
 
-  // Simulate an AI_PLATFORM license with this graph limit, through the real routing.
   memgraph::license::global_license_checker.EnableTesting(memgraph::license::LicenseType::AI_PLATFORM, limit);
 
   EXPECT_GT(embeddings_in_index, headroom)
@@ -301,12 +277,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, AiGraphLimit_RetainAbortsDiscardSurvives) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// 4. Query semantics: confirm the real interpreter reproduces the accessor-level model.
-//    MATCH (n) RETURN n retains all rows (graph elevated while the stream is alive);
-//    MATCH (n) RETURN count(n.emb) folds to one scalar (graph returns to baseline) yet still
-//    reconstructs each embedding (count == kNumVertices proves every n.emb was evaluated non-null).
-// ---------------------------------------------------------------------------
+// Query semantics via real interpreter: RETURN n retains all rows in graph memory;
+// count(n.emb) folds to one scalar (count == kNumVerticesBig proves every n.emb was evaluated).
 TEST_F(AiLicenseEmbeddingMemoryTest, QuerySemantics_ReturnNVsCountEmb) {
   auto gk = MakeDb("t4");
   memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
@@ -369,13 +341,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, QuerySemantics_ReturnNVsCountEmb) {
       << " held_count=" << held_count;
 }
 
-// ---------------------------------------------------------------------------
-// 5. Double-charge: at rest the embedding lives in the exempt vector_index domain (counted in
-//    total via vector_index). Materializing it adds a SECOND copy in the graph domain (also
-//    counted in total). So total_memory_tracker carries the same logical embedding TWICE while a
-//    result set is alive. Also refutes the earlier "reads route through the DB arena" hypothesis:
-//    reconstruction is std::allocator -> default arena, so DbStorageMemoryUsage does NOT grow.
-// ---------------------------------------------------------------------------
+// Double-charge: the index copy (exempt, in total) + the materialized copy (graph domain, in total)
+// means total_memory_tracker carries the same embedding twice while a result set is live.
 TEST_F(AiLicenseEmbeddingMemoryTest, DoubleCharge_IndexCopyPlusMaterializedCopyBothInTotal) {
   auto gk = MakeDb("t5");
   auto acc_opt = gk->access();
@@ -418,20 +385,14 @@ TEST_F(AiLicenseEmbeddingMemoryTest, DoubleCharge_IndexCopyPlusMaterializedCopyB
   EXPECT_GT(graph_delta, retained_bytes / 2) << "materialized copy lands in the graph domain";
   // ...so total grew by that second copy, on top of the index copy it already carried: double count.
   EXPECT_GT(total_delta, retained_bytes / 2) << "total_memory_tracker now carries the embedding twice";
-  // Reads use std::allocator -> default arena, NOT the DB arena: storage tracker stays flat.
-  // (Refutes the 'query reads route through db_memory_tracker' double-count hypothesis.)
+  // Reads use std::allocator -> default arena, not the DB arena: storage tracker stays flat.
   EXPECT_LT(storage_delta, retained_bytes / 8) << "reconstruction does not touch the per-DB storage arena";
 
   held.clear();
 }
 
-// ---------------------------------------------------------------------------
-// 6. Variant 1 (lazy value): an accumulating operator (sort / ORDER BY) can stay bounded if it holds
-//    cheap references and materializes the embedding transiently inside the comparator. Here we sort
-//    N vertices by their embedding using VertexAccessor::GetVectorInto — which reconstructs into a
-//    REUSED scratch buffer with zero per-comparison allocation — and show the sort's peak graph
-//    footprint is O(dim), not O(N*dim), while producing the same order as an eager sort.
-// ---------------------------------------------------------------------------
+// Lazy sort: GetVectorInto reconstructs into a REUSED scratch buffer (zero per-comparison allocation),
+// so the sort's peak graph footprint is O(dim), not O(N*dim); result matches an eager sort.
 TEST_F(AiLicenseEmbeddingMemoryTest, Variant1_LazySortBoundedVsEagerSort) {
   auto gk = MakeDb("t6");
   auto acc_opt = gk->access();
@@ -491,18 +452,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1_LazySortBoundedVsEagerSort) {
   EXPECT_EQ(lazy_sorted, eager_sorted) << "lazy comparator must produce the same order as an eager sort";
 }
 
-// ---------------------------------------------------------------------------
-// 7. Variant 1 end-to-end through the real interpreter. With the lazy embedding TypedValue (VectorRef)
-//    flowing out of PropertyLookup, an accumulating operator that would blow the AI_PLATFORM graph cap
-//    if it materialised every embedding stays bounded: it buffers only cheap references and materialises
-//    O(dim) transiently inside its comparator / hasher. Under a graph limit far below the total
-//    embedding footprint, driven through the real query engine:
-//      (a) ORDER BY n.emb  -> lazy sort keys + transient compare  -> SUCCEEDS (bounded).
-//      (b) DISTINCT n.emb  -> lazy set keys + transient hash/==    -> SUCCEEDS (bounded).
-//      (c) RETURN n.emb    -> result stream retains every materialised embedding -> ABORTS.
-//    (c) is the customer symptom, and it anchors that the cap is genuinely below O(N*dim), so (a)/(b)
-//    passing under the same cap is a real boundedness result, not a slack cap.
-// ---------------------------------------------------------------------------
+// Lazy-value interpreter end-to-end: ORDER BY and DISTINCT stay within the AI graph cap (bounded
+// O(dim) transient per step); RETURN n.emb blows the cap (anchors that the cap is genuinely tight).
 TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_OrderByAndDistinctBoundedThroughInterpreter) {
   auto gk = MakeDb("t7");
   memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
@@ -534,9 +485,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_OrderByAndDistinctBoundedThrou
   InterpreterFaker faker{&interpreter_context, db};
 
   const int64_t retained_bytes = static_cast<int64_t>(kNumVerticesBig) * kDimBig * sizeof(float);
-  // Headroom sits ABOVE the O(N) reference caches an ORDER BY / DISTINCT over kNumVerticesBig rows
-  // holds (~a few MiB of cheap VectorRef / vertex handles) but well BELOW the O(N*dim) cost of
-  // materialising every embedding (retained_bytes). That gap is exactly the lazy-value win.
+  // Headroom: above the O(N) reference cache (~few MiB of VectorRef/vertex handles) but well below
+  // the O(N*dim) cost of materialising every embedding — that gap is the lazy-value win.
   const int64_t headroom = 8 * kOneMiB;
   Stabilize(db.get());
   const int64_t limit = Graph() + headroom;
@@ -572,13 +522,8 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_OrderByAndDistinctBoundedThrou
   EXPECT_THROW(faker.Interpret("MATCH (n) RETURN n.emb"), memgraph::utils::OutOfMemoryException);
 }
 
-// ---------------------------------------------------------------------------
-// 8. Variant 1 map-projection round-trip: `n{.*}` reads properties WITHOUT reconstructing embeddings
-//    (they stay compact VectorIndexId references) and wraps each as a lazy VectorRef inside the map.
-//    Serialising the map must still yield the full embedding — this proves the no-decoder read + the
-//    VectorRef wrap + Bolt materialisation are correct end-to-end (a broken lazy path would surface an
-//    empty list here). Small/fast dataset; correctness only, no memory cap.
-// ---------------------------------------------------------------------------
+// Map-projection round-trip: `n{.*}` wraps the compact VectorIndexId as a lazy VectorRef;
+// Bolt serialisation must materialise the full embedding (a broken lazy path returns an empty list).
 TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_MapProjectionMaterialisesFullEmbedding) {
   auto gk = MakeDb("t8");
   memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -705,6 +705,14 @@ TEST_F(AiLicenseEmbeddingMemoryTest, Variant1Lazy_ListOperationsOnEmbedding) {
     auto stream = faker.Interpret("MATCH (n) WITH n LIMIT 1 UNWIND n.emb AS e RETURN count(e) AS c");
     EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), static_cast<int64_t>(kDim));
   }
+  // Dynamic string subscript n["emb"] reads the same property; it must also come back as a full list
+  // (and, like n.emb, be subscriptable) rather than an empty or unhandled value.
+  {
+    auto stream = faker.Interpret("MATCH (n) WITH n LIMIT 1 RETURN size(n[\"emb\"]) AS s, n[\"emb\"][0] AS x");
+    ASSERT_EQ(stream.GetResults().size(), 1u);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), static_cast<int64_t>(kDim));
+    EXPECT_TRUE(stream.GetResults()[0][1].IsDouble());
+  }
 }
 
 #endif  // USE_JEMALLOC

--- a/tests/unit/ai_license_embedding_memory.cpp
+++ b/tests/unit/ai_license_embedding_memory.cpp
@@ -1,0 +1,425 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Grounds the AI_PLATFORM license memory accounting for vector embeddings.
+//
+// Facts under test:
+//   1. Embeddings live ONLY in the usearch index; the vertex property is replaced by a compact
+//      VectorIndexId reference. Reading it reconstructs the full vector from the index.
+//   2. That reconstruction is a plain operator-new allocation -> default arena -> graph_memory_tracker
+//      (the AI_PLATFORM license limit), NOT the exempt vector_index_memory_tracker, and NOT the
+//      per-DB query PMR tracker.
+//   3. Under an AI_PLATFORM graph limit, retaining a whole result set of embeddings (RETURN n)
+//      aborts, while reconstructing-and-discarding one at a time (count(n.emb)) stays under the cap,
+//      even though the embedding index itself is far larger than the cap (it is exempt).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+#include "dbms/database.hpp"
+#include "interpreter_faker.hpp"
+#include "license/license.hpp"
+#include "memory/db_arena.hpp"
+#include "memory/global_memory_control.hpp"
+#include "query/interpreter_context.hpp"
+#include "replication/state.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/indices/vector_index.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/view.hpp"
+#include "system/system.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/memory_tracker.hpp"
+
+using memgraph::storage::PropertyValue;
+using memgraph::storage::View;
+
+namespace {
+
+// Small scale for the storage-model / query-semantics tests (fast).
+constexpr int kDim = 256;
+constexpr int kNumVertices = 1024;
+// graph_memory_tracker is fed by jemalloc EXTENT-COMMIT hooks, so it moves only when committed arena
+// memory grows past jemalloc's retained (dirty-page) slack. The accounting tests therefore use a
+// working set large enough to force new extent commits after a purge.
+constexpr int kDimBig = 512;
+constexpr int kNumVerticesBig = 6000;
+constexpr int64_t kOneMiB = 1 << 20;
+constexpr auto kNoHandler = nullptr;
+
+memgraph::storage::Config MakeConfig(const std::filesystem::path &dir) {
+  memgraph::storage::Config config{};
+  config.durability.storage_directory = dir;
+  config.disk.main_storage_directory = dir / "disk";
+  config.gc.type = memgraph::storage::Config::Gc::Type::NONE;
+  return config;
+}
+
+int64_t Graph() { return memgraph::utils::graph_memory_tracker.Amount(); }
+
+int64_t VectorIdx() { return memgraph::utils::vector_index_memory_tracker.Amount(); }
+
+int64_t Total() { return memgraph::utils::total_memory_tracker.Amount(); }
+
+// Free unused pages AND decommit jemalloc's retained dirty extents, so graph_memory_tracker starts
+// from a lean committed baseline and a fresh working set shows up as new extent commits.
+void Stabilize(memgraph::dbms::Database *db) {
+  db->storage()->FreeMemory();
+  db->storage()->FreeMemory();
+  memgraph::memory::PurgeUnusedMemory();
+}
+
+memgraph::storage::VectorIndexSpec MakeSpec(memgraph::storage::LabelId label, memgraph::storage::PropertyId prop,
+                                            int dim, int count) {
+  return memgraph::storage::VectorIndexSpec{
+      .index_name = "emb_index",
+      .label_filter =
+          memgraph::storage::VectorLabelFilter{.mode = memgraph::storage::VectorMatchMode::SINGLE, .ids = {label}},
+      .property = prop,
+      .metric_kind = unum::usearch::metric_kind_t::cos_k,
+      .dimension = static_cast<std::uint16_t>(dim),
+      .resize_coefficient = 2,
+      .capacity = static_cast<std::uint64_t>(2 * count),
+      .scalar_kind = unum::usearch::scalar_kind_t::f32_k,
+  };
+}
+
+}  // namespace
+
+#if USE_JEMALLOC
+
+class AiLicenseEmbeddingMemoryTest : public ::testing::Test {
+ protected:
+  std::filesystem::path data_dir_{std::filesystem::temp_directory_path() / "mg_test_ai_license_embedding"};
+
+  void SetUp() override {
+    std::filesystem::create_directories(data_dir_);
+    // Install the global graph arena hooks so plain operator-new allocations (the reconstructed
+    // embedding small_vector, the retained result set) are attributed to graph_memory_tracker,
+    // exactly as they are in a running server.
+    memgraph::memory::SetHooks();
+  }
+
+  void TearDown() override {
+    memgraph::license::global_license_checker.DisableTesting();  // clears any test-applied memory limit
+    std::filesystem::remove_all(data_dir_);
+  }
+
+  std::unique_ptr<memgraph::utils::Gatekeeper<memgraph::dbms::Database>> MakeDb(const std::string &name) {
+    auto dir = data_dir_ / name;
+    std::filesystem::create_directories(dir);
+    return std::make_unique<memgraph::utils::Gatekeeper<memgraph::dbms::Database>>(MakeConfig(dir));
+  }
+
+  static void Populate(memgraph::dbms::Database *db, memgraph::storage::LabelId label,
+                       memgraph::storage::PropertyId prop, int count, int dim) {
+    memgraph::memory::DbArenaScope scope{&db->Arena()};
+    auto acc = db->Access();
+    for (int i = 0; i < count; ++i) {
+      auto v = acc->CreateVertex();
+      ASSERT_TRUE(v.AddLabel(label).has_value());
+      std::vector<double> embedding(dim, static_cast<double>(i % 7) + 0.5);
+      ASSERT_TRUE(v.SetProperty(prop, PropertyValue(embedding)).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  static void CreateIndex(memgraph::dbms::Database *db, memgraph::storage::LabelId label,
+                          memgraph::storage::PropertyId prop, int dim, int count) {
+    memgraph::memory::DbArenaScope scope{&db->Arena()};
+    auto acc = db->UniqueAccess();
+    ASSERT_TRUE(acc->CreateVectorIndex(MakeSpec(label, prop, dim, count)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+};
+
+// ---------------------------------------------------------------------------
+// 1. Storage model: after indexing, the embedding is gone from the property store (replaced by a
+//    compact reference) and lives in the vector index. Reading reconstructs the full vector.
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, StorageModel_EmbeddingLivesOnlyInIndex) {
+  auto gk = MakeDb("t1");
+  auto acc_opt = gk->access();
+  ASSERT_TRUE(acc_opt);
+  auto &db = *acc_opt;
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+
+  Populate(db.get(), label, prop, kNumVertices, kDim);
+  Stabilize(db.get());
+  const int64_t emb_before = db->DbEmbeddingMemoryUsage();
+
+  CreateIndex(db.get(), label, prop, kDim, kNumVertices);
+  Stabilize(db.get());
+  const int64_t emb_after = db->DbEmbeddingMemoryUsage();
+
+  EXPECT_GT(emb_after - emb_before, static_cast<int64_t>(kNumVertices) * kDim * 2)
+      << "Vector index must now hold the embeddings (db_embedding_memory_tracker -> vector_index domain)";
+
+  // After indexing, the property is no longer a raw list: it is a compact VectorIndexId reference,
+  // and reading it reconstructs the full vector out of the index. (The property-store shrink is real
+  // but not observable via DbStorageMemoryUsage, which tracks committed arena extents, not logical
+  // property bytes.)
+  auto racc = db->Access();
+  int seen = 0;
+  for (auto v : racc->Vertices(View::OLD)) {
+    auto pv = v.GetProperty(prop, View::OLD);
+    ASSERT_TRUE(pv.has_value());
+    ASSERT_TRUE(pv->IsVectorIndexId()) << "Indexed property is stored as a reference, not a raw list";
+    EXPECT_EQ(pv->ValueVectorIndexList().size(), static_cast<size_t>(kDim))
+        << "Read reconstructs the full vector from the index";
+    if (++seen == 4) break;
+  }
+  EXPECT_EQ(seen, 4);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Materialization accounting: reconstructing embeddings on read charges graph_memory_tracker
+//    (the AI limit), leaves the exempt vector_index_memory_tracker untouched, and does NOT touch
+//    the per-DB query PMR tracker. (Answers: is it missed? no. which tracker? graph.)
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, Materialization_ChargesGraphNotVectorIndexNotQuery) {
+  auto gk = MakeDb("t2");
+  auto acc_opt = gk->access();
+  ASSERT_TRUE(acc_opt);
+  auto &db = *acc_opt;
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVerticesBig, kDimBig);
+  CreateIndex(db.get(), label, prop, kDimBig, kNumVerticesBig);
+  Stabilize(db.get());
+
+  const int64_t retained_bytes = static_cast<int64_t>(kNumVerticesBig) * kDimBig * sizeof(float);
+  const int64_t graph_before = Graph();
+  const int64_t vidx_before = VectorIdx();
+  const int64_t dbq_before = db->DbQueryMemoryUsage();
+
+  // Reconstruct and RETAIN every embedding (this is what a materialized result set does).
+  std::vector<PropertyValue> held;
+  held.reserve(kNumVerticesBig);
+  {
+    auto racc = db->Access();
+    for (auto v : racc->Vertices(View::OLD)) {
+      auto pv = v.GetProperty(prop, View::OLD);
+      ASSERT_TRUE(pv.has_value());
+      held.push_back(std::move(*pv));
+    }
+  }
+
+  const int64_t graph_delta = Graph() - graph_before;
+  const int64_t vidx_delta = VectorIdx() - vidx_before;
+  const int64_t dbq_delta = db->DbQueryMemoryUsage() - dbq_before;
+
+  EXPECT_EQ(held.size(), static_cast<size_t>(kNumVerticesBig));
+  // graph must grow by a large fraction of the retained embedding bytes (extent-commit granular).
+  EXPECT_GT(graph_delta, retained_bytes / 2)
+      << "Reconstructed embeddings are charged to graph_memory_tracker (the AI_PLATFORM limit)";
+  // The exempt vector_index domain is not re-charged by reading, and the per-DB query PMR tracker
+  // sees nothing: the reconstruction is a plain operator-new, not a PMR allocation. So "removing
+  // query-runtime tracking from the AI limit" (the db_query PMR path) would NOT exempt it.
+  EXPECT_LT(vidx_delta, retained_bytes / 8) << "The exempt vector_index domain is not re-charged by reading";
+  EXPECT_LT(dbq_delta, retained_bytes / 8) << "Reconstruction is not query PMR memory";
+  EXPECT_GT(graph_delta, vidx_delta * 4);
+  EXPECT_GT(graph_delta, dbq_delta * 4);
+
+  held.clear();
+}
+
+// ---------------------------------------------------------------------------
+// 3. AI limit behaviour: with a graph limit far below the embedding index size, the index/embeddings
+//    are fine (exempt), reconstruct-and-discard (count(n.emb)) survives, but retaining the whole set
+//    (RETURN n) throws OutOfMemory. This is the customer symptom, reproduced.
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, AiGraphLimit_RetainAbortsDiscardSurvives) {
+  auto gk = MakeDb("t3");
+  auto acc_opt = gk->access();
+  ASSERT_TRUE(acc_opt);
+  auto &db = *acc_opt;
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVerticesBig, kDimBig);
+  CreateIndex(db.get(), label, prop, kDimBig, kNumVerticesBig);
+  Stabilize(db.get());
+
+  const int64_t embeddings_in_index = VectorIdx();
+  const int64_t retained_bytes = static_cast<int64_t>(kNumVerticesBig) * kDimBig * sizeof(float);
+  // Headroom: generous enough for iteration machinery + a few transiently-reconstructed vectors,
+  // but far less than retaining all kNumVerticesBig vectors (retained_bytes).
+  const int64_t headroom = 4 * kOneMiB;
+  const int64_t limit = Graph() + headroom;
+  ASSERT_GT(retained_bytes, 2 * headroom) << "test must retain far more than the headroom";
+
+  // Simulate an AI_PLATFORM license with this graph limit, through the real routing.
+  memgraph::license::global_license_checker.EnableTesting(memgraph::license::LicenseType::AI_PLATFORM, limit);
+
+  EXPECT_GT(embeddings_in_index, headroom)
+      << "The embedding index is larger than the graph limit, yet coexists with it (it is exempt)";
+
+  // Enable OOM throwing on this thread (the tracker only throws inside an enabler scope).
+  memgraph::utils::MemoryTracker::OutOfMemoryExceptionEnabler enabler;
+
+  // count(n.emb) shape: reconstruct each, inspect, discard. Stays under the cap.
+  {
+    auto racc = db->Access();
+    EXPECT_NO_THROW({
+      for (auto v : racc->Vertices(View::OLD)) {
+        auto pv = v.GetProperty(prop, View::OLD);
+        ASSERT_TRUE(pv.has_value());
+        volatile auto sz = pv->ValueVectorIndexList().size();
+        (void)sz;  // discard immediately
+      }
+    });
+  }
+
+  // RETURN n shape: reconstruct and retain all. Must blow the graph cap.
+  {
+    auto racc = db->Access();
+    std::vector<PropertyValue> held;
+    EXPECT_THROW(
+        {
+          for (auto v : racc->Vertices(View::OLD)) {
+            auto pv = v.GetProperty(prop, View::OLD);
+            if (pv.has_value()) held.push_back(std::move(*pv));
+          }
+        },
+        memgraph::utils::OutOfMemoryException);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Query semantics: confirm the real interpreter reproduces the accessor-level model.
+//    MATCH (n) RETURN n retains all rows (graph elevated while the stream is alive);
+//    MATCH (n) RETURN count(n.emb) folds to one scalar (graph returns to baseline) yet still
+//    reconstructs each embedding (count == kNumVertices proves every n.emb was evaluated non-null).
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, QuerySemantics_ReturnNVsCountEmb) {
+  auto gk = MakeDb("t4");
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(MakeConfig(data_dir_ / "t4"))};
+  memgraph::dbms::DatabaseAccess db = [&]() {
+    auto a = gk->access();
+    MG_ASSERT(a, "db access");
+    return *a;
+  }();
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVerticesBig, kDimBig);
+  CreateIndex(db.get(), label, prop, kDimBig, kNumVerticesBig);
+
+  memgraph::system::System system_state;
+  memgraph::query::InterpreterContext interpreter_context{{},
+                                                          nullptr,
+                                                          nullptr,
+                                                          kNoHandler,
+                                                          &repl_state,
+                                                          system_state,
+                                                          nullptr
+#ifdef MG_ENTERPRISE
+                                                          ,
+                                                          nullptr,
+                                                          nullptr
+#endif
+  };
+  InterpreterFaker faker{&interpreter_context, db};
+
+  const int64_t retained_bytes = static_cast<int64_t>(kNumVerticesBig) * kDimBig * sizeof(float);
+
+  // RETURN n: the result stream retains every node and its reconstructed embedding.
+  Stabilize(db.get());
+  int64_t held_return = 0;
+  {
+    const int64_t before = Graph();
+    auto stream = faker.Interpret("MATCH (n) RETURN n");
+    held_return = Graph() - before;
+    EXPECT_EQ(stream.GetResults().size(), static_cast<size_t>(kNumVerticesBig));
+    EXPECT_GT(held_return, retained_bytes / 2)
+        << "RETURN n retains the whole materialized result set (embeddings) in graph memory";
+  }
+
+  // count(n.emb): reconstructs each embedding transiently, folds to one scalar. Only fixed
+  // query-execution machinery persists — far less than RETURN n's retained embeddings.
+  Stabilize(db.get());
+  int64_t held_count = 0;
+  {
+    const int64_t before = Graph();
+    auto stream = faker.Interpret("MATCH (n) RETURN count(n.emb)");
+    held_count = Graph() - before;
+    ASSERT_EQ(stream.GetResults().size(), 1u);
+    EXPECT_EQ(stream.GetResults()[0][0].ValueInt(), kNumVerticesBig)
+        << "count(n.emb) evaluated (reconstructed) every embedding";
+  }
+
+  EXPECT_GT(held_return, held_count * 4)
+      << "RETURN n materializes far more embedding memory than count(n.emb): held_return=" << held_return
+      << " held_count=" << held_count;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Double-charge: at rest the embedding lives in the exempt vector_index domain (counted in
+//    total via vector_index). Materializing it adds a SECOND copy in the graph domain (also
+//    counted in total). So total_memory_tracker carries the same logical embedding TWICE while a
+//    result set is alive. Also refutes the earlier "reads route through the DB arena" hypothesis:
+//    reconstruction is std::allocator -> default arena, so DbStorageMemoryUsage does NOT grow.
+// ---------------------------------------------------------------------------
+TEST_F(AiLicenseEmbeddingMemoryTest, DoubleCharge_IndexCopyPlusMaterializedCopyBothInTotal) {
+  auto gk = MakeDb("t5");
+  auto acc_opt = gk->access();
+  ASSERT_TRUE(acc_opt);
+  auto &db = *acc_opt;
+  auto label = db->storage()->NameToLabel("Doc");
+  auto prop = db->storage()->NameToProperty("emb");
+  Populate(db.get(), label, prop, kNumVerticesBig, kDimBig);
+  CreateIndex(db.get(), label, prop, kDimBig, kNumVerticesBig);
+  Stabilize(db.get());
+
+  const int64_t retained_bytes = static_cast<int64_t>(kNumVerticesBig) * kDimBig * sizeof(float);
+  const int64_t vidx_before = VectorIdx();
+  const int64_t graph_before = Graph();
+  const int64_t total_before = Total();
+  const int64_t storage_before = db->DbStorageMemoryUsage();
+
+  // At rest the index already holds ~a full copy of the embeddings, and it is counted in total.
+  EXPECT_GT(vidx_before, retained_bytes / 2) << "the exempt vector_index domain holds the embeddings at rest";
+
+  std::vector<PropertyValue> held;
+  held.reserve(kNumVerticesBig);
+  {
+    auto racc = db->Access();
+    for (auto v : racc->Vertices(View::OLD)) {
+      auto pv = v.GetProperty(prop, View::OLD);
+      ASSERT_TRUE(pv.has_value());
+      held.push_back(std::move(*pv));
+    }
+  }
+
+  const int64_t vidx_delta = VectorIdx() - vidx_before;
+  const int64_t graph_delta = Graph() - graph_before;
+  const int64_t total_delta = Total() - total_before;
+  const int64_t storage_delta = db->DbStorageMemoryUsage() - storage_before;
+
+  // The index copy is NOT released by reading (still resident, still counted in total)...
+  EXPECT_LT(vidx_delta, retained_bytes / 8) << "index copy is untouched by reading";
+  // ...and materialization adds a WHOLE SECOND copy in the graph domain...
+  EXPECT_GT(graph_delta, retained_bytes / 2) << "materialized copy lands in the graph domain";
+  // ...so total grew by that second copy, on top of the index copy it already carried: double count.
+  EXPECT_GT(total_delta, retained_bytes / 2) << "total_memory_tracker now carries the embedding twice";
+  // Reads use std::allocator -> default arena, NOT the DB arena: storage tracker stays flat.
+  // (Refutes the 'query reads route through db_memory_tracker' double-count hypothesis.)
+  EXPECT_LT(storage_delta, retained_bytes / 8) << "reconstruction does not touch the per-DB storage arena";
+
+  held.clear();
+}
+
+#endif  // USE_JEMALLOC

--- a/tests/unit/formatters.hpp
+++ b/tests/unit/formatters.hpp
@@ -13,6 +13,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "query/typed_value.hpp"
 #include "utils/algorithm.hpp"
@@ -117,6 +118,14 @@ inline std::string ToString(const memgraph::query::TypedValue &value, const TAcc
           os, value.ValueList(), ", ", [&](auto &stream, const auto &item) { stream << ToString(item, acc); });
       os << "]";
       break;
+    case memgraph::query::TypedValue::Type::VectorRef: {
+      std::vector<float> vec;
+      value.MaterializeVectorRefInto(vec);
+      os << "[";
+      memgraph::utils::PrintIterable(os, vec, ", ", [](auto &stream, const auto &item) { stream << item; });
+      os << "]";
+      break;
+    }
     case memgraph::query::TypedValue::Type::Map:
       os << "{";
       memgraph::utils::PrintIterable(os, value.ValueMap(), ", ", [&](auto &stream, const auto &pair) {


### PR DESCRIPTION
## Problem

Under the **AI_PLATFORM** license only *graph* memory is capped (the vector index is exempt), so customers can run large embeddings. But an indexed embedding is stored as a compact `VectorIndexId` **reference** (the floats live only in the usearch index); the moment a query reads it, `GetVectorPropertyFromIndex` reconstructs the full `small_vector<float>` via `operator new` → default arena → **`graph_memory_tracker`**. A `MATCH (n) RETURN n` / `ORDER BY n.emb` / `collect` over many embeddings therefore materialises `O(N·dim)` floats into the graph domain and **aborts below `--memory-limit`** — the reported customer symptom.

## Approach — keep the reference lazy through the query layer

The storage `PropertyValue` already had the lazy form (`VectorIndexId`, empty float list). This PR gives the **query layer its own matching reference** and stops the plumbing from eagerly collapsing it into floats:

- New lazy **`TypedValue::Type::VectorRef`** (holds a vertex-or-edge accessor + property id, no floats). `PropertyLookup` returns it instead of reconstructing.
- Floats are materialised **only transiently** — into reused `thread_local` scratch buffers inside the ORDER BY comparator and DISTINCT hash/equality (never the query's monotonic arena, which would accumulate across a whole sort), and one row at a time at Bolt serialisation.
- **Whole-vertex maps** (`RETURN n{.*}`, `properties(n)`, GET_ALL_PROPERTIES) read through a new no-decoder `Properties(view, with_vector_reconstruction=false)` and wrap each embedding as a `VectorRef`, so a retained map costs `O(references)`, not `O(N·dim)`.
- **Edges** get the same treatment (`EdgeAccessor::GetVectorInto` + `VectorEdgeIndex::GetVectorInto`; `VectorRef` holds a `variant<VertexAccessor, EdgeAccessor>`).
- **Delta-cache**: `manyDeltasCache` no longer pins reconstructed embeddings (only bit under long SNAPSHOT delta chains).

Net effect: an accumulating operator over embeddings is bounded at **O(N) references + O(dim) scratch** instead of O(N·dim) floats.

## Deliberately *not* changed

**WAL / snapshot / replication stay eager** — recovery *rebuilds* the usearch index from the persisted floats (`RecoverIndex` re-inserts snapshot/WAL vectors), so those encoders must materialise the floats; a reference alone would lose every embedding. Correct-by-necessity. `mgp` C-API property access is deferred (per-call bounded).

## Tests (`tests/unit/ai_license_embedding_memory.cpp`)

Grounding/characterisation of the accounting (storage model, reconstruction→graph, AI-limit retain-aborts/discard-survives, RETURN n vs count(n.emb), double-charge in `total`), plus fix validation: lazy sort is O(dim) not O(N·dim); interpreter `ORDER BY n.emb` / `DISTINCT n.emb` stay under a tight AI cap while eager `RETURN n.emb` aborts; `RETURN n{.*}` round-trips the full embedding. A test-only `LicenseChecker::EnableTesting(LicenseType, memory_limit)` installs an AI graph cap without a signed key.

Green on toolchain v8: `ai_license_embedding_memory` + `typed_value` (42/42).
