### PR TITLE
fix(query): propagate a null out of a container equality

### DIFF
--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -98,6 +98,7 @@ target_sources(mg-query
     procedure/module.cpp
     query_user.cpp
     relations/equality.cpp
+    relations/equivalence.cpp
     relations/orderability.cpp
     serialization/property_value.cpp
     stream/common.cpp

--- a/src/query/frame_change.hpp
+++ b/src/query/frame_change.hpp
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <utility>
 #include "query/frontend/ast/query/named_expression.hpp"
+#include "query/relations/equality.hpp"
 #include "query/typed_value.hpp"
 #include "utils/memory.hpp"
 #include "utils/pmr/unordered_map.hpp"
@@ -31,11 +32,19 @@ struct CachedSet {
   absl::flat_hash_set<TypedValue, absl::DefaultHashContainerHash<TypedValue>, TypedValue::BoolEqual, allocator_type>
       cache_;
 
+  /// Whether a lookup here answers the equality question `IN` asks.
+  ///
+  /// The set is keyed by equivalence, which reports a pair equal that equality leaves undecided.
+  /// The two are indistinguishable only when an element holds a Null below its top level.
+  bool answers_equality_{true};
+
   explicit CachedSet(allocator_type alloc) : cache_{alloc} {}
 
-  CachedSet(const CachedSet &other, allocator_type alloc) : cache_(other.cache_, alloc) {}
+  CachedSet(const CachedSet &other, allocator_type alloc)
+      : cache_(other.cache_, alloc), answers_equality_(other.answers_equality_) {}
 
-  CachedSet(CachedSet &&other, allocator_type alloc) : cache_(std::move(other.cache_), alloc) {}
+  CachedSet(CachedSet &&other, allocator_type alloc)
+      : cache_(std::move(other.cache_), alloc), answers_equality_(other.answers_equality_) {}
 
   CachedSet(CachedSet &&other) noexcept : CachedSet(std::move(other), other.get_allocator()) {}
 
@@ -49,7 +58,10 @@ struct CachedSet {
 
   ~CachedSet() = default;
 
-  void Reset() { cache_.clear(); }
+  void Reset() {
+    cache_.clear();
+    answers_equality_ = true;
+  }
 
   bool SetValue(const TypedValue &maybe_list) {
     if (!maybe_list.IsList()) {
@@ -57,6 +69,10 @@ struct CachedSet {
     }
     const auto &list = maybe_list.ValueList();
     for (const auto &element : list) {
+      // A Null element is answered by the explicit lookup for one, so it does not cost the set its
+      // exactness. A Null held inside an element does: no lookup can tell that element apart from
+      // one the sought value is decidedly equal to.
+      if (!element.IsNull() && relations::equality::HoldsANull(element)) answers_equality_ = false;
       cache_.insert(element);
     }
     return true;
@@ -64,6 +80,9 @@ struct CachedSet {
 
   // Func to check if cache_ contains value
   bool Contains(const TypedValue &value) const { return cache_.contains(value); }
+
+  /// Whether a lookup here answers the equality question `IN` asks.
+  bool AnswersEquality() const { return answers_equality_; }
 };
 
 // Class tracks keys for which user can cache values which help with faster search or faster retrieval
@@ -174,6 +193,11 @@ class FrameChangeCollector {
     // Merge inlist_cache_: combine cached values (union of sets)
     for (auto &&[key, cached_set] : other.inlist_cache_) {
       auto [it, inserted] = inlist_cache_.emplace(key, CachedSet(get_allocator()));
+      // Whether a lookup still answers equality is a property of what the set holds, and the
+      // merged set holds what both sides held. Inserting the values below goes around SetValue,
+      // which is where that is worked out, so it is carried over here instead: exactness survives
+      // only where neither side lost it.
+      it->second.answers_equality_ = it->second.answers_equality_ && cached_set.answers_equality_;
       // Merge the cached values (union of sets) - works for both new and existing keys
       for (auto &&value : cached_set.cache_) {
         it->second.cache_.emplace(value);

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -30,6 +30,7 @@
 #include "query/frontend/semantic/symbol_table.hpp"
 #include "query/interpret/awesome_memgraph_functions.hpp"
 #include "query/interpret/frame.hpp"
+#include "query/relations/equality.hpp"
 #include "query/typed_value.hpp"
 #include "spdlog/spdlog.h"
 #include "storage/v2/name_id_mapper.hpp"
@@ -463,6 +464,15 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (frame_change_collector_) {
       const auto cached_id = memgraph::utils::GetFrameChangeId(in_list);
       if (frame_change_collector_->IsInlistKeyTracked(cached_id)) {
+        // A lookup in the set answers by equivalence, which holds a Null
+        // equivalent to a Null. Equality answers Null against anything holding
+        // one, and a set can report present or absent but never Null, so the set
+        // is read only where neither side holds a Null. Anything else falls
+        // through to the loop below, which compares element by element.
+        auto const decidable_by_a_lookup = [this](TypedValue const &value) {
+          return !relations::equality::HoldsANull(value);
+        };
+
         auto cached_value_ref = frame_change_collector_->TryGetInlistCachedValue(cached_id);
         if (!cached_value_ref) {
           // Check only first time if everything is okay, later when we use
@@ -471,21 +481,21 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
           if (auto preoperational_checks = do_list_literal_checks(list)) {
             return std::move(*preoperational_checks);
           }
-          auto &cached_value = frame_change_collector_->GetInlistCachedValue(cached_id);
-          // Don't move here because we don't want to remove the element from the frame
-          cached_value.SetValue(list);
-          cached_value_ref = std::cref(cached_value);
+          if (std::ranges::all_of(list.ValueList(), decidable_by_a_lookup)) {
+            auto &cached_value = frame_change_collector_->GetInlistCachedValue(cached_id);
+            // Don't move here because we don't want to remove the element from the frame
+            cached_value.SetValue(list);
+            cached_value_ref = std::cref(cached_value);
+          }
         }
-        const auto &cached_value = cached_value_ref->get();
 
-        if (cached_value.Contains(literal)) {
-          return TypedValue(true, ctx_->memory);
+        if (cached_value_ref && decidable_by_a_lookup(literal)) {
+          const auto &cached_value = cached_value_ref->get();
+          if (cached_value.Contains(literal)) {
+            return TypedValue(true, ctx_->memory);
+          }
+          return TypedValue(false, ctx_->memory);
         }
-        // has null
-        if (cached_value.Contains(TypedValue(ctx_->memory))) {
-          return TypedValue(ctx_->memory);
-        }
-        return TypedValue(false, ctx_->memory);
       }
     }
     // When caching is not an option, we need to evaluate list literal every time

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -464,15 +464,6 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     if (frame_change_collector_) {
       const auto cached_id = memgraph::utils::GetFrameChangeId(in_list);
       if (frame_change_collector_->IsInlistKeyTracked(cached_id)) {
-        // A lookup in the set answers by equivalence, which holds a Null
-        // equivalent to a Null. Equality answers Null against anything holding
-        // one, and a set can report present or absent but never Null, so the set
-        // is read only where neither side holds a Null. Anything else falls
-        // through to the loop below, which compares element by element.
-        auto const decidable_by_a_lookup = [this](TypedValue const &value) {
-          return !relations::equality::HoldsANull(value);
-        };
-
         auto cached_value_ref = frame_change_collector_->TryGetInlistCachedValue(cached_id);
         if (!cached_value_ref) {
           // Check only first time if everything is okay, later when we use
@@ -481,18 +472,25 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
           if (auto preoperational_checks = do_list_literal_checks(list)) {
             return std::move(*preoperational_checks);
           }
-          if (std::ranges::all_of(list.ValueList(), decidable_by_a_lookup)) {
-            auto &cached_value = frame_change_collector_->GetInlistCachedValue(cached_id);
-            // Don't move here because we don't want to remove the element from the frame
-            cached_value.SetValue(list);
-            cached_value_ref = std::cref(cached_value);
-          }
+          auto &cached_value = frame_change_collector_->GetInlistCachedValue(cached_id);
+          // Don't move here because we don't want to remove the element from the frame
+          cached_value.SetValue(list);
+          cached_value_ref = std::cref(cached_value);
         }
+        const auto &cached_value = cached_value_ref->get();
 
-        if (cached_value_ref && decidable_by_a_lookup(literal)) {
-          const auto &cached_value = cached_value_ref->get();
+        // A lookup in the set answers by equivalence, which holds a Null equivalent to a Null.
+        // Equality answers Null against anything holding one, so the set stands in for the loop
+        // below only while neither the list's elements nor the sought value hold a Null below
+        // their top level. A top-level Null does not spoil it, because the explicit lookup for
+        // one answers exactly that case.
+        if (cached_value.AnswersEquality() && !relations::equality::HoldsANull(literal)) {
           if (cached_value.Contains(literal)) {
             return TypedValue(true, ctx_->memory);
+          }
+          // has null
+          if (cached_value.Contains(TypedValue(ctx_->memory))) {
+            return TypedValue(ctx_->memory);
           }
           return TypedValue(false, ctx_->memory);
         }

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -760,6 +760,10 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
           for (auto *elem : list->elements_) {
             auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters, mapper);
             if (!resolved) return db_accessor_->VerticesCount(property) * CardParam::kFilter;
+            // An element holding a Null matches nothing, and an empty range says so by carrying no
+            // bounds at all. It contributes nothing to the sum, and reading a bound it never set
+            // would read one that was never there.
+            if (resolved->type_ == storage::PropertyRangeType::INVALID) continue;
             sum += db_accessor_->VerticesCount(property, resolved->lower_->value());
           }
           auto n = static_cast<double>(list->elements_.size());

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -169,28 +169,35 @@ auto ExpressionRange::Range(std::optional<utils::Bound<Expression *>> lower,
 auto ExpressionRange::IsNotNull() -> ExpressionRange { return {Type::IS_NOT_NULL, std::nullopt, std::nullopt}; }
 
 auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage::PropertyValueRange {
+  auto const bound_from = [&](TypedValue const &typed_value, auto bound_type) {
+    if (!typed_value.IsPropertyValue()) {
+      throw QueryRuntimeException("'{}' cannot be used as a property value.", typed_value.type());
+    }
+    return utils::Bound{typed_value.ToPropertyValue(evaluator.GetNameIdMapper()), bound_type};
+  };
+
   auto const to_bounded_property_value = [&](auto &value) -> std::optional<utils::Bound<storage::PropertyValue>> {
     if (value == std::nullopt) {
       return std::nullopt;
     } else {
-      auto const typed_value = value->value()->Accept(evaluator);
-      if (!typed_value.IsPropertyValue()) {
-        throw QueryRuntimeException("'{}' cannot be used as a property value.", typed_value.type());
-      }
-      return utils::Bound{typed_value.ToPropertyValue(evaluator.GetNameIdMapper()), value->type()};
+      return bound_from(value->value()->Accept(evaluator), value->type());
     }
   };
 
   switch (type_) {
     case Type::EQUAL:
     case Type::IN: {
-      auto bounded_property_value = to_bounded_property_value(lower_);
-      // Equality against a value holding a Null answers Null for every row, so
-      // a filter keeps none of them. The scan has to agree, or the same query
-      // answers differently once an index exists.
-      if (bounded_property_value && relations::equality::HoldsANull(bounded_property_value->value())) {
+      if (!lower_) return storage::PropertyValueRange::Bounded(std::nullopt, std::nullopt);
+      auto const typed_value = lower_->value()->Accept(evaluator);
+      // Equality against a value holding a Null answers Null for every row, so a filter keeps
+      // none of them. The scan has to agree, or the same query answers differently once an index
+      // exists. The Null is read before the value is converted, because a value holding one need
+      // not be storable at all: converting `[null, <a node>]` raises where the filter this scan
+      // stands in for raises nothing.
+      if (relations::equality::HoldsANull(typed_value)) {
         return storage::PropertyValueRange::Empty();
       }
+      auto bounded_property_value = bound_from(typed_value, lower_->type());
       return storage::PropertyValueRange::Bounded(bounded_property_value, bounded_property_value);
     }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -12,6 +12,7 @@
 #include "query/plan/operator.hpp"
 #include <range/v3/all.hpp>
 #include "metrics/prometheus_metrics.hpp"
+#include "query/relations/equality.hpp"
 
 #include <algorithm>
 #include <charconv>
@@ -184,6 +185,12 @@ auto ExpressionRange::Evaluate(ExpressionEvaluator &evaluator) const -> storage:
     case Type::EQUAL:
     case Type::IN: {
       auto bounded_property_value = to_bounded_property_value(lower_);
+      // Equality against a value holding a Null answers Null for every row, so
+      // a filter keeps none of them. The scan has to agree, or the same query
+      // answers differently once an index exists.
+      if (bounded_property_value && relations::equality::HoldsANull(bounded_property_value->value())) {
+        return storage::PropertyValueRange::Empty();
+      }
       return storage::PropertyValueRange::Bounded(bounded_property_value, bounded_property_value);
     }
 
@@ -303,8 +310,13 @@ auto ExpressionRange::ResolveAtPlantime(Parameters const &params, storage::NameI
     case Type::IN: {
       auto bounded_property_value = to_bounded_property_value(lower_);
       if (std::holds_alternative<UnknownAtPlanTime>(bounded_property_value)) return std::nullopt;
-      return storage::PropertyValueRange::Bounded(std::get<obpv>(bounded_property_value),
-                                                  std::get<obpv>(bounded_property_value));
+      auto const &bound = std::get<obpv>(bounded_property_value);
+      // The same rule the evaluated form follows: nothing equals a value holding
+      // a Null, so the scan finds nothing and its cost is estimated on that.
+      if (bound && relations::equality::HoldsANull(bound->value())) {
+        return storage::PropertyValueRange::Empty();
+      }
+      return storage::PropertyValueRange::Bounded(bound, bound);
     }
 
     case Type::REGEX_MATCH:
@@ -1383,7 +1395,11 @@ std::optional<storage::PropertyValue> EvaluateExpressionToPropertyValue(Expressi
   ExpressionEvaluator evaluator = ExpressionEvaluator{&frame, context, view, nullptr, &context.number_of_hops};
 
   auto value = expression->Accept(evaluator);
-  if (value.IsNull()) {
+  // An equality against a value holding a Null answers Null for every row, so a
+  // filter keeps none of them and this scan has to find none. A Null within a
+  // list or a map counts: the lookup below compares by a relation that holds a
+  // Null equal to a Null, and would report a match the filter does not.
+  if (relations::equality::HoldsANull(value)) {
     return std::nullopt;
   }
   if (!value.IsPropertyValue()) {
@@ -9831,7 +9847,7 @@ class HashJoinCursor : public Cursor {
             ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
 
         auto right_value = self_.hash_join_condition_->expression2_->Accept(evaluator);
-        if (hashtable_.contains(right_value)) {
+        if (!relations::equality::HoldsANull(right_value) && hashtable_.contains(right_value)) {
           // If so, finish pulling for now and proceed to joining the pulled frame
           right_op_frame_.assign(frame.elems().begin(), frame.elems().end());
           common_value_found_ = true;
@@ -9880,7 +9896,11 @@ class HashJoinCursor : public Cursor {
           ExpressionEvaluator{&frame, context, storage::View::OLD, nullptr, &context.number_of_hops};
 
       auto left_value = self_.hash_join_condition_->expression1_->Accept(evaluator);
-      if (left_value.type() != TypedValue::Type::Null) {
+      // A join keeps a pair only where the equality it stands for is true, and
+      // an equality against a value holding a Null is never true. Such a row
+      // joins with nothing, so it is not offered to the table at all. The
+      // filter this join replaced would have dropped it too.
+      if (!relations::equality::HoldsANull(left_value)) {
         hashtable_[left_value].emplace_back(frame.elems().begin(), frame.elems().end());
       }
     }

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1685,6 +1685,9 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         for (auto *elem : list->elements_) {
           auto resolved = ExpressionRange::Equal(elem).ResolveAtPlantime(parameters_, mapper);
           if (!resolved) return static_cast<double>(db_->VerticesCount(scan_op->property_));
+          // The same rule the single-value path above follows: an empty range carries no bounds,
+          // and it counts for nothing rather than being read as one.
+          if (resolved->type_ == storage::PropertyRangeType::INVALID) continue;
           sum += db_->VerticesCount(scan_op->property_, resolved->lower_->value());
         }
         return sum;

--- a/src/query/relations/equality.cpp
+++ b/src/query/relations/equality.cpp
@@ -15,38 +15,71 @@
 
 namespace memgraph::query::relations::equality {
 
-TypedValue EqualOfContainers(const TypedValue &a, const TypedValue &b) {
-  switch (a.type()) {
-    case TypedValue::Type::List: {
-      // A list is equal only to a list of the same length holding equal
-      // elements, so `2 = [2]` is false however deeply either side is nested.
-      // Neo4j differs here, answering true for `2 = [2]` and for
-      // `[[2]] = [[[[[[2]]]]]]`.
-      const auto &list_a = a.ValueList();
-      const auto &list_b = b.ValueList();
-      if (list_a.size() != list_b.size()) return TypedValue(false, a.get_allocator());
-      // Elements are compared by equivalence rather than by equality, which is
-      // two-valued, so a list comparison never answers Null:
-      //    [1] == [null] -> false
-      //    [null] == [null] -> true
-      return TypedValue(std::equal(list_a.begin(), list_a.end(), list_b.begin(), TypedValue::BoolEqual{}),
-                        a.get_allocator());
-    }
-    case TypedValue::Type::Map: {
-      const auto &map_a = a.ValueMap();
-      const auto &map_b = b.ValueMap();
-      if (map_a.size() != map_b.size()) return TypedValue(false, a.get_allocator());
-      for (const auto &kv_a : map_a) {
-        auto found_b_it = map_b.find(kv_a.first);
-        if (found_b_it == map_b.end()) return TypedValue(false, a.get_allocator());
-        TypedValue comparison = Equal(kv_a.second, found_b_it->second);
-        if (comparison.IsNull() || !comparison.ValueBool()) return TypedValue(false, a.get_allocator());
-      }
-      return TypedValue(true, a.get_allocator());
-    }
+bool HoldsANull(const TypedValue &value) {
+  switch (value.type()) {
+    case TypedValue::Type::Null:
+      return true;
+    case TypedValue::Type::List:
+      return std::ranges::any_of(value.UnsafeValueList(), [](auto const &element) { return HoldsANull(element); });
+    case TypedValue::Type::Map:
+      return std::ranges::any_of(value.UnsafeValueMap(), [](auto const &entry) { return HoldsANull(entry.second); });
     default:
-      LOG_FATAL("Unhandled container comparison");
+      return false;
   }
+}
+
+bool HoldsANull(const storage::PropertyValue &value) {
+  switch (value.type()) {
+    case storage::PropertyValueType::Null:
+      return true;
+    case storage::PropertyValueType::List:
+      return std::ranges::any_of(value.ValueList(), [](auto const &element) { return HoldsANull(element); });
+    case storage::PropertyValueType::Map:
+      return std::ranges::any_of(value.ValueMap(), [](auto const &entry) { return HoldsANull(entry.second); });
+    default:
+      // The packed numeric representations of a list have no way to hold a Null.
+      return false;
+  }
+}
+
+TypedValue EqualOfLists(TypedValue::TVector const &a, TypedValue::TVector const &b, TypedValue::allocator_type alloc) {
+  // A list is equal only to a list of the same length holding equal elements,
+  // so `2 = [2]` is false however deeply either side is nested. Neo4j differs
+  // here, answering true for `2 = [2]` and for `[[2]] = [[[[[[2]]]]]]`.
+  if (a.size() != b.size()) return TypedValue(false, alloc);
+
+  // A part that differs settles the whole, whatever the rest holds: `[null, 1]`
+  // and `[null, 2]` differ however the first element turns out. So a difference
+  // answers at once, and an undecided part survives only to the end.
+  auto undecided = false;
+  for (size_t i = 0; i != a.size(); ++i) {
+    auto const element = Equal(a[i], b[i]);
+    if (element.IsNull()) {
+      undecided = true;
+    } else if (!element.UnsafeValueBool()) {
+      return TypedValue(false, alloc);
+    }
+  }
+  return undecided ? TypedValue(alloc) : TypedValue(true, alloc);
+}
+
+TypedValue EqualOfMaps(TypedValue::TMap const &a, TypedValue::TMap const &b, TypedValue::allocator_type alloc) {
+  if (a.size() != b.size()) return TypedValue(false, alloc);
+
+  auto undecided = false;
+  for (auto const &[key, value_a] : a) {
+    // Which keys a map holds is known, so a key the other side lacks settles it
+    // however the values would have compared.
+    auto const found = b.find(key);
+    if (found == b.end()) return TypedValue(false, alloc);
+    auto const value = Equal(value_a, found->second);
+    if (value.IsNull()) {
+      undecided = true;
+    } else if (!value.UnsafeValueBool()) {
+      return TypedValue(false, alloc);
+    }
+  }
+  return undecided ? TypedValue(alloc) : TypedValue(true, alloc);
 }
 
 }  // namespace memgraph::query::relations::equality

--- a/src/query/relations/equality.hpp
+++ b/src/query/relations/equality.hpp
@@ -18,10 +18,10 @@
 /// equivalent to a Null, and which a hash container reads.
 #pragma once
 
-#include "query/typed_value.hpp"
-// typed_value.hpp only forward-declares these, and equality reads the identity
-// out of each.
 #include "query/path.hpp"
+#include "query/typed_value.hpp"
+// typed_value.hpp only forward-declares these two, and equality reads the
+// identity out of each.
 #include "query/virtual_edge.hpp"
 #include "query/virtual_node.hpp"
 
@@ -31,7 +31,24 @@ namespace memgraph::query::relations::equality {
 ///
 /// Out of line so that Equal does not call itself. A compiler will not inline a
 /// function that recurses, whichever case reaches the recursion.
-TypedValue EqualOfContainers(const TypedValue &a, const TypedValue &b);
+///
+/// Each takes what it walks rather than the values holding it, so that neither
+/// can be handed a pair of unlike things. The answer carries the allocator the
+/// left value was made with, which is not always the one its elements use.
+TypedValue EqualOfLists(TypedValue::TVector const &a, TypedValue::TVector const &b, TypedValue::allocator_type alloc);
+TypedValue EqualOfMaps(TypedValue::TMap const &a, TypedValue::TMap const &b, TypedValue::allocator_type alloc);
+
+/// Whether a Null sits anywhere within the value, however deeply nested.
+///
+/// Ask this before answering equality from anything other than this relation. A
+/// value holding a Null can compare Null, and a container keyed by equivalence
+/// has no way to say so: it holds a Null equivalent to a Null and answers that
+/// the two are the same. So does a sorted index, and so does a hash join.
+///
+/// Both representations of a value are asked the same question, because a scan
+/// reads what is stored and a filter reads what the query built.
+bool HoldsANull(const TypedValue &value);
+bool HoldsANull(const storage::PropertyValue &value);
 
 /// Whether two values are equal, or Null where that cannot be decided.
 ///
@@ -44,18 +61,26 @@ inline TypedValue Equal(const TypedValue &a, const TypedValue &b) {
 
   // check we have values that can be compared
   // this means that either they're the same type, or (int, double) combo
-  if ((a.type() != b.type() && !(a.IsNumeric() && b.IsNumeric()))) return TypedValue(false, a.get_allocator());
+  // The tag tests read type() rather than IsNumeric()/IsDouble(), which are
+  // defined in the value's own translation unit and are calls anywhere else.
+  // Every element of a container reaches this.
+  auto const numeric = [](TypedValue::Type type) {
+    return type == TypedValue::Type::Int || type == TypedValue::Type::Double;
+  };
+  if (a.type() != b.type() && !(numeric(a.type()) && numeric(b.type()))) {
+    return TypedValue(false, a.get_allocator());
+  }
 
   switch (a.type()) {
     case TypedValue::Type::Bool:
       return TypedValue(a.UnsafeValueBool() == b.UnsafeValueBool(), a.get_allocator());
     case TypedValue::Type::Int:
-      if (b.IsDouble())
+      if (b.type() == TypedValue::Type::Double)
         return TypedValue(a.UnsafeValueInt() == b.UnsafeValueDouble(), a.get_allocator());
       else
         return TypedValue(a.UnsafeValueInt() == b.UnsafeValueInt(), a.get_allocator());
     case TypedValue::Type::Double:
-      if (b.IsInt())
+      if (b.type() == TypedValue::Type::Int)
         return TypedValue(a.UnsafeValueDouble() == b.UnsafeValueInt(), a.get_allocator());
       else
         return TypedValue(a.UnsafeValueDouble() == b.UnsafeValueDouble(), a.get_allocator());
@@ -69,9 +94,12 @@ inline TypedValue Equal(const TypedValue &a, const TypedValue &b) {
       return TypedValue(a.UnsafeValueVirtualEdge() == b.UnsafeValueVirtualEdge(), a.get_allocator());
     case TypedValue::Type::VirtualNode:
       return TypedValue(a.UnsafeValueVirtualNode() == b.UnsafeValueVirtualNode(), a.get_allocator());
+    // Reading `b` at `a`'s type is sound here: the guard above returns for a
+    // pair of unlike types unless both are numbers, and neither of these is.
     case TypedValue::Type::List:
+      return EqualOfLists(a.UnsafeValueList(), b.UnsafeValueList(), a.get_allocator());
     case TypedValue::Type::Map:
-      return EqualOfContainers(a, b);
+      return EqualOfMaps(a.UnsafeValueMap(), b.UnsafeValueMap(), a.get_allocator());
     case TypedValue::Type::Path:
       return TypedValue(a.UnsafeValuePath() == b.UnsafeValuePath(), a.get_allocator());
     case TypedValue::Type::Date:

--- a/src/query/relations/equivalence.cpp
+++ b/src/query/relations/equivalence.cpp
@@ -1,0 +1,44 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "query/relations/equivalence.hpp"
+
+#include <algorithm>
+
+namespace memgraph::query::relations::equivalence {
+
+bool EquivalentOfLists(TypedValue::TVector const &a, TypedValue::TVector const &b) {
+  return a.size() == b.size() &&
+         std::equal(
+             a.begin(), a.end(), b.begin(), [](TypedValue const &x, TypedValue const &y) { return Equivalent(x, y); });
+}
+
+bool EquivalentOfMaps(TypedValue::TMap const &a, TypedValue::TMap const &b) {
+  if (a.size() != b.size()) return false;
+  return std::ranges::all_of(a, [&b](auto const &entry) {
+    auto const found = b.find(entry.first);
+    return found != b.end() && Equivalent(entry.second, found->second);
+  });
+}
+
+bool EquivalentOfContainersHoldingANull(const TypedValue &a, const TypedValue &b) {
+  DMG_ASSERT(a.type() == b.type(), "Equality answers Null only over a pair holding the same type");
+  switch (a.type()) {
+    case TypedValue::Type::List:
+      return EquivalentOfLists(a.UnsafeValueList(), b.UnsafeValueList());
+    case TypedValue::Type::Map:
+      return EquivalentOfMaps(a.UnsafeValueMap(), b.UnsafeValueMap());
+    default:
+      LOG_FATAL("Equality answered Null for a pair holding no Null");
+  }
+}
+
+}  // namespace memgraph::query::relations::equivalence

--- a/src/query/relations/equivalence.hpp
+++ b/src/query/relations/equivalence.hpp
@@ -24,12 +24,36 @@
 
 namespace memgraph::query::relations::equivalence {
 
+/// The two cases that walk what they hold, and so reach this relation again.
+///
+/// Out of line so that Equivalent does not call itself. A compiler will not
+/// inline a function that recurses, whichever case reaches the recursion.
+///
+/// Each takes what it walks rather than the values holding it, so that neither
+/// can be handed a pair of unlike things.
+bool EquivalentOfLists(TypedValue::TVector const &a, TypedValue::TVector const &b);
+bool EquivalentOfMaps(TypedValue::TMap const &a, TypedValue::TMap const &b);
+
+/// Reads a pair equality could not decide, which is a container holding a Null.
+///
+/// @pre Both hold the same type of container. Equality answering Null over a
+/// pair that is not itself Null establishes exactly that.
+bool EquivalentOfContainersHoldingANull(const TypedValue &a, const TypedValue &b);
+
 inline bool Equivalent(const TypedValue &lhs, const TypedValue &rhs) {
-  if (lhs.IsNull() && rhs.IsNull()) return true;
-  TypedValue equality_result = equality::Equal(lhs, rhs);
-  DMG_ASSERT(equality_result.type() == TypedValue::Type::Bool || equality_result.type() == TypedValue::Type::Null,
-             "Equality between two TypedValues must result in either Null or Bool");
-  return equality_result.type() == TypedValue::Type::Bool && equality_result.ValueBool();
+  if (lhs.IsNull() || rhs.IsNull()) return lhs.IsNull() && rhs.IsNull();
+
+  // Equality decides this wherever it can, which is everywhere no Null sits
+  // inside either value. Where it cannot it says so, and only then is the
+  // container walked: collapsing that Null to false would make a value holding
+  // one not equivalent to itself, and a hash container would never find such a
+  // key again. Every hash lookup reaches this, so the deciding case is all that
+  // is left here and the walk is reached through one call.
+  TypedValue const equality_result = equality::Equal(lhs, rhs);
+  if (equality_result.type() == TypedValue::Type::Bool) [[likely]] {
+    return equality_result.UnsafeValueBool();
+  }
+  return EquivalentOfContainersHoldingANull(lhs, rhs);
 }
 
 /// A hash agreeing with Equivalent: two equivalent values hash alike.

--- a/src/query/relations/orderability.cpp
+++ b/src/query/relations/orderability.cpp
@@ -15,13 +15,9 @@
 
 namespace memgraph::query::relations::orderability {
 
-std::partial_ordering CompareOfLists(TypedValue const &a, TypedValue const &b) {
-  auto const &list_a = a.UnsafeValueList();
-  auto const &list_b = b.UnsafeValueList();
+std::partial_ordering CompareOfLists(TypedValue::TVector const &a, TypedValue::TVector const &b) {
   return std::lexicographical_compare_three_way(
-      list_a.begin(), list_a.end(), list_b.begin(), list_b.end(), [](TypedValue const &x, TypedValue const &y) {
-        return Compare(x, y);
-      });
+      a.begin(), a.end(), b.begin(), b.end(), [](TypedValue const &x, TypedValue const &y) { return Compare(x, y); });
 }
 
 }  // namespace memgraph::query::relations::orderability

--- a/src/query/relations/orderability.hpp
+++ b/src/query/relations/orderability.hpp
@@ -32,7 +32,10 @@ namespace memgraph::query::relations::orderability {
 ///
 /// Out of line so that Compare does not call itself. A compiler will not inline
 /// a function that recurses, and every sort reaches Compare through the caller.
-std::partial_ordering CompareOfLists(TypedValue const &a, TypedValue const &b);
+///
+/// Takes what it walks rather than the values holding it, so that it cannot be
+/// handed a pair of unlike things.
+std::partial_ordering CompareOfLists(TypedValue::TVector const &a, TypedValue::TVector const &b);
 
 /// Where `a` falls relative to `b`.
 ///
@@ -68,7 +71,7 @@ inline std::partial_ordering Compare(TypedValue const &a, TypedValue const &b) {
       case TypedValue::Type::Point3d:
         return a.UnsafeValuePoint3d() <=> b.UnsafeValuePoint3d();
       case TypedValue::Type::List:
-        return CompareOfLists(a, b);
+        return CompareOfLists(a.UnsafeValueList(), b.UnsafeValueList());
       case TypedValue::Type::Map:
       case TypedValue::Type::Vertex:
       case TypedValue::Type::Edge:

--- a/tests/e2e/queries/queries.py
+++ b/tests/e2e/queries/queries.py
@@ -89,5 +89,35 @@ def test_an_edge_property_equality_answers_the_same_way_with_and_without_an_inde
     assert count(sought_holding_none) == 1
 
 
+def test_equality_against_an_unstorable_value_holding_a_null_raises_on_no_plan(memgraph):
+    """A value holding a null answers every equality null, so nothing matches it
+    and no plan needs to convert it to a property. One holding a graph entity
+    beside the null cannot be converted at all, and a scan must not be the reason
+    the query raises when the filter it stands in for does not."""
+    memgraph.execute("MATCH (n) DETACH DELETE n;")
+    memgraph.execute("CREATE (:V {p: [1, 2]}), (:Anchor);")
+    memgraph.execute("CREATE (a:From), (b:To);")
+    memgraph.execute("MATCH (a:From), (b:To) CREATE (a)-[:T {p: [1, 2]}]->(b);")
+
+    def count(query):
+        rows = list(memgraph.execute_and_fetch(query))
+        return rows[0]["c"] if rows else 0
+
+    sought_holding_a_node = "MATCH (x:Anchor), (n:V) WHERE n.p = [null, x] RETURN count(n) AS c;"
+    sought_on_an_edge = "MATCH (x:Anchor), ()-[r:T]->() WHERE r.p = [null, x] RETURN count(r) AS c;"
+
+    # Without an index the filter reads the equality directly and keeps nothing.
+    assert count(sought_holding_a_node) == 0
+    assert count(sought_on_an_edge) == 0
+
+    memgraph.execute("CREATE INDEX ON :V(p);")
+    memgraph.execute("CREATE EDGE INDEX ON :T(p);")
+
+    # With one, the scan answers the same way rather than raising over a value it
+    # would never have had to store.
+    assert count(sought_holding_a_node) == 0
+    assert count(sought_on_an_edge) == 0
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/queries/queries.py
+++ b/tests/e2e/queries/queries.py
@@ -119,5 +119,35 @@ def test_equality_against_an_unstorable_value_holding_a_null_raises_on_no_plan(m
     assert count(sought_on_an_edge) == 0
 
 
+def test_negated_membership_keeps_no_row_whose_sought_value_is_null(memgraph):
+    """Membership of a null in a list holding anything is undecided, and a filter
+    keeps no row it cannot decide. Negating it keeps none either, since `NOT` of
+    an undecided answer is undecided. The set the operator caches the list in is
+    filled by the first row and read by every row after it, so a row holding a
+    null has to be answered the same way whichever of those it is."""
+    memgraph.execute("MATCH (n) DETACH DELETE n;")
+    memgraph.execute("UNWIND range(1, 5) AS i CREATE (:R {v: i});")
+    # A node with no `v` at all, so reading it gives null.
+    memgraph.execute("CREATE (:R {w: 1});")
+
+    def count(query):
+        rows = list(memgraph.execute_and_fetch(query))
+        return rows[0]["c"] if rows else 0
+
+    # Four rows hold a value that is decidedly not 1, and the row holding none is
+    # undecided rather than kept.
+    assert count("MATCH (n:R) WHERE NOT (n.v IN [1]) RETURN count(n) AS c;") == 4
+    assert count("MATCH (n:R) WHERE n.v IN [1] RETURN count(n) AS c;") == 1
+
+    # A null in the list leaves every row it does not otherwise match undecided,
+    # so only the rows the list does hold survive.
+    assert count("MATCH (n:R) WHERE n.v IN [1, 2, null] RETURN count(n) AS c;") == 2
+    assert count("MATCH (n:R) WHERE NOT (n.v IN [1, 2, null]) RETURN count(n) AS c;") == 0
+
+    # The row holding a null reaches the operator first here, so it fills the set
+    # rather than reading one already filled.
+    assert count("MATCH (n:R) WITH n ORDER BY n.v DESC WHERE NOT (n.v IN [1]) RETURN count(n) AS c;") == 4
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/queries/queries.py
+++ b/tests/e2e/queries/queries.py
@@ -35,5 +35,59 @@ def test_indexed_join_with_indices(memgraph):
         assert res["c"].prop == 1
 
 
+def test_equality_against_a_null_holding_list_answers_the_same_way_whichever_plan_runs(memgraph):
+    """A list holding a null compares null, so no row passes. Every way of
+    answering that equality has to agree: a filter, an index scan, and a join
+    that replaced the filter with a hash lookup."""
+    memgraph.execute("MATCH (n) DETACH DELETE n;")
+    memgraph.execute("CREATE (:V {p: [1, null]}), (:V {p: [1, null]});")
+    memgraph.execute("CREATE (:W {p: [1, 2]}), (:W {p: [1, 2]});")
+
+    def count(query):
+        rows = list(memgraph.execute_and_fetch(query))
+        return rows[0]["c"] if rows else 0
+
+    joined_on_a_null = "MATCH (a:V), (b:V) WHERE a.p = b.p RETURN count(*) AS c;"
+    joined_without_a_null = "MATCH (a:W), (b:W) WHERE a.p = b.p RETURN count(*) AS c;"
+
+    # A join reads the equality through a hash lookup, which cannot answer null.
+    assert count(joined_on_a_null) == 0
+    # And it still joins what it should.
+    assert count(joined_without_a_null) == 4
+
+    memgraph.execute("CREATE INDEX ON :V(p);")
+    memgraph.execute("CREATE INDEX ON :W(p);")
+
+    # The index gives the planner another way to answer, which must not change it.
+    assert count(joined_on_a_null) == 0
+    assert count(joined_without_a_null) == 4
+    assert count("MATCH (n:V) WHERE n.p = [1, null] RETURN count(n) AS c;") == 0
+    assert count("MATCH (n:W) WHERE n.p = [1, 2] RETURN count(n) AS c;") == 2
+
+
+def test_an_edge_property_equality_answers_the_same_way_with_and_without_an_index(memgraph):
+    """An edge property-value scan reads the equality from the index, and has to
+    find nothing where the filter it stands in for keeps nothing."""
+    memgraph.execute("MATCH (n) DETACH DELETE n;")
+    memgraph.execute("CREATE (a:From), (b:To);")
+    memgraph.execute("MATCH (a:From), (b:To) CREATE (a)-[:T {p: [1, null]}]->(b);")
+    memgraph.execute("MATCH (a:From), (b:To) CREATE (a)-[:T {p: [1, 2]}]->(b);")
+
+    def count(query):
+        rows = list(memgraph.execute_and_fetch(query))
+        return rows[0]["c"] if rows else 0
+
+    sought_holding_a_null = "MATCH ()-[r:T]->() WHERE r.p = [1, null] RETURN count(r) AS c;"
+    sought_holding_none = "MATCH ()-[r:T]->() WHERE r.p = [1, 2] RETURN count(r) AS c;"
+
+    assert count(sought_holding_a_null) == 0
+    assert count(sought_holding_none) == 1
+
+    memgraph.execute("CREATE EDGE INDEX ON :T(p);")
+
+    assert count(sought_holding_a_null) == 0
+    assert count(sought_holding_none) == 1
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/queries/workloads.yaml
+++ b/tests/e2e/queries/workloads.yaml
@@ -1,7 +1,7 @@
 queries_cluster: &queries_cluster
   cluster:
     main:
-      args: ["--bolt-port", "7687", "--log-level=TRACE"]
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-properties-on-edges"]
       log_file: "queries.log"
       setup_queries: []
       validation_queries: []

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -164,6 +164,37 @@ TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesConstant) {
   }
 }
 
+TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesEqualToAListHoldingNull) {
+  // Equality against a value holding a Null answers Null for every row, so the
+  // scan finds nothing and the estimate has to say so.
+  AddVertices(100, 30, 20);
+  // A vertex that does hold the sought value, so the index counts it. Without
+  // one, an exact-value range over a value nothing holds already estimates the
+  // minimum, and the rule below would make no difference.
+  {
+    auto vertex = dba->InsertVertex();
+    ASSERT_TRUE(vertex.AddLabel(label).has_value());
+    ASSERT_TRUE(
+        vertex
+            .SetProperty(prop_a,
+                         ms::PropertyValue{std::vector<ms::PropertyValue>{ms::PropertyValue{}, ms::PropertyValue{}}})
+            .has_value());
+    dba->AdvanceCommand();
+  }
+
+  // A parameter, because that is what the planner can resolve: a list literal is
+  // not known until the query runs, and is estimated as an unknown either way.
+  auto *held_null =
+      Parameter(std::vector<ms::ExternalPropertyValue>{ms::ExternalPropertyValue(), ms::ExternalPropertyValue()});
+  MakeOp<ScanAllByLabelProperties>(nullptr,
+                                   NextSymbol(),
+                                   label,
+                                   std::vector{ms::PropertyPath{prop_a}},
+                                   std::vector{ExpressionRange::Equal(held_null)});
+  // No entry can match, so the scan is charged only what everything is charged.
+  EXPECT_COST(CostParam::kMinimumCost);
+}
+
 TEST_F(QueryCostEstimator, ScanAllByLabelPropertiesConstExpr) {
   AddVertices(100, 30, 20);
   for (auto *const_val : {Literal(12), Parameter(12)}) {

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -732,6 +732,27 @@ TEST_F(QueryCostEstimatorStringPredicates, EstimateNarrowsToTheStringsWhenMostVa
   EXPECT_GT(string_band, CostParam::kMinimumCost);
 }
 
+TEST_F(QueryCostEstimatorStringPredicates, InListElementHoldingNullCountsForNothing) {
+  // An element holding a Null matches nothing, and the empty range that says so carries no bounds
+  // at all. Reading a bound it never set is undefined, and a Debug build asserts on it, so this
+  // covers the estimator rather than the answer: the scan is over a global property index, which
+  // is the only shape that reads an IN list's elements one by one.
+  auto *sought = Literal(std::string(1, 'a') + "0");
+  auto const one_element =
+      CostOf(ExpressionRange::In(sought, storage_.Create<ListLiteral>(std::vector<Expression *>{sought})));
+
+  // The Null element still costs an Unwind row, so it lowers the per-row average rather than
+  // vanishing from it. Halving it is what a second element matching nothing has to mean.
+  auto *held_null =
+      storage_.Create<ListLiteral>(std::vector<Expression *>{sought, Literal(ms::ExternalPropertyValue())});
+  EXPECT_FLOAT_EQ(CostOf(ExpressionRange::In(sought, held_null)), one_element / 2);
+
+  // A Null nested inside an element is undecidable for the same reason, so it counts the same.
+  auto *held_nested_null = storage_.Create<ListLiteral>(
+      std::vector<Expression *>{sought, Literal(std::vector<ms::ExternalPropertyValue>{ms::ExternalPropertyValue()})});
+  EXPECT_FLOAT_EQ(CostOf(ExpressionRange::In(sought, held_nested_null)), one_element / 2);
+}
+
 TEST_F(QueryCostEstimatorStringPredicates, StartsWithStillNarrowsToItsPrefix) {
   // The prefix is a real bound on what matches, and STARTS_WITH already accepts that its plan is
   // settled by the term. This pins the line between the two: only the prefix seek reads it.

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -471,6 +471,91 @@ TYPED_TEST(ExpressionEvaluatorTest, GreaterOperatorIncompatibleOperands) {
   }
 }
 
+TYPED_TEST(ExpressionEvaluatorTest, InListOperatorOverContainersHoldingNull) {
+  // A membership test asks equality of each element, so it inherits equality's
+  // answer: undecided against anything holding a Null that it does not
+  // otherwise differ from. The set the operator caches the list in answers by
+  // equivalence, which cannot say that, so these read the list element by
+  // element instead.
+  auto const list_of = [this](std::vector<Expression *> elements) {
+    return this->storage.template Create<ListLiteral>(std::move(elements));
+  };
+  auto const null_literal = [this] {
+    return this->storage.template Create<PrimitiveLiteral>(memgraph::storage::ExternalPropertyValue());
+  };
+  auto const in = [this](Expression *probe, Expression *list) {
+    return this->storage.template Create<InListOperator>(probe, list);
+  };
+
+  {
+    // The probe and the only element are the same shape and hold a Null.
+    auto value = this->Eval(in(list_of({null_literal()}), list_of({list_of({null_literal()})})));
+    EXPECT_TRUE(value.IsNull());
+  }
+  auto *probe_without_a_null =
+      in(list_of({this->storage.template Create<PrimitiveLiteral>(1)}),
+         list_of({list_of({null_literal()}), list_of({this->storage.template Create<PrimitiveLiteral>(2)})}));
+  {
+    // The probe holds no Null, but an element it does not otherwise differ from
+    // does.
+    EXPECT_TRUE(this->Eval(probe_without_a_null).IsNull());
+  }
+  // The operator caches the list only when the query tracks the key, which the
+  // evaluator above does not do. These read the same expressions through an
+  // evaluator that does, so the answer cannot depend on whether the list was
+  // cached.
+  auto const eval_with_the_list_cached = [this](InListOperator *op) {
+    FrameChangeCollector collector;
+    collector.AddInListKey(memgraph::utils::GetFrameChangeId(*op));
+    ExpressionEvaluator caching{&this->frame, this->execution_context, memgraph::storage::View::OLD, &collector};
+    return op->Accept(caching);
+  };
+
+  {
+    // The same, with the list cached. A lookup would report the probe absent,
+    // because no element is equivalent to it.
+    EXPECT_TRUE(eval_with_the_list_cached(probe_without_a_null).IsNull());
+  }
+  {
+    // The list holds no Null, so it is cached, and the probe holds one. A
+    // lookup reports the probe absent where equality cannot decide it.
+    auto *op = in(list_of({null_literal()}),
+                  list_of({list_of({this->storage.template Create<PrimitiveLiteral>(1)}),
+                           list_of({this->storage.template Create<PrimitiveLiteral>(2)})}));
+    EXPECT_TRUE(this->Eval(op).IsNull());
+    EXPECT_TRUE(eval_with_the_list_cached(op).IsNull());
+  }
+  {
+    // The same, but no element is even the same length, so the Null decides
+    // nothing and the answer is settled.
+    auto *op = in(list_of({null_literal()}),
+                  list_of({list_of({this->storage.template Create<PrimitiveLiteral>(1),
+                                    this->storage.template Create<PrimitiveLiteral>(2)})}));
+    EXPECT_EQ(this->Eval(op).ValueBool(), false);
+    EXPECT_EQ(eval_with_the_list_cached(op).ValueBool(), false);
+  }
+  {
+    // A list holding a Null is never cached, so this answers the same way
+    // whether the key is tracked or not.
+    auto *op = in(list_of({null_literal()}), list_of({list_of({null_literal()})}));
+    EXPECT_TRUE(this->Eval(op).IsNull());
+    EXPECT_TRUE(eval_with_the_list_cached(op).IsNull());
+  }
+  {
+    // Nothing holds a Null, so the answer is decided and the set may be read.
+    auto value = this->Eval(in(list_of({this->storage.template Create<PrimitiveLiteral>(1)}),
+                               list_of({list_of({this->storage.template Create<PrimitiveLiteral>(1)}),
+                                        list_of({this->storage.template Create<PrimitiveLiteral>(2)})})));
+    EXPECT_EQ(value.ValueBool(), true);
+  }
+  {
+    auto value = this->Eval(in(list_of({this->storage.template Create<PrimitiveLiteral>(3)}),
+                               list_of({list_of({this->storage.template Create<PrimitiveLiteral>(1)}),
+                                        list_of({this->storage.template Create<PrimitiveLiteral>(2)})})));
+    EXPECT_EQ(value.ValueBool(), false);
+  }
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, InListOperator) {
   auto *list_literal = this->storage.template Create<ListLiteral>(
       std::vector<Expression *>{this->storage.template Create<PrimitiveLiteral>(1),

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -590,6 +590,44 @@ TYPED_TEST(ExpressionEvaluatorTest, InListOperatorOverContainersHoldingNull) {
   }
 }
 
+TYPED_TEST(ExpressionEvaluatorTest, InListOperatorWhereTheSoughtValueIsNullOnALaterRow) {
+  // A filter reads one membership test over every row, so a row whose sought
+  // value is Null arrives after rows that filled the set. That row takes the
+  // path that reads the set rather than the one that fills it, and a lookup
+  // there can only report present or absent. Membership of a Null in a list
+  // holding anything is undecided, and `NOT` of it stays undecided, so a row no
+  // filter can judge is kept by neither.
+  auto *sought = this->storage.template Create<Identifier>("v", true);
+  auto const sought_symbol = this->symbol_table.CreateSymbol("v", true);
+  sought->MapTo(sought_symbol);
+  auto const bind = [this, sought_symbol](TypedValue value) {
+    auto frame_writer = FrameWriter(this->frame, nullptr, this->ctx.memory);
+    frame_writer.Write(sought_symbol, value);
+  };
+
+  auto *op = this->storage.template Create<InListOperator>(
+      sought,
+      this->storage.template Create<ListLiteral>(
+          std::vector<Expression *>{this->storage.template Create<PrimitiveLiteral>(10)}));
+  auto *negated = this->storage.template Create<NotOperator>(op);
+
+  FrameChangeCollector collector;
+  collector.AddInListKey(memgraph::utils::GetFrameChangeId(*op));
+  ExpressionEvaluator caching{&this->frame, this->execution_context, memgraph::storage::View::OLD, &collector};
+
+  bind(TypedValue(10));
+  EXPECT_EQ(op->Accept(caching).ValueBool(), true);
+  EXPECT_EQ(negated->Accept(caching).ValueBool(), false);
+
+  bind(TypedValue());
+  EXPECT_TRUE(op->Accept(caching).IsNull());
+  EXPECT_TRUE(negated->Accept(caching).IsNull());
+
+  bind(TypedValue(11));
+  EXPECT_EQ(op->Accept(caching).ValueBool(), false);
+  EXPECT_EQ(negated->Accept(caching).ValueBool(), true);
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, InListOperator) {
   auto *list_literal = this->storage.template Create<ListLiteral>(
       std::vector<Expression *>{this->storage.template Create<PrimitiveLiteral>(1),

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -535,8 +535,8 @@ TYPED_TEST(ExpressionEvaluatorTest, InListOperatorOverContainersHoldingNull) {
     EXPECT_EQ(eval_with_the_list_cached(op).ValueBool(), false);
   }
   {
-    // A list holding a Null is never cached, so this answers the same way
-    // whether the key is tracked or not.
+    // An element holding a Null below its top level costs the set its exactness, so the list is
+    // read element by element however the key is tracked.
     auto *op = in(list_of({null_literal()}), list_of({list_of({null_literal()})}));
     EXPECT_TRUE(this->Eval(op).IsNull());
     EXPECT_TRUE(eval_with_the_list_cached(op).IsNull());
@@ -553,6 +553,40 @@ TYPED_TEST(ExpressionEvaluatorTest, InListOperatorOverContainersHoldingNull) {
                                list_of({list_of({this->storage.template Create<PrimitiveLiteral>(1)}),
                                         list_of({this->storage.template Create<PrimitiveLiteral>(2)})})));
     EXPECT_EQ(value.ValueBool(), false);
+  }
+
+  // Every row after the first reads a set that is already populated, which is a different path
+  // through the operator than the row that fills it. These take both.
+  auto const eval_twice_through_one_collector = [this](InListOperator *op) {
+    FrameChangeCollector collector;
+    collector.AddInListKey(memgraph::utils::GetFrameChangeId(*op));
+    ExpressionEvaluator caching{&this->frame, this->execution_context, memgraph::storage::View::OLD, &collector};
+    auto const filling_the_set = op->Accept(caching);
+    auto const reading_it = op->Accept(caching);
+    EXPECT_EQ(filling_the_set.type(), reading_it.type());
+    return reading_it;
+  };
+  auto const literal = [this](int value) { return this->storage.template Create<PrimitiveLiteral>(value); };
+
+  {
+    // A top-level Null element keeps the set exact: the explicit lookup for a Null answers it, so
+    // the sought value the list does hold is still found by one lookup.
+    auto *op = in(literal(1), list_of({literal(1), null_literal()}));
+    EXPECT_EQ(this->Eval(op).ValueBool(), true);
+    EXPECT_EQ(eval_twice_through_one_collector(op).ValueBool(), true);
+  }
+  {
+    // And one the list does not hold is left undecided by that Null rather than answered absent.
+    auto *op = in(literal(3), list_of({literal(1), null_literal()}));
+    EXPECT_TRUE(this->Eval(op).IsNull());
+    EXPECT_TRUE(eval_twice_through_one_collector(op).IsNull());
+  }
+  {
+    // With no Null anywhere the set decides both answers on its own.
+    auto *present = in(literal(2), list_of({literal(1), literal(2)}));
+    EXPECT_EQ(eval_twice_through_one_collector(present).ValueBool(), true);
+    auto *absent = in(literal(3), list_of({literal(1), literal(2)}));
+    EXPECT_EQ(eval_twice_through_one_collector(absent).ValueBool(), false);
   }
 }
 

--- a/tests/unit/query_plan_match_filter_return.cpp
+++ b/tests/unit/query_plan_match_filter_return.cpp
@@ -3376,6 +3376,14 @@ TYPED_TEST(QueryPlan, Distinct) {
        TypedValue()},
       {TypedValue(3), TypedValue("two"), TypedValue(), TypedValue(true), TypedValue(false), TypedValue("TWO")},
       false);
+
+  // A container holding a Null is the same value as itself, so one of each
+  // survives. Equality cannot decide this and answers Null; DISTINCT reads
+  // equivalence, which decides.
+  auto const list_of_null = [] { return TypedValue(std::vector<TypedValue>{TypedValue()}); };
+  auto const map_of_null = [] { return TypedValue(std::map<std::string, TypedValue>{{"k", TypedValue()}}); };
+  check_distinct(
+      {list_of_null(), list_of_null(), map_of_null(), map_of_null()}, {list_of_null(), map_of_null()}, false);
 }
 
 TYPED_TEST(QueryPlan, ScanAllByLabel) {
@@ -3406,6 +3414,68 @@ TYPED_TEST(QueryPlan, ScanAllByLabel) {
   ASSERT_EQ(result_row.size(), 1);
   auto result_vertex = result_row[0].ValueVertex();
   EXPECT_EQ(result_vertex.Gid(), labeled_vertex.Gid());
+}
+
+TYPED_TEST(QueryPlan, EqualityAgainstAListHoldingNullKeepsNoRowWithOrWithoutAnIndex) {
+  // Equality against a value holding a Null answers Null, so no row passes the
+  // filter. The index has to keep none of them either, or the same query gives
+  // a different answer once the index exists.
+  auto label = this->db->NameToLabel("label");
+  auto prop = this->db->NameToProperty("prop");
+
+  {
+    auto storage_dba = this->db->Access(memgraph::storage::WRITE);
+    memgraph::query::DbAccessor dba(storage_dba.get());
+    for (auto const &stored :
+         {std::vector{memgraph::storage::PropertyValue()}, std::vector{memgraph::storage::PropertyValue(1)}}) {
+      auto vertex = dba.InsertVertex();
+      ASSERT_TRUE(vertex.AddLabel(label).has_value());
+      ASSERT_TRUE(vertex.SetProperty(prop, memgraph::storage::PropertyValue(stored)).has_value());
+    }
+    ASSERT_TRUE(dba.Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  auto count_without_the_index = [&](memgraph::query::DbAccessor &dba) {
+    SymbolTable symbol_table;
+    auto scan_all = MakeScanAll(this->storage, symbol_table, "n");
+    auto *sought = LIST(LITERAL(TypedValue()));
+    auto *filter_expression = EQ(PROPERTY_LOOKUP(dba, IDENT("n")->MapTo(scan_all.sym_), prop), sought);
+    auto filter =
+        std::make_shared<Filter>(scan_all.op_, std::vector<std::shared_ptr<LogicalOperator>>{}, filter_expression);
+    auto output = NEXPR("n", IDENT("n")->MapTo(scan_all.sym_))->MapTo(symbol_table.CreateSymbol("n", true));
+    auto produce = MakeProduce(filter, output);
+    auto context = MakeContext(this->storage, symbol_table, &dba);
+    return CollectProduce(*produce, &context).size();
+  };
+
+  auto count_with_the_index = [&](memgraph::query::DbAccessor &dba) {
+    SymbolTable symbol_table;
+    auto scan_all =
+        MakeScanAllByLabelPropertyValue(this->storage, symbol_table, "n", label, prop, LIST(LITERAL(TypedValue())));
+    auto output = NEXPR("n", IDENT("n")->MapTo(scan_all.sym_))->MapTo(symbol_table.CreateSymbol("n", true));
+    auto produce = MakeProduce(scan_all.op_, output);
+    auto context = MakeContext(this->storage, symbol_table, &dba);
+    return CollectProduce(*produce, &context).size();
+  };
+
+  {
+    auto storage_dba = this->db->Access(memgraph::storage::WRITE);
+    memgraph::query::DbAccessor dba(storage_dba.get());
+    EXPECT_EQ(0, count_without_the_index(dba));
+  }
+
+  {
+    auto unique_acc = this->db->UniqueAccess();
+    [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, {prop});
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto storage_dba = this->db->Access(memgraph::storage::WRITE);
+    memgraph::query::DbAccessor dba(storage_dba.get());
+    EXPECT_EQ(0, count_with_the_index(dba));
+    EXPECT_EQ(0, count_without_the_index(dba));
+  }
 }
 
 TYPED_TEST(QueryPlan, ScanAllByLabelProperties) {

--- a/tests/unit/typed_value.cpp
+++ b/tests/unit/typed_value.cpp
@@ -256,6 +256,51 @@ TEST(TypedValue, Comparison) {
   EXPECT_THROW((void)(point_2 < point_2), memgraph::query::TypedValueException);
 }
 
+namespace {
+TypedValue List(std::vector<TypedValue> elements) { return TypedValue(std::move(elements)); }
+
+TypedValue Map(std::map<std::string, TypedValue> entries) { return TypedValue(std::move(entries)); }
+}  // namespace
+
+TEST(TypedValue, EqualityOfAContainerHoldingNullIsUndecided) {
+  // A Null element stands for a value nobody knows, so a comparison that has to
+  // read one cannot answer. It answers Null, exactly as `null = null` does.
+  EXPECT_PROP_ISNULL(List({TypedValue()}) == List({TypedValue()}));
+  EXPECT_PROP_ISNULL(List({TypedValue(1), TypedValue(), TypedValue(3)}) ==
+                     List({TypedValue(1), TypedValue(), TypedValue(3)}));
+  EXPECT_PROP_ISNULL(List({TypedValue()}) != List({TypedValue()}));
+  EXPECT_PROP_ISNULL(Map({{"k", TypedValue()}}) == Map({{"k", TypedValue()}}));
+
+  // Null against a known value is undecided for the same reason: nothing here
+  // shows the two differ.
+  EXPECT_PROP_ISNULL(List({TypedValue()}) == List({TypedValue(1)}));
+  EXPECT_PROP_ISNULL(Map({{"k", TypedValue()}}) == Map({{"k", TypedValue(1)}}));
+}
+
+TEST(TypedValue, EqualityOfAContainerAnswersWhereOneElementSettlesIt) {
+  // An element that differs proves the two containers differ, whatever else
+  // they hold, so a Null elsewhere does not hide it.
+  EXPECT_PROP_NE(List({TypedValue(), TypedValue(1)}), List({TypedValue(), TypedValue(2)}));
+  EXPECT_PROP_NE(Map({{"a", TypedValue()}, {"b", TypedValue(1)}}), Map({{"a", TypedValue()}, {"b", TypedValue(2)}}));
+
+  // So does a length that differs, or a key one side does not have.
+  EXPECT_PROP_NE(List({TypedValue()}), List({TypedValue(), TypedValue()}));
+  EXPECT_PROP_NE(Map({{"a", TypedValue()}}), Map({{"b", TypedValue()}}));
+
+  // And a container holding no Null at all still answers.
+  EXPECT_PROP_EQ(List({TypedValue(1)}), List({TypedValue(1)}));
+  EXPECT_PROP_NE(List({TypedValue(1)}), List({TypedValue(2)}));
+}
+
+TEST(TypedValue, EquivalenceOfAContainerHoldingNullDecides) {
+  // Equivalence is two-valued, which is what a hash container needs: it holds a
+  // Null equivalent to a Null so a key can be found again.
+  auto eq = TypedValue::BoolEqual{};
+  EXPECT_TRUE(eq(List({TypedValue()}), List({TypedValue()})));
+  EXPECT_TRUE(eq(Map({{"k", TypedValue()}}), Map({{"k", TypedValue()}})));
+  EXPECT_FALSE(eq(List({TypedValue()}), List({TypedValue(1)})));
+}
+
 TEST(TypedValue, BoolEquals) {
   auto eq = TypedValue::BoolEqual{};
   EXPECT_TRUE(eq(TypedValue(1), TypedValue(1)));
@@ -782,13 +827,12 @@ TYPED_TEST(AllTypesFixture, CopyConstruction) {
       EXPECT_PROP_ISNULL(cpy);
     } else if (value.IsGraph()) {
       // not comparable
-    } else if (value.IsMap()) {
-      // map contains NULL so can't be true
-      auto res = cpy == value;
-      // THIS IS NOT THE SAME AS NEO4J
-      // NEO4J returns NULL
-      ASSERT_EQ(res.type(), TypedValue::Type::Bool);
-      ASSERT_EQ(res.ValueBool(), false);
+    } else if (value.IsList() || value.IsMap()) {
+      // Both hold a Null, so equality cannot decide that the copy is the same
+      // value: it answers Null. Equivalence is the relation that does decide,
+      // and the one that has to, since a hash container is keyed by it.
+      EXPECT_TRUE(TypedValue::BoolEqual{}(cpy, value));
+      EXPECT_PROP_ISNULL(cpy == value);
     } else {
       EXPECT_PROP_EQ(cpy, value);
     }


### PR DESCRIPTION
A Null stands for a value nobody knows, so `[null] = [null]` answers Null, as
`null = null` does. An element that differs still settles the whole, whatever
else the two hold, and so does a length or a key one side lacks. Equality over a
list or a map is three-valued from here on, matching what it already was over
everything else.

Equivalence keeps deciding, and now walks a container itself rather than reading
the answer equality gives. It is the relation DISTINCT, grouping and every hash
container are keyed by, and it has to hold a value equivalent to itself: a map
holding a Null was not, so DISTINCT kept one copy of it per row. Four things
answer an equality by some other means, and each now declines where a Null is
involved rather than reporting a match: an index range, a membership test
reading a cached list, an edge property scan, and a hash join standing in for
the filter it replaced. A query keeps the same rows however it is planned and
whatever indexes exist.
