### PR TITLE
test(telemetry): accept an event that arrives more than once

### DIFF
--- a/tests/integration/telemetry/server.py
+++ b/tests/integration/telemetry/server.py
@@ -107,6 +107,30 @@ def item_sort_key(obj):
     return obj["timestamp"]
 
 
+def drop_resends(storage):
+    """Collapse each event to the first copy of it that arrived.
+
+    A client keeps an event until the server acknowledges it, so an acknowledgement that
+    is lost or arrives too late leaves the event to be sent again. Delivery is therefore
+    at least once, and the checks below, which read an event's position as its number,
+    need one copy of each.
+
+    A repeat is built from the payload recorded when the event happened, so it must equal
+    the copy already held. One that differs is a defect rather than a repeat, and fails
+    here instead of being collapsed away.
+    """
+    first_by_event = {}
+    unique = []
+    for item in storage:
+        key = (item["run_id"], repr(item["event"]))
+        if key in first_by_event:
+            assert item == first_by_event[key], f"event {item['event']} arrived twice with different content"
+            continue
+        first_by_event[key] = item
+        unique.append(item)
+    return unique
+
+
 def verify_storage(storage, args):
     rid = storage[0]["run_id"]
     version = storage[0]["version"]
@@ -219,6 +243,8 @@ if __name__ == "__main__":
 
     # Order the received data.
     storage.sort(key=item_sort_key)
+
+    storage = drop_resends(storage)
 
     # Split the data into individual startups.
     startups = [[storage[0]]]


### PR DESCRIPTION
The client holds each event in local storage until the collector acknowledges
it, so an acknowledgement that is lost or arrives late leaves the event to be
sent again and delivery is at least once. The collector checks the sequence it
received by reading an event's position as its number, which needs one copy of
each.

Repeats collapse to the first copy of an event before that check. A repeat
carries the payload recorded when the event happened, so a copy that differs
from the one already held is a defect rather than a repeat, and fails naming
the event. What the client sends is unchanged.
