### PR TITLE
bench(ha): read-heavy concurrent read/write mix for the SYNC HA benchmark

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -138,10 +138,11 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync,') }}
         continue-on-error: true
         env:
-          # 5 repeats (each re-runs and re-uploads as its own point) so the series shows a median and a
+          # 3 repeats (each re-runs and re-uploads as its own point) so the series shows a median and a
           # spread rather than one measurement; the aggregate mix throughput is noisier than an isolated
           # per-query number, so a single point is not enough to compare baseline against the funnel.
-          LOOP_COUNT: ${{ inputs.loop_count || 5 }}
+          # Overridable per-dispatch via the loop_count input.
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
         run: |
           ./tools/ci/loop-benchmark.sh \
             "mgbench-ha --realistic" \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -40,6 +40,7 @@ jobs:
       DEFAULT_MGBENCH_HA_SYNC_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_sync_async.json'
       DEFAULT_MGBENCH_HA_STRICT_SYNC_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_strict_sync_async.json'
       DEFAULT_MGBENCH_HA_REALISTIC_SYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync.json'
+      DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync_routing.json'
       LOOP_COUNT: ${{ inputs.loop_count || 10 }}
       CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
       CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
@@ -148,6 +149,25 @@ jobs:
             "mgbench-ha --realistic" \
             mgbench-ha-realistic-sync \
             ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Run and upload mgbench-ha-realistic-sync-routing
+        id: mgbench-ha-realistic-sync-routing
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync-routing,') }}
+        continue-on-error: true
+        env:
+          # Same realistic mix as the direct-to-main step above, but reached through a bolt+routing
+          # python client against a coordinator, so reads/writes are dispatched by the routing table
+          # (reads-on-main enabled) as a real HA client connects. Same repeat rationale.
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --routing" \
+            mgbench-ha-realistic-sync-routing \
+            ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_EXPORT_RESULTS_FILE }} \
             ${{ github.run_id }} \
             ${{ github.run_number }} \
             $BRANCH_NAME \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -138,7 +138,10 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync,') }}
         continue-on-error: true
         env:
-          LOOP_COUNT: 1
+          # 5 repeats (each re-runs and re-uploads as its own point) so the series shows a median and a
+          # spread rather than one measurement; the aggregate mix throughput is noisier than an isolated
+          # per-query number, so a single point is not enough to compare baseline against the funnel.
+          LOOP_COUNT: ${{ inputs.loop_count || 5 }}
         run: |
           ./tools/ci/loop-benchmark.sh \
             "mgbench-ha --realistic" \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -374,6 +374,7 @@ jobs:
 
       - name: Run extended planner optimizations mgbench
         id: planner
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',planner,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -35,6 +35,7 @@ jobs:
       DEFAULT_MGBENCH_HA_2_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2_async.json'
       DEFAULT_MGBENCH_HA_SYNC_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_sync_async.json'
       DEFAULT_MGBENCH_HA_STRICT_SYNC_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_strict_sync_async.json'
+      DEFAULT_MGBENCH_HA_REALISTIC_SYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync.json'
       LOOP_COUNT: ${{ inputs.loop_count || 10 }}
       CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
       CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
@@ -119,6 +120,24 @@ jobs:
             mgbench-ha \
             mgbench-ha \
             ${{ env.DEFAULT_MGBENCH_HA_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      # Concurrent read+write mix on the SYNC cluster (ha_cluster.yaml). Unlike the isolated legs above,
+      # this drives many clients through the commit path while writes wait on the SYNC replica ACK, so it
+      # measures the aggregate-throughput win from parking pool workers instead of blocking them.
+      - name: Run and upload mgbench-ha-realistic-sync
+        id: mgbench-ha-realistic-sync
+        continue-on-error: true
+        env:
+          LOOP_COUNT: 1
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic" \
+            mgbench-ha-realistic-sync \
+            ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_EXPORT_RESULTS_FILE }} \
             ${{ github.run_id }} \
             ${{ github.run_number }} \
             $BRANCH_NAME \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -11,6 +11,10 @@ on:
         type: number
         description: "Number of times to run the benchmarks. Default is 10. Not applied to HA suites"
         default: 10
+      benchmarks:
+        type: string
+        description: "workflow_dispatch only: comma-separated step ids to run (e.g. mgbench-ha-realistic-sync), or all. Ignored by the nightly schedule, which always runs everything."
+        default: 'all'
   schedule:
     - cron: "0 0 * * *"
 
@@ -112,6 +116,7 @@ jobs:
 
       - name: Run and upload mgbench-ha
         id: mgbench-ha
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -130,6 +135,7 @@ jobs:
       # measures the aggregate-throughput win from parking pool workers instead of blocking them.
       - name: Run and upload mgbench-ha-realistic-sync
         id: mgbench-ha-realistic-sync
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -145,6 +151,7 @@ jobs:
 
       - name: Run and upload mgbench-ha-2-replicas
         id: mgbench-ha-2-replicas
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2-replicas,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -160,6 +167,7 @@ jobs:
 
       - name: Run and upload mgbench-ha-async
         id: mgbench-ha-async
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-async,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -175,6 +183,7 @@ jobs:
 
       - name: Run and upload mgbench-ha-strict-sync
         id: mgbench-ha-strict-sync
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-strict-sync,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -190,6 +199,7 @@ jobs:
 
       - name: Run and upload mgbench-ha-2-strict-sync
         id: mgbench-ha-2-strict-sync
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2-strict-sync,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -205,6 +215,7 @@ jobs:
 
       - name: Run and upload mgbench-ha-sync-async
         id: mgbench-ha-sync-async
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-sync-async,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -220,6 +231,7 @@ jobs:
 
       - name: Run and upload mgbench-ha-strict-sync-async
         id: mgbench-ha-strict-sync-async
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-strict-sync-async,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -235,6 +247,7 @@ jobs:
 
       - name: Run and upload mgbench-ha-2-async
         id: mgbench-ha-2-async
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2-async,') }}
         continue-on-error: true
         env:
           LOOP_COUNT: 1
@@ -250,6 +263,7 @@ jobs:
 
       - name: Run and upload load_parquet benchmark
         id: load-parquet
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',load-parquet,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \
@@ -262,6 +276,7 @@ jobs:
 
       - name: Run and upload mgbench-vector-search-index
         id: mgbench-vector-search-index
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-vector-search-index,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \
@@ -275,6 +290,7 @@ jobs:
 
       - name: Run and upload mgbench-vector-search-edge-index
         id: mgbench-vector-search-edge-index
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-vector-search-edge-index,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \
@@ -288,6 +304,7 @@ jobs:
 
       - name: Run and upload mgbench-text-search-index
         id: mgbench-text-search-index
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-text-search-index,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \
@@ -301,6 +318,7 @@ jobs:
 
       - name: Run and upload mgbench-text-search-edge-index
         id: mgbench-text-search-edge-index
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-text-search-edge-index,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \
@@ -314,6 +332,7 @@ jobs:
 
       - name: Run and upload macro benchmarks
         id: macro-benchmark
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',macro-benchmark,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \
@@ -327,6 +346,7 @@ jobs:
 
       - name: Run and upload mgbench-supernode
         id: mgbench-supernode
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-supernode,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \
@@ -340,6 +360,7 @@ jobs:
 
       - name: Run and upload mgbench
         id: mgbench
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench,') }}
         continue-on-error: true
         run: |
           ./tools/ci/loop-benchmark.sh \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -41,6 +41,7 @@ jobs:
       DEFAULT_MGBENCH_HA_STRICT_SYNC_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_strict_sync_async.json'
       DEFAULT_MGBENCH_HA_REALISTIC_SYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync.json'
       DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync_routing.json'
+      DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync_routing_implicit.json'
       LOOP_COUNT: ${{ inputs.loop_count || 10 }}
       CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
       CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
@@ -161,13 +162,33 @@ jobs:
         env:
           # Same realistic mix as the direct-to-main step above, but reached through a bolt+routing
           # python client against a coordinator, so reads/writes are dispatched by the routing table
-          # (reads-on-main enabled) as a real HA client connects. Same repeat rationale.
+          # (reads-on-main enabled) as a real HA client connects. Managed transactions
+          # (execute_read/execute_write). Same repeat rationale.
           LOOP_COUNT: ${{ inputs.loop_count || 3 }}
         run: |
           ./tools/ci/loop-benchmark.sh \
             "mgbench-ha --realistic --routing" \
             mgbench-ha-realistic-sync-routing \
             ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Run and upload mgbench-ha-realistic-sync-routing-implicit
+        id: mgbench-ha-realistic-sync-routing-implicit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync-routing-implicit,') }}
+        continue-on-error: true
+        env:
+          # Same routed realistic mix as the step above, but with implicit (auto-commit) transactions
+          # and a manually set session access mode instead of managed transaction functions, to
+          # compare the two transaction styles under routing.
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --routing --routing-tx-mode implicit" \
+            mgbench-ha-realistic-sync-routing-implicit \
+            ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE }} \
             ${{ github.run_id }} \
             ${{ github.run_number }} \
             $BRANCH_NAME \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -45,6 +45,9 @@ jobs:
       DEFAULT_MGBENCH_HA_2REP_MIX_DIRECT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_mix_direct.json'
       DEFAULT_MGBENCH_HA_2REP_MIX_ROUTING_EXPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_mix_routing_explicit.json'
       DEFAULT_MGBENCH_HA_2REP_MIX_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_mix_routing_implicit.json'
+      DEFAULT_MGBENCH_HA_2REP_BENCHREAD_DIRECT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_benchread_direct.json'
+      DEFAULT_MGBENCH_HA_2REP_BENCHREAD_ROUTING_EXPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_benchread_routing_explicit.json'
+      DEFAULT_MGBENCH_HA_2REP_BENCHREAD_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_benchread_routing_implicit.json'
       LOOP_COUNT: ${{ inputs.loop_count || 10 }}
       CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
       CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
@@ -231,6 +234,59 @@ jobs:
             "mgbench-ha --realistic --pinned --write-pct 20 --routing --routing-tx-mode implicit" \
             mgbench-ha-2rep-mix-routing-implicit \
             ${{ env.DEFAULT_MGBENCH_HA_2REP_MIX_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      # Heavy (~1ms) routed-read arm on the pinned 2-replica cluster using the write-isolated :Bench
+      # range-scan dataset (read-only). Direct (C++ client, single-instance ceiling) vs bolt+routing
+      # explicit/implicit (python client, reads dispatched to the two replicas). Unlike the microsecond
+      # pokec point-read, each query does real server work, so this probes whether routed reads reach
+      # the replicas rather than being purely client-bound.
+      - name: Run and upload mgbench-ha-2rep-benchread-direct
+        id: mgbench-ha-2rep-benchread-direct
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-benchread-direct,') }}
+        continue-on-error: true
+        env:
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --pinned --dataset bench --write-pct 0" \
+            mgbench-ha-2rep-benchread-direct \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_BENCHREAD_DIRECT_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Run and upload mgbench-ha-2rep-benchread-routing-explicit
+        id: mgbench-ha-2rep-benchread-routing-explicit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-benchread-routing-explicit,') }}
+        continue-on-error: true
+        env:
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --pinned --dataset bench --write-pct 0 --routing --routing-tx-mode managed" \
+            mgbench-ha-2rep-benchread-routing-explicit \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_BENCHREAD_ROUTING_EXPLICIT_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Run and upload mgbench-ha-2rep-benchread-routing-implicit
+        id: mgbench-ha-2rep-benchread-routing-implicit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-benchread-routing-implicit,') }}
+        continue-on-error: true
+        env:
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --pinned --dataset bench --write-pct 0 --routing --routing-tx-mode implicit" \
+            mgbench-ha-2rep-benchread-routing-implicit \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_BENCHREAD_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE }} \
             ${{ github.run_id }} \
             ${{ github.run_number }} \
             $BRANCH_NAME \

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -13,7 +13,7 @@ on:
         default: 10
       benchmarks:
         type: string
-        description: "workflow_dispatch only: comma-separated step ids to run (e.g. mgbench-ha-realistic-sync), or all. Ignored by the nightly schedule, which always runs everything."
+        description: "workflow_dispatch only: comma-separated step ids to run (e.g. mgbench-ha-2rep-mix-routing-implicit), or all. Ignored by the nightly schedule, which always runs everything."
         default: 'all'
   schedule:
     - cron: "0 0 * * *"
@@ -39,9 +39,12 @@ jobs:
       DEFAULT_MGBENCH_HA_2_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2_async.json'
       DEFAULT_MGBENCH_HA_SYNC_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_sync_async.json'
       DEFAULT_MGBENCH_HA_STRICT_SYNC_ASYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_strict_sync_async.json'
-      DEFAULT_MGBENCH_HA_REALISTIC_SYNC_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync.json'
-      DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync_routing.json'
-      DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_realistic_sync_routing_implicit.json'
+      DEFAULT_MGBENCH_HA_2REP_READ_DIRECT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_read_direct.json'
+      DEFAULT_MGBENCH_HA_2REP_READ_ROUTING_EXPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_read_routing_explicit.json'
+      DEFAULT_MGBENCH_HA_2REP_READ_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_read_routing_implicit.json'
+      DEFAULT_MGBENCH_HA_2REP_MIX_DIRECT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_mix_direct.json'
+      DEFAULT_MGBENCH_HA_2REP_MIX_ROUTING_EXPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_mix_routing_explicit.json'
+      DEFAULT_MGBENCH_HA_2REP_MIX_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE: 'benchmark_result_ha_2rep_mix_routing_implicit.json'
       LOOP_COUNT: ${{ inputs.loop_count || 10 }}
       CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
       CONAN_USERNAME: ${{ secrets.CONAN_USERNAME }}
@@ -132,63 +135,102 @@ jobs:
             $BRANCH_NAME \
             mgbench
 
-      # Concurrent read+write mix on the SYNC cluster (ha_cluster.yaml). Unlike the isolated legs above,
-      # this drives many clients through the commit path while writes wait on the SYNC replica ACK, so it
-      # measures the aggregate-throughput win from parking pool workers instead of blocking them.
-      - name: Run and upload mgbench-ha-realistic-sync
-        id: mgbench-ha-realistic-sync
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync,') }}
+      # Finalized HA read/write throughput matrix on a CPU-pinned 2-replica (reads-on-main OFF) cluster,
+      # 4 bolt-workers per instance. Two workloads (100% read; 20/80 write-read) each on three client
+      # modes: direct-to-main, bolt+routing with explicit (managed) transactions, and bolt+routing with
+      # implicit (auto-commit) transactions. Routing reads are dispatched only to the two replicas. The
+      # write mix exposes the aggregate-throughput win from freeing pool workers blocked behind SYNC ACK.
+      - name: Run and upload mgbench-ha-2rep-read-direct
+        id: mgbench-ha-2rep-read-direct
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-read-direct,') }}
         continue-on-error: true
         env:
-          # 3 repeats (each re-runs and re-uploads as its own point) so the series shows a median and a
-          # spread rather than one measurement; the aggregate mix throughput is noisier than an isolated
-          # per-query number, so a single point is not enough to compare baseline against the funnel.
-          # Overridable per-dispatch via the loop_count input.
           LOOP_COUNT: ${{ inputs.loop_count || 3 }}
         run: |
           ./tools/ci/loop-benchmark.sh \
-            "mgbench-ha --realistic" \
-            mgbench-ha-realistic-sync \
-            ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_EXPORT_RESULTS_FILE }} \
+            "mgbench-ha --realistic --pinned --write-pct 0" \
+            mgbench-ha-2rep-read-direct \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_READ_DIRECT_EXPORT_RESULTS_FILE }} \
             ${{ github.run_id }} \
             ${{ github.run_number }} \
             $BRANCH_NAME \
             mgbench
 
