### PR TITLE
test(utils): assert only one writer holds the exclusive lock at a time

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -561,9 +561,9 @@ add_unit_test(utils_pointer_pack
     LINK_TARGETS mg-utils
 )
 
-# TIMEOUT caps a run that wedges rather than fails. A writer that is never granted the exclusive
-# lock blocks in the acquisition, and the thread waiting on it cannot assert anything; without a
-# bound the whole job runs to its own cancellation with nothing naming this test.
+# A writer that is never granted the exclusive lock blocks in the acquisition with nothing
+# asserting on it, so a broken lock wedges rather than fails. TIMEOUT stops that from running to
+# the job's own cancellation with nothing naming this test.
 add_unit_test(utils_rwlock
     SOURCES utils_rwlock.cpp
     LINK_TARGETS mg-utils

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -561,9 +561,13 @@ add_unit_test(utils_pointer_pack
     LINK_TARGETS mg-utils
 )
 
+# TIMEOUT caps a run that wedges rather than fails. A writer that is never granted the exclusive
+# lock blocks in the acquisition, and the thread waiting on it cannot assert anything; without a
+# bound the whole job runs to its own cancellation with nothing naming this test.
 add_unit_test(utils_rwlock
     SOURCES utils_rwlock.cpp
     LINK_TARGETS mg-utils
+    TEST_PROPERTIES TIMEOUT 120
 )
 
 add_unit_test(utils_scheduler

--- a/tests/unit/utils_rwlock.cpp
+++ b/tests/unit/utils_rwlock.cpp
@@ -57,16 +57,12 @@ TEST(RWLock, ExclusiveLockAdmitsOneWriterAtATime) {
   memgraph::utils::RWLock rwlock(memgraph::utils::RWLock::Priority::READ);
   constexpr int num_writers{3};
 
-  // Atomic even though the lock is what orders these: a lock that admitted two writers together
-  // releases them within microseconds of each other, and plain increments would then be free to
-  // lose one another and record a peak of one. The counters have to survive the failure they exist
-  // to report. They still measure the lock and nothing else, since acquiring it is the only thing
-  // keeping a second writer out.
+  // A lock that admitted two writers would release them microseconds apart, and plain increments
+  // racing there could lose one another and record a peak of one.
   std::atomic<int> writers_inside{0};
   std::atomic<int> peak_writers_inside{0};
 
-  // Every writer exists before any of them asks for the lock, so the ones that lose have to queue
-  // rather than each finding a free lock in turn.
+  // All three ask at once, so the two that lose have to queue rather than each finding a free lock.
   auto all_started = std::latch{num_writers};
 
   {
@@ -81,18 +77,15 @@ TEST(RWLock, ExclusiveLockAdmitsOneWriterAtATime) {
         for (auto peak = peak_writers_inside.load();
              peak < inside && !peak_writers_inside.compare_exchange_weak(peak, inside);) {
         }
-        // Held long enough that an overlap has time to be seen in the peak. A writer that released
-        // straight away could be admitted and gone before the next one asked, and a lock granting
-        // both at once would read the same as one that sequenced them.
+        // Held long enough for two writers admitted together to overlap. Released at once, a lock
+        // granting both would read the same as one that sequenced them.
         std::this_thread::sleep_for(50ms);
         writers_inside.fetch_sub(1);
       });
     }
   }
 
-  // One rather than at most one: a peak of zero would mean no writer ever reached the critical
-  // section. A writer that never gets the lock cannot be asserted on at all, since it blocks in
-  // the acquisition and the join above waits on it; the target's ctest timeout bounds that.
+  // One rather than at most one: a peak of zero would mean no writer reached the critical section.
   EXPECT_EQ(peak_writers_inside, 1) << "two writers held the exclusive lock at the same time";
 }
 

--- a/tests/unit/utils_rwlock.cpp
+++ b/tests/unit/utils_rwlock.cpp
@@ -12,8 +12,8 @@
 #include "gtest/gtest.h"
 
 #include "utils/rw_lock.hpp"
-#include "utils/timer.hpp"
 
+#include <algorithm>
 #include <latch>
 #include <semaphore>
 #include <shared_mutex>
@@ -53,46 +53,44 @@ TEST(RWLock, SupportsMultipleConcurrentReaders) {
   may_release.release(num_workers);
 }
 
