### PR TITLE
fix(coordination): bound the log store restore to the entries it holds

### DIFF
--- a/src/coordination/coordinator_log_store.cpp
+++ b/src/coordination/coordinator_log_store.cpp
@@ -15,6 +15,7 @@
 
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
+#include <algorithm>
 #include <cstddef>
 #include <exception>
 #include <libnuraft/buffer.hxx>
@@ -74,11 +75,16 @@ bool CoordinatorLogStore::HandleVersionMigration(LogStoreVersion const stored_ve
       }
 
       uint64_t const last_log_entry = std::stoull(maybe_last_log_entry.value());
-      auto const durable_start_idx_value = std::stoull(maybe_start_idx.value());
+      uint64_t const durable_start_idx_value = std::stoull(maybe_start_idx.value());
       start_idx_.store(durable_start_idx_value, std::memory_order_release);
 
+      // A start index past the newest entry means everything the store ever held was compacted away, so there is
+      // nothing to restore and the leader refetches from the start index. The bound must never end up below the
+      // start of the range below: iota_view would then count away from it rather than yield nothing.
+      auto const restore_end = std::max(durable_start_idx_value, last_log_entry + 1);
+
       // Compaction might have happened so we might be missing some logs.
-      for (auto const id : std::ranges::iota_view{durable_start_idx_value, last_log_entry + 1}) {
+      for (auto const id : std::ranges::iota_view{durable_start_idx_value, restore_end}) {
         auto const entry = durability_->Get(fmt::format("{}{}", kLogEntryPrefix, id));
 
         if (!entry) {
@@ -325,7 +331,6 @@ void CoordinatorLogStore::apply_pack(uint64_t index, buffer &pack) {
 }
 
 // NOTE: Remove all logs up to given 'last_log_index' (inclusive).
-// NOTE: Remove all logs up to given 'last_log_index' (inclusive).
 bool CoordinatorLogStore::compact(uint64_t last_log_index) {
   logger_.Log(nuraft_log_level::TRACE, fmt::format("Compacting logs up to {}", last_log_index));
   auto lock = std::lock_guard{logs_lock_};
@@ -348,6 +353,12 @@ bool CoordinatorLogStore::compact(uint64_t last_log_index) {
     auto const new_idx = last_log_index + 1;
     start_idx_.store(new_idx, std::memory_order_release);
     put_batch.emplace(kStartIdx, std::to_string(new_idx));
+    // NuRaft compacts up to the index of a snapshot it installed, which can be past every entry this store holds.
+    // The durable last entry then still names an index below the new start, and the two keys must agree for the
+    // next restore to know which range to read.
+    if (logs_.empty()) {
+      put_batch.emplace(kLastLogEntry, std::to_string(last_log_index));
+    }
   }
 
   durability_->PutAndDeleteMultiple(put_batch, del_batch);

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -43,9 +43,8 @@ log = logging.getLogger("memgraph.tests.e2e")
 PORT_WINDOW_START_ENV = "MEMGRAPH_PORT_WINDOW_START"
 PORT_WINDOW_SIZE_ENV = "MEMGRAPH_PORT_WINDOW_SIZE"
 PORT_MAP_ENV = "MEMGRAPH_E2E_PORT_MAP"
+PORT_RESERVED_ENV = "MEMGRAPH_E2E_RESERVED_PORTS"
 HA_INIT_QUERIES_ENV = "MEMGRAPH_HA_CLUSTER_INIT_QUERIES"
-DEFAULT_MONITORING_PORT = 7444
-DEFAULT_METRICS_PORT = 9091
 PORT_FLAGS = {
     "--bolt-port",
     "--bolt_port",
@@ -73,6 +72,10 @@ class PortRemap:
         self.active = self.window_start > 0 and self.window_size > 0
         self.forward = {}
         self.reverse = {}
+        # Window ports handed out to a single instance rather than to an original port. They have no reverse mapping,
+        # so they must be kept out of the free-port search on their own.
+        self.reserved = set()
+        self.reserved_by_key = {}
         # Clusters start their instances from a thread pool, so allocation and the env override must be serialized.
         self.lock = threading.RLock()
         if not self.active:
@@ -84,9 +87,30 @@ class PortRemap:
         for original, mapped in seed.items():
             self.forward[int(original)] = int(mapped)
             self.reverse[int(mapped)] = int(original)
+        try:
+            self.reserved.update(int(port) for port in json.loads(os.getenv(PORT_RESERVED_ENV, "") or "[]"))
+        except Exception:
+            pass
 
     def is_candidate(self, port):
         return 1024 <= port < self.window_start
+
+    def _take_free_port(self):
+        """Returns an unused window port. Caller must hold the lock and record what it hands the port to."""
+        free = next(
+            (
+                p
+                for p in range(self.window_start, self.window_start + self.window_size)
+                if p not in self.reverse and p not in self.reserved
+            ),
+            None,
+        )
+        if free is None:
+            raise RuntimeError(
+                f"Port window {self.window_start}-{self.window_start + self.window_size - 1} exhausted, "
+                "increase --port-offset-step of runner_parallel.py."
+            )
+        return free
 
     def map_port(self, port):
         """Allocates a window port for `port` on first sight; later calls return the same one."""
@@ -94,22 +118,22 @@ class PortRemap:
             return port
         with self.lock:
             if port not in self.forward:
-                mapped = next(
-                    (
-                        p
-                        for p in range(self.window_start, self.window_start + self.window_size)
-                        if p not in self.reverse
-                    ),
-                    None,
-                )
-                if mapped is None:
-                    raise RuntimeError(
-                        f"Port window {self.window_start}-{self.window_start + self.window_size - 1} exhausted, "
-                        "increase --port-offset-step of runner_parallel.py."
-                    )
+                mapped = self._take_free_port()
                 self.forward[port] = mapped
                 self.reverse[mapped] = port
             return self.forward[port]
+
+    def reserve_port(self, key):
+        """Allocates a window port for `key` on first sight; later calls return the same one. Listeners the workload
+        never addresses share a single default port number across every instance, so `map_port` would hand the whole
+        cluster one port and only the first instance could bind it. The key stands for the instance, so a workload
+        that starts the same cluster once per test reserves ports for it once."""
+        with self.lock:
+            if key not in self.reserved_by_key:
+                reserved = self._take_free_port()
+                self.reserved_by_key[key] = reserved
+                self.reserved.add(reserved)
+            return self.reserved_by_key[key]
 
     def lookup_port(self, port):
         """Like map_port but never allocates: a port nothing was started on (e.g. a local Kafka) is left alone."""
@@ -276,6 +300,9 @@ class MemgraphInstanceRunner:
     ):
         self.host = "127.0.0.1"
         self.bolt_port = None
+        # Set when the workload leaves these listeners implicit and the port window is active.
+        self.monitoring_port = None
+        self.metrics_port = None
         self.binary_path = binary_path
         self.args = None
         self.proc_mg = None
@@ -452,13 +479,19 @@ class MemgraphInstanceRunner:
         if not any(arg.startswith("--metrics-format") for arg in self.args):
             default_args.append("--metrics-format=OpenMetrics")
         if PORT_REMAP.active:
-            # Give the implicit listeners explicit ports so they get remapped away from other workers too.
+            # Give the implicit listeners explicit ports so they get remapped away from other workers too. Monitoring
+            # and metrics get a port each of their own: every instance of a cluster would otherwise be handed the
+            # port that the single default number maps to, and only the first to start could bind it. The Bolt port
+            # identifies the instance, so a restart rebinds the ports it had.
+            instance_key = extract_bolt_port(self.args)
             if not any(arg.startswith("--bolt-port") or arg.startswith("--bolt_port") for arg in self.args):
                 default_args += ["--bolt-port", "7687"]
             if not any(arg.startswith("--monitoring-port") or arg.startswith("--monitoring_port") for arg in self.args):
-                default_args += ["--monitoring-port", str(DEFAULT_MONITORING_PORT)]
+                self.monitoring_port = PORT_REMAP.reserve_port(f"monitoring@{instance_key}")
+                default_args += ["--monitoring-port", str(self.monitoring_port)]
             if not any(arg.startswith("--metrics-port") or arg.startswith("--metrics_port") for arg in self.args):
-                default_args += ["--metrics-port", str(DEFAULT_METRICS_PORT)]
+                self.metrics_port = PORT_REMAP.reserve_port(f"metrics@{instance_key}")
+                default_args += ["--metrics-port", str(self.metrics_port)]
         args_mg = PORT_REMAP.map_args(default_args + self.args)
 
         if bolt_port:

--- a/tests/e2e/runner_parallel.py
+++ b/tests/e2e/runner_parallel.py
@@ -61,8 +61,6 @@ DISABLE_NODE = os.getenv("DISABLE_NODE", "false") == "true"
 PORT_NAMESPACE_BASE = 20000
 DEFAULT_PORT_OFFSET_STEP = 200
 DEFAULT_BOLT_PORT = 7687
-DEFAULT_MONITORING_PORT = 7444
-DEFAULT_METRICS_PORT = 9091
 
 OFFSETTABLE_FLAGS = {
     "--bolt-port",
@@ -330,15 +328,34 @@ def _has_port_flag(args, *flags):
 
 
 def _ensure_default_listener_ports(args):
-    """Memgraph listens on these even when not asked to, so they need remapping too."""
+    """Memgraph listens on Bolt even when not asked to, so that port needs remapping too."""
     normalized = list(args or [])
     if not _has_port_flag(normalized, "--bolt-port", "--bolt_port"):
         normalized += ["--bolt-port", str(DEFAULT_BOLT_PORT)]
-    if not _has_port_flag(normalized, "--monitoring-port", "--monitoring_port"):
-        normalized += ["--monitoring-port", str(DEFAULT_MONITORING_PORT)]
-    if not _has_port_flag(normalized, "--metrics-port", "--metrics_port"):
-        normalized += ["--metrics-port", str(DEFAULT_METRICS_PORT)]
     return normalized
+
+
+def _assign_implicit_listener_ports(prepared, namespace_start, port_map, port_offset_step):
+    """Gives every instance its own monitoring and metrics port, taken from the worker's window past what the port
+    map uses, and returns the ports handed out. The workload addresses neither listener, so both are left at one
+    default port number across the whole cluster; mapping them by that number would hand every instance the same
+    port and only the first could bind it."""
+    next_free = namespace_start + len(port_map)
+    namespace_end = namespace_start + port_offset_step
+    assigned = []
+    for config in prepared.get("cluster", {}).values():
+        for flag, underscored in (("--monitoring-port", "--monitoring_port"), ("--metrics-port", "--metrics_port")):
+            if _has_port_flag(config.get("args", []), flag, underscored):
+                continue
+            if next_free >= namespace_end:
+                raise RuntimeError(
+                    f"Worker window {namespace_start}-{namespace_end - 1} has no port left for {flag}. "
+                    "Increase --port-offset-step."
+                )
+            config["args"] = list(config.get("args", [])) + [flag, str(next_free)]
+            assigned.append(next_free)
+            next_free += 1
+    return assigned
 
 
 def _extract_bolt_port_from_args(args):
@@ -403,12 +420,14 @@ def prepare_workload_for_worker(workload, worker_slot, port_offset_step):
         if isinstance(config.get("data_directory"), str):
             config["data_directory"] = _append_suffix(config["data_directory"], suffix)
 
+    reserved_ports = _assign_implicit_listener_ports(prepared, namespace_start, port_map, port_offset_step)
+
     prepared["args"] = _remap_ports_in_args(prepared.get("args", []), port_map)
     # C++ e2e binaries default to --bolt-port 7687 when the workload passes no port at all.
     is_cpp_binary = not prepared["binary"].endswith(".sh")
     if is_cpp_binary and not _extract_ports_from_args(workload.get("args", [])) and DEFAULT_BOLT_PORT in port_map:
         prepared["args"] = prepared["args"] + ["--bolt-port", str(port_map[DEFAULT_BOLT_PORT])]
-    return prepared, namespace_start, port_map
+    return prepared, namespace_start, port_map, reserved_ports
 
 
 def find_leftover_processes(window=None):
@@ -500,13 +519,16 @@ def run_single_workload(workload, worker_slot, exclusive, args_dict):
     if exclusive:
         prepared = copy.deepcopy(workload)
     else:
-        prepared, port_namespace_start, port_map = prepare_workload_for_worker(
+        prepared, port_namespace_start, port_map, reserved_ports = prepare_workload_for_worker(
             workload, worker_slot, args_dict["port_offset_step"]
         )
         # Consumed by PortRemap in memgraph.py (through sitecustomize.py) inside the test process.
         env["MEMGRAPH_PORT_WINDOW_START"] = str(port_namespace_start)
         env["MEMGRAPH_PORT_WINDOW_SIZE"] = str(args_dict["port_offset_step"])
         env["MEMGRAPH_E2E_PORT_MAP"] = json.dumps(port_map)
+        # Instances the test starts itself allocate from the same window, so they have to know which ports the
+        # workload's own instances were already given.
+        env["MEMGRAPH_E2E_RESERVED_PORTS"] = json.dumps(reserved_ports)
         reverse_map = {mapped: original for original, mapped in port_map.items()}
         if prepared.get("cluster"):
             first_instance_config = next(iter(prepared["cluster"].values()))

--- a/tests/unit/coordinator_log_store.cpp
+++ b/tests/unit/coordinator_log_store.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include "coordination/coordinator_log_store.hpp"
+#include "coordination/constants.hpp"
 #include "coordination/coordinator_communication_config.hpp"
 #include "coordination/coordinator_state_machine.hpp"
 #include "coordination/coordinator_state_manager.hpp"
@@ -20,6 +21,11 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <thread>
 
 using memgraph::coordination::CoordinatorClusterStateDelta;
 using memgraph::coordination::CoordinatorInstanceContext;
@@ -569,4 +575,68 @@ TEST_F(CoordinatorLogStoreTests, TestLogsAfterSnapshotWithNewConfEntries) {
     EXPECT_EQ(entries[1].first, 3);
     EXPECT_EQ(entries[1].second->get_val_type(), nuraft::log_val_type::app_log);
   }
+}
+
+namespace {
+// Opening the store happens on its own thread so that a restore which fails to terminate is reported as a failed
+// test rather than hanging the suite.
+auto OpenLogStoreWithin(std::chrono::seconds const deadline, std::filesystem::path const &path)
+    -> std::shared_ptr<CoordinatorLogStore> {
+  auto promise = std::make_shared<std::promise<std::shared_ptr<CoordinatorLogStore>>>();
+  auto future = promise->get_future();
+  std::thread{[promise, path]() {
+    auto kv = std::make_shared<memgraph::kvstore::KVStore>(path);
+    memgraph::coordination::LogStoreDurability const durability{kv};
+    promise->set_value(std::make_shared<CoordinatorLogStore>(CoordinatorLogStoreTests::GetLogger(), durability));
+  }}.detach();
+
+  if (future.wait_for(deadline) != std::future_status::ready) {
+    return nullptr;
+  }
+  return future.get();
+}
+}  // namespace
+
+// A durable start index past the newest durable entry means everything below it was compacted away, so the store
+// restores as empty from that index on and leaves NuRaft to refetch.
+TEST_F(CoordinatorLogStoreTests, TestRestoreWithStartIdxPastLastEntry) {
+  auto const path = test_folder_ / "TestRestoreWithStartIdxPastLastEntry";
+
+  {
+    auto kv = std::make_shared<memgraph::kvstore::KVStore>(path);
+    ASSERT_TRUE(kv->Put(std::string{memgraph::coordination::kStartIdx}, "10"));
+    ASSERT_TRUE(kv->Put(std::string{memgraph::coordination::kLastLogEntry}, "3"));
+  }
+
+  auto const log_store = OpenLogStoreWithin(std::chrono::seconds{30}, path);
+  ASSERT_NE(log_store, nullptr) << "restoring a log store with start index 10 and last entry 3 did not terminate";
+  EXPECT_EQ(log_store->start_index(), 10);
+  EXPECT_EQ(log_store->next_slot(), 10);
+}
+
+// NuRaft compacts up to the index of a snapshot it installed, which can be past everything this store ever appended.
+TEST_F(CoordinatorLogStoreTests, TestCompactPastNewestEntry) {
+  auto const path = test_folder_ / "TestCompactPastNewestEntry";
+
+  {
+    auto kv = std::make_shared<memgraph::kvstore::KVStore>(path);
+    memgraph::coordination::LogStoreDurability const durability{kv};
+    CoordinatorLogStore log_store{GetLogger(), durability};
+
+    for (int i = 1; i <= 5; ++i) {
+      auto buf = MakeAppLogBuffer("entry_" + std::to_string(i));
+      auto entry = nuraft::cs_new<log_entry>(i, buf, nuraft::log_val_type::app_log);
+      log_store.append(entry);
+    }
+    ASSERT_EQ(log_store.next_slot(), 6);
+
+    ASSERT_TRUE(log_store.compact(7));
+    EXPECT_EQ(log_store.start_index(), 8);
+    EXPECT_EQ(log_store.next_slot(), 8);
+  }
+
+  auto const log_store = OpenLogStoreWithin(std::chrono::seconds{30}, path);
+  ASSERT_NE(log_store, nullptr) << "restoring a log store compacted past its newest entry did not terminate";
+  EXPECT_EQ(log_store->start_index(), 8);
+  EXPECT_EQ(log_store->next_slot(), 8);
 }


### PR DESCRIPTION
Restoring a coordinator's Raft log reads the durable entries from the start index up to the last entry. A start index above the last entry means compaction removed everything the store held, so the restore yields an empty log from that index on and leaves NuRaft to refetch. Taking the range as given walks keys until it wraps, and the coordinator spins without ever opening its Bolt port, which a cluster restarted from durability can hit while its peers wait for it to reach quorum.

Every instance also gets a monitoring and a metrics port of its own under the parallel e2e runner. A workload that leaves those two listeners implicit gets them at one default port number for every instance, and the runner's port window maps a number to a single port, so only the first instance of a cluster can bind them.