-      - name: Run and upload mgbench-ha-realistic-sync-routing
-        id: mgbench-ha-realistic-sync-routing
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync-routing,') }}
+      - name: Run and upload mgbench-ha-2rep-read-routing-explicit
+        id: mgbench-ha-2rep-read-routing-explicit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-read-routing-explicit,') }}
         continue-on-error: true
         env:
-          # Same realistic mix as the direct-to-main step above, but reached through a bolt+routing
-          # python client against a coordinator, so reads/writes are dispatched by the routing table
-          # (reads-on-main enabled) as a real HA client connects. Managed transactions
-          # (execute_read/execute_write). Same repeat rationale.
           LOOP_COUNT: ${{ inputs.loop_count || 3 }}
         run: |
           ./tools/ci/loop-benchmark.sh \
-            "mgbench-ha --realistic --routing" \
-            mgbench-ha-realistic-sync-routing \
-            ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_EXPORT_RESULTS_FILE }} \
+            "mgbench-ha --realistic --pinned --write-pct 0 --routing --routing-tx-mode managed" \
+            mgbench-ha-2rep-read-routing-explicit \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_READ_ROUTING_EXPLICIT_EXPORT_RESULTS_FILE }} \
             ${{ github.run_id }} \
             ${{ github.run_number }} \
             $BRANCH_NAME \
             mgbench
 
-      - name: Run and upload mgbench-ha-realistic-sync-routing-implicit
-        id: mgbench-ha-realistic-sync-routing-implicit
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-realistic-sync-routing-implicit,') }}
+      - name: Run and upload mgbench-ha-2rep-read-routing-implicit
+        id: mgbench-ha-2rep-read-routing-implicit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-read-routing-implicit,') }}
         continue-on-error: true
         env:
-          # Same routed realistic mix as the step above, but with implicit (auto-commit) transactions
-          # and a manually set session access mode instead of managed transaction functions, to
-          # compare the two transaction styles under routing.
           LOOP_COUNT: ${{ inputs.loop_count || 3 }}
         run: |
           ./tools/ci/loop-benchmark.sh \
-            "mgbench-ha --realistic --routing --routing-tx-mode implicit" \
-            mgbench-ha-realistic-sync-routing-implicit \
-            ${{ env.DEFAULT_MGBENCH_HA_REALISTIC_SYNC_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE }} \
+            "mgbench-ha --realistic --pinned --write-pct 0 --routing --routing-tx-mode implicit" \
+            mgbench-ha-2rep-read-routing-implicit \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_READ_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Run and upload mgbench-ha-2rep-mix-direct
+        id: mgbench-ha-2rep-mix-direct
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-mix-direct,') }}
+        continue-on-error: true
+        env:
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --pinned --write-pct 20" \
+            mgbench-ha-2rep-mix-direct \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_MIX_DIRECT_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Run and upload mgbench-ha-2rep-mix-routing-explicit
+        id: mgbench-ha-2rep-mix-routing-explicit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-mix-routing-explicit,') }}
+        continue-on-error: true
+        env:
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --pinned --write-pct 20 --routing --routing-tx-mode managed" \
+            mgbench-ha-2rep-mix-routing-explicit \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_MIX_ROUTING_EXPLICIT_EXPORT_RESULTS_FILE }} \
+            ${{ github.run_id }} \
+            ${{ github.run_number }} \
+            $BRANCH_NAME \
+            mgbench
+
+      - name: Run and upload mgbench-ha-2rep-mix-routing-implicit
+        id: mgbench-ha-2rep-mix-routing-implicit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.benchmarks == 'all' || contains(format(',{0},', inputs.benchmarks), ',mgbench-ha-2rep-mix-routing-implicit,') }}
+        continue-on-error: true
+        env:
+          LOOP_COUNT: ${{ inputs.loop_count || 3 }}
+        run: |
+          ./tools/ci/loop-benchmark.sh \
+            "mgbench-ha --realistic --pinned --write-pct 20 --routing --routing-tx-mode implicit" \
+            mgbench-ha-2rep-mix-routing-implicit \
+            ${{ env.DEFAULT_MGBENCH_HA_2REP_MIX_ROUTING_IMPLICIT_EXPORT_RESULTS_FILE }} \
             ${{ github.run_id }} \
             ${{ github.run_number }} \
             $BRANCH_NAME \

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2052,6 +2052,10 @@ test_memgraph() {
       # workers that would otherwise stall behind a commit holding its lock across the replication ACK.
       local MODE='isolated'
       local NUM_WORKERS=''
+      # routing: reach the cluster through a bolt+routing (neo4j://) python client against a
+      # coordinator instead of a direct bolt connection to main, so reads and writes are dispatched
+      # by the routing table the way a real HA client connects. Only meaningful with --realistic.
+      local ROUTING=0
 
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -2071,19 +2075,36 @@ test_memgraph() {
             MODE='realistic'
             shift 1
           ;;
+          --routing)
+            ROUTING=1
+            shift 1
+          ;;
           --num-workers)
             NUM_WORKERS="$2"
             shift 2
           ;;
           *)
             echo "Error: Unknown flag '$1' for mgbench-ha"
-            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --num-workers"
+            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --routing, --num-workers"
             exit 1
           ;;
         esac
       done
 
       check_support pokec_size $DATASET_SIZE
+      # bolt+routing goes through a python client speaking neo4j:// to a coordinator; the default
+      # cluster description switches to the one that enables reads on main so routed reads reach it.
+      local ROUTING_ARGS=''
+      if [[ "$ROUTING" == "1" ]]; then
+        if [[ "$MODE" != "realistic" ]]; then
+          echo "Error: --routing is only supported with --realistic for mgbench-ha"
+          exit 1
+        fi
+        ROUTING_ARGS='--client-language python --client-bolt-routing'
+        if [[ "$CLUSTER_DESCRIPTION" == "ha_cluster.yaml" ]]; then
+          CLUSTER_DESCRIPTION='ha_cluster_routing.yaml'
+        fi
+      fi
       if [[ "$MODE" == "realistic" ]]; then
         # Read-heavy realistic mix (20% write, 80% read, 0% update, 0% analytical) over the pokec arango
         # group, at high concurrency so many clients contend for the commit path while writes replicate.
