### PR TITLE
test(utils): have the reader ask only once the writer is queued

### DIFF
--- a/tests/unit/utils_rwlock.cpp
+++ b/tests/unit/utils_rwlock.cpp
@@ -166,29 +166,32 @@ TEST(RWLock, WritePriority) {
   // two would be a data race here rather than a passing test.
   bool writer_went_first = false;
 
-  std::binary_semaphore writer_requesting{0};
   std::binary_semaphore reader_behind_writer{0};
 
   std::thread writer([&] {
-    writer_requesting.release();
     auto lock = std::unique_lock{rwlock};
     writer_went_first = true;
   });
 
-  // Announcing is not the same as having asked, and the reader needs the request itself to be
-  // registered before it asks. It establishes that below rather than trusting this.
-  writer_requesting.acquire();
-
   std::thread reader([&] {
     // A waiting writer cannot be read off the lock. On a write-priority lock it is, however,
     // exactly what refuses a shared request while another shared hold is live, so probing until one
-    // is refused is how this thread learns the writer is queued ahead of it. Nothing here is timed.
-    // The bound only stops a hang: giving up leaves the assertion below to fail instead.
+    // is refused is how this thread learns the writer is queued ahead of it. The order the
+    // assertion checks is decided by the lock, never by how long anything took, which is what a
+    // reader starting from a sleep could not establish.
+    //
+    // The bound stops a lock without write priority from spinning here forever. It does not
+    // guarantee a failure: a writer that arrives after the bound expires still takes the lock
+    // first, and the assertion then passes without this thread having established what it set out
+    // to. That needs a writer delayed by the whole bound, so it costs a missed check rather than a
+    // false one.
     auto const give_up_at = std::chrono::steady_clock::now() + 10s;
     while (rwlock.try_lock_shared()) {
       rwlock.unlock_shared();
       if (std::chrono::steady_clock::now() > give_up_at) break;
-      std::this_thread::yield();
+      // Sleeping rather than yielding: on a lock that never refuses, yielding spins a core for the
+      // whole bound, and nothing here needs to observe the refusal promptly.
+      std::this_thread::sleep_for(100us);
     }
     reader_behind_writer.release();
     auto lock = std::shared_lock{rwlock};

--- a/tests/unit/utils_rwlock.cpp
+++ b/tests/unit/utils_rwlock.cpp
@@ -152,33 +152,55 @@ TEST(RWLock, ReadPriority) {
 
 TEST(RWLock, WritePriority) {
   /*
-   * - Main thread is holding a shared lock until T = 100ms.
-   * - Thread 1 tries to acquire an unique lock at T = 30ms.
-   * - Thread 2 tries to acquire a shared lock at T = 60ms, but it is not able
-   *   to because of write priority.
+   * With write priority a shared lock is refused while a writer waits for the exclusive one, so a
+   * reader that asks after the writer has to be let in behind it.
    */
   memgraph::utils::RWLock rwlock(memgraph::utils::RWLock::Priority::WRITE);
+
+  // Held until the reader is known to be behind the writer, so the writer has to queue for the
+  // lock rather than walk into a free one and settle the order by itself.
   rwlock.lock_shared();
-  bool first = true;
 
-  std::thread t1([&rwlock, &first] {
-    std::this_thread::sleep_for(30ms);
+  // Deliberately not atomic: the lock is the barrier under test. The writer sets this holding the
+  // exclusive lock and the reader reads it holding a shared one, so a lock that failed to order the
+  // two would be a data race here rather than a passing test.
+  bool writer_went_first = false;
+
+  std::binary_semaphore writer_requesting{0};
+  std::binary_semaphore reader_behind_writer{0};
+
+  std::thread writer([&] {
+    writer_requesting.release();
     auto lock = std::unique_lock{rwlock};
-    EXPECT_TRUE(first);
-    first = false;
+    writer_went_first = true;
   });
 
-  std::thread t2([&rwlock, &first] {
-    std::this_thread::sleep_for(60ms);
+  // Announcing is not the same as having asked, and the reader needs the request itself to be
+  // registered before it asks. It establishes that below rather than trusting this.
+  writer_requesting.acquire();
+
+  std::thread reader([&] {
+    // A waiting writer cannot be read off the lock. On a write-priority lock it is, however,
+    // exactly what refuses a shared request while another shared hold is live, so probing until one
+    // is refused is how this thread learns the writer is queued ahead of it. Nothing here is timed.
+    // The bound only stops a hang: giving up leaves the assertion below to fail instead.
+    auto const give_up_at = std::chrono::steady_clock::now() + 10s;
+    while (rwlock.try_lock_shared()) {
+      rwlock.unlock_shared();
+      if (std::chrono::steady_clock::now() > give_up_at) break;
+      std::this_thread::yield();
+    }
+    reader_behind_writer.release();
     auto lock = std::shared_lock{rwlock};
-    EXPECT_FALSE(first);
+    EXPECT_TRUE(writer_went_first) << "a reader that asked after a waiting writer was admitted ahead of it";
   });
 
-  std::this_thread::sleep_for(100ms);
+  reader_behind_writer.acquire();
+  // Released only now, so neither thread can have been given the lock for want of contention.
   rwlock.unlock_shared();
 
-  t1.join();
-  t2.join();
+  writer.join();
+  reader.join();
 }
 
 TEST(RWLock, TryLock) {


### PR DESCRIPTION
A write-priority lock admits a reader that asks after a waiting writer only
behind that writer, and the test for it needs the reader to ask second. A
waiting writer cannot be read off the lock, but it is exactly what refuses a
shared request while another shared hold is live, so the reader probes until a
request is refused and thereby knows the writer is queued ahead of it. The main
thread keeps its own shared hold until then, so neither thread can be handed
the lock for want of contention. Starting the two from sleeps of different
lengths ordered nothing on a machine with no CPU to spare, and the reader could
be admitted first and read a flag the writer had not yet set.

The reader's probe is bounded, and reaching that bound only stops a hang: the
assertion then fails rather than the test waiting forever. One assertion is
gone with the sleeps, the one made by the writer that the flag still held its
initial value, which no execution could have falsified since the writer is the
only thread that writes it and it read the flag first.
