### PR TITLE
fix(storage): request the async indexer stop before taking its mutex, notify under it

### DIFF
--- a/src/storage/v2/async_indexer.cpp
+++ b/src/storage/v2/async_indexer.cpp
@@ -145,9 +145,15 @@ void AsyncIndexer::Start(std::stop_token stop_token, Storage *storage) {
 }
 
 void AsyncIndexer::Shutdown() {
+  // Request first, without the mutex: a worker in the middle of an index build holds mutex_ for the whole build and
+  // polls the token, so it must see the request without waiting for the mutex. Then take the mutex before notifying:
+  // an idle worker evaluates its wait predicate (which reads the token) under mutex_ and then sleeps, so a notify
+  // without the mutex can land between that evaluation and the sleep and be lost, leaving the worker asleep for good
+  // and this wait never returning. Under the mutex the notify reaches a waiter that is already asleep, and a worker
+  // still evaluating the predicate sees the request.
   index_creator_thread_.request_stop();
-  cv_.notify_all();
   auto guard = std::unique_lock{mutex_};
+  cv_.notify_all();
   cv_.wait(guard, [this] { return HasThreadStopped(); });
 }
 


### PR DESCRIPTION
## Problem

`AsyncIndexer::Shutdown` requests the worker's stop and notifies the condition variable before taking `mutex_`. The worker evaluates its wait predicate, which reads the stop token, under that mutex and then sleeps. A request and notify that land between the evaluation and the sleep are lost: the worker sleeps for good and `Shutdown`'s own wait never returns.

A storage destroyed shortly after construction hits the window often. A test that recovers a directory and destroys the storage within milliseconds hung in about one run in four.

## Change

Request the stop first, without the mutex, so a worker in the middle of an index build (which holds `mutex_` for the whole build and polls the token) sees the request at its next poll instead of finishing the build. Then take the mutex before notifying and waiting: a worker still evaluating its predicate holds the mutex and will see the request, and a worker already asleep receives the notify.

Taking the mutex before the request would close the lost wake-up too, but a database dropped during a build would then wait for the build to finish instead of cancelling it.

## Tests

No new test. Reproduced with a construct/destroy stress harness (see the comment below): on `master` a process hangs about once every 600,000 cycles, 26 hangs in 16.3 million; with this change 16 million cycles complete with none. The hang was first noticed by death tests in a following series that create and destroy a storage within milliseconds. `storage_v2_indices` (215 passed, 53 skipped, 0 failed) and `storage_v2_durability_inmemory` (158 passed) pass on this branch.
