### PR TITLE
fix(ci): give the merge-queue culprit a failure conclusion

### DIFF
--- a/.github/actions/cancel-on-failure-in-merge-queue/action.yml
+++ b/.github/actions/cancel-on-failure-in-merge-queue/action.yml
@@ -1,10 +1,5 @@
 name: 'Cancel run on merge_group failure'
-description: 'Cancels the current workflow run via the GitHub API to fail fast, and emits an error annotation naming the job that failed. Must be used from a separate job that lists the failing job in `needs` and is gated with `if: failure() && github.event_name == ''merge_group''`. Running it as a step of the failing job cancels that job while it is still in progress, which replaces its conclusion with `cancelled` and leaves the run with no job concluding `failure`.'
-
-inputs:
-  job-name:
-    description: 'Qualified name of the job that failed, used in the annotation. `github.job` cannot supply this: it names the job running the action, which is the canceller rather than the culprit. Pass the name as it appears in the run summary, such as "Release / Core tests", since ids like `core` are shared by several `diff_*` workflows.'
-    required: true
+description: 'Cancels the current workflow run via the GitHub API to fail fast, and emits an error annotation pointing at the job that failed. Must be used from a separate job that lists the failing job in `needs` and is gated with `if: failure() && github.event_name == ''merge_group''`. Running it as a step of the failing job cancels that job while it is still in progress, which replaces its conclusion with `cancelled` and leaves the run with no job concluding `failure`. Name the calling job after the job it guards: GitHub files an annotation under the name of the job that emitted it, and that heading is what identifies the culprit.'
 
 runs:
   using: 'composite'
