### PR TITLE
refactor(storage): define the JSON serialisation out of line

### DIFF
--- a/src/dbms/CMakeLists.txt
+++ b/src/dbms/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(mg-dbms
     PRIVATE
     dbms_handler.cpp
     database.cpp
+    database_info.cpp
     tenant_profiles.cpp
     coordinator_handler.cpp
     inmemory/replication_handlers.cpp

--- a/src/dbms/database_info.cpp
+++ b/src/dbms/database_info.cpp
@@ -9,27 +9,22 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#pragma once
+#include "dbms/database_info.hpp"
 
-#include <cstdint>
-
-#include <nlohmann/json_fwd.hpp>
-
-#include "storage/v2/storage.hpp"
+#include <nlohmann/json.hpp>
 
 namespace memgraph::dbms {
 
-struct DatabaseInfo {
-  storage::StorageInfo storage_info;
-  uint64_t triggers;
-  uint64_t streams;
-  int64_t db_memory_tracked{0};
-  int64_t db_peak_memory_tracked{0};
-  int64_t db_storage_memory_tracked{0};
-  int64_t db_embedding_memory_tracked{0};
-  int64_t db_query_memory_tracked{0};
-};
-
-nlohmann::json ToJson(const DatabaseInfo &info);
+nlohmann::json ToJson(const DatabaseInfo &info) {
+  auto res = storage::ToJson(info.storage_info);
+  res["triggers"] = info.triggers;
+  res["streams"] = info.streams;
+  res["db_memory_tracked"] = info.db_memory_tracked;
+  res["db_peak_memory_tracked"] = info.db_peak_memory_tracked;
+  res["db_storage_memory_tracked"] = info.db_storage_memory_tracked;
+  res["db_embedding_memory_tracked"] = info.db_embedding_memory_tracked;
+  res["db_query_memory_tracked"] = info.db_query_memory_tracked;
+  return res;
+}
 
 }  // namespace memgraph::dbms

--- a/src/dbms/database_info.hpp
+++ b/src/dbms/database_info.hpp
@@ -13,6 +13,8 @@
 
 #include <cstdint>
 
+#include <nlohmann/json.hpp>
+
 #include "storage/v2/storage.hpp"
 
 namespace memgraph::dbms {

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -20,6 +20,8 @@
 #include <thread>
 #include <utility>
 
+#include <nlohmann/json.hpp>
+
 #include "dbms/constants.hpp"
 #include "dbms/global.hpp"
 #include "dbms/rpc.hpp"
@@ -1623,5 +1625,43 @@ void DbmsHandler::ApplyColdRecoveryMeta(std::string_view name, const storage::Co
 }
 
 #endif  // MG_ENTERPRISE
+
+nlohmann::json ToJson(const Statistics &stats) {
+  nlohmann::json res;
+
+  res["edges"] = stats.num_edges;
+  res["vertices"] = stats.num_vertex;
+  res["triggers"] = stats.triggers;
+  res["streams"] = stats.streams;
+  res["users"] = stats.users;
+  res["roles"] = stats.roles;
+  res["databases"] = stats.num_databases;
+  res["indices"] = stats.indices;
+  res["constraints"] = stats.constraints;
+  res["storage_modes"] = {{storage::StorageModeToString(static_cast<storage::StorageMode>(0)), stats.storage_modes[0]},
+                          {storage::StorageModeToString(static_cast<storage::StorageMode>(1)), stats.storage_modes[1]},
+                          {storage::StorageModeToString(static_cast<storage::StorageMode>(2)), stats.storage_modes[2]}};
+  res["isolation_levels"] = {
+      {storage::IsolationLevelToString(static_cast<storage::IsolationLevel>(0)), stats.isolation_levels[0]},
+      {storage::IsolationLevelToString(static_cast<storage::IsolationLevel>(1)), stats.isolation_levels[1]},
+      {storage::IsolationLevelToString(static_cast<storage::IsolationLevel>(2)), stats.isolation_levels[2]}};
+  res["durability"] = {{"snapshot_enabled", stats.snapshot_enabled}, {"WAL_enabled", stats.wal_enabled}};
+  res["property_store_compression_enabled"] = stats.property_store_compression_enabled;
+  res["property_store_compression_level"] = {
+      {utils::CompressionLevelToString(utils::CompressionLevel::LOW), stats.property_store_compression_level[0]},
+      {utils::CompressionLevelToString(utils::CompressionLevel::MID), stats.property_store_compression_level[1]},
+      {utils::CompressionLevelToString(utils::CompressionLevel::HIGH), stats.property_store_compression_level[2]}};
+  res["label_node_count_histogram"] = {{"1-9", stats.label_node_count_histogram[0]},
+                                       {"10-99", stats.label_node_count_histogram[1]},
+                                       {"100-999", stats.label_node_count_histogram[2]},
+                                       {"1K-9.99K", stats.label_node_count_histogram[3]},
+                                       {"10K-99.9K", stats.label_node_count_histogram[4]},
+                                       {"100K-999K", stats.label_node_count_histogram[5]},
+                                       {"1M+", stats.label_node_count_histogram[6]}};
+  res["num_parameters"] = stats.num_parameters;
+  res["num_descriptions"] = stats.num_descriptions;
+
+  return res;
+}
 
 }  // namespace memgraph::dbms

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -31,6 +31,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <nlohmann/json.hpp>
+
 #include "constants.hpp"
 #include "dbms/database.hpp"
 #include "dbms/database_info.hpp"

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -31,7 +31,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include "constants.hpp"
 #include "dbms/database.hpp"
@@ -84,42 +84,7 @@ struct Statistics {
   uint64_t num_descriptions;               //!< Number of server-side descriptions
 };
 
-static inline nlohmann::json ToJson(const Statistics &stats) {
-  nlohmann::json res;
-
-  res["edges"] = stats.num_edges;
-  res["vertices"] = stats.num_vertex;
-  res["triggers"] = stats.triggers;
-  res["streams"] = stats.streams;
-  res["users"] = stats.users;
-  res["roles"] = stats.roles;
-  res["databases"] = stats.num_databases;
-  res["indices"] = stats.indices;
-  res["constraints"] = stats.constraints;
-  res["storage_modes"] = {{storage::StorageModeToString((storage::StorageMode)0), stats.storage_modes[0]},
-                          {storage::StorageModeToString((storage::StorageMode)1), stats.storage_modes[1]},
-                          {storage::StorageModeToString((storage::StorageMode)2), stats.storage_modes[2]}};
-  res["isolation_levels"] = {{storage::IsolationLevelToString((storage::IsolationLevel)0), stats.isolation_levels[0]},
-                             {storage::IsolationLevelToString((storage::IsolationLevel)1), stats.isolation_levels[1]},
-                             {storage::IsolationLevelToString((storage::IsolationLevel)2), stats.isolation_levels[2]}};
-  res["durability"] = {{"snapshot_enabled", stats.snapshot_enabled}, {"WAL_enabled", stats.wal_enabled}};
-  res["property_store_compression_enabled"] = stats.property_store_compression_enabled;
-  res["property_store_compression_level"] = {
-      {utils::CompressionLevelToString(utils::CompressionLevel::LOW), stats.property_store_compression_level[0]},
-      {utils::CompressionLevelToString(utils::CompressionLevel::MID), stats.property_store_compression_level[1]},
-      {utils::CompressionLevelToString(utils::CompressionLevel::HIGH), stats.property_store_compression_level[2]}};
-  res["label_node_count_histogram"] = {{"1-9", stats.label_node_count_histogram[0]},
-                                       {"10-99", stats.label_node_count_histogram[1]},
-                                       {"100-999", stats.label_node_count_histogram[2]},
-                                       {"1K-9.99K", stats.label_node_count_histogram[3]},
-                                       {"10K-99.9K", stats.label_node_count_histogram[4]},
-                                       {"100K-999K", stats.label_node_count_histogram[5]},
-                                       {"1M+", stats.label_node_count_histogram[6]}};
-  res["num_parameters"] = stats.num_parameters;
-  res["num_descriptions"] = stats.num_descriptions;
-
-  return res;
-}
+nlohmann::json ToJson(const Statistics &stats);
 
 // Retry/timeout knobs for Resume_'s single-flight loser loop. Defaults are the production values;
 // a test can shrink them (via the DbmsHandler constructor or SetResumeRetryPolicy) to exercise the

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include "query/plan/pretty_print.hpp"
+#include <nlohmann/json.hpp>
 #include <range/v3/all.hpp>
 #include <utility>
 #include <variant>

--- a/src/query/serialization/property_value.hpp
+++ b/src/query/serialization/property_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,7 +11,8 @@
 
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+// The signatures name nlohmann::json's nested array_t and object_t, which json_fwd cannot declare.
+#include <nlohmann/json.hpp>
 
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/storage.hpp"

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -14,6 +14,8 @@
 #include <algorithm>
 #include <cstdint>
 
+#include <nlohmann/json.hpp>
+
 #include "dbms/database.hpp"
 #include "query/config.hpp"
 #include "query/context.hpp"

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(mg-storage-v2
         replication/slk.cpp
         gc_status.cpp
         schema_info.cpp
+        schema_info_types.cpp
         snapshot_progress.cpp
         storage.cpp
         storage_error.cpp

--- a/src/storage/v2/indices/text_edge_index.cpp
+++ b/src/storage/v2/indices/text_edge_index.cpp
@@ -11,6 +11,7 @@
 
 #include "storage/v2/indices/text_edge_index.hpp"
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 #include "mgcxx_text_search.hpp"
 #include "query/exceptions.hpp"
 #include "storage/v2/edge_accessor.hpp"

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -11,6 +11,7 @@
 
 #include "storage/v2/indices/text_index.hpp"
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 #include <range/v3/all.hpp>
 #include "mgcxx_text_search.hpp"
 #include "storage/v2/id_types.hpp"

--- a/src/storage/v2/schema_info.cpp
+++ b/src/storage/v2/schema_info.cpp
@@ -476,6 +476,28 @@ nlohmann::json SchemaTracking<TContainer>::ToJson(
   return json;
 }
 
+nlohmann::json SchemaInfo::ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store) const {
+  auto lock = std::unique_lock{operation_ordering_mutex_};  // No snapshot guarantees for ANALYTICAL
+  return tracking_.ToJson(name_id_mapper, enum_store);
+}
+
+nlohmann::json SchemaInfo::ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store,
+                                  const std::function<bool(VertexKey const &)> &node_predicate,
+                                  const std::function<bool(EdgeTypeId)> &edge_predicate) const {
+  auto lock = std::unique_lock{operation_ordering_mutex_};  // No snapshot guarantees for ANALYTICAL
+  return tracking_.ToJson(name_id_mapper, enum_store, node_predicate, edge_predicate);
+}
+
+nlohmann::json SchemaInfo::ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store,
+                                  const std::function<bool(VertexKey const &)> &node_predicate,
+                                  const std::function<bool(EdgeTypeId)> &edge_predicate,
+                                  const std::function<bool(VertexKey const &, PropertyId)> &node_property_predicate,
+                                  const std::function<bool(EdgeTypeId, PropertyId)> &edge_property_predicate) const {
+  auto lock = std::unique_lock{operation_ordering_mutex_};
+  return tracking_.ToJson(
+      name_id_mapper, enum_store, node_predicate, edge_predicate, node_property_predicate, edge_property_predicate);
+}
+
 template <template <class...> class TContainer>
 void SchemaTracking<TContainer>::DeleteVertex(Vertex *vertex) {
   auto &info = vertex_state_[vertex->labels];

--- a/src/storage/v2/schema_info.hpp
+++ b/src/storage/v2/schema_info.hpp
@@ -151,27 +151,17 @@ struct SchemaTracking final : public SchemaTrackingInterface {
 
 struct SchemaInfo {
   // Snapshot guaranteeing functions
-  nlohmann::json ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store) const {
-    auto lock = std::unique_lock{operation_ordering_mutex_};  // No snapshot guarantees for ANALYTICAL
-    return tracking_.ToJson(name_id_mapper, enum_store);
-  }
+  nlohmann::json ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store) const;
 
   nlohmann::json ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store,
                         const std::function<bool(VertexKey const &)> &node_predicate,
-                        const std::function<bool(EdgeTypeId)> &edge_predicate) const {
-    auto lock = std::unique_lock{operation_ordering_mutex_};  // No snapshot guarantees for ANALYTICAL
-    return tracking_.ToJson(name_id_mapper, enum_store, node_predicate, edge_predicate);
-  }
+                        const std::function<bool(EdgeTypeId)> &edge_predicate) const;
 
   nlohmann::json ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store,
                         const std::function<bool(VertexKey const &)> &node_predicate,
                         const std::function<bool(EdgeTypeId)> &edge_predicate,
                         const std::function<bool(VertexKey const &, PropertyId)> &node_property_predicate,
