### PR TITLE
fix(metrics): Update metrics UUID to the database's UUID during snapshot recovery

### DIFF
--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -154,6 +154,10 @@ Database::Database(storage::Config config, std::function<storage::DatabaseProtec
                                            db_arena_.get(),
                                            &db_embedding_memory_tracker_);
   }
+
+  // Recovery adopts the uuid of the snapshot or WAL it recovered from, which need not be the one the
+  // registration was made under.
+  metrics_.Rebind(storage_->uuid());
 }
 
 DatabaseInfo Database::GetInfo() const {

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -1100,7 +1100,7 @@ void PrometheusMetrics::Registration::Rebind(utils::UUID const &new_uuid) {
 }
 
 void PrometheusMetrics::RebindRegistration(uint64_t entry_id, utils::UUID const &new_uuid) {
-  std::lock_guard const lock{databases_.mutex};
+  std::scoped_lock const lock{databases_.mutex};
   auto it = r::find_if(databases_.entries, [entry_id](auto const &e) { return e.id == entry_id; });
   if (it == databases_.entries.end() || it->uuid == new_uuid) return;
   if (default_db_uuid_ && *default_db_uuid_ == it->uuid) {

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -1094,6 +1094,21 @@ void PrometheusMetrics::Registration::Release() noexcept {
   handles_ = {};
 }
 
+void PrometheusMetrics::Registration::Rebind(utils::UUID const &new_uuid) {
+  if (registry_ == nullptr) return;
+  registry_->RebindRegistration(entry_id_, new_uuid);
+}
+
+void PrometheusMetrics::RebindRegistration(uint64_t entry_id, utils::UUID const &new_uuid) {
+  std::lock_guard const lock{databases_.mutex};
+  auto it = r::find_if(databases_.entries, [entry_id](auto const &e) { return e.id == entry_id; });
+  if (it == databases_.entries.end() || it->uuid == new_uuid) return;
+  if (default_db_uuid_ && *default_db_uuid_ == it->uuid) {
+    default_db_uuid_ = new_uuid;
+  }
+  it->uuid = new_uuid;
+}
+
 void PrometheusMetrics::ReleaseRegistration(uint64_t entry_id) {
   std::lock_guard const lock{databases_.mutex};
   auto it = r::find_if(databases_.entries, [entry_id](auto const &e) { return e.id == entry_id; });

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -203,6 +203,9 @@ class PrometheusMetrics {
 
     DatabaseMetricHandles &handles() { return handles_; }
 
+    /// Points this entry at `new_uuid`. The metric objects and the handles into them stay put.
+    void Rebind(utils::UUID const &new_uuid);
+
    private:
     friend class PrometheusMetrics;
 
@@ -269,6 +272,8 @@ class PrometheusMetrics {
 
   /// Drops one registration of the entry, and the metrics with the last of them.
   void ReleaseRegistration(uint64_t entry_id);
+
+  void RebindRegistration(uint64_t entry_id, utils::UUID const &new_uuid);
 
   StorageSnapshot ResolveStorageSnapshot(utils::UUID const &uuid) const;
 

--- a/tests/e2e/show_metrics/show_metrics_recovery.py
+++ b/tests/e2e/show_metrics/show_metrics_recovery.py
@@ -117,7 +117,8 @@ def data_dir(name):
 def test_metrics_available_after_recovering_a_foreign_snapshot():
     """A snapshot carries the uuid of the database that wrote it, and recovery adopts it. Metrics are
     registered before recovery runs, so they must follow that uuid or SHOW METRICS INFO cannot find the
-    database. A replica recovering from MAIN is the production route into this state."""
+    database. Recovering a data directory holding a snapshot written elsewhere, such as a restored
+    backup, is the route into this state."""
     for name in FOREIGN_SNAPSHOT_DESCRIPTION:
         shutil.rmtree(data_dir(name), ignore_errors=True)
 

--- a/tests/e2e/show_metrics/show_metrics_recovery.py
+++ b/tests/e2e/show_metrics/show_metrics_recovery.py
@@ -9,7 +9,9 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
+import glob
 import os
+import shutil
 import sys
 
 import interactive_mg_runner
@@ -34,6 +36,32 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
         "data_directory": "show_metrics/recovery/main",
         "setup_queries": [],
     }
+}
+
+# Two instances so one can recover from the other's snapshot, which carries a different database uuid.
+FOREIGN_SNAPSHOT_DESCRIPTION = {
+    "first": {
+        "args": [
+            "--bolt-port",
+            "7687",
+            "--log-level=TRACE",
+            "--storage-snapshot-on-exit=true",
+        ],
+        "log_file": "show_metrics/foreign/first.log",
+        "data_directory": "show_metrics/foreign/first",
+        "setup_queries": [],
+    },
+    "second": {
+        "args": [
+            "--bolt-port",
+            "7688",
+            "--log-level=TRACE",
+            "--storage-snapshot-on-exit=true",
+        ],
+        "log_file": "show_metrics/foreign/second.log",
+        "data_directory": "show_metrics/foreign/second",
+        "setup_queries": [],
+    },
 }
 
 
@@ -73,6 +101,51 @@ def test_index_and_constraint_gauges_correct_after_recovery():
     assert get_metric_value(instance, "ActiveExistenceConstraints") == 1
     assert get_metric_value(instance, "ActiveUniqueConstraints") == 1
     assert get_metric_value(instance, "SnapshotRecoveryLatency_us_50p") > 0
+
+
+def database_uuid(instance):
+    for row in instance.query("SHOW STORAGE INFO ON CURRENT DATABASE"):
+        if row[0] == "database_uuid":
+            return row[1]
+    return None
+
+
+def data_dir(name):
+    return os.path.join(interactive_mg_runner.BUILD_DIR, "e2e", "data", "show_metrics", "foreign", name)
+
+
+def test_metrics_available_after_recovering_a_foreign_snapshot():
+    """A snapshot carries the uuid of the database that wrote it, and recovery adopts it. Metrics are
+    registered before recovery runs, so they must follow that uuid or SHOW METRICS INFO cannot find the
+    database. A replica recovering from MAIN is the production route into this state."""
+    for name in FOREIGN_SNAPSHOT_DESCRIPTION:
+        shutil.rmtree(data_dir(name), ignore_errors=True)
+
+    interactive_mg_runner.start_all(FOREIGN_SNAPSHOT_DESCRIPTION)
+    first = interactive_mg_runner.MEMGRAPH_INSTANCES["first"]
+    second = interactive_mg_runner.MEMGRAPH_INSTANCES["second"]
+
+    first.query("CREATE (:Node);")
+    second.query("CREATE (:Node);")
+    second.query("CREATE (:Node);")
+    foreign_uuid = database_uuid(second)
+    assert database_uuid(first) != foreign_uuid
+
+    interactive_mg_runner.stop(FOREIGN_SNAPSHOT_DESCRIPTION, "first")
+    interactive_mg_runner.stop(FOREIGN_SNAPSHOT_DESCRIPTION, "second")
+
+    for stale in glob.glob(os.path.join(data_dir("first"), "snapshots", "*")) + glob.glob(
+        os.path.join(data_dir("first"), "wal", "*")
+    ):
+        os.remove(stale)
+    for snapshot in glob.glob(os.path.join(data_dir("second"), "snapshots", "*")):
+        shutil.copy(snapshot, os.path.join(data_dir("first"), "snapshots"))
+
+    interactive_mg_runner.start(FOREIGN_SNAPSHOT_DESCRIPTION, "first")
+    first = interactive_mg_runner.MEMGRAPH_INSTANCES["first"]
+
+    assert database_uuid(first) == foreign_uuid
+    assert get_metric_value(first, "VertexCount") == 2
 
 
 if __name__ == "__main__":

--- a/tests/unit/dbms_database.cpp
+++ b/tests/unit/dbms_database.cpp
@@ -17,6 +17,7 @@
 #include "dbms/database_handler.hpp"
 #include "dbms/global.hpp"
 #include "memory/db_arena.hpp"
+#include "metrics/prometheus_metrics.hpp"
 
 #include "license/license.hpp"
 #include "query_plan_common.hpp"
@@ -234,6 +235,47 @@ TEST_F(DBMS_Database, DeleteAndRecover) {
       ASSERT_EQ(dba.VerticesCount(), 3);
     }
   }
+}
+
+// The metrics registration is made before recovery runs, so it must follow the uuid recovery adopts.
+TEST_F(DBMS_Database, MetricsFollowUuidAdoptedDuringRecovery) {
+  memgraph::license::global_license_checker.EnableTesting();
+  memgraph::dbms::DatabaseHandler db_handler;
+
+  auto make_conf = [](memgraph::utils::UUID uuid, bool recover) {
+    memgraph::storage::Config conf{
+        .durability = {.storage_directory = storage_directory / "recov",
+                       .recover_on_startup = recover,
+                       .snapshot_wal_mode =
+                           memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_on_exit = true},
+        .disk = {.main_storage_directory = storage_directory / "recov" / "disk"},
+        .salient.name = "recov"};
+    conf.salient.uuid = uuid;
+    return conf;
+  };
+
+  memgraph::utils::UUID const snapshot_uuid{};
+  {
+    auto db = db_handler.New(make_conf(snapshot_uuid, false));
+    ASSERT_TRUE(db.has_value());
+    const memgraph::memory::DbArenaScope arena_scope{&db.value()->Arena()};
+    auto storage_dba = db.value()->Access(memgraph::storage::WRITE);
+    memgraph::query::DbAccessor dba{storage_dba.get()};
+    dba.InsertVertex();
+    ASSERT_TRUE(dba.Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  ASSERT_TRUE(db_handler.TryDelete("recov"));
+
+  // Rebuild from the snapshot, with a config carrying a different uuid.
+  memgraph::utils::UUID const config_uuid{};
+  ASSERT_NE(std::string(config_uuid), std::string(snapshot_uuid));
+  auto db = db_handler.New(make_conf(config_uuid, true));
+  ASSERT_TRUE(db.has_value());
+
+  ASSERT_EQ(std::string(db.value()->uuid()), std::string(snapshot_uuid));
+
+  EXPECT_TRUE(memgraph::metrics::Metrics().GetDbMetricsInfo(db.value()->uuid()).has_value());
 }
 
 #endif


### PR DESCRIPTION
A database tells the metrics system its UUID before it loads its data. Loading can change the UUID, as recovering from a snapshot adopts the UUID stored in that snapshot, which is not always the one the database started with. Nothing tells the metrics system, so it kept the old UUID and any `SHOW METRICS INFO` queries would fail because the metrics for the main database could not be found.

A snapshot carrying a different ID is normal: a replica gets one from its main.

The fix updates the metrics system with the ID the database ends up with, once its data is loaded.

The OpenMetrics scrape also reports a stale ID after this. That is a separate problem, fixed by #4275.
