### PR TITLE
fix(storage): signal the async indexer under the mutex it waits on

### DIFF
--- a/src/storage/v2/async_indexer.cpp
+++ b/src/storage/v2/async_indexer.cpp
@@ -146,8 +146,13 @@ void AsyncIndexer::Start(std::stop_token stop_token, Storage *storage) {
 
 void AsyncIndexer::Shutdown() {
   index_creator_thread_.request_stop();
-  cv_.notify_all();
+  // The notification must be issued under the mutex the worker evaluates its wait condition under.
+  // Issued before taking it, it can land in the window where the worker has read that condition as
+  // false and has not yet registered on the condition variable. The wake-up then reaches nobody,
+  // the worker sleeps with a stop already requested, and the wait below never finishes, because
+  // only the worker can satisfy it.
   auto guard = std::unique_lock{mutex_};
+  cv_.notify_all();
   cv_.wait(guard, [this] { return HasThreadStopped(); });
 }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -881,6 +881,11 @@ add_unit_test(storage_v2_index_drop_visibility
     LINK_TARGETS mg::storage mg-utils
 )
 
+add_unit_test(storage_v2_async_indexer
+    SOURCES storage_v2_async_indexer.cpp
+    LINK_TARGETS mg::storage mg-utils
+)
+
 add_unit_test(storage_v2_index_entry_lifetime
     SOURCES storage_v2_index_entry_lifetime.cpp
     LINK_TARGETS mg::storage mg-utils

--- a/tests/unit/storage_v2_async_indexer.cpp
+++ b/tests/unit/storage_v2_async_indexer.cpp
@@ -1,0 +1,57 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Stopping a storage waits for the async indexer's worker to finish, so a wake-up that reaches that
+// worker only some of the time is enough to hang an instance on shutdown or on a dropped database.
+// The window is at the worker's own startup, between reading its wait condition and registering to
+// be woken, and it is only a few instructions wide. Nothing here indexes anything: the test starts
+// and stops a worker that has no work, which is the shortest path to that window.
+
+#include <gtest/gtest.h>
+
+#include <stop_token>
+
+#include "storage/v2/async_indexer.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+
+namespace {
+
+// A stopped indexer reports itself stopped for good, so each round needs a fresh one. The count is
+// set from how far the window actually reaches, measured against the defect this guards: at a tenth
+// of this it caught it in four runs out of ten, so a tenth is not enough to rely on a single run.
+// Correct code pays a fixed dozen seconds or so for it.
+constexpr int kRounds = 400'000;
+
+}  // namespace
+
+// The deadlock this guards against presents as the test not finishing, since a lost wake-up leaves
+// both the worker and the thread waiting for it asleep. That is the honest shape for a deadlock,
+// and the unit-test timeout turns it into a named failure with a core rather than an unattributed
+// cancellation. The assertion in the loop is not what catches it; see the note there.
+TEST(AsyncIndexer, ShutdownCompletesWhenTheWorkerIsStillStarting) {
+  memgraph::storage::Config config{};
+  // Nothing in this test needs collection, and a periodic pass would only add unrelated threads.
+  config.gc.type = memgraph::storage::Config::Gc::Type::NONE;
+  memgraph::storage::InMemoryStorage storage{config};
+
+  for (int round = 0; round < kRounds; ++round) {
+    std::stop_source stop_source;
+    memgraph::storage::AsyncIndexer indexer;
+    indexer.Start(stop_source.get_token(), &storage);
+    indexer.Shutdown();
+    // Shutdown waits on exactly this condition before returning, so it cannot fail while Shutdown
+    // keeps that promise. It is here for the regression where Shutdown stops waiting: a worker
+    // outliving the call is then reported here rather than as a crash somewhere later.
+    ASSERT_TRUE(indexer.HasThreadStopped())
+        << "Shutdown returned on round " << round << " while the worker was still running";
+  }
+}


### PR DESCRIPTION
Stopping a storage waits for the async indexer's worker thread to finish, and
that worker holds one mutex from the moment it starts, giving it up only inside
its own wait. A signal issued without that mutex can land in the window between
the worker reading its wait condition and registering to be woken, where it
reaches nobody. The worker then sleeps with a stop already requested, and
nothing signals again because the only remaining signaller is the worker on its
way out. Shutting an instance down or dropping a database sleeps forever.

Taking the mutex before signalling closes that window and costs nothing, since
the wait on the next line took it anyway. The stop request stays outside the
mutex: a worker part-way through building an index holds it for the whole build
while polling for a stop, so it has to see that request without waiting for the
mutex. A unit test starts and stops a worker often enough to reach the window,
and reports the defect by not finishing, which is what a deadlock leaves to
report.
