### PR TITLE
test(query): pin the join that makes a cross-pattern index bound sound

### DIFF
--- a/tests/e2e/query_planning/query_planning_cartesian.py
+++ b/tests/e2e/query_planning/query_planning_cartesian.py
@@ -114,5 +114,30 @@ def test_cartesian_with_nested_property_join(memgraph):
     assert expected_explain == actual_explain
 
 
+def test_indexed_join_for_cross_pattern_range_after_with(memgraph):
+    # A range bound built from the other pattern's property only holds if that pattern is
+    # already bound, so the branches must be joined rather than left independent.
+    memgraph.execute("CREATE INDEX ON :Node;")
+    memgraph.execute("CREATE INDEX ON :Node(id);")
+
+    expected_explain = [
+        " * Produce {n1, n2}",
+        " * Produce {n1, n2}",
+        " * IndexedJoin",
+        " |\\ ",
+        " | * ScanAllByLabelProperties (n2 :Node {id})",
+        " | * Once",
+        " * ScanAllByLabel (n1 :Node)",
+        " * Once",
+    ]
+
+    results = list(
+        memgraph.execute_and_fetch("EXPLAIN MATCH (n1:Node), (n2:Node) WITH * WHERE n1.id < n2.id RETURN *;")
+    )
+    actual_explain = [x[QUERY_PLAN] for x in results]
+
+    assert expected_explain == actual_explain
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/gql_behave/tests/memgraph_V1/features/indices.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/indices.feature
@@ -263,3 +263,19 @@ Feature: Indices
             DROP INDEX ON :L(prop) WITH CONFIG {"foo": "ASC"};
             """
         Then an error should be raised
+
+    Scenario: An index whose bound reads another pattern's property returns the unindexed result
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:L1 {a: 'b'}), (:L1 {a: 'x'}), (:L2 {b: 'm'}), (:L2 {b: 'c'});
+            """
+        And with new index :L2(b)
+        When executing query:
+            """
+            MATCH (n :L1), (m :L2) WITH * WHERE n.a < m.b RETURN m.b ORDER BY m.b;
+            """
+        Then the result should be:
+            | m.b |
+            | 'c' |
+            | 'm' |


### PR DESCRIPTION
A label-property scan whose range bound reads a property of a node from
another pattern is only correct if that other pattern is already bound, so the
two branches have to be joined rather than scanned independently. The
behavioural test states the invariant a user sees: adding the index leaves the
result set alone. The planning test pins the join that delivers it.

Existing coverage misses this. Every case pairs the cross-pattern filter with
equality, or omits the WITH * that separates the patterns from the predicate,
and all of it asserts plan shape against an empty graph, so no test reads a
row.