@@ -2094,7 +2115,7 @@ test_memgraph() {
         # "50000_20_80_0_0" distribution string, so every run executes the identical query stream — an
         # A/B (baseline vs funnel) differs only in timing, not in composition.
         local WORKERS="${NUM_WORKERS:-18}"
-        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --warm-up hot --num-workers-for-benchmark $WORKERS --workload-realistic 50000 20 80 0 0 --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
+        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 20 80 0 0 --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
       else
         local WORKERS="${NUM_WORKERS:-6}"
         docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --num-workers-for-benchmark $WORKERS --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/create/pattern pokec/$DATASET_SIZE/create/vertex_big pokec/$DATASET_SIZE/arango/single_vertex_write pokec/$DATASET_SIZE/arango/single_edge_write pokec/$DATASET_SIZE/basic/single_vertex_property_update_update pokec/$DATASET_SIZE/arango/single_vertex_read"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2047,6 +2047,11 @@ test_memgraph() {
       local DATASET_SIZE='medium'
       local EXPORT_RESULTS_FILE="$default_benchmark_result_ha_file"
       local CLUSTER_DESCRIPTION='ha_cluster.yaml'
+      # isolated (default): each query benchmarked on its own, the per-query "replication tax".
+      # realistic: one concurrent read+write mix, to expose throughput wins from unblocking pool
+      # workers that would otherwise stall behind a commit holding its lock across the replication ACK.
+      local MODE='isolated'
+      local NUM_WORKERS=''
 
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -2062,16 +2067,33 @@ test_memgraph() {
             CLUSTER_DESCRIPTION="$2"
             shift 2
           ;;
+          --realistic)
+            MODE='realistic'
+            shift 1
+          ;;
+          --num-workers)
+            NUM_WORKERS="$2"
+            shift 2
+          ;;
           *)
             echo "Error: Unknown flag '$1' for mgbench-ha"
-            echo "Supported flags: --size, --export-results-file, --cluster-description"
+            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --num-workers"
             exit 1
           ;;
         esac
       done
 
       check_support pokec_size $DATASET_SIZE
-      docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --num-workers-for-benchmark 6 --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/create/pattern pokec/$DATASET_SIZE/create/vertex_big pokec/$DATASET_SIZE/arango/single_vertex_write pokec/$DATASET_SIZE/arango/single_edge_write pokec/$DATASET_SIZE/basic/single_vertex_property_update_update pokec/$DATASET_SIZE/arango/single_vertex_read"
+      if [[ "$MODE" == "realistic" ]]; then
+        # Read-heavy realistic mix (20% write, 80% read, 0% update, 0% analytical) over the pokec arango
+        # group, at high concurrency so many clients contend for the commit path while writes replicate.
+        # This is the workload the funnel improves and that isolated per-query benchmarks cannot show.
+        local WORKERS="${NUM_WORKERS:-18}"
+        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --num-workers-for-benchmark $WORKERS --workload-realistic 5000 20 80 0 0 --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
+      else
+        local WORKERS="${NUM_WORKERS:-6}"
+        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --num-workers-for-benchmark $WORKERS --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/create/pattern pokec/$DATASET_SIZE/create/vertex_big pokec/$DATASET_SIZE/arango/single_vertex_write pokec/$DATASET_SIZE/arango/single_edge_write pokec/$DATASET_SIZE/basic/single_vertex_property_update_update pokec/$DATASET_SIZE/arango/single_vertex_read"
+      fi
     ;;
     mgbench-supernode)
       shift 1

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2056,6 +2056,9 @@ test_memgraph() {
       # coordinator instead of a direct bolt connection to main, so reads and writes are dispatched
       # by the routing table the way a real HA client connects. Only meaningful with --realistic.
       local ROUTING=0
+      # managed (execute_read/execute_write transaction functions) vs implicit (auto-commit run()
+      # with a manually set session access mode); measured separately to compare the two styles.
+      local ROUTING_TX_MODE='managed'
 
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -2079,13 +2082,17 @@ test_memgraph() {
             ROUTING=1
             shift 1
           ;;
+          --routing-tx-mode)
+            ROUTING_TX_MODE="$2"
+            shift 2
+          ;;
           --num-workers)
             NUM_WORKERS="$2"
             shift 2
           ;;
           *)
             echo "Error: Unknown flag '$1' for mgbench-ha"
-            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --routing, --num-workers"
+            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --routing, --routing-tx-mode, --num-workers"
             exit 1
           ;;
         esac
