### PR TITLE
fix(tests): increase unwind size for termination test

### DIFF
--- a/tests/e2e/parallel/test_termination.py
+++ b/tests/e2e/parallel/test_termination.py
@@ -56,17 +56,17 @@ LARGE_DATASET_SIZE = 100000
 # The key pattern is: MATCH(n) WITH n UNWIND range(...) which creates a
 # large cross product that takes significant time to process.
 #
-# With 100k nodes and UNWIND range(1, 1000), we get 100M intermediate rows.
+# With 100k nodes and UNWIND range(1, 30000), we get 3B intermediate rows.
 # =============================================================================
 
 # Query with aggregation - creates cross product of all nodes with unwind range
-# 100k nodes × 1000 range = 100M intermediate rows
+# 100k nodes × 30000 range = 3B intermediate rows
 # Uses P ScanAll and P Aggregate operators
 LONG_RUNNING_AGGREGATION_QUERY = """
 USING PARALLEL EXECUTION
 MATCH (n:TestNode)
 WITH n
-UNWIND range(1, 1000) AS i
+UNWIND range(1, 30000) AS i
 RETURN i, count(n) AS cnt
 """
 


### PR DESCRIPTION
The `UNWIND` in this test runs too quickly on faster CI runners around 30% of the time and completes before the terminate can happen, so increasing the size of the unwind removes this source of flakiness.