-                        const std::function<bool(EdgeTypeId, PropertyId)> &edge_property_predicate) const {
-    auto lock = std::unique_lock{operation_ordering_mutex_};
-    return tracking_.ToJson(
-        name_id_mapper, enum_store, node_predicate, edge_predicate, node_property_predicate, edge_property_predicate);
-  }
+                        const std::function<bool(EdgeTypeId, PropertyId)> &edge_property_predicate) const;
 
   void ProcessTransaction(LocalSchemaTracking &tracking, SchemaInfoPostProcess &post_process, uint64_t start_ts,
                           uint64_t commit_ts, bool property_on_edges) {

--- a/src/storage/v2/schema_info_types.cpp
+++ b/src/storage/v2/schema_info_types.cpp
@@ -1,0 +1,116 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/schema_info_types.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <unordered_map>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+namespace memgraph::storage {
+
+template <template <class...> class TContainer>
+nlohmann::json PropertyInfo<TContainer>::ToJson(const EnumStore &enum_store, std::string_view key,
+                                                uint32_t max_count) const {
+  nlohmann::json::object_t property_info;
+  property_info.emplace("key", key);
+  const auto num = n.load();
+  property_info.emplace("count", num);
+  property_info.emplace("filling_factor", (100.0 * num) / max_count);
+  const auto &[types_itr, _] = property_info.emplace("types", nlohmann::json::array_t{});
+  for (const auto &type : types) {
+    nlohmann::json::object_t type_info;
+    std::stringstream ss;
+    if (type.first.type == PropertyValueType::TemporalData) {
+      ss << type.first.temporal_type;
+    } else if (type.first.type == PropertyValueType::Enum) {
+      ss << "Enum::" << *enum_store.ToTypeString(type.first.enum_type);
+    } else {
+      // Unify formatting
+      switch (type.first.type) {
+        break;
+        case PropertyValueType::Null:
+          ss << "Null";
+          break;
+        case PropertyValueType::Bool:
+          ss << "Boolean";
+          break;
+        case PropertyValueType::Int:
+          ss << "Integer";
+          break;
+        case PropertyValueType::Double:
+          ss << "Float";
+          break;
+        case PropertyValueType::String:
+          ss << "String";
+          break;
+        case PropertyValueType::List:
+        case PropertyValueType::IntList:
+        case PropertyValueType::DoubleList:
+        case PropertyValueType::NumericList:
+        case PropertyValueType::VectorIndexId:
+          ss << "List";
+          break;
+        case PropertyValueType::Map:
+          ss << "Map";
+          break;
+        case PropertyValueType::TemporalData:
+          ss << "TemporalData";
+          break;
+        case PropertyValueType::ZonedTemporalData:
+          ss << "ZonedDateTime";
+          break;
+        case PropertyValueType::Enum:
+          ss << "Enum";
+          break;
+        case PropertyValueType::Point2d:
+          ss << "Point2D";
+          break;
+        case PropertyValueType::Point3d:
+          ss << "Point3D";
+          break;
+      }
+    }
+    type_info.emplace("type", ss.str());
+    type_info.emplace("count", type.second.load());
+    types_itr->second.emplace_back(std::move(type_info));
+  }
+  return property_info;
+}
+
+template <template <class...> class TContainer>
+nlohmann::json TrackingInfo<TContainer>::ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store) const {
+  return ToJson(name_id_mapper, enum_store, [](PropertyId) { return true; });
+}
+
+template <template <class...> class TContainer>
+nlohmann::json TrackingInfo<TContainer>::ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store,
+                                                const std::function<bool(PropertyId)> &property_predicate) const {
+  nlohmann::json::object_t tracking_info;
+  tracking_info.emplace("count", n.load());
+  const auto &[prop_itr, _] = tracking_info.emplace("properties", nlohmann::json::array_t{});
+  for (const auto &[p, info] : properties) {
+    if (!property_predicate(p)) continue;
+    prop_itr->second.emplace_back(info.ToJson(enum_store, name_id_mapper.IdToName(p.AsUint()), std::max(n.load(), 1)));
+  }
+  return tracking_info;
+}
+
+}  // namespace memgraph::storage
+
+// A schema tracking instantiated with a third container needs its instantiation added here.
+template struct memgraph::storage::PropertyInfo<std::unordered_map>;
+template struct memgraph::storage::PropertyInfo<memgraph::utils::ConcurrentUnorderedMap>;
+template struct memgraph::storage::TrackingInfo<std::unordered_map>;
+template struct memgraph::storage::TrackingInfo<memgraph::utils::ConcurrentUnorderedMap>;