@@ -2100,7 +2107,7 @@ test_memgraph() {
           echo "Error: --routing is only supported with --realistic for mgbench-ha"
           exit 1
         fi
-        ROUTING_ARGS='--client-language python --client-bolt-routing'
+        ROUTING_ARGS="--client-language python --client-bolt-routing --client-bolt-routing-tx-mode $ROUTING_TX_MODE"
         if [[ "$CLUSTER_DESCRIPTION" == "ha_cluster.yaml" ]]; then
           CLUSTER_DESCRIPTION='ha_cluster_routing.yaml'
         fi

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2064,6 +2064,9 @@ test_memgraph() {
       local PINNED=0
       # write-pct: percentage of writes in the realistic mix (rest are reads). 0 = 100% read.
       local WRITE_PCT=20
+      # dataset: which workload the realistic mix runs over. pokec (default) = read/write mix over
+      # the pokec arango group; bench = a write-isolated ~1ms range-scan READ workload (read-only).
+      local DATASET='pokec'
 
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -2103,9 +2106,13 @@ test_memgraph() {
             WRITE_PCT="$2"
             shift 2
           ;;
+          --dataset)
+            DATASET="$2"
+            shift 2
+          ;;
           *)
             echo "Error: Unknown flag '$1' for mgbench-ha"
-            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --routing, --routing-tx-mode, --num-workers, --pinned, --write-pct"
+            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --routing, --routing-tx-mode, --num-workers, --pinned, --write-pct, --dataset"
             exit 1
           ;;
         esac
@@ -2132,6 +2139,16 @@ test_memgraph() {
         fi
       fi
       if [[ "$MODE" == "realistic" ]]; then
+        # bench is a read-only dataset (single range-scan read query, no write query), so it only
+        # makes sense at 100% read; refuse a write mix over it rather than fail deep in validation.
+        local TARGET="pokec/$DATASET_SIZE/arango/*"
+        if [[ "$DATASET" == "bench" ]]; then
+          if [[ "$WRITE_PCT" != "0" ]]; then
+            echo "Error: --dataset bench is read-only; use --write-pct 0"
+            exit 1
+          fi
+          TARGET="bench/default/scan/*"
+        fi
         # Realistic mix over the pokec arango group at high concurrency: many clients contend for the
         # commit path while writes replicate SYNC. WRITE_PCT% write / the rest read (0 => 100% read).
         # 50k queries so the window is ~80s of steady state (noise ~1/sqrt(window)); --warm-up hot drops
@@ -2143,9 +2160,9 @@ test_memgraph() {
           # Each instance is pinned by ha_pin_wrapper.sh (passed as --vendor-binary); ha_pin_map.sh
           # computes MG_PIN_MAP + CLIENT_CPUS from the container's effective cpuset; the client is
           # taskset-pinned to the leftover cores.
-          docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && export MG_REAL_BINARY=$MGBUILD_ROOT_DIR/build/memgraph && eval \"\$(./ha_pin_map.sh)\" && export MG_PIN_MAP && taskset -c \"\$CLIENT_CPUS\" ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 $MIX --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION --vendor-binary $MGBUILD_ROOT_DIR/tests/mgbench/ha_pin_wrapper.sh -- pokec/$DATASET_SIZE/arango/*"
+          docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && export MG_REAL_BINARY=$MGBUILD_ROOT_DIR/build/memgraph && eval \"\$(./ha_pin_map.sh)\" && export MG_PIN_MAP && taskset -c \"\$CLIENT_CPUS\" ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 $MIX --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION --vendor-binary $MGBUILD_ROOT_DIR/tests/mgbench/ha_pin_wrapper.sh -- $TARGET"
         else
-          docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 $MIX --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
+          docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 $MIX --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- $TARGET"
         fi
       else
         local WORKERS="${NUM_WORKERS:-6}"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2088,8 +2088,13 @@ test_memgraph() {
         # Read-heavy realistic mix (20% write, 80% read, 0% update, 0% analytical) over the pokec arango
         # group, at high concurrency so many clients contend for the commit path while writes replicate.
         # This is the workload the funnel improves and that isolated per-query benchmarks cannot show.
+        # 50k queries (not 5k) so the measured window is ~80s of steady state rather than ~8s: relative
+        # timing noise scales ~1/sqrt(window), and the aggregate throughput is the only signal here.
+        # --warm-up hot excludes cold-cache/first-touch cost from the sample. The mix is seeded on the
+        # "50000_20_80_0_0" distribution string, so every run executes the identical query stream — an
+        # A/B (baseline vs funnel) differs only in timing, not in composition.
         local WORKERS="${NUM_WORKERS:-18}"
-        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --num-workers-for-benchmark $WORKERS --workload-realistic 5000 20 80 0 0 --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
+        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --warm-up hot --num-workers-for-benchmark $WORKERS --workload-realistic 50000 20 80 0 0 --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
       else
         local WORKERS="${NUM_WORKERS:-6}"
         docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --num-workers-for-benchmark $WORKERS --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/create/pattern pokec/$DATASET_SIZE/create/vertex_big pokec/$DATASET_SIZE/arango/single_vertex_write pokec/$DATASET_SIZE/arango/single_edge_write pokec/$DATASET_SIZE/basic/single_vertex_property_update_update pokec/$DATASET_SIZE/arango/single_vertex_read"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -2059,6 +2059,11 @@ test_memgraph() {
       # managed (execute_read/execute_write transaction functions) vs implicit (auto-commit run()
       # with a manually set session access mode); measured separately to compare the two styles.
       local ROUTING_TX_MODE='managed'
+      # pinned: CPU-pin each cluster instance to its own cores (via ha_pin_wrapper.sh + ha_pin_map.sh)
+      # and the client to the leftover cores, for a stable, contention-free HA read/write measurement.
+      local PINNED=0
+      # write-pct: percentage of writes in the realistic mix (rest are reads). 0 = 100% read.
+      local WRITE_PCT=20
 
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -2090,15 +2095,29 @@ test_memgraph() {
             NUM_WORKERS="$2"
             shift 2
           ;;
+          --pinned)
+            PINNED=1
+            shift 1
+          ;;
+          --write-pct)
+            WRITE_PCT="$2"
+            shift 2
+          ;;
           *)
             echo "Error: Unknown flag '$1' for mgbench-ha"
-            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --routing, --routing-tx-mode, --num-workers"
+            echo "Supported flags: --size, --export-results-file, --cluster-description, --realistic, --routing, --routing-tx-mode, --num-workers, --pinned, --write-pct"
             exit 1
           ;;
         esac
       done
 
       check_support pokec_size $DATASET_SIZE
+      # The pinned CI harness always runs the 2-replica, reads-on-main-OFF cluster (with 4 bolt workers
+      # per instance) regardless of client mode, so routed reads go only to replicas. Switch to it here
+      # so the routing block below does not fall through to the reads-on-main routing description.
+      if [[ "$PINNED" == "1" && "$CLUSTER_DESCRIPTION" == "ha_cluster.yaml" ]]; then
+        CLUSTER_DESCRIPTION='ha_cluster_2_replicas.yaml'
+      fi
       # bolt+routing goes through a python client speaking neo4j:// to a coordinator; the default
       # cluster description switches to the one that enables reads on main so routed reads reach it.
       local ROUTING_ARGS=''
@@ -2113,16 +2132,21 @@ test_memgraph() {
         fi
       fi
       if [[ "$MODE" == "realistic" ]]; then
-        # Read-heavy realistic mix (20% write, 80% read, 0% update, 0% analytical) over the pokec arango
-        # group, at high concurrency so many clients contend for the commit path while writes replicate.
-        # This is the workload the funnel improves and that isolated per-query benchmarks cannot show.
-        # 50k queries (not 5k) so the measured window is ~80s of steady state rather than ~8s: relative
-        # timing noise scales ~1/sqrt(window), and the aggregate throughput is the only signal here.
-        # --warm-up hot excludes cold-cache/first-touch cost from the sample. The mix is seeded on the
-        # "50000_20_80_0_0" distribution string, so every run executes the identical query stream — an
-        # A/B (baseline vs funnel) differs only in timing, not in composition.
+        # Realistic mix over the pokec arango group at high concurrency: many clients contend for the
+        # commit path while writes replicate SYNC. WRITE_PCT% write / the rest read (0 => 100% read).
+        # 50k queries so the window is ~80s of steady state (noise ~1/sqrt(window)); --warm-up hot drops
+        # cold-cache cost; the mix is seeded on the "50000_<w>_<r>_0_0" string so every run executes the
+        # identical query stream (an A/B differs only in timing, not composition).
+        local MIX="$WRITE_PCT $((100 - WRITE_PCT)) 0 0"
         local WORKERS="${NUM_WORKERS:-18}"
-        docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 20 80 0 0 --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
+        if [[ "$PINNED" == "1" ]]; then
+          # Each instance is pinned by ha_pin_wrapper.sh (passed as --vendor-binary); ha_pin_map.sh
+          # computes MG_PIN_MAP + CLIENT_CPUS from the container's effective cpuset; the client is
+          # taskset-pinned to the leftover cores.
+          docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && export MG_REAL_BINARY=$MGBUILD_ROOT_DIR/build/memgraph && eval \"\$(./ha_pin_map.sh)\" && export MG_PIN_MAP && taskset -c \"\$CLIENT_CPUS\" ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 $MIX --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION --vendor-binary $MGBUILD_ROOT_DIR/tests/mgbench/ha_pin_wrapper.sh -- pokec/$DATASET_SIZE/arango/*"
+        else
+          docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --warm-up hot $ROUTING_ARGS --num-workers-for-benchmark $WORKERS --workload-realistic 50000 $MIX --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/arango/*"
+        fi
       else
         local WORKERS="${NUM_WORKERS:-6}"
         docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && export PYTHONUNBUFFERED=1 && source $MGBUILD_ROOT_DIR/tests/ve3/bin/activate && cd $MGBUILD_ROOT_DIR/tests/mgbench && ./benchmark.py --ha-only --no-authorization --num-workers-for-benchmark $WORKERS --export-results $EXPORT_RESULTS_FILE --vendor-specific ha-cluster-yaml=$CLUSTER_DESCRIPTION -- pokec/$DATASET_SIZE/create/pattern pokec/$DATASET_SIZE/create/vertex_big pokec/$DATASET_SIZE/arango/single_vertex_write pokec/$DATASET_SIZE/arango/single_edge_write pokec/$DATASET_SIZE/basic/single_vertex_property_update_update pokec/$DATASET_SIZE/arango/single_vertex_read"

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -345,6 +345,16 @@ def parse_args():
         "cluster and --client-language python.",
     )
 
+    benchmark_parser.add_argument(
+        "--client-bolt-routing-tx-mode",
+        type=str,
+        default="managed",
+        choices=["managed", "implicit"],
+        help="bolt+routing transaction style: 'managed' (execute_read/execute_write transaction "
+        "functions) or 'implicit' (auto-commit run() with a manually set session access mode). Only "
+        "used with --client-bolt-routing.",
+    )
+
     return benchmark_parser.parse_args()
 
 
@@ -1321,6 +1331,7 @@ if __name__ == "__main__":
         ),
         client_language=args.client_language,
         client_bolt_routing=args.client_bolt_routing,
+        client_bolt_routing_tx_mode=args.client_bolt_routing_tx_mode,
         databases=args.databases,
         client_bolt_address=args.client_bolt_address,
         num_workers_for_import=args.num_workers_for_import,

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -648,7 +648,9 @@ def warmup(condition: str, client, queries: list = None):
     if condition == DATABASE_CONDITION_HOT:
         log.log("Execute warm-up to match condition: {} ".format(condition))
         warmup_to_hot_queries = get_warmup_to_hot_queries(client)
-        if len(queries) > 0:
+        # queries is None on the realistic/mixed paths (no explicit benchmark query list); only an
+        # explicitly empty list means "nothing to benchmark, skip warm-up".
+        if queries is None or len(queries) > 0:
             client.execute(
                 queries=warmup_to_hot_queries,
                 num_workers=1,

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -337,6 +337,14 @@ def parse_args():
         help="Client language implementation (cpp or python)",
     )
 
+    benchmark_parser.add_argument(
+        "--client-bolt-routing",
+        action="store_true",
+        help="Connect the (python) client with bolt+routing (neo4j://) to a coordinator and route "
+        "reads/writes by access mode, instead of a direct bolt connection to main. Requires an HA "
+        "cluster and --client-language python.",
+    )
+
     return benchmark_parser.parse_args()
 
 
@@ -348,7 +356,14 @@ def resolve_high_availability_args(args):
     """
     args.run_ha_leg = False
     if not (args.run_ha or args.ha_only):
+        if args.client_bolt_routing:
+            raise ValueError("--client-bolt-routing needs an HA cluster; pass --ha-only or --run-ha.")
         return
+
+    if args.client_bolt_routing and args.client_language != BenchmarkClientLanguage.PYTHON:
+        raise ValueError(
+            "--client-bolt-routing is only implemented by the python client; pass --client-language python."
+        )
 
     # A cluster is started from binaries on this machine, so it cannot be measured through a type that
     # runs the database in a container or expects one to be running already.
@@ -1305,6 +1320,7 @@ if __name__ == "__main__":
             else None
         ),
         client_language=args.client_language,
+        client_bolt_routing=args.client_bolt_routing,
         databases=args.databases,
         client_bolt_address=args.client_bolt_address,
         num_workers_for_import=args.num_workers_for_import,

--- a/tests/mgbench/benchmark_context.py
+++ b/tests/mgbench/benchmark_context.py
@@ -28,6 +28,7 @@ class BenchmarkContext:
         client_binary: str = None,
         client_language: str = None,
         client_bolt_routing: bool = False,
+        client_bolt_routing_tx_mode: str = "managed",
         num_workers_for_import: int = None,
         num_workers_for_benchmark: int = None,
         database_workers: int = None,
@@ -62,6 +63,7 @@ class BenchmarkContext:
         self.client_binary = client_binary
         self.client_language = client_language
         self.client_bolt_routing = client_bolt_routing
+        self.client_bolt_routing_tx_mode = client_bolt_routing_tx_mode
         self.num_workers_for_import = num_workers_for_import
         self.num_workers_for_benchmark = num_workers_for_benchmark
         # If database_workers is not specified, use num_workers_for_benchmark for backward compatibility

--- a/tests/mgbench/benchmark_context.py
+++ b/tests/mgbench/benchmark_context.py
@@ -27,6 +27,7 @@ class BenchmarkContext:
         installation_type: str = None,
         client_binary: str = None,
         client_language: str = None,
+        client_bolt_routing: bool = False,
         num_workers_for_import: int = None,
         num_workers_for_benchmark: int = None,
         database_workers: int = None,
@@ -60,6 +61,7 @@ class BenchmarkContext:
         self.installation_type = installation_type
         self.client_binary = client_binary
         self.client_language = client_language
+        self.client_bolt_routing = client_bolt_routing
         self.num_workers_for_import = num_workers_for_import
         self.num_workers_for_benchmark = num_workers_for_benchmark
         # If database_workers is not specified, use num_workers_for_benchmark for backward compatibility

--- a/tests/mgbench/ha_cluster_2_replicas.yaml
+++ b/tests/mgbench/ha_cluster_2_replicas.yaml
@@ -30,6 +30,7 @@ instance_1:
   args:
     - "--log-level=WARNING"
     - "--bolt-port=7687"
+    - "--bolt-num-workers=4"
     - "--management-port=10011"
     - "--data-recovery-on-startup=true"
     - "--storage-recovery-thread-count=8"
@@ -44,6 +45,7 @@ instance_2:
   args:
     - "--log-level=WARNING"
     - "--bolt-port=7688"
+    - "--bolt-num-workers=4"
     - "--management-port=10012"
     - "--data-recovery-on-startup=true"
     - "--storage-recovery-thread-count=8"
@@ -58,6 +60,7 @@ instance_3:
   args:
     - "--log-level=WARNING"
     - "--bolt-port=7689"
+    - "--bolt-num-workers=4"
     - "--management-port=10013"
     - "--data-recovery-on-startup=true"
     - "--storage-recovery-thread-count=8"

--- a/tests/mgbench/ha_cluster_routing.yaml
+++ b/tests/mgbench/ha_cluster_routing.yaml
@@ -1,0 +1,100 @@
+# Cluster description for replication benchmarks: three coordinators, one main and one SYNC
+# replica, all on localhost distinguished by port. Consumed by the MemgraphHA runner
+# (--installation-type ha) in the shape tests/e2e/interactive_mg_runner.py accepts.
+#
+# Every top-level key is an instance name; coordinators are recognized by --coordinator-id.
+# data_directory is deliberately absent: the runner injects one per instance so directories are
+# pinned for a whole run and fresh for the next one.
+#
+# Log level stays at WARNING. Trace-level logging on the commit path would dominate the
+# measurement rather than the replication it is meant to expose.
+#
+# Snapshot recovery runs in parallel. Importing the dataset leaves a snapshot in each instance's
+# data directory and the WAL carries whatever the measurements write, so --data-recovery-on-startup
+# restores both on every restart a run makes and nothing has to be written out on the way down.
+# The thread count is pinned rather than left to the default, which derives from the host's CPU
+# count and so ignores the cpuset the benchmark container is confined to; parallel schema
+# recovery only engages above one thread.
+#
+# Edges carry properties, which is not the flag's default but is what the standalone Memgraph
+# runner forces on itself. The two series are only comparable while both sides store edges the
+# same way, and the replication tax this suite reports is a ratio between them.
+#
+# Each instance's console output is discarded, since a run restarts them all once per measurement and
+# every start would otherwise print a banner and a couple of notices. The log files are unaffected.
+# Set silence_output: false on an instance to watch it start.
+
+instance_1:
+  args:
+    - "--log-level=WARNING"
+    - "--bolt-port=7687"
+    - "--management-port=10011"
+    - "--data-recovery-on-startup=true"
+    - "--storage-recovery-thread-count=8"
+    - "--storage-parallel-schema-recovery=true"
+    - "--storage-properties-on-edges=true"
+    - "--storage-wal-enabled=true"
+  log_file: "mgbench_ha_instance_1.log"
+  storage_snapshot_on_exit: false
+  setup_queries: []
+
+instance_2:
+  args:
+    - "--log-level=WARNING"
+    - "--bolt-port=7688"
+    - "--management-port=10012"
+    - "--data-recovery-on-startup=true"
+    - "--storage-recovery-thread-count=8"
+    - "--storage-parallel-schema-recovery=true"
+    - "--storage-properties-on-edges=true"
+    - "--storage-wal-enabled=true"
+  log_file: "mgbench_ha_instance_2.log"
+  storage_snapshot_on_exit: false
+  setup_queries: []
+
+coordinator_1:
+  args:
+    - "--log-level=WARNING"
+    - "--bolt-port=7690"
+    - "--coordinator-id=1"
+    - "--coordinator-port=10111"
+    - "--management-port=10121"
+    - "--coordinator-hostname=localhost"
+  log_file: "mgbench_ha_coordinator_1.log"
+  setup_queries: []
+
+coordinator_2:
+  args:
+    - "--log-level=WARNING"
+    - "--bolt-port=7691"
+    - "--coordinator-id=2"
+    - "--coordinator-port=10112"
+    - "--management-port=10122"
+    - "--coordinator-hostname=localhost"
+  log_file: "mgbench_ha_coordinator_2.log"
+  setup_queries: []
+
+# The cluster-level setup runs from the last coordinator in this file, after every process is up.
+# Re-running it on a restart is expected to fail and is ignored: the coordinators keep their Raft
+# state for the whole run, so nothing is ever registered twice.
+coordinator_3:
+  args:
+    - "--log-level=WARNING"
+    - "--bolt-port=7692"
+    - "--coordinator-id=3"
+    - "--coordinator-port=10113"
+    - "--management-port=10123"
+    - "--coordinator-hostname=localhost"
+  log_file: "mgbench_ha_coordinator_3.log"
+  setup_queries:
+    - "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}"
+    - "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}"
+    - "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113', 'management_server': 'localhost:10123'}"
+    - "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'}"
+    - "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'}"
+    - "SET INSTANCE instance_1 TO MAIN"
+    # A routed client sends read transactions to whatever the routing table lists as read servers.
+    # Enabling reads on main puts main in that set, so reads and writes both land on main and contend
+    # for its worker pool - the contention the adaptive lock funnel (#4777) relieves. Without this,
+    # reads route only to the replica and main sees writes alone, hiding the effect.
+    - "SET COORDINATOR SETTING 'enabled_reads_on_main' TO 'true'"

--- a/tests/mgbench/ha_pin_map.sh
+++ b/tests/mgbench/ha_pin_map.sh
@@ -22,6 +22,7 @@
 # acceptable.
 #
 # Cpuset detection order: HA_PIN_CPUSET_OVERRIDE (for self-tests only) →
+# taskset -cp $$ (process affinity — always reflects --cpuset-cpus) →
 # /sys/fs/cgroup/cpuset.cpus.effective (cgroup v2) →
 # /sys/fs/cgroup/cpuset/cpuset.cpus  (cgroup v1) →
 # 0-$(nproc-1) fallback.
@@ -38,6 +39,16 @@ _cpuset_spec() {
     if [[ -n "${HA_PIN_CPUSET_OVERRIDE:-}" ]]; then
         printf '%s' "$HA_PIN_CPUSET_OVERRIDE"
         return
+    fi
+    # Primary: process's actual affinity — always reflects --cpuset-cpus and
+    # is the authoritative ceiling for any subsequent taskset -c call.
+    if command -v taskset &>/dev/null; then
+        local _ts_list
+        _ts_list=$(taskset -cp $$ 2>/dev/null | sed -n 's/.*: *//p')
+        if [[ "$_ts_list" =~ ^[0-9]+([,-][0-9]+)*$ ]]; then
+            printf '%s' "$_ts_list"
+            return
+        fi
     fi
     local v2=/sys/fs/cgroup/cpuset.cpus.effective
     local v1=/sys/fs/cgroup/cpuset/cpuset.cpus

--- a/tests/mgbench/ha_pin_map.sh
+++ b/tests/mgbench/ha_pin_map.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# ha_pin_map.sh — Compute a CPU pin map from the container's effective cpuset.
+#
+# Reads the container's effective cpuset and deterministically carves it into
+# per-instance core assignments, then prints two shell-eval'able lines for the
+# benchmark driver:
+#
+#   MG_PIN_MAP   — consumed by ha_pin_wrapper.sh; PORT:CPULIST pairs separated
+#                  by commas.  CPULIST uses range notation (e.g. 0-3) so it
+#                  does not collide with the comma delimiter that separates the
+#                  PORT:CPULIST entries.
+#   CLIENT_CPUS  — taskset -c cpulist for the benchmark client process.
+#
+# Core-reservation policy (N = total allowed CPUs):
+#   CPD = min(4, floor((N-2)/3)), clamped to [1, 4]   — cores per data instance
+#   main  (7687): CPUS[0 .. CPD-1]
+#   rep1  (7688): CPUS[CPD .. 2*CPD-1]
+#   rep2  (7689): CPUS[2*CPD .. 3*CPD-1]
+#   coord (7690-7692): one shared core — CPUS[min(3*CPD, N-1)]
+#   client: CPUS[coord_idx+1 .. N-1]; falls back to the coord core when empty.
+# Indices are clamped to [0, N-1]: overlap/sharing under small cpusets is
+# acceptable.
+#
+# Cpuset detection order: HA_PIN_CPUSET_OVERRIDE (for self-tests only) →
+# /sys/fs/cgroup/cpuset.cpus.effective (cgroup v2) →
+# /sys/fs/cgroup/cpuset/cpuset.cpus  (cgroup v1) →
+# 0-$(nproc-1) fallback.
+#
+# Usage: eval "$(./ha_pin_map.sh)"          # default / --print mode
+#        HA_PIN_CPUSET_OVERRIDE=0-7 ./ha_pin_map.sh   # self-test injection
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# _cpuset_spec — emit the raw cpuset string, honouring the override env var.
+# ---------------------------------------------------------------------------
+_cpuset_spec() {
+    if [[ -n "${HA_PIN_CPUSET_OVERRIDE:-}" ]]; then
+        printf '%s' "$HA_PIN_CPUSET_OVERRIDE"
+        return
+    fi
+    local v2=/sys/fs/cgroup/cpuset.cpus.effective
+    local v1=/sys/fs/cgroup/cpuset/cpuset.cpus
+    if [[ -r "$v2" && -s "$v2" ]]; then
+        tr -d '[:space:]' < "$v2"
+    elif [[ -r "$v1" && -s "$v1" ]]; then
+        tr -d '[:space:]' < "$v1"
+    else
+        printf '0-%d' "$(( $(nproc) - 1 ))"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# _expand SPEC — expand "a-b,c,d-e,..." into sorted unique integers, one/line.
+# ---------------------------------------------------------------------------
+_expand() {
+    local spec="$1" segment lo hi cpu
+    local -a segments
+    IFS=',' read -ra segments <<< "$spec"
+    for segment in "${segments[@]}"; do
+        segment="${segment// /}"
+        if [[ "$segment" == *-* ]]; then
+            lo="${segment%-*}"
+            hi="${segment#*-}"
+            for ((cpu = lo; cpu <= hi; cpu++)); do printf '%d\n' "$cpu"; done
+        elif [[ -n "$segment" ]]; then
+            printf '%d\n' "$segment"
+        fi
+    done | sort -un
+}
+
+# ---------------------------------------------------------------------------
+# _compact CPU... — collapse ascending integers into a compact taskset range
+# spec with no trailing comma; e.g. "0 1 2 3" → "0-3", "5 8 9" → "5,8-9".
+# Emits nothing for zero arguments.
+# ---------------------------------------------------------------------------
+_compact() {
+    local -a cpus=("$@")
+    local n=${#cpus[@]}
+    (( n == 0 )) && return
+    local result='' start=${cpus[0]} prev=${cpus[0]} cur i
+    for ((i = 1; i < n; i++)); do
+        cur=${cpus[$i]}
+        if (( cur - prev == 1 )); then
+            prev=$cur
+        else
+            [[ -n "$result" ]] && result+=','
+            if (( prev == start )); then result+="$start"; else result+="${start}-${prev}"; fi
+            start=$cur; prev=$cur
+        fi
+    done
+    [[ -n "$result" ]] && result+=','
+    if (( prev == start )); then result+="$start"; else result+="${start}-${prev}"; fi
+    printf '%s' "$result"
+}
+
+# ---------------------------------------------------------------------------
+# _bounded_slice NAMEREF START END — append CPUS[START..END] into the named
+# array, clamping both indices to [0, N-1].  CPUS and N are read from the
+# dynamic scope of the caller (main).
+# ---------------------------------------------------------------------------
+_bounded_slice() {
+    local -n _bsl_out=$1
+    local s=$2 e=$3
+    (( s >= N )) && s=$(( N - 1 ))
+    (( e >= N )) && e=$(( N - 1 ))
+    (( e < s  )) && e=$s
+    local j
+    for ((j = s; j <= e; j++)); do _bsl_out+=("${CPUS[$j]}"); done
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+    local spec
+    spec=$(_cpuset_spec)
+    # Strip any residual whitespace the cgroup file might carry.
+    spec="${spec//[$'\t\r\n ']}"
+
+    local -a CPUS=()
+    while IFS= read -r cpu; do CPUS+=("$cpu"); done < <(_expand "$spec")
+
+    local N=${#CPUS[@]}
+    if (( N == 0 )); then
+        printf 'ha_pin_map: empty cpuset — cannot assign pins\n' >&2
+        exit 1
+    fi
+
+    # Cores per data instance: floor((N-2)/3), clamped to [1, 4].
+    local cpd=$(( (N - 2) / 3 ))
+    (( cpd < 1 )) && cpd=1
+    (( cpd > 4 )) && cpd=4
+
+    local -a main_c=() rep1_c=() rep2_c=() client_c=()
+    _bounded_slice main_c  0           $(( cpd - 1   ))
+    _bounded_slice rep1_c  $((cpd))    $(( 2*cpd - 1 ))
+    _bounded_slice rep2_c  $((2*cpd))  $(( 3*cpd - 1 ))
+
+    local coord_idx=$(( 3*cpd < N ? 3*cpd : N - 1 ))
+    local coord_core="${CPUS[$coord_idx]}"
+
+    local cli_start=$(( coord_idx + 1 ))
+    if (( cli_start < N )); then
+        _bounded_slice client_c $cli_start $(( N - 1 ))
+    else
+        # Small cpuset: no spare core; share the coordinator core.
+        client_c=("$coord_core")
+    fi
+
+    local main_s rep1_s rep2_s client_s
+    main_s=$(_compact   "${main_c[@]}")
+    rep1_s=$(_compact   "${rep1_c[@]}")
+    rep2_s=$(_compact   "${rep2_c[@]}")
+    client_s=$(_compact "${client_c[@]}")
+
+    printf "MG_PIN_MAP='7687:%s,7688:%s,7689:%s,7690:%s,7691:%s,7692:%s'\n" \
+        "$main_s" "$rep1_s" "$rep2_s" \
+        "$coord_core" "$coord_core" "$coord_core"
+    printf "CLIENT_CPUS='%s'\n" "$client_s"
+}
+
+main "$@"

--- a/tests/mgbench/ha_pin_wrapper.sh
+++ b/tests/mgbench/ha_pin_wrapper.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# ha_pin_wrapper.sh — CPU-pinning shim for the mgbench HA benchmark harness.
+#
+# The HA runner starts each Memgraph instance (main, replicas, coordinators) by
+# exec'ing a "vendor binary".  Pass this script as that binary so every instance
+# lands on its own core range; it resolves the right cpuset from the instance's
+# bolt port, delegates to taskset, and exec's the real binary — the wrapper
+# vanishes from the process table.
+#
+# Environment variables:
+#   MG_REAL_BINARY  (required) — absolute path to the real memgraph binary.
+#   MG_PIN_MAP      (optional) — comma-separated PORT:CPULIST pairs, e.g.
+#                     "7687:0-3,7688:4-7,7689:8-11,7690:12,7691:12,7692:12"
+#                   CPULIST is any spec accepted by taskset -c (ranges or lists).
+#                   If unset/empty, the port is absent from the map, or taskset is
+#                   not installed, the binary runs unpinned — no error is raised.
+
+set -euo pipefail
+
+# Validate required env var.
+if [[ -z "${MG_REAL_BINARY:-}" ]]; then
+    echo "ha_pin_wrapper: MG_REAL_BINARY is unset or empty — cannot exec memgraph" >&2
+    exit 1
+fi
+
+# Parse --bolt-port from "$@".  Accepts both --bolt-port=PORT (equals form) and
+# --bolt-port PORT (space form); stops at the first match.
+bolt_port=""
+prev=""
+for arg in "$@"; do
+    case "$arg" in
+        --bolt-port=*)
+            bolt_port="${arg#--bolt-port=}"
+            break
+            ;;
+        --bolt-port)
+            prev="--bolt-port"
+            ;;
+        *)
+            if [[ "$prev" == "--bolt-port" ]]; then
+                bolt_port="$arg"
+                break
+            fi
+            prev=""
+            ;;
+    esac
+done
+
+# Resolve the CPULIST for this port from MG_PIN_MAP.
+cpulist=""
+if [[ -n "$bolt_port" && -n "${MG_PIN_MAP:-}" ]]; then
+    IFS=',' read -ra entries <<< "$MG_PIN_MAP"
+    for entry in "${entries[@]}"; do
+        port="${entry%%:*}"
+        cpus="${entry#*:}"
+        if [[ "$port" == "$bolt_port" ]]; then
+            cpulist="$cpus"
+            break
+        fi
+    done
+fi
+
+# Exec the real binary, pinned when a cpulist was found and taskset is available.
+if [[ -n "$cpulist" ]] && command -v taskset > /dev/null 2>&1; then
+    exec taskset -c "$cpulist" "$MG_REAL_BINARY" "$@"
+else
+    exec "$MG_REAL_BINARY" "$@"
+fi

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -1,13 +1,25 @@
 import argparse
 import json
+import re
 import time
 from abc import ABC, abstractmethod
 from multiprocessing import Array, Lock, Manager, Process, Value
 
+import neo4j
 import psycopg2
 import psycopg2.extras
 from falkordb import FalkorDB
 from neo4j import GraphDatabase
+
+# A query is routed as a write (to main) when it contains a write clause, and as a read otherwise.
+# Whole-word match so substrings like OFFSET or a "set"-containing property name are not mistaken
+# for the SET clause. Sufficient for the mgbench workloads; a read misrouted to a replica would be
+# rejected, so keep this in sync with the clauses the workloads actually emit.
+_WRITE_CLAUSE = re.compile(r"\b(CREATE|MERGE|SET|DELETE|REMOVE|DROP|CALL)\b", re.IGNORECASE)
+
+
+def _is_write_query(query):
+    return bool(_WRITE_CLAUSE.search(query))
 
 
 class PythonClient(ABC):
@@ -47,17 +59,36 @@ class FalkorDBClient(PythonClient):
 
 
 class Neo4jClient(PythonClient):
-    def __init__(self, host, port, user="", password=""):
-        self._driver = GraphDatabase.driver(f"bolt://{host}:{port}", auth=(user, password))
-        self._session = self._driver.session()
+    def __init__(self, host, port, user="", password="", routing=False):
+        self._routing = routing
+        if routing:
+            # bolt+routing against a coordinator: the driver discovers the cluster and routes each
+            # query by its session's access mode. Two long-lived sessions carry the two modes so
+            # writes always land on main while reads use a read server (main included when the
+            # coordinator has enabled_reads_on_main), which is what makes reads and writes contend
+            # on main's worker pool as a routed client would.
+            self._driver = GraphDatabase.driver(f"neo4j://{host}:{port}", auth=(user, password))
+            self._read_session = self._driver.session(default_access_mode=neo4j.READ_ACCESS)
+            self._write_session = self._driver.session(default_access_mode=neo4j.WRITE_ACCESS)
+        else:
+            self._driver = GraphDatabase.driver(f"bolt://{host}:{port}", auth=(user, password))
+            self._session = self._driver.session()
 
     def close(self):
-        self._session.close()
+        if self._routing:
+            self._read_session.close()
+            self._write_session.close()
+        else:
+            self._session.close()
         self._driver.close()
 
     def execute_query(self, query, params=None):
+        if self._routing:
+            session = self._write_session if _is_write_query(query) else self._read_session
+        else:
+            session = self._session
         start = time.time()
-        result = self._session.run(query, parameters=params or {})
+        result = session.run(query, parameters=params or {})
         _ = result.consume()
         end = time.time()
         return (end - start) * 1000
@@ -95,15 +126,23 @@ def get_python_client(vendor):
     raise Exception(f"Unknown vendor {vendor} when running benchmarks with a Python client!")
 
 
+def _make_client(vendor, host, port, routing):
+    # Only the neo4j/bolt client speaks bolt+routing; other vendors ignore the flag.
+    client_cls = get_python_client(vendor)
+    if client_cls is Neo4jClient:
+        return client_cls(host, port, routing=routing)
+    return client_cls(host, port)
+
+
 def execute_validation_task(
-    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit
+    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit, routing
 ):
     # The method uses same set of arguments so it can be called with multiple workers with the same pattern
     # For this reason, in this function we will not use the following argumetns:
     # - Time limit: Validation queries are performed which are independent from timed execution
     # - Position and lock: There is no synchronization needed as validation query is the sole query needed
     #   to be executed.
-    client = get_python_client(vendor)(host, port)
+    client = _make_client(vendor, host, port, routing)
 
     if len(queries) != 1:
         raise Exception("Validation query should be performed with only one query!")
@@ -126,12 +165,12 @@ def execute_validation_task(
 
 
 def execute_queries_task(
-    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit
+    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit, routing
 ):
     # The method uses same set of arguments so it can be called with multiple workers with the same pattern
     # For this reason, in this function we will not use the following argumetns:
     # - Time limit: This task is independent from timed execution as every query will be executed only once
-    client = get_python_client(vendor)(host, port)
+    client = _make_client(vendor, host, port, routing)
 
     size = len(queries)
 
@@ -170,9 +209,9 @@ def execute_queries_task(
 
 
 def execute_time_dependent_task(
-    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit
+    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit, routing
 ):
-    client = get_python_client(vendor)(host, port)
+    client = _make_client(vendor, host, port, routing)
 
     size = len(queries)
 
@@ -244,6 +283,7 @@ def execute_workload(queries, args):
                 durations,
                 args.max_retries,
                 time_limit,
+                args.routing,
             ),
         )
         process.start()
@@ -299,6 +339,15 @@ def main():
     parser.add_argument("--password", default="", help="Password for the database")
     parser.add_argument("--num-workers", type=int, default=1, help="Number of worker threads")
     parser.add_argument("--max-retries", type=int, default=50, help="Maximum number of retries for each query")
+    parser.add_argument(
+        "--routing",
+        type=str2bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="Connect with bolt+routing (neo4j://) to a coordinator and route reads/writes by access "
+        "mode, instead of a direct bolt:// connection to a single instance.",
+    )
     parser.add_argument("--input", default="", help="Input file containing queries in JSON format")
     parser.add_argument("--output", default="", help="Output file to write results in JSON format")
     parser.add_argument(

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -18,9 +18,17 @@ from neo4j import GraphDatabase
 # rejected, so keep this in sync with the clauses the workloads actually emit.
 _WRITE_CLAUSE = re.compile(r"\b(CREATE|MERGE|SET|DELETE|REMOVE|DROP|CALL)\b", re.IGNORECASE)
 
+# DDL / schema commands that Memgraph refuses inside an explicit (multicommand) transaction and so
+# must run as an implicit auto-commit query even in managed routing (e.g. dataset-import index setup).
+_DDL_CLAUSE = re.compile(r"\b(INDEX|CONSTRAINT|TRIGGER)\b", re.IGNORECASE)
+
 
 def _is_write_query(query):
     return bool(_WRITE_CLAUSE.search(query))
+
+
+def _is_ddl_query(query):
+    return bool(_DDL_CLAUSE.search(query))
 
 
 class PythonClient(ABC):
@@ -102,7 +110,12 @@ class Neo4jClient(PythonClient):
                 # load-balanced across the routing table's READ servers, writes to main) and release
                 # the connection on commit, so routing distributes the load per query.
                 if write:
-                    self._write_session.execute_write(lambda tx: tx.run(query, parameters=params or {}).consume())
+                    if _is_ddl_query(query):
+                        # DDL cannot run in a managed (explicit) transaction; auto-commit on the
+                        # write session so it still routes to main but as an implicit transaction.
+                        self._write_session.run(query, parameters=params or {}).consume()
+                    else:
+                        self._write_session.execute_write(lambda tx: tx.run(query, parameters=params or {}).consume())
                 else:
                     self._read_session.execute_read(lambda tx: tx.run(query, parameters=params or {}).consume())
             else:

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -6,10 +6,11 @@ from abc import ABC, abstractmethod
 from multiprocessing import Array, Lock, Manager, Process, Value
 
 import neo4j
-import psycopg2
-import psycopg2.extras
-from falkordb import FalkorDB
 from neo4j import GraphDatabase
+
+# psycopg2 (PostgreSQL) and falkordb are optional vendor drivers, imported lazily in their client
+# classes so this module loads with only the neo4j driver present, which is all the mgbench venv
+# installs. A memgraph run must not fail because an unrelated vendor's driver is absent.
 
 # A query is routed as a write (to main) when it contains a write clause, and as a read otherwise.
 # Whole-word match so substrings like OFFSET or a "set"-containing property name are not mistaken
@@ -47,6 +48,8 @@ class FalkorDBClient(PythonClient):
 
     def __init__(self, host, port):
         super().__init__()
+        from falkordb import FalkorDB
+
         self._db = FalkorDB(host=host, port=port)
         self._graph = self._db.select_graph(FalkorDBClient.GRAPH_NAME)
 
@@ -96,6 +99,9 @@ class Neo4jClient(PythonClient):
 
 class PostgreSQLClient(PythonClient):
     def __init__(self, host, port, user="postgres", password="postgres", database="postgres"):
+        import psycopg2
+        import psycopg2.extras
+
         self._conn = psycopg2.connect(host=host, port=port, user=user, password=password, database=database)
         self._conn.autocommit = True
         self._cursor = self._conn.cursor(cursor_factory=psycopg2.extras.DictCursor)

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -87,11 +87,21 @@ class Neo4jClient(PythonClient):
 
     def execute_query(self, query, params=None):
         if self._routing:
-            session = self._write_session if _is_write_query(query) else self._read_session
-        else:
-            session = self._session
+            # Managed read/write transactions, not session.run(): an auto-commit run() pins the
+            # session to the first server it connects to and never re-routes, so reads would never
+            # reach a replica. execute_read/execute_write route each transaction by access mode
+            # (readers load-balanced across the routing table's READ servers, writes to main) and
+            # release the connection on commit, so routing actually distributes the load.
+            start = time.time()
+            if _is_write_query(query):
+                self._write_session.execute_write(lambda tx: tx.run(query, parameters=params or {}).consume())
+            else:
+                self._read_session.execute_read(lambda tx: tx.run(query, parameters=params or {}).consume())
+            end = time.time()
+            return (end - start) * 1000
+
         start = time.time()
-        result = session.run(query, parameters=params or {})
+        result = self._session.run(query, parameters=params or {})
         _ = result.consume()
         end = time.time()
         return (end - start) * 1000

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -85,18 +85,19 @@ class Neo4jClient(PythonClient):
         self._routing_tx_mode = routing_tx_mode
         if routing:
             self._driver = GraphDatabase.driver(f"neo4j://{host}:{port}", auth=(user, password))
-            if routing_tx_mode == "managed":
-                self._read_session = self._driver.session(default_access_mode=neo4j.READ_ACCESS)
-                self._write_session = self._driver.session(default_access_mode=neo4j.WRITE_ACCESS)
+            # Two long-lived access-mode sessions serve both tx modes: the driver releases a session's
+            # connection when each result is consumed and re-acquires (re-routes) on the next query,
+            # so a reused session still load-balances across the routing table's servers.
+            self._read_session = self._driver.session(default_access_mode=neo4j.READ_ACCESS)
+            self._write_session = self._driver.session(default_access_mode=neo4j.WRITE_ACCESS)
         else:
             self._driver = GraphDatabase.driver(f"bolt://{host}:{port}", auth=(user, password))
             self._session = self._driver.session()
 
     def close(self):
         if self._routing:
-            if self._routing_tx_mode == "managed":
-                self._read_session.close()
-                self._write_session.close()
+            self._read_session.close()
+            self._write_session.close()
         else:
             self._session.close()
         self._driver.close()
@@ -119,11 +120,11 @@ class Neo4jClient(PythonClient):
                 else:
                     self._read_session.execute_read(lambda tx: tx.run(query, parameters=params or {}).consume())
             else:
-                # Implicit (auto-commit) transaction with a manually set session access mode. A fresh
-                # session per query so each one re-routes by access mode rather than pinning.
-                mode = neo4j.WRITE_ACCESS if write else neo4j.READ_ACCESS
-                with self._driver.session(default_access_mode=mode) as session:
-                    session.run(query, parameters=params or {}).consume()
+                # Implicit (auto-commit) run() on the persistent access-mode session. Consuming the
+                # result releases the connection, so the next run re-routes across READ servers — no
+                # per-query BEGIN/COMMIT and no session churn.
+                session = self._write_session if write else self._read_session
+                session.run(query, parameters=params or {}).consume()
             end = time.time()
             return (end - start) * 1000
 

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -164,27 +164,6 @@ def _make_client(vendor, host, port, routing, routing_tx_mode):
     return client_cls(host, port)
 
 
-def _probe_routing_read_servers(args):
-    # DIAGNOSTIC: confirm read transactions actually reach a replica and are not all served by main
-    # (which would make the routing variant identical to the direct one). Runs SHOW REPLICATION ROLE
-    # on a READ-mode session repeatedly and reports the distribution of serving roles to stderr.
-    import sys
-    from collections import Counter
-
-    roles = Counter()
-    driver = GraphDatabase.driver(f"neo4j://{args.host}:{args.port}", auth=(args.username, args.password))
-    try:
-        for _ in range(30):
-            with driver.session(default_access_mode=neo4j.READ_ACCESS) as session:
-                record = session.run("SHOW REPLICATION ROLE").single()
-                roles[str(record[0]) if record else "?"] += 1
-    except Exception as e:
-        print(f"[routing-probe] failed: {e}", file=sys.stderr)
-    finally:
-        driver.close()
-    print(f"[routing-probe] READ-session serving roles over 30 acquisitions: {dict(roles)}", file=sys.stderr)
-
-
 def execute_validation_task(
     worker_id,
     vendor,
@@ -512,9 +491,6 @@ def main():
     if not queries:
         print("Error: No queries provided. Exiting.")
         exit(1)
-
-    if args.routing and len(queries) > 1:
-        _probe_routing_read_servers(args)
 
     results, durations = execute_workload(queries, args)
     results = list(results)

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -71,13 +71,14 @@ class FalkorDBClient(PythonClient):
 
 class Neo4jClient(PythonClient):
     # bolt+routing transaction styles (routing_tx_mode):
-    #   "managed"  - session.execute_read/execute_write (transaction functions). Each query is a
-    #                BEGIN/run/COMMIT managed transaction, routed by access mode and retried on
-    #                transient errors.
-    #   "implicit" - a fresh access-mode session per query with auto-commit session.run() (implicit
-    #                transactions). Lighter per query (single RUN+PULL, no explicit BEGIN/COMMIT).
-    # A fresh session per query is used in implicit mode because a reused session pins to the server
-    # it first connected to and never re-routes, so reads would never reach a replica.
+    #   "managed"  - execute_read/execute_write transaction functions (BEGIN/run/COMMIT), routed by
+    #                access mode and retried on transient errors.
+    #   "implicit" - auto-commit session.run() with the session's access mode (single RUN+PULL).
+    # A FRESH session is opened per query in both modes. A reused session keeps reusing its warm
+    # connection under load and stops load-balancing, pinning reads to whichever server it first hit
+    # (main, when reads-on-main is enabled); a fresh session re-routes each query so reads actually
+    # distribute across the routing table's READ servers. This matches the canonical driver usage in
+    # tests/e2e/high_availability/implicit_routing.py.
     ROUTING_TX_MODES = ("managed", "implicit")
 
     def __init__(self, host, port, user="", password="", routing=False, routing_tx_mode="managed"):
@@ -85,46 +86,31 @@ class Neo4jClient(PythonClient):
         self._routing_tx_mode = routing_tx_mode
         if routing:
             self._driver = GraphDatabase.driver(f"neo4j://{host}:{port}", auth=(user, password))
-            # Two long-lived access-mode sessions serve both tx modes: the driver releases a session's
-            # connection when each result is consumed and re-acquires (re-routes) on the next query,
-            # so a reused session still load-balances across the routing table's servers.
-            self._read_session = self._driver.session(default_access_mode=neo4j.READ_ACCESS)
-            self._write_session = self._driver.session(default_access_mode=neo4j.WRITE_ACCESS)
         else:
             self._driver = GraphDatabase.driver(f"bolt://{host}:{port}", auth=(user, password))
             self._session = self._driver.session()
 
     def close(self):
-        if self._routing:
-            self._read_session.close()
-            self._write_session.close()
-        else:
+        if not self._routing:
             self._session.close()
         self._driver.close()
 
     def execute_query(self, query, params=None):
         if self._routing:
             write = _is_write_query(query)
+            mode = neo4j.WRITE_ACCESS if write else neo4j.READ_ACCESS
             start = time.time()
-            if self._routing_tx_mode == "managed":
-                # Managed transaction functions: route each query by access mode (readers
-                # load-balanced across the routing table's READ servers, writes to main) and release
-                # the connection on commit, so routing distributes the load per query.
-                if write:
-                    if _is_ddl_query(query):
-                        # DDL cannot run in a managed (explicit) transaction; auto-commit on the
-                        # write session so it still routes to main but as an implicit transaction.
-                        self._write_session.run(query, parameters=params or {}).consume()
-                    else:
-                        self._write_session.execute_write(lambda tx: tx.run(query, parameters=params or {}).consume())
+            # Fresh session per query so each one re-routes by access mode (readers load-balanced
+            # across the routing table's READ servers, writes to main).
+            with self._driver.session(default_access_mode=mode) as session:
+                if self._routing_tx_mode == "implicit" or (write and _is_ddl_query(query)):
+                    # Implicit auto-commit run(). DDL (CREATE/DROP INDEX/CONSTRAINT/TRIGGER) must be
+                    # auto-commit even in managed mode (it cannot run in an explicit transaction).
+                    session.run(query, parameters=params or {}).consume()
+                elif write:
+                    session.execute_write(lambda tx: tx.run(query, parameters=params or {}).consume())
                 else:
-                    self._read_session.execute_read(lambda tx: tx.run(query, parameters=params or {}).consume())
-            else:
-                # Implicit (auto-commit) run() on the persistent access-mode session. Consuming the
-                # result releases the connection, so the next run re-routes across READ servers — no
-                # per-query BEGIN/COMMIT and no session churn.
-                session = self._write_session if write else self._read_session
-                session.run(query, parameters=params or {}).consume()
+                    session.execute_read(lambda tx: tx.run(query, parameters=params or {}).consume())
             end = time.time()
             return (end - start) * 1000
 

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -62,41 +62,55 @@ class FalkorDBClient(PythonClient):
 
 
 class Neo4jClient(PythonClient):
-    def __init__(self, host, port, user="", password="", routing=False):
+    # bolt+routing transaction styles (routing_tx_mode):
+    #   "managed"  - session.execute_read/execute_write (transaction functions). Each query is a
+    #                BEGIN/run/COMMIT managed transaction, routed by access mode and retried on
+    #                transient errors.
+    #   "implicit" - a fresh access-mode session per query with auto-commit session.run() (implicit
+    #                transactions). Lighter per query (single RUN+PULL, no explicit BEGIN/COMMIT).
+    # A fresh session per query is used in implicit mode because a reused session pins to the server
+    # it first connected to and never re-routes, so reads would never reach a replica.
+    ROUTING_TX_MODES = ("managed", "implicit")
+
+    def __init__(self, host, port, user="", password="", routing=False, routing_tx_mode="managed"):
         self._routing = routing
+        self._routing_tx_mode = routing_tx_mode
         if routing:
-            # bolt+routing against a coordinator: the driver discovers the cluster and routes each
-            # query by its session's access mode. Two long-lived sessions carry the two modes so
-            # writes always land on main while reads use a read server (main included when the
-            # coordinator has enabled_reads_on_main), which is what makes reads and writes contend
-            # on main's worker pool as a routed client would.
             self._driver = GraphDatabase.driver(f"neo4j://{host}:{port}", auth=(user, password))
-            self._read_session = self._driver.session(default_access_mode=neo4j.READ_ACCESS)
-            self._write_session = self._driver.session(default_access_mode=neo4j.WRITE_ACCESS)
+            if routing_tx_mode == "managed":
+                self._read_session = self._driver.session(default_access_mode=neo4j.READ_ACCESS)
+                self._write_session = self._driver.session(default_access_mode=neo4j.WRITE_ACCESS)
         else:
             self._driver = GraphDatabase.driver(f"bolt://{host}:{port}", auth=(user, password))
             self._session = self._driver.session()
 
     def close(self):
         if self._routing:
-            self._read_session.close()
-            self._write_session.close()
+            if self._routing_tx_mode == "managed":
+                self._read_session.close()
+                self._write_session.close()
         else:
             self._session.close()
         self._driver.close()
 
     def execute_query(self, query, params=None):
         if self._routing:
-            # Managed read/write transactions, not session.run(): an auto-commit run() pins the
-            # session to the first server it connects to and never re-routes, so reads would never
-            # reach a replica. execute_read/execute_write route each transaction by access mode
-            # (readers load-balanced across the routing table's READ servers, writes to main) and
-            # release the connection on commit, so routing actually distributes the load.
+            write = _is_write_query(query)
             start = time.time()
-            if _is_write_query(query):
-                self._write_session.execute_write(lambda tx: tx.run(query, parameters=params or {}).consume())
+            if self._routing_tx_mode == "managed":
+                # Managed transaction functions: route each query by access mode (readers
+                # load-balanced across the routing table's READ servers, writes to main) and release
+                # the connection on commit, so routing distributes the load per query.
+                if write:
+                    self._write_session.execute_write(lambda tx: tx.run(query, parameters=params or {}).consume())
+                else:
+                    self._read_session.execute_read(lambda tx: tx.run(query, parameters=params or {}).consume())
             else:
-                self._read_session.execute_read(lambda tx: tx.run(query, parameters=params or {}).consume())
+                # Implicit (auto-commit) transaction with a manually set session access mode. A fresh
+                # session per query so each one re-routes by access mode rather than pinning.
+                mode = neo4j.WRITE_ACCESS if write else neo4j.READ_ACCESS
+                with self._driver.session(default_access_mode=mode) as session:
+                    session.run(query, parameters=params or {}).consume()
             end = time.time()
             return (end - start) * 1000
 
@@ -142,11 +156,11 @@ def get_python_client(vendor):
     raise Exception(f"Unknown vendor {vendor} when running benchmarks with a Python client!")
 
 
-def _make_client(vendor, host, port, routing):
-    # Only the neo4j/bolt client speaks bolt+routing; other vendors ignore the flag.
+def _make_client(vendor, host, port, routing, routing_tx_mode):
+    # Only the neo4j/bolt client speaks bolt+routing; other vendors ignore the flags.
     client_cls = get_python_client(vendor)
     if client_cls is Neo4jClient:
-        return client_cls(host, port, routing=routing)
+        return client_cls(host, port, routing=routing, routing_tx_mode=routing_tx_mode)
     return client_cls(host, port)
 
 
@@ -172,14 +186,26 @@ def _probe_routing_read_servers(args):
 
 
 def execute_validation_task(
-    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit, routing
+    worker_id,
+    vendor,
+    host,
+    port,
+    queries,
+    position,
+    lock,
+    results,
+    durations,
+    max_retries,
+    time_limit,
+    routing,
+    routing_tx_mode,
 ):
     # The method uses same set of arguments so it can be called with multiple workers with the same pattern
     # For this reason, in this function we will not use the following argumetns:
     # - Time limit: Validation queries are performed which are independent from timed execution
     # - Position and lock: There is no synchronization needed as validation query is the sole query needed
     #   to be executed.
-    client = _make_client(vendor, host, port, routing)
+    client = _make_client(vendor, host, port, routing, routing_tx_mode)
 
     if len(queries) != 1:
         raise Exception("Validation query should be performed with only one query!")
@@ -202,12 +228,24 @@ def execute_validation_task(
 
 
 def execute_queries_task(
-    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit, routing
+    worker_id,
+    vendor,
+    host,
+    port,
+    queries,
+    position,
+    lock,
+    results,
+    durations,
+    max_retries,
+    time_limit,
+    routing,
+    routing_tx_mode,
 ):
     # The method uses same set of arguments so it can be called with multiple workers with the same pattern
     # For this reason, in this function we will not use the following argumetns:
     # - Time limit: This task is independent from timed execution as every query will be executed only once
-    client = _make_client(vendor, host, port, routing)
+    client = _make_client(vendor, host, port, routing, routing_tx_mode)
 
     size = len(queries)
 
@@ -246,9 +284,21 @@ def execute_queries_task(
 
 
 def execute_time_dependent_task(
-    worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit, routing
+    worker_id,
+    vendor,
+    host,
+    port,
+    queries,
+    position,
+    lock,
+    results,
+    durations,
+    max_retries,
+    time_limit,
+    routing,
+    routing_tx_mode,
 ):
-    client = _make_client(vendor, host, port, routing)
+    client = _make_client(vendor, host, port, routing, routing_tx_mode)
 
     size = len(queries)
 
@@ -321,6 +371,7 @@ def execute_workload(queries, args):
                 args.max_retries,
                 time_limit,
                 args.routing,
+                args.routing_tx_mode,
             ),
         )
         process.start()
@@ -384,6 +435,15 @@ def main():
         default=False,
         help="Connect with bolt+routing (neo4j://) to a coordinator and route reads/writes by access "
         "mode, instead of a direct bolt:// connection to a single instance.",
+    )
+    parser.add_argument(
+        "--routing-tx-mode",
+        type=str,
+        default="managed",
+        choices=Neo4jClient.ROUTING_TX_MODES,
+        help="bolt+routing transaction style: 'managed' (execute_read/execute_write transaction "
+        "functions) or 'implicit' (auto-commit session.run() with a manually set session access "
+        "mode). Only used with --routing.",
     )
     parser.add_argument("--input", default="", help="Input file containing queries in JSON format")
     parser.add_argument("--output", default="", help="Output file to write results in JSON format")

--- a/tests/mgbench/python_client.py
+++ b/tests/mgbench/python_client.py
@@ -140,6 +140,27 @@ def _make_client(vendor, host, port, routing):
     return client_cls(host, port)
 
 
+def _probe_routing_read_servers(args):
+    # DIAGNOSTIC: confirm read transactions actually reach a replica and are not all served by main
+    # (which would make the routing variant identical to the direct one). Runs SHOW REPLICATION ROLE
+    # on a READ-mode session repeatedly and reports the distribution of serving roles to stderr.
+    import sys
+    from collections import Counter
+
+    roles = Counter()
+    driver = GraphDatabase.driver(f"neo4j://{args.host}:{args.port}", auth=(args.username, args.password))
+    try:
+        for _ in range(30):
+            with driver.session(default_access_mode=neo4j.READ_ACCESS) as session:
+                record = session.run("SHOW REPLICATION ROLE").single()
+                roles[str(record[0]) if record else "?"] += 1
+    except Exception as e:
+        print(f"[routing-probe] failed: {e}", file=sys.stderr)
+    finally:
+        driver.close()
+    print(f"[routing-probe] READ-session serving roles over 30 acquisitions: {dict(roles)}", file=sys.stderr)
+
+
 def execute_validation_task(
     worker_id, vendor, host, port, queries, position, lock, results, durations, max_retries, time_limit, routing
 ):
@@ -421,6 +442,9 @@ def main():
     if not queries:
         print("Error: No queries provided. Exiting.")
         exit(1)
+
+    if args.routing and len(queries) > 1:
+        _probe_routing_read_servers(args)
 
     results, durations = execute_workload(queries, args)
     results = list(results)

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -466,6 +466,7 @@ class PythonClient(BaseClient):
         self._configured_database_port = database_port
         self._runner = runner
         self._routing = benchmark_context.client_bolt_routing
+        self._routing_tx_mode = benchmark_context.client_bolt_routing_tx_mode
 
     @property
     def _database_port(self):
@@ -511,6 +512,7 @@ class PythonClient(BaseClient):
             password=self._password,
             port=self._database_port,
             routing=self._routing,
+            routing_tx_mode=self._routing_tx_mode,
             validation=False,
             time_dependent_execution=time_dependent_execution,
         )
@@ -548,6 +550,7 @@ class PythonClient(BaseClient):
             password=self._password,
             port=self._database_port,
             routing=self._routing,
+            routing_tx_mode=self._routing_tx_mode,
             validation=validation,
             time_dependent_execution=time_dependent_execution,
         )

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -465,14 +465,17 @@ class PythonClient(BaseClient):
         self._password = ""
         self._configured_database_port = database_port
         self._runner = runner
+        self._routing = benchmark_context.client_bolt_routing
 
     @property
     def _database_port(self):
         """
         Same reason as BoltClient: the port is only stable for vendors whose database cannot move.
+        With bolt+routing the client connects to a coordinator (which serves the routing table)
+        rather than directly to main.
         """
         if self._runner is not None:
-            return self._runner.get_database_port()
+            return self._runner.get_coordinator_port() if self._routing else self._runner.get_database_port()
         return self._configured_database_port
 
     def _get_args(self, **kwargs):
@@ -507,6 +510,7 @@ class PythonClient(BaseClient):
             username=self._username,
             password=self._password,
             port=self._database_port,
+            routing=self._routing,
             validation=False,
             time_dependent_execution=time_dependent_execution,
         )
@@ -543,6 +547,7 @@ class PythonClient(BaseClient):
             username=self._username,
             password=self._password,
             port=self._database_port,
+            routing=self._routing,
             validation=validation,
             time_dependent_execution=time_dependent_execution,
         )
