### PR TITLE
fix(metrics): report live `MemoryRes` in `SHOW METRICS INFO`

### DIFF
--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -2066,8 +2066,12 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfo() const {
 
   // Memory (global only)
   auto const memory_res = utils::GetMemoryRES();
-  out.push_back({"MemoryRes", "Memory", "Gauge", static_cast<int64_t>(memory_res)});
-  out.push_back({"PeakMemoryRes", "Memory", "Gauge", static_cast<int64_t>(UpdateAndGetPeakMemoryRes(memory_res))});
+  out.push_back(
+      {.name = "MemoryRes", .type = "Memory", .metric_type = "Gauge", .value = static_cast<int64_t>(memory_res)});
+  out.push_back({.name = "PeakMemoryRes",
+                 .type = "Memory",
+                 .metric_type = "Gauge",
+                 .value = static_cast<int64_t>(UpdateAndGetPeakMemoryRes(memory_res))});
 
   // Hot/cold databases (global only)
   out.push_back({"DatabaseSuspends", "HotCold", "Counter", static_cast<int64_t>(global.database_suspends->Value())});

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -2065,8 +2065,9 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfo() const {
   std::vector<MetricInfo> out;
 
   // Memory (global only)
-  out.push_back({"MemoryRes", "Memory", "Gauge", static_cast<int64_t>(global.memory_res_bytes->Value())});
-  out.push_back({"PeakMemoryRes", "Memory", "Gauge", static_cast<int64_t>(global.peak_memory_res_bytes->Value())});
+  auto const memory_res = utils::GetMemoryRES();
+  out.push_back({"MemoryRes", "Memory", "Gauge", static_cast<int64_t>(memory_res)});
+  out.push_back({"PeakMemoryRes", "Memory", "Gauge", static_cast<int64_t>(UpdateAndGetPeakMemoryRes(memory_res))});
 
   // Hot/cold databases (global only)
   out.push_back({"DatabaseSuspends", "HotCold", "Counter", static_cast<int64_t>(global.database_suspends->Value())});

--- a/tests/unit/prometheus_metrics.cpp
+++ b/tests/unit/prometheus_metrics.cpp
@@ -13,6 +13,8 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <string_view>
+#include <variant>
 
 #include <gtest/gtest.h>
 #include <prometheus/metric_family.h>
@@ -93,6 +95,24 @@ TEST(PrometheusMetrics, UpdateGaugesSetsStorageValues) {
   EXPECT_EQ(FindSample(families, "memgraph_disk_usage_bytes", "db1"), 1024.0);
   EXPECT_EQ(FindSample(families, "memgraph_db_memory_tracked_bytes", "db1"), 4096.0);
   EXPECT_EQ(FindSample(families, "memgraph_db_peak_memory_tracked_bytes", "db1"), 8192.0);
+}
+
+TEST(PrometheusMetrics, GetGlobalMetricsInfoReportsCorrectMemoryUsage) {
+  memgraph::metrics::PrometheusMetrics pm;
+
+  auto const global = pm.GetGlobalMetricsInfo();
+  auto const value = [&global](std::string_view name) -> std::optional<int64_t> {
+    auto const it = std::ranges::find(global, name, &memgraph::metrics::MetricInfo::name);
+    if (it == global.end()) return std::nullopt;
+    return std::get<int64_t>(it->value);
+  };
+
+  auto const memory_res = value("MemoryRes");
+  auto const peak_memory_res = value("PeakMemoryRes");
+  ASSERT_TRUE(memory_res.has_value());
+  ASSERT_TRUE(peak_memory_res.has_value());
+  EXPECT_GT(*memory_res, 0);
+  EXPECT_GE(*peak_memory_res, *memory_res);
 }
 
 TEST(PrometheusMetrics, RemoveDatabaseRemovesMetrics) {


### PR DESCRIPTION
`MemoryRes` read 0 until the metrics endpoint was first scraped, then held that scrape's value. The gauge is only written by `UpdateGauges()`, which runs on the two HTTP handlers, but `SHOW METRICS INFO` reads the gauge without refreshing it.

Read RSS directly instead, and feed it through `UpdateAndGetPeakMemoryRes()` so `PeakMemoryRes` stays at least MemoryRes.