-TEST(RWLock, SingleWriter) {
+TEST(RWLock, ExclusiveLockAdmitsOneWriterAtATime) {
   memgraph::utils::RWLock rwlock(memgraph::utils::RWLock::Priority::READ);
-  auto count_down_start = std::latch{3};
-  auto count_down_finish = std::latch{4};
+  constexpr int num_writers{3};
 
-  memgraph::utils::Timer timer;
-  std::chrono::duration<double> start;
-  std::chrono::duration<double> total_time;
+  // Deliberately not atomic: the lock is the barrier under test. Every access below is made
+  // holding the exclusive lock, so a lock that admitted two writers together would be a data race
+  // here rather than a passing test.
+  int writers_inside = 0;
+  int peak_writers_inside = 0;
+  int admissions = 0;
 
-  auto j1 = [&] {
-    // Start only when all threads exist
-    count_down_start.arrive_and_wait();
-
-    {
-      // In smallest scope possible
-      auto lock = std::unique_lock{rwlock};
-      std::this_thread::sleep_for(100ms);
-    }
-
-    // Signal that the thread's work has finished
-    count_down_finish.count_down();
-  };
-  auto j2 = [&] {
-    start = timer.Elapsed();  // time from here to avoid the timing cost of setting up threads
-    j1();
-  };
+  // Every writer exists before any of them asks for the lock, so the ones that lose have to queue
+  // rather than each finding a free lock in turn.
+  auto all_started = std::latch{num_writers};
 
   {
-    auto threads = std::vector<std::jthread>{};
-    threads.emplace_back(j1);
-    threads.emplace_back(j1);
-    std::this_thread::sleep_for(1ms);  // Give time for other threads to have started
-    threads.emplace_back(j2);
-    // avoid timing cost to tear down threads
-    count_down_finish.arrive_and_wait();
-    total_time = timer.Elapsed() - start;
+    auto writers = std::vector<std::jthread>{};
+    writers.reserve(num_writers);
+
+    for (int i = 0; i < num_writers; ++i) {
+      writers.emplace_back([&] {
+        all_started.arrive_and_wait();
+        auto lock = std::unique_lock{rwlock};
+        ++admissions;
+        ++writers_inside;
+        peak_writers_inside = std::max(peak_writers_inside, writers_inside);
+        // Held long enough that an overlap has time to be seen in the peak. A writer that released
+        // straight away could be admitted and gone before the next one asked, and a lock granting
+        // both at once would read the same as one that sequenced them.
+        std::this_thread::sleep_for(50ms);
+        --writers_inside;
+      });
+    }
   }
 
-  EXPECT_LE(total_time, 350ms);
-  EXPECT_GE(total_time, 290ms);
+  EXPECT_EQ(peak_writers_inside, 1) << "two writers held the exclusive lock at the same time";
+  EXPECT_EQ(admissions, num_writers) << "a writer never got the exclusive lock";
+  EXPECT_EQ(writers_inside, 0);
 }
 
 TEST(RWLock, ReadPriority) {

--- a/tests/unit/utils_rwlock.cpp
+++ b/tests/unit/utils_rwlock.cpp
@@ -13,7 +13,7 @@
 
 #include "utils/rw_lock.hpp"
 
-#include <algorithm>
+#include <atomic>
 #include <latch>
 #include <semaphore>
 #include <shared_mutex>
@@ -57,12 +57,13 @@ TEST(RWLock, ExclusiveLockAdmitsOneWriterAtATime) {
   memgraph::utils::RWLock rwlock(memgraph::utils::RWLock::Priority::READ);
   constexpr int num_writers{3};
 
-  // Deliberately not atomic: the lock is the barrier under test. Every access below is made
-  // holding the exclusive lock, so a lock that admitted two writers together would be a data race
-  // here rather than a passing test.
-  int writers_inside = 0;
-  int peak_writers_inside = 0;
-  int admissions = 0;
+  // Atomic even though the lock is what orders these: a lock that admitted two writers together
+  // releases them within microseconds of each other, and plain increments would then be free to
+  // lose one another and record a peak of one. The counters have to survive the failure they exist
+  // to report. They still measure the lock and nothing else, since acquiring it is the only thing
+  // keeping a second writer out.
+  std::atomic<int> writers_inside{0};
+  std::atomic<int> peak_writers_inside{0};
 
   // Every writer exists before any of them asks for the lock, so the ones that lose have to queue
   // rather than each finding a free lock in turn.
@@ -76,21 +77,23 @@ TEST(RWLock, ExclusiveLockAdmitsOneWriterAtATime) {
       writers.emplace_back([&] {
         all_started.arrive_and_wait();
         auto lock = std::unique_lock{rwlock};
-        ++admissions;
-        ++writers_inside;
-        peak_writers_inside = std::max(peak_writers_inside, writers_inside);
+        auto const inside = writers_inside.fetch_add(1) + 1;
+        for (auto peak = peak_writers_inside.load();
+             peak < inside && !peak_writers_inside.compare_exchange_weak(peak, inside);) {
+        }
         // Held long enough that an overlap has time to be seen in the peak. A writer that released
         // straight away could be admitted and gone before the next one asked, and a lock granting
         // both at once would read the same as one that sequenced them.
         std::this_thread::sleep_for(50ms);
-        --writers_inside;
+        writers_inside.fetch_sub(1);
       });
     }
   }
 
+  // One rather than at most one: a peak of zero would mean no writer ever reached the critical
+  // section. A writer that never gets the lock cannot be asserted on at all, since it blocks in
+  // the acquisition and the join above waits on it; the target's ctest timeout bounds that.
   EXPECT_EQ(peak_writers_inside, 1) << "two writers held the exclusive lock at the same time";
-  EXPECT_EQ(admissions, num_writers) << "a writer never got the exclusive lock";
-  EXPECT_EQ(writers_inside, 0);
 }
 
 TEST(RWLock, ReadPriority) {


### PR DESCRIPTION
Three writers ask for the exclusive lock at the same time, and the test records
the highest number of them holding it together, which is one for a lock that
admits writers singly. A wall-clock bound on how long the three take measures
how much CPU the machine has to spare, so a loaded runner exceeds it while the
lock is doing its job.

The counters are atomic. A lock that admitted two writers at once would release
them within microseconds of each other, and plain increments racing there can
lose one another and record a peak of one, so the counters have to survive the
failure they exist to report. A writer that is never admitted blocks in the
acquisition and the thread waiting on it cannot assert anything, so the target
carries a ctest timeout: a wedge is then reported against this test rather than
left to run until the job is cancelled.