@@ -1222,6 +1227,11 @@ class MemgraphHA(BaseRunner):
         if self._main_name is not None:
             return self._bolt_ports[self._main_name]
         return self._bolt_port
+
+    def get_coordinator_port(self):
+        # bolt+routing entry point: any coordinator can serve the routing table (a follower forwards
+        # the request to the leader), so the first one is enough regardless of who currently leads.
+        return self._bolt_ports[self._coordinators[0]]
 
 
 class Neo4j(BaseRunner):

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -150,6 +150,10 @@ class BaseClient(ABC):
         self.benchmark_context = benchmark_context
         self._vendor = benchmark_context.vendor_name
 
+    @property
+    def vendor(self):
+        return self._vendor
+
     @abstractmethod
     def execute(self):
         pass

--- a/tests/mgbench/workloads/bench.py
+++ b/tests/mgbench/workloads/bench.py
@@ -1,0 +1,53 @@
+# Copyright 2024 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import random
+
+from workloads.base import Workload
+
+
+class Bench(Workload):
+    # Write-isolated read dataset: a single :Bench label with a b-tree index on id, so a bounded
+    # id-range scan is served straight from the index. Used for HA routed-read throughput where each
+    # query does ~1ms of real server work (unlike a microsecond point lookup), so read load actually
+    # reaches the replicas instead of being client-bound.
+    NAME = "bench"
+    VARIANTS = ["default"]
+    DEFAULT_VARIANT = "default"
+    SIZES = {"default": {"vertices": 500000, "edges": 0}}
+
+    # ~1ms window: scanning 8000 indexed nodes (calibrated); id range is [0, TOTAL).
+    TOTAL = 500000
+    WINDOW = 8000
+
+    def indexes_generator(self):
+        return [("CREATE INDEX ON :Bench(id);", {})]
+
+    def dataset_generator(self):
+        # UNWIND batches so import completes in seconds rather than minutes.
+        batch = 10000
+        queries = []
+        for start in range(0, self.TOTAL, batch):
+            end = min(start + batch, self.TOTAL) - 1
+            queries.append(
+                (
+                    "UNWIND range($a, $b) AS i CREATE (:Bench {id: i, x: i % 1000})",
+                    {"a": start, "b": end},
+                )
+            )
+        return queries
+
+    def benchmark__scan__range_read(self):
+        lo = random.randint(0, self.TOTAL - self.WINDOW)
+        return (
+            "MATCH (n:Bench) WHERE n.id >= $lo AND n.id < $lo + $w RETURN sum(n.x)",
+            {"lo": lo, "w": self.WINDOW},
+        )


### PR DESCRIPTION
## What
Adds a concurrent read+write mixed-workload benchmark against the SYNC HA cluster.

- `mgbench-ha` build target gains a `--realistic` mode (plus `--num-workers`) that runs one concurrent mix (20% write / 80% read, 0 update/analytical) over the pokec `arango` group at high worker concurrency, instead of the per-query isolated legs.
- A `mgbench-ha-realistic-sync` step in the daily benchmark runs it against `ha_cluster.yaml` (one main + one SYNC replica) and uploads the result.

## Why
The existing HA legs benchmark each query in isolation — the per-query replication tax. They cannot surface aggregate-throughput changes that come from how the commit path behaves under concurrent load: a write holding its lock across the SYNC replica ACK stalls other pool workers. This mixed read-while-writing workload measures that, establishing a master baseline to compare future write-path scheduling changes against.