### PR TITLE
perf(storage): batch small durability encoder writes

### DIFF
--- a/src/storage/v2/durability/serialization.cpp
+++ b/src/storage/v2/durability/serialization.cpp
@@ -367,6 +367,8 @@ template <typename FileType>
 void Encoder<FileType>::TryFlushing()
   requires std::same_as<FileType, utils::OutputFile>
 {
+  // The drain is an ordinary file write and waits on the flush lock like every fragment did
+  // before staging; only the flush of the file layer's buffer below is best effort.
   DrainStage();
   file_.TryFlushing();
 }

--- a/src/storage/v2/durability/serialization.cpp
+++ b/src/storage/v2/durability/serialization.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <optional>
 
 #include "storage/v2/durability/marker.hpp"
@@ -69,16 +70,35 @@ bool Encoder<FileType>::OpenExisting(const std::filesystem::path &path) {
 template <typename FileType>
 void Encoder<FileType>::Close() {
   if (file_.IsOpen()) {
+    DrainStage();
     file_.Close();
   }
 }
 
 template <typename FileType>
+void Encoder<FileType>::DrainStage() {
+  if (staged_ == 0) return;
+  file_.Write(stage_.data(), staged_);
+  crc_acc.Update(stage_.data(), static_cast<uint32_t>(staged_));
+  staged_ = 0;
+}
+
+template <typename FileType>
 void Encoder<FileType>::Write(const uint8_t *data, uint64_t size) {
-  file_.Write(data, size);
+  // Also prevents a null empty view from resetting the running CRC: crc32(c, NULL, 0) returns 0.
+  if (size == 0) return;
   logical_position_ += size;
   logical_size_ = std::max(logical_size_, logical_position_);
-  crc_acc.Update(data, size);
+  if (size > kStageCapacity / 2) {
+    // Large payloads go straight through, after whatever precedes them in the stream.
+    DrainStage();
+    file_.Write(data, size);
+    crc_acc.Update(data, static_cast<uint32_t>(size));
+    return;
+  }
+  if (staged_ + size > kStageCapacity) DrainStage();
+  memcpy(stage_.data() + staged_, data, size);
+  staged_ += size;
 }
 
 template <typename FileType>
@@ -297,6 +317,7 @@ template <typename FileType>
 std::optional<uint64_t> Encoder<FileType>::AppendFrom(int src_fd, uint64_t size)
   requires std::same_as<FileType, utils::NonConcurrentOutputFile>
 {
+  DrainStage();
   auto const appended = file_.AppendFrom(src_fd, size);
   if (appended) {
     logical_position_ += *appended;
@@ -307,16 +328,19 @@ std::optional<uint64_t> Encoder<FileType>::AppendFrom(int src_fd, uint64_t size)
 
 template <typename FileType>
 void Encoder<FileType>::SetPosition(uint64_t position) {
+  DrainStage();
   logical_position_ = file_.SetPosition(FileType::Position::SET, position);
 }
 
 template <typename FileType>
 void Encoder<FileType>::Sync() {
+  DrainStage();
   file_.Sync();
 }
 
 template <typename FileType>
 void Encoder<FileType>::Finalize(utils::PageCachePolicy page_cache) {
+  DrainStage();
   file_.Sync();
   // After the sync every page is clean, which is the only state in which dropping them works.
   if (page_cache == utils::PageCachePolicy::kDrop) file_.DropCachedPages();
@@ -327,6 +351,8 @@ template <typename FileType>
 void Encoder<FileType>::DisableFlushing()
   requires std::same_as<FileType, utils::OutputFile>
 {
+  // A reader that pins the buffer must see everything written so far.
+  DrainStage();
   file_.DisableFlushing();
 }
 
@@ -341,11 +367,13 @@ template <typename FileType>
 void Encoder<FileType>::TryFlushing()
   requires std::same_as<FileType, utils::OutputFile>
 {
+  DrainStage();
   file_.TryFlushing();
 }
 
 template <typename FileType>
 std::pair<const uint8_t *, size_t> Encoder<FileType>::CurrentFileBuffer() const {
+  // Exposes the file layer's buffer, which is what pinning freezes.
   return file_.CurrentBuffer();
 }
 

--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -54,6 +54,13 @@ class BaseEncoder {
 template <typename FileType>
 class Encoder final : public BaseEncoder {
  public:
+  Encoder() = default;
+  // Pending writes belong to this encoder; copying and moving are unsupported.
+  Encoder(Encoder const &) = delete;
+  Encoder &operator=(Encoder const &) = delete;
+  Encoder(Encoder &&) = delete;
+  Encoder &operator=(Encoder &&) = delete;
+
   bool Initialize(const std::filesystem::path &path);
   bool Initialize(const std::filesystem::path &path, std::string_view magic, uint64_t version);
 

--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>
 #include <concepts>
 #include <cstdint>
 #include <filesystem>
@@ -59,8 +60,6 @@ class Encoder final : public BaseEncoder {
   bool OpenExisting(const std::filesystem::path &path);
 
   void Close();
-  // Main write function, the only one that is allowed to write to the `file_`
-  // directly.
   void Write(const uint8_t *data, uint64_t size);
 
   /// See NonConcurrentOutputFile::AppendFrom.
@@ -112,16 +111,33 @@ class Encoder final : public BaseEncoder {
 
   auto GetPath() const { return file_.path(); }
 
-  void ResetCrcAcc() override { crc_acc.Reset(); }
+  // A CRC reset marks a point in the stream, so whatever is staged belongs to the stream before it.
+  void ResetCrcAcc() override {
+    DrainStage();
+    crc_acc.Reset();
+  }
 
-  auto CrcAccValue() const -> uint32_t override { return crc_acc.Value(); }
+  // The accumulator only covers bytes handed to the file; fold the staged tail in without disturbing it.
+  auto CrcAccValue() const -> uint32_t override {
+    if (staged_ == 0) return crc_acc.Value();
+    auto acc = crc_acc;
+    acc.Update(stage_.data(), static_cast<uint32_t>(staged_));
+    return acc.Value();
+  }
+
+  ~Encoder() { DrainStage(); }
 
  private:
+  // Batch small writes to amortize file locking and encoder CRC updates. Position/size getters
+  // are logical; operations that read or reposition the file drain first.
+  static constexpr size_t kStageCapacity = 16 * 1024;
+  void DrainStage();
+
   FileType file_;
   utils::CrcAccumulator crc_acc;
-  // Logical write position: the file offset plus the bytes still sitting in file_'s buffer. Tracked
-  // here so GetPosition never has to flush the buffer and seek — two syscalls per query which, on the
-  // WAL hot path (every transaction records its start and end positions), defeat write batching.
+  std::array<uint8_t, kStageCapacity> stage_;  // intentionally uninitialized for performance
+  size_t staged_{0};
+  // File offset plus bytes in both buffers, avoiding a flush and seek for GetPosition().
   uint64_t logical_position_{0};
   // High-water mark of logical_position_: the size of everything this encoder wrote, so GetSize
   // never has to seek to the end of the file. Encoders write files from scratch or from their end

--- a/tests/unit/storage_v2_decoder_encoder.cpp
+++ b/tests/unit/storage_v2_decoder_encoder.cpp
@@ -10,9 +10,14 @@
 // licenses/APL.txt.
 
 #include <gtest/gtest.h>
+#include <zlib.h>
 
+#include <algorithm>
+#include <cstdio>
 #include <filesystem>
 #include <limits>
+#include <memory>
+#include <vector>
 
 #include "storage/v2/durability/marker.hpp"
 #include "storage/v2/durability/serialization.hpp"
@@ -39,6 +44,19 @@ class DecoderEncoderTest : public ::testing::Test {
   std::filesystem::path alternate_file{std::filesystem::temp_directory_path() /
                                        "MG_test_unit_storage_v2_decoder_encoder_alternate.bin"};
 
+  void ExpectBytes(const std::vector<uint8_t> &expected) {
+    memgraph::utils::InputFile file;
+    ASSERT_TRUE(file.Open(storage_file));
+    ASSERT_EQ(file.GetSize(), expected.size());
+    std::vector<uint8_t> actual(expected.size());
+    ASSERT_TRUE(file.Read(actual.data(), actual.size()));
+    EXPECT_EQ(actual, expected);
+  }
+
+  static uint32_t ExpectedCrc(const std::vector<uint8_t> &bytes) {
+    return crc32(0, bytes.data(), static_cast<uInt>(bytes.size()));
+  }
+
  private:
   void Clear() {
     if (std::filesystem::exists(this->storage_file)) {
@@ -52,6 +70,164 @@ class DecoderEncoderTest : public ::testing::Test {
 
 using FileTypes = testing::Types<memgraph::utils::OutputFile, memgraph::utils::NonConcurrentOutputFile>;
 TYPED_TEST_SUITE(DecoderEncoderTest, FileTypes);
+
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(DecoderEncoderTest, StagedCapacityAndBypass) {
+  memgraph::storage::durability::Encoder<TypeParam> encoder;
+  ASSERT_TRUE(encoder.Initialize(this->storage_file));
+  std::vector<uint8_t> expected(8192, 0x11);
+  expected.insert(expected.end(), 8192, 0x22);
+  encoder.Write(expected.data(), 8192);
+  encoder.Write(expected.data() + 8192, 8192);  // Exactly one full stage.
+  EXPECT_EQ(encoder.GetPosition(), 16384);
+  EXPECT_EQ(encoder.GetSize(), 16384);
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(expected));
+  const std::vector<uint8_t> prefix{0x33}, payload(8193, 0x44), suffix{0x55, 0x66};
+  encoder.Write(prefix.data(), prefix.size());  // Overflow leaves a new staged prefix.
+  EXPECT_EQ(encoder.GetPosition(), expected.size() + prefix.size());
+  EXPECT_EQ(encoder.GetSize(), expected.size() + prefix.size());
+  encoder.Write(payload.data(), payload.size());
+  EXPECT_EQ(encoder.GetPosition(), expected.size() + prefix.size() + payload.size());
+  EXPECT_EQ(encoder.GetSize(), expected.size() + prefix.size() + payload.size());
+  encoder.Write(suffix.data(), suffix.size());
+  expected.insert(expected.end(), prefix.begin(), prefix.end());
+  expected.insert(expected.end(), payload.begin(), payload.end());
+  expected.insert(expected.end(), suffix.begin(), suffix.end());
+  EXPECT_EQ(encoder.GetPosition(), expected.size());
+  EXPECT_EQ(encoder.GetSize(), expected.size());
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(expected));
+  encoder.Finalize();
+  this->ExpectBytes(expected);
+}
+
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(DecoderEncoderTest, StagedCrcAndEmptyWrites) {
+  memgraph::storage::durability::Encoder<TypeParam> encoder;
+  ASSERT_TRUE(encoder.Initialize(this->storage_file));
+  std::vector<uint8_t> expected{0x12, 0x34, 0x56};
+  encoder.Write(expected.data(), expected.size());
+  encoder.Sync();  // Give empty writes a nonzero accumulated CRC to preserve.
+  encoder.Write(nullptr, 0);
+  encoder.Write(expected.data(), 0);
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(expected));
+  encoder.WriteString(std::string_view{});
+  expected.push_back(static_cast<uint8_t>(memgraph::storage::durability::Marker::TYPE_STRING));
+  expected.insert(expected.end(), sizeof(uint64_t), 0);
+  for (int i = 0; i < 3; ++i) EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(expected));
+  expected.push_back(static_cast<uint8_t>(memgraph::storage::durability::Marker::TYPE_INT));
+  const uint64_t crc = this->ExpectedCrc(expected);
+  EXPECT_EQ(encoder.WriteCrc(), crc);
+  for (unsigned i = 0; i < sizeof(crc); ++i) expected.push_back(static_cast<uint8_t>(crc >> (8 * i)));
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(expected));
+  EXPECT_EQ(encoder.GetPosition(), expected.size());
+  encoder.Finalize();
+  this->ExpectBytes(expected);
+}
+
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(DecoderEncoderTest, StagedResetCrc) {
+  memgraph::storage::durability::Encoder<TypeParam> encoder;
+  ASSERT_TRUE(encoder.Initialize(this->storage_file));
+  const std::vector<uint8_t> prefix{1, 2, 3}, suffix{4, 5};
+  encoder.Write(prefix.data(), prefix.size());
+  encoder.ResetCrcAcc();
+  EXPECT_EQ(encoder.CrcAccValue(), 0);
+  encoder.Write(suffix.data(), suffix.size());
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(suffix));
+  encoder.Finalize();
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(suffix));
+  this->ExpectBytes({1, 2, 3, 4, 5});
+}
+
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(DecoderEncoderTest, StagedSeekAndCrcPatch) {
+  memgraph::storage::durability::Encoder<TypeParam> encoder;
+  ASSERT_TRUE(encoder.Initialize(this->storage_file));
+  std::vector<uint8_t> expected(32, 0x55);
+  auto accumulated = expected;
+  encoder.Write(expected.data(), expected.size());
+  constexpr uint64_t patch_crc = 0x12345678;
+  std::vector<uint8_t> patch{static_cast<uint8_t>(memgraph::storage::durability::Marker::TYPE_INT)};
+  for (unsigned i = 0; i < sizeof(patch_crc); ++i) patch.push_back(static_cast<uint8_t>(patch_crc >> (8 * i)));
+  encoder.WriteCrcAt(3, patch_crc);
+  std::copy(patch.begin(), patch.end(), expected.begin() + 3);
+  accumulated.insert(accumulated.end(), patch.begin(), patch.end());
+  EXPECT_EQ(encoder.GetPosition(), 12);
+  EXPECT_EQ(encoder.GetSize(), 32);
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(accumulated));  // Write order, including overwritten bytes.
+  const std::vector<uint8_t> suffix{0xaa, 0xbb, 0xcc};
+  encoder.SetPosition(31);
+  encoder.Write(suffix.data(), suffix.size());
+  expected.resize(31);
+  expected.insert(expected.end(), suffix.begin(), suffix.end());
+  accumulated.insert(accumulated.end(), suffix.begin(), suffix.end());
+  EXPECT_EQ(encoder.GetPosition(), 34);
+  EXPECT_EQ(encoder.GetSize(), 34);
+  EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(accumulated));
+  encoder.Finalize();
+  this->ExpectBytes(expected);
+}
+
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(DecoderEncoderTest, StagedCompletion) {
+  const std::vector<uint8_t> expected{1, 3, 5, 7};
+  for (int completion = 0; completion < 4; ++completion) {
+    SCOPED_TRACE(completion);  // Sync, Close, Finalize, then destructor alone.
+    std::filesystem::remove(this->storage_file);
+    {
+      memgraph::storage::durability::Encoder<TypeParam> encoder;
+      ASSERT_TRUE(encoder.Initialize(this->storage_file));
+      encoder.Write(expected.data(), expected.size());
+      EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(expected));
+      switch (completion) {
+        case 0:
+          encoder.Sync();
+          break;
+        case 1:
+          encoder.Close();
+          break;
+        case 2:
+          encoder.Finalize();
+          break;
+      }
+      if (completion != 3) this->ExpectBytes(expected);
+    }
+    this->ExpectBytes(expected);
+  }
+}
+
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(DecoderEncoderTest, StagedFileVisibility) {
+  memgraph::storage::durability::Encoder<TypeParam> encoder;
+  ASSERT_TRUE(encoder.Initialize(this->storage_file));
+  const std::vector<uint8_t> prefix{1, 2, 3}, suffix{4, 5};
+  encoder.Write(prefix.data(), prefix.size());
+  if constexpr (std::same_as<TypeParam, memgraph::utils::OutputFile>) {
+    encoder.DisableFlushing();
+    encoder.Write(suffix.data(), suffix.size());
+    const auto [data, size] = encoder.CurrentFileBuffer();
+    EXPECT_EQ(size, prefix.size());
+    EXPECT_EQ(std::vector<uint8_t>(data, data + size), prefix);
+    EXPECT_EQ(encoder.GetPosition(), prefix.size() + suffix.size());
+    encoder.EnableFlushing();
+    encoder.TryFlushing();
+    this->ExpectBytes({1, 2, 3, 4, 5});
+  } else {
+    const auto source = std::unique_ptr<FILE, decltype(&std::fclose)>{
+        std::fopen(this->alternate_file.c_str(), "w+b"), &std::fclose};
+    ASSERT_NE(source, nullptr);
+    ASSERT_EQ(std::fwrite(suffix.data(), 1, suffix.size(), source.get()), suffix.size());
+    ASSERT_EQ(std::fflush(source.get()), 0);
+    const auto appended = encoder.AppendFrom(::fileno(source.get()), suffix.size());
+    ASSERT_TRUE(appended);
+    EXPECT_EQ(*appended, suffix.size());
+    EXPECT_EQ(encoder.GetPosition(), prefix.size() + suffix.size());
+    EXPECT_EQ(encoder.GetSize(), prefix.size() + suffix.size());
+    EXPECT_EQ(encoder.CrcAccValue(), this->ExpectedCrc(prefix));  // AppendFrom does not accumulate copied bytes.
+    encoder.Finalize();
+    this->ExpectBytes({1, 2, 3, 4, 5});
+  }
+}
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(DecoderEncoderTest, ReadMarker) {


### PR DESCRIPTION
The durability encoder sent each marker, size and payload through the file
layer separately and updated its CRC for every fragment. WAL output also
takes the file buffer lock for each call. In the eight-property update
workload, a 1000-row transaction makes roughly a hundred thousand such calls
while holding engine_lock_. Batching these fragments reduces that per-call
cost across many deltas.

Stage small writes in a fixed 16 KiB encoder buffer, with payloads larger than
half the capacity bypassing it after draining the preceding bytes. Position
and size remain logical; seeks and file visibility boundaries drain the
stage, and CRC reads include its pending tail. Stream order and durability
boundaries are preserved. Empty writes now return immediately, also fixing
the null empty-view case that could reset zlib's running CRC. Buffer pinning
continues to freeze the file layer's buffer.
