### PR TITLE
perf(storage): pipelined commit: encode the WAL outside the commit serializer (experimental)

### DIFF
--- a/docs/pipelined-commit-base-notes.md
+++ b/docs/pipelined-commit-base-notes.md
@@ -1,0 +1,56 @@
+# Pipelined commit: base and citation notes
+
+The implementation plan (`docs/superpowers/plans/2026-09-07-memgraph-pipelined-commit.md` in tgraph-api, revision 13)
+cites `U file:line` on the head of `feat/adaptive-commit-lock-scheduling` at `cd7a8f8814617eab2357da203cd81a28a090908b`.
+This branch was cut from `master` and merged with that head:
+
+| Item | Value |
+|---|---|
+| `master` pin | `be32bab6bebef32c8d1eafb4420fe8f6221dd5ba` (2026-09-08) |
+| Merged head | `cd7a8f8814617eab2357da203cd81a28a090908b` (memgraph#4777) |
+| Merge base | `cdd8b5e1285f2b4a8ee4c29710aecb7619f3e98d` |
+| Merge result | clean, no conflicts (45 commits ahead, 22 behind at merge time) |
+| Toolchain | v8 (clang 22.1.8); required by `master` and by the merged head alike |
+| Durability format | `kVersion = 37` (`kWalHeader`); v3.12.0 writes 36. A downgrade after this binary has written is not possible without a backup. |
+
+## Citation revalidation
+
+Every cited site was revalidated by content on the merged tree before use. The 22 `master` commits past the merge base
+did not touch the cited regions, so the line numbers the plan quotes for `src/storage/v2/**`, `src/memgraph.cpp`,
+`src/flags/experimental.*`, `src/dbms/inmemory/replication_handlers.*`, `src/utils/**` and `tests/unit/**` held
+exactly as quoted. In particular:
+
+| Plan citation | Location on this branch (before this work) |
+|---|---|
+| `inmemory/storage.cpp:1091` `PrepareForCommitPhase` | 1091 |
+| `inmemory/storage.cpp:1152-1156` mint + unique validation | 1152-1156 |
+| `inmemory/storage.cpp:1186` `InitializeWalFile` | 1186 |
+| `inmemory/storage.cpp:1273` `FinalizeCommitPhase` | 1273 |
+| `inmemory/storage.cpp:3905, 3924` `InitializeWalFile`, `FinalizeWalFile` | 3905, 3924 |
+| `inmemory/storage.cpp:4006-4019` anonymous `TxnDataCommand`/`TxnCommands` | 4006-4019 (replaced by `inmemory/txn_commands.hpp`) |
+| `inmemory/storage.cpp:4231` `HandleDurabilityAndReplicate` | 4231 |
+| `inmemory/storage.cpp:5028-5030` `GetCommitTimestamp`, `PrepareForNewEpoch` | 5028-5030 |
+| `inmemory/storage.cpp:578` shutdown ordering | 578-585 |
+| `inmemory/replication/recovery.cpp:89` recovery-step commit serializer | 89-94 |
+| `replication/replication_client.cpp:245, 894, 992` quiesce sites | 245-249, 894-899, 992-996 |
+| `replication/replication_transaction.cpp:274-300` constructor | 274-300 |
+| `durability/wal.cpp:1346, 1358` transaction start/end encoding | 1346, 1358 |
+| `durability/wal.cpp:2402, 2431-2448` commit patch, end bookkeeping | 2402, 2431-2448 |
+| `durability/serialization.cpp:108` `WriteCrc` | 108 |
+| `src/memgraph.cpp:293` environment append | 293-298 |
+| `src/memgraph.cpp:557` TEMP forced lock-free default | 557-560 (reverted in the first commit) |
+| `config.hpp:129` TEMP default | 129-130 (reverted) |
+| `src/flags/experimental.hpp:32` `enum class Experiments` | 30-34 |
+| `src/utils/on_scope_exit.hpp:51-52` | 51-52 |
+| `src/utils/logging.hpp:68-74` `DMG_ASSERT` | 68-74 |
+| `dbms/inmemory/replication_handlers.cpp:512-518, 585-596` | 512-518, 585-596 |
+| `tests/unit/storage_v2_wal_file.cpp:287, 813` `DeltaGenerator` ctor, `WalFileTest` | 287, 813 |
+| `tests/unit/storage_v2_replication.cpp:140-188` `MinMemgraph` | 140-188 |
+| `tests/unit/storage_v2_durability_inmemory.cpp:3106` `WalTransactionOrdering` | 3106 |
+
+## Deviations from the plan
+
+- The build uses toolchain v8, which the plan's build recipe (written for a v7 container) did not mention; the
+  container was given v8 from `deps.memgraph.io`.
+- `Task 9` produces `docs/pipelined-commit-upstream-pr.md` instead of a GitHub pull request, as the handoff
+  requires.

--- a/docs/pipelined-commit-base-notes.md
+++ b/docs/pipelined-commit-base-notes.md
@@ -1,15 +1,17 @@
 # Pipelined commit: base and citation notes
 
-The implementation plan (`docs/superpowers/plans/2026-09-07-memgraph-pipelined-commit.md` in tgraph-api, revision 13)
-cites `U file:line` on the head of `feat/adaptive-commit-lock-scheduling` at `cd7a8f8814617eab2357da203cd81a28a090908b`.
-This branch was cut from `master` and merged with that head:
+The implementation plan this series followed cites `U file:line` on the head of `feat/adaptive-commit-lock-scheduling` at `cd7a8f8814617eab2357da203cd81a28a090908b`.
+The branch was first cut from `master` at `be32bab6bebef32c8d1eafb4420fe8f6221dd5ba` merged with that head
+(merge base `cdd8b5e1285f2b4a8ee4c29710aecb7619f3e98d`, clean, 45 ahead / 22 behind). On 2026-09-08 the upstream
+branch was rewritten (its old head is no longer an ancestor of it), so the series was rebased onto the current head;
+`master` is not merged in, so a pull request against that branch shows only this series:
 
 | Item | Value |
 |---|---|
-| `master` pin | `be32bab6bebef32c8d1eafb4420fe8f6221dd5ba` (2026-09-08) |
-| Merged head | `cd7a8f8814617eab2357da203cd81a28a090908b` (memgraph#4777) |
-| Merge base | `cdd8b5e1285f2b4a8ee4c29710aecb7619f3e98d` |
-| Merge result | clean, no conflicts (45 commits ahead, 22 behind at merge time) |
+| Base | `d22a37bb0b9186dc31c71a093f25e75e28bdec80`, head of `feat/adaptive-commit-lock-scheduling` (memgraph#4777) on 2026-09-08 |
+| `master` at that time | `9e70eab5e`; 24 commits not in the base, none needed by this series (a variant with `master` merged in builds and passes the same suites and the full storage sweep) |
+| Rebase conflicts | three files, all one change: upstream renamed the serializer's lock to `CommitLock` (`std::unique_lock<std::timed_mutex>`), which `QuiesceCommits`, `CommitWithTicket` and `OrderedLegacyCommit` now take and return |
+| Upstream changes absorbed | `SeedReadSnapshotWatermarkFromLocalCounter` (recovery watermark), the strictly-increasing watermark `DMG_ASSERT` in `FinalizeCommitPhase` (holds: tickets publish in mint order), `TryAccessFor` and the park stack; none touch the encode or ordered stages |
 | Toolchain | v8 (clang 22.1.8); required by `master` and by the merged head alike |
 | Durability format | `kVersion = 37` (`kWalHeader`); v3.12.0 writes 36. A downgrade after this binary has written is not possible without a backup. |
 

--- a/specs/pipelined-commit.md
+++ b/specs/pipelined-commit.md
@@ -54,7 +54,9 @@ code after entering the gate, so every main-side commit belongs to one ordering 
 - **Unique constraints are validated against a settled predecessor set.** A commit
   validates only after every earlier-minted commit has published or fully aborted.
 - **Off is identical to today.** With the flag off the commit path is the same code, and a
-  deterministic harness compares its WAL output byte for byte against the base.
+  deterministic harness compares its WAL output byte for byte against the base. The
+  comparison holds for the same `lockfree-read-snapshot` setting on both sides; that flag,
+  not this one, decides whether the engine lock is released during durability.
 - **Durable data does not depend on the flag.** A transaction encoded to a private buffer
   and appended verbatim produces exactly the bytes and CRC the inline path produces.
 - **Failure semantics unchanged.** Partial WAL writes and fsync failures stay fatal; a
@@ -93,6 +95,15 @@ Enabling `pipelined-commit` without `lockfree-read-snapshot` is rejected at star
 - **Budget fallback.** When the retained bytes would exceed the budget, the commit is not
   refused and does not wait; it takes the ordered legacy path, which holds no more memory
   than today but re-serializes the encoding for that transaction.
+- **The budget bounds retained bytes only.** It charges the materialized commands, the
+  tracking sets, the vertex cache and the WAL buffer: everything the encode stage keeps
+  until the ordered stage consumes it. It does not charge the short-lived temporaries the
+  encoder creates while it converts one property value at a time (the decoded
+  `PropertyValue` and its external form), which are the same allocations any property read
+  makes and which are freed before the next value is encoded. With N committers encoding at
+  once that transient peak is N times the single-committer peak of today's inline encoder,
+  bounded by N times the largest single property value in flight; it is not covered by
+  `--storage-pipelined-commit-max-bytes`.
 - **Quiescence drains the gate.** Every maintenance site that used to exclude one in-flight
   committer now waits until every issued ticket has retired. One of those sites is the
   per-replica heartbeat reconciliation, which runs on a timer, so with replicas registered

--- a/specs/pipelined-commit.md
+++ b/specs/pipelined-commit.md
@@ -93,6 +93,14 @@ Enabling `pipelined-commit` without `lockfree-read-snapshot` is rejected at star
 - **Budget fallback.** When the retained bytes would exceed the budget, the commit is not
   refused and does not wait; it takes the ordered legacy path, which holds no more memory
   than today but re-serializes the encoding for that transaction.
+- **Quiescence drains the gate.** Every maintenance site that used to exclude one in-flight
+  committer now waits until every issued ticket has retired. One of those sites is the
+  per-replica heartbeat reconciliation, which runs on a timer, so with replicas registered
+  the pipeline is periodically drained.
+- **STRICT_SYNC replicas encode twice.** Whether a commit needs two-phase commit is known
+  only once its replication streams are open, after the encode stage; with a STRICT_SYNC
+  replica registered every eligible commit encodes its buffer, discards it, and takes the
+  ordered legacy path.
 
 ## Deferred
 

--- a/specs/pipelined-commit.md
+++ b/specs/pipelined-commit.md
@@ -1,0 +1,110 @@
+# Pipelined commit (`--experimental-enabled=pipelined-commit`)
+
+**Status:** Experimental (opt-in, off by default; requires `lockfree-read-snapshot`)
+**Area:** storage/v2 (commit path, durability), replication
+
+One-line summary: an experimental commit mode that lets concurrent writers encode their
+write-ahead-log payload in parallel, so the serialized part of a commit no longer contains
+the encoding of every delta, and two to eight large-batch writers gain throughput instead
+of queueing behind each other.
+
+## Problem Statement
+
+With `lockfree-read-snapshot` a main-side commit runs as: mint a commit timestamp (under
+the commit serializer and, briefly, the engine lock), then write the transaction to the WAL
+and ship it to replicas while still holding the commit serializer, then publish. The
+serializer is held for the whole of durability and replication because unique-constraint
+validation and the read watermark both need commits to become visible in mint order.
+
+For a batch of a thousand rows the serial section is dominated by one piece of work that
+does not need to be serial at all: encoding every delta into WAL bytes. On the reference
+workload roughly 26 of the 41 milliseconds a commit spends are serialized, and the largest
+single piece is the encoding of about 8,000 deltas. Adding writers therefore adds queueing,
+not throughput: the commit lane has a ceiling that a single core's encoding speed sets.
+
+## Solution
+
+An opt-in, startup-only flag, `--experimental-enabled=pipelined-commit` (default off),
+valid only together with `lockfree-read-snapshot`. With it on, an eligible main-side commit
+runs in three stages:
+
+1. **Mint.** Under the commit serializer and briefly the engine lock: mint the commit
+   timestamp, register a ticket with the commit-order gate, release both locks.
+2. **Encode.** With no serializer held: materialize the transaction's commands and encode
+   them into a private, CRC-complete WAL buffer. Every byte this stage retains is charged to
+   a per-database budget (`--storage-pipelined-commit-max-bytes`, default 256 MiB) before it
+   is allocated; a refused charge never blocks, it converts the commit into the ordered
+   legacy path.
+3. **Ordered.** Enter the gate in commit-timestamp order: validate unique constraints,
+   append the buffer verbatim to the WAL, replicate exactly as before, publish, retire the
+   ticket.
+
+Only the WAL encoding leaves the serial section. Replication, publication and two-phase
+commit are unchanged code executed in ticket order. Commits that are not eligible (metadata
+transactions, transactions on a storage without a WAL, transactions that turn out to need
+two-phase commit, over-budget transactions) take the same ticket and run today's durability
+code after entering the gate, so every main-side commit belongs to one ordering domain.
+
+## Guarantees
+
+- **WAL order and replica order are unchanged.** Every WAL file holds transactions in
+  strictly increasing commit-timestamp order and replicas receive them in that order.
+- **Publication order is unchanged.** Commit timestamps become visible in mint order, so the
+  read watermark stays contiguous.
+- **Unique constraints are validated against a settled predecessor set.** A commit
+  validates only after every earlier-minted commit has published or fully aborted.
+- **Off is identical to today.** With the flag off the commit path is the same code, and a
+  deterministic harness compares its WAL output byte for byte against the base.
+- **Durable data does not depend on the flag.** A transaction encoded to a private buffer
+  and appended verbatim produces exactly the bytes and CRC the inline path produces.
+- **Failure semantics unchanged.** Partial WAL writes and fsync failures stay fatal; a
+  synchronous replica failure still reports the transaction as committed; aborts never
+  advance the read watermark.
+
+## Configuration
+
+| | |
+|---|---|
+| Flag | `--experimental-enabled=lockfree-read-snapshot,pipelined-commit` |
+| Default | off |
+| Scope | per instance, set at startup, immutable while running |
+| Budget | `--storage-pipelined-commit-max-bytes` (default 256 MiB) |
+
+Enabling `pipelined-commit` without `lockfree-read-snapshot` is rejected at startup.
+
+## Applicability
+
+- In-memory transactional storage with `PERIODIC_SNAPSHOT_WITH_WAL` durability only. Without
+  a WAL there is nothing to encode ahead of time, and analytical mode has no commit ordering
+  to pipeline.
+- Data transactions. A transaction carrying metadata deltas (index and constraint changes)
+  takes the ordered legacy path.
+- Main-side commits. Replica-side writes are applied by the replication server on one thread
+  in main's order and are outside the ordering domain.
+
+## Costs and trade-offs
+
+- **A blocked worker at the gate.** A committer whose predecessor is still encoding,
+  validating, replicating or publishing waits on its own worker thread. There is no latency
+  bound on that wait and the interpreter's commit-lock parking does not cover it.
+- **More unpublished commits in flight.** Several minted-but-unpublished transactions can
+  coexist. Their deltas stay protected until they publish, so readers see nothing new, but
+  memory for their materialized commands and WAL buffers is held for the duration.
+- **Budget fallback.** When the retained bytes would exceed the budget, the commit is not
+  refused and does not wait; it takes the ordered legacy path, which holds no more memory
+  than today but re-serializes the encoding for that transaction.
+
+## Deferred
+
+- **Gate parking.** Parking a committer that waits at the gate instead of blocking its
+  worker needs an owned commit continuation the interpreter's commit guards cannot provide.
+- **A private replication transport.** Replica payloads are still encoded by the existing
+  per-replica tasks in the ordered stage.
+
+## Out of scope
+
+- Making a single commit faster; the flag only stops concurrent commits from serializing
+  their encoding.
+- Any change to on-disk or analytical storage.
+- Any new user-facing query surface beyond the startup flag and the new counters in
+  `SHOW STORAGE INFO`.

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -513,9 +513,18 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(
       two_pc_cache_.commit_accessor_ = std::move(deltas_res->commit_acc);
       two_pc_cache_.durability_commit_timestamp_ = req.durability_commit_timestamp;
       res.success = true;
+      // Test-only: a prepared replica that votes no, so main sees a failed prepare with a live stream.
+      if (auto *hooks = storage->replication_test_hooks();
+          hooks != nullptr && hooks->refuse_next_prepare &&
+          hooks->refuse_next_prepare(req.durability_commit_timestamp)) {
+        res.success = false;
+      }
     }
   }
   rpc::SendFinalResponse(res, request_version, res_builder, storage->name());
+  if (auto *hooks = storage->replication_test_hooks(); hooks != nullptr && hooks->on_prepared) {
+    hooks->on_prepared(req.durability_commit_timestamp);
+  }
 }
 
 void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_handler,
@@ -592,8 +601,19 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
     mem_storage->FinalizeWalFile();
   }
 
-  storage::replication::FinalizeCommitRes const res(true);
+  bool success = true;
+  auto *hooks = mem_storage->replication_test_hooks();
+  if (!req.decision && hooks != nullptr) {
+    // Test-only: the abort was applied; answer the decision with failure when asked to.
+    if (hooks->refuse_next_abort_decision && hooks->refuse_next_abort_decision(req.durability_commit_timestamp)) {
+      success = false;
+    }
+  }
+  storage::replication::FinalizeCommitRes const res(success);
   rpc::SendFinalResponse(res, request_version, res_builder);
+  if (!req.decision && hooks != nullptr && hooks->on_abort_applied) {
+    hooks->on_abort_applied(req.durability_commit_timestamp);
+  }
 }
 
 void InMemoryReplicationHandlers::DestroyReplAccessor(rpc::ProgressHeartbeat *heartbeat) {

--- a/src/flags/experimental.cpp
+++ b/src/flags/experimental.cpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <map>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <range/v3/algorithm/any_of.hpp>
 #include <range/v3/functional/bind_back.hpp>
 #include <range/v3/iterator/basic_iterator.hpp>
@@ -50,10 +51,12 @@ namespace memgraph::flags {
 auto const mapping = std::map{
     std::pair{"planner-v2"sv, Experiments::PLANNER_V2},
     std::pair{"lockfree-read-snapshot"sv, Experiments::LOCKFREE_READ_SNAPSHOT},
+    std::pair{"pipelined-commit"sv, Experiments::PIPELINED_COMMIT},
 };
 auto const reverse_mapping = std::map{
     std::pair{Experiments::PLANNER_V2, "planner-v2"sv},
     std::pair{Experiments::LOCKFREE_READ_SNAPSHOT, "lockfree-read-snapshot"sv},
+    std::pair{Experiments::PIPELINED_COMMIT, "pipelined-commit"sv},
 };
 auto const config_mapping = std::map<std::string_view, Experiments>{};
 
@@ -130,6 +133,16 @@ auto ReadExperimental(std::string const &flags_experimental) -> Experiments {
   }
 
   return static_cast<Experiments>(to_set);
+}
+
+auto ValidateExperimentDependencies(Experiments experiments) -> std::optional<std::string> {
+  auto const enabled = [experiments](Experiments experiment) {
+    return (std::to_underlying(experiments) & std::to_underlying(experiment)) == std::to_underlying(experiment);
+  };
+  if (enabled(Experiments::PIPELINED_COMMIT) && !enabled(Experiments::LOCKFREE_READ_SNAPSHOT)) {
+    return "Experimental feature pipelined-commit requires lockfree-read-snapshot to be enabled as well.";
+  }
+  return std::nullopt;
 }
 
 void SetExperimental(Experiments const &experiments) { ExperimentsInstance() = experiments; }

--- a/src/flags/experimental.hpp
+++ b/src/flags/experimental.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <nlohmann/json_fwd.hpp>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -33,9 +34,14 @@ enum class Experiments : uint8_t {
   NONE = 0,
   PLANNER_V2 = 1 << 0,
   LOCKFREE_READ_SNAPSHOT = 1 << 1,
+  PIPELINED_COMMIT = 1 << 2,
 };
 
 bool AreExperimentsEnabled(Experiments experiments);
+
+/// Checks that every enabled experiment has the experiments it depends on enabled as well (pipelined-commit
+/// requires lockfree-read-snapshot). Returns the reason when the combination is invalid.
+auto ValidateExperimentDependencies(Experiments experiments) -> std::optional<std::string>;
 
 auto ReadExperimental(std::string const &) -> Experiments;
 void SetExperimental(Experiments const &);

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -123,6 +123,13 @@ DEFINE_VALIDATED_uint64(storage_wal_file_flush_every_n_tx,
 DEFINE_bool(storage_snapshot_on_exit, false, "Controls whether the storage creates another snapshot on exit.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_VALIDATED_uint64(storage_pipelined_commit_max_bytes, memgraph::storage::Config().pipelined_commit_max_bytes,
+                        "With --experimental-enabled=pipelined-commit, the number of bytes a database's in-flight "
+                        "commits may retain outside the commit serializer (materialized commands and private WAL "
+                        "buffers) before a commit falls back to the serialized path.",
+                        FLAG_IN_RANGE(1, std::numeric_limits<uint64_t>::max()));
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(storage_allow_recovery_failure, false,
             "If true, a database that fails to recover on startup comes up in a broken state instead of crashing the "
             "process. Broken databases reject queries until recovered via RECOVER SNAPSHOT.");

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -82,6 +82,8 @@ DECLARE_uint64(storage_wal_file_flush_every_n_tx);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_snapshot_on_exit);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_uint64(storage_pipelined_commit_max_bytes);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_allow_recovery_failure);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint64(storage_items_per_batch);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -292,10 +292,19 @@ int main(int argc, char **argv) {
 
   auto flags_experimental = memgraph::flags::ReadExperimental(FLAGS_experimental_enabled);
   memgraph::flags::SetExperimental(flags_experimental);
+  auto combined_experimental = std::to_underlying(flags_experimental);
   auto *maybe_experimental = std::getenv(kMgExperimentalEnabled);
   if (maybe_experimental) {
     auto env_experimental = memgraph::flags::ReadExperimental(maybe_experimental);
     memgraph::flags::AppendExperimental(env_experimental);
+    combined_experimental |= std::to_underlying(env_experimental);
+  }
+  // Validated on the combined command-line plus environment mask, since either may supply a dependency.
+  if (auto const dependency_error = memgraph::flags::ValidateExperimentDependencies(
+          static_cast<memgraph::flags::Experiments>(combined_experimental));
+      dependency_error) {
+    spdlog::critical("{}", *dependency_error);
+    return EXIT_FAILURE;
   }
   // Initialize the logger. Done after experimental setup so that we could print which experimental features are enabled
   // even if --also-log-to-stderr is false
@@ -556,6 +565,9 @@ int main(int argc, char **argv) {
       // persisted, so durable data is identical regardless of this flag (flip across restart is safe).
       .experimental_lockfree_read_snapshot =
           memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::LOCKFREE_READ_SNAPSHOT),
+      .experimental_pipelined_commit =
+          memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::PIPELINED_COMMIT),
+      .pipelined_commit_max_bytes = FLAGS_storage_pipelined_commit_max_bytes,
       .transaction = {.isolation_level = memgraph::flags::ParseIsolationLevel()},
       .disk = {.main_storage_directory = FLAGS_data_directory + "/rocksdb_main_storage",
                .label_index_directory = FLAGS_data_directory + "/rocksdb_label_index",

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -555,10 +555,7 @@ int main(int argc, char **argv) {
       // EXPERIMENTAL (lock-free-read-snapshot): CLI-only, immutable during execution. Runtime-only, never
       // persisted, so durable data is identical regardless of this flag (flip across restart is safe).
       .experimental_lockfree_read_snapshot =
-          // TEMP(CI): force ON so server/e2e CI runs with the flag on regardless of --experimental-enabled.
-          // REVERT to `memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::LOCKFREE_READ_SNAPSHOT)`
-          // before merge.
-      true,
+          memgraph::flags::AreExperimentsEnabled(memgraph::flags::Experiments::LOCKFREE_READ_SNAPSHOT),
       .transaction = {.isolation_level = memgraph::flags::ParseIsolationLevel()},
       .disk = {.main_storage_directory = FLAGS_data_directory + "/rocksdb_main_storage",
                .label_index_directory = FLAGS_data_directory + "/rocksdb_label_index",

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -8162,7 +8162,7 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
           const auto db_peak_memory = static_cast<double>(db->DbPeakMemoryUsage());
           const auto tenant_limit = db->TenantMemoryLimit();
 
-          const std::vector<std::vector<TypedValue>> results{
+          std::vector<std::vector<TypedValue>> results{
               {TypedValue("name"), TypedValue(storage->name())},
               {TypedValue("database_uuid"), TypedValue(static_cast<std::string>(storage->uuid()))},
               {TypedValue("state"), TypedValue(std::string("HOT"))},
@@ -8183,6 +8183,20 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
               {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
               {TypedValue("health"), TypedValue(storage->IsBroken() ? "broken" : "ready")},
           };
+          // EXPERIMENTAL (pipelined-commit): the pipeline counters, reported only while the experiment is enabled.
+          if (auto const *mem_storage = dynamic_cast<storage::InMemoryStorage const *>(storage);
+              mem_storage != nullptr && mem_storage->IsPipelinedCommit()) {
+            auto const stats = mem_storage->GetPipelineStats();
+            results.push_back(
+                {TypedValue("pipelined_commit_s2_encodes"), TypedValue(static_cast<int64_t>(stats.s2_encodes))});
+            results.push_back({TypedValue("pipelined_commit_budget_fallbacks"),
+                               TypedValue(static_cast<int64_t>(stats.budget_fallbacks))});
+            results.push_back({TypedValue("pipelined_commit_two_pc_fallbacks"),
+                               TypedValue(static_cast<int64_t>(stats.two_pc_fallbacks))});
+            results.push_back(
+                {TypedValue("pipelined_commit_gate_wait_ns"), TypedValue(static_cast<int64_t>(stats.gate_wait_ns))});
+            results.push_back({TypedValue("pipelined_commit_s3_ns"), TypedValue(static_cast<int64_t>(stats.s3_ns))});
+          }
           return std::pair{results, QueryHandlerResult::NOTHING};
         };
       } else {

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(mg-storage-v2
         disk/storage.cpp
         disk/unique_constraints.cpp
         durability/durability.cpp
+        durability/buffer_encoder.cpp
         durability/serialization.cpp
         durability/snapshot.cpp
         durability/wal.cpp

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(mg-storage-v2
         async_indexer.cpp
         commit_args.cpp
         commit_log.cpp
+        commit_order_gate.cpp
         config.cpp
         constraint_verification_info.cpp
         delta.cpp

--- a/src/storage/v2/async_indexer.cpp
+++ b/src/storage/v2/async_indexer.cpp
@@ -145,9 +145,13 @@ void AsyncIndexer::Start(std::stop_token stop_token, Storage *storage) {
 }
 
 void AsyncIndexer::Shutdown() {
+  auto guard = std::unique_lock{mutex_};
+  // The worker evaluates its wait predicate (which reads the stop token) under mutex_ and then sleeps; requesting
+  // the stop and notifying without the mutex can land between that evaluation and the sleep, and the wake-up is
+  // lost: the worker sleeps for good and this wait never returns. Under the mutex the request is either seen by
+  // the predicate or delivered to a sleeping waiter.
   index_creator_thread_.request_stop();
   cv_.notify_all();
-  auto guard = std::unique_lock{mutex_};
   cv_.wait(guard, [this] { return HasThreadStopped(); });
 }
 

--- a/src/storage/v2/async_indexer.cpp
+++ b/src/storage/v2/async_indexer.cpp
@@ -145,12 +145,14 @@ void AsyncIndexer::Start(std::stop_token stop_token, Storage *storage) {
 }
 
 void AsyncIndexer::Shutdown() {
-  auto guard = std::unique_lock{mutex_};
-  // The worker evaluates its wait predicate (which reads the stop token) under mutex_ and then sleeps; requesting
-  // the stop and notifying without the mutex can land between that evaluation and the sleep, and the wake-up is
-  // lost: the worker sleeps for good and this wait never returns. Under the mutex the request is either seen by
-  // the predicate or delivered to a sleeping waiter.
+  // Request first, without the mutex: a worker in the middle of an index build holds mutex_ for the whole build and
+  // polls the token, so it must see the request without waiting for the mutex. Then take the mutex before notifying:
+  // an idle worker evaluates its wait predicate (which reads the token) under mutex_ and then sleeps, so a notify
+  // without the mutex can land between that evaluation and the sleep and be lost, leaving the worker asleep for good
+  // and this wait never returning. Under the mutex the notify reaches a waiter that is already asleep, and a worker
+  // still evaluating the predicate sees the request.
   index_creator_thread_.request_stop();
+  auto guard = std::unique_lock{mutex_};
   cv_.notify_all();
   cv_.wait(guard, [this] { return HasThreadStopped(); });
 }

--- a/src/storage/v2/commit_order_gate.cpp
+++ b/src/storage/v2/commit_order_gate.cpp
@@ -1,0 +1,95 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/commit_order_gate.hpp"
+
+#include "utils/logging.hpp"
+
+namespace memgraph::storage {
+
+void CommitOrderGate::Issue(Node &node) noexcept {
+  auto guard = std::lock_guard{mutex_};
+  node.next = nullptr;
+  if (tail_ == nullptr) {
+    head_ = &node;
+  } else {
+    // Tickets are issued under engine_lock_ in mint order, so the newest always goes last.
+    DMG_ASSERT(tail_->ticket < node.ticket, "Commit tickets must be issued in mint order");
+    tail_->next = &node;
+  }
+  tail_ = &node;
+  ++pending_;
+}
+
+auto CommitOrderGate::HeadTicket() const -> uint64_t { return head_ != nullptr ? head_->ticket : 0; }
+
+void CommitOrderGate::Enter(uint64_t ticket) {
+  auto guard = std::unique_lock{mutex_};
+  cv_.wait(guard, [&] { return head_ != nullptr && head_->ticket == ticket; });
+}
+
+void CommitOrderGate::Retire(Node &node) noexcept {
+  {
+    auto guard = std::lock_guard{mutex_};
+    Node *prev = nullptr;
+    auto *current = head_;
+    while (current != nullptr && current != &node) {
+      prev = current;
+      current = current->next;
+    }
+    MG_ASSERT(current != nullptr, "Retiring a commit ticket that is not pending");
+    if (prev == nullptr) {
+      head_ = node.next;
+    } else {
+      prev->next = node.next;
+    }
+    if (tail_ == &node) tail_ = prev;
+    node.next = nullptr;
+    --pending_;
+  }
+  cv_.notify_all();
+}
+
+void CommitOrderGate::WaitIdle() {
+  auto guard = std::unique_lock{mutex_};
+  cv_.wait(guard, [&] { return head_ == nullptr; });
+}
+
+auto CommitOrderGate::Pending() const -> size_t {
+  auto guard = std::lock_guard{mutex_};
+  return pending_;
+}
+
+CommitTicket::CommitTicket(CommitOrderGate &gate, uint64_t ticket) noexcept : gate_{gate} {
+  node_.ticket = ticket;
+  gate_.Issue(node_);
+}
+
+CommitTicket::~CommitTicket() {
+  // Retirement is the only way out: an unretired ticket would leave its node linked into the gate after this
+  // object is gone, and retiring here would let a successor validate against an unresolved transaction.
+  MG_ASSERT(retired_, "Commit ticket {} destroyed without being retired", node_.ticket);
+}
+
+void CommitTicket::Enter() {
+  if (entered_) return;
+  gate_.Enter(node_.ticket);
+  entered_ = true;
+}
+
+void CommitTicket::Retire() noexcept {
+  MG_ASSERT(terminal(), "Commit ticket {} retired without a terminal outcome", node_.ticket);
+  MG_ASSERT(!retired_, "Commit ticket {} retired twice", node_.ticket);
+  retired_ = true;
+  gate_.Retire(node_);
+}
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/commit_order_gate.cpp
+++ b/src/storage/v2/commit_order_gate.cpp
@@ -29,8 +29,6 @@ void CommitOrderGate::Issue(Node &node) noexcept {
   ++pending_;
 }
 
-auto CommitOrderGate::HeadTicket() const -> uint64_t { return head_ != nullptr ? head_->ticket : 0; }
-
 void CommitOrderGate::Enter(uint64_t ticket) {
   auto guard = std::unique_lock{mutex_};
   cv_.wait(guard, [&] { return head_ != nullptr && head_->ticket == ticket; });

--- a/src/storage/v2/commit_order_gate.cpp
+++ b/src/storage/v2/commit_order_gate.cpp
@@ -31,7 +31,7 @@ void CommitOrderGate::Issue(Node &node) noexcept {
 
 void CommitOrderGate::Enter(uint64_t ticket) {
   auto guard = std::unique_lock{mutex_};
-  cv_.wait(guard, [&] { return head_ != nullptr && head_->ticket == ticket; });
+  cv_.wait(guard, [this, ticket] { return head_ != nullptr && head_->ticket == ticket; });
 }
 
 void CommitOrderGate::Retire(Node &node) noexcept {
@@ -58,7 +58,7 @@ void CommitOrderGate::Retire(Node &node) noexcept {
 
 void CommitOrderGate::WaitIdle() {
   auto guard = std::unique_lock{mutex_};
-  cv_.wait(guard, [&] { return head_ == nullptr; });
+  cv_.wait(guard, [this] { return head_ == nullptr; });
 }
 
 auto CommitOrderGate::Pending() const -> size_t {

--- a/src/storage/v2/commit_order_gate.hpp
+++ b/src/storage/v2/commit_order_gate.hpp
@@ -45,8 +45,6 @@ class CommitOrderGate {
   auto Pending() const -> size_t;
 
  private:
-  auto HeadTicket() const -> uint64_t;
-
   mutable std::mutex mutex_;
   mutable std::condition_variable cv_;
   mutable Node *head_{nullptr};
@@ -95,8 +93,6 @@ class CommitTicket {
   auto entered() const noexcept -> bool { return entered_; }
 
   auto terminal() const noexcept -> bool { return outcome_ != Outcome::none; }
-
-  auto published() const noexcept -> bool { return outcome_ == Outcome::published; }
 
   auto irreversible() const noexcept -> bool { return irreversible_; }
 

--- a/src/storage/v2/commit_order_gate.hpp
+++ b/src/storage/v2/commit_order_gate.hpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+namespace memgraph::storage {
+
+/// Orders main-side committers by commit timestamp. Issue() is noexcept (the ticket owns its list node) and is
+/// called under engine_lock_ right after the mint, so tickets are issued in mint order. Enter() blocks until every
+/// earlier ticket has retired. Retire() wakes the next. WaitIdle() blocks until no ticket is pending; it is only
+/// called with commit_mutex_ held so no new ticket can be issued meanwhile. All members are mutable so a const
+/// InMemoryStorage caller (recovery-step selection) can quiesce.
+class CommitOrderGate {
+ public:
+  struct Node {
+    uint64_t ticket{0};
+    Node *next{nullptr};
+  };
+
+  /// Links `node` into the pending list. Tickets arrive in mint order, so the node is appended.
+  void Issue(Node &node) noexcept;
+
+  /// Blocks until `ticket` is the oldest pending ticket.
+  void Enter(uint64_t ticket);
+
+  /// Unlinks `node` and wakes every waiter so the next oldest ticket can enter.
+  void Retire(Node &node) noexcept;
+
+  /// Blocks until no ticket is pending.
+  void WaitIdle();
+
+  auto Pending() const -> size_t;
+
+ private:
+  auto HeadTicket() const -> uint64_t;
+
+  mutable std::mutex mutex_;
+  mutable std::condition_variable cv_;
+  mutable Node *head_{nullptr};
+  mutable Node *tail_{nullptr};
+  mutable size_t pending_{0};
+};
+
+/// Owning ticket, noncopyable and nonmovable. States: registered -> entered -> published | aborted, plus an
+/// independent `irreversible` mark set at the first committing file write (or at the start of publication on a
+/// WAL-disabled path). MarkPublished/MarkAborted record the outcome; Retire() is a separate, explicit call made only
+/// after the whole durability/outcome continuation has finished, by CommitWithTicket only. The destructor terminates
+/// (release builds too) whenever Retire() has not run, published or aborted included; it never aborts implicitly and
+/// never retires silently. RecordState brackets a WAL record: BeginRecord before the start frame, EndRecord after the
+/// end frame.
+class CommitTicket {
+ public:
+  enum class RecordState : uint8_t { not_started, incomplete, complete };
+
+  /// Registers with the gate.
+  CommitTicket(CommitOrderGate &gate, uint64_t ticket) noexcept;
+  ~CommitTicket();
+
+  CommitTicket(CommitTicket const &) = delete;
+  CommitTicket &operator=(CommitTicket const &) = delete;
+  CommitTicket(CommitTicket &&) = delete;
+  CommitTicket &operator=(CommitTicket &&) = delete;
+
+  /// Idempotent.
+  void Enter();
+
+  void MarkIrreversible() noexcept { irreversible_ = true; }
+
+  void BeginRecord() noexcept { record_state_ = RecordState::incomplete; }
+
+  void EndRecord() noexcept { record_state_ = RecordState::complete; }
+
+  void MarkPublished() noexcept { outcome_ = Outcome::published; }
+
+  void MarkAborted() noexcept { outcome_ = Outcome::aborted; }
+
+  /// Requires a terminal mark; exactly once; wakes the next ticket.
+  void Retire() noexcept;
+
+  auto ticket() const noexcept -> uint64_t { return node_.ticket; }
+
+  auto entered() const noexcept -> bool { return entered_; }
+
+  auto terminal() const noexcept -> bool { return outcome_ != Outcome::none; }
+
+  auto published() const noexcept -> bool { return outcome_ == Outcome::published; }
+
+  auto irreversible() const noexcept -> bool { return irreversible_; }
+
+  auto record_state() const noexcept -> RecordState { return record_state_; }
+
+  auto incomplete_record() const noexcept -> bool { return record_state_ == RecordState::incomplete; }
+
+  auto retired() const noexcept -> bool { return retired_; }
+
+ private:
+  enum class Outcome : uint8_t { none, published, aborted };
+
+  CommitOrderGate &gate_;
+  CommitOrderGate::Node node_;
+  bool entered_{false};
+  bool irreversible_{false};
+  bool retired_{false};
+  RecordState record_state_{RecordState::not_started};
+  Outcome outcome_{Outcome::none};
+};
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/commit_probe.hpp
+++ b/src/storage/v2/commit_probe.hpp
@@ -11,11 +11,17 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstdint>
 #include <functional>
+#include <string>
+#include <string_view>
+
+#include "storage/v2/pipeline_budget.hpp"
 
 namespace memgraph::storage {
 
-// Test-only instrumentation for the commit path (lock-free-read-snapshot experiment).
+// Test-only instrumentation for the commit path (lock-free-read-snapshot and pipelined-commit experiments).
 // A test installs a CommitProbe on the storage; the commit path invokes each hook at the
 // corresponding phase boundary so the test can block it on a latch and run another
 // transaction at a precise instant. In production the storage's probe pointer is null and
@@ -25,11 +31,57 @@ struct CommitProbe {
   std::function<void()> during_durability;  // inside the (unlocked) WAL+replication window
   std::function<void()> before_publish;     // about to reacquire engine_lock to publish
   std::function<void()> after_publish;      // visibility store + watermark advanced
+
+  // Pipelined commit. Ticketed execution only.
+  std::function<void()> after_ticket;               // once per transaction: after the serializer release (eligible
+                                                    // writers) or after gate entry with the serializer retained
+  std::function<void()> before_validate;            // gate entered, about to validate unique constraints
+  std::function<void()> before_append;              // pipeline: WAL initialized and streams open, before scheduling
+  std::function<void()> after_append;               // pipeline: buffered transaction appended
+  std::function<void()> after_finalize_wal;         // pipeline: WAL finalized, WAL promise not yet satisfied
+  std::function<void()> after_prepare_record;       // legacy: complete commit=false record, WAL promise satisfied
+  std::function<void()> after_schedule_ship;        // right after ScheduleEncodeAndShip, before any frame
+  std::function<void()> between_frames;             // legacy: after the start frame, before the end frame
+  std::function<void()> before_legacy_fallback;     // pipeline: S2 charges released, gate not yet entered
+  std::function<void()> before_legacy_materialize;  // legacy materialization on a ticketed execution
+
+  // Test-only injection state.
+  BudgetRefuse budget_refuse;
+  std::atomic<uint64_t> minted_ticket{0};  // stored by CommitWithTicket right after registration, before after_mint
+  std::atomic<bool> abort_throws_once{false};
+  std::atomic<bool> finalize_wal_throws_once{false};
+  std::atomic<bool> decision_schedule_throws_once{false};
+  // Each instrumented fault site appends one line here before consuming its one-shot flag.
+  std::string fault_attempt_marker_path;
 };
 
 // Safe invoker: no-op if the hook is unset. Call sites use InvokeProbe(probe, &CommitProbe::after_mint).
 inline void InvokeProbe(CommitProbe *probe, std::function<void()> CommitProbe::*hook) {
   if (probe != nullptr && (probe->*hook)) (probe->*hook)();
 }
+
+// Test-only replication instrumentation, owned by a storage (null in production). Main-side callbacks are read
+// through the storage the replication object retains; replica-side callbacks are installed on the replica's
+// storage so identity is implicit. Every observation callback is by contract nonthrowing: it records into
+// test-owned atomics and performs only bounded synchronization, because OnScopeExit invokes callbacks directly
+// and an observer throwing during unwind would terminate an otherwise abortable case.
+struct ReplicationTestHooks {
+  // Main side: receive the replica name and the durability timestamp.
+  std::function<void(std::string const &, uint64_t)> before_wal_result_wait;  // task about to wait on the WAL gate
+  std::function<void(std::string const &, uint64_t)> on_task_done;            // a fused task's lambda finished
+  // Invoked by a scope guard placed right after the command-owning object in each path; owner_scope is "legacy"
+  // or "pipeline".
+  std::function<void(std::string_view owner_scope, uint64_t)> on_commands_released;
+  std::function<void()> after_async_abort_cleanup;  // ticketed ASYNC arm: stream reset, client MAYBE_BEHIND
+  std::function<void(std::string const &)> before_reconcile_quiesce;  // UpdateReplicaState, before QuiesceCommits
+  std::function<bool(std::string const &, uint64_t)> throw_before_enqueue_for;  // ScheduleEncodeAndShip
+  std::function<bool(std::string const &, uint64_t)> throw_on_open_for;         // TransactionReplication ctor
+  // Replica side.
+  std::function<bool(uint64_t)> refuse_next_prepare;             // after the prepared accessor is cached: vote no
+  std::function<bool(uint64_t)> refuse_next_abort_decision;      // after the abort is applied: answer with failure
+  std::function<void(uint64_t, bool)> on_abort_decision_result;  // main side: AbortTwoPcOrTerminate outcome
+  std::function<void(uint64_t)> on_prepared;                     // after the prepare response is sent
+  std::function<void(uint64_t)> on_abort_applied;                // after the abort decision is applied
+};
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -126,8 +126,7 @@ struct Config {
   // EXPERIMENTAL, per-instance, RUNTIME-ONLY. Enables the lock-free read-snapshot
   // (commit-lock-narrowing) MVCC path. MUST NOT be persisted or placed in SalientConfig:
   // durable data must be identical regardless of this flag (flip across restart is safe).
-  bool experimental_lockfree_read_snapshot{
-      true};  // TEMP(CI): default ON to run the suite with the flag on. REVERT before merge.
+  bool experimental_lockfree_read_snapshot{false};
 
   struct Transaction {
     IsolationLevel isolation_level{IsolationLevel::SNAPSHOT_ISOLATION};

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -128,6 +128,14 @@ struct Config {
   // durable data must be identical regardless of this flag (flip across restart is safe).
   bool experimental_lockfree_read_snapshot{false};
 
+  // EXPERIMENTAL, per-instance, RUNTIME-ONLY. Encodes a commit's WAL payload outside the commit serializer and
+  // orders commits through a ticket gate. Requires experimental_lockfree_read_snapshot; validated by
+  // InMemoryStorage's constructor. Never persisted: durable data is identical regardless of this flag.
+  bool experimental_pipelined_commit{false};
+  // Bytes a database's in-flight pipelined commits may retain (materialized commands and private WAL buffers)
+  // before a commit falls back to the ordered legacy path.
+  uint64_t pipelined_commit_max_bytes{256ull << 20};
+
   struct Transaction {
     IsolationLevel isolation_level{IsolationLevel::SNAPSHOT_ISOLATION};
     friend bool operator==(const Transaction &lrh, const Transaction &rhs) = default;

--- a/src/storage/v2/durability/buffer_encoder.cpp
+++ b/src/storage/v2/durability/buffer_encoder.cpp
@@ -1,0 +1,247 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/durability/buffer_encoder.hpp"
+
+#include <algorithm>
+#include <bit>
+#include <variant>
+
+#include "storage/v2/durability/marker.hpp"
+#include "storage/v2/point.hpp"
+#include "storage/v2/temporal.hpp"
+#include "utils/endian.hpp"
+
+namespace memgraph::storage::durability {
+
+namespace {
+// The smallest allocation a buffer starts with; growth is geometric from there so a large transaction is charged
+// a bounded number of times.
+constexpr uint64_t kInitialCapacity = 64;
+}  // namespace
+
+BufferEncoder::BufferEncoder(TxnAllocPolicy policy) : policy_{policy}, buffer_{BudgetAllocator<uint8_t>{policy}} {}
+
+BufferEncoder::~BufferEncoder() = default;
+
+void BufferEncoder::Write(const uint8_t *data, uint64_t size) {
+  auto const needed = buffer_.size() + size;
+  if (needed > buffer_.capacity()) {
+    // The allocator charges the replacement while the old allocation is still charged and releases the old charge
+    // only when the vector frees it, so a refused growth leaves the old buffer and its charge intact.
+    buffer_.reserve(std::max({2 * buffer_.capacity(), needed, kInitialCapacity}));
+  }
+  buffer_.insert(buffer_.end(), data, data + size);
+  crc_acc_.Update(data, size);
+}
+
+void BufferEncoder::WriteSize(uint64_t size) {
+  size = utils::HostToLittleEndian(size);
+  Write(reinterpret_cast<const uint8_t *>(&size), sizeof(size));
+}
+
+void BufferEncoder::WriteMarker(Marker marker) {
+  auto value = static_cast<uint8_t>(marker);
+  Write(&value, sizeof(value));
+}
+
+void BufferEncoder::WriteBool(bool const value) {
+  WriteMarker(Marker::TYPE_BOOL);
+  if (value) {
+    WriteMarker(Marker::VALUE_TRUE);
+  } else {
+    WriteMarker(Marker::VALUE_FALSE);
+  }
+}
+
+void BufferEncoder::WriteUint(uint64_t value) {
+  value = utils::HostToLittleEndian(value);
+  WriteMarker(Marker::TYPE_INT);
+  Write(reinterpret_cast<const uint8_t *>(&value), sizeof(value));
+}
+
+uint32_t BufferEncoder::WriteCrc() {
+  WriteMarker(Marker::TYPE_INT);
+
+  auto const value = CrcAccValue();
+  auto const wire = utils::HostToLittleEndian(static_cast<uint64_t>(value));
+  Write(reinterpret_cast<const uint8_t *>(&wire), sizeof(wire));
+  return value;
+}
+
+void BufferEncoder::WriteDouble(double value) {
+  auto value_uint = std::bit_cast<uint64_t>(value);
+  value_uint = utils::HostToLittleEndian(value_uint);
+  WriteMarker(Marker::TYPE_DOUBLE);
+  Write(reinterpret_cast<const uint8_t *>(&value_uint), sizeof(value_uint));
+}
+
+void BufferEncoder::WriteString(const std::string_view value) {
+  WriteMarker(Marker::TYPE_STRING);
+  WriteSize(value.size());
+  Write(reinterpret_cast<const uint8_t *>(value.data()), value.size());
+}
+
+void BufferEncoder::WriteEnum(storage::Enum value) {
+  WriteMarker(Marker::TYPE_ENUM);
+  auto etype = utils::HostToLittleEndian(value.type_id().value_of());
+  Write(reinterpret_cast<const uint8_t *>(&etype), sizeof(etype));
+  auto evalue = utils::HostToLittleEndian(value.value_id().value_of());
+  Write(reinterpret_cast<const uint8_t *>(&evalue), sizeof(evalue));
+}
+
+void BufferEncoder::WritePoint2d(storage::Point2d value) {
+  WriteMarker(Marker::TYPE_POINT_2D);
+  WriteUint(CrsToSrid(value.crs()).value_of());
+  WriteDouble(value.x());
+  WriteDouble(value.y());
+}
+
+void BufferEncoder::WritePoint3d(storage::Point3d value) {
+  WriteMarker(Marker::TYPE_POINT_3D);
+  WriteUint(CrsToSrid(value.crs()).value_of());
+  WriteDouble(value.x());
+  WriteDouble(value.y());
+  WriteDouble(value.z());
+}
+
+void BufferEncoder::WriteExternalPropertyValue(const ExternalPropertyValue &value) {
+  WriteMarker(Marker::TYPE_PROPERTY_VALUE);
+  switch (value.type()) {
+    case ExternalPropertyValue::Type::Null: {
+      WriteMarker(Marker::TYPE_NULL);
+      break;
+    }
+    case ExternalPropertyValue::Type::Bool: {
+      WriteBool(value.ValueBool());
+      break;
+    }
+    case ExternalPropertyValue::Type::Int: {
+      WriteUint(std::bit_cast<uint64_t>(value.ValueInt()));
+      break;
+    }
+    case ExternalPropertyValue::Type::Double: {
+      WriteDouble(value.ValueDouble());
+      break;
+    }
+    case ExternalPropertyValue::Type::String: {
+      WriteString(value.ValueString());
+      break;
+    }
+    case ExternalPropertyValue::Type::List: {
+      const auto &list = value.ValueList();
+      WriteMarker(Marker::TYPE_LIST);
+      WriteSize(list.size());
+      for (const auto &item : list) {
+        WriteExternalPropertyValue(item);
+      }
+      break;
+    }
+    case ExternalPropertyValue::Type::NumericList: {
+      const auto &list = value.ValueNumericList();
+      WriteMarker(Marker::TYPE_LIST);
+      WriteSize(list.size());
+      for (const auto &item : list) {
+        WriteMarker(Marker::TYPE_PROPERTY_VALUE);
+        if (std::holds_alternative<int>(item)) {
+          WriteUint(static_cast<uint64_t>(std::get<int>(item)));
+        } else {
+          WriteDouble(std::get<double>(item));
+        }
+      }
+      break;
+    }
+    case ExternalPropertyValue::Type::IntList: {
+      const auto &list = value.ValueIntList();
+      WriteMarker(Marker::TYPE_LIST);
+      WriteSize(list.size());
+      for (const auto &item : list) {
+        WriteMarker(Marker::TYPE_PROPERTY_VALUE);
+        WriteUint(static_cast<uint64_t>(item));
+      }
+      break;
+    }
+    case ExternalPropertyValue::Type::DoubleList: {
+      const auto &list = value.ValueDoubleList();
+      WriteMarker(Marker::TYPE_LIST);
+      WriteSize(list.size());
+      for (const auto &item : list) {
+        WriteMarker(Marker::TYPE_PROPERTY_VALUE);
+        WriteDouble(item);
+      }
+      break;
+    }
+    case ExternalPropertyValue::Type::Map: {
+      const auto &map = value.ValueMap();
+      WriteMarker(Marker::TYPE_MAP);
+      WriteSize(map.size());
+      for (const auto &item : map) {
+        WriteString(item.first);
+        WriteExternalPropertyValue(item.second);
+      }
+      break;
+    }
+    case ExternalPropertyValue::Type::TemporalData: {
+      const auto temporal_data = value.ValueTemporalData();
+      WriteMarker(Marker::TYPE_TEMPORAL_DATA);
+      WriteUint(static_cast<uint64_t>(temporal_data.type));
+      WriteUint(std::bit_cast<uint64_t>(temporal_data.microseconds));
+      break;
+    }
+    case ExternalPropertyValue::Type::ZonedTemporalData: {
+      const auto zoned_temporal_data = value.ValueZonedTemporalData();
+      WriteMarker(Marker::TYPE_ZONED_TEMPORAL_DATA);
+      WriteUint(static_cast<uint64_t>(zoned_temporal_data.type));
+      WriteUint(std::bit_cast<uint64_t>(zoned_temporal_data.IntMicroseconds()));
+      if (zoned_temporal_data.timezone.InTzDatabase()) {
+        WriteString(zoned_temporal_data.timezone.TimezoneName());
+      } else {
+        WriteUint(zoned_temporal_data.timezone.DefiningOffset());
+      }
+      break;
+    }
+    case ExternalPropertyValue::Type::Enum: {
+      WriteEnum(value.ValueEnum());
+      break;
+    }
+    case ExternalPropertyValue::Type::Point2d: {
+      WritePoint2d(value.ValuePoint2d());
+      break;
+    }
+    case ExternalPropertyValue::Type::Point3d: {
+      WritePoint3d(value.ValuePoint3d());
+      break;
+    }
+    case ExternalPropertyValue::Type::VectorIndexId: {
+      const auto &vector_index_ids = value.ValueVectorIndexIds();
+      WriteMarker(Marker::TYPE_VECTOR_INDEX_ID);
+      WriteSize(vector_index_ids.size());
+      for (const auto &id : vector_index_ids) {
+        WriteString(id);
+      }
+      const auto &list = value.ValueVectorIndexList();
+      WriteSize(list.size());
+      for (auto item : list) {
+        WriteDouble(item);
+      }
+      break;
+    }
+  }
+}
+
+auto BufferEncoder::GetPosition() -> uint64_t { return buffer_.size(); }
+
+auto BufferEncoder::charged_bytes() const -> uint64_t {
+  // The vector holds exactly one allocation of capacity() elements, which is what the allocator charged.
+  return policy_.budget != nullptr ? buffer_.capacity() : 0;
+}
+
+}  // namespace memgraph::storage::durability

--- a/src/storage/v2/durability/buffer_encoder.cpp
+++ b/src/storage/v2/durability/buffer_encoder.cpp
@@ -30,8 +30,6 @@ constexpr uint64_t kInitialCapacity = 64;
 
 BufferEncoder::BufferEncoder(TxnAllocPolicy policy) : policy_{policy}, buffer_{BudgetAllocator<uint8_t>{policy}} {}
 
-BufferEncoder::~BufferEncoder() = default;
-
 void BufferEncoder::Write(const uint8_t *data, uint64_t size) {
   auto const needed = buffer_.size() + size;
   if (needed > buffer_.capacity()) {

--- a/src/storage/v2/durability/buffer_encoder.hpp
+++ b/src/storage/v2/durability/buffer_encoder.hpp
@@ -1,0 +1,73 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "storage/v2/durability/serialization.hpp"
+#include "storage/v2/pipeline_budget.hpp"
+#include "utils/crc_accumulator.hpp"
+
+namespace memgraph::storage::durability {
+
+/// BaseEncoder over an in-memory buffer with WAL-identical byte layout and CRC accumulation, so a transaction
+/// encoded here can be appended verbatim to a WAL file. The buffer is std::vector<uint8_t, BudgetAllocator<uint8_t>>,
+/// so every capacity growth is charged at the allocation boundary and throws PipelineBudgetExceeded when refused;
+/// charges are released as allocations are freed and finally by the destructor.
+class BufferEncoder final : public BaseEncoder {
+ public:
+  /// A policy with a null budget selects the plain allocator (no charging).
+  explicit BufferEncoder(TxnAllocPolicy policy);
+  ~BufferEncoder();
+
+  BufferEncoder(BufferEncoder const &) = delete;
+  BufferEncoder &operator=(BufferEncoder const &) = delete;
+  BufferEncoder(BufferEncoder &&) = delete;
+  BufferEncoder &operator=(BufferEncoder &&) = delete;
+
+  void WriteMarker(Marker marker) override;
+  void WriteBool(bool value) override;
+  void WriteUint(uint64_t value) override;
+  uint32_t WriteCrc() override;
+  void WriteDouble(double value) override;
+  void WriteString(std::string_view value) override;
+  void WriteEnum(storage::Enum value) override;
+  void WritePoint2d(storage::Point2d value) override;
+  void WritePoint3d(storage::Point3d value) override;
+  void WriteExternalPropertyValue(const ExternalPropertyValue &value) override;
+
+  /// The number of bytes written so far; positions handed out to callers are relative to the buffer start.
+  auto GetPosition() -> uint64_t override;
+
+  void ResetCrcAcc() override { crc_acc_.Reset(); }
+
+  auto CrcAccValue() const -> uint32_t override { return crc_acc_.Value(); }
+
+  auto bytes() const -> std::span<const uint8_t> { return {buffer_.data(), buffer_.size()}; }
+
+  /// Bytes currently charged to the budget for this buffer (its single live allocation); 0 without a budget.
+  auto charged_bytes() const -> uint64_t;
+
+ private:
+  // The only function that appends to the buffer: grows the allocation when needed, copies, feeds the CRC.
+  void Write(const uint8_t *data, uint64_t size);
+  void WriteSize(uint64_t size);
+
+  TxnAllocPolicy policy_;
+  std::vector<uint8_t, BudgetAllocator<uint8_t>> buffer_;
+  utils::CrcAccumulator crc_acc_;
+};
+
+}  // namespace memgraph::storage::durability

--- a/src/storage/v2/durability/buffer_encoder.hpp
+++ b/src/storage/v2/durability/buffer_encoder.hpp
@@ -30,7 +30,6 @@ class BufferEncoder final : public BaseEncoder {
  public:
   /// A policy with a null budget selects the plain allocator (no charging).
   explicit BufferEncoder(TxnAllocPolicy policy);
-  ~BufferEncoder();
 
   BufferEncoder(BufferEncoder const &) = delete;
   BufferEncoder &operator=(BufferEncoder const &) = delete;

--- a/src/storage/v2/durability/serialization.cpp
+++ b/src/storage/v2/durability/serialization.cpp
@@ -82,6 +82,13 @@ void Encoder<FileType>::Write(const uint8_t *data, uint64_t size) {
 }
 
 template <typename FileType>
+void Encoder<FileType>::WriteRaw(const uint8_t *data, uint64_t size) {
+  file_.Write(data, size);
+  logical_position_ += size;
+  logical_size_ = std::max(logical_size_, logical_position_);
+}
+
+template <typename FileType>
 void Encoder<FileType>::WriteMarker(Marker marker) {
   auto value = static_cast<uint8_t>(marker);
   Write(&value, sizeof(value));

--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -59,7 +59,7 @@ class Encoder final : public BaseEncoder {
   bool OpenExisting(const std::filesystem::path &path);
 
   void Close();
-  // Main write function, the only one that is allowed to write to the `file_`
+  // Main write function; together with WriteRaw the only ones that are allowed to write to the `file_`
   // directly.
   void Write(const uint8_t *data, uint64_t size);
 

--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -63,6 +63,10 @@ class Encoder final : public BaseEncoder {
   // directly.
   void Write(const uint8_t *data, uint64_t size);
 
+  /// Writes already-encoded bytes: advances the logical position and size, does not touch the CRC accumulator.
+  /// For appending a transaction that was encoded, CRC included, into a private buffer.
+  void WriteRaw(const uint8_t *data, uint64_t size);
+
   /// See NonConcurrentOutputFile::AppendFrom.
   [[nodiscard]] std::optional<uint64_t> AppendFrom(int src_fd, uint64_t size)
     requires std::same_as<FileType, utils::NonConcurrentOutputFile>;

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -2437,6 +2437,8 @@ WalTxnEndPos WalFile::AppendTransactionEnd(uint64_t timestamp) {
 }
 
 auto WalFile::AppendEncodedTransaction(TxnWalBuffer const &buffer) -> WalTxnDataPos {
+  // The caller fills both after encoding; a forgotten timestamp would silently summarize the file as from/to 0.
+  MG_ASSERT(buffer.timestamp != 0 && buffer.result.frame_count >= 2, "Appending an incomplete transaction buffer");
   auto const base = wal_.GetPosition();
   auto const bytes = buffer.encoder.bytes();
   wal_.WriteRaw(bytes.data(), bytes.size());

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -2436,6 +2436,24 @@ WalTxnEndPos WalFile::AppendTransactionEnd(uint64_t timestamp) {
   return txn_end_pos;
 }
 
+auto WalFile::AppendEncodedTransaction(TxnWalBuffer const &buffer) -> WalTxnDataPos {
+  auto const base = wal_.GetPosition();
+  auto const bytes = buffer.encoder.bytes();
+  wal_.WriteRaw(bytes.data(), bytes.size());
+  CompleteTransactionBookkeeping(buffer.result, buffer.timestamp);
+  return {.commit_flag_wal_position_ = base + buffer.result.commit_flag_position,
+          .crc_wal_pos_ = base + buffer.result.crc_position,
+          .stored_crc_ = buffer.result.stored_crc};
+}
+
+void WalFile::CompleteTransactionBookkeeping(TxnEncodeResult const &result, uint64_t timestamp) {
+  for (uint64_t frame = 0; frame < result.frame_count; ++frame) {
+    UpdateStats(timestamp);
+  }
+  // Everything appended so far now belongs to a completed transaction.
+  num_deltas_ = count_;
+}
+
 void WalFile::Sync() { wal_.Sync(); }
 
 uint64_t WalFile::GetSize() { return wal_.GetSize(); }

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -20,6 +20,7 @@
 #include "storage/v2/access_type.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/description_store.hpp"
+#include "storage/v2/durability/buffer_encoder.hpp"
 #include "storage/v2/durability/metadata.hpp"
 #include "storage/v2/durability/serialization.hpp"
 #include "storage/v2/durability/storage_global_operation.hpp"
@@ -544,6 +545,26 @@ struct WalTxnEndPos {
   uint32_t stored_crc_{0};   // the CRC value written at crc_wal_pos_
 };
 
+/// What encoding a whole transaction through one encoder produced. Positions are the encoder's native positions:
+/// absolute file offsets on a file encoder, buffer-relative on a fresh buffer that starts at zero.
+struct TxnEncodeResult {
+  uint64_t commit_flag_position{0};  // where the commit flag of the transaction-start frame was written
+  uint64_t crc_position{0};          // where the transaction-end CRC value was written
+  uint32_t stored_crc{0};            // the CRC value written at crc_position
+  uint64_t frame_count{0};           // start + metadata + data + end, one per UpdateStats call on the file path
+};
+
+/// A transaction encoded, CRC included, into a private buffer, ready to be appended verbatim to a WAL file.
+struct TxnWalBuffer {
+  BufferEncoder encoder;
+  TxnEncodeResult result{};
+  uint64_t timestamp{0};
+
+  explicit TxnWalBuffer(TxnAllocPolicy policy) : encoder{policy} {}
+
+  explicit TxnWalBuffer(PipelineBudget &budget) : TxnWalBuffer(TxnAllocPolicy{&budget, 0}) {}
+};
+
 /// Function used to encode the transaction start
 /// Returns the position where the flag 'commit' is about to be written
 uint64_t EncodeTransactionStart(BaseEncoder *encoder, uint64_t timestamp, bool commit, StorageAccessType access_type);
@@ -633,6 +654,11 @@ class WalFile {
 
   WalTxnEndPos AppendTransactionEnd(uint64_t timestamp);
 
+  /// Appends a complete buffered transaction verbatim, updates count_/from_/to_timestamp_ once per frame and
+  /// num_deltas_ to the completed-transaction boundary, and returns absolute positions for 2PC patching. The caller
+  /// holds the WAL ordering (CommitOrderGate).
+  auto AppendEncodedTransaction(TxnWalBuffer const &buffer) -> WalTxnDataPos;
+
   void AppendOperation(StorageMetadataOperation operation, const std::optional<std::string> text_index_name,
                        LabelId label, const std::set<PropertyId> &properties, const LabelIndexStats &stats,
                        const LabelPropertyIndexStats &property_stats, uint64_t timestamp);
@@ -674,6 +700,11 @@ class WalFile {
  private:
   /// Fills in the summary of what was actually written, over the placeholders the constructor reserved.
   void WriteSummary();
+
+  /// The per-frame bookkeeping the inline append path performs as it goes, applied at once for a transaction that
+  /// was appended whole from a private buffer. Only correct for a fully appended transaction, which is also what a
+  /// complete `commit=false` prepare record is.
+  void CompleteTransactionBookkeeping(TxnEncodeResult const &result, uint64_t timestamp);
 
   /// Bytes the summary region occupies: three values plus its own CRC trailer, each a marker and a uint64.
   static constexpr uint64_t kSummaryBytes = 4 * (sizeof(Marker) + sizeof(uint64_t));

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -89,9 +89,11 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   // EXPERIMENTAL (lock-free-read-snapshot): under the flag the committer holds commit_mutex_ (not engine_lock_)
   // across its WAL-append window, so take commit_mutex_ here — in the committer's lock order, before engine_lock_ —
   // to keep the current WAL stable while its seq/timestamps are read. Released together with transaction_guard.
+  // With pipelined-commit a committer can be past the serializer but not yet published, so quiesce the ticket gate
+  // too (QuiesceCommits takes commit_mutex_ first and returns it held).
   std::optional<CommitLock> commit_serializer;
   if (main_storage->config_.experimental_lockfree_read_snapshot) {
-    commit_serializer.emplace(main_storage->commit_mutex_);
+    commit_serializer.emplace(main_storage->QuiesceCommits());
   }
   std::unique_lock transaction_guard(
       main_storage->engine_lock_);  // Hold the main_storage lock so the current wal file cannot be changed

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -350,12 +350,14 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
   if (config_.experimental_pipelined_commit && !config_.experimental_lockfree_read_snapshot) {
     throw utils::BasicException("pipelined-commit requires lockfree-read-snapshot to be enabled as well.");
   }
+#ifndef NDEBUG
   if (auto const *park = std::getenv("MG_TEST_PIPELINED_S2_PARK_FIFO"); park != nullptr && *park != '\0') {
     s2_park_path_ = park;
     if (auto const *skip = std::getenv("MG_TEST_PIPELINED_S2_PARK_SKIP"); skip != nullptr && *skip != '\0') {
       s2_park_skip_ = std::strtoll(skip, nullptr, 10);
     }
   }
+#endif
   if (config_.experimental_lockfree_read_snapshot) {
     // NOLINTNEXTLINE(modernize-avoid-c-arrays) — make_unique<T[]> is the idiomatic heap array (cf. ring_buffer.hpp).
     snapshot_slots_ = std::make_unique<SnapshotSlot[]>(kSnapshotSlots);
@@ -1558,10 +1560,12 @@ auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit
                                              progress);
     wal_buffer->timestamp = durability_commit_timestamp;
     mem_storage->pipeline_stats_.s2_encodes.fetch_add(1, std::memory_order_relaxed);
+#ifndef NDEBUG
     if (!mem_storage->s2_park_path_.empty() && mem_storage->s2_park_skip_.fetch_sub(1) <= 0 &&
         !mem_storage->s2_park_consumed_.exchange(true)) {
-      // Test-only: the out-of-band controller releases the head by creating the file. The park holds a ticket, so it
-      // is bounded: a stray environment variable must not be able to stall every later commit and quiescence.
+      // Test-only, compiled out of release builds: the out-of-band controller releases the head by creating the
+      // file. The park holds a ticket, so it is bounded even in a test build: a stray environment variable must not
+      // be able to stall every later commit and quiescence.
       auto const park_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
       while (!std::filesystem::exists(mem_storage->s2_park_path_)) {
         if (std::chrono::steady_clock::now() > park_deadline) {
@@ -1572,6 +1576,7 @@ auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
     }
+#endif
   } catch (PipelineBudgetExceeded const &) {
     wal_buffer.reset();  // every charged S2 allocation is destroyed before the fallback
     commands.reset();
@@ -1605,10 +1610,16 @@ auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit
         std::memory_order_relaxed);
   }
   auto const s3_started = std::chrono::steady_clock::now();
-  utils::OnScopeExit const s3_timer{[&]() noexcept {
+  auto const add_s3_elapsed = [&]() noexcept {
     mem_storage->pipeline_stats_.s3_ns.fetch_add(
         std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - s3_started).count(),
         std::memory_order_relaxed);
+  };
+  // OrderedLegacyCommit times its own scope; the two-phase fallback hands the rest of S3 to it, so this timer
+  // accounts only for the part of S3 that ran here.
+  bool s3_timer_armed = true;
+  utils::OnScopeExit const s3_timer{[&]() noexcept {
+    if (s3_timer_armed) add_s3_elapsed();
   }};
   InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_validate);
   if (auto const validation = UniqueConstraintsViolation(); !validation.has_value()) {
@@ -1629,6 +1640,8 @@ auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit
     wal_buffer.reset();
     commands.reset();
     mem_storage->pipeline_stats_.two_pc_fallbacks.fetch_add(1, std::memory_order_relaxed);
+    add_s3_elapsed();
+    s3_timer_armed = false;
     return OrderedLegacyCommit(
         commit_args, CommitLock{}, ticket, durability_commit_timestamp, &*replicating_txn);
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -316,6 +316,10 @@ class DeltaVertexCache {
   std::unordered_map<Delta const *, Vertex *, std::hash<Delta const *>, std::equal_to<>, CacheAllocator> cache_;
 };
 
+// Defined with the other WAL encoding helpers further down; the pipelined commit's replica task uses it as well.
+void EncodeMetadataDelta(durability::BaseEncoder &encoder, MetadataDelta const &md_delta, Storage *mem_storage,
+                         uint64_t durability_commit_timestamp);
+
 };  // namespace
 
 using OOMExceptionEnabler = utils::MemoryTracker::OutOfMemoryExceptionEnabler;
@@ -337,9 +341,21 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
                 .wal_directory_ = config.durability.storage_directory / durability::kWalDirectory},
       lock_file_path_(config.durability.storage_directory / durability::kLockFile),
       snapshot_periodic_observer_(std::make_shared<PeriodicSnapshotObserver>(snapshot_runner_)),
+      pipeline_budget_{config.pipelined_commit_max_bytes},
       global_locker_(file_retainer_.AddLocker()) {
   MG_ASSERT(config.salient.storage_mode != StorageMode::ON_DISK_TRANSACTIONAL,
             "Invalid storage mode sent to InMemoryStorage constructor!");
+  // EXPERIMENTAL (pipelined-commit): the pipeline relies on the lock-free read snapshot's three-phase commit; the
+  // startup flag validation catches the CLI case, this catches directly constructed configs.
+  if (config_.experimental_pipelined_commit && !config_.experimental_lockfree_read_snapshot) {
+    throw utils::BasicException("pipelined-commit requires lockfree-read-snapshot to be enabled as well.");
+  }
+  if (auto const *park = std::getenv("MG_TEST_PIPELINED_S2_PARK_FIFO"); park != nullptr && *park != '\0') {
+    s2_park_path_ = park;
+    if (auto const *skip = std::getenv("MG_TEST_PIPELINED_S2_PARK_SKIP"); skip != nullptr && *skip != '\0') {
+      s2_park_skip_ = std::strtoll(skip, nullptr, 10);
+    }
+  }
   if (config_.experimental_lockfree_read_snapshot) {
     // NOLINTNEXTLINE(modernize-avoid-c-arrays) — make_unique<T[]> is the idiomatic heap array (cf. ring_buffer.hpp).
     snapshot_slots_ = std::make_unique<SnapshotSlot[]>(kSnapshotSlots);
@@ -575,9 +591,17 @@ InMemoryStorage::~InMemoryStorage() {
   // both commit transactions that write to wal_file_, so resetting wal_file_ while
   // they are still running causes a null dereference in HandleDurabilityAndReplicate.
   StopAllBackgroundTasks();
-  if (wal_file_) {
-    wal_file_->FinalizeWal();
-    wal_file_.reset();
+  {
+    // EXPERIMENTAL (pipelined-commit): a committer past the serializer may still own the WAL; exclude it for the
+    // final WAL exclusion only, released before the snapshot work below.
+    std::optional<CommitLock> commit_serializer;
+    if (config_.experimental_lockfree_read_snapshot) {
+      commit_serializer.emplace(QuiesceCommits());
+    }
+    if (wal_file_) {
+      wal_file_->FinalizeWal();
+      wal_file_.reset();
+    }
   }
 
   // On destruction, we want to stop snapshot creation unless snapshot_on_exit is set to true.
@@ -1145,6 +1169,13 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
     }
   }
 
+  // EXPERIMENTAL (pipelined-commit): every main-side minted commit takes a ticket and runs through the ordered
+  // domain. Replica-side writes are serialized by the replication server already and keep the code below.
+  if (mem_storage->IsPipelinedCommit() && commit_args.replication_allowed()) {
+    DMG_ASSERT(commit_serializer.has_value(), "pipelined-commit requires the lock-free read snapshot's serializer");
+    return CommitWithTicket(commit_args, std::move(*commit_serializer));
+  }
+
   auto engine_guard = std::unique_lock{storage_->engine_lock_};
   commit_timestamp_.emplace(mem_storage->GetCommitTimestamp());
 
@@ -1266,8 +1297,384 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
   return *std::move(res);
 }
 
+// ---------------------------------------------------------------------------------------------------------------
+// EXPERIMENTAL (pipelined-commit): the ticketed commit domain.
+// ---------------------------------------------------------------------------------------------------------------
+
+void InMemoryStorage::InMemoryAccessor::AbortTicketOrTerminate(CommitTicket &ticket) noexcept {
+  try {
+    if (!ticket.entered()) ticket.Enter();
+    if (auto *probe = static_cast<InMemoryStorage *>(storage_)->commit_probe_;
+        probe != nullptr && probe->abort_throws_once.exchange(false)) {
+      // Test-only: proves a failed abort terminates and is never retried.
+      throw std::runtime_error("injected abort failure");
+    }
+    AbortAndResetCommitTs();  // takes engine_lock_ itself; completes the minted commit-log slot
+    ticket.MarkAborted();
+  } catch (...) {
+    std::terminate();
+  }
+}
+
+void InMemoryStorage::InMemoryAccessor::AbortTwoPcOrTerminate(TransactionReplication &repl, TwoPcAbortState &state,
+                                                              uint64_t durability_commit_timestamp,
+                                                              CommitArgs const &commit_args) noexcept {
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  try {
+    // Each flag is set only after its call returned: a thrown exception terminates and no step is ever retried,
+    // whether the caller is the failed-vote branch or the unwind guard.
+    if (!state.wal_finalized) {
+      if (mem_storage->wal_file_) mem_storage->FinalizeWalFile();
+      state.wal_finalized = true;
+    }
+    if (!state.decisions_done) {
+      state.decision_ok = repl.FinalizeTransaction(
+          false, mem_storage->uuid(), commit_args.database_protector(), durability_commit_timestamp);
+      state.decisions_done = true;
+      // A returned false is an ordinary replication failure, reported through the prepare failure the caller
+      // already carries; the nonthrowing observer lets a test see it.
+      if (auto *hooks = mem_storage->replication_test_hooks(); hooks != nullptr && hooks->on_abort_decision_result) {
+        hooks->on_abort_decision_result(durability_commit_timestamp, state.decision_ok);
+      }
+    }
+  } catch (...) {
+    std::terminate();
+  }
+}
+
+bool InMemoryStorage::InMemoryAccessor::PipelineEligible(Transaction const &transaction,
+                                                         CommitArgs const &commit_args) const {
+  auto const *mem_storage = static_cast<InMemoryStorage const *>(storage_);
+  return mem_storage->storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL && transaction.md_deltas.empty() &&
+         !transaction.deltas.empty() && commit_args.replication_allowed() &&
+         mem_storage->config_.durability.snapshot_wal_mode ==
+             Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+}
+
+auto InMemoryStorage::InMemoryAccessor::CommitWithTicket(CommitArgs const &commit_args,
+                                                         CommitLock commit_serializer)
+    -> std::expected<void, StorageManipulationError> {
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  // S1: mint and register, under engine_lock_, serializer held. Registration is noexcept and the mint is a plain
+  // increment, so a timestamp is never taken without a ticket.
+  std::optional<CommitTicket> ticket;
+  {
+    auto engine_guard = std::unique_lock{storage_->engine_lock_};
+    commit_timestamp_.emplace(mem_storage->GetCommitTimestamp());
+    ticket.emplace(mem_storage->commit_order_gate_, *commit_timestamp_);
+  }
+  auto const durability_commit_timestamp = commit_args.durable_timestamp(*commit_timestamp_);
+  // Sole owner of abort cleanup and retirement. One boundary covers everything after registration, probes included.
+  // after_mint fires here for every ticketed commit (immediately after registration and engine-lock release,
+  // serializer still held) and is the arrival handshake the ordering tests use. after_ticket fires exactly once per
+  // transaction: after the serializer release for eligible writers, and after gate entry with the serializer
+  // retained for legacy writers; a fallback never fires it again.
+  std::expected<void, StorageManipulationError> result;
+  try {
+    if (auto *probe = mem_storage->commit_probe_; probe != nullptr) probe->minted_ticket.store(ticket->ticket());
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_mint);
+    if (!PipelineEligible(transaction_, commit_args)) {
+      result =
+          OrderedLegacyCommit(commit_args, std::move(commit_serializer), *ticket, durability_commit_timestamp, nullptr);
+    } else {
+      commit_serializer.unlock();  // S2 runs with no serializer
+      InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_ticket);
+      result = PipelinedCommit(commit_args, *ticket, durability_commit_timestamp);
+    }
+  } catch (...) {
+    if (ticket->irreversible() || ticket->incomplete_record()) std::terminate();
+    if (!ticket->terminal()) AbortTicketOrTerminate(*ticket);  // a failed abort terminates, it is never retried
+    ticket->Retire();
+    throw;
+  }
+  DMG_ASSERT(ticket->terminal(), "helper returned without recording an outcome");
+  ticket->Retire();  // exactly once, after the whole continuation
+  return result;
+}
+
+auto InMemoryStorage::InMemoryAccessor::OrderedLegacyCommit(CommitArgs const &commit_args,
+                                                            CommitLock commit_serializer,
+                                                            CommitTicket &ticket, uint64_t durability_commit_timestamp,
+                                                            TransactionReplication *replicating_txn)
+    -> std::expected<void, StorageManipulationError> {
+  // The base's continuation from unique validation to the end, entered in ticket order: the engine lock was released
+  // in S1; validation happens exactly once, after Enter; every WAL and replication-state access happens after Enter.
+  // A non-null `replicating_txn` means gate entry, validation and WAL initialization already completed in the caller
+  // (the pipeline's 2PC fallback): the continuation resumes at HandleDurabilityAndReplicate with that object, which
+  // the caller owns. This function records outcomes and returns; it has no catch-all and never retires.
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  auto record_abort = [&](auto error) -> std::expected<void, StorageManipulationError> {
+    AbortTicketOrTerminate(ticket);
+    return std::unexpected{std::move(error)};
+  };
+  std::optional<TransactionReplication> local_replication;  // owned by this scope
+  if (replicating_txn == nullptr) {
+    {
+      auto const wait_started = std::chrono::steady_clock::now();
+      ticket.Enter();
+      mem_storage->pipeline_stats_.gate_wait_ns.fetch_add(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - wait_started).count(),
+          std::memory_order_relaxed);
+    }
+    // Legacy writers only, once; a fallback (no serializer) already fired it before its encode stage.
+    if (commit_serializer.owns_lock()) InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_ticket);
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_validate);
+    if (auto const validation = UniqueConstraintsViolation(); !validation.has_value()) {
+      if (commit_serializer.owns_lock()) commit_serializer.unlock();
+      return record_abort(validation.error());
+    }
+    if (!mem_storage->InitializeWalFile(mem_storage->repl_storage_state_.epoch_.id())) {
+      // WAL-disabled: before_publish and the engine lock come first; the irreversible mark goes immediately before
+      // the first publication mutation, inside FinalizeCommitPhase.
+      InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_publish);
+      {
+        auto engine_guard = std::unique_lock{mem_storage->engine_lock_};
+        FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/false, &ticket);
+      }
+      ticket.MarkPublished();
+      if (commit_serializer.owns_lock()) commit_serializer.unlock();
+      return {};
+    }
+    local_replication.emplace(durability_commit_timestamp,
+                              mem_storage,
+                              commit_args,
+                              mem_storage->repl_storage_state_.replication_storage_clients_,
+                              &ticket);
+  }
+  auto &repl = replicating_txn != nullptr ? *replicating_txn : *local_replication;
+  // Borrower cleanup for the object THIS scope owns; a borrowed object is drained and discarded by its owner's
+  // guard. Runs after the WAL promise (declared inside HandleDurabilityAndReplicate) is gone, on every exit.
+  utils::OnScopeExit const drain_local{[&]() noexcept {
+    if (!local_replication || ticket.terminal()) return;
+    local_replication->DrainShipFutures();
+    if (std::uncaught_exceptions() != 0 && ticket.record_state() == CommitTicket::RecordState::not_started &&
+        !ticket.irreversible()) {
+      local_replication->DiscardUnpreparedStreams();
+    }
+  }};
+  // The unwind guard, installed BEFORE HandleDurabilityAndReplicate so it also covers exceptions from inside it.
+  bool const two_pc = commit_args.two_phase_commit(repl);
+  TwoPcAbortState abort_state{};
+  bool guard_armed = true;
+  utils::OnScopeExit const unwind{[&]() noexcept {
+    if (!guard_armed || std::uncaught_exceptions() == 0) return;
+    if (ticket.irreversible()) std::terminate();
+    switch (ticket.record_state()) {
+      case CommitTicket::RecordState::incomplete:
+        std::terminate();
+      case CommitTicket::RecordState::not_started:
+        // Streams open, no frame written: the owner of the replication object discards them.
+        return;
+      case CommitTicket::RecordState::complete:
+        // A complete commit=true record is irreversible and handled above; a complete prepare is abortable.
+        if (two_pc) AbortTwoPcOrTerminate(repl, abort_state, durability_commit_timestamp, commit_args);
+        return;
+    }
+  }};
+
+  auto const s3_started = std::chrono::steady_clock::now();
+  utils::OnScopeExit const s3_timer{[&]() noexcept {
+    mem_storage->pipeline_stats_.s3_ns.fetch_add(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - s3_started).count(),
+        std::memory_order_relaxed);
+  }};
+
+  bool const repl_prepare_phase_ok =
+      HandleDurabilityAndReplicate(durability_commit_timestamp, repl, commit_args, &ticket);
+
+  if (!repl.ShouldRunTwoPC()) {
+    // NON-2PC: the WAL file was already finalized inside HandleDurabilityAndReplicate.
+    FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/true, &ticket);
+    guard_armed = false;
+    ticket.MarkPublished();
+    auto failures = repl.CollectAllFailures();
+    // update replicas' cached commit info to this txn's absolute committed-txn count
+    repl.UpdateCommitTsInfo();
+    if (commit_serializer.owns_lock()) commit_serializer.unlock();
+    if (!failures.empty()) {
+      return std::unexpected{ReplicationError{.failures = std::move(failures), .transaction_committed = true}};
+    }
+    return {};
+  }
+
+  if (!repl_prepare_phase_ok) {
+    // FAILED PREPARE VOTE: an ordinary ordered abort. The continuation runs once; a returned decision failure is
+    // reported through the prepare failure this branch already carries.
+    AbortTwoPcOrTerminate(repl, abort_state, durability_commit_timestamp, commit_args);
+    guard_armed = false;
+    auto failures = repl.CollectAllFailures();
+    AbortTicketOrTerminate(ticket);  // exactly one local undo
+    if (commit_serializer.owns_lock()) commit_serializer.unlock();
+    return std::unexpected{ReplicationError{.failures = std::move(failures), .transaction_committed = false}};
+  }
+
+  // SUCCESSFUL 2PC: all replicas voted yes.
+  FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/true, &ticket);
+  guard_armed = false;
+  // The WAL file is finalized after FinalizeCommitPhase, which patched the commit flag.
+  if (mem_storage->wal_file_) {
+    mem_storage->FinalizeWalFile();
+  }
+  // Send to all replicas they can finalize a transaction
+  repl.FinalizeTransaction(true, mem_storage->uuid(), commit_args.database_protector(), durability_commit_timestamp);
+  ticket.MarkPublished();
+  auto failures = repl.CollectAllFailures();
+  repl.UpdateCommitTsInfo();
+  if (commit_serializer.owns_lock()) commit_serializer.unlock();
+  if (!failures.empty()) {
+    return std::unexpected{ReplicationError{.failures = std::move(failures), .transaction_committed = true}};
+  }
+  return {};
+}
+
+auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit_args, CommitTicket &ticket,
+                                                        uint64_t durability_commit_timestamp)
+    -> std::expected<void, StorageManipulationError> {
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  auto const progress = [&commit_args] { commit_args.apply_cb_if_replica_write(); };  // no-op on main; parity
+  // ---- S2: materialize and encode, charged to the budget; refusal -> ordered legacy fallback, no serializer.
+  std::optional<TxnCommands> commands;
+  std::optional<durability::TxnWalBuffer> wal_buffer;
+  utils::OnScopeExit const commands_released{[mem_storage, durability_commit_timestamp]() noexcept {
+    if (auto *hooks = mem_storage->replication_test_hooks(); hooks != nullptr && hooks->on_commands_released) {
+      hooks->on_commands_released("pipeline", durability_commit_timestamp);
+    }
+  }};
+  try {
+    auto *refuse = mem_storage->commit_probe_ != nullptr ? &mem_storage->commit_probe_->budget_refuse : nullptr;
+    TxnAllocPolicy const materializer_policy{
+        &mem_storage->pipeline_budget_, ticket.ticket(), refuse, BudgetRefuse::kMaterializer};
+    TxnAllocPolicy const encoder_policy{
+        &mem_storage->pipeline_budget_, ticket.ticket(), refuse, BudgetRefuse::kEncoder};
+    commands.emplace(MaterializeTxnCommands(materializer_policy, progress));
+    wal_buffer.emplace(encoder_policy);
+    wal_buffer->result = EncodeTxnCommandsTo(wal_buffer->encoder,
+                                             *commands,
+                                             mem_storage,
+                                             mem_storage->config_.salient.items,
+                                             durability_commit_timestamp,
+                                             /*commit=*/true,
+                                             original_access_type_,
+                                             progress);
+    wal_buffer->timestamp = durability_commit_timestamp;
+    mem_storage->pipeline_stats_.s2_encodes.fetch_add(1, std::memory_order_relaxed);
+    if (!mem_storage->s2_park_path_.empty() && mem_storage->s2_park_skip_.fetch_sub(1) <= 0 &&
+        !mem_storage->s2_park_consumed_.exchange(true)) {
+      // Test-only: the out-of-band controller releases the head by creating the file.
+      while (!std::filesystem::exists(mem_storage->s2_park_path_)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    }
+  } catch (PipelineBudgetExceeded const &) {
+    wal_buffer.reset();  // every charged S2 allocation is destroyed before the fallback
+    commands.reset();
+    mem_storage->pipeline_stats_.budget_fallbacks.fetch_add(1, std::memory_order_relaxed);
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_legacy_fallback);
+    return OrderedLegacyCommit(
+        commit_args, CommitLock{}, ticket, durability_commit_timestamp, nullptr);
+  } catch (std::bad_alloc const &) {
+    wal_buffer.reset();
+    commands.reset();
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_legacy_fallback);
+    return OrderedLegacyCommit(
+        commit_args, CommitLock{}, ticket, durability_commit_timestamp, nullptr);
+  }
+  // Any other exception from S2 propagates to CommitWithTicket's boundary, which aborts in order and retires.
+  // ---- S3: ordered. No try/catch here: CommitWithTicket owns cleanup and retirement; this function records outcomes.
+  std::optional<TransactionReplication> replicating_txn;  // owned by this scope; the guard drains it on any exit
+  utils::OnScopeExit const drain_repl{[&]() noexcept {
+    if (!replicating_txn || ticket.terminal()) return;
+    replicating_txn->DrainShipFutures();  // after the WAL promise (block-scoped below) is gone
+    if (std::uncaught_exceptions() != 0 && ticket.record_state() == CommitTicket::RecordState::not_started &&
+        !ticket.irreversible()) {
+      replicating_txn->DiscardUnpreparedStreams();  // the owner of the object owns the discard; once; noexcept
+    }
+  }};
+  {
+    auto const wait_started = std::chrono::steady_clock::now();
+    ticket.Enter();
+    mem_storage->pipeline_stats_.gate_wait_ns.fetch_add(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - wait_started).count(),
+        std::memory_order_relaxed);
+  }
+  auto const s3_started = std::chrono::steady_clock::now();
+  utils::OnScopeExit const s3_timer{[&]() noexcept {
+    mem_storage->pipeline_stats_.s3_ns.fetch_add(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - s3_started).count(),
+        std::memory_order_relaxed);
+  }};
+  InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_validate);
+  if (auto const validation = UniqueConstraintsViolation(); !validation.has_value()) {
+    AbortTicketOrTerminate(ticket);  // recorded; CommitWithTicket retires
+    return std::unexpected{validation.error()};
+  }
+  auto const wal_initialized = mem_storage->InitializeWalFile(mem_storage->repl_storage_state_.epoch_.id());
+  MG_ASSERT(wal_initialized, "eligibility requires WAL");  // a real call: DMG_ASSERT discards its argument under NDEBUG
+  replicating_txn.emplace(durability_commit_timestamp,
+                          mem_storage,
+                          commit_args,
+                          mem_storage->repl_storage_state_.replication_storage_clients_,
+                          &ticket);
+  if (commit_args.two_phase_commit(*replicating_txn)) {
+    // A STRICT_SYNC replica is registered: nothing from the buffer has been appended, so discard it and resume the
+    // base's 2PC continuation (commit=false record, patch, decision RPCs) with this replication object, by pointer,
+    // still in order; validation and WAL initialization are NOT repeated.
+    wal_buffer.reset();
+    commands.reset();
+    mem_storage->pipeline_stats_.two_pc_fallbacks.fetch_add(1, std::memory_order_relaxed);
+    return OrderedLegacyCommit(
+        commit_args, CommitLock{}, ticket, durability_commit_timestamp, &*replicating_txn);
+  }
+  {
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_append);
+    std::promise<void> wal_promise;
+    std::shared_future<void> const wal_result = wal_promise.get_future().share();
+    // The base's fused encode-and-ship task over the same commands; the buffer is main's own copy.
+    replicating_txn->ScheduleEncodeAndShip(
+        [mem_storage, &commands = *commands, durability_commit_timestamp, access_type = original_access_type_](
+            ReplicaStream &stream) {
+          const memory::DbArenaScope db_arena_scope{mem_storage->DbArenaPool()};
+          stream.AppendTransactionStart(durability_commit_timestamp, /*commit=*/true, access_type);
+          for (auto const *md_delta : commands.metadata) {
+            auto encoder = stream.encoder();
+            EncodeMetadataDelta(encoder, *md_delta, mem_storage, durability_commit_timestamp);
+          }
+          for (auto const &cmd : commands.data) {
+            if (cmd.edge != nullptr) {
+              stream.AppendDelta(
+                  *cmd.delta, cmd.edge, durability_commit_timestamp, mem_storage, cmd.in_vertex_gid, cmd.edge_type_id);
+            } else {
+              stream.AppendDelta(*cmd.delta, cmd.vertex, durability_commit_timestamp, mem_storage);
+            }
+          }
+        },
+        wal_result,
+        durability_commit_timestamp,
+        &commit_args.database_protector());
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_schedule_ship);  // live borrowers; still abortable
+    needs_wal_update_ = false;
+    ticket.MarkIrreversible();  // a commit=true record is about to be appended
+    ticket.BeginRecord();
+    wal_txn_positions_ = mem_storage->wal_file_->AppendEncodedTransaction(*wal_buffer);
+    ticket.EndRecord();
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_append);
+    mem_storage->FinalizeWalFile();  // finalize BEFORE releasing the replica transaction ends
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_finalize_wal);
+    wal_promise.set_value();  // the promise dies at the end of this block, before drain_repl
+    replicating_txn->ShipDeltas(durability_commit_timestamp, commit_args);
+  }
+  FinalizeCommitPhase(durability_commit_timestamp, /*acquire_engine_lock=*/true, &ticket);
+  ticket.MarkPublished();  // recorded; CommitWithTicket retires after we return
+  auto failures = replicating_txn->CollectAllFailures();
+  replicating_txn->UpdateCommitTsInfo();
+  if (!failures.empty()) {
+    return std::unexpected{ReplicationError{.failures = std::move(failures), .transaction_committed = true}};
+  }
+  return {};
+}
+
 void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durability_commit_timestamp,
-                                                            bool const acquire_engine_lock) {
+                                                            bool const acquire_engine_lock, CommitTicket *ticket) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
   std::optional<std::unique_lock<utils::SpinLock>> pub_guard;
@@ -1275,6 +1682,10 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
     InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_publish);
     pub_guard.emplace(storage_->engine_lock_);
   }
+
+  // From here on state moves into the schema queue, the WAL commit flag and the visibility store; a ticketed
+  // commit that fails past this point can no longer be aborted, only terminated.
+  if (ticket != nullptr) ticket->MarkIrreversible();
 
   if (config_.enable_schema_info) {
     // Queue schema update instead of processing immediately. This ensures
@@ -3944,6 +4355,19 @@ bool InMemoryStorage::InitializeWalFile(std::string_view const epoch_id) {
 }
 
 void InMemoryStorage::FinalizeWalFile() {
+  pipeline_test_counters_.finalize_wal_calls.fetch_add(1, std::memory_order_relaxed);
+  if (commit_probe_ != nullptr && commit_probe_->finalize_wal_throws_once.load()) {
+    // Test-only: the attempt is recorded before the one-shot flag is consumed, so a retry stays visible.
+    if (!commit_probe_->fault_attempt_marker_path.empty()) {
+      utils::OutputFile marker;
+      marker.Open(commit_probe_->fault_attempt_marker_path, utils::OutputFile::Mode::APPEND_TO_EXISTING);
+      marker.Write(std::string_view{"finalize_wal\n"});
+      marker.Close();
+    }
+    if (commit_probe_->finalize_wal_throws_once.exchange(false)) {
+      throw std::runtime_error("injected WAL finalization failure");
+    }
+  }
   ++wal_unsynced_transactions_;
   if (wal_unsynced_transactions_ >= config_.durability.wal_file_flush_every_n_tx) {
     wal_file_->Sync();
@@ -4557,8 +4981,12 @@ auto InMemoryStorage::InMemoryAccessor::MaterializeTxnCommands(TxnAllocPolicy po
 
 auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
                                                                      TransactionReplication &replicating_txn,
-                                                                     CommitArgs const &commit_args) -> bool {
+                                                                     CommitArgs const &commit_args,
+                                                                     CommitTicket *ticket) -> bool {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  // Ticketed executions only (both locally owned and borrowed legacy continuations); replica-side writes and the
+  // flag-off path pass no ticket and see none of the probes below.
+  if (ticket != nullptr) InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_legacy_materialize);
 
   // If replica executes this:
   //   STRICT_SYNC: commit_immediately is false because such replica needs to commit only after receiving
@@ -4578,6 +5006,13 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
   // The plain allocation policy keeps this path's allocation behaviour unchanged; only a pipelined commit charges.
   auto const progress = [&commit_args] { commit_args.apply_cb_if_replica_write(); };
   TxnCommands commands = MaterializeTxnCommands(TxnAllocPolicy{}, progress);
+  // Test-only observation of the command-owning scope's end, after every borrower was collected (the guard below
+  // is declared after this one, so it runs first).
+  utils::OnScopeExit const commands_released{[mem_storage, durability_commit_timestamp]() noexcept {
+    if (auto *hooks = mem_storage->replication_test_hooks(); hooks != nullptr && hooks->on_commands_released) {
+      hooks->on_commands_released("legacy", durability_commit_timestamp);
+    }
+  }};
 
   // Every fused task borrows this frame (commands, streams), so if anything below throws before
   // ShipDeltas collected them, collect them here; on the normal path this is a no-op. Declared before
@@ -4617,14 +5052,22 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
       wal_result,
       durability_commit_timestamp,
       commit_args.replication_allowed() ? &commit_args.database_protector() : nullptr);
+  if (ticket != nullptr) InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_schedule_ship);
 
   // The WAL write runs inline: the commit thread would otherwise only sleep on the fused futures, and
   // it still has the just-traversed deltas hot in cache. WAL commit order follows from engine_lock_.
   {
     durability::WalTxnDataPos positions;
+    if (ticket != nullptr) {
+      // A commit=true record is irreversible from its first byte; a commit=false prepare record is abortable
+      // again once it is complete, and fatal while it is not.
+      if (!two_phase_commit) ticket->MarkIrreversible();
+      ticket->BeginRecord();
+    }
     // Append txn start delta and remember the position in the WAL file in which this delta is saved.
     positions.commit_flag_wal_position_ = mem_storage->wal_file_->AppendTransactionStart(
         durability_commit_timestamp, !two_phase_commit, original_access_type_);
+    if (ticket != nullptr) InvokeProbe(mem_storage->commit_probe_, &CommitProbe::between_frames);
     for (auto const *md_delta : commands.metadata) {
       EncodeMetadataDelta(mem_storage->wal_file_->encoder(), *md_delta, mem_storage, durability_commit_timestamp);
       mem_storage->wal_file_->UpdateStats(durability_commit_timestamp);
@@ -4643,6 +5086,7 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
     auto const txn_end_positions = mem_storage->wal_file_->AppendTransactionEnd(durability_commit_timestamp);
     positions.crc_wal_pos_ = txn_end_positions.crc_wal_pos_;
     positions.stored_crc_ = txn_end_positions.stored_crc_;
+    if (ticket != nullptr) ticket->EndRecord();
     // When committing immediately the WAL file must be finalized before transaction ends ship to replicas.
     if (!two_phase_commit) {
       mem_storage->FinalizeWalFile();
@@ -4651,6 +5095,8 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
   }
   // Durability achieved: open the gate so the fused tasks may ship their transaction ends.
   wal_promise.set_value();
+  if (ticket != nullptr && two_phase_commit)
+    InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_prepare_record);
 
   // Collects every fused task, so no worker is left borrowing this frame, and folds their results
   // into the replication failures (the collect_workers guard backstops the unwind paths). Encoding
@@ -5072,12 +5518,27 @@ void InMemoryStorage::FreeMemory(utils::ResourceLockGuard main_guard, bool perio
 
 uint64_t InMemoryStorage::GetCommitTimestamp() { return timestamp_++; }
 
+auto InMemoryStorage::QuiesceCommits() const -> CommitLock {
+  CommitLock guard{commit_mutex_};  // no new mint, hence no new ticket
+  commit_order_gate_.WaitIdle();          // every issued ticket has retired
+  return guard;
+}
+
+auto InMemoryStorage::GetPipelineStats() const -> PipelineStatsSnapshot {
+  return {.s2_encodes = pipeline_stats_.s2_encodes.load(std::memory_order_relaxed),
+          .budget_fallbacks = pipeline_stats_.budget_fallbacks.load(std::memory_order_relaxed),
+          .two_pc_fallbacks = pipeline_stats_.two_pc_fallbacks.load(std::memory_order_relaxed),
+          .gate_wait_ns = pipeline_stats_.gate_wait_ns.load(std::memory_order_relaxed),
+          .s3_ns = pipeline_stats_.s3_ns.load(std::memory_order_relaxed)};
+}
+
 void InMemoryStorage::PrepareForNewEpoch() {
   // EXPERIMENTAL (lock-free-read-snapshot): take commit_mutex_ before engine_lock_ (committer order) so this
-  // WAL reset cannot race a committer's WAL append under the flag.
+  // WAL reset cannot race a committer's WAL append under the flag. With pipelined-commit a committer may be past
+  // the serializer but not yet published, so quiesce the gate as well.
   std::optional<CommitLock> commit_serializer;
   if (config_.experimental_lockfree_read_snapshot) {
-    commit_serializer.emplace(commit_mutex_);
+    commit_serializer.emplace(QuiesceCommits());
   }
   std::unique_lock engine_guard{engine_lock_};
   if (wal_file_) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1560,8 +1560,15 @@ auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit
     mem_storage->pipeline_stats_.s2_encodes.fetch_add(1, std::memory_order_relaxed);
     if (!mem_storage->s2_park_path_.empty() && mem_storage->s2_park_skip_.fetch_sub(1) <= 0 &&
         !mem_storage->s2_park_consumed_.exchange(true)) {
-      // Test-only: the out-of-band controller releases the head by creating the file.
+      // Test-only: the out-of-band controller releases the head by creating the file. The park holds a ticket, so it
+      // is bounded: a stray environment variable must not be able to stall every later commit and quiescence.
+      auto const park_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
       while (!std::filesystem::exists(mem_storage->s2_park_path_)) {
+        if (std::chrono::steady_clock::now() > park_deadline) {
+          spdlog::warn("MG_TEST_PIPELINED_S2_PARK_FIFO: release file {} did not appear within 60 s; continuing",
+                       mem_storage->s2_park_path_);
+          break;
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       }
     }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -261,7 +261,8 @@ void UnlinkAndRemoveDeltas(delta_container &deltas, BatchedList<Edge *> &current
  */
 class DeltaVertexCache {
  public:
-  explicit DeltaVertexCache(uint64_t commit_timestamp) : commit_timestamp_(commit_timestamp) {}
+  explicit DeltaVertexCache(uint64_t commit_timestamp, TxnAllocPolicy policy = {})
+      : commit_timestamp_(commit_timestamp), policy_(policy), cache_(CacheAllocator{policy}) {}
 
   Vertex *GetVertexFromDelta(Delta const *delta) {
     auto prev = delta->prev.Get();
@@ -270,7 +271,8 @@ class DeltaVertexCache {
     auto const it = cache_.find(delta);
     if (it != cache_.cend()) return it->second;
 
-    std::vector<Delta const *> discovered_subchain_heads{delta};
+    BudgetVector<Delta const *> discovered_subchain_heads{BudgetAllocator<Delta const *>{policy_}};
+    discovered_subchain_heads.push_back(delta);
 
     auto const write_to_cache = [&](auto *vertex) {
       for (auto const *uncached : discovered_subchain_heads) cache_[uncached] = vertex;
@@ -307,8 +309,11 @@ class DeltaVertexCache {
   }
 
  private:
+  using CacheAllocator = BudgetAllocator<std::pair<Delta const *const, Vertex *>>;
+
   uint64_t commit_timestamp_;
-  std::unordered_map<Delta const *, Vertex *> cache_;
+  TxnAllocPolicy policy_;
+  std::unordered_map<Delta const *, Vertex *, std::hash<Delta const *>, std::equal_to<>, CacheAllocator> cache_;
 };
 
 };  // namespace
@@ -4018,23 +4023,6 @@ bool InMemoryStorage::ArchiveSupersededDurabilityFiles(std::filesystem::path con
 
 namespace {
 
-// One MVCC delta resolved by the commit thread's traversal: the delta, the object it belongs to
-// (exactly one of vertex/edge set), and the edge lookup data workers cannot pull from the transaction.
-struct TxnDataCommand {
-  Delta const *delta;
-  Vertex *vertex;
-  Edge *edge;
-  Gid in_vertex_gid;
-  EdgeTypeId edge_type_id;
-};
-
-// Everything a transaction writes, in encode order. Built once on the commit thread; the WAL worker
-// and every replica worker encode from it concurrently, so it must outlive all of their tasks.
-struct TxnCommands {
-  std::vector<MetadataDelta const *> metadata;
-  std::vector<TxnDataCommand> data;
-};
-
 void EncodeMetadataDelta(durability::BaseEncoder &encoder, MetadataDelta const &md_delta, Storage *mem_storage,
                          uint64_t durability_commit_timestamp) {
   auto const apply_encode = [&](durability::StorageMetadataOperation const op, auto &&encode_operation) {
@@ -4245,27 +4233,45 @@ void EncodeMetadataDelta(durability::BaseEncoder &encoder, MetadataDelta const &
 
 }  // namespace
 
-auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
-                                                                     TransactionReplication &replicating_txn,
-                                                                     CommitArgs const &commit_args) -> bool {
-  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+auto EncodeTxnCommandsTo(durability::BaseEncoder &encoder, TxnCommands const &commands, Storage *storage,
+                         SalientConfig::Items const &items, uint64_t durability_ts, bool commit,
+                         StorageAccessType access_type, std::function<void()> const &progress)
+    -> durability::TxnEncodeResult {
+  durability::TxnEncodeResult result;
+  result.commit_flag_position = durability::EncodeTransactionStart(&encoder, durability_ts, commit, access_type);
+  result.frame_count = 1;
+  for (auto const *md_delta : commands.metadata) {
+    EncodeMetadataDelta(encoder, *md_delta, storage, durability_ts);
+    ++result.frame_count;
+    progress();
+  }
+  for (auto const &cmd : commands.data) {
+    if (cmd.edge != nullptr) {
+      durability::EncodeDelta(
+          &encoder, storage, *cmd.delta, cmd.edge, durability_ts, cmd.in_vertex_gid, cmd.edge_type_id);
+    } else {
+      durability::EncodeDelta(&encoder, storage, items, *cmd.delta, cmd.vertex, durability_ts);
+    }
+    ++result.frame_count;
+    progress();
+  }
+  auto const end = durability::EncodeTransactionEnd(&encoder, durability_ts);
+  result.crc_position = end.crc_wal_pos_;
+  result.stored_crc = end.stored_crc_;
+  ++result.frame_count;
+  return result;
+}
 
-  // If replica executes this:
-  //   STRICT_SYNC: commit_immediately is false because such replica needs to commit only after receiving
-  //   FinalizeCommitRpc SYNC/ASYNC:  commit_immediately is true because such replica needs to commit immediately
-  // If main executes this:
-  //   Any STRICT_SYNC replica registered -> need to run 2PC, don't commit immediately
-  // else:
-  //   All SYNC/ASYNC replicas -> commit immediately
-  bool const two_phase_commit = commit_args.two_phase_commit(replicating_txn);
-  // The WAL file needs to be updated only if we don't commit immediately.
-  needs_wal_update_ = two_phase_commit;
-
+auto InMemoryStorage::InMemoryAccessor::MaterializeTxnCommands(TxnAllocPolicy policy,
+                                                               std::function<void()> const &progress) -> TxnCommands {
+  // The traversal the inline durability path used to perform, extracted whole so a pipelined commit can run it
+  // with no serializer held: processed-head/tail tracking for concurrent abort rewiring included. Every container
+  // allocates through `policy`, so a pipelined commit's scratch memory is charged at the allocation boundary.
   // IMPORTANT: In most transactions there can only be one, either data or metadata deltas.
   //            But since we introduced auto index creation, a data transaction can also introduce a metadata delta.
   //            For correctness on the REPLICA side we need to send the metadata deltas first in order to acquire a
   //            unique transaction to apply the index creation safely.
-  TxnCommands commands;
+  TxnCommands commands{policy};
   commands.metadata.reserve(transaction_.md_deltas.size());
   for (auto const &md_delta : transaction_.md_deltas) {
     commands.metadata.push_back(&md_delta);
@@ -4273,7 +4279,9 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
 
   // A single transaction will always be fully-contained in a single WAL file.
   auto current_commit_timestamp = transaction_.commit_info->timestamp.load(std::memory_order_acquire);
-  DeltaVertexCache vertex_cache(current_commit_timestamp);
+  DeltaVertexCache vertex_cache(current_commit_timestamp, policy);
+  // The collector ignores the timestamp the traversal hands it; the inline path passed the durability timestamp.
+  auto const durability_commit_timestamp = current_commit_timestamp;
 
   auto append_deltas = [&](auto callback) {
     // Helper lambda that traverses the delta chain to find the first delta
@@ -4297,8 +4305,10 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
     // D.prev = C
     // In this cases, following the `next` pointers would read A, B, D, E, and
     // the `prev` pointers would read `E`, D`, `C`, `B`, `A`.
-    std::unordered_set<Delta const *> processed_subchain_heads;
-    std::unordered_set<Delta const *> processed_subchain_tails;
+    using TrackingSet =
+        std::unordered_set<Delta const *, std::hash<Delta const *>, std::equal_to<>, BudgetAllocator<Delta const *>>;
+    TrackingSet processed_subchain_heads{BudgetAllocator<Delta const *>{policy}};
+    TrackingSet processed_subchain_tails{BudgetAllocator<Delta const *>{policy}};
     bool const should_track_nonseq_subchains{transaction_.has_non_sequential_deltas};
     constexpr auto kNoTracking = std::bool_constant<false>{};
     constexpr auto kTrackTails = std::bool_constant<true>{};
@@ -4539,9 +4549,35 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
       } else {
         commands.data.push_back({.delta = &delta, .vertex = parent, .edge = nullptr});
       }
-      commit_args.apply_cb_if_replica_write();
+      progress();
     });
   }
+  return commands;
+}
+
+auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
+                                                                     TransactionReplication &replicating_txn,
+                                                                     CommitArgs const &commit_args) -> bool {
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+
+  // If replica executes this:
+  //   STRICT_SYNC: commit_immediately is false because such replica needs to commit only after receiving
+  //   FinalizeCommitRpc SYNC/ASYNC:  commit_immediately is true because such replica needs to commit immediately
+  // If main executes this:
+  //   Any STRICT_SYNC replica registered -> need to run 2PC, don't commit immediately
+  // else:
+  //   All SYNC/ASYNC replicas -> commit immediately
+  bool const two_phase_commit = commit_args.two_phase_commit(replicating_txn);
+  // The WAL file needs to be updated only if we don't commit immediately.
+  needs_wal_update_ = two_phase_commit;
+
+  // IMPORTANT: In most transactions there can only be one, either data or metadata deltas.
+  //            But since we introduced auto index creation, a data transaction can also introduce a metadata delta.
+  //            For correctness on the REPLICA side we need to send the metadata deltas first in order to acquire a
+  //            unique transaction to apply the index creation safely.
+  // The plain allocation policy keeps this path's allocation behaviour unchanged; only a pipelined commit charges.
+  auto const progress = [&commit_args] { commit_args.apply_cb_if_replica_write(); };
+  TxnCommands commands = MaterializeTxnCommands(TxnAllocPolicy{}, progress);
 
   // Every fused task borrows this frame (commands, streams), so if anything below throws before
   // ShipDeltas collected them, collect them here; on the normal path this is a no-op. Declared before

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1353,8 +1353,7 @@ bool InMemoryStorage::InMemoryAccessor::PipelineEligible(Transaction const &tran
              Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
 }
 
-auto InMemoryStorage::InMemoryAccessor::CommitWithTicket(CommitArgs const &commit_args,
-                                                         CommitLock commit_serializer)
+auto InMemoryStorage::InMemoryAccessor::CommitWithTicket(CommitArgs const &commit_args, CommitLock commit_serializer)
     -> std::expected<void, StorageManipulationError> {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
   // S1: mint and register, under engine_lock_, serializer held. Registration is noexcept and the mint is a plain
@@ -1394,8 +1393,7 @@ auto InMemoryStorage::InMemoryAccessor::CommitWithTicket(CommitArgs const &commi
   return result;
 }
 
-auto InMemoryStorage::InMemoryAccessor::OrderedLegacyCommit(CommitArgs const &commit_args,
-                                                            CommitLock commit_serializer,
+auto InMemoryStorage::InMemoryAccessor::OrderedLegacyCommit(CommitArgs const &commit_args, CommitLock commit_serializer,
                                                             CommitTicket &ticket, uint64_t durability_commit_timestamp,
                                                             TransactionReplication *replicating_txn)
     -> std::expected<void, StorageManipulationError> {
@@ -1409,6 +1407,16 @@ auto InMemoryStorage::InMemoryAccessor::OrderedLegacyCommit(CommitArgs const &co
     AbortTicketOrTerminate(ticket);
     return std::unexpected{std::move(error)};
   };
+  // Time inside the ordered stage, from gate entry to return, whatever the outcome; a borrowed continuation entered
+  // the gate in its caller, which counted its own part up to the hand-off, so its clock starts here.
+  std::optional<std::chrono::steady_clock::time_point> s3_started;
+  if (replicating_txn != nullptr) s3_started = std::chrono::steady_clock::now();
+  utils::OnScopeExit const s3_timer{[&]() noexcept {
+    if (!s3_started) return;
+    mem_storage->pipeline_stats_.s3_ns.fetch_add(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - *s3_started).count(),
+        std::memory_order_relaxed);
+  }};
   std::optional<TransactionReplication> local_replication;  // owned by this scope
   if (replicating_txn == nullptr) {
     {
@@ -1417,6 +1425,7 @@ auto InMemoryStorage::InMemoryAccessor::OrderedLegacyCommit(CommitArgs const &co
       mem_storage->pipeline_stats_.gate_wait_ns.fetch_add(
           std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - wait_started).count(),
           std::memory_order_relaxed);
+      s3_started = std::chrono::steady_clock::now();
     }
     // Legacy writers only, once; a fallback (no serializer) already fired it before its encode stage.
     if (commit_serializer.owns_lock()) InvokeProbe(mem_storage->commit_probe_, &CommitProbe::after_ticket);
@@ -1472,13 +1481,6 @@ auto InMemoryStorage::InMemoryAccessor::OrderedLegacyCommit(CommitArgs const &co
         if (two_pc) AbortTwoPcOrTerminate(repl, abort_state, durability_commit_timestamp, commit_args);
         return;
     }
-  }};
-
-  auto const s3_started = std::chrono::steady_clock::now();
-  utils::OnScopeExit const s3_timer{[&]() noexcept {
-    mem_storage->pipeline_stats_.s3_ns.fetch_add(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - s3_started).count(),
-        std::memory_order_relaxed);
   }};
 
   bool const repl_prepare_phase_ok =
@@ -1582,14 +1584,12 @@ auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit
     commands.reset();
     mem_storage->pipeline_stats_.budget_fallbacks.fetch_add(1, std::memory_order_relaxed);
     InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_legacy_fallback);
-    return OrderedLegacyCommit(
-        commit_args, CommitLock{}, ticket, durability_commit_timestamp, nullptr);
+    return OrderedLegacyCommit(commit_args, CommitLock{}, ticket, durability_commit_timestamp, nullptr);
   } catch (std::bad_alloc const &) {
     wal_buffer.reset();
     commands.reset();
     InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_legacy_fallback);
-    return OrderedLegacyCommit(
-        commit_args, CommitLock{}, ticket, durability_commit_timestamp, nullptr);
+    return OrderedLegacyCommit(commit_args, CommitLock{}, ticket, durability_commit_timestamp, nullptr);
   }
   // Any other exception from S2 propagates to CommitWithTicket's boundary, which aborts in order and retires.
   // ---- S3: ordered. No try/catch here: CommitWithTicket owns cleanup and retirement; this function records outcomes.
@@ -1642,8 +1642,7 @@ auto InMemoryStorage::InMemoryAccessor::PipelinedCommit(CommitArgs const &commit
     mem_storage->pipeline_stats_.two_pc_fallbacks.fetch_add(1, std::memory_order_relaxed);
     add_s3_elapsed();
     s3_timer_armed = false;
-    return OrderedLegacyCommit(
-        commit_args, CommitLock{}, ticket, durability_commit_timestamp, &*replicating_txn);
+    return OrderedLegacyCommit(commit_args, CommitLock{}, ticket, durability_commit_timestamp, &*replicating_txn);
   }
   {
     InvokeProbe(mem_storage->commit_probe_, &CommitProbe::before_append);
@@ -5540,7 +5539,7 @@ uint64_t InMemoryStorage::GetCommitTimestamp() { return timestamp_++; }
 
 auto InMemoryStorage::QuiesceCommits() const -> CommitLock {
   CommitLock guard{commit_mutex_};  // no new mint, hence no new ticket
-  commit_order_gate_.WaitIdle();          // every issued ticket has retired
+  commit_order_gate_.WaitIdle();    // every issued ticket has retired
   return guard;
 }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -977,21 +977,26 @@ class InMemoryStorage final : public Storage {
     return last_committed_mvcc_ts_.load(std::memory_order_acquire);
   }
 
-  // EXPERIMENTAL (pipelined-commit).
+  /// EXPERIMENTAL (pipelined-commit).
   [[nodiscard]] bool IsPipelinedCommit() const noexcept { return config_.experimental_pipelined_commit; }
 
-  // Excludes every in-flight main-side committer: takes commit_mutex_ (no new mint, hence no new ticket) and then
-  // waits until every issued ticket has retired. The returned guard keeps the serializer until the caller is done.
-  // const so a const caller (recovery-step selection) can quiesce; the gate and the serializer are mutable.
+  /// Excludes every in-flight main-side committer: takes commit_mutex_ (no new mint, hence no new ticket) and then
+  /// waits until every issued ticket has retired. The returned guard keeps the serializer until the caller is done.
+  /// const so a const caller (recovery-step selection) can quiesce; the gate and the serializer are mutable.
+  /// The wait is for ticket retirement, which includes the committer's replication: a caller must not hold
+  /// engine_lock_ or a replica's RPC lock, and must not run on a replica client's worker pool, or it deadlocks
+  /// with the committer it waits for.
   auto QuiesceCommits() const -> CommitLock;
 
   [[nodiscard]] auto GetPipelineStats() const -> PipelineStatsSnapshot;
 
-  // Test-only.
-  void SetReplicationTestHooks(ReplicationTestHooks *hooks) noexcept { replication_test_hooks_ = hooks; }
+  /// Test-only.
+  void SetReplicationTestHooks(ReplicationTestHooks *hooks) noexcept {
+    replication_test_hooks_.store(hooks, std::memory_order_release);
+  }
 
   [[nodiscard]] auto replication_test_hooks() const noexcept -> ReplicationTestHooks * {
-    return replication_test_hooks_;
+    return replication_test_hooks_.load(std::memory_order_acquire);
   }
 
   auto commit_order_gate_for_tests() -> CommitOrderGate & { return commit_order_gate_; }
@@ -1163,7 +1168,8 @@ class InMemoryStorage final : public Storage {
   PipelineBudget pipeline_budget_;
   PipelineStats pipeline_stats_;
   PipelineTestCounters pipeline_test_counters_;
-  ReplicationTestHooks *replication_test_hooks_{nullptr};
+  // Written by a test thread, read by commit, replica-worker and heartbeat threads.
+  std::atomic<ReplicationTestHooks *> replication_test_hooks_{nullptr};
   // Test-only, from the MG_TEST_PIPELINED_S2_PARK_FIFO environment variable: the first eligible committer parks
   // after its encode stage until this path exists, polling with a 10 ms sleep so nothing goes through the worker
   // pool. Lets an end-to-end test saturate the pool with committers waiting behind a slow head.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -1170,13 +1170,16 @@ class InMemoryStorage final : public Storage {
   PipelineTestCounters pipeline_test_counters_;
   // Written by a test thread, read by commit, replica-worker and heartbeat threads.
   std::atomic<ReplicationTestHooks *> replication_test_hooks_{nullptr};
-  // Test-only, from the MG_TEST_PIPELINED_S2_PARK_FIFO environment variable: the first eligible committer parks
-  // after its encode stage until this path exists, polling with a 10 ms sleep so nothing goes through the worker
-  // pool. Lets an end-to-end test saturate the pool with committers waiting behind a slow head.
+#ifndef NDEBUG
+  // Test-only and compiled out of release builds, from the MG_TEST_PIPELINED_S2_PARK_FIFO environment variable: the
+  // first eligible committer parks after its encode stage until this path exists, polling with a 10 ms sleep so
+  // nothing goes through the worker pool. Lets an end-to-end test saturate the pool with committers waiting behind a
+  // slow head.
   std::string s2_park_path_;
   std::atomic<bool> s2_park_consumed_{false};
   // MG_TEST_PIPELINED_S2_PARK_SKIP: how many eligible commits pass before the one that parks.
   std::atomic<int64_t> s2_park_skip_{0};
+#endif
 
   memory::ArenaAwareUniquePtr<durability::WalFile> wal_file_;
   uint64_t wal_unsynced_transactions_{0};

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -37,6 +37,7 @@
 #include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/inmemory/replication/recovery.hpp"
 #include "storage/v2/inmemory/snapshot_info.hpp"
+#include "storage/v2/inmemory/txn_commands.hpp"
 #include "storage/v2/replication/replication_client.hpp"
 #include "storage/v2/replication/replication_transaction.hpp"
 #include "storage/v2/schema_info.hpp"
@@ -186,6 +187,11 @@ class InMemoryStorage final : public Storage {
                                                    storage::Gid gid,
                                                    std::optional<SchemaInfo::ModifyingAccessor> &schema_acc,
                                                    std::optional<utils::SkipListDb<Edge>::Accessor> &edge_acc);
+
+    // Resolves every delta this transaction wrote into encode-ordered commands (the traversal with processed-head/tail
+    // tracking that tolerates concurrent abort rewiring). `progress` is invoked where the inline path invoked the
+    // replica progress callback; `policy` is propagated to every container the traversal allocates.
+    auto MaterializeTxnCommands(TxnAllocPolicy policy, std::function<void()> const &progress) -> TxnCommands;
 
     [[nodiscard]] auto HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
                                                     TransactionReplication &replicating_txn,

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <ranges>
 #include <string_view>
@@ -26,6 +27,8 @@
 #include "replication_coordination_glue/role.hpp"
 #include "storage/v2/batched_list.hpp"
 #include "storage/v2/commit_log.hpp"
+#include "storage/v2/commit_order_gate.hpp"
+#include "storage/v2/commit_probe.hpp"
 #include "storage/v2/edge_metadata_index.hpp"
 #include "storage/v2/edge_ref.hpp"
 #include "storage/v2/gc_status.hpp"
@@ -70,6 +73,39 @@ struct ReplicationHandler;
 namespace memgraph::storage {
 
 using EdgeInfo = std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>;
+
+/// Progress of the single 2PC abort continuation (AbortTwoPcOrTerminate): each flag is set only after its step
+/// returned, so a step that threw is never retried, whichever caller (the failed-vote branch or the unwind guard)
+/// runs the continuation. decision_ok records the replicas' answer to the abort decision.
+struct TwoPcAbortState {
+  bool wal_finalized{false};
+  bool decisions_done{false};
+  bool decision_ok{true};
+};
+
+/// Counters a pipelined commit maintains; exposed through SHOW STORAGE INFO and pipeline_stats_for_tests().
+struct PipelineStats {
+  std::atomic<uint64_t> s2_encodes{0};        // transactions encoded outside the serializer
+  std::atomic<uint64_t> budget_fallbacks{0};  // encode-stage budget refusals that took the ordered legacy path
+  std::atomic<uint64_t> two_pc_fallbacks{0};  // eligible commits that needed 2PC and took the ordered legacy path
+  std::atomic<uint64_t> gate_wait_ns{0};      // time ticketed commits spent waiting to enter the gate
+  std::atomic<uint64_t> s3_ns{0};             // time spent inside the ordered stage
+};
+
+/// A copy of PipelineStats for reporting.
+struct PipelineStatsSnapshot {
+  uint64_t s2_encodes{0};
+  uint64_t budget_fallbacks{0};
+  uint64_t two_pc_fallbacks{0};
+  uint64_t gate_wait_ns{0};
+  uint64_t s3_ns{0};
+};
+
+/// Test-only counters for the failure-protocol tests (zero cost in production beyond the increments).
+struct PipelineTestCounters {
+  std::atomic<uint64_t> finalize_wal_calls{0};
+  std::atomic<uint64_t> decision_calls{0};
+};
 
 // The storage is based on this paper:
 // https://db.in.tum.de/~muehlbau/papers/mvcc.pdf
@@ -193,9 +229,29 @@ class InMemoryStorage final : public Storage {
     // replica progress callback; `policy` is propagated to every container the traversal allocates.
     auto MaterializeTxnCommands(TxnAllocPolicy policy, std::function<void()> const &progress) -> TxnCommands;
 
+    // `ticket` is non-null on a ticketed (pipelined-commit) execution: the record state and irreversibility marks
+    // are recorded on it. OFF and replica callers pass nothing.
     [[nodiscard]] auto HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
                                                     TransactionReplication &replicating_txn,
-                                                    CommitArgs const &commit_args) -> bool;
+                                                    CommitArgs const &commit_args, CommitTicket *ticket = nullptr)
+        -> bool;
+
+    // Pipelined commit (flag on, main-side minted commits). CommitWithTicket is the sole owner of ticket abort
+    // cleanup and retirement; the helpers record outcomes and return.
+    auto CommitWithTicket(CommitArgs const &commit_args, CommitLock commit_serializer)
+        -> std::expected<void, StorageManipulationError>;
+    auto OrderedLegacyCommit(CommitArgs const &commit_args, CommitLock commit_serializer,
+                             CommitTicket &ticket, uint64_t durability_commit_timestamp,
+                             TransactionReplication *replicating_txn) -> std::expected<void, StorageManipulationError>;
+    auto PipelinedCommit(CommitArgs const &commit_args, CommitTicket &ticket, uint64_t durability_commit_timestamp)
+        -> std::expected<void, StorageManipulationError>;
+    bool PipelineEligible(Transaction const &transaction, CommitArgs const &commit_args) const;
+    // Every local abort of a ticketed commit: enter if necessary, AbortAndResetCommitTs, MarkAborted; a failed abort
+    // terminates and is never retried. Never retires.
+    void AbortTicketOrTerminate(CommitTicket &ticket) noexcept;
+    // The single 2PC abort continuation: WAL finalization then the abort decisions, each step once.
+    void AbortTwoPcOrTerminate(TransactionReplication &repl, TwoPcAbortState &state,
+                               uint64_t durability_commit_timestamp, CommitArgs const &commit_args) noexcept;
 
    public:
     InMemoryAccessor(const InMemoryAccessor &) = delete;
@@ -488,7 +544,9 @@ class InMemoryStorage final : public Storage {
     // re-acquires it for the brief publish.
     // NOTE: If there is a single instance, PrepareForCommitPhase will call this method, you shouldn't call this method
     // independently of PrepareForCommitPhase.
-    void FinalizeCommitPhase(uint64_t durability_commit_timestamp, bool acquire_engine_lock = false);
+    // `ticket` (ticketed executions only) is marked irreversible immediately before the first publication mutation.
+    void FinalizeCommitPhase(uint64_t durability_commit_timestamp, bool acquire_engine_lock = false,
+                             CommitTicket *ticket = nullptr);
 
     /// @throw std::bad_alloc
     void Abort() override;
@@ -919,6 +977,31 @@ class InMemoryStorage final : public Storage {
     return last_committed_mvcc_ts_.load(std::memory_order_acquire);
   }
 
+  // EXPERIMENTAL (pipelined-commit).
+  [[nodiscard]] bool IsPipelinedCommit() const noexcept { return config_.experimental_pipelined_commit; }
+
+  // Excludes every in-flight main-side committer: takes commit_mutex_ (no new mint, hence no new ticket) and then
+  // waits until every issued ticket has retired. The returned guard keeps the serializer until the caller is done.
+  // const so a const caller (recovery-step selection) can quiesce; the gate and the serializer are mutable.
+  auto QuiesceCommits() const -> CommitLock;
+
+  [[nodiscard]] auto GetPipelineStats() const -> PipelineStatsSnapshot;
+
+  // Test-only.
+  void SetReplicationTestHooks(ReplicationTestHooks *hooks) noexcept { replication_test_hooks_ = hooks; }
+
+  [[nodiscard]] auto replication_test_hooks() const noexcept -> ReplicationTestHooks * {
+    return replication_test_hooks_;
+  }
+
+  auto commit_order_gate_for_tests() -> CommitOrderGate & { return commit_order_gate_; }
+
+  auto pipeline_stats_for_tests() -> PipelineStats & { return pipeline_stats_; }
+
+  auto pipeline_budget_for_tests() -> PipelineBudget & { return pipeline_budget_; }
+
+  auto pipeline_test_counters() -> PipelineTestCounters & { return pipeline_test_counters_; }
+
  private:
   /// @throw std::system_error
   /// @throw std::bad_alloc
@@ -1073,6 +1156,21 @@ class InMemoryStorage final : public Storage {
 
   // Sequence number used to keep track of the chain of WALs.
   uint64_t wal_seq_num_{0};
+
+  // EXPERIMENTAL (pipelined-commit): main-side committers are ordered through this gate; the budget bounds what
+  // their encode stage may retain.
+  mutable CommitOrderGate commit_order_gate_;
+  PipelineBudget pipeline_budget_;
+  PipelineStats pipeline_stats_;
+  PipelineTestCounters pipeline_test_counters_;
+  ReplicationTestHooks *replication_test_hooks_{nullptr};
+  // Test-only, from the MG_TEST_PIPELINED_S2_PARK_FIFO environment variable: the first eligible committer parks
+  // after its encode stage until this path exists, polling with a 10 ms sleep so nothing goes through the worker
+  // pool. Lets an end-to-end test saturate the pool with committers waiting behind a slow head.
+  std::string s2_park_path_;
+  std::atomic<bool> s2_park_consumed_{false};
+  // MG_TEST_PIPELINED_S2_PARK_SKIP: how many eligible commits pass before the one that parks.
+  std::atomic<int64_t> s2_park_skip_{0};
 
   memory::ArenaAwareUniquePtr<durability::WalFile> wal_file_;
   uint64_t wal_unsynced_transactions_{0};

--- a/src/storage/v2/inmemory/txn_commands.hpp
+++ b/src/storage/v2/inmemory/txn_commands.hpp
@@ -1,0 +1,63 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include "storage/v2/access_type.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/delta.hpp"
+#include "storage/v2/durability/serialization.hpp"
+#include "storage/v2/durability/wal.hpp"
+#include "storage/v2/id_types.hpp"
+#include "storage/v2/pipeline_budget.hpp"
+
+namespace memgraph::storage {
+
+class Storage;
+struct Vertex;
+struct Edge;
+struct MetadataDelta;
+
+/// One MVCC delta resolved by the commit thread's traversal: the delta, the object it belongs to (exactly one of
+/// vertex/edge set), and the edge lookup data workers cannot pull from the transaction.
+struct TxnDataCommand {
+  Delta const *delta;
+  Vertex *vertex;
+  Edge *edge;
+  Gid in_vertex_gid;
+  EdgeTypeId edge_type_id;
+};
+
+/// Everything a transaction writes, in encode order. Built once on the commit thread; the WAL encoder and every
+/// replica worker encode from it concurrently, so it must outlive all of their tasks. The vectors allocate through
+/// the policy they are given: a budget-charging one for a pipelined commit, the plain allocator otherwise.
+struct TxnCommands {
+  explicit TxnCommands(TxnAllocPolicy policy)
+      : metadata{BudgetAllocator<MetadataDelta const *>{policy}}, data{BudgetAllocator<TxnDataCommand>{policy}} {}
+
+  BudgetVector<MetadataDelta const *> metadata;
+  BudgetVector<TxnDataCommand> data;
+};
+
+/// Encodes a whole transaction (start frame, metadata, data, end frame) from materialized commands into `encoder`,
+/// emitting exactly the frames the inline WAL path emits and invoking `progress` where that path invokes the
+/// replica progress callback. Positions in the result are the encoder's native positions, not adjusted: absolute
+/// file offsets on a file encoder, buffer-relative on a fresh buffer that starts at zero.
+/// WalFile::AppendEncodedTransaction adds the destination file base exactly once.
+auto EncodeTxnCommandsTo(durability::BaseEncoder &encoder, TxnCommands const &commands, Storage *storage,
+                         SalientConfig::Items const &items, uint64_t durability_ts, bool commit,
+                         StorageAccessType access_type, std::function<void()> const &progress)
+    -> durability::TxnEncodeResult;
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/pipeline_budget.hpp
+++ b/src/storage/v2/pipeline_budget.hpp
@@ -27,6 +27,9 @@ namespace memgraph::storage {
 /// Per-database byte budget for the memory a pipelined commit retains outside the commit serializer (its
 /// materialized commands and its private WAL buffer). Charging never blocks: a charge that would exceed the
 /// maximum is refused, and the committer converts itself into the ordered legacy path instead of waiting.
+/// Charges are taken per allocation, so a container's growth holds the old and the new allocation at once: the
+/// accounted peak of one buffer is up to three times its final size, and the maximum bounds that peak, not the
+/// steady-state size.
 class PipelineBudget {
  public:
   explicit PipelineBudget(uint64_t max_bytes) noexcept : max_bytes_{max_bytes} {}

--- a/src/storage/v2/pipeline_budget.hpp
+++ b/src/storage/v2/pipeline_budget.hpp
@@ -1,0 +1,191 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <limits>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+namespace memgraph::storage {
+
+/// Per-database byte budget for the memory a pipelined commit retains outside the commit serializer (its
+/// materialized commands and its private WAL buffer). Charging never blocks: a charge that would exceed the
+/// maximum is refused, and the committer converts itself into the ordered legacy path instead of waiting.
+class PipelineBudget {
+ public:
+  explicit PipelineBudget(uint64_t max_bytes) noexcept : max_bytes_{max_bytes} {}
+
+  /// Charges `bytes` if the total stays within the maximum; false (and no change) otherwise. Never blocks.
+  [[nodiscard]] bool TryCharge(uint64_t bytes) noexcept {
+    auto current = in_flight_.load(std::memory_order_relaxed);
+    while (true) {
+      if (bytes > max_bytes_ || current > max_bytes_ - bytes) return false;
+      if (in_flight_.compare_exchange_weak(
+              current, current + bytes, std::memory_order_acq_rel, std::memory_order_relaxed)) {
+        return true;
+      }
+    }
+  }
+
+  void Release(uint64_t bytes) noexcept { in_flight_.fetch_sub(bytes, std::memory_order_acq_rel); }
+
+  auto InFlightBytes() const noexcept -> uint64_t { return in_flight_.load(std::memory_order_acquire); }
+
+  auto MaxBytes() const noexcept -> uint64_t { return max_bytes_; }
+
+ private:
+  uint64_t max_bytes_;
+  std::atomic<uint64_t> in_flight_{0};
+};
+
+/// Thrown by a budget-charging allocation when the pipeline budget refuses the charge.
+struct PipelineBudgetExceeded : std::exception {
+  const char *what() const noexcept override { return "pipelined commit budget exceeded"; }
+};
+
+/// RAII charge: the constructor calls TryCharge and throws PipelineBudgetExceeded on refusal; the destructor
+/// releases the charge unless ownership was detached. Move-only.
+class BudgetCharge {
+ public:
+  BudgetCharge(PipelineBudget &budget, uint64_t bytes) : budget_{&budget}, bytes_{bytes} {
+    if (!budget_->TryCharge(bytes_)) throw PipelineBudgetExceeded{};
+  }
+
+  ~BudgetCharge() {
+    if (budget_ != nullptr) budget_->Release(bytes_);
+  }
+
+  BudgetCharge(BudgetCharge const &) = delete;
+  BudgetCharge &operator=(BudgetCharge const &) = delete;
+
+  BudgetCharge(BudgetCharge &&other) noexcept : budget_{other.budget_}, bytes_{other.bytes_} {
+    other.budget_ = nullptr;
+  }
+
+  BudgetCharge &operator=(BudgetCharge &&other) noexcept {
+    if (this != &other) {
+      if (budget_ != nullptr) budget_->Release(bytes_);
+      budget_ = other.budget_;
+      bytes_ = other.bytes_;
+      other.budget_ = nullptr;
+    }
+    return *this;
+  }
+
+  /// Gives up ownership of the charge without releasing it; the caller now owes the matching Release.
+  void Detach() noexcept { budget_ = nullptr; }
+
+ private:
+  PipelineBudget *budget_;
+  uint64_t bytes_;
+};
+
+/// Test-only refusal injection, consulted by BudgetAllocator::allocate on the first allocation at `site` by the
+/// committer whose ticket equals `ticket`. Installed through TxnAllocPolicy::refuse (a pointer the storage fills
+/// from the commit probe when one is set; nullptr in production).
+struct BudgetRefuse {
+  enum Site : uint8_t { kNone, kMaterializer, kEncoder };
+
+  // kThrowRuntimeError is the generic S2 fault for the lifecycle tests.
+  enum Mode : uint8_t { kRefuse, kThrowRuntimeError };
+
+  std::atomic<uint64_t> ticket{0};
+  std::atomic<Site> site{kNone};
+  std::atomic<Mode> mode{kRefuse};
+  std::atomic<bool> fired{false};
+};
+
+/// Allocation policy handed to everything the encode stage allocates. A null `budget` selects the plain
+/// std::allocator with no charging and no refusal (the flag-off path and the ordered legacy continuation).
+struct TxnAllocPolicy {
+  PipelineBudget *budget{nullptr};
+  uint64_t ticket{0};
+  BudgetRefuse *refuse{nullptr};
+  BudgetRefuse::Site site{BudgetRefuse::kNone};
+};
+
+/// Allocator adapter over std::allocator<T>: allocate(n) charges n*sizeof(T) before delegating (throwing
+/// PipelineBudgetExceeded on refusal and releasing the charge if the underlying allocation throws); deallocate
+/// frees first and then releases exactly once. Rebinding covers unordered-container nodes and buckets. The
+/// allocator holds only the policy; a charge belongs to the allocation it covers, so copies and rebinds carry
+/// no state of their own.
+template <class T>
+class BudgetAllocator {
+ public:
+  using value_type = T;
+  using propagate_on_container_move_assignment = std::true_type;
+  using propagate_on_container_swap = std::true_type;
+  using is_always_equal = std::false_type;
+
+  template <class U>
+  struct rebind {
+    using other = BudgetAllocator<U>;
+  };
+
+  explicit BudgetAllocator(TxnAllocPolicy policy) noexcept : policy_{policy} {}
+
+  template <class U>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  BudgetAllocator(BudgetAllocator<U> const &other) noexcept : policy_{other.policy()} {}
+
+  [[nodiscard]] T *allocate(std::size_t n) {
+    if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) throw std::bad_array_new_length{};
+    if (policy_.budget == nullptr) return std::allocator<T>{}.allocate(n);
+    ConsultRefusal();
+    BudgetCharge charge{*policy_.budget, n * sizeof(T)};
+    T *memory = std::allocator<T>{}.allocate(n);
+    // The charge now belongs to the allocation and is released by deallocate.
+    charge.Detach();
+    return memory;
+  }
+
+  void deallocate(T *memory, std::size_t n) noexcept {
+    std::allocator<T>{}.deallocate(memory, n);
+    if (policy_.budget != nullptr) policy_.budget->Release(n * sizeof(T));
+  }
+
+  auto policy() const noexcept -> TxnAllocPolicy const & { return policy_; }
+
+  template <class U>
+  friend bool operator==(BudgetAllocator const &lhs, BudgetAllocator<U> const &rhs) noexcept {
+    return lhs.policy_.budget == rhs.policy().budget;
+  }
+
+ private:
+  void ConsultRefusal() const {
+    auto *refuse = policy_.refuse;
+    if (refuse == nullptr) return;
+    if (refuse->site.load(std::memory_order_acquire) != policy_.site ||
+        refuse->ticket.load(std::memory_order_acquire) != policy_.ticket) {
+      return;
+    }
+    if (refuse->fired.exchange(true, std::memory_order_acq_rel)) return;
+    if (refuse->mode.load(std::memory_order_acquire) == BudgetRefuse::kThrowRuntimeError) {
+      throw std::runtime_error("injected encode-stage failure");
+    }
+    throw PipelineBudgetExceeded{};
+  }
+
+  TxnAllocPolicy policy_;
+};
+
+template <class T>
+using BudgetVector = std::vector<T, BudgetAllocator<T>>;
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -244,9 +244,15 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
   // EXPERIMENTAL (lock-free-read-snapshot): engine_lock_ alone is stale for the ldt read at ~line 287;
   // under the flag, ldt advances at publish outside the post-mint engine_lock_ hold, so hold commit_mutex_
   // first (committer's order: commit_mutex_ then engine_lock_) to exclude any in-flight committer.
+  // With pipelined-commit the committer may be past the serializer but not yet published, so quiesce the ticket
+  // gate as well (QuiesceCommits takes commit_mutex_ first and returns it held).
   std::optional<CommitLock> commit_serializer;
   if (static_cast<InMemoryStorage *>(main_storage)->config_.experimental_lockfree_read_snapshot) {
-    commit_serializer.emplace(static_cast<InMemoryStorage *>(main_storage)->commit_mutex_);
+    if (auto *hooks = static_cast<InMemoryStorage *>(main_storage)->replication_test_hooks();
+        hooks != nullptr && hooks->before_reconcile_quiesce) {
+      hooks->before_reconcile_quiesce(client_.name_);
+    }
+    commit_serializer.emplace(static_cast<InMemoryStorage *>(main_storage)->QuiesceCommits());
   }
   // Lock engine lock in order to read main_storage timestamp and synchronize with any active commits
   auto engine_lock = std::unique_lock{main_storage->engine_lock_};
@@ -896,7 +902,8 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                 // with transaction_guard; the subsequent Path()/transfer is covered by DisableFlushing()'s flush_lock_.
                 std::optional<CommitLock> commit_serializer;
                 if (main_mem_storage->config_.experimental_lockfree_read_snapshot) {
-                  commit_serializer.emplace(main_mem_storage->commit_mutex_);
+                  // Quiesces the pipelined-commit gate as well; released before the transfer, as before.
+                  commit_serializer.emplace(main_mem_storage->QuiesceCommits());
                 }
                 std::unique_lock transaction_guard(main_mem_storage->engine_lock_);
                 if (main_mem_storage->wal_file_ &&
@@ -993,7 +1000,8 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
   // any in-flight committer so the READY decision reflects it.
   std::optional<CommitLock> commit_serializer;
   if (main_mem_storage->config_.experimental_lockfree_read_snapshot) {
-    commit_serializer.emplace(main_mem_storage->commit_mutex_);
+    // Quiesces the pipelined-commit gate as well: a committer past the serializer has not published yet.
+    commit_serializer.emplace(main_mem_storage->QuiesceCommits());
   }
   auto lock = std::lock_guard{main_storage->engine_lock_};
   const auto last_durable_timestamp =

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "replication/replication_client.hpp"
 #include "rpc/client.hpp"
 #include "storage/v2/access_type.hpp"
@@ -123,7 +125,15 @@ class ReplicationStorageClient {
 
   auto Endpoint() const -> io::network::Endpoint const & { return client_.rpc_client_.Endpoint(); }
 
-  void AbortRpcClient() const { client_.rpc_client_.Shutdown(); }
+  void AbortRpcClient() const {
+    abort_rpc_client_calls_.fetch_add(1, std::memory_order_relaxed);
+    client_.rpc_client_.Shutdown();
+  }
+
+  // Test-only: how many times this client's connection was retired through AbortRpcClient.
+  auto abort_rpc_client_calls() const noexcept -> uint64_t {
+    return abort_rpc_client_calls_.load(std::memory_order_relaxed);
+  }
 
   void SetMaybeBehind() const {
     replica_state_.WithLock([](auto &val) { val = replication::ReplicaState::MAYBE_BEHIND; });
@@ -262,6 +272,8 @@ class ReplicationStorageClient {
   mutable utils::Synchronized<replication::ReplicaState, utils::SpinLock> replica_state_{
       replication::ReplicaState::MAYBE_BEHIND};
   mutable std::atomic<CommitTsInfo> commit_ts_info_;
+  // Test-only observation of connection retirements.
+  mutable std::atomic<uint64_t> abort_rpc_client_calls_{0};
   const utils::UUID main_uuid_;
 };
 

--- a/src/storage/v2/replication/replication_transaction.cpp
+++ b/src/storage/v2/replication/replication_transaction.cpp
@@ -51,6 +51,11 @@ void RecordFaultAttempt(CommitProbe *probe, std::string_view site) {
   marker.Close();
 }
 
+auto ResolveTestHooks(Storage *storage) noexcept -> ReplicationTestHooks * {
+  auto *mem_storage = dynamic_cast<InMemoryStorage *>(storage);
+  return mem_storage != nullptr ? mem_storage->replication_test_hooks() : nullptr;
+}
+
 auto StartTxnErrorToReason(StartTxnReplicationError const &error) -> ReplicaFailureReason {
   return std::visit(utils::Overloaded{
                         [](FailedToConnectErr const &) { return ReplicaFailureReason::NOT_IN_SYNC; },
@@ -308,6 +313,7 @@ TransactionReplication::TransactionReplication(uint64_t const durability_commit_
                                                CommitArgs const &commit_args, ReplicationStorageClientList &clients,
                                                CommitTicket *ticket)
     : storage_{storage},
+      hooks_{ResolveTestHooks(storage)},
       ticketed_{ticket != nullptr},
       locked_clients{clients.ReadLock()},
       arena_pool_{storage->DbArenaPool()},
@@ -362,11 +368,6 @@ void TransactionReplication::DiscardUnpreparedStreams() noexcept {
     replica_stream.reset();
     client->SetMaybeBehind();
   }
-}
-
-auto TransactionReplication::TestHooks() const noexcept -> ReplicationTestHooks * {
-  auto *mem_storage = dynamic_cast<InMemoryStorage *>(storage_);
-  return mem_storage != nullptr ? mem_storage->replication_test_hooks() : nullptr;
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/replication/replication_transaction.cpp
+++ b/src/storage/v2/replication/replication_transaction.cpp
@@ -13,8 +13,11 @@
 
 #include "memory/db_arena_fwd.hpp"
 #include "storage/v2/commit_args.hpp"
+#include "storage/v2/commit_probe.hpp"
+#include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 #include "utils/atomic_utils.hpp"
+#include "utils/file.hpp"
 #include "utils/variant_helpers.hpp"
 
 #include <algorithm>
@@ -35,6 +38,17 @@ auto ReplicationModeToString(replication_coordination_glue::ReplicationMode mode
       return "STRICT_SYNC";
   }
   return "UNKNOWN";
+}
+
+// Test-only: records one attempt line before a one-shot fault flag is consumed, so a retry after consumption is
+// still visible to the test.
+void RecordFaultAttempt(CommitProbe *probe, std::string_view site) {
+  if (probe == nullptr || probe->fault_attempt_marker_path.empty()) return;
+  utils::OutputFile marker;
+  marker.Open(probe->fault_attempt_marker_path, utils::OutputFile::Mode::APPEND_TO_EXISTING);
+  auto const line = std::string{site} + "\n";
+  marker.Write(line);
+  marker.Close();
 }
 
 auto StartTxnErrorToReason(StartTxnReplicationError const &error) -> ReplicaFailureReason {
@@ -155,6 +169,11 @@ auto TransactionReplication::ShipOne(ReplicationStorageClient *raw_client, std::
 auto TransactionReplication::FinalizeTransaction(bool const decision, utils::UUID const &storage_uuid,
                                                  DatabaseProtector const &protector,
                                                  uint64_t const durability_commit_timestamp) -> bool {
+  if (auto *mem_storage = dynamic_cast<InMemoryStorage *>(storage_); mem_storage != nullptr) {
+    mem_storage->pipeline_test_counters().decision_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+  auto *probe = storage_ != nullptr ? storage_->commit_probe() : nullptr;
+  auto *hooks = TestHooks();
   std::vector<std::pair<ReplicationStorageClient *, std::future<bool>>> decisions;
   // Reserve first: an emplace_back that throws after its task was enqueued would orphan a running
   // task with no future to collect.
@@ -169,6 +188,13 @@ auto TransactionReplication::FinalizeTransaction(bool const decision, utils::UUI
         continue;
       }
       auto *raw_client = client.get();
+      // Test-only: a failure while scheduling a later decision, after an earlier one was enqueued.
+      if (ticketed_ && probe != nullptr && !decisions.empty() && probe->decision_schedule_throws_once.load()) {
+        RecordFaultAttempt(probe, "decision_schedule");
+        if (probe->decision_schedule_throws_once.exchange(false)) {
+          throw std::runtime_error("injected decision scheduling failure");
+        }
+      }
       decisions.emplace_back(raw_client,
                              raw_client->ScheduleTask([this,
                                                        raw_client,
@@ -199,6 +225,13 @@ auto TransactionReplication::FinalizeTransaction(bool const decision, utils::UUI
         // Reconnect needed because we optimistically prepared PrepareCommitReq message already.
         // We should only do this if we own the RPC lock.
         client->AbortRpcClient();
+        if (ticketed_) {
+          // A client left REPLICATING is not rescued by a reconnect (heartbeats reconcile MAYBE_BEHIND only) and
+          // would only be repaired by a later transaction; release the stream and let reconciliation run.
+          replica_stream.reset();
+          client->SetMaybeBehind();
+          if (hooks != nullptr && hooks->after_async_abort_cleanup) hooks->after_async_abort_cleanup();
+        }
       }
     }
   }
@@ -272,8 +305,11 @@ void TransactionReplication::UpdateCommitTsInfo() {
 }
 
 TransactionReplication::TransactionReplication(uint64_t const durability_commit_timestamp, Storage *storage,
-                                               CommitArgs const &commit_args, ReplicationStorageClientList &clients)
-    : locked_clients{clients.ReadLock()},
+                                               CommitArgs const &commit_args, ReplicationStorageClientList &clients,
+                                               CommitTicket *ticket)
+    : storage_{storage},
+      ticketed_{ticket != nullptr},
+      locked_clients{clients.ReadLock()},
       arena_pool_{storage->DbArenaPool()},
       durability_commit_timestamp_{durability_commit_timestamp},
       // This transaction is the next one main commits, so its absolute committed-txn count is main's current count
@@ -284,23 +320,53 @@ TransactionReplication::TransactionReplication(uint64_t const durability_commit_
   if (!locked_clients->empty()) {
     streams.reserve(locked_clients->size());
     auto const &db_acc = commit_args.database_protector();
-    for (const auto &client : *locked_clients) {
-      // If any client requires two phase commit, then we are running that phase
-      run_two_phase_commit |= client->TwoPhaseCommit();
-      auto res = client->StartTransactionReplication(storage, db_acc, durability_commit_timestamp);
-      if (res.has_value()) {
-        streams.emplace_back(std::move(res.value()));
-      } else {
-        streams.emplace_back(std::nullopt);
-        // ASYNC replica errors are not reported — fire-and-forget
-        if (client->Mode() != replication_coordination_glue::ReplicationMode::ASYNC) {
-          replication_failures_.push_back({.name = client->Name(),
-                                           .mode = ReplicationModeToString(client->Mode()),
-                                           .reason = StartTxnErrorToReason(res.error())});
+    auto *hooks = TestHooks();
+    try {
+      for (const auto &client : *locked_clients) {
+        // If any client requires two phase commit, then we are running that phase
+        run_two_phase_commit |= client->TwoPhaseCommit();
+        // Test-only: a failure after an earlier stream was retained.
+        if (hooks != nullptr && hooks->throw_on_open_for &&
+            hooks->throw_on_open_for(client->Name(), durability_commit_timestamp)) {
+          throw std::runtime_error("injected stream open failure");
+        }
+        auto res = client->StartTransactionReplication(storage, db_acc, durability_commit_timestamp);
+        if (res.has_value()) {
+          streams.emplace_back(std::move(res.value()));
+        } else {
+          streams.emplace_back(std::nullopt);
+          // ASYNC replica errors are not reported — fire-and-forget
+          if (client->Mode() != replication_coordination_glue::ReplicationMode::ASYNC) {
+            replication_failures_.push_back({.name = client->Name(),
+                                             .mode = ReplicationModeToString(client->Mode()),
+                                             .reason = StartTxnErrorToReason(res.error())});
+          }
         }
       }
+    } catch (...) {
+      // A stream opened and left REPLICATING would otherwise only be repaired by a later commit; on a ticketed
+      // execution retire it completely before the members unwind. The flag-off path keeps its behaviour.
+      if (ticketed_) DiscardUnpreparedStreams();
+      throw;
     }
   }
+}
+
+void TransactionReplication::DiscardUnpreparedStreams() noexcept {
+  for (auto &&[client, replica_stream] : ranges::views::zip(*locked_clients, streams)) {
+    if (!replica_stream) continue;
+    // Retire the connection while the stream still owns the RPC lock (reset-first would release the lock before
+    // the socket is retired and let another RPC intervene), then release the stream, then mark the client so the
+    // heartbeat reconciles it.
+    client->AbortRpcClient();
+    replica_stream.reset();
+    client->SetMaybeBehind();
+  }
+}
+
+auto TransactionReplication::TestHooks() const noexcept -> ReplicationTestHooks * {
+  auto *mem_storage = dynamic_cast<InMemoryStorage *>(storage_);
+  return mem_storage != nullptr ? mem_storage->replication_test_hooks() : nullptr;
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/replication/replication_transaction.hpp
+++ b/src/storage/v2/replication/replication_transaction.hpp
@@ -176,8 +176,9 @@ class TransactionReplication {
   std::unordered_set<std::string> failed_replicas_;
   // last_durable_ts this transaction commits at; paired with commit_num_committed_txns_ when advancing replica caches.
   uint64_t durability_commit_timestamp_;
-  // Absolute num_committed_txns_ this transaction advances every up-to-date replica to. Captured once at construction
-  // (under engine_lock_, before main bumps its own counter) so replica caches converge to a single authoritative
+  // Absolute num_committed_txns_ this transaction advances every up-to-date replica to. Captured once at construction,
+  // before FinalizeCommitPhase bumps main's counter and ordered against other committers by the commit serializer
+  // (or, on a ticketed execution, by the commit-order gate), so replica caches converge to a single authoritative
   // value via Max instead of being blindly incremented, which would double-count against the heartbeat merge.
   uint64_t commit_num_committed_txns_;
 };

--- a/src/storage/v2/replication/replication_transaction.hpp
+++ b/src/storage/v2/replication/replication_transaction.hpp
@@ -150,12 +150,13 @@ class TransactionReplication {
   auto ShipOne(ReplicationStorageClient *raw_client, std::optional<ReplicaStream> &replica_stream,
                uint64_t durability_commit_timestamp, DatabaseProtector const &db_acc) const -> ShipResult;
 
-  // The storage-owned test hooks (null in production).
-  auto TestHooks() const noexcept -> ReplicationTestHooks *;
+  // The storage-owned test hooks (null in production), resolved once at construction.
+  auto TestHooks() const noexcept -> ReplicationTestHooks * { return hooks_; }
 
   // The storage this transaction commits on; retained so the scheduled tasks and the decision phase can reach its
   // test hooks and counters.
   Storage *storage_{nullptr};
+  ReplicationTestHooks *hooks_{nullptr};
   // True when constructed by a ticketed (pipelined-commit) execution; gates every cleanup the flag-off path lacks.
   bool ticketed_{false};
   std::vector<std::optional<ReplicaStream>> streams;

--- a/src/storage/v2/replication/replication_transaction.hpp
+++ b/src/storage/v2/replication/replication_transaction.hpp
@@ -14,11 +14,13 @@
 #include <expected>
 #include <future>
 #include <optional>
+#include <stdexcept>
 #include <unordered_set>
 #include <vector>
 
 #include "memory/db_arena_fwd.hpp"
 #include "spdlog/spdlog.h"
+#include "storage/v2/commit_probe.hpp"
 #include "storage/v2/database_protector.hpp"
 #include "storage/v2/replication/replication_client.hpp"
 #include "utils/rw_spin_lock.hpp"
@@ -29,6 +31,7 @@
 namespace memgraph::storage {
 
 struct CommitArgs;
+class CommitTicket;
 
 using ReplicationStorageClientList =
     utils::Synchronized<std::vector<std::unique_ptr<ReplicationStorageClient>>, utils::RWSpinLock>;
@@ -37,8 +40,11 @@ class TransactionReplication {
  public:
   // This will block until we retrieve RPC streams for all STRICT_SYNC and SYNC replicas. It is OK to not be able to
   // obtain the RPC lock for the ASYNC replica.
+  // `ticket` is non-null on a ticketed (pipelined-commit) execution and selects the stream cleanup that execution
+  // needs; OFF and replica callers omit it. A stream opened before the constructor throws is shut down while it
+  // still owns the RPC lock, reset and its client set MAYBE_BEHIND before the exception propagates.
   TransactionReplication(uint64_t durability_commit_timestamp, Storage *storage, CommitArgs const &commit_args,
-                         ReplicationStorageClientList &clients);
+                         ReplicationStorageClientList &clients, CommitTicket *ticket = nullptr);
 
   ~TransactionReplication() = default;
 
@@ -57,6 +63,7 @@ class TransactionReplication {
     // Reserve first: an emplace_back that throws after its task was enqueued would orphan a running
     // task with no future to collect.
     ship_futures_.reserve(locked_clients->size());
+    auto *hooks = TestHooks();
     for (auto &&[client, replica_stream] : ranges::views::zip(*locked_clients, streams)) {
       // A streamless replica already failed to start this transaction; ShipDeltas runs its quick,
       // RPC-free bookkeeping inline. Queueing a no-op would make the commit thread await this
@@ -67,25 +74,49 @@ class TransactionReplication {
       }
       auto *raw_client = client.get();
       auto *stream_ptr = &replica_stream;
+      // Test-only: a scheduling failure part-way through, after earlier tasks were enqueued.
+      if (hooks != nullptr && hooks->throw_before_enqueue_for &&
+          hooks->throw_before_enqueue_for(raw_client->Name(), durability_commit_timestamp)) {
+        throw std::runtime_error("injected scheduling failure");
+      }
       ship_futures_.emplace_back(
           raw_client,
           raw_client->ScheduleTask(
-              [this, raw_client, stream_ptr, encode, wal_result, durability_commit_timestamp, db_acc]() -> ShipResult {
+              [this, raw_client, stream_ptr, encode, wal_result, durability_commit_timestamp, db_acc, hooks]()
+                  -> ShipResult {
                 try {
                   const memory::DbArenaScope db_arena_scope{arena_pool_};
                   raw_client->IfStreamingTransaction(encode, *stream_ptr);
+                  if (hooks != nullptr && hooks->before_wal_result_wait) {
+                    hooks->before_wal_result_wait(raw_client->Name(), durability_commit_timestamp);
+                  }
                   // The durability gate: rethrows on a WAL failure, so the transaction end never ships.
                   wal_result.get();
-                  return ShipOne(raw_client, *stream_ptr, durability_commit_timestamp, *db_acc);
+                  auto result = ShipOne(raw_client, *stream_ptr, durability_commit_timestamp, *db_acc);
+                  if (hooks != nullptr && hooks->on_task_done)
+                    hooks->on_task_done(raw_client->Name(), durability_commit_timestamp);
+                  return result;
                 } catch (...) {
                   spdlog::error("Failed to replicate transaction to replica {}.", raw_client->Name());
+                  // A partially transmitted request must not survive on the connection: retire the socket while this
+                  // task still owns the stream's RPC lock, then release it. Ticketed executions only; the flag-off path
+                  // keeps its behaviour.
+                  if (ticketed_ && stream_ptr->has_value()) raw_client->AbortRpcClient();
                   stream_ptr->reset();
                   raw_client->SetMaybeBehind();
+                  if (hooks != nullptr && hooks->on_task_done)
+                    hooks->on_task_done(raw_client->Name(), durability_commit_timestamp);
                   return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
                 }
               }));
     }
   }
+
+  // Shuts down, resets and marks MAYBE_BEHIND every stream this transaction still holds; for a ticketed execution
+  // that exits before any WAL frame was written. Skips empty optionals entirely, so a second invocation is a no-op.
+  void DiscardUnpreparedStreams() noexcept;
+
+  auto ticketed() const noexcept -> bool { return ticketed_; }
 
   // Waits for every scheduled fused task without consuming results; for the unwind paths, so no
   // worker is left referencing the caller's frame.
@@ -119,6 +150,14 @@ class TransactionReplication {
   auto ShipOne(ReplicationStorageClient *raw_client, std::optional<ReplicaStream> &replica_stream,
                uint64_t durability_commit_timestamp, DatabaseProtector const &db_acc) const -> ShipResult;
 
+  // The storage-owned test hooks (null in production).
+  auto TestHooks() const noexcept -> ReplicationTestHooks *;
+
+  // The storage this transaction commits on; retained so the scheduled tasks and the decision phase can reach its
+  // test hooks and counters.
+  Storage *storage_{nullptr};
+  // True when constructed by a ticketed (pipelined-commit) execution; gates every cleanup the flag-off path lacks.
+  bool ticketed_{false};
   std::vector<std::optional<ReplicaStream>> streams;
   std::vector<std::pair<ReplicationStorageClient *, std::future<ShipResult>>> ship_futures_;
   utils::Synchronized<std::vector<std::unique_ptr<ReplicationStorageClient>>, utils::RWSpinLock>::ReadLockedPtr

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -320,6 +320,9 @@ class Storage {
   // Test-only: install commit-path instrumentation (lock-free-read-snapshot experiment). Null in production.
   void SetCommitProbe(CommitProbe *probe) noexcept { commit_probe_ = probe; }
 
+  // Test-only instrumentation (null in production); read by the replication objects a commit owns.
+  auto commit_probe() const noexcept -> CommitProbe * { return commit_probe_; }
+
   memory::ArenaPool *DbArenaPool() const noexcept { return db_arena_pool_; }
 
   using Accessor = memgraph::storage::Accessor;

--- a/tests/manual/pipelined_commit_worker_liveness.py
+++ b/tests/manual/pipelined_commit_worker_liveness.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+"""
+Worker liveness under a saturated pool with the pipelined commit enabled.
+
+Starts a server with --experimental-enabled=lockfree-read-snapshot,pipelined-commit
+and a small, explicitly configured Bolt worker count, then drives real storage
+commits through the pool from 16 connections while the head committer is parked
+in its encode stage by an out-of-band controller: the server reads the
+MG_TEST_PIPELINED_S2_PARK_FIFO environment variable and the first eligible
+committer after MG_TEST_PIPELINED_S2_PARK_SKIP others polls, with a 10 ms
+sleep, until that file exists. Nothing goes
+through the saturated worker pool to release it. A 17th connection issues a
+read-only query while the writers are queued behind the head; the script
+records how long that read waited for admission, releases the head, and asserts
+that every writer and the reader finish within a bound. PERIODIC COMMIT and a
+before-commit trigger are exercised through the interpreter afterwards.
+
+    ./pipelined_commit_worker_liveness.py --binary build/memgraph --workers 4
+
+The read has no admission guarantee while every worker is blocked in a
+synchronous commit; the delay is reported, not asserted.
+"""
+
+import argparse
+import multiprocessing
+import os
+import queue
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+import mgclient
+
+WRITERS = 16
+PORT = 7699
+
+
+def connect(port):
+    connection = mgclient.connect(host="127.0.0.1", port=port)
+    connection.autocommit = True
+    return connection
+
+
+def execute(connection, query, params=None):
+    cursor = connection.cursor()
+    cursor.execute(query, params or {})
+    return cursor.fetchall()
+
+
+def wait_for_port(port, timeout=60):
+    import socket
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket() as sock:
+            sock.settimeout(0.5)
+            try:
+                sock.connect(("127.0.0.1", port))
+                return True
+            except OSError:
+                time.sleep(0.2)
+    return False
+
+
+def writer(port, index, started, results):
+    try:
+        connection = connect(port)
+        execute(connection, "MATCH (n:Node {id: $id}) SET n.v = n.v + 1 RETURN n.v", {"id": index})
+        results.put(("writer", index, time.perf_counter() - started))
+    except Exception as error:  # noqa: BLE001
+        results.put(("error", f"writer {index}", str(error)))
+
+
+def reader(port, results):
+    try:
+        connection = connect(port)
+        read_started = time.perf_counter()
+        execute(connection, "MATCH (n:Node) RETURN count(n)")
+        results.put(("reader", 0, time.perf_counter() - read_started))
+    except Exception as error:  # noqa: BLE001
+        results.put(("error", "reader", str(error)))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--workers", type=int, default=4, help="Bolt worker count for the server")
+    parser.add_argument("--port", type=int, default=PORT)
+    parser.add_argument("--bound", type=float, default=30.0, help="seconds every writer and the reader must finish in")
+    args = parser.parse_args()
+
+    workdir = tempfile.mkdtemp(prefix="mg_liveness_")
+    park_file = os.path.join(workdir, "release-head")
+    # The seeding query below is the first eligible commit; the parked head is the one after it.
+    env = dict(os.environ, MG_TEST_PIPELINED_S2_PARK_FIFO=park_file, MG_TEST_PIPELINED_S2_PARK_SKIP="1")
+    server = subprocess.Popen(
+        [
+            args.binary,
+            f"--data-directory={workdir}/data",
+            f"--bolt-port={args.port}",
+            f"--bolt-num-workers={args.workers}",
+            "--log-level=WARNING",
+            f"--log-file={workdir}/memgraph.log",
+            "--also-log-to-stderr=false",
+            "--telemetry-enabled=false",
+            "--storage-snapshot-on-exit=false",
+            "--storage-snapshot-interval-sec=86400",
+            "--storage-wal-enabled=true",
+            "--query-modules-directory=",
+            "--experimental-enabled=lockfree-read-snapshot,pipelined-commit",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        assert wait_for_port(args.port), "server did not start"
+        setup = connect(args.port)
+        execute(setup, "CREATE INDEX ON :Node(id)")
+        execute(setup, "UNWIND range(0, 99) AS i CREATE (:Node {id: i, v: 0})")
+        print(f"server pid {server.pid}, {args.workers} bolt workers, {WRITERS} writers + 1 reader")
+
+        # Separate processes, not threads: the client library holds the GIL while it waits on the socket, so
+        # threads would never let this controller run while the writers are blocked.
+        results = multiprocessing.Queue()
+        started = time.perf_counter()
+        writers = [
+            multiprocessing.Process(target=writer, args=(args.port, index, started, results))
+            for index in range(WRITERS)
+        ]
+        for process in writers:
+            process.start()
+        # The head is parked in its encode stage; the other writers queue behind it (gate or pool).
+        time.sleep(1.0)
+        reader_process = multiprocessing.Process(target=reader, args=(args.port, results))
+        reader_process.start()
+        time.sleep(1.0)
+        with open(park_file, "w") as release:
+            release.write("go\n")
+        release_at = time.perf_counter() - started
+        finished, errors, read_result = {}, [], {}
+        deadline = time.time() + args.bound
+        while len(finished) + len(errors) < WRITERS or ("admission_s" not in read_result and not errors):
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            try:
+                kind, key, value = results.get(timeout=remaining)
+            except queue.Empty:
+                break
+            if kind == "writer":
+                finished[key] = value
+            elif kind == "reader":
+                read_result["admission_s"] = value
+            else:
+                errors.append(f"{kind} {key}: {value}")
+        for process in writers:
+            process.join(timeout=5)
+        reader_process.join(timeout=5)
+        assert not errors, errors
+        assert len(finished) == WRITERS, f"only {len(finished)} writers finished within {args.bound}s"
+        assert "admission_s" in read_result, f"the reader did not finish within {args.bound}s"
+        last = max(finished.values())
+        print(f"head released at {release_at * 1000:.0f} ms; last writer finished at {last * 1000:.0f} ms")
+        print(f"reader admission delay during saturation: {read_result['admission_s'] * 1000:.0f} ms")
+        assert last - release_at < args.bound, "writers did not complete in bound after the release"
+
+        # Interpreter paths that commit through the same storage path.
+        rows = execute(setup, "USING PERIODIC COMMIT 100 UNWIND range(0, 499) AS i CREATE (:Periodic {i: i})")
+        assert execute(setup, "MATCH (p:Periodic) RETURN count(p)")[0][0] == 500, rows
+        execute(
+            setup,
+            "CREATE TRIGGER guard ON () CREATE BEFORE COMMIT EXECUTE " "UNWIND createdVertices AS v SET v.seen = true",
+        )
+        execute(setup, "CREATE (:Guarded {i: 1})")
+        assert execute(setup, "MATCH (g:Guarded) RETURN g.seen")[0][0] is True
+        execute(setup, "DROP TRIGGER guard")
+        counters = {row[0]: row[1] for row in execute(setup, "SHOW STORAGE INFO ON CURRENT DATABASE")}
+        print(
+            "pipelined_commit_s2_encodes",
+            counters.get("pipelined_commit_s2_encodes"),
+            "budget_fallbacks",
+            counters.get("pipelined_commit_budget_fallbacks"),
+        )
+        assert counters.get("pipelined_commit_s2_encodes", 0) >= WRITERS
+        print("OK")
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            server.kill()
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/manual/pipelined_commit_worker_liveness.py
+++ b/tests/manual/pipelined_commit_worker_liveness.py
@@ -18,6 +18,10 @@ before-commit trigger are exercised through the interpreter afterwards.
 
     ./pipelined_commit_worker_liveness.py --binary build/memgraph --workers 4
 
+The park hook is compiled only into builds without NDEBUG (Debug, RelWithDebInfo
+with assertions), so --binary must point at such a build; a release binary
+ignores the environment variables and the first assertion below fails.
+
 The read has no admission guarantee while every worker is blocked in a
 synchronous commit; the delay is reported, not asserted.
 """

--- a/tests/manual/pipelined_commit_worker_liveness.py
+++ b/tests/manual/pipelined_commit_worker_liveness.py
@@ -76,8 +76,9 @@ def writer(port, index, started, results):
 
 def reader(port, results):
     try:
-        connection = connect(port)
+        # The clock starts before the connection: the accept and handshake wait is part of the admission delay.
         read_started = time.perf_counter()
+        connection = connect(port)
         execute(connection, "MATCH (n:Node) RETURN count(n)")
         results.put(("reader", 0, time.perf_counter() - read_started))
     except Exception as error:  # noqa: BLE001
@@ -157,14 +158,19 @@ def main():
                 read_result["admission_s"] = value
             else:
                 errors.append(f"{kind} {key}: {value}")
-        for process in writers:
+        for process in writers + [reader_process]:
             process.join(timeout=5)
-        reader_process.join(timeout=5)
+            if process.is_alive():
+                process.terminate()
         assert not errors, errors
         assert len(finished) == WRITERS, f"only {len(finished)} writers finished within {args.bound}s"
         assert "admission_s" in read_result, f"the reader did not finish within {args.bound}s"
         last = max(finished.values())
+        first = min(finished.values())
         print(f"head released at {release_at * 1000:.0f} ms; last writer finished at {last * 1000:.0f} ms")
+        # Every writer waited for the parked head (at the gate or on the commit lock): none finished before the
+        # release, which is what proves a committer actually parked.
+        assert first >= release_at - 0.05, f"a writer finished at {first * 1000:.0f} ms, before the release"
         print(f"reader admission delay during saturation: {read_result['admission_s'] * 1000:.0f} ms")
         assert last - release_at < args.bound, "writers did not complete in bound after the release"
 

--- a/tests/manual/unique_constraint_property_update_bench.py
+++ b/tests/manual/unique_constraint_property_update_bench.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+"""
+Measures the cost of updating properties that take part in no unique
+constraint, on vertices whose label does carry a unique constraint.
+
+Every non-null property write used to put its vertex into the commit-time
+unique constraint verification set, so a batch that only touched unrelated
+properties still paid one constraint update and one validation per vertex
+inside the storage engine lock. This script reproduces that workload:
+
+    (:Node {id})<-[:VALUE_OF]-(:Value {id, v, ts, ...})
+
+with unique constraints on Node(id) and Value(id), then runs batches of
+1000 UPDATE-style writes that change only Value.v, Value.ts, and friends.
+Batches never share a vertex, so the concurrent runs measure commit-path
+serialization rather than write-write conflicts.
+
+Run against a fresh, empty instance, one binary at a time:
+
+    ./unique_constraint_property_update_bench.py --port 7687 --pid $(pgrep -x memgraph)
+
+The --pid argument is optional and only used to report the CPU time the
+server process consumed during the timed trials (read from /proc).
+"""
+
+import argparse
+import multiprocessing
+import os
+import random
+import statistics
+import time
+
+import mgclient
+
+VERTICES = 100_000
+BATCH_SIZE = 1_000
+BATCHES = 48
+TRIALS = 3
+WRITER_COUNTS = (1, 12)
+SEED = 20260907
+
+SCHEMA = [
+    "CREATE INDEX ON :Node(id)",
+    "CREATE INDEX ON :Value(id)",
+    "CREATE CONSTRAINT ON (n:Node) ASSERT n.id IS UNIQUE",
+    "CREATE CONSTRAINT ON (v:Value) ASSERT v.id IS UNIQUE",
+]
+
+LOAD = (
+    "UNWIND $ids AS id "
+    "CREATE (n:Node {id: id, name: 'x'})<-[:VALUE_OF]-(:Value {id: id, v: 1.0, dv: '1.0', ts: 't', q: null})"
+)
+
+UPDATE = (
+    "UNWIND $rows AS row "
+    "MATCH (n:Node {id: row[0]})<-[:VALUE_OF]-(v:Value) "
+    "SET v.prev_v = v.v, v.prev_dv = v.dv, v.prev_ts = v.ts, v.prev_q = v.q, "
+    "    v.v = row[1], v.dv = row[2], v.ts = row[3], v.q = row[4] "
+    "RETURN count(*)"
+)
+
+
+def connect(args):
+    connection = mgclient.connect(host=args.host, port=args.port)
+    connection.autocommit = True
+    return connection
+
+
+def execute(connection, query, params=None):
+    cursor = connection.cursor()
+    cursor.execute(query, params or {})
+    return cursor.fetchall()
+
+
+def process_cpu_seconds(pid):
+    if pid is None:
+        return 0.0
+    with open(f"/proc/{pid}/stat") as stat:
+        fields = stat.read().rsplit(")", 1)[1].split()
+    return (int(fields[11]) + int(fields[12])) / os.sysconf("SC_CLK_TCK")
+
+
+def load(args, ids):
+    connection = connect(args)
+    for statement in SCHEMA:
+        execute(connection, statement)
+    for start in range(0, len(ids), 5_000):
+        execute(connection, LOAD, {"ids": ids[start : start + 5_000]})
+    constraints = {(row[1], tuple(row[2])) for row in execute(connection, "SHOW CONSTRAINT INFO") if row[0] == "unique"}
+    assert {("Node", ("id",)), ("Value", ("id",))} <= constraints, constraints
+
+
+def make_batches(ids, rng, batches):
+    chosen = rng.sample(ids, batches * BATCH_SIZE)
+    return [
+        [
+            [vertex_id, round(rng.random() * 100, 3), "x", "2026-01-01T00:00:00+00:00", None]
+            for vertex_id in chosen[start : start + BATCH_SIZE]
+        ]
+        for start in range(0, len(chosen), BATCH_SIZE)
+    ]
+
+
+def writer(args, batches, results):
+    """Runs its share of `batches` on its own connection, reports each latency or the first error, then signals completion."""
+    try:
+        connection = connect(args)
+        for batch in batches:
+            started = time.perf_counter()
+            try:
+                execute(connection, UPDATE, {"rows": batch})
+            except Exception as error:  # noqa: BLE001 - report every failure, whatever its type
+                results.put(("error", str(error)))
+                return
+            results.put(("latency", time.perf_counter() - started))
+    finally:
+        results.put(("done", None))
+
+
+def trial(args, ids, rng, writers):
+    # Separate processes, not threads: a client library that holds the GIL while it waits on the
+    # socket would otherwise serialize the writers and hide the commit-path contention being measured.
+    batches = make_batches(ids, rng, args.batches)
+    shares = [batches[index::writers] for index in range(writers)]
+    results = multiprocessing.Queue()
+    processes = [multiprocessing.Process(target=writer, args=(args, share, results)) for share in shares]
+
+    time.sleep(0.5)
+    cpu_before = process_cpu_seconds(args.pid)
+    wall_started = time.perf_counter()
+    for process in processes:
+        process.start()
+
+    # Every writer ends with a completion message, so blocking reads until all of them have arrived
+    # drain the queue deterministically; Queue.empty() is not reliable for that.
+    latencies, errors = [], []
+    remaining = writers
+    while remaining:
+        kind, value = results.get()
+        if kind == "done":
+            remaining -= 1
+        elif kind == "latency":
+            latencies.append(value)
+        else:
+            errors.append(value)
+    wall = time.perf_counter() - wall_started
+    for process in processes:
+        process.join()
+    cpu = process_cpu_seconds(args.pid) - cpu_before
+
+    assert not errors and len(latencies) == args.batches, (errors, len(latencies))
+    latencies.sort()
+    p99 = latencies[min(len(latencies) - 1, int(round(0.99 * (len(latencies) - 1))))]
+    return wall, cpu, statistics.median(latencies) * 1000, p99 * 1000
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7687)
+    parser.add_argument("--pid", type=int, default=None, help="server pid, for CPU accounting via /proc")
+    parser.add_argument(
+        "--writers",
+        default=",".join(str(count) for count in WRITER_COUNTS),
+        help="comma-separated writer counts to sweep (default: %(default)s)",
+    )
+    parser.add_argument("--batches", type=int, default=BATCHES, help="batches per trial (default: %(default)s)")
+    args = parser.parse_args()
+    writer_counts = [int(count) for count in args.writers.split(",") if count]
+
+    rng = random.Random(SEED)
+    ids = [f"bench-{i:06d}" for i in range(VERTICES)]
+    load(args, ids)
+    print(f"loaded {VERTICES} Node/Value pairs; {args.batches} disjoint batches of {BATCH_SIZE} rows per trial")
+    print(
+        f"{'writers':>7}  {'wall_s':>7}  {'tx_per_s':>8}  {'rows_per_s':>10}  {'server_cpu_s':>12}  "
+        f"{'cpu_ms_per_tx':>13}  {'tx_p50_ms':>9}  {'tx_p99_ms':>9}   (medians of {TRIALS} trials)"
+    )
+    for writers in writer_counts:
+        trial(args, ids, rng, writers)  # warm-up, not reported
+        results = [trial(args, ids, rng, writers) for _ in range(TRIALS)]
+        wall = statistics.median(r[0] for r in results)
+        cpu = statistics.median(r[1] for r in results)
+        p50 = statistics.median(r[2] for r in results)
+        p99 = statistics.median(r[3] for r in results)
+        tx_per_s = args.batches / wall
+        print(
+            f"{writers:>7}  {wall:>7.2f}  {tx_per_s:>8.1f}  {tx_per_s * BATCH_SIZE:>10.0f}  {cpu:>12.2f}  "
+            f"{cpu * 1000 / args.batches:>13.2f}  {p50:>9.1f}  {p99:>9.1f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -872,6 +872,11 @@ add_unit_test(storage_v2_wal_file
     LINK_TARGETS mg::storage storage_test_utils fmt::fmt
 )
 
+add_unit_test(storage_v2_buffer_encoder
+    SOURCES storage_v2_buffer_encoder.cpp
+    LINK_TARGETS mg::storage storage_test_utils
+)
+
 add_unit_test(storage_v2_replication
     SOURCES storage_v2_replication.cpp
     LINK_TARGETS mg::storage mg-dbms fmt::fmt mg-repl_coord_glue

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -883,6 +883,12 @@ add_unit_test(storage_v2_commit_order_gate
     CUSTOM_MAIN
 )
 
+add_unit_test(storage_v2_pipelined_commit
+    SOURCES storage_v2_pipelined_commit.cpp
+    LINK_TARGETS mg::storage mg-flags storage_test_utils
+    CUSTOM_MAIN
+)
+
 add_unit_test(storage_v2_buffer_encoder
     SOURCES storage_v2_buffer_encoder.cpp
     LINK_TARGETS mg::storage storage_test_utils
@@ -891,6 +897,7 @@ add_unit_test(storage_v2_buffer_encoder
 add_unit_test(storage_v2_replication
     SOURCES storage_v2_replication.cpp
     LINK_TARGETS mg::storage mg-dbms fmt::fmt mg-repl_coord_glue
+    CUSTOM_MAIN
 )
 
 add_unit_test(storage_v2_error

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -872,6 +872,11 @@ add_unit_test(storage_v2_wal_file
     LINK_TARGETS mg::storage storage_test_utils fmt::fmt
 )
 
+# Deterministic flag-off WAL identity harness (not a gtest): storage_v2_off_identity <output-directory>.
+add_executable(memgraph__unit__storage_v2_off_identity storage_v2_off_identity.cpp)
+target_link_libraries(memgraph__unit__storage_v2_off_identity PRIVATE mg::storage storage_test_utils)
+set_target_properties(memgraph__unit__storage_v2_off_identity PROPERTIES OUTPUT_NAME storage_v2_off_identity)
+
 add_unit_test(storage_v2_commit_order_gate
     SOURCES storage_v2_commit_order_gate.cpp
     LINK_TARGETS mg::storage

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -872,6 +872,12 @@ add_unit_test(storage_v2_wal_file
     LINK_TARGETS mg::storage storage_test_utils fmt::fmt
 )
 
+add_unit_test(storage_v2_commit_order_gate
+    SOURCES storage_v2_commit_order_gate.cpp
+    LINK_TARGETS mg::storage
+    CUSTOM_MAIN
+)
+
 add_unit_test(storage_v2_buffer_encoder
     SOURCES storage_v2_buffer_encoder.cpp
     LINK_TARGETS mg::storage storage_test_utils

--- a/tests/unit/replication_min_memgraph.hpp
+++ b/tests/unit/replication_min_memgraph.hpp
@@ -1,0 +1,88 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+// The minimal main/replica instance the replication unit tests run: a DBMS with one database, its replication state
+// and a replication handler. Shared between the in-process tests and the process-isolated replica role.
+
+#include <memory>
+
+#include "auth/auth.hpp"
+#include "dbms/database.hpp"
+#include "dbms/database_protector.hpp"
+#include "dbms/dbms_handler.hpp"
+#include "parameters/parameters.hpp"
+#include "replication/state.hpp"
+#include "replication_handler/replication_handler.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "system/system.hpp"
+#include "utils/rw_spin_lock.hpp"
+#include "utils/synchronized.hpp"
+
+namespace memgraph::tests {
+
+inline auto MakeCommitArgs(const memgraph::dbms::DatabaseAccess &db_acc) -> memgraph::storage::CommitArgs {
+  return memgraph::storage::CommitArgs::make_main(std::make_unique<memgraph::dbms::DatabaseProtector>(db_acc));
+}
+
+struct MinMemgraph {
+  explicit MinMemgraph(const memgraph::storage::Config &conf)
+      : auth{conf.durability.storage_directory / "auth", memgraph::auth::Auth::Config{/* default */}},
+        parameters_{conf.durability.storage_directory},
+        repl_state{ReplicationStateRootPath(conf)},
+        dbms{conf},
+        db_acc{dbms.Get()},
+        db{*db_acc.get()},
+        repl_handler(repl_state, dbms, system_
+#ifdef MG_ENTERPRISE
+                     ,
+                     auth
+#endif
+                     ,
+                     parameters_) {
+  }
+
+  auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> { return db.ReadOnlyAccess(); }
+
+  auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
+    return db.Access(memgraph::storage::StorageAccessType::READ);
+  }
+
+  ~MinMemgraph() {
+    auto locked_repl_state = repl_state.Lock();
+    if (locked_repl_state->IsReplica()) {
+      auto &replica_data = std::get<memgraph::replication::RoleReplicaData>(locked_repl_state->ReplicationData());
+      replica_data.server.reset();
+    } else if (locked_repl_state->IsMain()) {
+      auto &main_data = std::get<memgraph::replication::RoleMainData>(locked_repl_state->ReplicationData());
+      for (auto &client : main_data.registered_replicas_) {
+        client.Shutdown();
+      }
+      dbms.ForEach([](memgraph::dbms::DatabaseAccess db_acc) {
+        auto *storage = db_acc->storage();
+        storage->repl_storage_state_.replication_storage_clients_.WithLock([](auto &clients) { clients.clear(); });
+      });
+    }
+  }
+
+  memgraph::auth::SynchedAuth auth;
+  memgraph::system::System system_;
+  memgraph::parameters::Parameters parameters_;
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state;
+  memgraph::dbms::DbmsHandler dbms;
+  memgraph::dbms::DatabaseAccess db_acc;
+  memgraph::dbms::Database &db;
+  memgraph::replication::ReplicationHandler repl_handler;
+};
+
+}  // namespace memgraph::tests

--- a/tests/unit/replication_process_fixture.hpp
+++ b/tests/unit/replication_process_fixture.hpp
@@ -22,11 +22,15 @@
 //   replica -> controller: "ready" once the replication server listens; "prepared <ts>" after a prepare response was
 //   sent; "abort_applied <ts>" after an abort decision was applied.
 
+#include <fcntl.h>
 #include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <gtest/gtest.h>
+
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <csignal>
 #include <cstring>
@@ -38,6 +42,7 @@
 #include <thread>
 #include <vector>
 
+#include "dbms/inmemory/replication_handlers.hpp"
 #include "io/network/endpoint.hpp"
 #include "replication/config.hpp"
 #include "storage/v2/commit_probe.hpp"
@@ -49,20 +54,32 @@ namespace memgraph::tests {
 constexpr char kReplicaRoleFlag[] = "--mg-replica-role";
 
 // The replica role: runs until "quit" on stdin. Arguments: <port> <data-directory>.
+// Writes the whole buffer, retrying on EINTR; false when the peer is gone.
+inline bool WriteAll(int fd, std::string const &data) {
+  size_t written = 0;
+  while (written < data.size()) {
+    auto const n = write(fd, data.data() + written, data.size() - written);
+    if (n < 0 && errno == EINTR) continue;
+    if (n <= 0) return false;
+    written += static_cast<size_t>(n);
+  }
+  return true;
+}
+
 inline int RunReplicaRole(int argc, char **argv) {
   if (argc < 4) return 2;
+  // The IPC channel is the inherited stdout; point fd 1 at stderr so nothing the logger prints can be parsed as an
+  // event.
+  int const ipc_fd = dup(STDOUT_FILENO);
+  dup2(STDERR_FILENO, STDOUT_FILENO);
+  signal(SIGPIPE, SIG_IGN);
   auto const port = static_cast<uint16_t>(std::stoi(argv[2]));
   std::filesystem::path const data_dir{argv[3]};
   std::filesystem::remove_all(data_dir);
   std::filesystem::create_directories(data_dir);
-  auto const emit = [](std::string line) {
+  auto const emit = [ipc_fd](std::string line) {
     line.push_back('\n');
-    size_t written = 0;
-    while (written < line.size()) {
-      auto const n = write(STDOUT_FILENO, line.data() + written, line.size() - written);
-      if (n <= 0) return;
-      written += static_cast<size_t>(n);
-    }
+    static_cast<void>(WriteAll(ipc_fd, line));
   };
 
   storage::Config config{
@@ -92,6 +109,7 @@ inline int RunReplicaRole(int argc, char **argv) {
   char chunk[256];
   while (true) {
     auto const n = read(STDIN_FILENO, chunk, sizeof(chunk));
+    if (n < 0 && errno == EINTR) continue;
     if (n <= 0) break;  // the controller went away
     buffer.append(chunk, static_cast<size_t>(n));
     size_t newline = 0;
@@ -107,6 +125,9 @@ inline int RunReplicaRole(int argc, char **argv) {
       } else if (command == "quit") {
         emit("ok");
         static_cast<storage::InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+        // A prepared transaction the main never decided on (it was killed by a death test) lives in the static 2PC
+        // cache and would be destroyed after the storage; abort it while the storage is still alive.
+        dbms::InMemoryReplicationHandlers::AbortTwoPCForTenant(replica.db.storage()->uuid());
         return 0;
       } else {
         emit("unknown");
@@ -121,15 +142,21 @@ inline int RunReplicaRole(int argc, char **argv) {
 class ReplicaProcess {
  public:
   ReplicaProcess(uint16_t port, std::filesystem::path data_dir) : port_{port}, data_dir_{std::move(data_dir)} {
+    signal(SIGPIPE, SIG_IGN);  // a dead replica must not take the controller down on the next Send
     int to_child[2];
     int from_child[2];
-    if (pipe(to_child) != 0 || pipe(from_child) != 0) throw std::runtime_error("pipe failed");
+    // Close-on-exec so a later spawn does not inherit an earlier replica's pipe ends (which would defeat the
+    // "controller went away" EOF); the dup2 file actions clear the flag on the child's own ends.
+    if (pipe2(to_child, O_CLOEXEC) != 0) throw std::runtime_error("pipe failed");
+    if (pipe2(from_child, O_CLOEXEC) != 0) {
+      close(to_child[0]);
+      close(to_child[1]);
+      throw std::runtime_error("pipe failed");
+    }
     posix_spawn_file_actions_t actions;
     posix_spawn_file_actions_init(&actions);
     posix_spawn_file_actions_adddup2(&actions, to_child[0], STDIN_FILENO);
     posix_spawn_file_actions_adddup2(&actions, from_child[1], STDOUT_FILENO);
-    posix_spawn_file_actions_addclose(&actions, to_child[1]);
-    posix_spawn_file_actions_addclose(&actions, from_child[0]);
     auto const port_arg = std::to_string(port_);
     auto const dir_arg = data_dir_.string();
     std::vector<char *> argv{const_cast<char *>("/proc/self/exe"),
@@ -141,7 +168,12 @@ class ReplicaProcess {
     posix_spawn_file_actions_destroy(&actions);
     close(to_child[0]);
     close(from_child[1]);
-    if (rc != 0) throw std::runtime_error("posix_spawn failed");
+    if (rc != 0) {
+      close(to_child[1]);
+      close(from_child[0]);
+      pid_ = -1;
+      throw std::runtime_error("posix_spawn failed");
+    }
     stdin_fd_ = to_child[1];
     stdout_fd_ = from_child[0];
     reader_ = std::thread{[this] { ReadLoop(); }};
@@ -150,17 +182,25 @@ class ReplicaProcess {
   ReplicaProcess(ReplicaProcess const &) = delete;
   ReplicaProcess &operator=(ReplicaProcess const &) = delete;
 
+  // Asks the replica to quit, reaps it (SIGKILL after 10 s) and records how it ended; a replica that crashed
+  // rather than exited is reported as a test failure.
   ~ReplicaProcess() {
     if (pid_ > 0) {
       static_cast<void>(Send("quit"));
       int status = 0;
+      pid_t reaped = 0;
       auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-      while (waitpid(pid_, &status, WNOHANG) == 0 && std::chrono::steady_clock::now() < deadline) {
+      while ((reaped = waitpid(pid_, &status, WNOHANG)) == 0 && std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
       }
-      if (waitpid(pid_, &status, WNOHANG) == 0) {
+      if (reaped == 0) {
         kill(pid_, SIGKILL);
-        waitpid(pid_, &status, 0);
+        reaped = waitpid(pid_, &status, 0);
+        ADD_FAILURE() << "replica process on port " << port_ << " did not quit and was killed";
+      } else if (reaped == pid_ && WIFSIGNALED(status)) {
+        ADD_FAILURE() << "replica process on port " << port_ << " died with signal " << WTERMSIG(status);
+      } else if (reaped == pid_ && WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+        ADD_FAILURE() << "replica process on port " << port_ << " exited with status " << WEXITSTATUS(status);
       }
     }
     if (stdin_fd_ >= 0) close(stdin_fd_);
@@ -180,13 +220,7 @@ class ReplicaProcess {
 
   // Sends one command and waits for its acknowledgement.
   bool Send(std::string const &command, std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
-    auto line = command + "\n";
-    size_t written = 0;
-    while (written < line.size()) {
-      auto const n = write(stdin_fd_, line.data() + written, line.size() - written);
-      if (n <= 0) return false;
-      written += static_cast<size_t>(n);
-    }
+    if (!WriteAll(stdin_fd_, command + "\n")) return false;
     return WaitEvent("ok", timeout).has_value();
   }
 
@@ -225,6 +259,7 @@ class ReplicaProcess {
     char chunk[256];
     while (true) {
       auto const n = read(stdout_fd_, chunk, sizeof(chunk));
+      if (n < 0 && errno == EINTR) continue;
       if (n <= 0) return;
       buffer.append(chunk, static_cast<size_t>(n));
       size_t newline = 0;

--- a/tests/unit/replication_process_fixture.hpp
+++ b/tests/unit/replication_process_fixture.hpp
@@ -1,0 +1,249 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+// Process-isolated replica fixture. The replica handlers' two-phase-commit cache is static and process-global, so
+// several replicas in one process would share one prepared-accessor slot; every test with more than one real
+// replica server launches each replica as a fresh executable (this test binary in its replica role) through
+// posix_spawn, with MinMemgraph constructed only there. Fault selection and observations travel over pipes; the
+// controller (the test process) owns and reaps every role process.
+//
+// Protocol (one line per message):
+//   controller -> replica: "refuse_prepare", "refuse_abort_decision", "quit"; each answered with "ok".
+//   replica -> controller: "ready" once the replication server listens; "prepared <ts>" after a prepare response was
+//   sent; "abort_applied <ts>" after an abort decision was applied.
+
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstring>
+#include <deque>
+#include <filesystem>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "io/network/endpoint.hpp"
+#include "replication/config.hpp"
+#include "storage/v2/commit_probe.hpp"
+#include "storage/v2/config.hpp"
+#include "tests/unit/replication_min_memgraph.hpp"
+
+namespace memgraph::tests {
+
+constexpr char kReplicaRoleFlag[] = "--mg-replica-role";
+
+// The replica role: runs until "quit" on stdin. Arguments: <port> <data-directory>.
+inline int RunReplicaRole(int argc, char **argv) {
+  if (argc < 4) return 2;
+  auto const port = static_cast<uint16_t>(std::stoi(argv[2]));
+  std::filesystem::path const data_dir{argv[3]};
+  std::filesystem::remove_all(data_dir);
+  std::filesystem::create_directories(data_dir);
+  auto const emit = [](std::string line) {
+    line.push_back('\n');
+    size_t written = 0;
+    while (written < line.size()) {
+      auto const n = write(STDOUT_FILENO, line.data() + written, line.size() - written);
+      if (n <= 0) return;
+      written += static_cast<size_t>(n);
+    }
+  };
+
+  storage::Config config{
+      .durability =
+          {
+              .root_data_directory = data_dir,
+              .snapshot_wal_mode = storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+          },
+      .salient.items = {.properties_on_edges = true},
+      .register_metrics = false,
+  };
+  storage::UpdatePaths(config, data_dir);
+  MinMemgraph replica(config);
+  std::atomic<bool> refuse_prepare{false};
+  std::atomic<bool> refuse_abort_decision{false};
+  storage::ReplicationTestHooks hooks;
+  hooks.refuse_next_prepare = [&](uint64_t) { return refuse_prepare.exchange(false); };
+  hooks.refuse_next_abort_decision = [&](uint64_t) { return refuse_abort_decision.exchange(false); };
+  hooks.on_prepared = [&](uint64_t ts) { emit("prepared " + std::to_string(ts)); };
+  hooks.on_abort_applied = [&](uint64_t ts) { emit("abort_applied " + std::to_string(ts)); };
+  static_cast<storage::InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&hooks);
+  replica.repl_handler.TrySetReplicationRoleReplica(
+      replication::ReplicationServerConfig{.repl_server = io::network::Endpoint("127.0.0.1", port)});
+  emit("ready");
+
+  std::string buffer;
+  char chunk[256];
+  while (true) {
+    auto const n = read(STDIN_FILENO, chunk, sizeof(chunk));
+    if (n <= 0) break;  // the controller went away
+    buffer.append(chunk, static_cast<size_t>(n));
+    size_t newline = 0;
+    while ((newline = buffer.find('\n')) != std::string::npos) {
+      auto const command = buffer.substr(0, newline);
+      buffer.erase(0, newline + 1);
+      if (command == "refuse_prepare") {
+        refuse_prepare = true;
+        emit("ok");
+      } else if (command == "refuse_abort_decision") {
+        refuse_abort_decision = true;
+        emit("ok");
+      } else if (command == "quit") {
+        emit("ok");
+        static_cast<storage::InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+        return 0;
+      } else {
+        emit("unknown");
+      }
+    }
+  }
+  static_cast<storage::InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+  return 0;
+}
+
+// A replica running in its own process, owned and reaped by the test.
+class ReplicaProcess {
+ public:
+  ReplicaProcess(uint16_t port, std::filesystem::path data_dir) : port_{port}, data_dir_{std::move(data_dir)} {
+    int to_child[2];
+    int from_child[2];
+    if (pipe(to_child) != 0 || pipe(from_child) != 0) throw std::runtime_error("pipe failed");
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_adddup2(&actions, to_child[0], STDIN_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, from_child[1], STDOUT_FILENO);
+    posix_spawn_file_actions_addclose(&actions, to_child[1]);
+    posix_spawn_file_actions_addclose(&actions, from_child[0]);
+    auto const port_arg = std::to_string(port_);
+    auto const dir_arg = data_dir_.string();
+    std::vector<char *> argv{const_cast<char *>("/proc/self/exe"),
+                             const_cast<char *>(kReplicaRoleFlag),
+                             const_cast<char *>(port_arg.c_str()),
+                             const_cast<char *>(dir_arg.c_str()),
+                             nullptr};
+    auto const rc = posix_spawn(&pid_, "/proc/self/exe", &actions, nullptr, argv.data(), environ);
+    posix_spawn_file_actions_destroy(&actions);
+    close(to_child[0]);
+    close(from_child[1]);
+    if (rc != 0) throw std::runtime_error("posix_spawn failed");
+    stdin_fd_ = to_child[1];
+    stdout_fd_ = from_child[0];
+    reader_ = std::thread{[this] { ReadLoop(); }};
+  }
+
+  ReplicaProcess(ReplicaProcess const &) = delete;
+  ReplicaProcess &operator=(ReplicaProcess const &) = delete;
+
+  ~ReplicaProcess() {
+    if (pid_ > 0) {
+      static_cast<void>(Send("quit"));
+      int status = 0;
+      auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+      while (waitpid(pid_, &status, WNOHANG) == 0 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      }
+      if (waitpid(pid_, &status, WNOHANG) == 0) {
+        kill(pid_, SIGKILL);
+        waitpid(pid_, &status, 0);
+      }
+    }
+    if (stdin_fd_ >= 0) close(stdin_fd_);
+    if (reader_.joinable()) reader_.join();
+    if (stdout_fd_ >= 0) close(stdout_fd_);
+    std::filesystem::remove_all(data_dir_);
+  }
+
+  auto port() const -> uint16_t { return port_; }
+
+  auto endpoint() const -> io::network::Endpoint { return io::network::Endpoint("127.0.0.1", port_); }
+
+  // Blocks until the replica reports that its server listens.
+  bool WaitReady(std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
+    return WaitEvent("ready", timeout).has_value();
+  }
+
+  // Sends one command and waits for its acknowledgement.
+  bool Send(std::string const &command, std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
+    auto line = command + "\n";
+    size_t written = 0;
+    while (written < line.size()) {
+      auto const n = write(stdin_fd_, line.data() + written, line.size() - written);
+      if (n <= 0) return false;
+      written += static_cast<size_t>(n);
+    }
+    return WaitEvent("ok", timeout).has_value();
+  }
+
+  // Waits for the next event line starting with `prefix` and returns it (consumed); other events stay queued.
+  std::optional<std::string> WaitEvent(std::string const &prefix, std::chrono::milliseconds timeout) {
+    auto const deadline = std::chrono::steady_clock::now() + timeout;
+    while (true) {
+      {
+        auto guard = std::lock_guard{mutex_};
+        for (auto it = events_.begin(); it != events_.end(); ++it) {
+          if (it->starts_with(prefix)) {
+            auto event = *it;
+            events_.erase(it);
+            return event;
+          }
+        }
+      }
+      if (std::chrono::steady_clock::now() > deadline) return std::nullopt;
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  // Number of queued events starting with `prefix` (not consumed).
+  size_t CountEvents(std::string const &prefix) {
+    auto guard = std::lock_guard{mutex_};
+    size_t count = 0;
+    for (auto const &event : events_) {
+      if (event.starts_with(prefix)) ++count;
+    }
+    return count;
+  }
+
+ private:
+  void ReadLoop() {
+    std::string buffer;
+    char chunk[256];
+    while (true) {
+      auto const n = read(stdout_fd_, chunk, sizeof(chunk));
+      if (n <= 0) return;
+      buffer.append(chunk, static_cast<size_t>(n));
+      size_t newline = 0;
+      while ((newline = buffer.find('\n')) != std::string::npos) {
+        auto guard = std::lock_guard{mutex_};
+        events_.push_back(buffer.substr(0, newline));
+        buffer.erase(0, newline + 1);
+      }
+    }
+  }
+
+  uint16_t port_;
+  std::filesystem::path data_dir_;
+  pid_t pid_{-1};
+  int stdin_fd_{-1};
+  int stdout_fd_{-1};
+  std::thread reader_;
+  std::mutex mutex_;
+  std::deque<std::string> events_;
+};
+
+}  // namespace memgraph::tests

--- a/tests/unit/replication_process_fixture.hpp
+++ b/tests/unit/replication_process_fixture.hpp
@@ -126,7 +126,9 @@ inline int RunReplicaRole(int argc, char **argv) {
         emit("ok");
         static_cast<storage::InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
         // A prepared transaction the main never decided on (it was killed by a death test) lives in the static 2PC
-        // cache and would be destroyed after the storage; abort it while the storage is still alive.
+        // cache and would be destroyed after the storage; abort it while the storage is still alive. The abort
+        // hands the transaction's deltas to GC, so it runs under the database's arena scope like any storage work.
+        const memory::DbArenaScope arena_scope{&replica.db.Arena()};
         dbms::InMemoryReplicationHandlers::AbortTwoPCForTenant(replica.db.storage()->uuid());
         return 0;
       } else {

--- a/tests/unit/storage_v2_buffer_encoder.cpp
+++ b/tests/unit/storage_v2_buffer_encoder.cpp
@@ -1,0 +1,139 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "storage/v2/durability/buffer_encoder.hpp"
+#include "storage/v2/durability/marker.hpp"
+#include "storage/v2/durability/serialization.hpp"
+#include "storage/v2/pipeline_budget.hpp"
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/temporal.hpp"
+#include "utils/file.hpp"
+
+using namespace memgraph::storage;
+using namespace memgraph::storage::durability;
+
+namespace {
+
+uint32_t WriteAll(BaseEncoder &e) {
+  e.ResetCrcAcc();
+  e.WriteMarker(Marker::SECTION_DELTA);
+  e.WriteUint(42);
+  e.WriteBool(true);
+  e.WriteDouble(3.5);
+  e.WriteString("pipelined");
+  e.WriteExternalPropertyValue(ExternalPropertyValue(
+      std::vector<ExternalPropertyValue>{ExternalPropertyValue(int64_t{1}), ExternalPropertyValue("x")}));
+  ExternalPropertyValue::map_t map;
+  map.emplace("k", ExternalPropertyValue(2.0));
+  e.WriteExternalPropertyValue(ExternalPropertyValue(std::move(map)));
+  e.WriteExternalPropertyValue(ExternalPropertyValue(TemporalData{TemporalType::Date, 17}));
+  return e.WriteCrc();
+}
+
+}  // namespace
+
+TEST(BufferEncoder, MatchesFileEncoderBytesAndCrc) {
+  auto const dir = std::filesystem::temp_directory_path() / "mg_buffer_encoder_test";
+  std::filesystem::remove_all(dir);
+  std::filesystem::create_directories(dir);
+  Encoder<memgraph::utils::OutputFile> file_encoder;
+  ASSERT_TRUE(file_encoder.Initialize(dir / "reference.bin", "TEST", 1));
+  auto const header_size = file_encoder.GetPosition();
+  PipelineBudget budget{1 << 20};
+  BufferEncoder buffer_encoder{TxnAllocPolicy{&budget, 0}};
+  auto const crc_file = WriteAll(file_encoder);
+  auto const crc_buffer = WriteAll(buffer_encoder);
+  file_encoder.Finalize();
+  memgraph::utils::InputFile file;
+  ASSERT_TRUE(file.Open(dir / "reference.bin"));
+  std::vector<uint8_t> reference(file.GetSize() - header_size);
+  ASSERT_TRUE(file.SetPosition(memgraph::utils::InputFile::Position::SET, header_size).has_value());
+  ASSERT_TRUE(file.Read(reference.data(), reference.size()));
+  auto const bytes = buffer_encoder.bytes();
+  EXPECT_EQ(std::vector<uint8_t>(bytes.begin(), bytes.end()), reference);
+  EXPECT_EQ(crc_buffer, crc_file);
+  EXPECT_EQ(buffer_encoder.GetPosition(), reference.size());
+  EXPECT_GE(buffer_encoder.charged_bytes(), reference.size());
+  EXPECT_EQ(budget.InFlightBytes(), buffer_encoder.charged_bytes());
+  std::filesystem::remove_all(dir);
+}
+
+TEST(BufferEncoder, BudgetIsChargedBeforeGrowthAndReleasedOnDestruction) {
+  PipelineBudget budget{200};
+  {
+    BufferEncoder e{TxnAllocPolicy{&budget, 0}};
+    e.WriteString(std::string(100, 'a'));  // fits
+    EXPECT_THROW(e.WriteString(std::string(300, 'b')), PipelineBudgetExceeded);
+    EXPECT_LE(budget.InFlightBytes(), 200);                // never charged beyond max
+    EXPECT_EQ(budget.InFlightBytes(), e.charged_bytes());  // the failed growth released its charge
+    EXPECT_GT(e.charged_bytes(), 0);
+  }
+  EXPECT_EQ(budget.InFlightBytes(), 0);
+}
+
+TEST(BufferEncoder, NullBudgetNeverChargesOrRefuses) {
+  BufferEncoder e{TxnAllocPolicy{nullptr, 0}};
+  e.WriteString(std::string(1 << 16, 'c'));
+  EXPECT_EQ(e.charged_bytes(), 0);
+  EXPECT_EQ(e.GetPosition(), (1 << 16) + 1 + sizeof(uint64_t));
+}
+
+TEST(BudgetAllocator, RefusalInjectionFiresOnceForTheSelectedTicketAndSite) {
+  PipelineBudget budget{1 << 20};
+  BudgetRefuse refuse;
+  refuse.ticket = 7;
+  refuse.site = BudgetRefuse::kEncoder;
+  // A different ticket at the same site is untouched.
+  {
+    BufferEncoder other{TxnAllocPolicy{&budget, 8, &refuse, BudgetRefuse::kEncoder}};
+    other.WriteUint(1);
+    EXPECT_FALSE(refuse.fired.load());
+  }
+  // The same ticket at a different site is untouched.
+  {
+    BudgetVector<int> materializer{
+        BudgetAllocator<int>{TxnAllocPolicy{&budget, 7, &refuse, BudgetRefuse::kMaterializer}}};
+    materializer.push_back(1);
+    EXPECT_FALSE(refuse.fired.load());
+  }
+  // The selected committer's first allocation at the site throws, later ones proceed.
+  {
+    BufferEncoder selected{TxnAllocPolicy{&budget, 7, &refuse, BudgetRefuse::kEncoder}};
+    EXPECT_THROW(selected.WriteUint(1), PipelineBudgetExceeded);
+    EXPECT_TRUE(refuse.fired.load());
+    selected.WriteUint(1);
+    EXPECT_EQ(selected.GetPosition(), 1 + sizeof(uint64_t));
+  }
+  EXPECT_EQ(budget.InFlightBytes(), 0);
+  // The runtime-error mode is the generic fault.
+  refuse.fired = false;
+  refuse.mode = BudgetRefuse::kThrowRuntimeError;
+  BufferEncoder faulted{TxnAllocPolicy{&budget, 7, &refuse, BudgetRefuse::kEncoder}};
+  EXPECT_THROW(faulted.WriteUint(1), std::runtime_error);
+}
+
+TEST(BudgetAllocator, ReboundContainersChargeAndRelease) {
+  PipelineBudget budget{1 << 20};
+  {
+    std::unordered_set<int, std::hash<int>, std::equal_to<>, BudgetAllocator<int>> set{
+        BudgetAllocator<int>{TxnAllocPolicy{&budget, 0}}};
+    for (int i = 0; i < 1000; ++i) set.insert(i);
+    EXPECT_GT(budget.InFlightBytes(), 1000 * sizeof(int));
+  }
+  EXPECT_EQ(budget.InFlightBytes(), 0);
+}

--- a/tests/unit/storage_v2_commit_order_gate.cpp
+++ b/tests/unit/storage_v2_commit_order_gate.cpp
@@ -1,0 +1,205 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <latch>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "storage/v2/commit_order_gate.hpp"
+
+using memgraph::storage::CommitOrderGate;
+using memgraph::storage::CommitTicket;
+
+namespace {
+
+template <class Pred>
+bool WaitFor(Pred pred, std::chrono::milliseconds timeout) {
+  auto const deadline = std::chrono::steady_clock::now() + timeout;
+  while (!pred()) {
+    if (std::chrono::steady_clock::now() > deadline) return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  return true;
+}
+
+}  // namespace
+
+TEST(CommitOrderGate, EntersInTicketOrderWhateverTheArrivalOrder) {
+  CommitOrderGate gate;
+  constexpr uint64_t kTickets = 64;
+  // Issue in mint order (the storage does this under engine_lock_).
+  std::vector<std::unique_ptr<CommitTicket>> tickets;
+  tickets.reserve(kTickets);
+  for (uint64_t t = 1; t <= kTickets; ++t) tickets.push_back(std::make_unique<CommitTicket>(gate, t));
+  EXPECT_EQ(gate.Pending(), kTickets);
+
+  // Arrive at the gate in a shuffled order; every entrant records its exit order.
+  std::vector<size_t> order(kTickets);
+  std::iota(order.begin(), order.end(), 0);
+  std::shuffle(order.begin(), order.end(), std::mt19937{42});
+  std::mutex exits_mutex;
+  std::vector<uint64_t> exits;
+  std::latch all_started{kTickets};
+  std::vector<std::thread> threads;
+  threads.reserve(kTickets);
+  for (auto const index : order) {
+    threads.emplace_back([&, index] {
+      all_started.count_down();
+      all_started.wait();
+      auto &ticket = *tickets[index];
+      ticket.Enter();
+      {
+        auto guard = std::lock_guard{exits_mutex};
+        exits.push_back(ticket.ticket());
+      }
+      ticket.MarkPublished();
+      ticket.Retire();
+    });
+  }
+  for (auto &thread : threads) thread.join();
+  ASSERT_EQ(exits.size(), kTickets);
+  EXPECT_TRUE(std::ranges::is_sorted(exits));
+  EXPECT_EQ(gate.Pending(), 0);
+}
+
+TEST(CommitOrderGate, LaterTicketWaitsForEarlierIssuedEarlier) {
+  CommitOrderGate gate;
+  CommitTicket first{gate, 10};
+  CommitTicket second{gate, 11};
+  std::atomic<bool> second_entered{false};
+  std::thread waiter{[&] {
+    second.Enter();
+    second_entered = true;
+  }};
+  EXPECT_FALSE(WaitFor([&] { return second_entered.load(); }, std::chrono::milliseconds(200)));
+  first.Enter();
+  EXPECT_FALSE(second_entered.load());
+  first.MarkAborted();
+  first.Retire();
+  EXPECT_TRUE(WaitFor([&] { return second_entered.load(); }, std::chrono::seconds(5)));
+  waiter.join();
+  second.MarkPublished();
+  second.Retire();
+  EXPECT_EQ(gate.Pending(), 0);
+}
+
+TEST(CommitOrderGate, WaitIdleBlocksUntilAllRetired) {
+  CommitOrderGate gate;
+  std::optional<CommitTicket> a;
+  std::optional<CommitTicket> b;
+  a.emplace(gate, 1);
+  b.emplace(gate, 2);
+  std::atomic<bool> idle{false};
+  std::thread waiter{[&] {
+    gate.WaitIdle();
+    idle = true;
+  }};
+  EXPECT_FALSE(WaitFor([&] { return idle.load(); }, std::chrono::milliseconds(200)));
+  a->Enter();
+  a->MarkPublished();
+  a->Retire();
+  EXPECT_FALSE(WaitFor([&] { return idle.load(); }, std::chrono::milliseconds(200)));
+  b->Enter();
+  b->MarkAborted();
+  b->Retire();
+  EXPECT_TRUE(WaitFor([&] { return idle.load(); }, std::chrono::seconds(5)));
+  waiter.join();
+  // An idle gate returns immediately.
+  gate.WaitIdle();
+  EXPECT_EQ(gate.Pending(), 0);
+}
+
+namespace {
+
+void RetireWithoutMark() {
+  CommitOrderGate gate;
+  CommitTicket ticket{gate, 1};
+  ticket.Enter();
+  ticket.Retire();
+}
+
+void RetireTwice() {
+  CommitOrderGate gate;
+  CommitTicket ticket{gate, 1};
+  ticket.Enter();
+  ticket.MarkPublished();
+  ticket.Retire();
+  ticket.Retire();
+}
+
+void DestroyRegisteredTicket() {
+  CommitOrderGate gate;
+  CommitTicket ticket{gate, 1};
+}
+
+void DestroyPublishedUnretiredTicket() {
+  CommitOrderGate gate;
+  CommitTicket ticket{gate, 1};
+  ticket.Enter();
+  ticket.MarkPublished();
+}
+
+}  // namespace
+
+TEST(CommitOrderGate, RetireRequiresTerminalMark) {
+  {
+    CommitOrderGate gate;
+    CommitTicket ticket{gate, 1};
+    ticket.Enter();
+    EXPECT_TRUE(ticket.entered());
+    EXPECT_FALSE(ticket.terminal());
+    ticket.MarkAborted();
+    EXPECT_TRUE(ticket.terminal());
+    ticket.Retire();
+    EXPECT_TRUE(ticket.retired());
+    EXPECT_EQ(gate.Pending(), 0);
+  }
+  EXPECT_DEATH(RetireWithoutMark(), "");
+  EXPECT_DEATH(RetireTwice(), "");
+}
+
+TEST(CommitOrderGate, DestructorTerminatesOnUnretiredTicket) {
+  EXPECT_DEATH(DestroyRegisteredTicket(), "");
+  EXPECT_DEATH(DestroyPublishedUnretiredTicket(), "");
+}
+
+TEST(CommitOrderGate, RecordStateAndIrreversibleMarks) {
+  CommitOrderGate gate;
+  CommitTicket ticket{gate, 3};
+  EXPECT_EQ(ticket.record_state(), CommitTicket::RecordState::not_started);
+  EXPECT_FALSE(ticket.incomplete_record());
+  ticket.BeginRecord();
+  EXPECT_TRUE(ticket.incomplete_record());
+  ticket.EndRecord();
+  EXPECT_EQ(ticket.record_state(), CommitTicket::RecordState::complete);
+  EXPECT_FALSE(ticket.irreversible());
+  ticket.MarkIrreversible();
+  EXPECT_TRUE(ticket.irreversible());
+  ticket.Enter();
+  ticket.MarkPublished();
+  ticket.Retire();
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  return RUN_ALL_TESTS();
+}

--- a/tests/unit/storage_v2_commit_order_gate.cpp
+++ b/tests/unit/storage_v2_commit_order_gate.cpp
@@ -129,6 +129,8 @@ TEST(CommitOrderGate, WaitIdleBlocksUntilAllRetired) {
 
 namespace {
 
+// The assertion message itself goes to the logger, not to stderr, so the death matcher checks the std::terminate
+// call MG_ASSERT ends in rather than the message text.
 void RetireWithoutMark() {
   CommitOrderGate gate;
   CommitTicket ticket{gate, 1};
@@ -172,13 +174,13 @@ TEST(CommitOrderGate, RetireRequiresTerminalMark) {
     EXPECT_TRUE(ticket.retired());
     EXPECT_EQ(gate.Pending(), 0);
   }
-  EXPECT_DEATH(RetireWithoutMark(), "");
-  EXPECT_DEATH(RetireTwice(), "");
+  EXPECT_DEATH(RetireWithoutMark(), "terminate called");
+  EXPECT_DEATH(RetireTwice(), "terminate called");
 }
 
 TEST(CommitOrderGate, DestructorTerminatesOnUnretiredTicket) {
-  EXPECT_DEATH(DestroyRegisteredTicket(), "");
-  EXPECT_DEATH(DestroyPublishedUnretiredTicket(), "");
+  EXPECT_DEATH(DestroyRegisteredTicket(), "terminate called");
+  EXPECT_DEATH(DestroyPublishedUnretiredTicket(), "terminate called");
 }
 
 TEST(CommitOrderGate, RecordStateAndIrreversibleMarks) {

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -3450,7 +3450,8 @@ TEST_P(DurabilityTest, PipelinedWalDeathResilience) {
   constexpr int kWriters = 6;
   pid_t pid = fork();
   if (pid == 0) {
-    {
+    // The child never returns into gtest: it runs until it is killed, and any failure exits explicitly.
+    try {
       memgraph::storage::Config config{
           .durability = {.storage_directory = storage_directory,
                          .snapshot_wal_mode =
@@ -3494,7 +3495,10 @@ TEST_P(DurabilityTest, PipelinedWalDeathResilience) {
         });
       }
       for (auto &t : writers) t.join();
+    } catch (...) {
+      _exit(1);
     }
+    _exit(0);
   } else if (pid > 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1500 + (std::random_device{}() % 1000)));
     int status;
@@ -3510,6 +3514,7 @@ TEST_P(DurabilityTest, PipelinedWalDeathResilience) {
 
   // Every complete transaction in every WAL file is strictly ordered by commit timestamp with a valid CRC; only the
   // last file may end in an unfinished tail.
+  size_t complete_transactions = 0;
   {
     using namespace memgraph::storage::durability;
     auto wal_files = GetWalFiles(storage_directory / kWalDirectory);
@@ -3547,10 +3552,12 @@ TEST_P(DurabilityTest, PipelinedWalDeathResilience) {
     ASSERT_GT(complete, kWriters);
     EXPECT_TRUE(std::ranges::is_sorted(starts));
     EXPECT_TRUE(std::ranges::adjacent_find(starts) == starts.end());
+    complete_transactions = complete;
   }
 
-  // Recovered values: every writer's counter is a valid round and the writers' rounds differ by no more than the
-  // number of in-flight transactions the pipeline allows before publication (bounded by the writer count).
+  // Recovered values form a prefix-consistent state: each writer's transactions are sequential and transaction r
+  // sets p = r, so a writer's recovered p equals its number of recovered transactions minus one, and the sum over
+  // writers of (p + 1) must equal the number of complete non-seed transactions found in the WAL.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
       .salient = {.items = {.properties_on_edges = GetParam(),
@@ -3562,14 +3569,17 @@ TEST_P(DurabilityTest, PipelinedWalDeathResilience) {
   auto acc = db.Access(memgraph::storage::WRITE);
   auto const prop = db.storage()->NameToProperty("p");
   size_t vertices = 0;
+  int64_t recovered_rounds = 0;
   for (auto v : acc->Vertices(memgraph::storage::View::OLD)) {
     ++vertices;
     auto const value = v.GetProperty(prop, memgraph::storage::View::OLD);
     ASSERT_TRUE(value.has_value());
     ASSERT_TRUE(value->IsInt());
-    EXPECT_GE(value->ValueInt(), -1);
+    ASSERT_GE(value->ValueInt(), -1);
+    recovered_rounds += value->ValueInt() + 1;
   }
   EXPECT_EQ(vertices, kWriters);
+  EXPECT_EQ(recovered_rounds, static_cast<int64_t>(complete_transactions) - kWriters);
   ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
 }
 

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <random>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -3436,6 +3437,140 @@ TEST_P(DurabilityTest, WalDeathResilience) {
     ASSERT_TRUE(edge.has_value());
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
+}
+
+// Pipelined-commit variant of WalDeathResilience: the child runs six pipelined writers with both experiment flags on
+// and is killed at a random point. The parent recovers and asserts every complete transaction is strictly ordered
+// with a valid CRC (an unfinished tail is tolerated) and that the recovered values form a prefix-consistent state.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST_P(DurabilityTest, PipelinedWalDeathResilience) {
+#if defined(__SANITIZE_THREAD__) || __has_feature(thread_sanitizer)
+  GTEST_SKIP() << "fork() with TSAN is not supported when other threads are running";
+#endif
+  constexpr int kWriters = 6;
+  pid_t pid = fork();
+  if (pid == 0) {
+    {
+      memgraph::storage::Config config{
+          .durability = {.storage_directory = storage_directory,
+                         .snapshot_wal_mode =
+                             memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                         .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
+                         .wal_file_size_kibibytes = 64,
+                         .wal_file_flush_every_n_tx = 1},
+          .salient = {.items = {.properties_on_edges = GetParam(),
+                                .enable_schema_info = false,
+                                .storage_light_edge = GetParam().light_edge}},
+      };
+      config.experimental_lockfree_read_snapshot = true;
+      config.experimental_pipelined_commit = true;
+      memgraph::dbms::Database db{config};
+      const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+      auto const prop = db.storage()->NameToProperty("p");
+      auto const writer_prop = db.storage()->NameToProperty("w");
+      std::vector<memgraph::storage::Gid> gids;
+      for (int w = 0; w < kWriters; ++w) {
+        auto acc = db.Access(memgraph::storage::WRITE);
+        auto v = acc->CreateVertex();
+        gids.push_back(v.Gid());
+        MG_ASSERT(v.SetProperty(writer_prop, memgraph::storage::PropertyValue(w)).has_value());
+        MG_ASSERT(v.SetProperty(prop, memgraph::storage::PropertyValue(-1)).has_value());
+        MG_ASSERT(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+      }
+      std::vector<std::thread> writers;
+      for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w] {
+          for (int r = 0;; ++r) {
+            auto acc = db.Access(memgraph::storage::WRITE);
+            auto v = acc->FindVertex(gids[w], memgraph::storage::View::NEW);
+            MG_ASSERT(v.has_value());
+            MG_ASSERT(v->SetProperty(prop, memgraph::storage::PropertyValue(r)).has_value());
+            MG_ASSERT(v->SetProperty(db.storage()->NameToProperty("s"),
+                                     memgraph::storage::PropertyValue(std::string(200, 'x')))
+                          .has_value());
+            MG_ASSERT(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value(),
+                      "Couldn't commit transaction!");
+          }
+        });
+      }
+      for (auto &t : writers) t.join();
+    }
+  } else if (pid > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500 + (std::random_device{}() % 1000)));
+    int status;
+    EXPECT_EQ(waitpid(pid, &status, WNOHANG), 0);
+    EXPECT_EQ(kill(pid, SIGKILL), 0);
+    EXPECT_EQ(waitpid(pid, &status, 0), pid);
+    EXPECT_NE(status, 0);
+  } else {
+    LOG_FATAL("Couldn't create process to execute test!");
+  }
+
+  ASSERT_GE(GetWalsList().size(), 1);
+
+  // Every complete transaction in every WAL file is strictly ordered by commit timestamp with a valid CRC; only the
+  // last file may end in an unfinished tail.
+  {
+    using namespace memgraph::storage::durability;
+    auto wal_files = GetWalFiles(storage_directory / kWalDirectory);
+    ASSERT_TRUE(wal_files.has_value());
+    std::ranges::sort(*wal_files, [](auto const &a, auto const &b) { return a.seq_num < b.seq_num; });
+    std::vector<uint64_t> starts;
+    size_t complete = 0;
+    for (auto const &wal_file : *wal_files) {
+      Decoder wal;
+      auto const version = wal.Initialize(wal_file.path, kWalMagic);
+      ASSERT_TRUE(version.has_value());
+      auto const info = ReadWalHeader(wal_file.path);
+      wal.SetPosition(info.offset_deltas);
+      wal.ResetCrcAcc();
+      bool const last = &wal_file == &wal_files->back();
+      while (true) {
+        uint64_t timestamp = 0;
+        WalDeltaData delta_data;
+        try {
+          timestamp = ReadWalDeltaHeader(&wal);
+          delta_data = ReadWalDeltaData(&wal);
+        } catch (RecoveryFailure const &) {
+          ASSERT_TRUE(last) << "an unfinished tail is only tolerated in the last file";
+          break;
+        }
+        if (std::get_if<WalTransactionStart>(&delta_data.data_) != nullptr) starts.push_back(timestamp);
+        if (std::get_if<WalTransactionEnd>(&delta_data.data_) != nullptr) {
+          ASSERT_TRUE(memgraph::utils::CrcAccumulator::Verify(wal.CrcAccValue()));
+          wal.ResetCrcAcc();
+          ++complete;
+        }
+        if (wal.GetPosition() >= wal.GetSize()) break;
+      }
+    }
+    ASSERT_GT(complete, kWriters);
+    EXPECT_TRUE(std::ranges::is_sorted(starts));
+    EXPECT_TRUE(std::ranges::adjacent_find(starts) == starts.end());
+  }
+
+  // Recovered values: every writer's counter is a valid round and the writers' rounds differ by no more than the
+  // number of in-flight transactions the pipeline allows before publication (bounded by the writer count).
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+      .salient = {.items = {.properties_on_edges = GetParam(),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+  auto acc = db.Access(memgraph::storage::WRITE);
+  auto const prop = db.storage()->NameToProperty("p");
+  size_t vertices = 0;
+  for (auto v : acc->Vertices(memgraph::storage::View::OLD)) {
+    ++vertices;
+    auto const value = v.GetProperty(prop, memgraph::storage::View::OLD);
+    ASSERT_TRUE(value.has_value());
+    ASSERT_TRUE(value->IsInt());
+    EXPECT_GE(value->ValueInt(), -1);
+  }
+  EXPECT_EQ(vertices, kWriters);
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -3481,6 +3481,10 @@ TEST_P(DurabilityTest, PipelinedWalDeathResilience) {
       std::vector<std::thread> writers;
       for (int w = 0; w < kWriters; ++w) {
         writers.emplace_back([&, w] {
+          // Every thread that allocates on behalf of a database runs under its arena scope, as the interpreter's
+          // worker threads do; without it the deltas land in the thread's default jemalloc arena and the scoped GC
+          // thread's debug ownership check fires when it frees them.
+          const memgraph::memory::DbArenaScope writer_scope{&db.Arena()};
           for (int r = 0;; ++r) {
             auto acc = db.Access(memgraph::storage::WRITE);
             auto v = acc->FindVertex(gids[w], memgraph::storage::View::NEW);

--- a/tests/unit/storage_v2_off_identity.cpp
+++ b/tests/unit/storage_v2_off_identity.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Deterministic flag-off identity harness for the pipelined-commit work. Runs a fixed accessor sequence on an
+// InMemoryStorage with a fixed UUID, epoch and WAL sequence number, GC and snapshots disabled and no background
+// activity, and leaves the finalized WAL files in the directory named on the command line. Built against two
+// revisions and run on each, the resulting WAL files must compare byte for byte (CRCs and summaries included).
+//
+//   storage_v2_off_identity <output-directory>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "storage/v2/config.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/view.hpp"
+#include "tests/test_commit_args_helper.hpp"
+
+using memgraph::storage::Config;
+using memgraph::storage::Gid;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::PropertyValue;
+using memgraph::storage::View;
+
+namespace {
+
+constexpr int kTransactions = 200;
+constexpr std::string_view kUuid = "0f6c1d2e-7b3a-4c5d-8e9f-0a1b2c3d4e5f";
+constexpr std::string_view kEpoch = "off-identity-epoch";
+
+int Run(std::filesystem::path const &out_dir) {
+  std::filesystem::remove_all(out_dir);
+  std::filesystem::create_directories(out_dir);
+
+  Config config;
+  config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  config.durability.snapshot_on_exit = false;
+  config.durability.snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::hours(24)};
+  config.durability.wal_file_flush_every_n_tx = 1;
+  config.gc.type = Config::Gc::Type::NONE;
+  config.salient.uuid.set(kUuid);
+  config.register_metrics = false;
+  memgraph::storage::UpdatePaths(config, out_dir);
+  {
+    auto storage = std::make_unique<InMemoryStorage>(config);
+    storage->repl_storage_state_.epoch_.SetEpoch(std::string{kEpoch});
+    auto const label = storage->NameToLabel("L");
+    auto const other = storage->NameToLabel("M");
+    auto const prop = storage->NameToProperty("p");
+    auto const text = storage->NameToProperty("t");
+    auto const edge_type = storage->NameToEdgeType("E");
+    std::vector<Gid> vertices;
+    std::vector<Gid> edges;
+    for (int i = 0; i < kTransactions; ++i) {
+      auto acc = storage->Access(memgraph::storage::WRITE);
+      auto const kind = i % 5;
+      if (kind == 0 || vertices.size() < 2) {
+        auto vertex = acc->CreateVertex();
+        vertices.push_back(vertex.Gid());
+        if (!vertex.SetProperty(prop, PropertyValue(i)).has_value()) return 2;
+      } else if (kind == 1) {
+        auto vertex = acc->FindVertex(vertices[i % vertices.size()], View::NEW);
+        if (!vertex || !vertex->AddLabel(i % 2 == 0 ? label : other).has_value()) return 2;
+      } else if (kind == 2) {
+        auto vertex = acc->FindVertex(vertices[i % vertices.size()], View::NEW);
+        if (!vertex || !vertex->SetProperty(text, PropertyValue("value-" + std::to_string(i))).has_value()) return 2;
+        if (!vertex->SetProperty(prop, PropertyValue(static_cast<double>(i) / 3.0)).has_value()) return 2;
+      } else if (kind == 3) {
+        auto from = acc->FindVertex(vertices[i % vertices.size()], View::NEW);
+        auto to = acc->FindVertex(vertices[(i + 1) % vertices.size()], View::NEW);
+        if (!from || !to) return 2;
+        auto edge = acc->CreateEdge(&*from, &*to, edge_type);
+        if (!edge.has_value()) return 2;
+        edges.push_back(edge->Gid());
+        if (!edge->SetProperty(prop, PropertyValue(i)).has_value()) return 2;
+      } else {
+        // Delete the oldest vertex still present (detaching its edges) roughly every fifth transaction, but keep at
+        // least two vertices so later transactions have something to touch.
+        if (vertices.size() > 2) {
+          auto victim = acc->FindVertex(vertices.front(), View::NEW);
+          if (!victim) return 2;
+          if (!acc->DetachDeleteVertex(&*victim).has_value()) return 2;
+          vertices.erase(vertices.begin());
+        } else {
+          auto vertex = acc->FindVertex(vertices.back(), View::NEW);
+          if (!vertex || !vertex->RemoveLabel(label).has_value()) return 2;
+        }
+      }
+      if (!acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) return 3;
+    }
+  }
+  // The storage destructor finalizes the current WAL file.
+  size_t files = 0;
+  for (auto const &entry : std::filesystem::directory_iterator(out_dir / "wal")) {
+    if (entry.is_regular_file()) ++files;
+  }
+  std::cout << "wrote " << files << " WAL file(s) to " << (out_dir / "wal").string() << '\n';
+  return files == 0 ? 4 : 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: " << argv[0] << " <output-directory>\n";
+    return 1;
+  }
+  return Run(std::filesystem::path{argv[1]});
+}

--- a/tests/unit/storage_v2_pipelined_commit.cpp
+++ b/tests/unit/storage_v2_pipelined_commit.cpp
@@ -1,0 +1,1134 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <csignal>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <functional>
+#include <latch>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <unistd.h>
+
+#include "flags/experimental.hpp"
+#include "storage/v2/commit_order_gate.hpp"
+#include "storage/v2/commit_probe.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/constraints/constraint_violation.hpp"
+#include "storage/v2/durability/durability.hpp"
+#include "storage/v2/durability/paths.hpp"
+#include "storage/v2/durability/serialization.hpp"
+#include "storage/v2/durability/wal.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/storage_error.hpp"
+#include "storage/v2/view.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/crc_accumulator.hpp"
+#include "utils/exceptions.hpp"
+
+using memgraph::storage::BudgetRefuse;
+using memgraph::storage::CommitOrderGate;
+using memgraph::storage::CommitProbe;
+using memgraph::storage::CommitTicket;
+using memgraph::storage::Config;
+using memgraph::storage::ConstraintViolation;
+using memgraph::storage::Gid;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::LabelId;
+using memgraph::storage::PropertyId;
+using memgraph::storage::PropertyValue;
+using memgraph::storage::StorageManipulationError;
+using memgraph::storage::View;
+
+namespace {
+
+template <class Pred>
+bool WaitFor(Pred pred, std::chrono::milliseconds timeout) {
+  auto const deadline = std::chrono::steady_clock::now() + timeout;
+  while (!pred()) {
+    if (std::chrono::steady_clock::now() > deadline) return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  return true;
+}
+
+// Signal-safe watchdog: a hung parked-thread test exits 124 instead of hanging the runner.
+extern "C" void WatchdogHandler(int) { _exit(124); }
+
+void ArmWatchdog(unsigned seconds) {
+  struct sigaction action{};
+  action.sa_handler = WatchdogHandler;
+  sigemptyset(&action.sa_mask);
+  sigaction(SIGALRM, &action, nullptr);
+  alarm(seconds);
+}
+
+// Enumerates the WAL files under `dir`, decodes each with the durability decoder, returns the timestamp of every
+// DELTA_TRANSACTION_START in file order and verifies every transaction CRC on the way.
+std::vector<uint64_t> ReadWalTransactionTimestamps(std::filesystem::path const &dir, bool *crcs_ok = nullptr) {
+  using namespace memgraph::storage::durability;
+  std::vector<uint64_t> timestamps;
+  bool all_ok = true;
+  auto wal_files = GetWalFiles(dir / kWalDirectory);
+  if (!wal_files) return timestamps;
+  std::ranges::sort(*wal_files, [](auto const &a, auto const &b) { return a.seq_num < b.seq_num; });
+  for (auto const &wal_file : *wal_files) {
+    auto const info = ReadWalInfo(wal_file.path);
+    Decoder wal;
+    wal.Initialize(wal_file.path, kWalMagic);
+    wal.SetPosition(info.offset_deltas);
+    wal.ResetCrcAcc();
+    for (uint64_t i = 0; i < info.num_deltas; ++i) {
+      auto const timestamp = ReadWalDeltaHeader(&wal);
+      auto delta_data = ReadWalDeltaData(&wal);
+      if (std::get_if<WalTransactionStart>(&delta_data.data_) != nullptr) timestamps.push_back(timestamp);
+      if (std::get_if<WalTransactionEnd>(&delta_data.data_) != nullptr) {
+        all_ok &= memgraph::utils::CrcAccumulator::Verify(wal.CrcAccValue());
+        wal.ResetCrcAcc();
+      }
+    }
+  }
+  if (crcs_ok != nullptr) *crcs_ok = all_ok;
+  return timestamps;
+}
+
+bool VerifyAllTransactionCrcs(std::filesystem::path const &dir) {
+  bool ok = false;
+  static_cast<void>(ReadWalTransactionTimestamps(dir, &ok));
+  return ok;
+}
+
+// One-shot park with arrival handshakes and timed, idempotent release. Hooks fire for every commit, so the callback
+// parks exactly one caller and records everyone else's arrival.
+struct OneShotPark {
+  std::mutex m;
+  std::condition_variable cv;
+  bool armed{true}, parked{false}, released{false};
+  std::atomic<int> others{0};
+
+  void operator()() {
+    std::unique_lock l{m};
+    if (!armed) {
+      ++others;
+      return;
+    }
+    armed = false;
+    parked = true;
+    cv.notify_all();
+    cv.wait(l, [&] { return released; });
+  }
+
+  bool WaitParked(std::chrono::milliseconds t) {
+    std::unique_lock l{m};
+    return cv.wait_for(l, t, [&] { return parked; });
+  }
+
+  void Release() {
+    {
+      std::lock_guard l{m};
+      released = true;
+    }
+    cv.notify_all();
+  }
+};
+
+// Workers never call gtest ASSERT_*; they use REQUIRE_OK, which throws, and the exception is captured per worker.
+#define REQUIRE_OK(expr)                                            \
+  do {                                                              \
+    if (!(expr)) throw std::runtime_error("worker failed: " #expr); \
+  } while (0)
+
+// Cleanup-before-wait for every threaded example. Declared right after the probe is installed, BEFORE any worker
+// starts, wait, or assertion. The destructor releases the park, joins every worker, and clears the probe.
+struct WorkerSet {
+  OneShotPark &park;
+  InMemoryStorage &storage;
+  std::vector<std::thread> threads;
+  std::vector<std::exception_ptr> errors;
+
+  WorkerSet(OneShotPark &p, InMemoryStorage &s, size_t max_workers = 16) : park{p}, storage{s} {
+    threads.reserve(max_workers);
+    errors.resize(max_workers);
+  }
+
+  template <class F>
+  void Start(F f) {
+    auto *slot = &errors[threads.size()];
+    threads.emplace_back([slot, f = std::move(f)] {
+      try {
+        f();
+      } catch (...) {
+        *slot = std::current_exception();
+      }
+    });
+  }
+
+  void JoinAll() {
+    for (auto &t : threads) {
+      if (t.joinable()) t.join();
+    }
+  }
+
+  auto FirstError() const -> std::string {
+    for (auto const &e : errors) {
+      if (!e) continue;
+      try {
+        std::rethrow_exception(e);
+      } catch (std::exception const &x) {
+        return x.what();
+      } catch (...) {
+        return "non-std exception";
+      }
+    }
+    return {};
+  }
+
+  auto ok() const -> bool { return FirstError().empty(); }
+
+  ~WorkerSet() {
+    park.Release();
+    JoinAll();
+    storage.SetCommitProbe(nullptr);
+  }
+};
+
+Config MakeConfig(std::filesystem::path const &dir) {
+  Config config;
+  // UpdatePaths rebases every directory under `dir`; it must see the default storage directory as the old base.
+  config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL;
+  config.durability.snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::hours(24)};
+  config.durability.snapshot_on_exit = false;
+  config.durability.wal_file_flush_every_n_tx = 1;
+  config.gc.type = Config::Gc::Type::NONE;
+  config.register_metrics = false;
+  config.experimental_lockfree_read_snapshot = true;
+  config.experimental_pipelined_commit = true;
+  memgraph::storage::UpdatePaths(config, dir);
+  return config;
+}
+
+}  // namespace
+
+class PipelinedCommitTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    dir_ = std::filesystem::temp_directory_path() /
+           ("mg_pipelined_" + std::to_string(getpid()) + "_" + std::to_string(counter_++));
+    std::filesystem::remove_all(dir_);
+    std::filesystem::create_directories(dir_);
+    config_ = MakeConfig(dir_);
+    ArmWatchdog(120);
+    Open();
+    {
+      auto acc = storage_->UniqueAccess();
+      ASSERT_TRUE(acc->CreateUniqueConstraint(label_, {id_}).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    baseline_txns_ = 1;  // transactions committed by SetUp, excluded from WAL-order assertions
+  }
+
+  void Open() {
+    storage_ = std::make_unique<InMemoryStorage>(config_);
+    ResolveNames();
+  }
+
+  // Names are re-resolved after every reopen because recovery assigns ids from names in replay order.
+  void ResolveNames() {
+    label_ = storage_->NameToLabel("L");
+    prop_ = storage_->NameToProperty("p");
+    id_ = storage_->NameToProperty("id");
+  }
+
+  void Reopen(bool pipelined) {
+    storage_.reset();
+    config_.durability.recover_on_startup = true;
+    config_.experimental_pipelined_commit = pipelined;
+    Open();
+  }
+
+  void TearDown() override {
+    storage_.reset();
+    alarm(0);
+    std::filesystem::remove_all(dir_);
+  }
+
+  Gid Seed(int id) {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    EXPECT_TRUE(v.AddLabel(label_).has_value());
+    EXPECT_TRUE(v.SetProperty(id_, PropertyValue(id)).has_value());
+    EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    ++baseline_txns_;
+    return v.Gid();
+  }
+
+  size_t CountVisibleVertices() {
+    auto acc = storage_->Access(memgraph::storage::READ);
+    size_t n = 0;
+    for (auto v : acc->Vertices(View::OLD)) {
+      static_cast<void>(v);
+      ++n;
+    }
+    return n;
+  }
+
+  std::vector<uint64_t> MeasuredFrames() {
+    auto frames = ReadWalTransactionTimestamps(dir_);
+    EXPECT_GE(frames.size(), baseline_txns_);
+    frames.erase(frames.begin(), frames.begin() + std::min(frames.size(), baseline_txns_));
+    return frames;
+  }
+
+  static inline int counter_ = 0;
+  std::filesystem::path dir_;
+  Config config_;
+  std::unique_ptr<InMemoryStorage> storage_;
+  LabelId label_;
+  PropertyId prop_, id_;
+  size_t baseline_txns_{0};
+};
+
+// ---- Task 4: flags and quiescence --------------------------------------------------------------------------------
+
+TEST(PipelinedCommitFlags, PipelinedCommitRequiresLockfreeReadSnapshot) {
+  using memgraph::flags::Experiments;
+  using memgraph::flags::ValidateExperimentDependencies;
+  EXPECT_TRUE(ValidateExperimentDependencies(memgraph::flags::ReadExperimental("pipelined-commit")).has_value());
+  EXPECT_FALSE(
+      ValidateExperimentDependencies(memgraph::flags::ReadExperimental("lockfree-read-snapshot,pipelined-commit"))
+          .has_value());
+  EXPECT_FALSE(ValidateExperimentDependencies(Experiments::NONE).has_value());
+  EXPECT_FALSE(ValidateExperimentDependencies(Experiments::LOCKFREE_READ_SNAPSHOT).has_value());
+  // CLI `pipelined-commit` with environment `lockfree-read-snapshot`: validation runs on the combined mask.
+  auto const combined =
+      static_cast<Experiments>(std::to_underlying(memgraph::flags::ReadExperimental("pipelined-commit")) |
+                               std::to_underlying(memgraph::flags::ReadExperimental("lockfree-read-snapshot")));
+  EXPECT_FALSE(ValidateExperimentDependencies(combined).has_value());
+}
+
+TEST(PipelinedCommitFlags, StorageRejectsPipelinedCommitWithoutLockfreeReadSnapshot) {
+  auto const dir = std::filesystem::temp_directory_path() / ("mg_pipelined_flags_" + std::to_string(getpid()));
+  std::filesystem::remove_all(dir);
+  auto config = MakeConfig(dir);
+  config.experimental_lockfree_read_snapshot = false;
+  EXPECT_THROW(InMemoryStorage{config}, memgraph::utils::BasicException);
+  std::filesystem::remove_all(dir);
+}
+
+TEST_F(PipelinedCommitTest, SyntheticTicketQuiescesEpochChange) {
+  auto &gate = storage_->commit_order_gate_for_tests();
+  std::optional<CommitTicket> ticket;
+  ticket.emplace(gate, 1'000'000);
+  std::atomic<bool> epoch_done{false};
+  std::thread epoch{[&] {
+    // The InMemoryStorage override is private; the public entry point is Storage::PrepareForNewEpoch.
+    static_cast<memgraph::storage::Storage &>(*storage_).PrepareForNewEpoch();
+    epoch_done = true;
+  }};
+  EXPECT_FALSE(WaitFor([&] { return epoch_done.load(); }, std::chrono::milliseconds(200)));
+  ticket->Enter();
+  ticket->MarkAborted();
+  ticket->Retire();
+  EXPECT_TRUE(WaitFor([&] { return epoch_done.load(); }, std::chrono::seconds(5)));
+  epoch.join();
+  EXPECT_EQ(gate.Pending(), 0);
+}
+
+TEST_F(PipelinedCommitTest, EpochChangeWaitsForInFlightTicket) {
+  auto const a = Seed(1);
+  OneShotPark park;
+  CommitProbe probe;
+  probe.before_append = std::ref(park);
+  storage_->SetCommitProbe(&probe);
+  std::latch epoch_started{1};
+  std::atomic<bool> epoch_done{false};  // captured state BEFORE the WorkerSet
+  {
+    WorkerSet w{park, *storage_};
+    w.Start([&] {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      REQUIRE_OK(acc->FindVertex(a, View::NEW)->SetProperty(prop_, PropertyValue(1)).has_value());
+      REQUIRE_OK(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    });
+    ASSERT_TRUE(park.WaitParked(std::chrono::seconds(5)));
+    w.Start([&] {
+      epoch_started.count_down();
+      static_cast<memgraph::storage::Storage &>(*storage_).PrepareForNewEpoch();
+      epoch_done = true;
+    });
+    epoch_started.wait();
+    EXPECT_FALSE(WaitFor([&] { return epoch_done.load(); }, std::chrono::milliseconds(200)));  // must NOT complete
+    park.Release();
+    w.JoinAll();
+    ASSERT_TRUE(w.ok()) << w.FirstError();
+    EXPECT_TRUE(epoch_done.load());
+  }  // WorkerSet scope ends before Reopen
+  EXPECT_TRUE(VerifyAllTransactionCrcs(dir_));
+  Reopen(false);
+  EXPECT_EQ(
+      storage_->Access(memgraph::storage::READ)->FindVertex(a, View::OLD)->GetProperty(prop_, View::OLD)->ValueInt(),
+      1);
+}
+
+// ---- Task 5: ticketed legacy path ----------------------------------------------------------------------------------
+
+// Serializer exclusion: a ticketed LEGACY writer parked at after_ticket still holds commit_mutex_, so a second
+// committer cannot mint until it finishes. The first worker is metadata-only (DropIndex through Access(READ)) so it
+// stays ineligible after Task 6; the successor is a data writer.
+TEST_F(PipelinedCommitTest, LegacyWriterHoldsSerializerAcrossItsTicket) {
+  {
+    auto acc = storage_->UniqueAccess();
+    ASSERT_TRUE(acc->CreateIndex(label_).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    ++baseline_txns_;
+  }
+  auto const a = Seed(1);
+  auto const finalizations_before = storage_->pipeline_test_counters().finalize_wal_calls.load();
+  OneShotPark park;
+  CommitProbe probe;
+  probe.after_ticket = std::ref(park);
+  std::atomic<int> mints{0};
+  probe.after_mint = [&] { ++mints; };
+  storage_->SetCommitProbe(&probe);
+  bool first_ok = false, data_ok = false;
+  std::atomic<bool> data_done{false};
+  WorkerSet w{park, *storage_};
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::READ);
+    first_ok = acc->DropIndex(label_).has_value() &&
+               acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+  });
+  ASSERT_TRUE(park.WaitParked(std::chrono::seconds(5)));  // first: minted, ticketed, entered, serializer held
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    data_ok = acc->FindVertex(a, View::NEW)->SetProperty(prop_, PropertyValue(1)).has_value() &&
+              acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+    data_done = true;
+  });
+  EXPECT_FALSE(WaitFor([&] { return mints.load() >= 2; }, std::chrono::milliseconds(200)));  // serializer held
+  EXPECT_FALSE(data_done.load());
+  auto const watermark_before = storage_->LastCommittedMvccTimestamp();
+  park.Release();
+  w.JoinAll();
+  ASSERT_TRUE(w.ok()) << w.FirstError();
+  EXPECT_TRUE(first_ok);
+  EXPECT_TRUE(data_ok);
+  EXPECT_GT(storage_->LastCommittedMvccTimestamp(), watermark_before);
+  // One WAL finalization per legacy transaction (the data writer is pipelined and finalizes once as well).
+  EXPECT_EQ(storage_->pipeline_test_counters().finalize_wal_calls.load() - finalizations_before, 2);
+  auto const frames = MeasuredFrames();
+  ASSERT_EQ(frames.size(), 2);
+  EXPECT_LT(frames[0], frames[1]);
+}
+
+// Failure protocol: an exception injected before append aborts in order and retires the ticket; the successor commits.
+TEST_F(PipelinedCommitTest, ExceptionBeforeAppendAbortsInOrderAndReleasesSuccessor) {
+  auto const a = Seed(1);
+  auto const b = Seed(2);
+  CommitProbe probe;
+  std::atomic<bool> armed{true};
+  probe.before_validate = [&] {
+    if (armed.exchange(false)) throw std::runtime_error("injected");
+  };
+  storage_->SetCommitProbe(&probe);
+  std::expected<void, StorageManipulationError> r_a;
+  bool threw = false;
+  OneShotPark unused_park;
+  {
+    WorkerSet w{unused_park, *storage_};
+    w.Start([&] {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      REQUIRE_OK(acc->FindVertex(a, View::NEW)->SetProperty(prop_, PropertyValue(1)).has_value());
+      try {
+        r_a = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+      } catch (std::runtime_error const &) {
+        threw = true;
+      }
+    });
+    w.JoinAll();
+    ASSERT_TRUE(w.ok()) << w.FirstError();
+  }
+  EXPECT_TRUE(threw);
+  {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    ASSERT_TRUE(acc->FindVertex(b, View::NEW)->SetProperty(prop_, PropertyValue(2)).has_value());
+    EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());  // not blocked
+  }
+  storage_->SetCommitProbe(nullptr);
+  EXPECT_EQ(storage_->commit_order_gate_for_tests().Pending(), 0);
+  auto r = storage_->Access(memgraph::storage::READ);
+  EXPECT_EQ(r->FindVertex(a, View::OLD)->GetProperty(prop_, View::OLD)->type(), PropertyValue::Type::Null);
+  EXPECT_EQ(r->FindVertex(b, View::OLD)->GetProperty(prop_, View::OLD)->ValueInt(), 2);
+}
+
+// ---- Task 6: the pipelined branch ---------------------------------------------------------------------------------
+
+// INV-UNIQUE: both committers create the same id; the first is parked between ticket and validation; exactly one wins.
+TEST_F(PipelinedCommitTest, ConcurrentDuplicateCreatesAdmitExactlyOne) {
+  OneShotPark park;
+  CommitProbe probe;
+  probe.after_ticket = std::ref(park);
+  storage_->SetCommitProbe(&probe);
+  std::expected<void, StorageManipulationError> first_result, second_result;
+  WorkerSet w{park, *storage_};
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    REQUIRE_OK(v.AddLabel(label_).has_value());
+    REQUIRE_OK(v.SetProperty(id_, PropertyValue(7)).has_value());
+    first_result = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+  });
+  ASSERT_TRUE(park.WaitParked(std::chrono::seconds(5)));
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    REQUIRE_OK(v.AddLabel(label_).has_value());
+    REQUIRE_OK(v.SetProperty(id_, PropertyValue(7)).has_value());
+    second_result = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+  });
+  ASSERT_TRUE(WaitFor([&] { return park.others.load() >= 1; }, std::chrono::seconds(5)));  // second minted
+  park.Release();
+  w.JoinAll();
+  ASSERT_TRUE(w.ok()) << w.FirstError();
+  EXPECT_TRUE(first_result.has_value());
+  ASSERT_FALSE(second_result.has_value());
+  ASSERT_TRUE(std::holds_alternative<ConstraintViolation>(second_result.error()));
+  EXPECT_EQ(CountVisibleVertices(), 1);  // ApproximateVertexCount would count the aborted vertex until GC
+  EXPECT_GE(storage_->pipeline_stats_for_tests().s2_encodes.load(), 2);
+}
+
+// Duplicate UPDATES: two writers set different vertices to the same unique value; exactly one may succeed.
+TEST_F(PipelinedCommitTest, ConcurrentDuplicateUpdatesAdmitExactlyOne) {
+  auto const a = Seed(1);
+  auto const b = Seed(2);
+  OneShotPark park;
+  CommitProbe probe;
+  probe.after_ticket = std::ref(park);
+  storage_->SetCommitProbe(&probe);
+  std::expected<void, StorageManipulationError> ra, rb;  // captured state BEFORE the WorkerSet
+  {
+    WorkerSet w{park, *storage_};
+    w.Start([&] {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      REQUIRE_OK(acc->FindVertex(a, View::NEW)->SetProperty(id_, PropertyValue(9)).has_value());
+      ra = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+    });
+    ASSERT_TRUE(park.WaitParked(std::chrono::seconds(5)));
+    w.Start([&] {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      REQUIRE_OK(acc->FindVertex(b, View::NEW)->SetProperty(id_, PropertyValue(9)).has_value());
+      rb = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+    });
+    ASSERT_TRUE(WaitFor([&] { return park.others.load() >= 1; }, std::chrono::seconds(5)));
+    park.Release();
+    w.JoinAll();
+    ASSERT_TRUE(w.ok()) << w.FirstError();
+  }  // WorkerSet scope ends before Reopen
+  EXPECT_TRUE(ra.has_value());
+  ASSERT_FALSE(rb.has_value());
+  ASSERT_TRUE(std::holds_alternative<ConstraintViolation>(rb.error()));
+  Reopen(false);
+  auto acc = storage_->Access(memgraph::storage::READ);
+  EXPECT_EQ(acc->FindVertex(a, View::OLD)->GetProperty(id_, View::OLD)->ValueInt(), 9);
+  EXPECT_EQ(acc->FindVertex(b, View::OLD)->GetProperty(id_, View::OLD)->ValueInt(), 2);
+}
+
+// Selective refusal protocol, shared by the mixed tests: park the predecessor at before_validate (after its S2
+// completed). The successor's after_mint hook (armed after the predecessor parked, so the second mint is the
+// successor) reads minted_ticket and arms budget_refuse for that ticket at the site under test BEFORE returning, so
+// refusal is armed before the successor's S2. The budget itself is large so every other allocation succeeds.
+class PipelinedCommitRefusalTest : public PipelinedCommitTest,
+                                   public ::testing::WithParamInterface<BudgetRefuse::Site> {
+ protected:
+  struct Outcome {
+    std::expected<void, StorageManipulationError> first, second;
+    std::atomic<uint64_t> retained_at_park{0};
+    std::atomic<uint64_t> retained_before_fallback{0};
+    std::atomic<bool> fallback_seen{false};
+  };
+
+  // Runs `first` then `second` as concurrent committers under the protocol; both operations receive an accessor.
+  void RunProtocol(Outcome &outcome, std::function<void(memgraph::storage::Storage::Accessor &)> first,
+                   std::function<void(memgraph::storage::Storage::Accessor &)> second) {
+    auto const in_flight_before = storage_->pipeline_budget_for_tests().InFlightBytes();
+    auto const fallbacks_before = storage_->pipeline_stats_for_tests().budget_fallbacks.load();
+    OneShotPark park;
+    CommitProbe probe;
+    std::atomic<bool> arm_successor{false};
+    probe.before_validate = std::ref(park);
+    probe.after_mint = [&] {
+      if (!arm_successor.load()) return;
+      probe.budget_refuse.ticket = probe.minted_ticket.load();
+      probe.budget_refuse.site = GetParam();
+    };
+    probe.before_legacy_fallback = [&] {
+      outcome.retained_before_fallback = storage_->pipeline_budget_for_tests().InFlightBytes();
+      outcome.fallback_seen = true;
+    };
+    storage_->SetCommitProbe(&probe);
+    WorkerSet w{park, *storage_};
+    w.Start([&] {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      first(*acc);
+      outcome.first = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+    });
+    ASSERT_TRUE(park.WaitParked(std::chrono::seconds(5)));
+    // The successor has not started: what is in flight now is exactly what the parked predecessor retains.
+    outcome.retained_at_park = storage_->pipeline_budget_for_tests().InFlightBytes();
+    EXPECT_GT(outcome.retained_at_park.load(), 0);
+    arm_successor = true;
+    w.Start([&] {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      second(*acc);
+      outcome.second = acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+    });
+    ASSERT_TRUE(WaitFor([&] { return outcome.fallback_seen.load(); }, std::chrono::seconds(5)));
+    // Release-BEFORE-fallback: the successor's charges were released while the predecessor is still parked.
+    EXPECT_EQ(outcome.retained_before_fallback.load(), outcome.retained_at_park.load());
+    park.Release();
+    w.JoinAll();
+    ASSERT_TRUE(w.ok()) << w.FirstError();
+    EXPECT_TRUE(probe.budget_refuse.fired.load());
+    EXPECT_EQ(storage_->pipeline_stats_for_tests().budget_fallbacks.load() - fallbacks_before, 1);
+    EXPECT_EQ(storage_->pipeline_budget_for_tests().InFlightBytes(), in_flight_before);  // eventual release
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(Sites, PipelinedCommitRefusalTest,
+                         ::testing::Values(BudgetRefuse::kMaterializer, BudgetRefuse::kEncoder));
+
+TEST_P(PipelinedCommitRefusalTest, DuplicateCreateAgainstOverBudgetFallbackAdmitsExactlyOne) {
+  Outcome outcome;
+  auto const create = [&](memgraph::storage::Storage::Accessor &acc) {
+    auto v = acc.CreateVertex();
+    REQUIRE_OK(v.AddLabel(label_).has_value());
+    REQUIRE_OK(v.SetProperty(id_, PropertyValue(7)).has_value());
+  };
+  RunProtocol(outcome, create, create);
+  EXPECT_TRUE(outcome.first.has_value());
+  ASSERT_FALSE(outcome.second.has_value());
+  ASSERT_TRUE(std::holds_alternative<ConstraintViolation>(outcome.second.error()));
+  EXPECT_EQ(CountVisibleVertices(), 1);
+  Reopen(false);
+  EXPECT_EQ(CountVisibleVertices(), 1);
+}
+
+TEST_P(PipelinedCommitRefusalTest, ConcurrentDuplicateUpdateAgainstOverBudgetFallbackAdmitsExactlyOne) {
+  auto const a = Seed(1);
+  auto const b = Seed(2);
+  Outcome outcome;
+  RunProtocol(
+      outcome,
+      [&](memgraph::storage::Storage::Accessor &acc) {
+        REQUIRE_OK(acc.FindVertex(a, View::NEW)->SetProperty(id_, PropertyValue(9)).has_value());
+      },
+      [&](memgraph::storage::Storage::Accessor &acc) {
+        REQUIRE_OK(acc.FindVertex(b, View::NEW)->SetProperty(id_, PropertyValue(9)).has_value());
+      });
+  EXPECT_TRUE(outcome.first.has_value());
+  ASSERT_FALSE(outcome.second.has_value());
+  ASSERT_TRUE(std::holds_alternative<ConstraintViolation>(outcome.second.error()));
+  Reopen(false);
+  auto acc = storage_->Access(memgraph::storage::READ);
+  EXPECT_EQ(acc->FindVertex(a, View::OLD)->GetProperty(id_, View::OLD)->ValueInt(), 9);
+  EXPECT_EQ(acc->FindVertex(b, View::OLD)->GetProperty(id_, View::OLD)->ValueInt(), 2);
+}
+
+// INV-ONE-DOMAIN across paths: pipelined predecessor parked after the serializer release, legacy successor (DDL) must
+// wait in the gate.
+TEST_F(PipelinedCommitTest, LegacyCommitDoesNotOvertakePipelinedTicket) {
+  {
+    auto acc = storage_->UniqueAccess();
+    ASSERT_TRUE(acc->CreateIndex(label_).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    ++baseline_txns_;
+  }
+  auto const a = Seed(1);
+  OneShotPark park;
+  CommitProbe probe;
+  probe.after_ticket = std::ref(park);
+  std::atomic<int> mints{0};
+  probe.after_mint = [&] { ++mints; };
+  storage_->SetCommitProbe(&probe);  // both hooks installed BEFORE either worker starts
+  bool first_ok = false, ddl_ok = false;
+  std::atomic<bool> ddl_done{false};
+  WorkerSet w{park, *storage_};
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    first_ok = acc->FindVertex(a, View::NEW)->SetProperty(prop_, PropertyValue(1)).has_value() &&
+               acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+  });
+  ASSERT_TRUE(park.WaitParked(std::chrono::seconds(5)));  // eligible writer: minted, ticketed, serializer released
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::READ);
+    ddl_ok = acc->DropIndex(label_).has_value() &&
+             acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value();
+    ddl_done = true;
+  });
+  ASSERT_TRUE(WaitFor([&] { return mints.load() >= 2; }, std::chrono::seconds(5)));        // the DDL minted
+  EXPECT_FALSE(WaitFor([&] { return ddl_done.load(); }, std::chrono::milliseconds(200)));  // waiting in the gate
+  auto const watermark_before = storage_->LastCommittedMvccTimestamp();
+  park.Release();
+  w.JoinAll();
+  ASSERT_TRUE(w.ok()) << w.FirstError();
+  EXPECT_TRUE(first_ok);
+  EXPECT_TRUE(ddl_ok);
+  EXPECT_GT(storage_->LastCommittedMvccTimestamp(), watermark_before);
+  auto const frames = MeasuredFrames();
+  ASSERT_EQ(frames.size(), 2);
+  EXPECT_LT(frames[0], frames[1]);
+}
+
+// INV-ORDER: a later-minted committer with a tiny encode must not append before an earlier one with a large encode.
+TEST_F(PipelinedCommitTest, WalFramesStayInCommitTimestampOrder) {
+  auto const a = Seed(1);
+  auto const b = Seed(2);
+  OneShotPark park;
+  CommitProbe probe;
+  probe.after_ticket = std::ref(park);
+  storage_->SetCommitProbe(&probe);
+  WorkerSet w{park, *storage_};
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    auto v = acc->FindVertex(a, View::NEW);
+    for (int i = 0; i < 2000; ++i) REQUIRE_OK(v->SetProperty(prop_, PropertyValue(i)).has_value());
+    REQUIRE_OK(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  });
+  ASSERT_TRUE(park.WaitParked(std::chrono::seconds(5)));
+  w.Start([&] {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    REQUIRE_OK(acc->FindVertex(b, View::NEW)->SetProperty(prop_, PropertyValue(1)).has_value());
+    REQUIRE_OK(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  });
+  ASSERT_TRUE(WaitFor([&] { return park.others.load() >= 1; }, std::chrono::seconds(5)));
+  park.Release();
+  w.JoinAll();
+  ASSERT_TRUE(w.ok()) << w.FirstError();
+  auto const frames = MeasuredFrames();
+  ASSERT_EQ(frames.size(), 2);
+  EXPECT_LT(frames[0], frames[1]);
+}
+
+TEST_F(PipelinedCommitTest, RotationBetweenTicketAndAppendIsSafe) {
+  config_.durability.wal_file_size_kibibytes = 1;
+  Reopen(true);
+  std::vector<Gid> gids;
+  for (int i = 0; i < 400; ++i) gids.push_back(Seed(100 + i));
+  OneShotPark unused_park;  // no park in this test; WorkerSet still owns cleanup
+  {
+    WorkerSet w{unused_park, *storage_};
+    for (int k = 0; k < 8; ++k) {
+      w.Start([&, k] {
+        for (int r = 0; r < 10; ++r) {
+          auto acc = storage_->Access(memgraph::storage::WRITE);
+          for (int i = k; i < 400; i += 8) {
+            REQUIRE_OK(acc->FindVertex(gids[i], View::NEW)->SetProperty(prop_, PropertyValue(r)).has_value());
+          }
+          REQUIRE_OK(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+        }
+      });
+    }
+    w.JoinAll();
+    ASSERT_TRUE(w.ok()) << w.FirstError();
+  }
+  EXPECT_GE(storage_->pipeline_stats_for_tests().s2_encodes.load(), 80);
+  Reopen(false);  // recovers on a flag-off instance
+  auto acc = storage_->Access(memgraph::storage::READ);
+  for (auto gid : gids) EXPECT_EQ(acc->FindVertex(gid, View::OLD)->GetProperty(prop_, View::OLD)->ValueInt(), 9);
+}
+
+// 9d: with a 1-byte budget every measured data commit takes the legacy fallback; one fallback and one finalization
+// per measured transaction, rotation really happens, and recovery succeeds.
+TEST_F(PipelinedCommitTest, LegacyForcedRotationFinalizesOncePerTransaction) {
+  config_.durability.wal_file_size_kibibytes = 1;
+  config_.pipelined_commit_max_bytes = 1;
+  Reopen(true);
+  std::vector<Gid> gids;
+  for (int i = 0; i < 64; ++i) gids.push_back(Seed(200 + i));
+  auto const fallbacks_before = storage_->pipeline_stats_for_tests().budget_fallbacks.load();
+  auto const finalizations_before = storage_->pipeline_test_counters().finalize_wal_calls.load();
+  constexpr int kMeasured = 32;
+  for (int r = 0; r < kMeasured; ++r) {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    for (auto gid : gids)
+      ASSERT_TRUE(acc->FindVertex(gid, View::NEW)->SetProperty(prop_, PropertyValue(r)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  EXPECT_EQ(storage_->pipeline_stats_for_tests().budget_fallbacks.load() - fallbacks_before, kMeasured);
+  EXPECT_EQ(storage_->pipeline_test_counters().finalize_wal_calls.load() - finalizations_before, kMeasured);
+  auto wal_files = memgraph::storage::durability::GetWalFiles(dir_ / memgraph::storage::durability::kWalDirectory);
+  ASSERT_TRUE(wal_files.has_value());
+  EXPECT_GT(wal_files->size(), 1);
+  Reopen(false);
+  auto acc = storage_->Access(memgraph::storage::READ);
+  for (auto gid : gids) {
+    EXPECT_EQ(acc->FindVertex(gid, View::OLD)->GetProperty(prop_, View::OLD)->ValueInt(), kMeasured - 1);
+  }
+}
+
+TEST_F(PipelinedCommitTest, WalDisabledMainIsNotEligible) {
+  storage_.reset();
+  config_.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT;
+  config_.durability.recover_on_startup = true;
+  Open();
+  auto const encodes_before = storage_->pipeline_stats_for_tests().s2_encodes.load();
+  for (int i = 0; i < 5; ++i) {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    ASSERT_TRUE(v.AddLabel(label_).has_value());
+    ASSERT_TRUE(v.SetProperty(id_, PropertyValue(300 + i)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  EXPECT_EQ(storage_->pipeline_stats_for_tests().s2_encodes.load(), encodes_before);
+  EXPECT_EQ(storage_->commit_order_gate_for_tests().Pending(), 0);
+  EXPECT_EQ(CountVisibleVertices(), 5);
+}
+
+// WAL-disabled companions: a before_publish exception aborts and releases its successor.
+TEST_F(PipelinedCommitTest, WalDisabledExceptionBeforePublishAbortsInOrder) {
+  storage_.reset();
+  config_.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT;
+  config_.durability.recover_on_startup = true;
+  Open();
+  auto const a = Seed(1);
+  auto const b = Seed(2);
+  CommitProbe probe;
+  std::atomic<bool> armed{true};
+  probe.before_publish = [&] {
+    if (armed.exchange(false)) throw std::runtime_error("injected");
+  };
+  storage_->SetCommitProbe(&probe);
+  bool threw = false;
+  {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    ASSERT_TRUE(acc->FindVertex(a, View::NEW)->SetProperty(prop_, PropertyValue(1)).has_value());
+    try {
+      static_cast<void>(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+    } catch (std::runtime_error const &) {
+      threw = true;
+    }
+  }
+  EXPECT_TRUE(threw);
+  {
+    auto acc = storage_->Access(memgraph::storage::WRITE);
+    ASSERT_TRUE(acc->FindVertex(b, View::NEW)->SetProperty(prop_, PropertyValue(2)).has_value());
+    EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  storage_->SetCommitProbe(nullptr);
+  EXPECT_EQ(storage_->commit_order_gate_for_tests().Pending(), 0);
+  auto r = storage_->Access(memgraph::storage::READ);
+  EXPECT_EQ(r->FindVertex(a, View::OLD)->GetProperty(prop_, View::OLD)->type(), PropertyValue::Type::Null);
+  EXPECT_EQ(r->FindVertex(b, View::OLD)->GetProperty(prop_, View::OLD)->ValueInt(), 2);
+}
+
+// ---- Task 6 lifecycle faults (nonfatal) --------------------------------------------------------------------------
+
+class PipelinedCommitLifecycleTest : public PipelinedCommitTest {
+ protected:
+  // Injects one exception through `arm`, expects the faulting commit to abort in order, then a successor commits and
+  // the gate is empty.
+  void ExpectOrderedAbortThenSuccessor(std::function<void(CommitProbe &)> arm) {
+    auto const a = Seed(1);
+    auto const b = Seed(2);
+    CommitProbe probe;
+    arm(probe);
+    storage_->SetCommitProbe(&probe);
+    auto const watermark_before = storage_->LastCommittedMvccTimestamp();
+    bool threw = false;
+    {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      ASSERT_TRUE(acc->FindVertex(a, View::NEW)->SetProperty(prop_, PropertyValue(1)).has_value());
+      try {
+        static_cast<void>(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+      } catch (std::runtime_error const &) {
+        threw = true;
+      }
+    }
+    EXPECT_TRUE(threw);
+    EXPECT_EQ(storage_->LastCommittedMvccTimestamp(), watermark_before);
+    EXPECT_EQ(storage_->commit_order_gate_for_tests().Pending(), 0);
+    {
+      auto acc = storage_->Access(memgraph::storage::WRITE);
+      ASSERT_TRUE(acc->FindVertex(b, View::NEW)->SetProperty(prop_, PropertyValue(2)).has_value());
+      EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    storage_->SetCommitProbe(nullptr);
+    EXPECT_EQ(storage_->commit_order_gate_for_tests().Pending(), 0);
+    EXPECT_TRUE(VerifyAllTransactionCrcs(dir_));
+    Reopen(false);
+    auto r = storage_->Access(memgraph::storage::READ);
+    EXPECT_EQ(r->FindVertex(a, View::OLD)->GetProperty(prop_, View::OLD)->type(), PropertyValue::Type::Null);
+    EXPECT_EQ(r->FindVertex(b, View::OLD)->GetProperty(prop_, View::OLD)->ValueInt(), 2);
+  }
+};
+
+TEST_F(PipelinedCommitLifecycleTest, AfterMintThrowsAbortsInOrder) {
+  ExpectOrderedAbortThenSuccessor([](CommitProbe &probe) {
+    auto armed = std::make_shared<std::atomic<bool>>(true);
+    probe.after_mint = [armed] {
+      if (armed->exchange(false)) throw std::runtime_error("injected after_mint");
+    };
+  });
+}
+
+TEST_F(PipelinedCommitLifecycleTest, EligibleAfterTicketThrowsAbortsInOrder) {
+  ExpectOrderedAbortThenSuccessor([](CommitProbe &probe) {
+    auto armed = std::make_shared<std::atomic<bool>>(true);
+    probe.after_ticket = [armed] {
+      if (armed->exchange(false)) throw std::runtime_error("injected after_ticket");
+    };
+  });
+}
+
+TEST_F(PipelinedCommitLifecycleTest, MaterializationFaultAbortsInOrder) {
+  ExpectOrderedAbortThenSuccessor([](CommitProbe &probe) {
+    probe.budget_refuse.mode = BudgetRefuse::kThrowRuntimeError;
+    probe.budget_refuse.site = BudgetRefuse::kMaterializer;
+    // The first ticketed commit after installation is the faulting one.
+    probe.after_mint = [&probe] {
+      if (probe.budget_refuse.ticket.load() == 0) probe.budget_refuse.ticket = probe.minted_ticket.load();
+    };
+  });
+}
+
+// 10: first eligible commit on an empty WAL, then rotation through the real InitializeWalFile call.
+class PipelinedCommitEmptyWalTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    dir_ = std::filesystem::temp_directory_path() / ("mg_pipelined_empty_" + std::to_string(getpid()));
+    std::filesystem::remove_all(dir_);
+    std::filesystem::create_directories(dir_);
+    ArmWatchdog(120);
+  }
+
+  void TearDown() override {
+    alarm(0);
+    std::filesystem::remove_all(dir_);
+  }
+
+  std::filesystem::path dir_;
+};
+
+TEST_F(PipelinedCommitEmptyWalTest, FirstEligibleCommitInitializesTheWalAndRotationReinitializes) {
+  auto config = MakeConfig(dir_);
+  Gid gid;
+  {
+    // NO preliminary commit: the first write is pipeline-eligible and initializes the WAL itself.
+    InMemoryStorage storage{config};
+    auto const prop = storage.NameToProperty("p");
+    auto acc = storage.Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    gid = v.Gid();
+    ASSERT_TRUE(v.SetProperty(prop, PropertyValue(1)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    EXPECT_EQ(storage.pipeline_stats_for_tests().s2_encodes.load(), 1);
+  }
+  {
+    // The storage copies its config at construction, so the rotation threshold is set in the config used to open.
+    config.durability.recover_on_startup = true;
+    config.durability.wal_file_size_kibibytes = 1;
+    InMemoryStorage storage{config};
+    auto const prop = storage.NameToProperty("p");
+    {
+      auto acc = storage.Access(memgraph::storage::WRITE);
+      auto v = acc->FindVertex(gid, View::NEW);
+      ASSERT_TRUE(v.has_value());
+      for (int i = 0; i < 300; ++i)
+        ASSERT_TRUE(v->SetProperty(storage.NameToProperty("q" + std::to_string(i)), PropertyValue(i)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());  // forces rotation
+    }
+    {
+      auto acc = storage.Access(memgraph::storage::WRITE);
+      ASSERT_TRUE(acc->FindVertex(gid, View::NEW)->SetProperty(prop, PropertyValue(2)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());  // new WAL file
+    }
+    EXPECT_EQ(storage.pipeline_stats_for_tests().s2_encodes.load(), 2);
+    auto wal_files = memgraph::storage::durability::GetWalFiles(dir_ / memgraph::storage::durability::kWalDirectory);
+    ASSERT_TRUE(wal_files.has_value());
+    EXPECT_GE(wal_files->size(), 2);
+  }
+  {
+    config.durability.wal_file_size_kibibytes = 20 * 1024;
+    config.experimental_pipelined_commit = false;
+    InMemoryStorage storage{config};
+    auto const prop = storage.NameToProperty("p");
+    auto acc = storage.Access(memgraph::storage::READ);
+    EXPECT_EQ(acc->FindVertex(gid, View::OLD)->GetProperty(prop, View::OLD)->ValueInt(), 2);
+  }
+}
+
+// ---- Task 6 lifecycle faults (fatal) --------------------------------------------------------------------------------
+
+// Opens NO storage in the parent SetUp and installs no alarm: the death statement arms the watchdog and constructs the
+// storage in a directory taken from MG_DEATH_DIR (inherited across gtest's re-exec), so the parent recovers exactly
+// that directory afterwards. A child hang exits 124 and fails the KilledBySignal(SIGABRT) matcher.
+class PipelinedCommitDeathTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (auto const *inherited = std::getenv("MG_DEATH_DIR"); inherited != nullptr && *inherited != '\0') {
+      dir_ = inherited;
+    } else {
+      dir_ = std::filesystem::temp_directory_path() /
+             ("mg_pipelined_death_" + std::to_string(getpid()) + "_" + std::to_string(counter_++));
+      std::filesystem::remove_all(dir_);
+      std::filesystem::create_directories(dir_);
+      setenv("MG_DEATH_DIR", dir_.c_str(), 1);
+    }
+  }
+
+  void TearDown() override {
+    unsetenv("MG_DEATH_DIR");
+    std::filesystem::remove_all(dir_);
+  }
+
+  // The child: warm-up commits, then the faulting one; never returns normally when the fault fires.
+  void RunChild(std::function<void(CommitProbe &)> arm, bool wal_disabled = false) {
+    ArmWatchdog(60);
+    auto config = MakeConfig(dir_);
+    if (wal_disabled) config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT;
+    InMemoryStorage storage{config};
+    auto const prop = storage.NameToProperty("p");
+    std::vector<Gid> gids;
+    for (int i = 0; i < kWarmUp; ++i) {
+      auto acc = storage.Access(memgraph::storage::WRITE);
+      auto v = acc->CreateVertex();
+      gids.push_back(v.Gid());
+      if (!v.SetProperty(prop, PropertyValue(i)).has_value()) _exit(3);
+      if (!acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) _exit(3);
+    }
+    CommitProbe probe;
+    arm(probe);
+    storage.SetCommitProbe(&probe);
+    auto acc = storage.Access(memgraph::storage::WRITE);
+    if (!acc->FindVertex(gids.front(), View::NEW)->SetProperty(prop, PropertyValue(1000)).has_value()) _exit(3);
+    static_cast<void>(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+    _exit(5);  // the fault did not fire
+  }
+
+  // The parent: recovers the child's directory and reports how many warm-up vertices came back and the value of
+  // the faulting transaction's target.
+  struct Recovered {
+    size_t vertices{0};
+    std::optional<int64_t> faulted_value;
+    bool crcs_ok{false};
+  };
+
+  Recovered Recover(bool wal_disabled = false) {
+    Recovered recovered;
+    recovered.crcs_ok = wal_disabled || VerifyAllTransactionCrcs(dir_);
+    auto config = MakeConfig(dir_);
+    config.experimental_pipelined_commit = false;
+    config.durability.recover_on_startup = true;
+    if (wal_disabled) config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT;
+    InMemoryStorage storage{config};
+    auto const prop = storage.NameToProperty("p");
+    auto acc = storage.Access(memgraph::storage::READ);
+    for (auto v : acc->Vertices(View::OLD)) {
+      ++recovered.vertices;
+      auto const value = v.GetProperty(prop, View::OLD);
+      if (value.has_value() && value->IsInt() && value->ValueInt() == 1000) recovered.faulted_value = 1000;
+    }
+    return recovered;
+  }
+
+  static constexpr int kWarmUp = 20;
+  static inline int counter_ = 0;
+  std::filesystem::path dir_;
+};
+
+TEST_F(PipelinedCommitDeathTest, AfterAppendThrowsTerminatesAndWarmUpRecovers) {
+  EXPECT_EXIT(RunChild([](CommitProbe &probe) { probe.after_append = [] { throw std::runtime_error("injected"); }; }),
+              ::testing::KilledBySignal(SIGABRT),
+              "");
+  auto const recovered = Recover();
+  EXPECT_TRUE(recovered.crcs_ok);
+  EXPECT_EQ(recovered.vertices, kWarmUp);  // loss of the faulting transaction's user-space tail is allowed
+}
+
+TEST_F(PipelinedCommitDeathTest, AfterFinalizeWalThrowsTerminatesAndTheTransactionRecoversCommitted) {
+  EXPECT_EXIT(
+      RunChild([](CommitProbe &probe) { probe.after_finalize_wal = [] { throw std::runtime_error("injected"); }; }),
+      ::testing::KilledBySignal(SIGABRT),
+      "");
+  auto const recovered = Recover();
+  EXPECT_TRUE(recovered.crcs_ok);
+  EXPECT_EQ(recovered.vertices, kWarmUp);
+  EXPECT_TRUE(recovered.faulted_value.has_value());  // FinalizeWalFile synced it (flush every transaction)
+}
+
+TEST_F(PipelinedCommitDeathTest, AfterPublishThrowsTerminatesAndTheTransactionRecoversCommitted) {
+  EXPECT_EXIT(RunChild([](CommitProbe &probe) { probe.after_publish = [] { throw std::runtime_error("injected"); }; }),
+              ::testing::KilledBySignal(SIGABRT),
+              "");
+  auto const recovered = Recover();
+  EXPECT_TRUE(recovered.crcs_ok);
+  EXPECT_EQ(recovered.vertices, kWarmUp);
+  EXPECT_TRUE(recovered.faulted_value.has_value());
+}
+
+TEST_F(PipelinedCommitDeathTest, WalDisabledAfterPublishThrowsTerminates) {
+  EXPECT_EXIT(RunChild([](CommitProbe &probe) { probe.after_publish = [] { throw std::runtime_error("injected"); }; },
+                       /*wal_disabled=*/true),
+              ::testing::KilledBySignal(SIGABRT),
+              "");
+}
+
+// 7: a failed abort (AbortAndResetCommitTs throwing while a validation failure aborts) terminates, never retried.
+TEST_F(PipelinedCommitDeathTest, FailedAbortTerminates) {
+  EXPECT_EXIT(
+      {
+        ArmWatchdog(60);
+        auto config = MakeConfig(dir_);
+        InMemoryStorage storage{config};
+        auto const label = storage.NameToLabel("L");
+        auto const id = storage.NameToProperty("id");
+        {
+          auto acc = storage.UniqueAccess();
+          if (!acc->CreateUniqueConstraint(label, {id}).has_value()) _exit(3);
+          if (!acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) _exit(3);
+        }
+        {
+          auto acc = storage.Access(memgraph::storage::WRITE);
+          auto v = acc->CreateVertex();
+          if (!v.AddLabel(label).has_value() || !v.SetProperty(id, PropertyValue(1)).has_value()) _exit(3);
+          if (!acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) _exit(3);
+        }
+        CommitProbe probe;
+        probe.abort_throws_once = true;
+        storage.SetCommitProbe(&probe);
+        auto acc = storage.Access(memgraph::storage::WRITE);
+        auto v = acc->CreateVertex();
+        if (!v.AddLabel(label).has_value() || !v.SetProperty(id, PropertyValue(1)).has_value()) _exit(3);
+        static_cast<void>(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));  // duplicate: aborts
+        _exit(5);
+      },
+      ::testing::KilledBySignal(SIGABRT),
+      "");
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  return RUN_ALL_TESTS();
+}

--- a/tests/unit/storage_v2_pipelined_commit.cpp
+++ b/tests/unit/storage_v2_pipelined_commit.cpp
@@ -29,6 +29,7 @@
 #include <thread>
 #include <vector>
 
+#include <sys/resource.h>
 #include <unistd.h>
 
 #include "flags/experimental.hpp"
@@ -83,6 +84,14 @@ void ArmWatchdog(unsigned seconds) {
   sigemptyset(&action.sa_mask);
   sigaction(SIGALRM, &action, nullptr);
   alarm(seconds);
+}
+
+// A death child aborts on purpose; it must not leave a core file behind.
+void DisableCoreDumps() {
+  struct rlimit limit{};
+  limit.rlim_cur = 0;
+  limit.rlim_max = 0;
+  setrlimit(RLIMIT_CORE, &limit);
 }
 
 // Enumerates the WAL files under `dir`, decodes each with the durability decoder, returns the timestamp of every
@@ -1004,6 +1013,7 @@ class PipelinedCommitDeathTest : public ::testing::Test {
 
   // The child: warm-up commits, then the faulting one; never returns normally when the fault fires.
   void RunChild(std::function<void(CommitProbe &)> arm, bool wal_disabled = false) {
+    DisableCoreDumps();
     ArmWatchdog(60);
     auto config = MakeConfig(dir_);
     if (wal_disabled) config.durability.snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT;
@@ -1098,6 +1108,7 @@ TEST_F(PipelinedCommitDeathTest, WalDisabledAfterPublishThrowsTerminates) {
 TEST_F(PipelinedCommitDeathTest, FailedAbortTerminates) {
   EXPECT_EXIT(
       {
+        DisableCoreDumps();
         ArmWatchdog(60);
         auto config = MakeConfig(dir_);
         InMemoryStorage storage{config};

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <sys/resource.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -2421,6 +2422,55 @@ std::optional<int64_t> ReadIntProperty(MinMemgraph &instance, Gid gid, std::stri
 // shutdown-while-locked rule rather than left on the connection.
 std::string LargePayload() { return std::string(2 * memgraph::slk::kSegmentMaxDataSize, 'x'); }
 
+// Installs test hooks and a probe on a storage and clears them on every exit, so a fatal assertion cannot leave a
+// heartbeat or a scheduled task pointing at destroyed stack objects. Declared before any worker or wait.
+class HookGuard {
+ public:
+  HookGuard(InMemoryStorage *storage, ReplicationTestHooks *hooks, CommitProbe *probe = nullptr) : storage_{storage} {
+    if (hooks != nullptr) storage_->SetReplicationTestHooks(hooks);
+    if (probe != nullptr) storage_->SetCommitProbe(probe);
+  }
+
+  HookGuard(HookGuard const &) = delete;
+  HookGuard &operator=(HookGuard const &) = delete;
+
+  ~HookGuard() {
+    storage_->SetCommitProbe(nullptr);
+    storage_->SetReplicationTestHooks(nullptr);
+  }
+
+ private:
+  InMemoryStorage *storage_;
+};
+
+auto ReplicaStorage(MinMemgraph &replica) -> InMemoryStorage * {
+  return static_cast<InMemoryStorage *>(replica.db.storage());
+}
+
+// Runs `f` on a thread and always releases `release` and joins on destruction, so an assertion that returns from
+// the test body cannot destroy a joinable thread or the state the worker still references.
+class JoinedThread {
+ public:
+  template <class F, class R>
+  JoinedThread(F f, R release) : release_{std::move(release)}, thread_{std::move(f)} {}
+
+  JoinedThread(JoinedThread const &) = delete;
+  JoinedThread &operator=(JoinedThread const &) = delete;
+
+  void Join() {
+    if (thread_.joinable()) thread_.join();
+  }
+
+  ~JoinedThread() {
+    release_();
+    Join();
+  }
+
+ private:
+  std::function<void()> release_;
+  std::thread thread_;
+};
+
 }  // namespace
 
 class PipelinedReplicationTest : public ReplicationTest {
@@ -2514,7 +2564,7 @@ TEST_F(PipelinedReplicationTest, FailedPrepareVoteAbortsInOrder) {
     std::atomic<int> aborts_applied{0};
     replica_hooks.refuse_next_prepare = [&](uint64_t) { return refusals.fetch_add(1) == 0; };
     replica_hooks.on_abort_applied = [&](uint64_t) { ++aborts_applied; };
-    static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+    HookGuard replica_guard{ReplicaStorage(replica), &replica_hooks};
     ReplicationTestHooks main_hooks;
     std::atomic<int> decision_results{0};
     std::atomic<bool> last_decision_ok{false};
@@ -2522,7 +2572,7 @@ TEST_F(PipelinedReplicationTest, FailedPrepareVoteAbortsInOrder) {
       last_decision_ok = ok;
       ++decision_results;
     };
-    MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+    HookGuard main_guard{MainStorage(main), &main_hooks};
 
     auto const watermark_before = MainStorage(main)->LastCommittedMvccTimestamp();
     auto const ldt_before = LastDurableTimestamp(main);
@@ -2542,8 +2592,6 @@ TEST_F(PipelinedReplicationTest, FailedPrepareVoteAbortsInOrder) {
     EXPECT_TRUE(Update(main, seeded, 3, /*large=*/false).has_value());
     EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
     EXPECT_EQ(ReadIntProperty(replica, seeded, "p"), 3);
-    static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
-    MainStorage(main)->SetReplicationTestHooks(nullptr);
     gid = seeded;
   }
   ASSERT_TRUE(gid.has_value());
@@ -2570,11 +2618,11 @@ TEST_F(PipelinedReplicationTest, ExceptionAfterCompletePrepareRecordAbortsInOrde
     if (prepared_count.fetch_add(1) == 0) prepared.count_down();
   };
   replica_hooks.on_abort_applied = [&](uint64_t) { ++aborts_applied; };
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+  HookGuard replica_guard{ReplicaStorage(replica), &replica_hooks};
   ReplicationTestHooks main_hooks;
   std::atomic<int> decision_results{0};
   main_hooks.on_abort_decision_result = [&](uint64_t, bool) { ++decision_results; };
-  MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+  HookGuard main_guard{MainStorage(main), &main_hooks};
   CommitProbe probe;
   std::atomic<bool> armed{true};
   probe.after_prepare_record = [&] {
@@ -2601,8 +2649,6 @@ TEST_F(PipelinedReplicationTest, ExceptionAfterCompletePrepareRecordAbortsInOrde
   EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
   EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
   EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
-  MainStorage(main)->SetReplicationTestHooks(nullptr);
 }
 
 // Nondeath returned-false abort decision, failed-vote caller: the replica answers the abort decision with failure.
@@ -2619,7 +2665,7 @@ TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterFailedVoteIsNotFatal) 
   std::atomic<int> decision_refusals{0};
   replica_hooks.refuse_next_prepare = [&](uint64_t) { return refusals.fetch_add(1) == 0; };
   replica_hooks.refuse_next_abort_decision = [&](uint64_t) { return decision_refusals.fetch_add(1) == 0; };
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+  HookGuard replica_guard{ReplicaStorage(replica), &replica_hooks};
   ReplicationTestHooks main_hooks;
   std::atomic<int> decision_results{0};
   std::atomic<bool> last_decision_ok{true};
@@ -2627,7 +2673,7 @@ TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterFailedVoteIsNotFatal) 
     last_decision_ok = ok;
     ++decision_results;
   };
-  MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+  HookGuard main_guard{MainStorage(main), &main_hooks};
 
   auto const watermark_before = MainStorage(main)->LastCommittedMvccTimestamp();
   auto const ldt_before = LastDurableTimestamp(main);
@@ -2643,8 +2689,6 @@ TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterFailedVoteIsNotFatal) 
   EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
   EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
   EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
-  MainStorage(main)->SetReplicationTestHooks(nullptr);
 }
 
 // Nondeath returned-false abort decision, unwind caller (after_prepare_record exception).
@@ -2663,7 +2707,7 @@ TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterUnwindIsNotFatal) {
     if (prepared_count.fetch_add(1) == 0) prepared.count_down();
   };
   replica_hooks.refuse_next_abort_decision = [&](uint64_t) { return decision_refusals.fetch_add(1) == 0; };
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+  HookGuard replica_guard{ReplicaStorage(replica), &replica_hooks};
   ReplicationTestHooks main_hooks;
   std::atomic<int> decision_results{0};
   std::atomic<bool> last_decision_ok{true};
@@ -2671,7 +2715,7 @@ TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterUnwindIsNotFatal) {
     last_decision_ok = ok;
     ++decision_results;
   };
-  MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+  HookGuard main_guard{MainStorage(main), &main_hooks};
   CommitProbe probe;
   std::atomic<bool> armed{true};
   probe.after_prepare_record = [&] {
@@ -2696,8 +2740,6 @@ TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterUnwindIsNotFatal) {
   EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
   EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
   EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
-  MainStorage(main)->SetReplicationTestHooks(nullptr);
 }
 
 // 3b: live-borrower abort. A real replica task waits on the WAL promise while after_schedule_ship throws. The abort is
@@ -2721,18 +2763,21 @@ class PipelinedLiveBorrowerTest : public PipelinedReplicationTest {
 
     ReplicationTestHooks hooks;
     std::latch borrower_waiting{1};
+    std::atomic<int> borrower_waits{0};
     std::atomic<int> tasks_done{0};
     std::atomic<int> tasks_done_at_release{-1};
     std::atomic<int> commands_released{0};
     std::string const expected_scope = variant == Variant::kDirectSyncPipeline ? "pipeline" : "legacy";
-    hooks.before_wal_result_wait = [&](std::string const &, uint64_t) { borrower_waiting.count_down(); };
+    hooks.before_wal_result_wait = [&](std::string const &, uint64_t) {
+      if (borrower_waits.fetch_add(1) == 0) borrower_waiting.count_down();  // once; the successor fires it too
+    };
     hooks.on_task_done = [&](std::string const &, uint64_t) { ++tasks_done; };
     hooks.on_commands_released = [&](std::string_view scope, uint64_t) {
       if (scope != expected_scope) return;
       tasks_done_at_release = tasks_done.load();
       ++commands_released;
     };
-    storage->SetReplicationTestHooks(&hooks);
+    HookGuard hook_guard{storage, &hooks};
     CommitProbe probe;
     std::atomic<bool> armed{true};
     probe.after_schedule_ship = [&] {
@@ -2770,7 +2815,6 @@ class PipelinedLiveBorrowerTest : public PipelinedReplicationTest {
     EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
     EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
     EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
-    storage->SetReplicationTestHooks(nullptr);
   }
 };
 
@@ -2876,7 +2920,7 @@ TEST_F(PipelinedReplicationTest, PartialReplicationConstructionRollsBackTheOpene
   hooks.throw_on_open_for = [&](std::string const &name, uint64_t) {
     return name == "REPLICA2" && armed.exchange(false);
   };
-  storage->SetReplicationTestHooks(&hooks);
+  HookGuard hook_guard{storage, &hooks};
 
   auto const watermark_before = storage->LastCommittedMvccTimestamp();
   auto const ldt_before = LastDurableTimestamp(main);
@@ -2889,7 +2933,6 @@ TEST_F(PipelinedReplicationTest, PartialReplicationConstructionRollsBackTheOpene
   storage->repl_storage_state_.replication_storage_clients_.WithReadLock(
       [&](auto const &clients) { aborts_after = clients.front()->abort_rpc_client_calls(); });
   EXPECT_EQ(aborts_after - aborts_before, 1);
-  storage->SetReplicationTestHooks(nullptr);
 
   ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
   ASSERT_TRUE(WaitForReplicaState(main, "REPLICA2", ReplicaState::READY));
@@ -2952,7 +2995,7 @@ TEST_F(PipelinedReplicationTest, ConcurrentWritersReplicateInOrderWithConsistent
     auto guard = std::lock_guard{prepared_mutex};
     prepared_timestamps.push_back(ts);
   };
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+  HookGuard replica_guard{ReplicaStorage(replica), &replica_hooks};
 
   std::atomic<bool> stop{false};
   std::atomic<bool> bad_state_seen{false};
@@ -2991,7 +3034,6 @@ TEST_F(PipelinedReplicationTest, ConcurrentWritersReplicateInOrderWithConsistent
       [&](auto const &clients) { replica_cached = clients.front()->GetNumCommittedTxns(); });
   EXPECT_EQ(replica_cached, NumCommittedTxns(main));
   EXPECT_EQ(MainStorage(main)->commit_order_gate_for_tests().Pending(), 0);
-  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
 }
 
 // ---- Process-isolated multi-replica cases ----------------------------------------------------------------------
@@ -3013,6 +3055,11 @@ void ArmReplicationWatchdog(unsigned seconds) {
   sigemptyset(&action.sa_mask);
   sigaction(SIGALRM, &action, nullptr);
   alarm(seconds);
+  // A death child aborts on purpose; it must not leave a core file behind.
+  struct rlimit limit{};
+  limit.rlim_cur = 0;
+  limit.rlim_max = 0;
+  setrlimit(RLIMIT_CORE, &limit);
 }
 
 size_t CountLines(std::filesystem::path const &path) {
@@ -3197,7 +3244,7 @@ TEST_F(PipelinedMixedAbortTest, HeldAsyncBorrowerDelaysTheAbortContinuation) {
     tasks_done_at_cleanup = tasks_done.load();
     ++async_cleanups;
   };
-  storage->SetReplicationTestHooks(&hooks);
+  HookGuard hook_guard{storage, &hooks};
   CommitProbe probe;
   std::atomic<bool> armed{true};
   probe.after_prepare_record = [&] {
@@ -3212,33 +3259,30 @@ TEST_F(PipelinedMixedAbortTest, HeldAsyncBorrowerDelaysTheAbortContinuation) {
   auto const committed_before = NumCommittedTxns(main);
   std::atomic<bool> threw{false};
   std::atomic<bool> commit_returned{false};
-  std::thread committer{[&] {
-    bool local_threw = false;
-    static_cast<void>(Update(main, gid, 2, /*large=*/false, &local_threw));
-    threw = local_threw;
-    commit_returned = true;
-  }};
-  if (!WaitFor([&] { return borrower_held.load(); }, std::chrono::seconds(10))) {
-    // Release everything before failing so the committer thread can be joined.
+  auto const release = [&] {
     {
       std::lock_guard lock{hold_mutex};
       release_borrower = true;
     }
     hold_cv.notify_all();
-    committer.join();
-    FAIL() << "the ASYNC borrower was never held (WAL waits seen: " << wal_waits_seen.load() << ")";
-  }
+  };
+  // Released and joined on every exit, so an assertion cannot return over a live committer.
+  JoinedThread committer{[&] {
+                           bool local_threw = false;
+                           static_cast<void>(Update(main, gid, 2, /*large=*/false, &local_threw));
+                           threw = local_threw;
+                           commit_returned = true;
+                         },
+                         release};
+  ASSERT_TRUE(WaitFor([&] { return borrower_held.load(); }, std::chrono::seconds(10)))
+      << "the ASYNC borrower was never held (WAL waits seen: " << wal_waits_seen.load() << ")";
   // The STRICT_SYNC prepare completes while the ASYNC borrower is held.
   ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
   EXPECT_FALSE(WaitFor([&] { return commit_returned.load(); }, std::chrono::milliseconds(500)));
   EXPECT_EQ(storage->pipeline_test_counters().decision_calls.load(), decisions_before);  // no decision yet
   EXPECT_EQ(async_cleanups.load(), 0);                                                   // no ASYNC cleanup yet
-  {
-    std::lock_guard lock{hold_mutex};
-    release_borrower = true;
-  }
-  hold_cv.notify_all();
-  committer.join();
+  release();
+  committer.Join();
   EXPECT_TRUE(threw.load());
   EXPECT_EQ(storage->pipeline_test_counters().decision_calls.load() - decisions_before, 1);
   EXPECT_EQ(async_cleanups.load(), 1);
@@ -3253,7 +3297,6 @@ TEST_F(PipelinedMixedAbortTest, HeldAsyncBorrowerDelaysTheAbortContinuation) {
   EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
   ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
   ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
-  storage->SetReplicationTestHooks(nullptr);
 }
 
 // Interleaving 2: the abort is parked at after_async_abort_cleanup while a heartbeat enqueues reconciliation for the
@@ -3284,7 +3327,7 @@ TEST_F(PipelinedMixedAbortTest, ReconciliationWaitsForTheParkedAbortToRetire) {
   hooks.before_reconcile_quiesce = [&](std::string const &name) {
     if (name == "ASYNC") ++async_reconcile_arrivals;  // the STRICT client also goes MAYBE_BEHIND; select by name
   };
-  storage->SetReplicationTestHooks(&hooks);
+  HookGuard hook_guard{storage, &hooks};
   ASSERT_TRUE(strict_->Send("refuse_prepare"));
 
   auto const watermark_before = storage->LastCommittedMvccTimestamp();
@@ -3292,10 +3335,18 @@ TEST_F(PipelinedMixedAbortTest, ReconciliationWaitsForTheParkedAbortToRetire) {
   auto const committed_before = NumCommittedTxns(main);
   std::atomic<bool> commit_returned{false};
   std::expected<void, memgraph::storage::StorageManipulationError> result;
-  std::thread committer{[&] {
-    result = Update(main, gid, 2, /*large=*/false);
-    commit_returned = true;
-  }};
+  auto const release = [&] {
+    {
+      std::lock_guard lock{park_mutex};
+      release_abort = true;
+    }
+    park_cv.notify_all();
+  };
+  JoinedThread committer{[&] {
+                           result = Update(main, gid, 2, /*large=*/false);
+                           commit_returned = true;
+                         },
+                         release};
   ASSERT_TRUE(WaitFor([&] { return abort_parked.load(); }, std::chrono::seconds(10)));
   // A frequent heartbeat enqueues reconciliation for the MAYBE_BEHIND ASYNC client; it arrives at its quiescence
   // point but cannot complete while the abort still holds the ticket.
@@ -3303,12 +3354,8 @@ TEST_F(PipelinedMixedAbortTest, ReconciliationWaitsForTheParkedAbortToRetire) {
   EXPECT_FALSE(WaitFor([&] { return main.db.storage()->GetReplicaState("ASYNC") == ReplicaState::READY; },
                        std::chrono::milliseconds(500)));
   EXPECT_FALSE(commit_returned.load());
-  {
-    std::lock_guard lock{park_mutex};
-    release_abort = true;
-  }
-  park_cv.notify_all();
-  committer.join();
+  release();
+  committer.Join();
   ASSERT_FALSE(result.has_value());
   ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
   EXPECT_EQ(tasks_done.load(), 2);
@@ -3320,7 +3367,132 @@ TEST_F(PipelinedMixedAbortTest, ReconciliationWaitsForTheParkedAbortToRetire) {
   EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
   ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
   ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
-  storage->SetReplicationTestHooks(nullptr);
+}
+
+// 3b, second variant: two replicas and a scheduling failure part-way through ScheduleEncodeAndShip. The first
+// task is already parked on the WAL gate when the second enqueue throws; the mixed case must drain the scheduled
+// task (which poisons its own stream) and discard the never-scheduled stream, in both the direct pipeline and the
+// locally owned legacy scope.
+class PipelinedPartialSchedulingTest : public PipelinedReplicationTest {
+ protected:
+  void Run(bool legacy_scope) {
+    MinMemgraph main(main_conf);
+    MinMemgraph replica1(repl_conf);
+    MinMemgraph replica2(repl2_conf);
+    Register(main, replica1, ReplicationMode::SYNC, "REPLICA1", ports[0]);
+    Register(main, replica2, ReplicationMode::SYNC, "REPLICA2", ports[1]);
+    auto const gid = Seed(main, 1);
+    ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica1));
+    ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica2));
+    auto *storage = MainStorage(main);
+    auto const finalizations_before = storage->pipeline_test_counters().finalize_wal_calls.load();
+    std::array<uint64_t, 2> aborts_before{};
+    storage->repl_storage_state_.replication_storage_clients_.WithReadLock([&](auto const &clients) {
+      for (size_t i = 0; i < 2; ++i) aborts_before[i] = clients[i]->abort_rpc_client_calls();
+    });
+
+    ReplicationTestHooks hooks;
+    std::latch first_waiting{1};
+    std::atomic<int> first_waits{0};
+    std::atomic<int> tasks_done{0};
+    std::atomic<int> tasks_done_at_release{-1};
+    std::atomic<int> commands_released{0};
+    std::atomic<bool> armed{true};
+    std::string const expected_scope = legacy_scope ? "legacy" : "pipeline";
+    hooks.before_wal_result_wait = [&](std::string const &name, uint64_t) {
+      if (name == "REPLICA1" && first_waits.fetch_add(1) == 0) first_waiting.count_down();
+    };
+    hooks.on_task_done = [&](std::string const &, uint64_t) { ++tasks_done; };
+    hooks.on_commands_released = [&](std::string_view scope, uint64_t) {
+      if (scope != expected_scope) return;
+      tasks_done_at_release = tasks_done.load();
+      ++commands_released;
+    };
+    hooks.throw_before_enqueue_for = [&](std::string const &name, uint64_t) {
+      if (name != "REPLICA2" || !armed.exchange(false)) return false;
+      first_waiting.wait();  // the first task holds a partially transmitted request on the WAL gate
+      return true;
+    };
+    HookGuard hook_guard{storage, &hooks};
+    CommitProbe probe;
+    if (legacy_scope) {
+      probe.budget_refuse.site = memgraph::storage::BudgetRefuse::kMaterializer;
+      probe.after_mint = [&probe] {
+        if (probe.budget_refuse.ticket.load() == 0) probe.budget_refuse.ticket = probe.minted_ticket.load();
+      };
+      storage->SetCommitProbe(&probe);
+    }
+
+    auto const watermark_before = storage->LastCommittedMvccTimestamp();
+    auto const ldt_before = LastDurableTimestamp(main);
+    auto const committed_before = NumCommittedTxns(main);
+    bool threw = false;
+    static_cast<void>(Update(main, gid, 2, /*large=*/true, &threw));
+    EXPECT_TRUE(threw);
+    ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+    EXPECT_EQ(storage->pipeline_test_counters().finalize_wal_calls.load(), finalizations_before);
+    EXPECT_EQ(commands_released.load(), 1);
+    EXPECT_EQ(tasks_done_at_release.load(), 1);  // exactly the one successfully scheduled task, finished first
+    std::array<uint64_t, 2> aborts_after{};
+    storage->repl_storage_state_.replication_storage_clients_.WithReadLock([&](auto const &clients) {
+      for (size_t i = 0; i < 2; ++i) aborts_after[i] = clients[i]->abort_rpc_client_calls();
+    });
+    EXPECT_EQ(aborts_after[0] - aborts_before[0], 1);  // the scheduled task poisoned its own stream
+    EXPECT_EQ(aborts_after[1] - aborts_before[1], 1);  // the never-scheduled stream was discarded by the owner
+    storage->SetCommitProbe(nullptr);
+
+    ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+    ASSERT_TRUE(WaitForReplicaState(main, "REPLICA2", ReplicaState::READY));
+    EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+    EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica1));
+    EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica2));
+    EXPECT_EQ(ReadIntProperty(replica1, gid, "p"), 3);
+    EXPECT_EQ(ReadIntProperty(replica2, gid, "p"), 3);
+  }
+};
+
+TEST_F(PipelinedPartialSchedulingTest, DirectPipeline) { Run(/*legacy_scope=*/false); }
+
+TEST_F(PipelinedPartialSchedulingTest, LocallyOwnedLegacyScope) { Run(/*legacy_scope=*/true); }
+
+// 9: an exception between the frames of a legacy STRICT_SYNC prepare record leaves an incomplete record on disk,
+// which is fatal. The replica runs in its own process so the death child owns nothing but the main.
+class PipelinedBetweenFramesDeathTest : public PipelinedReplicationTest {
+ protected:
+  void SetUp() override {
+    PipelinedReplicationTest::SetUp();
+    if (::testing::internal::InDeathTestChild()) return;
+    replica_ = std::make_unique<ReplicaProcess>(ports[0], ProcessReplicaDir(0));
+    ASSERT_TRUE(replica_->WaitReady());
+  }
+
+  void TearDown() override {
+    if (!::testing::internal::InDeathTestChild()) replica_.reset();
+    PipelinedReplicationTest::TearDown();
+  }
+
+  void RunMain() {
+    ArmReplicationWatchdog(120);
+    MinMemgraph main(main_conf);
+    auto const reg = main.repl_handler.TryRegisterReplica(
+        ReplicationClientConfig{.name = "REPLICA1",
+                                .mode = ReplicationMode::STRICT_SYNC,
+                                .repl_server_endpoint = Endpoint(local_host, ports[0])});
+    if (!reg.has_value()) _exit(3);
+    if (!WaitForReplicaState(main, "REPLICA1", ReplicaState::READY)) _exit(3);
+    auto const gid = Seed(main, 1);
+    CommitProbe probe;
+    probe.between_frames = [] { throw std::runtime_error("injected between frames"); };
+    MainStorage(main)->SetCommitProbe(&probe);
+    static_cast<void>(Update(main, gid, 2, /*large=*/false));
+    _exit(5);  // the incomplete record did not terminate
+  }
+
+  std::unique_ptr<ReplicaProcess> replica_;
+};
+
+TEST_F(PipelinedBetweenFramesDeathTest, ExceptionWithAnIncompleteRecordIsFatal) {
+  EXPECT_EXIT(RunMain(), ::testing::KilledBySignal(SIGABRT), "");
 }
 
 int main(int argc, char **argv) {

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -9,12 +9,28 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <csignal>
 #include <cstdint>
+#include <cstdlib>
+#include <expected>
+#include <fstream>
+#include <latch>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include <fmt/format.h>
@@ -34,6 +50,8 @@
 #include "replication/config.hpp"
 #include "replication/state.hpp"
 #include "replication_handler/replication_handler.hpp"
+#include "slk/streams.hpp"
+#include "storage/v2/commit_probe.hpp"
 #include "storage/v2/durability/durability.hpp"
 #include "storage/v2/durability/paths.hpp"
 #include "storage/v2/id_types.hpp"
@@ -43,6 +61,8 @@
 #include "storage/v2/storage.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "tests/unit/replication_min_memgraph.hpp"
+#include "tests/unit/replication_process_fixture.hpp"
 #include "tests/unit/storage_test_utils.hpp"
 #include "utils/exceptions.hpp"
 
@@ -62,10 +82,8 @@ using memgraph::storage::InMemoryStorage;
 using memgraph::storage::PropertyValue;
 using memgraph::storage::View;
 
-// Helper function to create CommitArgs from a DatabaseAccess
-auto MakeCommitArgs(const memgraph::dbms::DatabaseAccess &db_acc) -> memgraph::storage::CommitArgs {
-  return memgraph::storage::CommitArgs::make_main(std::make_unique<memgraph::dbms::DatabaseProtector>(db_acc));
-}
+using memgraph::tests::MakeCommitArgs;
+using memgraph::tests::MinMemgraph;
 
 using memgraph::storage::replication::ReplicaState;
 
@@ -135,56 +153,6 @@ class ReplicationTest : public ::testing::Test {
     if (std::filesystem::exists(repl_storage_directory)) std::filesystem::remove_all(repl_storage_directory);
     if (std::filesystem::exists(repl2_storage_directory)) std::filesystem::remove_all(repl2_storage_directory);
   }
-};
-
-struct MinMemgraph {
-  explicit MinMemgraph(const memgraph::storage::Config &conf)
-      : auth{conf.durability.storage_directory / "auth", memgraph::auth::Auth::Config{/* default */}},
-        parameters_{conf.durability.storage_directory},
-        repl_state{ReplicationStateRootPath(conf)},
-        dbms{conf},
-        db_acc{dbms.Get()},
-        db{*db_acc.get()},
-        repl_handler(repl_state, dbms, system_
-#ifdef MG_ENTERPRISE
-                     ,
-                     auth
-#endif
-                     ,
-                     parameters_) {
-  }
-
-  auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> { return db.ReadOnlyAccess(); }
-
-  auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    return db.Access(memgraph::storage::StorageAccessType::READ);
-  }
-
-  ~MinMemgraph() {
-    auto locked_repl_state = repl_state.Lock();
-    if (locked_repl_state->IsReplica()) {
-      auto &replica_data = std::get<memgraph::replication::RoleReplicaData>(locked_repl_state->ReplicationData());
-      replica_data.server.reset();
-    } else if (locked_repl_state->IsMain()) {
-      auto &main_data = std::get<memgraph::replication::RoleMainData>(locked_repl_state->ReplicationData());
-      for (auto &client : main_data.registered_replicas_) {
-        client.Shutdown();
-      }
-      dbms.ForEach([](memgraph::dbms::DatabaseAccess db_acc) {
-        auto *storage = db_acc->storage();
-        storage->repl_storage_state_.replication_storage_clients_.WithLock([](auto &clients) { clients.clear(); });
-      });
-    }
-  }
-
-  memgraph::auth::SynchedAuth auth;
-  memgraph::system::System system_;
-  memgraph::parameters::Parameters parameters_;
-  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state;
-  memgraph::dbms::DbmsHandler dbms;
-  memgraph::dbms::DatabaseAccess db_acc;
-  memgraph::dbms::Database &db;
-  ReplicationHandler repl_handler;
 };
 
 TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
@@ -2397,4 +2365,969 @@ TEST_F(ReplicationTestLightEdge, RecoveryProcess) {
     ASSERT_EQ(out_edges->edges.size(), 1U);
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
+}
+
+// ---- Pipelined commit (--experimental-enabled=lockfree-read-snapshot,pipelined-commit) --------------------------
+
+namespace {
+
+using memgraph::storage::CommitProbe;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::PropertyValue;
+using memgraph::storage::ReplicationTestHooks;
+
+template <class Pred>
+bool WaitFor(Pred pred, std::chrono::milliseconds timeout) {
+  auto const deadline = std::chrono::steady_clock::now() + timeout;
+  while (!pred()) {
+    if (std::chrono::steady_clock::now() > deadline) return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  return true;
+}
+
+bool WaitForReplicaState(MinMemgraph &main, std::string const &name, ReplicaState state,
+                         std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
+  return WaitFor([&] { return main.db.storage()->GetReplicaState(name) == state; }, timeout);
+}
+
+auto MainStorage(MinMemgraph &main) -> InMemoryStorage * { return static_cast<InMemoryStorage *>(main.db.storage()); }
+
+auto LastDurableTimestamp(MinMemgraph &instance) -> uint64_t {
+  return instance.db.storage()->repl_storage_state_.commit_ts_info_.load(std::memory_order_acquire).ldt_;
+}
+
+auto NumCommittedTxns(MinMemgraph &instance) -> uint64_t {
+  return instance.db.storage()->repl_storage_state_.commit_ts_info_.load(std::memory_order_acquire).num_committed_txns_;
+}
+
+// Polls the replica's durable timestamp until it reaches main's.
+bool WaitForReplicaToCatchUp(MinMemgraph &main, MinMemgraph &replica,
+                             std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
+  return WaitFor([&] { return LastDurableTimestamp(replica) >= LastDurableTimestamp(main); }, timeout);
+}
+
+std::optional<int64_t> ReadIntProperty(MinMemgraph &instance, Gid gid, std::string const &property) {
+  const memgraph::memory::DbArenaScope arena_scope{&instance.db.Arena()};
+  auto acc = instance.db.Access(memgraph::storage::READ);
+  auto v = acc->FindVertex(gid, View::OLD);
+  if (!v) return std::nullopt;
+  auto const value = v->GetProperty(instance.db.storage()->NameToProperty(property), View::OLD);
+  if (!value.has_value() || !value->IsInt()) return std::nullopt;
+  return value->ValueInt();
+}
+
+// A payload larger than one SLK segment, so a partially transmitted request must be poisoned by the
+// shutdown-while-locked rule rather than left on the connection.
+std::string LargePayload() { return std::string(2 * memgraph::slk::kSegmentMaxDataSize, 'x'); }
+
+}  // namespace
+
+class PipelinedReplicationTest : public ReplicationTest {
+ protected:
+  void SetUp() override {
+    ReplicationTest::SetUp();
+    main_conf.experimental_lockfree_read_snapshot = true;
+    main_conf.experimental_pipelined_commit = true;
+    main_conf.durability.wal_file_flush_every_n_tx = 1;
+  }
+
+  // Registers `mode` replica REPLICA1 on ports[0] and waits for READY.
+  void Register(MinMemgraph &main, MinMemgraph &replica, ReplicationMode mode, std::string const &name = "REPLICA1",
+                uint16_t port = 10'000) {
+    replica.repl_handler.TrySetReplicationRoleReplica(
+        ReplicationServerConfig{.repl_server = Endpoint(local_host, port)});
+    auto const reg = main.repl_handler.TryRegisterReplica(
+        ReplicationClientConfig{.name = name, .mode = mode, .repl_server_endpoint = Endpoint(local_host, port)});
+    ASSERT_TRUE(reg.has_value()) << static_cast<int>(reg.error());
+    ASSERT_TRUE(WaitForReplicaState(main, name, ReplicaState::READY));
+  }
+
+  Gid Seed(MinMemgraph &main, int value) {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v = acc->CreateVertex();
+    EXPECT_TRUE(v.SetProperty(main.db.storage()->NameToProperty("p"), PropertyValue(value)).has_value());
+    EXPECT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+    return v.Gid();
+  }
+
+  // Sets p=value (and a large payload when asked) on `gid`; returns the outcome or rethrows a runtime_error as
+  // `threw`.
+  auto Update(MinMemgraph &main, Gid gid, int value, bool large, bool *threw = nullptr)
+      -> std::expected<void, memgraph::storage::StorageManipulationError> {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v = acc->FindVertex(gid, View::NEW);
+    EXPECT_TRUE(v.has_value());
+    if (!v.has_value()) return std::unexpected{memgraph::storage::SerializationError{}};
+    EXPECT_TRUE(v->SetProperty(main.db.storage()->NameToProperty("p"), PropertyValue(value)).has_value());
+    if (large) {
+      EXPECT_TRUE(v->SetProperty(main.db.storage()->NameToProperty("blob"), PropertyValue(LargePayload())).has_value());
+    }
+    try {
+      return acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc));
+    } catch (std::runtime_error const &) {
+      if (threw != nullptr) *threw = true;
+      return {};
+    }
+  }
+
+  // Main-side invariants after a nonfatal ticketed abort.
+  void ExpectNothingCommitted(MinMemgraph &main, uint64_t watermark_before, uint64_t ldt_before,
+                              uint64_t committed_before) {
+    EXPECT_EQ(MainStorage(main)->LastCommittedMvccTimestamp(), watermark_before);
+    EXPECT_EQ(LastDurableTimestamp(main), ldt_before);
+    EXPECT_EQ(NumCommittedTxns(main), committed_before);
+    EXPECT_EQ(MainStorage(main)->commit_order_gate_for_tests().Pending(), 0);
+  }
+};
+
+// An eligible write with a STRICT_SYNC replica takes the ordered legacy continuation (2PC) and lands on the replica.
+TEST_F(PipelinedReplicationTest, StrictSyncReplicaTakesTheOrderedLegacyContinuation) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+  Register(main, replica, ReplicationMode::STRICT_SYNC);
+  auto const gid = Seed(main, 1);
+  auto const fallbacks_before = MainStorage(main)->pipeline_stats_for_tests().two_pc_fallbacks.load();
+  EXPECT_TRUE(Update(main, gid, 2, /*large=*/false).has_value());
+  EXPECT_EQ(MainStorage(main)->pipeline_stats_for_tests().two_pc_fallbacks.load() - fallbacks_before, 1);
+  EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+  EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 2);
+  EXPECT_EQ(MainStorage(main)->commit_order_gate_for_tests().Pending(), 0);
+}
+
+// Failed-2PC regression (a): a prepared replica that votes no. Main aborts nonfatally in order, its progress is
+// unchanged, the ticket retires, the replica's preparation is explicitly abandoned, a successor commits, and the
+// aborted transaction is excluded on recovery.
+TEST_F(PipelinedReplicationTest, FailedPrepareVoteAbortsInOrder) {
+  std::optional<Gid> gid;
+  {
+    MinMemgraph main(main_conf);
+    MinMemgraph replica(repl_conf);
+    Register(main, replica, ReplicationMode::STRICT_SYNC);
+    auto const seeded = Seed(main, 1);
+    ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+
+    ReplicationTestHooks replica_hooks;
+    std::atomic<int> refusals{0};
+    std::atomic<int> aborts_applied{0};
+    replica_hooks.refuse_next_prepare = [&](uint64_t) { return refusals.fetch_add(1) == 0; };
+    replica_hooks.on_abort_applied = [&](uint64_t) { ++aborts_applied; };
+    static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+    ReplicationTestHooks main_hooks;
+    std::atomic<int> decision_results{0};
+    std::atomic<bool> last_decision_ok{false};
+    main_hooks.on_abort_decision_result = [&](uint64_t, bool ok) {
+      last_decision_ok = ok;
+      ++decision_results;
+    };
+    MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+
+    auto const watermark_before = MainStorage(main)->LastCommittedMvccTimestamp();
+    auto const ldt_before = LastDurableTimestamp(main);
+    auto const committed_before = NumCommittedTxns(main);
+    auto const result = Update(main, seeded, 2, /*large=*/false);
+    ASSERT_FALSE(result.has_value());
+    ASSERT_TRUE(std::holds_alternative<memgraph::storage::ReplicationError>(result.error()));
+    EXPECT_FALSE(std::get<memgraph::storage::ReplicationError>(result.error()).transaction_committed);
+    ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+    EXPECT_TRUE(WaitFor([&] { return aborts_applied.load() == 1; }, std::chrono::seconds(10)));
+    EXPECT_EQ(decision_results.load(), 1);
+    EXPECT_TRUE(last_decision_ok.load());
+    EXPECT_EQ(ReadIntProperty(main, seeded, "p"), 1);
+
+    // A negative prepare response moves the client to MAYBE_BEHIND; wait for READY before the successor.
+    ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+    EXPECT_TRUE(Update(main, seeded, 3, /*large=*/false).has_value());
+    EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+    EXPECT_EQ(ReadIntProperty(replica, seeded, "p"), 3);
+    static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+    MainStorage(main)->SetReplicationTestHooks(nullptr);
+    gid = seeded;
+  }
+  ASSERT_TRUE(gid.has_value());
+  // Recovery excludes the aborted prepare record.
+  main_conf.durability.recover_on_startup = true;
+  MinMemgraph recovered(main_conf);
+  EXPECT_EQ(ReadIntProperty(recovered, *gid, "p"), 3);
+}
+
+// Failed-2PC regression (b): an exception after the complete commit=false prepare record, once the replica has cached
+// its prepared accessor and answered. The unwind guard sends the abort decision exactly once.
+TEST_F(PipelinedReplicationTest, ExceptionAfterCompletePrepareRecordAbortsInOrder) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+  Register(main, replica, ReplicationMode::STRICT_SYNC);
+  auto const gid = Seed(main, 1);
+  ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+
+  ReplicationTestHooks replica_hooks;
+  std::latch prepared{1};
+  std::atomic<int> prepared_count{0};
+  std::atomic<int> aborts_applied{0};
+  replica_hooks.on_prepared = [&](uint64_t) {
+    if (prepared_count.fetch_add(1) == 0) prepared.count_down();
+  };
+  replica_hooks.on_abort_applied = [&](uint64_t) { ++aborts_applied; };
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+  ReplicationTestHooks main_hooks;
+  std::atomic<int> decision_results{0};
+  main_hooks.on_abort_decision_result = [&](uint64_t, bool) { ++decision_results; };
+  MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+  CommitProbe probe;
+  std::atomic<bool> armed{true};
+  probe.after_prepare_record = [&] {
+    if (!armed.exchange(false)) return;
+    prepared.wait();  // the replica has cached its prepared accessor and sent its vote
+    throw std::runtime_error("injected after_prepare_record");
+  };
+  MainStorage(main)->SetCommitProbe(&probe);
+
+  auto const decision_calls_before = MainStorage(main)->pipeline_test_counters().decision_calls.load();
+  auto const watermark_before = MainStorage(main)->LastCommittedMvccTimestamp();
+  auto const ldt_before = LastDurableTimestamp(main);
+  auto const committed_before = NumCommittedTxns(main);
+  bool threw = false;
+  static_cast<void>(Update(main, gid, 2, /*large=*/false, &threw));
+  EXPECT_TRUE(threw);
+  ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+  EXPECT_EQ(MainStorage(main)->pipeline_test_counters().decision_calls.load() - decision_calls_before, 1);
+  EXPECT_EQ(decision_results.load(), 1);
+  EXPECT_TRUE(WaitFor([&] { return aborts_applied.load() == 1; }, std::chrono::seconds(10)));
+  MainStorage(main)->SetCommitProbe(nullptr);
+
+  ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+  EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+  EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+  EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+  MainStorage(main)->SetReplicationTestHooks(nullptr);
+}
+
+// Nondeath returned-false abort decision, failed-vote caller: the replica answers the abort decision with failure.
+// Nonfatal completion, one local abort, decision_ok observed false, successor succeeds.
+TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterFailedVoteIsNotFatal) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+  Register(main, replica, ReplicationMode::STRICT_SYNC);
+  auto const gid = Seed(main, 1);
+  ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+
+  ReplicationTestHooks replica_hooks;
+  std::atomic<int> refusals{0};
+  std::atomic<int> decision_refusals{0};
+  replica_hooks.refuse_next_prepare = [&](uint64_t) { return refusals.fetch_add(1) == 0; };
+  replica_hooks.refuse_next_abort_decision = [&](uint64_t) { return decision_refusals.fetch_add(1) == 0; };
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+  ReplicationTestHooks main_hooks;
+  std::atomic<int> decision_results{0};
+  std::atomic<bool> last_decision_ok{true};
+  main_hooks.on_abort_decision_result = [&](uint64_t, bool ok) {
+    last_decision_ok = ok;
+    ++decision_results;
+  };
+  MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+
+  auto const watermark_before = MainStorage(main)->LastCommittedMvccTimestamp();
+  auto const ldt_before = LastDurableTimestamp(main);
+  auto const committed_before = NumCommittedTxns(main);
+  auto const result = Update(main, gid, 2, /*large=*/false);
+  ASSERT_FALSE(result.has_value());
+  ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+  EXPECT_EQ(decision_results.load(), 1);
+  EXPECT_FALSE(last_decision_ok.load());
+  EXPECT_EQ(decision_refusals.load(), 1);
+
+  ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+  EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+  EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+  EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+  MainStorage(main)->SetReplicationTestHooks(nullptr);
+}
+
+// Nondeath returned-false abort decision, unwind caller (after_prepare_record exception).
+TEST_F(PipelinedReplicationTest, RefusedAbortDecisionAfterUnwindIsNotFatal) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+  Register(main, replica, ReplicationMode::STRICT_SYNC);
+  auto const gid = Seed(main, 1);
+  ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+
+  ReplicationTestHooks replica_hooks;
+  std::latch prepared{1};
+  std::atomic<int> prepared_count{0};
+  std::atomic<int> decision_refusals{0};
+  replica_hooks.on_prepared = [&](uint64_t) {
+    if (prepared_count.fetch_add(1) == 0) prepared.count_down();
+  };
+  replica_hooks.refuse_next_abort_decision = [&](uint64_t) { return decision_refusals.fetch_add(1) == 0; };
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+  ReplicationTestHooks main_hooks;
+  std::atomic<int> decision_results{0};
+  std::atomic<bool> last_decision_ok{true};
+  main_hooks.on_abort_decision_result = [&](uint64_t, bool ok) {
+    last_decision_ok = ok;
+    ++decision_results;
+  };
+  MainStorage(main)->SetReplicationTestHooks(&main_hooks);
+  CommitProbe probe;
+  std::atomic<bool> armed{true};
+  probe.after_prepare_record = [&] {
+    if (!armed.exchange(false)) return;
+    prepared.wait();
+    throw std::runtime_error("injected after_prepare_record");
+  };
+  MainStorage(main)->SetCommitProbe(&probe);
+
+  auto const watermark_before = MainStorage(main)->LastCommittedMvccTimestamp();
+  auto const ldt_before = LastDurableTimestamp(main);
+  auto const committed_before = NumCommittedTxns(main);
+  bool threw = false;
+  static_cast<void>(Update(main, gid, 2, /*large=*/false, &threw));
+  EXPECT_TRUE(threw);
+  ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+  EXPECT_EQ(decision_results.load(), 1);
+  EXPECT_FALSE(last_decision_ok.load());
+  MainStorage(main)->SetCommitProbe(nullptr);
+
+  ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+  EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+  EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+  EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+  MainStorage(main)->SetReplicationTestHooks(nullptr);
+}
+
+// 3b: live-borrower abort. A real replica task waits on the WAL promise while after_schedule_ship throws. The abort is
+// bounded and nonfatal (not_started: streams discarded, no WAL finalization), the borrower completes before the
+// command-owning scope is released, one retirement, READY handshake, successful successor.
+class PipelinedLiveBorrowerTest : public PipelinedReplicationTest {
+ protected:
+  enum class Variant { kDirectSyncPipeline, kLocalSyncLegacyFallback, kBorrowedStrictSyncFallback };
+
+  void Run(Variant variant) {
+    MinMemgraph main(main_conf);
+    MinMemgraph replica(repl_conf);
+    auto const mode =
+        variant == Variant::kBorrowedStrictSyncFallback ? ReplicationMode::STRICT_SYNC : ReplicationMode::SYNC;
+    Register(main, replica, mode);
+    auto const gid = Seed(main, 1);
+    ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+    auto *storage = MainStorage(main);
+    auto const finalizations_before = storage->pipeline_test_counters().finalize_wal_calls.load();
+    auto const decisions_before = storage->pipeline_test_counters().decision_calls.load();
+
+    ReplicationTestHooks hooks;
+    std::latch borrower_waiting{1};
+    std::atomic<int> tasks_done{0};
+    std::atomic<int> tasks_done_at_release{-1};
+    std::atomic<int> commands_released{0};
+    std::string const expected_scope = variant == Variant::kDirectSyncPipeline ? "pipeline" : "legacy";
+    hooks.before_wal_result_wait = [&](std::string const &, uint64_t) { borrower_waiting.count_down(); };
+    hooks.on_task_done = [&](std::string const &, uint64_t) { ++tasks_done; };
+    hooks.on_commands_released = [&](std::string_view scope, uint64_t) {
+      if (scope != expected_scope) return;
+      tasks_done_at_release = tasks_done.load();
+      ++commands_released;
+    };
+    storage->SetReplicationTestHooks(&hooks);
+    CommitProbe probe;
+    std::atomic<bool> armed{true};
+    probe.after_schedule_ship = [&] {
+      if (!armed.exchange(false)) return;
+      borrower_waiting.wait();  // the task is parked on the WAL gate with a partially transmitted request
+      throw std::runtime_error("injected after_schedule_ship");
+    };
+    if (variant == Variant::kLocalSyncLegacyFallback) {
+      // Force the ordered legacy fallback: the first ticketed commit after installation is refused at the materializer.
+      probe.budget_refuse.site = memgraph::storage::BudgetRefuse::kMaterializer;
+      probe.after_mint = [&probe] {
+        if (probe.budget_refuse.ticket.load() == 0) probe.budget_refuse.ticket = probe.minted_ticket.load();
+      };
+    }
+    storage->SetCommitProbe(&probe);
+
+    auto const watermark_before = storage->LastCommittedMvccTimestamp();
+    auto const ldt_before = LastDurableTimestamp(main);
+    auto const committed_before = NumCommittedTxns(main);
+    bool threw = false;
+    static_cast<void>(Update(main, gid, 2, /*large=*/true, &threw));
+    EXPECT_TRUE(threw);
+    ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+    EXPECT_EQ(storage->pipeline_test_counters().finalize_wal_calls.load(), finalizations_before);
+    EXPECT_EQ(storage->pipeline_test_counters().decision_calls.load(), decisions_before);
+    EXPECT_EQ(commands_released.load(), 1);
+    EXPECT_EQ(tasks_done_at_release.load(), 1);  // the borrower finished before the commands were destroyed
+    if (variant == Variant::kLocalSyncLegacyFallback) {
+      EXPECT_TRUE(probe.budget_refuse.fired.load());
+    }
+    storage->SetCommitProbe(nullptr);
+
+    // The discarded stream left the client MAYBE_BEHIND; reconciliation brings it back to READY.
+    ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+    EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+    EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+    EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
+    storage->SetReplicationTestHooks(nullptr);
+  }
+};
+
+TEST_F(PipelinedLiveBorrowerTest, DirectSyncPipeline) { Run(Variant::kDirectSyncPipeline); }
+
+TEST_F(PipelinedLiveBorrowerTest, LocallyOwnedSyncLegacyFallback) { Run(Variant::kLocalSyncLegacyFallback); }
+
+TEST_F(PipelinedLiveBorrowerTest, BorrowedStrictSyncFallback) { Run(Variant::kBorrowedStrictSyncFallback); }
+
+// 9b: all-unscheduled unstarted-record unwind with a real replica: streams open, no shipping task exists.
+class PipelinedUnscheduledAbortTest : public PipelinedReplicationTest {
+ protected:
+  enum class Site { kPipelineBeforeAppend, kLegacyBeforeMaterialize, kBorrowedStrictSyncBeforeMaterialize };
+
+  void Run(Site site) {
+    MinMemgraph main(main_conf);
+    MinMemgraph replica(repl_conf);
+    auto const mode =
+        site == Site::kBorrowedStrictSyncBeforeMaterialize ? ReplicationMode::STRICT_SYNC : ReplicationMode::SYNC;
+    Register(main, replica, mode);
+    auto const gid = Seed(main, 1);
+    ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+    auto *storage = MainStorage(main);
+    auto const finalizations_before = storage->pipeline_test_counters().finalize_wal_calls.load();
+    auto const decisions_before = storage->pipeline_test_counters().decision_calls.load();
+    uint64_t aborts_before = 0;
+    storage->repl_storage_state_.replication_storage_clients_.WithReadLock(
+        [&](auto const &clients) { aborts_before = clients.front()->abort_rpc_client_calls(); });
+
+    CommitProbe probe;
+    std::atomic<bool> armed{true};
+    auto const fault = [&] {
+      if (armed.exchange(false)) throw std::runtime_error("injected before any frame");
+    };
+    if (site == Site::kPipelineBeforeAppend) {
+      probe.before_append = fault;
+    } else {
+      probe.before_legacy_materialize = fault;
+    }
+    storage->SetCommitProbe(&probe);
+
+    auto const watermark_before = storage->LastCommittedMvccTimestamp();
+    auto const ldt_before = LastDurableTimestamp(main);
+    auto const committed_before = NumCommittedTxns(main);
+    bool threw = false;
+    if (site == Site::kLegacyBeforeMaterialize) {
+      // An ineligible (metadata) transaction routed through the locally owned legacy continuation.
+      const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+      auto acc = main.db.ReadOnlyAccess();
+      ASSERT_TRUE(acc->CreateIndex(main.db.storage()->NameToLabel("L")).has_value());
+      try {
+        static_cast<void>(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)));
+      } catch (std::runtime_error const &) {
+        threw = true;
+      }
+    } else {
+      static_cast<void>(Update(main, gid, 2, /*large=*/false, &threw));
+    }
+    EXPECT_TRUE(threw);
+    ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+    EXPECT_EQ(storage->pipeline_test_counters().finalize_wal_calls.load(), finalizations_before);
+    EXPECT_EQ(storage->pipeline_test_counters().decision_calls.load(), decisions_before);
+    uint64_t aborts_after = 0;
+    storage->repl_storage_state_.replication_storage_clients_.WithReadLock(
+        [&](auto const &clients) { aborts_after = clients.front()->abort_rpc_client_calls(); });
+    EXPECT_EQ(aborts_after - aborts_before, 1);  // exactly one effective stream cleanup
+    storage->SetCommitProbe(nullptr);
+
+    ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+    EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+    EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+    EXPECT_EQ(ReadIntProperty(replica, gid, "p"), 3);
+  }
+};
+
+TEST_F(PipelinedUnscheduledAbortTest, PipelineBeforeAppend) { Run(Site::kPipelineBeforeAppend); }
+
+TEST_F(PipelinedUnscheduledAbortTest, LegacyBeforeMaterialize) { Run(Site::kLegacyBeforeMaterialize); }
+
+TEST_F(PipelinedUnscheduledAbortTest, BorrowedStrictSyncBeforeMaterialize) {
+  Run(Site::kBorrowedStrictSyncBeforeMaterialize);
+}
+
+// 9c: partial replication-object construction. Two SYNC replicas; the constructor throws before opening the second
+// stream, after the first was retained: the rollback shuts the first stream down, resets it and marks its client
+// MAYBE_BEHIND, then a nonfatal abort, the READY handshake, and a successful successor.
+TEST_F(PipelinedReplicationTest, PartialReplicationConstructionRollsBackTheOpenedStream) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica1(repl_conf);
+  MinMemgraph replica2(repl2_conf);
+  Register(main, replica1, ReplicationMode::SYNC, "REPLICA1", ports[0]);
+  Register(main, replica2, ReplicationMode::SYNC, "REPLICA2", ports[1]);
+  auto const gid = Seed(main, 1);
+  ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica1));
+  ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica2));
+  auto *storage = MainStorage(main);
+  uint64_t aborts_before = 0;
+  storage->repl_storage_state_.replication_storage_clients_.WithReadLock(
+      [&](auto const &clients) { aborts_before = clients.front()->abort_rpc_client_calls(); });
+
+  ReplicationTestHooks hooks;
+  std::atomic<bool> armed{true};
+  hooks.throw_on_open_for = [&](std::string const &name, uint64_t) {
+    return name == "REPLICA2" && armed.exchange(false);
+  };
+  storage->SetReplicationTestHooks(&hooks);
+
+  auto const watermark_before = storage->LastCommittedMvccTimestamp();
+  auto const ldt_before = LastDurableTimestamp(main);
+  auto const committed_before = NumCommittedTxns(main);
+  bool threw = false;
+  static_cast<void>(Update(main, gid, 2, /*large=*/false, &threw));
+  EXPECT_TRUE(threw);
+  ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+  uint64_t aborts_after = 0;
+  storage->repl_storage_state_.replication_storage_clients_.WithReadLock(
+      [&](auto const &clients) { aborts_after = clients.front()->abort_rpc_client_calls(); });
+  EXPECT_EQ(aborts_after - aborts_before, 1);
+  storage->SetReplicationTestHooks(nullptr);
+
+  ASSERT_TRUE(WaitForReplicaState(main, "REPLICA1", ReplicaState::READY));
+  ASSERT_TRUE(WaitForReplicaState(main, "REPLICA2", ReplicaState::READY));
+  EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+  EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica1));
+  EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica2));
+  EXPECT_EQ(ReadIntProperty(replica1, gid, "p"), 3);
+  EXPECT_EQ(ReadIntProperty(replica2, gid, "p"), 3);
+}
+
+// 9f: the before_legacy_materialize probe is gated on the ticket, never on the flag: with both flags on the replica
+// too, replicated writes never invoke it, while a locally owned main-side legacy commit invokes it exactly once.
+TEST_F(PipelinedReplicationTest, LegacyMaterializeProbeIsTicketGatedNotFlagGated) {
+  repl_conf.experimental_lockfree_read_snapshot = true;
+  repl_conf.experimental_pipelined_commit = true;
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+  Register(main, replica, ReplicationMode::SYNC);
+  CommitProbe replica_probe;
+  std::atomic<int> replica_invocations{0};
+  replica_probe.before_legacy_materialize = [&] { ++replica_invocations; };
+  replica.db.storage()->SetCommitProbe(&replica_probe);
+  CommitProbe main_probe;
+  std::atomic<int> main_invocations{0};
+  main_probe.before_legacy_materialize = [&] { ++main_invocations; };
+  main.db.storage()->SetCommitProbe(&main_probe);
+
+  auto const gid = Seed(main, 1);  // pipelined: no legacy materialization on main
+  EXPECT_TRUE(Update(main, gid, 2, /*large=*/false).has_value());
+  {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = main.db.ReadOnlyAccess();
+    ASSERT_TRUE(acc->CreateIndex(main.db.storage()->NameToLabel("L")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());  // legacy, once
+  }
+  EXPECT_TRUE(WaitForReplicaToCatchUp(main, replica));
+  EXPECT_EQ(main_invocations.load(), 1);
+  EXPECT_EQ(replica_invocations.load(), 0);
+  replica.db.storage()->SetCommitProbe(nullptr);
+  main.db.storage()->SetCommitProbe(nullptr);
+}
+
+// Task 7: replica ordering and counts under concurrent pipelined writers. Live replication is distinguished from
+// recovery: a healthy SYNC stream moves the client READY<->REPLICATING only.
+TEST_F(PipelinedReplicationTest, ConcurrentWritersReplicateInOrderWithConsistentCounts) {
+  MinMemgraph main(main_conf);
+  MinMemgraph replica(repl_conf);
+  Register(main, replica, ReplicationMode::SYNC);
+  constexpr int kWriters = 8;
+  constexpr int kRounds = 20;
+  std::vector<Gid> gids;
+  for (int i = 0; i < kWriters; ++i) gids.push_back(Seed(main, 0));
+  ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+  auto const committed_before = NumCommittedTxns(main);
+
+  ReplicationTestHooks replica_hooks;
+  std::mutex prepared_mutex;
+  std::vector<uint64_t> prepared_timestamps;
+  replica_hooks.on_prepared = [&](uint64_t ts) {
+    auto guard = std::lock_guard{prepared_mutex};
+    prepared_timestamps.push_back(ts);
+  };
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(&replica_hooks);
+
+  std::atomic<bool> stop{false};
+  std::atomic<bool> bad_state_seen{false};
+  std::thread state_watcher{[&] {
+    while (!stop.load()) {
+      auto const state = main.db.storage()->GetReplicaState("REPLICA1");
+      if (state != ReplicaState::READY && state != ReplicaState::REPLICATING) bad_state_seen = true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }};
+  std::vector<std::thread> writers;
+  std::atomic<int> failures{0};
+  for (int w = 0; w < kWriters; ++w) {
+    writers.emplace_back([&, w] {
+      for (int r = 0; r < kRounds; ++r) {
+        if (!Update(main, gids[w], r, /*large=*/false).has_value()) ++failures;
+      }
+    });
+  }
+  for (auto &t : writers) t.join();
+  stop = true;
+  state_watcher.join();
+  EXPECT_EQ(failures.load(), 0);
+  EXPECT_FALSE(bad_state_seen.load());
+  ASSERT_TRUE(WaitForReplicaToCatchUp(main, replica));
+  for (int w = 0; w < kWriters; ++w) EXPECT_EQ(ReadIntProperty(replica, gids[w], "p"), kRounds - 1);
+  {
+    auto guard = std::lock_guard{prepared_mutex};
+    EXPECT_EQ(prepared_timestamps.size(), kWriters * kRounds);
+    EXPECT_TRUE(std::ranges::is_sorted(prepared_timestamps));
+    EXPECT_TRUE(std::ranges::adjacent_find(prepared_timestamps) == prepared_timestamps.end());  // strictly increasing
+  }
+  EXPECT_EQ(NumCommittedTxns(main) - committed_before, kWriters * kRounds);
+  uint64_t replica_cached = 0;
+  MainStorage(main)->repl_storage_state_.replication_storage_clients_.WithReadLock(
+      [&](auto const &clients) { replica_cached = clients.front()->GetNumCommittedTxns(); });
+  EXPECT_EQ(replica_cached, NumCommittedTxns(main));
+  EXPECT_EQ(MainStorage(main)->commit_order_gate_for_tests().Pending(), 0);
+  static_cast<InMemoryStorage *>(replica.db.storage())->SetReplicationTestHooks(nullptr);
+}
+
+// ---- Process-isolated multi-replica cases ----------------------------------------------------------------------
+
+namespace {
+
+using memgraph::tests::ReplicaProcess;
+
+std::filesystem::path ProcessReplicaDir(int index) {
+  return std::filesystem::temp_directory_path() /
+         ("MG_test_unit_storage_v2_replication_proc" + std::to_string(index) + "_" + std::to_string(getpid()));
+}
+
+extern "C" void ReplicationWatchdogHandler(int) { _exit(124); }
+
+void ArmReplicationWatchdog(unsigned seconds) {
+  struct sigaction action{};
+  action.sa_handler = ReplicationWatchdogHandler;
+  sigemptyset(&action.sa_mask);
+  sigaction(SIGALRM, &action, nullptr);
+  alarm(seconds);
+}
+
+size_t CountLines(std::filesystem::path const &path) {
+  std::ifstream file{path};
+  size_t lines = 0;
+  std::string line;
+  while (std::getline(file, line)) {
+    if (!line.empty()) ++lines;
+  }
+  return lines;
+}
+
+}  // namespace
+
+// 8: abort-continuation-step death. Two STRICT_SYNC replicas in their own processes (so a "later decision" exists),
+// a failed prepare vote from the first, and exactly one step of AbortTwoPcOrTerminate throwing once: the main
+// terminates, and the attempt marker shows exactly one attempt for the selected step (no retry).
+class PipelinedAbortStepDeathTest : public PipelinedReplicationTest, public ::testing::WithParamInterface<std::string> {
+ protected:
+  // The controller (the gtest parent) owns the replica processes; the death child inherits their ports through
+  // the environment and must not spawn its own.
+  void SetUp() override {
+    PipelinedReplicationTest::SetUp();
+    if (::testing::internal::InDeathTestChild()) return;
+    replicas_.push_back(std::make_unique<ReplicaProcess>(ports[0], ProcessReplicaDir(0)));
+    replicas_.push_back(std::make_unique<ReplicaProcess>(ports[1], ProcessReplicaDir(1)));
+    for (auto &replica : replicas_) ASSERT_TRUE(replica->WaitReady());
+    marker_ = std::filesystem::temp_directory_path() / ("MG_abort_step_marker_" + std::to_string(getpid()));
+    go_file_ = std::filesystem::temp_directory_path() / ("MG_abort_step_go_" + std::to_string(getpid()));
+    std::filesystem::remove(marker_);
+    std::filesystem::remove(go_file_);
+    setenv("MG_ABORT_STEP_MARKER", marker_.c_str(), 1);
+    setenv("MG_ABORT_STEP_GO", go_file_.c_str(), 1);
+  }
+
+  void TearDown() override {
+    if (!::testing::internal::InDeathTestChild()) {
+      if (controller_.joinable()) controller_.join();
+      replicas_.clear();
+      std::filesystem::remove(marker_);
+      std::filesystem::remove(go_file_);
+      unsetenv("MG_ABORT_STEP_MARKER");
+      unsetenv("MG_ABORT_STEP_GO");
+    }
+    PipelinedReplicationTest::TearDown();
+  }
+
+  // The controller: once the seed transaction has been prepared on the first replica, arm its refusal and release
+  // the main (which polls for the go file before issuing the faulting transaction).
+  void StartController() {
+    controller_ = std::thread{[this] {
+      if (!replicas_[0]->WaitEvent("prepared", std::chrono::seconds(60))) return;
+      if (!replicas_[0]->Send("refuse_prepare")) return;
+      std::ofstream{go_file_} << "go\n";
+    }};
+  }
+
+  // Runs in the death child.
+  void RunMain(std::string const &step) {
+    ArmReplicationWatchdog(120);
+    MinMemgraph main(main_conf);
+    for (int i = 0; i < 2; ++i) {
+      auto const reg = main.repl_handler.TryRegisterReplica(
+          ReplicationClientConfig{.name = replicas_names_[i],
+                                  .mode = ReplicationMode::STRICT_SYNC,
+                                  .repl_server_endpoint = Endpoint(local_host, ports[i])});
+      if (!reg.has_value()) _exit(3);
+      if (!WaitForReplicaState(main, replicas_names_[i], ReplicaState::READY)) _exit(3);
+    }
+    auto const gid = Seed(main, 1);
+    // The controller arms the refusal after it saw the seed prepared, then releases us.
+    std::filesystem::path const go_file{std::getenv("MG_ABORT_STEP_GO")};
+    while (!std::filesystem::exists(go_file)) std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    CommitProbe probe;
+    probe.fault_attempt_marker_path = std::getenv("MG_ABORT_STEP_MARKER");
+    if (step == "finalize_wal") {
+      probe.finalize_wal_throws_once = true;
+    } else {
+      probe.decision_schedule_throws_once = true;
+    }
+    MainStorage(main)->SetCommitProbe(&probe);
+    // The first replica votes no.
+    static_cast<void>(Update(main, gid, 2, /*large=*/false));
+    _exit(5);  // the step did not throw
+  }
+
+  std::vector<std::unique_ptr<ReplicaProcess>> replicas_;
+  std::array<std::string, 2> replicas_names_{"REPLICA1", "REPLICA2"};
+  std::filesystem::path marker_;
+  std::filesystem::path go_file_;
+  std::thread controller_;
+};
+
+INSTANTIATE_TEST_SUITE_P(Steps, PipelinedAbortStepDeathTest, ::testing::Values("finalize_wal", "decision_schedule"));
+
+TEST_P(PipelinedAbortStepDeathTest, StepThrowsOnceTerminatesWithoutRetry) {
+  if (!::testing::internal::InDeathTestChild()) StartController();
+  EXPECT_EXIT(RunMain(GetParam()), ::testing::KilledBySignal(SIGABRT), "");
+  if (controller_.joinable()) controller_.join();
+  EXPECT_EQ(CountLines(marker_), 1);
+  // The controller reaps the replica processes in TearDown.
+}
+
+// 9e: mixed STRICT_SYNC + ASYNC complete-prepare abort with both replicas in their own processes, in both the
+// refused-prepare and the after_prepare_record-exception forms, with the two forced interleavings.
+class PipelinedMixedAbortTest : public PipelinedReplicationTest {
+ protected:
+  void SetUp() override {
+    PipelinedReplicationTest::SetUp();
+    strict_ = std::make_unique<ReplicaProcess>(ports[0], ProcessReplicaDir(0));
+    async_ = std::make_unique<ReplicaProcess>(ports[1], ProcessReplicaDir(1));
+    ASSERT_TRUE(strict_->WaitReady());
+    ASSERT_TRUE(async_->WaitReady());
+  }
+
+  void TearDown() override {
+    strict_.reset();
+    async_.reset();
+    PipelinedReplicationTest::TearDown();
+  }
+
+  void RegisterBoth(MinMemgraph &main) {
+    for (auto const &[name, mode, port] : {std::tuple{"STRICT", ReplicationMode::STRICT_SYNC, ports[0]},
+                                           std::tuple{"ASYNC", ReplicationMode::ASYNC, ports[1]}}) {
+      auto const reg = main.repl_handler.TryRegisterReplica(ReplicationClientConfig{
+          .name = name,
+          .mode = mode,
+          .repl_server_endpoint = Endpoint(local_host, port),
+          .replica_check_frequency = std::chrono::seconds(1),
+      });
+      ASSERT_TRUE(reg.has_value()) << static_cast<int>(reg.error());
+      ASSERT_TRUE(WaitForReplicaState(main, name, ReplicaState::READY));
+    }
+  }
+
+  uint64_t AsyncAbortCalls(MinMemgraph &main) {
+    uint64_t calls = 0;
+    MainStorage(main)->repl_storage_state_.replication_storage_clients_.WithReadLock([&](auto const &clients) {
+      for (auto const &client : clients) {
+        if (client->Name() == "ASYNC") calls = client->abort_rpc_client_calls();
+      }
+    });
+    return calls;
+  }
+
+  std::unique_ptr<ReplicaProcess> strict_;
+  std::unique_ptr<ReplicaProcess> async_;
+};
+
+// Interleaving 1: the ASYNC shipping task is held at before_wal_result_wait while the STRICT_SYNC prepare
+// completes and after_prepare_record throws. No decision call and no ASYNC cleanup happens until the borrower is
+// released; the task's completion precedes the cleanup.
+TEST_F(PipelinedMixedAbortTest, HeldAsyncBorrowerDelaysTheAbortContinuation) {
+  MinMemgraph main(main_conf);
+  RegisterBoth(main);
+  auto const gid = Seed(main, 1);
+  ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
+  // The ASYNC client returns to READY from its own finalize task; the faulting write needs it streaming.
+  ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
+  auto *storage = MainStorage(main);
+  auto const async_aborts_before = AsyncAbortCalls(main);
+  auto const decisions_before = storage->pipeline_test_counters().decision_calls.load();
+
+  ReplicationTestHooks hooks;
+  std::mutex hold_mutex;
+  std::condition_variable hold_cv;
+  bool release_borrower = false;
+  std::atomic<bool> borrower_held{false};
+  std::atomic<int> tasks_done{0};
+  std::atomic<int> async_cleanups{0};
+  std::atomic<int> tasks_done_at_cleanup{-1};
+  std::atomic<int> wal_waits_seen{0};
+  hooks.before_wal_result_wait = [&](std::string const &name, uint64_t) {
+    ++wal_waits_seen;
+    if (name != "ASYNC") return;
+    std::unique_lock lock{hold_mutex};
+    borrower_held = true;
+    hold_cv.wait_for(lock, std::chrono::seconds(30), [&] { return release_borrower; });
+  };
+  hooks.on_task_done = [&](std::string const &, uint64_t) { ++tasks_done; };
+  hooks.after_async_abort_cleanup = [&] {
+    tasks_done_at_cleanup = tasks_done.load();
+    ++async_cleanups;
+  };
+  storage->SetReplicationTestHooks(&hooks);
+  CommitProbe probe;
+  std::atomic<bool> armed{true};
+  probe.after_prepare_record = [&] {
+    if (!armed.exchange(false)) return;
+    // The STRICT_SYNC replica has voted (its task ran ShipOne); the ASYNC borrower is still held.
+    throw std::runtime_error("injected after_prepare_record");
+  };
+  storage->SetCommitProbe(&probe);
+
+  auto const watermark_before = storage->LastCommittedMvccTimestamp();
+  auto const ldt_before = LastDurableTimestamp(main);
+  auto const committed_before = NumCommittedTxns(main);
+  std::atomic<bool> threw{false};
+  std::atomic<bool> commit_returned{false};
+  std::thread committer{[&] {
+    bool local_threw = false;
+    static_cast<void>(Update(main, gid, 2, /*large=*/false, &local_threw));
+    threw = local_threw;
+    commit_returned = true;
+  }};
+  if (!WaitFor([&] { return borrower_held.load(); }, std::chrono::seconds(10))) {
+    // Release everything before failing so the committer thread can be joined.
+    {
+      std::lock_guard lock{hold_mutex};
+      release_borrower = true;
+    }
+    hold_cv.notify_all();
+    committer.join();
+    FAIL() << "the ASYNC borrower was never held (WAL waits seen: " << wal_waits_seen.load() << ")";
+  }
+  // The STRICT_SYNC prepare completes while the ASYNC borrower is held.
+  ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
+  EXPECT_FALSE(WaitFor([&] { return commit_returned.load(); }, std::chrono::milliseconds(500)));
+  EXPECT_EQ(storage->pipeline_test_counters().decision_calls.load(), decisions_before);  // no decision yet
+  EXPECT_EQ(async_cleanups.load(), 0);                                                   // no ASYNC cleanup yet
+  {
+    std::lock_guard lock{hold_mutex};
+    release_borrower = true;
+  }
+  hold_cv.notify_all();
+  committer.join();
+  EXPECT_TRUE(threw.load());
+  EXPECT_EQ(storage->pipeline_test_counters().decision_calls.load() - decisions_before, 1);
+  EXPECT_EQ(async_cleanups.load(), 1);
+  EXPECT_EQ(tasks_done_at_cleanup.load(), 2);  // both shipping tasks existed and finished before the cleanup
+  EXPECT_EQ(AsyncAbortCalls(main) - async_aborts_before, 1);
+  ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+  ASSERT_TRUE(strict_->WaitEvent("abort_applied", std::chrono::seconds(10)).has_value());
+  storage->SetCommitProbe(nullptr);
+
+  ASSERT_TRUE(WaitForReplicaState(main, "STRICT", ReplicaState::READY));
+  ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
+  EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+  ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
+  ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
+  storage->SetReplicationTestHooks(nullptr);
+}
+
+// Interleaving 2: the abort is parked at after_async_abort_cleanup while a heartbeat enqueues reconciliation for the
+// ASYNC client; reconciliation reaches its quiescence point but cannot complete until the ticket retires.
+TEST_F(PipelinedMixedAbortTest, ReconciliationWaitsForTheParkedAbortToRetire) {
+  MinMemgraph main(main_conf);
+  RegisterBoth(main);
+  auto const gid = Seed(main, 1);
+  ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
+  // The ASYNC client returns to READY from its own finalize task; the faulting write needs it streaming.
+  ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
+  auto *storage = MainStorage(main);
+  auto const async_aborts_before = AsyncAbortCalls(main);
+
+  ReplicationTestHooks hooks;
+  std::mutex park_mutex;
+  std::condition_variable park_cv;
+  bool release_abort = false;
+  std::atomic<bool> abort_parked{false};
+  std::atomic<int> async_reconcile_arrivals{0};
+  std::atomic<int> tasks_done{0};
+  hooks.on_task_done = [&](std::string const &, uint64_t) { ++tasks_done; };
+  hooks.after_async_abort_cleanup = [&] {
+    std::unique_lock lock{park_mutex};
+    abort_parked = true;
+    park_cv.wait_for(lock, std::chrono::seconds(30), [&] { return release_abort; });
+  };
+  hooks.before_reconcile_quiesce = [&](std::string const &name) {
+    if (name == "ASYNC") ++async_reconcile_arrivals;  // the STRICT client also goes MAYBE_BEHIND; select by name
+  };
+  storage->SetReplicationTestHooks(&hooks);
+  ASSERT_TRUE(strict_->Send("refuse_prepare"));
+
+  auto const watermark_before = storage->LastCommittedMvccTimestamp();
+  auto const ldt_before = LastDurableTimestamp(main);
+  auto const committed_before = NumCommittedTxns(main);
+  std::atomic<bool> commit_returned{false};
+  std::expected<void, memgraph::storage::StorageManipulationError> result;
+  std::thread committer{[&] {
+    result = Update(main, gid, 2, /*large=*/false);
+    commit_returned = true;
+  }};
+  ASSERT_TRUE(WaitFor([&] { return abort_parked.load(); }, std::chrono::seconds(10)));
+  // A frequent heartbeat enqueues reconciliation for the MAYBE_BEHIND ASYNC client; it arrives at its quiescence
+  // point but cannot complete while the abort still holds the ticket.
+  ASSERT_TRUE(WaitFor([&] { return async_reconcile_arrivals.load() >= 1; }, std::chrono::seconds(10)));
+  EXPECT_FALSE(WaitFor([&] { return main.db.storage()->GetReplicaState("ASYNC") == ReplicaState::READY; },
+                       std::chrono::milliseconds(500)));
+  EXPECT_FALSE(commit_returned.load());
+  {
+    std::lock_guard lock{park_mutex};
+    release_abort = true;
+  }
+  park_cv.notify_all();
+  committer.join();
+  ASSERT_FALSE(result.has_value());
+  ExpectNothingCommitted(main, watermark_before, ldt_before, committed_before);
+  EXPECT_EQ(tasks_done.load(), 2);
+  EXPECT_EQ(AsyncAbortCalls(main) - async_aborts_before, 1);
+  ASSERT_TRUE(strict_->WaitEvent("abort_applied", std::chrono::seconds(10)).has_value());
+
+  ASSERT_TRUE(WaitForReplicaState(main, "STRICT", ReplicaState::READY));
+  ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
+  EXPECT_TRUE(Update(main, gid, 3, /*large=*/false).has_value());
+  ASSERT_TRUE(strict_->WaitEvent("prepared", std::chrono::seconds(10)).has_value());
+  ASSERT_TRUE(WaitForReplicaState(main, "ASYNC", ReplicaState::READY));
+  storage->SetReplicationTestHooks(nullptr);
+}
+
+int main(int argc, char **argv) {
+  if (argc > 1 && std::string_view{argv[1]} == memgraph::tests::kReplicaRoleFlag) {
+    return memgraph::tests::RunReplicaRole(argc, argv);
+  }
+  ::testing::InitGoogleTest(&argc, argv);
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  return RUN_ALL_TESTS();
 }

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -31,10 +31,12 @@
 #include "storage/v2/indices/text_index_utils.hpp"
 #include "storage/v2/indices/vector_index.hpp"
 #include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/inmemory/txn_commands.hpp"
 #include "storage/v2/inmemory/unique_constraints.hpp"
 #include "storage/v2/inmemory/vertex_property_index.hpp"
 #include "storage/v2/mvcc.hpp"
 #include "storage/v2/name_id_mapper.hpp"
+#include "storage/v2/pipeline_budget.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage_test_utils.hpp"
 #include "utils/file.hpp"
@@ -250,6 +252,61 @@ class DeltaGenerator final {
       }
     }
 
+    // Emits exactly what the storage engine's inline WAL path emits for this transaction: one start frame (which
+    // resets the CRC accumulator), then the deltas, then the end frame. Deltas are visited in the order Commands()
+    // returns them, so an encoded-and-appended copy of Commands() is byte-identical to this.
+    void FinalizeEngineFormat(uint64_t timestamp, bool commit, memgraph::storage::StorageAccessType access_type) {
+      auto const commit_flag_position = gen_->wal_file_.AppendTransactionStart(timestamp, commit, access_type);
+      auto const commands = Commands();
+      for (auto const &cmd : commands.data) {
+        if (cmd.edge != nullptr) {
+          gen_->wal_file_.AppendDelta(
+              *cmd.delta, cmd.edge, timestamp, gen_->storage_.get(), cmd.in_vertex_gid, cmd.edge_type_id);
+        } else {
+          gen_->wal_file_.AppendDelta(*cmd.delta, cmd.vertex, timestamp, gen_->storage_.get());
+        }
+      }
+      auto const txn_end_pos = gen_->wal_file_.AppendTransactionEnd(timestamp);
+      gen_->last_txn_positions_ = {.commit_flag_wal_position_ = commit_flag_position,
+                                   .crc_wal_pos_ = txn_end_pos.crc_wal_pos_,
+                                   .stored_crc_ = txn_end_pos.stored_crc_};
+      gen_->txn_end_marker_positions_.push_back(txn_end_pos.crc_wal_pos_ - 1);
+      gen_->UpdateStats(timestamp, commands.data.size() + 2);
+    }
+
+    // The generator-owned deltas as encode-ordered commands, resolved the way Finalize resolves their owners.
+    memgraph::storage::TxnCommands Commands() {
+      memgraph::storage::TxnCommands commands{memgraph::storage::TxnAllocPolicy{}};
+      for (const auto &delta : transaction_.deltas) {
+        if (delta.action == memgraph::storage::Delta::Action::ADD_IN_EDGE ||
+            delta.action == memgraph::storage::Delta::Action::REMOVE_IN_EDGE) {
+          continue;
+        }
+        auto owner = delta.prev.Get();
+        while (owner.type == memgraph::storage::PreviousPtr::Type::DELTA) {
+          owner = owner.delta->prev.Get();
+        }
+        if (owner.type == memgraph::storage::PreviousPtr::Type::VERTEX) {
+          commands.data.push_back({.delta = &delta, .vertex = owner.vertex, .edge = nullptr});
+        } else if (owner.type == memgraph::storage::PreviousPtr::Type::EDGE) {
+          if (delta.action != memgraph::storage::Delta::Action::SET_PROPERTY) continue;
+          auto it = gen_->edge_metadata_.find(owner.edge->gid.AsUint());
+          auto in_vertex_gid =
+              (it != gen_->edge_metadata_.end()) ? it->second.to_vertex->gid : memgraph::storage::kInvalidGid;
+          auto edge_type_id =
+              (it != gen_->edge_metadata_.end()) ? it->second.edge_type_id : memgraph::storage::kInvalidEdgeTypeId;
+          commands.data.push_back({.delta = &delta,
+                                   .vertex = nullptr,
+                                   .edge = owner.edge,
+                                   .in_vertex_gid = in_vertex_gid,
+                                   .edge_type_id = edge_type_id});
+        } else {
+          LOG_FATAL("Invalid delta owner!");
+        }
+      }
+      return commands;
+    }
+
     void StartTx() {
       auto timestamp = gen_->timestamp_;
       constexpr bool commit{true};
@@ -286,14 +343,41 @@ class DeltaGenerator final {
 
   DeltaGenerator(const std::filesystem::path &data_directory, bool properties_on_edges, uint64_t seq_num,
                  memgraph::storage::StorageMode storage_mode = memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL)
-      : epoch_id_(memgraph::utils::GenerateUUID()),
+      : DeltaGenerator(data_directory, properties_on_edges, seq_num, memgraph::utils::UUID{},
+                       memgraph::utils::GenerateUUID(), storage_mode) {}
+
+  // Fixed UUID and epoch, so two generators can produce byte-identical files (the header CRC covers both).
+  DeltaGenerator(const std::filesystem::path &data_directory, bool properties_on_edges, uint64_t seq_num,
+                 memgraph::utils::UUID uuid, std::string epoch_id,
+                 memgraph::storage::StorageMode storage_mode = memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL)
+      : uuid_(uuid),
+        epoch_id_(std::move(epoch_id)),
         seq_num_(seq_num),
         storage_(std::make_unique<memgraph::storage::InMemoryStorage>()),
-        wal_file_(data_directory, uuid_, epoch_id_, {.properties_on_edges = properties_on_edges},
-                  storage_->name_id_mapper_.get(), seq_num, &file_retainer_),
+        items_{.properties_on_edges = properties_on_edges},
+        wal_file_(data_directory, uuid_, epoch_id_, items_, storage_->name_id_mapper_.get(), seq_num, &file_retainer_),
         storage_mode_(storage_mode) {}
 
   Transaction CreateTransaction() { return Transaction(this); }
+
+  auto Path() const -> std::filesystem::path const & { return wal_file_.Path(); }
+
+  auto wal() -> memgraph::storage::durability::WalFile & { return wal_file_; }
+
+  auto LastTxnPositions() const -> memgraph::storage::durability::WalTxnDataPos const & { return last_txn_positions_; }
+
+  auto storage() -> memgraph::storage::InMemoryStorage * { return storage_.get(); }
+
+  // The items the generator passed to its own WAL (the test's edge-property mode), not the storage's defaults.
+  auto items() const -> memgraph::storage::SalientConfig::Items const & { return items_; }
+
+  // Bookkeeping for a transaction appended whole from a private buffer, mirroring FinalizeEngineFormat.
+  void RecordEncodedAppend(memgraph::storage::durability::WalTxnDataPos positions, uint64_t timestamp,
+                           uint64_t frame_count) {
+    last_txn_positions_ = positions;
+    txn_end_marker_positions_.push_back(positions.crc_wal_pos_ - 1);
+    UpdateStats(timestamp, frame_count);
+  }
 
   void EraseEdgeMetadata(memgraph::storage::Gid edge_gid) { edge_metadata_.erase(edge_gid.AsUint()); }
 
@@ -713,7 +797,9 @@ class DeltaGenerator final {
   std::unique_ptr<memgraph::storage::InMemoryStorage> storage_;
   memgraph::storage::EnumStore enum_store_;
 
+  memgraph::storage::SalientConfig::Items items_;
   memgraph::storage::durability::WalFile wal_file_;
+  memgraph::storage::durability::WalTxnDataPos last_txn_positions_;
 
   memgraph::storage::NameIdMapper &mapper() { return *storage_->name_id_mapper_; }
 
@@ -1690,6 +1776,219 @@ TEST_P(WalFileTest, FinalizedFileEndingMidTransactionFailsRecovery) {
   // the phantom vertex the flipped marker decodes into.
   ASSERT_TRUE(memgraph::storage::durability::ReadWalHeader(wal_file).summary.has_value());
   EXPECT_THROW(ReplayWal(wal_file, GetParam()), memgraph::storage::durability::RecoveryFailure);
+}
+
+// ---- Pipelined commit: encode-to-buffer and verbatim append -------------------------------------------------------
+
+std::vector<uint8_t> ReadFileBytes(std::filesystem::path const &path) {
+  memgraph::utils::InputFile file;
+  EXPECT_TRUE(file.Open(path)) << path;
+  std::vector<uint8_t> bytes(file.GetSize());
+  EXPECT_TRUE(file.Read(bytes.data(), bytes.size()));
+  return bytes;
+}
+
+// The summary as ReadWalContents/LoadWal trust it, without scanning the deltas.
+memgraph::storage::durability::WalSummary HeaderSummary(std::filesystem::path const &path) {
+  auto const header = memgraph::storage::durability::ReadWalHeader(path);
+  EXPECT_TRUE(header.summary.has_value()) << "a finalized WAL file must carry its summary";
+  return header.summary.value_or(memgraph::storage::durability::WalSummary{});
+}
+
+// Replays a WAL file the way recovery does and counts the vertices that survived it.
+size_t RecoverAndCountVisibleVertices(std::filesystem::path const &path, bool properties_on_edges) {
+  memgraph::storage::durability::RecoveredIndicesAndConstraints indices_constraints;
+  memgraph::utils::SkipListDb<memgraph::storage::Vertex> vertices;
+  memgraph::utils::SkipListDb<memgraph::storage::Edge> edges;
+  memgraph::storage::NameIdMapper name_id_mapper;
+  std::atomic<uint64_t> edge_count{0};
+  memgraph::storage::EnumStore enum_store;
+  auto find_edge = [](memgraph::storage::Gid) -> std::optional<std::tuple<memgraph::storage::EdgeRef,
+                                                                          memgraph::storage::EdgeTypeId,
+                                                                          memgraph::storage::Vertex *,
+                                                                          memgraph::storage::Vertex *>> {
+    return std::nullopt;
+  };
+  static_cast<void>(memgraph::storage::durability::LoadWal(
+      path,
+      &indices_constraints,
+      std::nullopt,
+      &vertices,
+      &edges,
+      &name_id_mapper,
+      &edge_count,
+      memgraph::storage::SalientConfig::Items{.properties_on_edges = properties_on_edges},
+      &enum_store,
+      nullptr,
+      find_edge,
+      nullptr,
+      nullptr));
+  size_t visible = 0;
+  auto acc = vertices.access();
+  for (auto const &vertex : acc) {
+    if (!vertex.deleted()) ++visible;
+  }
+  return visible;
+}
+
+// Decodes every transaction in the file and checks each one's CRC (the pattern of WalTransactionOrdering).
+bool VerifyAllTransactionCrcs(std::filesystem::path const &path) {
+  auto const info = memgraph::storage::durability::ReadWalInfo(path);
+  memgraph::storage::durability::Decoder wal;
+  wal.Initialize(path, memgraph::storage::durability::kWalMagic);
+  wal.SetPosition(info.offset_deltas);
+  wal.ResetCrcAcc();
+  bool all_ok = true;
+  for (uint64_t i = 0; i < info.num_deltas; ++i) {
+    static_cast<void>(memgraph::storage::durability::ReadWalDeltaHeader(&wal));
+    auto delta_data = memgraph::storage::durability::ReadWalDeltaData(&wal);
+    if (std::get_if<memgraph::storage::durability::WalTransactionEnd>(&delta_data.data_) != nullptr) {
+      all_ok &= memgraph::utils::CrcAccumulator::Verify(wal.CrcAccValue());
+      wal.ResetCrcAcc();
+    }
+  }
+  return all_ok;
+}
+
+// Encodes the generator-owned transaction into a private buffer and appends it verbatim, the way a pipelined commit
+// does; returns the absolute positions the WAL file reported.
+memgraph::storage::durability::WalTxnDataPos AppendEncoded(DeltaGenerator &gen, DeltaGenerator::Transaction &tx,
+                                                           memgraph::storage::PipelineBudget &budget,
+                                                           uint64_t timestamp, bool commit) {
+  memgraph::storage::durability::TxnWalBuffer buffer{budget};
+  buffer.result = memgraph::storage::EncodeTxnCommandsTo(buffer.encoder,
+                                                         tx.Commands(),
+                                                         gen.storage(),
+                                                         gen.items(),
+                                                         timestamp,
+                                                         commit,
+                                                         memgraph::storage::StorageAccessType::WRITE,
+                                                         [] {});
+  buffer.timestamp = timestamp;
+  auto const positions = gen.wal().AppendEncodedTransaction(buffer);
+  gen.RecordEncodedAppend(positions, timestamp, buffer.result.frame_count);
+  return positions;
+}
+
+TEST_P(WalFileTest, EncodedAppendIsByteIdenticalToDirectAppend) {
+  // DeltaGenerator(path, properties_on_edges, seq_num, uuid, epoch): the third argument is the WAL sequence number.
+  auto const uuid = memgraph::utils::UUID{};
+  auto const epoch = std::string{"epoch-1"};
+  std::filesystem::create_directories(storage_directory);
+  DeltaGenerator direct(storage_directory / "direct", GetParam(), /*seq_num=*/7, uuid, epoch);
+  DeltaGenerator encoded(storage_directory / "encoded", GetParam(), /*seq_num=*/7, uuid, epoch);
+  auto d = direct.CreateTransaction();
+  auto *dv = d.CreateVertex();
+  d.AddLabel(dv, "L");
+  d.SetProperty(dv, "p", memgraph::storage::PropertyValue(1));
+  d.SetProperty(dv, "q", memgraph::storage::PropertyValue("x"));
+  auto *dw = d.CreateVertex();
+  // Without properties on edges the generator's edge reference is a pointer that EncodeDelta reads as a gid, so two
+  // generators cannot agree on it; the edge part of the identity check is meaningful only with properties on edges.
+  if (GetParam()) {
+    auto *de = d.CreateEdge(dv, dw, "E");
+    d.SetEdgeProperty(de, dv, "r", memgraph::storage::PropertyValue(2.5));
+  }
+  d.FinalizeEngineFormat(/*timestamp=*/100, /*commit=*/true, memgraph::storage::StorageAccessType::WRITE);
+
+  auto e = encoded.CreateTransaction();
+  auto *ev = e.CreateVertex();
+  e.AddLabel(ev, "L");
+  e.SetProperty(ev, "p", memgraph::storage::PropertyValue(1));
+  e.SetProperty(ev, "q", memgraph::storage::PropertyValue("x"));
+  auto *ew = e.CreateVertex();
+  if (GetParam()) {
+    auto *ee = e.CreateEdge(ev, ew, "E");
+    e.SetEdgeProperty(ee, ev, "r", memgraph::storage::PropertyValue(2.5));
+  }
+  memgraph::storage::PipelineBudget budget{1 << 20};
+  auto const positions = AppendEncoded(encoded, e, budget, /*timestamp=*/100, /*commit=*/true);
+  EXPECT_EQ(budget.InFlightBytes(), 0);
+
+  direct.Finalize();
+  encoded.Finalize();
+  EXPECT_EQ(ReadFileBytes(direct.Path()), ReadFileBytes(encoded.Path()));
+  auto const di = memgraph::storage::durability::ReadWalInfo(direct.Path());
+  auto const ei = memgraph::storage::durability::ReadWalInfo(encoded.Path());
+  EXPECT_EQ(ei.num_deltas, di.num_deltas);
+  EXPECT_EQ(ei.from_timestamp, 100);
+  EXPECT_EQ(ei.to_timestamp, 100);
+  EXPECT_EQ(positions.commit_flag_wal_position_, direct.LastTxnPositions().commit_flag_wal_position_);
+  EXPECT_EQ(positions.crc_wal_pos_, direct.LastTxnPositions().crc_wal_pos_);
+  EXPECT_EQ(positions.stored_crc_, direct.LastTxnPositions().stored_crc_);
+  EXPECT_EQ(positions.crc_wal_pos_ - positions.commit_flag_wal_position_,
+            direct.LastTxnPositions().crc_wal_pos_ - direct.LastTxnPositions().commit_flag_wal_position_);
+  EXPECT_TRUE(VerifyAllTransactionCrcs(encoded.Path()));
+}
+
+TEST_P(WalFileTest, MixedDirectAndEncodedAppendsSummarizeAndRecover) {
+  // Ten transactions, odd ones direct, even ones buffered; the header summary must equal a scan (the pattern of
+  // FinalizedHeaderSummaryMatchesScan) and LoadWal must recover all fifty vertices.
+  std::filesystem::create_directories(storage_directory);
+  DeltaGenerator gen(storage_directory, GetParam(), /*seq_num=*/3);
+  memgraph::storage::PipelineBudget budget{1 << 20};
+  for (int i = 0; i < 10; ++i) {
+    auto tx = gen.CreateTransaction();
+    for (int j = 0; j < 5; ++j) {
+      auto *vertex = tx.CreateVertex();
+      tx.AddLabel(vertex, "L");
+      tx.SetProperty(vertex, "p", memgraph::storage::PropertyValue(i * 5 + j));
+    }
+    auto const timestamp = static_cast<uint64_t>(100 + i);
+    if (i % 2 == 0) {
+      AppendEncoded(gen, tx, budget, timestamp, /*commit=*/true);
+    } else {
+      tx.FinalizeEngineFormat(timestamp, /*commit=*/true, memgraph::storage::StorageAccessType::WRITE);
+    }
+  }
+  gen.Finalize();
+  auto const info = memgraph::storage::durability::ReadWalInfo(gen.Path());  // scans
+  auto const summary = HeaderSummary(gen.Path());  // header, trusted by ReadWalContents/LoadWal
+  EXPECT_EQ(summary.num_deltas, info.num_deltas);
+  EXPECT_EQ(summary.from_timestamp, info.from_timestamp);
+  EXPECT_EQ(summary.to_timestamp, info.to_timestamp);
+  EXPECT_EQ(info.from_timestamp, 100);
+  EXPECT_EQ(info.to_timestamp, 109);
+  // Every transaction: start + 5 creates + 5 labels + 5 properties + end.
+  EXPECT_EQ(info.num_deltas, 10 * 17);
+  EXPECT_TRUE(VerifyAllTransactionCrcs(gen.Path()));
+  EXPECT_EQ(RecoverAndCountVisibleVertices(gen.Path(), GetParam()), 50);
+}
+
+TEST_P(WalFileTest, CommitFlagPatchWorksAtRelocatedOffsets) {
+  // One direct transaction first so the buffered one lands at a nonzero offset; the buffered one is a commit=false
+  // prepare record; UpdateCommitStatus(positions) flips it and patches the CRC, and recovery sees it committed.
+  std::filesystem::create_directories(storage_directory);
+  DeltaGenerator gen(storage_directory, GetParam(), /*seq_num=*/4);
+  memgraph::storage::PipelineBudget budget{1 << 20};
+  {
+    auto tx = gen.CreateTransaction();
+    auto *vertex = tx.CreateVertex();
+    tx.AddLabel(vertex, "L");
+    tx.FinalizeEngineFormat(/*timestamp=*/100, /*commit=*/true, memgraph::storage::StorageAccessType::WRITE);
+  }
+  memgraph::storage::durability::WalTxnDataPos positions;
+  {
+    auto tx = gen.CreateTransaction();
+    for (int j = 0; j < 3; ++j) {
+      auto *vertex = tx.CreateVertex();
+      tx.SetProperty(vertex, "p", memgraph::storage::PropertyValue(j));
+    }
+    positions = AppendEncoded(gen, tx, budget, /*timestamp=*/101, /*commit=*/false);
+  }
+  EXPECT_GT(positions.commit_flag_wal_position_, 0);
+  // A later transaction follows the prepare record, so the patch has to seek back and restore the append position.
+  {
+    auto tx = gen.CreateTransaction();
+    static_cast<void>(tx.CreateVertex());
+    tx.FinalizeEngineFormat(/*timestamp=*/102, /*commit=*/true, memgraph::storage::StorageAccessType::WRITE);
+  }
+  gen.wal().UpdateCommitStatus(positions);
+  gen.Finalize();
+  EXPECT_TRUE(VerifyAllTransactionCrcs(gen.Path()));
+  EXPECT_EQ(RecoverAndCountVisibleVertices(gen.Path(), GetParam()), 5);
+  auto const info = memgraph::storage::durability::ReadWalInfo(gen.Path());
+  EXPECT_EQ(HeaderSummary(gen.Path()).num_deltas, info.num_deltas);
 }
 
 class StorageModeWalFileTest : public ::testing::TestWithParam<memgraph::storage::StorageMode> {

--- a/tests/unit/utils_priority_thread_pool.cpp
+++ b/tests/unit/utils_priority_thread_pool.cpp
@@ -11,7 +11,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 
 #include <utils/priority_thread_pool.hpp>
@@ -904,6 +907,60 @@ TEST(PriorityThreadPool, MonitorSweep_DeadlineExpiredAnyTag) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   ASSERT_EQ(ran.load(std::memory_order_acquire), 2);
+
+  pool.ShutDown();
+  pool.AwaitShutdown();
+}
+
+// ==================================================================================
+// Pipelined commit: worker liveness under a slow head
+// ==================================================================================
+
+// Sixteen commit-shaped tasks on a four-worker pool. Each task encodes (off the serializer), then enters an
+// order gate in ticket order and retires; the head parks in its encode stage for 500 ms while the fifteen
+// others wait at the gate, holding their worker threads. A gate wait is a blocking wait on the worker (the plan
+// promises no latency bound there), so the assertion is bounded completion after the head releases: nothing
+// deadlocks and nothing is lost when more committers than workers are in flight.
+TEST(PriorityThreadPool, PipelinedCommitShapedTasksCompleteAfterSlowHead) {
+  using namespace memgraph;
+  constexpr int kTasks = 16;
+  constexpr int kWorkers = 4;
+  utils::PriorityThreadPool pool{kWorkers, 1};
+
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  int next_ticket = 1;  // the gate admits tickets in order
+  std::atomic<int> completed{0};
+  std::atomic<int> minted{0};
+  auto const enqueue_started = std::chrono::steady_clock::now();
+  for (int i = 0; i < kTasks; ++i) {
+    pool.ScheduledAddTask(
+        [&](utils::Priority) {
+          // S1: a ticket is minted when the committer runs, so a queued task never holds one and every ticket
+          // ahead of a waiter is already on a worker.
+          int const ticket = minted.fetch_add(1, std::memory_order_acq_rel) + 1;
+          // S2: the head is slow, everyone else encodes quickly.
+          std::this_thread::sleep_for(ticket == 1 ? std::chrono::milliseconds(500) : std::chrono::milliseconds(1));
+          // S3: enter in ticket order, publish, retire.
+          {
+            std::unique_lock lock{gate_mutex};
+            gate_cv.wait(lock, [&] { return next_ticket == ticket; });
+            ++next_ticket;
+          }
+          gate_cv.notify_all();
+          completed.fetch_add(1, std::memory_order_acq_rel);
+        },
+        utils::Priority::LOW);
+  }
+
+  // Bounded completion: the head's 500 ms plus generous slack for fifteen quick successors.
+  for (int w = 0; completed.load(std::memory_order_acquire) < kTasks && w < 500; ++w) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  auto const elapsed = std::chrono::steady_clock::now() - enqueue_started;
+  ASSERT_EQ(completed.load(std::memory_order_acquire), kTasks);
+  EXPECT_GE(elapsed, std::chrono::milliseconds(500));
+  EXPECT_LT(elapsed, std::chrono::seconds(5));
 
   pool.ShutDown();
   pool.AwaitShutdown();

--- a/tests/unit/utils_priority_thread_pool.cpp
+++ b/tests/unit/utils_priority_thread_pool.cpp
@@ -917,10 +917,10 @@ TEST(PriorityThreadPool, MonitorSweep_DeadlineExpiredAnyTag) {
 // ==================================================================================
 
 // Sixteen commit-shaped tasks on a four-worker pool. Each task encodes (off the serializer), then enters an
-// order gate in ticket order and retires; the head parks in its encode stage for 500 ms while the fifteen
-// others wait at the gate, holding their worker threads. A gate wait is a blocking wait on the worker (the plan
-// promises no latency bound there), so the assertion is bounded completion after the head releases: nothing
-// deadlocks and nothing is lost when more committers than workers are in flight.
+// order gate in ticket order and retires; the head parks in its encode stage for 500 ms while the other running
+// tasks wait at the gate, holding their worker threads, and the rest queue in the pool. A gate wait is a blocking
+// wait on the worker (the plan promises no latency bound there), so the assertion is bounded completion after the
+// head releases: nothing deadlocks and nothing is lost when more committers than workers are in flight.
 TEST(PriorityThreadPool, PipelinedCommitShapedTasksCompleteAfterSlowHead) {
   using namespace memgraph;
   constexpr int kTasks = 16;
@@ -944,8 +944,8 @@ TEST(PriorityThreadPool, PipelinedCommitShapedTasksCompleteAfterSlowHead) {
           // S3: enter in ticket order, publish, retire.
           {
             std::unique_lock lock{gate_mutex};
-            gate_cv.wait(lock, [&] { return next_ticket == ticket; });
-            ++next_ticket;
+            gate_cv.wait(lock, [&] { return next_ticket >= ticket; });
+            if (next_ticket == ticket) ++next_ticket;
           }
           gate_cv.notify_all();
           completed.fetch_add(1, std::memory_order_acq_rel);
@@ -953,15 +953,23 @@ TEST(PriorityThreadPool, PipelinedCommitShapedTasksCompleteAfterSlowHead) {
         utils::Priority::LOW);
   }
 
-  // Bounded completion: the head's 500 ms plus generous slack for fifteen quick successors.
-  for (int w = 0; completed.load(std::memory_order_acquire) < kTasks && w < 500; ++w) {
+  // Bounded completion: the head's 500 ms plus generous slack for fifteen quick successors. The poll outlasts the
+  // asserted bound so a late completion fails the bound rather than the count, and the pool is always shut down
+  // before any assertion can return over workers that still reference this frame.
+  for (int w = 0; completed.load(std::memory_order_acquire) < kTasks && w < 1000; ++w) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   auto const elapsed = std::chrono::steady_clock::now() - enqueue_started;
-  ASSERT_EQ(completed.load(std::memory_order_acquire), kTasks);
-  EXPECT_GE(elapsed, std::chrono::milliseconds(500));
-  EXPECT_LT(elapsed, std::chrono::seconds(5));
-
+  auto const all_completed = completed.load(std::memory_order_acquire) == kTasks;
+  if (!all_completed) {
+    // Let every waiter through so the shutdown below can join them.
+    std::lock_guard lock{gate_mutex};
+    next_ticket = kTasks + 1;
+    gate_cv.notify_all();
+  }
   pool.ShutDown();
   pool.AwaitShutdown();
+  EXPECT_TRUE(all_completed);
+  EXPECT_GE(elapsed, std::chrono::milliseconds(500));
+  EXPECT_LT(elapsed, std::chrono::seconds(5));
 }


### PR DESCRIPTION
Tracking issue: #4789. Stacked on #4777: the base branch is `feat/adaptive-commit-lock-scheduling` and this series sits directly on its head, so the diff shows only this change. Measured together with #4769.

## What this is, in plain terms

Today a Memgraph commit does three things while holding one lock (`commit_mutex_`): it hands out the commit
timestamp, it turns every change the transaction made into bytes and writes them to the write-ahead log (and sends
the same bytes to replicas), and it makes the transaction visible. Because the lock is held for all three, two
writers can never encode at the same time; the second one waits for the first to finish writing its log. For a
1,000-row upsert most of the time under that lock is spent producing the log bytes, so adding writers only adds
queueing.

Postgres solved the same problem long ago: a backend builds its WAL record in its own memory first, then takes a
short lock only to reserve a position in the log and copy the finished bytes in, and commit visibility is a
separate, ordered step. The log stays in order because positions are handed out in order, not because one
transaction at a time is allowed to do all of its work.

This change borrows that shape. With `--experimental-enabled=pipelined-commit`, a commit now:

1. takes the lock only long enough to get its timestamp and a ticket in the commit queue;
2. releases the lock and encodes its changes into a private buffer, in parallel with other committers;
3. waits for its ticket to come up, and only then checks unique constraints, copies the finished buffer into the
   log in one write, replicates, and becomes visible.

Nothing about what ends up in the log changes: the buffer is byte-for-byte what the old inline path would have
written, checksum included, and a harness proves the flag-off path still writes identical files. Replication,
two-phase commit and constraint checking are the existing code, just executed in ticket order. Transactions that
do not fit the fast path (index changes, storages without a log, commits that need two-phase commit, commits that
would exceed a memory budget) take the same ticket and run the old code after their turn comes, so every commit is
still ordered by one mechanism.

The flag is off by default and requires `lockfree-read-snapshot` from memgraph#4777
(`feat/adaptive-commit-lock-scheduling`, not yet merged), whose three-phase commit (mint, then durability with the
engine lock released, then publish) this builds on; this series sits directly on that branch's head. The constraint
optimization in memgraph#4769 (skip unique-constraint bookkeeping for properties no constraint covers) is
independent and is the "after constraint optimization" column in the tables below.

## How big a change is it

About 1,800 lines of production code across 28 files, 4,100 lines of tests, and 640 lines of docs. Roughly half
the production code is new, self-contained pieces (a buffer encoder, a commit-order gate and ticket, a memory
budget); the other half is the commit path in `inmemory/storage.cpp` and the replication object, where the
existing durability continuation was moved under a ticket rather than rewritten. It touches the most sensitive
path in the storage engine, which is why the failure protocol (what happens when something throws between "log
bytes written" and "visible") takes up most of the design and most of the tests. It changes no file format, no
wire format and no query surface beyond the flag, the budget flag and five counters.

## Design

Flag `--experimental-enabled=pipelined-commit`, startup-only, off by default, valid only together with
`lockfree-read-snapshot` from memgraph#4777 (validated on the combined command-line plus environment mask, and again
by the storage constructor). Budget `--storage-pipelined-commit-max-bytes` (default 256 MiB).

An eligible main-side commit (in-memory transactional storage with a WAL, data deltas only, no metadata deltas) runs
in three stages:

| Stage | Holds | Work |
|---|---|---|
| S1 mint | `commit_mutex_`; `engine_lock_` briefly | mint the commit timestamp, register a `CommitTicket` with the `CommitOrderGate`, release both locks |
| S2 encode | accessor and transaction only | `MaterializeTxnCommands` (the existing traversal, extracted whole), `EncodeTxnCommandsTo` into a private, CRC-complete `TxnWalBuffer` through a budget-charging allocator |
| S3 ordered | gate ticket; `engine_lock_` only inside publish | `gate.Enter(ts)`, unique validation, `InitializeWalFile`, replication streams open, `AppendEncodedTransaction` (verbatim), `FinalizeWalFile`, ship, `FinalizeCommitPhase`, retire the ticket |

Invariants kept:

- INV-ORDER: WAL frames in each file are in strictly increasing commit-timestamp order; replicas receive them in that
  order (streams open in S3, one transaction per client at a time).
- INV-PUBLISH: commit timestamps are published in mint order, so `last_committed_mvcc_ts_` stays contiguous and the
  schema-info queue never receives an insertion below its processed bound.
- INV-UNIQUE: a commit validates unique constraints only after every earlier-minted commit has published or fully
  aborted.
- Failure semantics are unchanged: partial WAL writes and fsync failures stay fatal, a SYNC replica failure still
  reports the transaction as committed, aborts never advance the read watermark.
- The flag-off path is the same code; a deterministic harness (`tests/unit/storage_v2_off_identity.cpp`) run on the
  base and on this branch produces byte-identical WAL files, for the same `lockfree-read-snapshot` setting on both.
  Note that the first commit on this branch restores the opt-in default for `lockfree-read-snapshot`, which the
  memgraph#4777 head forces on for CI with a "revert before merge" note; with no experimental flags at all, this
  branch therefore holds the engine lock through durability the way `master` does, and the #4777 head does not.

Maintenance sites that used to take `commit_mutex_` to exclude an in-flight committer now call
`InMemoryStorage::QuiesceCommits()` (take `commit_mutex_`, then wait until every issued ticket has retired): epoch
change, recovery-step selection, current-WAL transfer, recovery completion, heartbeat reconciliation, and shutdown's
final WAL exclusion (after the async indexer and TTL workers have stopped).

## Ticket lifecycle

`CommitTicket` is a noncopyable owning object with states registered, entered, published or aborted, plus an
independent irreversible mark and a WAL record state (not started, incomplete, complete). `CommitWithTicket` is the
sole owner of abort cleanup and retirement: one exception boundary covers everything after registration; a failed
local abort terminates and is never retried (`AbortTicketOrTerminate`); an exception after the irreversible mark or
while a record is incomplete terminates; an exception after a complete `commit=false` prepare record runs the single
2PC abort continuation once (`AbortTwoPcOrTerminate`: WAL finalization, then the abort decisions, each step set done
only after it returned); an abortable exit before any WAL frame drains replica borrowers and discards the unprepared
streams (connection retired while the stream still owns the RPC lock, stream reset, client MAYBE_BEHIND), performed
only by the scope that owns the replication object. `TransactionReplication` gains a trailing `CommitTicket *`,
constructor rollback for already-opened streams, and, on ticketed execution only, the same retire-reset-MAYBE_BEHIND
sequence for the ASYNC arm of an abort decision.

## Budget

Every retained S2 allocation (materialized commands, tracking sets, the vertex cache, the WAL buffer) goes through
`BudgetAllocator`, which charges the per-database `PipelineBudget` before allocating and releases in `deallocate`.
Refusal never blocks: it converts the commit into the ordered legacy path after destroying every charged allocation.
The budget covers retained bytes only. The per-value temporaries the encoder makes while converting one property at
a time (the decoded `PropertyValue` and its external form) are not charged; they are the allocations any property
read makes, freed before the next value, so with N concurrent encoders the transient peak is N times today's
single-encoder peak, bounded by the largest single property value in flight.

## Deferred

- Gate parking: a committer waiting at the gate blocks its worker thread. The interpreter's commit-lock parking is
  unchanged and does not cover gate waits; the end-to-end liveness script shows readers are still admitted during
  saturation because commit-lock parking frees workers, but there is no latency bound at the gate.
- A private replication transport: replica payloads are still encoded by the per-replica tasks in S3.

## Measurements

Local (16-core box, WAL on, `--storage-delta-on-identical-property-update=false`, the writer sweep from
`tests/manual/unique_constraint_property_update_bench.py`: 100,000 Node/Value pairs, 48 batches of 1,000 rows per
trial, medians of 3 trials; two launches per cell). Baseline is v3.12.0; "after constraint optimization" is
v3.12.0 plus memgraph#4769 (skip unique-constraint verification for unrelated property writes); "after WAL
optimization" is this branch (memgraph#4777's lock-free read snapshot plus the pipelined commit) with
`lockfree-read-snapshot,pipelined-commit` enabled, on top of #4769. Milliseconds per transaction throughout.

| Writers | Tx p50 baseline | after constraint optimization | after WAL optimization | CPU per tx baseline | after constraint optimization | after WAL optimization |
|---|---|---|---|---|---|---|
| 1 | 13.3 / 13.3 | 8.6 / 8.3 | 7.0 / 7.6 | 14.0 / 13.5 | 9.2 / 8.5 | 7.3 / 7.9 |
| 12 | 56.5 / 53.9 | 17.5 / 13.1 | 10.2 / 8.8 | 61.5 / 60.0 | 17.7 / 13.3 | 9.4 / 9.2 |

The same binary with the flags off measures 7.0 / 7.2 ms (1 writer) and 12.1 / 12.9 ms (12 writers) p50, so the
12-writer gain is the pipeline's: 12.5 to 9.5 ms p50, 14.3 to 9.3 ms CPU per transaction, 635 to 830 tx/s, p99
26 to 16 ms. With one writer the flag changes nothing, as designed. Counters: every measured transaction was
encoded outside the serializer, 0 budget fallbacks, 0 two-phase fallbacks.

Production instance (5-minute in-pod windows, upsert batches of up to 1,000 rows from 2 and 12 writer pods; the
same three builds as above, #4769 being the constraint optimization):

| Writer pods | MAIN cores baseline | after constraint optimization | after WAL optimization | Tx p50 baseline | after constraint optimization | after WAL optimization | Tx p90 baseline | after constraint optimization | after WAL optimization |
|---|---|---|---|---|---|---|---|---|---|
| 2 | 2.40 | 1.48 | 1.03 | 28 | 11 | 12 | 63 | 21 | 22 |
| 12 | 5.18 | 1.97 | 1.30 | 81 | 24 | 16 | 277 | 140 | 53 |

## Also in this series

`AsyncIndexer::Shutdown` requested the worker's stop and notified its condition variable before taking the mutex the
worker's wait predicate runs under, so a request landing between the predicate and the sleep was lost and the
destructor hung. A storage destroyed shortly after construction hits it often (the pipelined death tests, which recover
a directory and destroy the storage within milliseconds, hung in about one run in four); taking the mutex first fixes
it, and it is independent of the flag. The stop is requested before the mutex is taken, because a worker in the middle of an index build holds the mutex for the whole build and polls the token from inside it. The two commits can be split out on request.

Re-measured on the rebased head (this series on `d22a37bb0`, with #4769 and the async indexer fix): local writer sweep,
same setup as above, 1 writer p50 6.1 / 6.4 ms and CPU 6.5 / 6.9 ms per transaction with the flags on versus 6.3 / 6.5
and 6.7 / 6.9 with them off; 12 writers p50 9.0 / 9.2 ms, CPU 9.2 / 9.4, 885 / 944 tx/s, p99 16.8 / 14.4 ms with the
flags on versus p50 10.5 / 11.4, CPU 11.9 / 11.9, 711 / 753 tx/s, p99 21.3 / 18.3 with them off; 404 of 404
transactions encoded outside the serializer, 0 fallbacks. Production instance, same windows: 2 writer pods 1.01 cores,
p50 12 ms, p90 23 ms; 12 pods 1.15 cores, p50 20 ms, p90 64 ms; 19,466 pipelined commits, 0 budget or two-phase
fallbacks, mean gate wait 3.5 ms, mean ordered stage 1.7 ms.

## Tests

- `storage_v2_buffer_encoder`: byte and CRC identity with the file encoder, budget charging before growth and
  release on destruction, refusal injection, rebound containers.
- `storage_v2_commit_order_gate`: ordered entry under shuffled arrival, WaitIdle, retirement rules, destructor
  termination on an unretired ticket.
- `storage_v2_wal_file`: encoded append byte-identical to the direct append, mixed direct and buffered transactions
  summarize and recover, commit-flag patch at relocated offsets.
- `storage_v2_pipelined_commit`: flag dependency, quiescence (synthetic ticket and in-flight pipelined commit),
  serializer exclusion for legacy writers, INV-UNIQUE for concurrent duplicate creates and updates with and without
  the budget fallback (both refusal sites), legacy commits not overtaking pipelined tickets, INV-ORDER with unequal
  encode sizes, rotation, the legacy-forced rotation with one finalization per transaction, WAL-less storages, the
  lifecycle faults (after_mint, after_ticket, materialization fault, before_publish) and the death cases
  (after_append, after_finalize_wal, after_publish, WAL-disabled after_publish, failed abort), the first eligible
  commit on an empty WAL and rotation through the real `InitializeWalFile`.
- `storage_v2_replication`: STRICT_SYNC fallback through 2PC, a refused prepare vote, an exception after a complete
  prepare record, refused abort decisions for both continuation callers, live-borrower aborts on the direct SYNC
  pipeline, the locally owned legacy fallback and the borrowed STRICT_SYNC fallback, all-unscheduled aborts before
  any frame in all three scopes, partial replication-object construction, ticket-gated probe exclusion, replica
  ordering and counts under eight concurrent writers, and, with each replica in its own process (the replica
  handlers' 2PC cache is static), the abort-step death cases (WAL finalization, decision scheduling) and the mixed
  STRICT_SYNC + ASYNC complete-prepare abort with both forced interleavings.
- `storage_v2_durability_inmemory`: a pipelined `WalDeathResilience` variant (six writers killed at a random point).
- `utils_priority_thread_pool`: sixteen commit-shaped tasks on four workers with a slow head.
- `tests/manual/pipelined_commit_worker_liveness.py`: sixteen Bolt writers and a reader against a real server with
  four Bolt workers while the head is parked in its encode stage; PERIODIC COMMIT and a before-commit trigger. The
  park hook it drives (`MG_TEST_PIPELINED_S2_PARK_FIFO`) is compiled only into builds without `NDEBUG`.
- The full storage sweep passes with no new skips. A build of memgraph's sources without `NDEBUG` (so `DMG_ASSERT`
  and the debug arena-ownership check in `DbDeallocateBytes` are live) passes every suite above and the liveness
  script.

## Scope

Storage/v2 and replication only. No new query surface beyond the flag, the budget flag, and the counters in
`SHOW STORAGE INFO ON CURRENT DATABASE` (`pipelined_commit_s2_encodes`, `pipelined_commit_budget_fallbacks`,
`pipelined_commit_two_pc_fallbacks`, `pipelined_commit_gate_wait_ns`, `pipelined_commit_s3_ns`).