@@ -15,15 +10,14 @@ runs:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
-        JOB: ${{ inputs.job-name }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         set -euo pipefail
-        # Every job still running when the cancel lands reports "cancelled",
-        # so the annotation names the culprit in the run summary for readers
-        # who reach the annotation list before the job list.
-        echo "::error title=Merge queue fail-fast triggered by job '${JOB}'::Job '${JOB}' failed and is cancelling run ${RUN_ID} to fail fast. It is the job that concluded 'failure'; jobs reported as 'cancelled' were stopped as a side effect. ${RUN_URL}"
-        echo "Cancelling workflow run ${RUN_ID} in ${GH_REPO} after merge_group failure in job '${JOB}'"
+        # Every job still running when the cancel lands reports "cancelled", so
+        # the annotation tells a reader which conclusion distinguishes the one
+        # job that failed from the ones stopped on its behalf.
+        echo "::error title=Merge queue fail-fast::Cancelling run ${RUN_ID} to fail fast. The job concluding 'failure' is the one that failed; jobs reported as 'cancelled' were stopped as a side effect. ${RUN_URL}"
+        echo "Cancelling workflow run ${RUN_ID} in ${GH_REPO} after a merge_group failure"
         curl -fsSL -X POST \
           --proto '=https' --proto-redir '=https' \
           -H "Accept: application/vnd.github+json" \

--- a/.github/actions/cancel-on-failure-in-merge-queue/action.yml
+++ b/.github/actions/cancel-on-failure-in-merge-queue/action.yml
@@ -1,11 +1,10 @@
 name: 'Cancel run on merge_group failure'
-description: 'Emits an error annotation naming the failing job, then cancels the current workflow run via the GitHub API to fail fast. The annotation makes the real culprit identifiable in the run summary even though cancellation marks every job as cancelled. The caller must gate this with `if: failure() && github.event_name == ''merge_group''` because composite actions cannot read the calling job''s runtime status.'
+description: 'Cancels the current workflow run via the GitHub API to fail fast, and emits an error annotation naming the job that failed. Must be used from a separate job that lists the failing job in `needs` and is gated with `if: failure() && github.event_name == ''merge_group''`. Running it as a step of the failing job cancels that job while it is still in progress, which replaces its conclusion with `cancelled` and leaves the run with no job concluding `failure`.'
 
 inputs:
   job-name:
-    description: 'Name used to identify the failing job in the annotation. Defaults to `github.job`, the job id, which is ambiguous when several reusable workflows in the same run share an id (e.g. the `core` job of every `diff_*` workflow) — pass a qualified name such as "Release / Core tests" in that case.'
-    required: false
-    default: ''
+    description: 'Qualified name of the job that failed, used in the annotation. `github.job` cannot supply this: it names the job running the action, which is the canceller rather than the culprit. Pass the name as it appears in the run summary, such as "Release / Core tests", since ids like `core` are shared by several `diff_*` workflows.'
+    required: true
 
 runs:
   using: 'composite'
@@ -16,15 +15,14 @@ runs:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
-        JOB: ${{ inputs.job-name != '' && inputs.job-name || github.job }}
+        JOB: ${{ inputs.job-name }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         set -euo pipefail
-        # Cancelling the run marks every still-running job as "cancelled", which
-        # hides which job actually failed. Emit an error annotation from this
-        # (the failing) job first: it is attributed to this job and shows up in
-        # the run summary, pointing reviewers at the real culprit.
-        echo "::error title=Merge queue fail-fast triggered by job '${JOB}'::Job '${JOB}' failed and is cancelling run ${RUN_ID} to fail fast. Other jobs reported as 'cancelled' were stopped as a side effect — '${JOB}' is the job that actually failed. ${RUN_URL}"
+        # Every job still running when the cancel lands reports "cancelled",
+        # so the annotation names the culprit in the run summary for readers
+        # who reach the annotation list before the job list.
+        echo "::error title=Merge queue fail-fast triggered by job '${JOB}'::Job '${JOB}' failed and is cancelling run ${RUN_ID} to fail fast. It is the job that concluded 'failure'; jobs reported as 'cancelled' were stopped as a side effect. ${RUN_URL}"
         echo "Cancelling workflow run ${RUN_ID} in ${GH_REPO} after merge_group failure in job '${JOB}'"
         curl -fsSL -X POST \
           --proto '=https' --proto-redir '=https' \

--- a/.github/actions/mgbuild-session/action.yml
+++ b/.github/actions/mgbuild-session/action.yml
@@ -1,0 +1,73 @@
+name: 'Open an mgbuild session'
+description: 'Prepares a self-hosted runner to build with mgbuild: clears leftover Docker state, logs in to Docker Hub, spins up the mgbuild container for the given toolchain and platform, and checks that the container can produce core dumps. The caller closes the session with its own `mgbuild.sh stop --remove` step, so the build and test steps it wraps stay in the calling workflow. Requires the repository to be checked out first, since this action and the Docker Hub login it performs are both local.'
+
+inputs:
+  username:
+    description: 'Docker Hub username.'
+    required: true
+  password:
+    description: 'Docker Hub password or token.'
+    required: true
+  os:
+    description: 'Target OS for the mgbuild container, such as `ubuntu-24.04`.'
+    required: true
+  arch:
+    description: 'Target architecture, `amd` or `arm`.'
+    required: true
+  toolchain:
+    description: 'Toolchain version the container is built for, such as `v8`.'
+    required: true
+  no-ccache:
+    description: 'Set to `true` to spin the container up with ccache disabled.'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Clean up Docker
+      if: always()
+      continue-on-error: true
+      shell: bash
+      run: |
+        ./tools/ci/docker_cleanup.sh
+
+    - name: Log in to Docker Hub
+      uses: ./.github/actions/docker-login
+      with:
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Spin up mgbuild container
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        OS: ${{ inputs.os }}
+        ARCH: ${{ inputs.arch }}
+        TOOLCHAIN: ${{ inputs.toolchain }}
+        NO_CCACHE: ${{ inputs.no-ccache }}
+      run: |
+        CCACHE_FLAG=""
+        if [ "$NO_CCACHE" = "true" ]; then
+          CCACHE_FLAG="--no-ccache"
+        fi
+        USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
+        ./release/package/mgbuild.sh \
+        --toolchain $TOOLCHAIN \
+        --os $OS \
+        --arch $ARCH \
+        $CCACHE_FLAG \
+        run --custom-mirror $USE_CUSTOM_MIRROR
+
+    - name: Check core dump support
+      shell: bash
+      env:
+        OS: ${{ inputs.os }}
+        ARCH: ${{ inputs.arch }}
+        TOOLCHAIN: ${{ inputs.toolchain }}
+      run: |
+        ./release/package/mgbuild.sh \
+        --toolchain $TOOLCHAIN \
+        --os $OS \
+        --arch $ARCH \
+        check-core-dumps

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -171,8 +171,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  core_fail_fast:
+    name: "Fail fast (Core tests)"
+    needs: core
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Community / Core tests"

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -182,5 +182,3 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Community / Core tests"

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -243,8 +243,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Coverage / Core tests"
 
   clang-tidy:
     if: ${{ inputs.run_clang_tidy == 'true' }}
@@ -380,5 +378,3 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Coverage / Clang tidy"

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -232,8 +232,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  core_fail_fast:
+    name: "Fail fast (Core tests)"
+    needs: core
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Coverage / Core tests"
@@ -361,8 +369,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  clang_tidy_fail_fast:
+    name: "Fail fast (Clang tidy)"
+    needs: clang-tidy
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Coverage / Clang tidy"

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -227,8 +227,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  core_fail_fast:
+    name: "Fail fast (Core tests)"
+    needs: core
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Debug / Core tests"
@@ -344,8 +352,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  integration_fail_fast:
+    name: "Fail fast (Integration test)"
+    needs: integration
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Debug / Integration test"

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -238,8 +238,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Debug / Core tests"
 
   integration:
     if: ${{ inputs.run_integration == 'true' }}
@@ -363,5 +361,3 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Debug / Integration test"

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -225,5 +225,3 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Jepsen / Core tests"

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -214,8 +214,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  core_fail_fast:
+    name: "Fail fast (Core tests)"
+    needs: core
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Jepsen / Core tests"

--- a/.github/workflows/diff_mgcxx.yml
+++ b/.github/workflows/diff_mgcxx.yml
@@ -40,8 +40,16 @@ jobs:
         make -j$(nproc)
         ctest --output-on-failure -j$(nproc)
 
+  MGCXXTest_fail_fast:
+    name: "Fail fast (Test MGCXX)"
+    needs: MGCXXTest
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Set up repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Cancel run on merge_group failure
-      if: ${{ failure() && github.event_name == 'merge_group' }}
       uses: ./.github/actions/cancel-on-failure-in-merge-queue
       with:
         job-name: "MGCXX / Test MGCXX"

--- a/.github/workflows/diff_mgcxx.yml
+++ b/.github/workflows/diff_mgcxx.yml
@@ -51,5 +51,3 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Cancel run on merge_group failure
       uses: ./.github/actions/cancel-on-failure-in-merge-queue
-      with:
-        job-name: "MGCXX / Test MGCXX"

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -328,8 +328,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Release / Core tests"
 
   benchmark:
     if: ${{ inputs.run_benchmark == 'true' }}
@@ -698,8 +696,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Release / Benchmark"
 
   e2e:
     if: ${{ inputs.run_e2e == 'true' }}
@@ -871,8 +867,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Release / End to end tests"
 
   stress:
     if: ${{ inputs.run_stress == 'true' }}
@@ -1063,5 +1057,3 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Release / Stress tests"

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -317,8 +317,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  core_fail_fast:
+    name: "Fail fast (Core tests)"
+    needs: core
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Release / Core tests"
@@ -679,8 +687,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  benchmark_fail_fast:
+    name: "Fail fast (Benchmark)"
+    needs: benchmark
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Release / Benchmark"
@@ -844,8 +860,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  e2e_fail_fast:
+    name: "Fail fast (End to end tests)"
+    needs: e2e
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Release / End to end tests"
@@ -1028,8 +1052,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  stress_fail_fast:
+    name: "Fail fast (Stress tests)"
+    needs: stress
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Release / Stress tests"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -1248,8 +1248,16 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+  BuildAndPush_fail_fast:
+    name: "Fail fast (Build and Test MAGE)"
+    needs: BuildAndPush
+    if: ${{ failure() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
         with:
           job-name: "Build and Test MAGE (${{ inputs.arch }}${{ inputs.cuda && ', cuda' || '' }})"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -1259,5 +1259,3 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cancel run on merge_group failure
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
-        with:
-          job-name: "Build and Test MAGE (${{ inputs.arch }}${{ inputs.cuda && ', cuda' || '' }})"

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -66,36 +66,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build community binary
         run: |
@@ -173,37 +151,15 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          --no-ccache \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
+          no-ccache: 'true'
 
       - name: Build coverage binaries
         run: |
@@ -299,36 +255,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build debug binary
         run: |
@@ -454,36 +388,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build debug binary
         run: |
@@ -564,36 +476,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build release binaries
         run: |
@@ -705,36 +595,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build release binaries
         run: |
@@ -872,36 +740,14 @@ jobs:
           fetch-depth: 0
           ref:  ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build release binaries
         run: |
@@ -1006,36 +852,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build release binaries
         run: |
@@ -1144,36 +968,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build release binaries
         run: |
@@ -1495,36 +1297,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build release binaries
         run: |

--- a/.github/workflows/reusable_stress_tests.yaml
+++ b/.github/workflows/reusable_stress_tests.yaml
@@ -64,36 +64,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build enterprise binary
         run: |
@@ -193,36 +171,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
-      - name: Clean up Docker
-        if: always()
-        continue-on-error: true
-        run: |
-          ./tools/ci/docker_cleanup.sh
-
-      - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+      - name: Open mgbuild session
+        uses: ./.github/actions/mgbuild-session
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Spin up mgbuild container
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          USE_CUSTOM_MIRROR="$(./tools/ci/ubuntu-mirrors/use_custom_mirror.sh --os "$OS" --arch "$ARCH")"
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          run --custom-mirror $USE_CUSTOM_MIRROR
-
-      - name: Check core dump support
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          check-core-dumps
+          os: ${{ env.OS }}
+          arch: ${{ env.ARCH }}
+          toolchain: ${{ env.TOOLCHAIN }}
 
       - name: Build enterprise binary
         run: |


### PR DESCRIPTION
Cancelling a run overwrites the conclusion of every job still in progress, and
the REST API cannot cancel an individual job. The merge-queue fail-fast cancel
therefore runs in a job of its own that lists the failing job in its needs,
which holds it until that job has finished its diagnostic uploads and cleanup
and has recorded a failure conclusion. The job list then identifies the culprit.
The annotation names the conclusion to look for, so no call site has to carry a
job name assembled from two other workflows.

Twelve jobs in the release and stress test workflows open their mgbuild session
through one action: clear leftover Docker state, log in to Docker Hub, spin up
the container, and check that it can write core dumps. The caller still closes
the session with its own stop step, because its build and test steps sit between
the two. The fail-fast path itself runs only on a merge_group failure, so no
pull request exercises it.