--- a/src/storage/v2/schema_info_types.hpp
+++ b/src/storage/v2/schema_info_types.hpp
@@ -14,7 +14,7 @@
 #include <boost/container_hash/hash_fwd.hpp>
 #include <cstdint>
 #include <functional>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
@@ -105,72 +105,7 @@ struct PropertyInfo {
   std::atomic_int n{0};                                     //!< Number of objects with this property
   TContainer<ExtendedPropertyType, std::atomic_int> types;  //!< Numer of property instances with a specific type
 
-  nlohmann::json ToJson(const EnumStore &enum_store, std::string_view key, uint32_t max_count) const {
-    nlohmann::json::object_t property_info;
-    property_info.emplace("key", key);
-    const auto num = n.load();
-    property_info.emplace("count", num);
-    property_info.emplace("filling_factor", (100.0 * num) / max_count);
-    const auto &[types_itr, _] = property_info.emplace("types", nlohmann::json::array_t{});
-    for (const auto &type : types) {
-      nlohmann::json::object_t type_info;
-      std::stringstream ss;
-      if (type.first.type == PropertyValueType::TemporalData) {
-        ss << type.first.temporal_type;
-      } else if (type.first.type == PropertyValueType::Enum) {
-        ss << "Enum::" << *enum_store.ToTypeString(type.first.enum_type);
-      } else {
-        // Unify formatting
-        switch (type.first.type) {
-          break;
-          case PropertyValueType::Null:
-            ss << "Null";
-            break;
-          case PropertyValueType::Bool:
-            ss << "Boolean";
-            break;
-          case PropertyValueType::Int:
-            ss << "Integer";
-            break;
-          case PropertyValueType::Double:
-            ss << "Float";
-            break;
-          case PropertyValueType::String:
-            ss << "String";
-            break;
-          case PropertyValueType::List:
-          case PropertyValueType::IntList:
-          case PropertyValueType::DoubleList:
-          case PropertyValueType::NumericList:
-          case PropertyValueType::VectorIndexId:
-            ss << "List";
-            break;
-          case PropertyValueType::Map:
-            ss << "Map";
-            break;
-          case PropertyValueType::TemporalData:
-            ss << "TemporalData";
-            break;
-          case PropertyValueType::ZonedTemporalData:
-            ss << "ZonedDateTime";
-            break;
-          case PropertyValueType::Enum:
-            ss << "Enum";
-            break;
-          case PropertyValueType::Point2d:
-            ss << "Point2D";
-            break;
-          case PropertyValueType::Point3d:
-            ss << "Point3D";
-            break;
-        }
-      }
-      type_info.emplace("type", ss.str());
-      type_info.emplace("count", type.second.load());
-      types_itr->second.emplace_back(std::move(type_info));
-    }
-    return property_info;
-  }
+  nlohmann::json ToJson(const EnumStore &enum_store, std::string_view key, uint32_t max_count) const;
 };
 
 /**
@@ -181,22 +116,10 @@ struct TrackingInfo {
   std::atomic_int n{0};                                         //!< Number of tracked objects
   TContainer<PropertyId, PropertyInfo<TContainer>> properties;  //!< Property statistics defined by the tracked object
 
-  nlohmann::json ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store) const {
-    return ToJson(name_id_mapper, enum_store, [](PropertyId) { return true; });
-  }
+  nlohmann::json ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store) const;
 
   nlohmann::json ToJson(NameIdMapper &name_id_mapper, const EnumStore &enum_store,
-                        const std::function<bool(PropertyId)> &property_predicate) const {
-    nlohmann::json::object_t tracking_info;
-    tracking_info.emplace("count", n.load());
-    const auto &[prop_itr, _] = tracking_info.emplace("properties", nlohmann::json::array_t{});
-    for (const auto &[p, info] : properties) {
-      if (!property_predicate(p)) continue;
-      prop_itr->second.emplace_back(
-          info.ToJson(enum_store, name_id_mapper.IdToName(p.AsUint()), std::max(n.load(), 1)));
-    }
-    return tracking_info;
-  }
+                        const std::function<bool(PropertyId)> &property_predicate) const;
 
   template <template <class...> class TOtherContainer>
   TrackingInfo &operator+=(const TrackingInfo<TOtherContainer> &rhs) {

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -13,6 +13,8 @@
 #include <shared_mutex>
 #include <tuple>
 
+#include <nlohmann/json.hpp>
+
 #include "flags/general.hpp"
 #include "spdlog/spdlog.h"
 
@@ -782,6 +784,32 @@ std::expected<void, storage::StorageIndexDefinitionError> Storage::Accessor::Dro
   }
   transaction_.md_deltas.emplace_back(MetadataDelta::text_index_drop, index_name);
   return {};
+}
+
+nlohmann::json ToJson(const StorageInfo &info) {
+  nlohmann::json res;
+
+  res["edges"] = info.edge_count;
+  res["vertices"] = info.vertex_count;
+  res["memory"] = info.memory_res;
+  res["disk"] = info.disk_usage;
+  res["label_indices"] = info.label_indices;
+  res["label_prop_indices"] = info.label_property_indices;
+  res["text_indices"] = info.text_indices;
+  res["vector_indices"] = info.vector_indices;
+  res["vector_edge_indices"] = info.vector_edge_indices;
+  res["existence_constraints"] = info.existence_constraints;
+  res["unique_constraints"] = info.unique_constraints;
+  res["type_constraints"] = info.type_constraints;
+  res["storage_mode"] = storage::StorageModeToString(info.storage_mode);
+  res["isolation_level"] = storage::IsolationLevelToString(info.isolation_level);
+  res["durability"] = {{"snapshot_enabled", info.durability_snapshot_enabled},
+                       {"WAL_enabled", info.durability_wal_enabled}};
+  res["property_store_compression_enabled"] = info.property_store_compression_enabled;
+  res["property_store_compression_level"] = utils::CompressionLevelToString(info.property_store_compression_level);
+  res["schema_vertex_count"] = info.schema_vertex_count;
+  res["schema_edge_count"] = info.schema_edge_count;
+  return res;
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -16,6 +16,8 @@
 #include <set>
 #include <string>
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "common_function_signatures.hpp"
 #include "memory/db_arena_fwd.hpp"
 #include "mg_procedure.h"
@@ -220,31 +222,7 @@ struct ColdTenantRecovery {
   StorageInfo stats{};  // value-init: a default-constructed recovery carries zeroed stats
 };
 
-static inline nlohmann::json ToJson(const StorageInfo &info) {
-  nlohmann::json res;
-
-  res["edges"] = info.edge_count;
-  res["vertices"] = info.vertex_count;
-  res["memory"] = info.memory_res;
-  res["disk"] = info.disk_usage;
-  res["label_indices"] = info.label_indices;
-  res["label_prop_indices"] = info.label_property_indices;
-  res["text_indices"] = info.text_indices;
-  res["vector_indices"] = info.vector_indices;
-  res["vector_edge_indices"] = info.vector_edge_indices;
-  res["existence_constraints"] = info.existence_constraints;
-  res["unique_constraints"] = info.unique_constraints;
-  res["type_constraints"] = info.type_constraints;
-  res["storage_mode"] = storage::StorageModeToString(info.storage_mode);
-  res["isolation_level"] = storage::IsolationLevelToString(info.isolation_level);
-  res["durability"] = {{"snapshot_enabled", info.durability_snapshot_enabled},
-                       {"WAL_enabled", info.durability_wal_enabled}};
-  res["property_store_compression_enabled"] = info.property_store_compression_enabled;
-  res["property_store_compression_level"] = utils::CompressionLevelToString(info.property_store_compression_level);
-  res["schema_vertex_count"] = info.schema_vertex_count;
-  res["schema_edge_count"] = info.schema_edge_count;
-  return res;
-}
+nlohmann::json ToJson(const StorageInfo &info);
 
 struct EdgeInfoForDeletion {
   std::unordered_set<Gid> partial_src_edge_ids{};

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -909,7 +909,7 @@ add_unit_test(storage_v2_wal_file
 
 add_unit_test(storage_v2_replication
     SOURCES storage_v2_replication.cpp
-    LINK_TARGETS mg::storage mg-dbms fmt::fmt mg-repl_coord_glue
+    LINK_TARGETS mg::storage mg-dbms fmt::fmt mg-repl_coord_glue storage_test_utils
 )
 
 add_unit_test(storage_v2_error
@@ -944,7 +944,7 @@ add_unit_test(storage_v2_storage_mode
 
 add_unit_test(storage_v2_schema_info
     SOURCES storage_v2_schema_info.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage storage_test_utils
 )
 
 add_unit_test(storage_v2_config

--- a/tests/unit/plan_pretty_print.cpp
+++ b/tests/unit/plan_pretty_print.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include "disk_test_utils.hpp"
 #include "query/frontend/ast/ast.hpp"

--- a/tests/unit/storage_test_utils.cpp
+++ b/tests/unit/storage_test_utils.cpp
@@ -11,6 +11,10 @@
 
 #include "storage_test_utils.hpp"
 
+#include <algorithm>
+
+#include <nlohmann/json.hpp>
+
 size_t CountVertices(memgraph::storage::Storage::Accessor &storage_accessor, memgraph::storage::View view) {
   auto vertices = storage_accessor.Vertices(view);
   size_t count = 0U;
@@ -29,4 +33,29 @@ std::string_view StorageModeToString(memgraph::storage::StorageMode storage_mode
     case memgraph::storage::StorageMode::N:
       __builtin_unreachable();
   }
+}
+
+bool ConfrontJSON(const nlohmann::json &lhs, const nlohmann::json &rhs) {
+  if (lhs.type() == rhs.type()) {
+    if (lhs.type() == nlohmann::detail::value_t::array) {
+      // Comparing two arrays (NO NESTED ARRAYS)
+      const auto &lhs_array = lhs.get_ref<const nlohmann::json::array_t &>();
+      const auto &rhs_array = rhs.get_ref<const nlohmann::json::array_t &>();
+      return std::is_permutation(lhs_array.begin(), lhs_array.end(), rhs_array.begin(), rhs_array.end(), ConfrontJSON);
+    }
+    if (lhs.type() == nlohmann::detail::value_t::object) {
+      const auto &lhs_object = lhs.get_ref<const nlohmann::json::object_t &>();
+      const auto &rhs_object = rhs.get_ref<const nlohmann::json::object_t &>();
+      if (lhs_object.size() != rhs_object.size()) return false;
+      for (const auto &[key, val] : lhs_object) {
+        try {
+          if (!ConfrontJSON(val, rhs_object.at(key))) return false;
+        } catch (std::range_error &) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+  return lhs == rhs;
 }

--- a/tests/unit/storage_test_utils.hpp
+++ b/tests/unit/storage_test_utils.hpp
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/storage.hpp"
@@ -29,30 +29,7 @@ inline auto &FindProp(auto &in, std::string_view key) {
   return *itr;
 }
 
-inline bool ConfrontJSON(const nlohmann::json &lhs, const nlohmann::json &rhs) {
-  if (lhs.type() == rhs.type()) {
-    if (lhs.type() == nlohmann::detail::value_t::array) {
-      // Comparing two arrays (NO NESTED ARRAYS)
-      const auto &lhs_array = lhs.get_ref<const nlohmann::json::array_t &>();
-      const auto &rhs_array = rhs.get_ref<const nlohmann::json::array_t &>();
-      return std::is_permutation(lhs_array.begin(), lhs_array.end(), rhs_array.begin(), rhs_array.end(), ConfrontJSON);
-    }
-    if (lhs.type() == nlohmann::detail::value_t::object) {
-      const auto &lhs_object = lhs.get_ref<const nlohmann::json::object_t &>();
-      const auto &rhs_object = rhs.get_ref<const nlohmann::json::object_t &>();
-      if (lhs_object.size() != rhs_object.size()) return false;
-      for (const auto &[key, val] : lhs_object) {
-        try {
-          if (!ConfrontJSON(val, rhs_object.at(key))) return false;
-        } catch (std::range_error &) {
-          return false;
-        }
-      }
-      return true;
-    }
-  }
-  return lhs == rhs;
-}
+bool ConfrontJSON(const nlohmann::json &lhs, const nlohmann::json &rhs);
 
 /** Test helper to validate the properties of any vertices within the given
  * property ranges.

--- a/tests/unit/storage_test_utils.hpp
+++ b/tests/unit/storage_test_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -10,6 +10,8 @@
 // licenses/APL.txt.
 
 #pragma once
+
+#include <nlohmann/json.hpp>
 
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/storage.hpp"

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -31,6 +31,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <nlohmann/json.hpp>
+
 #include "dbms/database.hpp"
 #include "flags/experimental.hpp"
 #include "flags/general.hpp"

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -20,6 +20,7 @@
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include <storage/v2/inmemory/storage.hpp>
 #include <storage/v2/property_value.hpp>

--- a/tests/unit/typed_value.cpp
+++ b/tests/unit/typed_value.cpp
@@ -15,6 +15,8 @@
 //
 #include <vector>
 
+#include <nlohmann/json.hpp>
+
 #include "gtest/gtest.h"
 
 #include "disk_test_utils.hpp"


### PR DESCRIPTION
The storage, schema-tracking and database serialisation is declared in the headers and defined alongside the code that uses it, so compiling something that only touches those types does not parse the JSON library. The schema tracking's serialisation belongs to a class template, so it is instantiated explicitly for each container a tracking is built from, and the test helper that compares two JSON values moves the same way, which makes a test calling it link the library holding the definition.

Every file that named the JSON type while relying on another header to supply it now includes it itself. One header still needs the library complete: the serialisation declarations in `query/serialization` name its nested array and object types, and no forward declaration covers a nested type.
