### PR TITLE
feat: add core_limit to license

### DIFF
--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -469,6 +469,7 @@ std::string Encode(const License &license) {
   slk::Save(license.valid_until, &builder);
   slk::Save(license.memory_limit, &builder);
   slk::Save(license.type, &builder);
+  slk::Save(license.core_limit, &builder);
   builder.Finalize();
 
   return std::string{license_key_prefix} + utils::base64_encode(buffer.data(), buffer.size());
@@ -503,13 +504,19 @@ std::optional<License> Decode(std::string_view license_key) {
     slk::Load(&memory_limit, &reader);
     std::underlying_type_t<LicenseType> license_type{0};
     slk::Load(&license_type, &reader);
+    int64_t core_limit{0};
+    try {
+      slk::Load(&core_limit, &reader);
+    } catch (const slk::SlkReaderException & /*exception*/) {
+      core_limit = 0;
+    }
     const auto typed = static_cast<LicenseType>(license_type);
     switch (typed) {
       case LicenseType::ENTERPRISE:
       case LicenseType::OEM_COMMUNITY:
       case LicenseType::AI_PLATFORM:
       case LicenseType::OEM:
-        return License{organization_name, valid_until, memory_limit, typed};
+        return License{organization_name, valid_until, memory_limit, typed, core_limit};
     }
     return std::nullopt;
   } catch (const slk::SlkReaderException &e) {

--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -507,8 +507,7 @@ std::optional<License> Decode(std::string_view license_key) {
     int64_t core_limit{0};
     try {
       slk::Load(&core_limit, &reader);
-    } catch (const slk::SlkReaderException & /*exception*/) {
-      core_limit = 0;
+    } catch (const slk::SlkReaderException & /*exception*/) {  // NOLINT(bugprone-empty-catch)
     }
     const auto typed = static_cast<LicenseType>(license_type);
     switch (typed) {
@@ -516,7 +515,7 @@ std::optional<License> Decode(std::string_view license_key) {
       case LicenseType::OEM_COMMUNITY:
       case LicenseType::AI_PLATFORM:
       case LicenseType::OEM:
-        return License{organization_name, valid_until, memory_limit, typed, core_limit};
+        return License{std::move(organization_name), valid_until, memory_limit, typed, core_limit};
     }
     return std::nullopt;
   } catch (const slk::SlkReaderException &e) {

--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -101,6 +101,9 @@ std::string LicenseTypeToString(const LicenseType license_type) {
     case LicenseType::OEM: {
       return std::string{kLicenseTypeOem};
     }
+    case LicenseType::MEMGQL: {
+      return std::string{kLicenseTypeMemgql};
+    }
   }
   std::unreachable();
 }
@@ -445,6 +448,7 @@ DetailedLicenseInfo LicenseChecker::GetDetailedLicenseInfo() {
       info.status = "You are running a valid Memgraph OEM License.";
       break;
     case LicenseType::OEM_COMMUNITY:
+    case LicenseType::MEMGQL:
       std::unreachable();
   }
   return info;
@@ -516,6 +520,8 @@ std::optional<License> Decode(std::string_view license_key) {
       case LicenseType::AI_PLATFORM:
       case LicenseType::OEM:
         return License{std::move(organization_name), valid_until, memory_limit, typed, core_limit};
+      case LicenseType::MEMGQL:
+        return std::nullopt;
     }
     return std::nullopt;
   } catch (const slk::SlkReaderException &e) {

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -32,6 +32,7 @@ enum class LicenseType : uint8_t {
   OEM = 1,
   AI_PLATFORM = 2,
   OEM_COMMUNITY = 3,
+  MEMGQL = 4,
 };
 
 constexpr bool IsEnterpriseTier(LicenseType type) noexcept {
@@ -44,6 +45,7 @@ inline constexpr std::string_view kLicenseTypeEnterprise = "enterprise";
 inline constexpr std::string_view kLicenseTypeOem = "oem";
 inline constexpr std::string_view kLicenseTypeOemCommunity = "oem_community";
 inline constexpr std::string_view kLicenseTypeAiPlatform = "ai_platform";
+inline constexpr std::string_view kLicenseTypeMemgql = "memgql";
 
 struct License {
   License() = default;

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -48,16 +48,19 @@ inline constexpr std::string_view kLicenseTypeAiPlatform = "ai_platform";
 struct License {
   License() = default;
 
-  License(std::string organization_name, int64_t valid_until, int64_t memory_limit, LicenseType license_type)
+  License(std::string organization_name, int64_t valid_until, int64_t memory_limit, LicenseType license_type,
+          int64_t core_limit = 0)
       : organization_name{std::move(organization_name)},
         valid_until{valid_until},
         memory_limit{memory_limit},
-        type{license_type} {}
+        type{license_type},
+        core_limit{core_limit} {}
 
   std::string organization_name;
   int64_t valid_until;
   int64_t memory_limit;
   LicenseType type;
+  int64_t core_limit{0};
 
   bool operator==(const License &) const = default;
 };

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -60,6 +60,7 @@ struct License {
   int64_t valid_until;
   int64_t memory_limit;
   LicenseType type;
+  // a core_limit of 0 means unlimited — legacy keys decode to 0.
   int64_t core_limit{0};
 
   bool operator==(const License &) const = default;

--- a/tests/unit/license.cpp
+++ b/tests/unit/license.cpp
@@ -617,3 +617,9 @@ TEST_F(LicenseTest, Decode_RejectsUnknownLicenseTypeByte) {
   const auto encoded = memgraph::license::Encode(crafted);
   EXPECT_FALSE(memgraph::license::Decode(encoded).has_value());
 }
+
+TEST_F(LicenseTest, Decode_RejectsMemgqlLicense) {
+  const auto memgql = memgraph::license::License{"Memgraph", 0, 0, memgraph::license::LicenseType::MEMGQL, 16};
+  EXPECT_FALSE(memgraph::license::Decode(memgraph::license::Encode(memgql)).has_value());
+  EXPECT_FALSE(memgraph::license::IsEnterpriseTier(memgraph::license::LicenseType::MEMGQL));
+}

--- a/tests/unit/license.cpp
+++ b/tests/unit/license.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include <gtest/gtest.h>
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/tests/unit/license.cpp
+++ b/tests/unit/license.cpp
@@ -12,8 +12,12 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "license/license.hpp"
+#include "slk/serialization.hpp"
+#include "slk/streams.hpp"
+#include "utils/base64.hpp"
 #include "utils/memory_tracker.hpp"
 #include "utils/settings.hpp"
 
@@ -50,6 +54,9 @@ TEST_F(LicenseTest, EncodeDecode) {
       memgraph::license::License{
           "Some very long name for the organization Ltd", -999, -9999, memgraph::license::LicenseType::ENTERPRISE},
       memgraph::license::License{"AI Org", 0, 1024, memgraph::license::LicenseType::AI_PLATFORM},
+      memgraph::license::License{"Core Org", 0, 0, memgraph::license::LicenseType::ENTERPRISE, 16},
+      memgraph::license::License{"Core And Memory Org", 42, 1024, memgraph::license::LicenseType::OEM, 8},
+      memgraph::license::License{"Negative Core Org", -1, 0, memgraph::license::LicenseType::OEM_COMMUNITY, -4},
   };
 
   for (const auto &license : licenses) {
@@ -57,7 +64,29 @@ TEST_F(LicenseTest, EncodeDecode) {
     auto maybe_license = memgraph::license::Decode(result);
     ASSERT_TRUE(maybe_license);
     ASSERT_EQ(*maybe_license, license);
+    ASSERT_EQ(maybe_license->core_limit, license.core_limit);
   }
+}
+
+TEST_F(LicenseTest, DecodeLegacyKeyWithoutCoreLimit) {
+  const auto encode_without_core_limit = [](const memgraph::license::License &license) {
+    std::vector<uint8_t> buffer;
+    memgraph::slk::Builder builder([&buffer](const uint8_t *data, size_t size, bool /*have_more*/) {
+      buffer.insert(buffer.end(), data, data + size);
+    });
+    memgraph::slk::Save(license.organization_name, &builder);
+    memgraph::slk::Save(license.valid_until, &builder);
+    memgraph::slk::Save(license.memory_limit, &builder);
+    memgraph::slk::Save(license.type, &builder);
+    builder.Finalize();
+    return "mglk-" + memgraph::utils::base64_encode(buffer.data(), buffer.size());
+  };
+
+  const memgraph::license::License license{"Legacy Org", 0, 1024, memgraph::license::LicenseType::ENTERPRISE, 0};
+  const auto maybe_license = memgraph::license::Decode(encode_without_core_limit(license));
+  ASSERT_TRUE(maybe_license);
+  ASSERT_EQ(*maybe_license, license);
+  ASSERT_EQ(maybe_license->core_limit, 0);
 }
 
 TEST_F(LicenseTest, TestingFlag) {


### PR DESCRIPTION
Added optional `core_limit` field to the License struct to go with https://github.com/memgraph/mgkeygen/pull/15.

